### PR TITLE
Use 11-bit mask in Bloom.check

### DIFF
--- a/lib/bloom.js
+++ b/lib/bloom.js
@@ -42,7 +42,7 @@ Bloom.prototype.add = function (e) {
  */
 Bloom.prototype.check = function (e) {
   e = utils.sha3(e)
-  var mask = 511 // binary 111111111
+  var mask = 2047 // binary 11111111111
   var match = true
 
   for (var i = 0; i < 3 && match; i++) {


### PR DESCRIPTION
Fixes #303.

Page 5-6 of the [Ethereum Yellow Paper](https://ethereum.github.io/yellowpaper/paper.pdf) specifies that the bloom filter take the low-order 11 bits from each of the first 3 pair of bytes of the hash. The proper bitmask for the low 11 bits is `2^11 - 1 = 2047`.

For some reason the `check` function in `bloom.js` only takes the low-order 9 bits using a mask of 511, so `check` always returns false.

I think the `check` method is not used anywhere in this library (I only found this by trying to use `bloom.js` in my own code), but probably still worth fixing.