### PR TITLE
Updated tests to v6.0.0-beta.3 (v1.2.6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "coveralls": "^3.0.0",
     "documentation": "^8.1.2",
     "ethereumjs-blockchain": "^3.3.3",
-    "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#v1.2.5",
+    "ethereumjs-testing": "git+https://github.com/ethereumjs/ethereumjs-testing.git#v1.2.6",
     "ethereumjs-tx": "1.3.7",
     "level": "^4.0.0",
     "level-mem": "^3.0.1",


### PR DESCRIPTION
Running the latest tests `v6.0.0-beta.3` from `ethereumjs-testing` [v1.2.6](https://github.com/ethereumjs/ethereumjs-testing/releases/tag/v1.2.6).