### PR TITLE
runevm: evm interpreter on ewasm

### DIFF
--- a/lib/ewasm/env.js
+++ b/lib/ewasm/env.js
@@ -2,6 +2,7 @@ const assert = require('assert')
 const fs = require('fs')
 const path = require('path')
 const BN = require('bn.js')
+const ethUtil = require('ethereumjs-util')
 const { VmError, ERROR, FinishExecution } = require('../exceptions.js')
 
 const transformerRaw = fs.readFileSync(path.join(__dirname, '/system/transform-i64.wasm'))
@@ -27,6 +28,10 @@ module.exports = class Env {
         callStatic: this._callStatic.bind(this)
       }
     })
+
+    // TODO: Mock state, to be replaced with stateManager
+    // [addressHex]: { storage: Map }
+    this._state = data.state ? data.state : new Map()
   }
 
   get imports () {
@@ -64,37 +69,30 @@ module.exports = class Env {
   }
 
   getAddress () {
-    console.log('getAddress')
     return this._data.address
   }
 
   getBalance () {
-    console.log('getBalance')
     return this._data.balance
   }
 
   getTxGasPrice () {
-    console.log('getTxGasPrice')
     return this._data.gasPrice
   }
 
   getTxOrigin () {
-    console.log('getTxOrigin')
     return this._data.origin
   }
 
   getCaller () {
-    console.log('getCaller')
     return this._data.caller
   }
 
   getCodeSize () {
-    console.log('getCodeSize', this._data.code.length)
     return this._data.code.length
   }
 
   codeCopy (resultOffset, codeOffset, length) {
-    console.log('codeCopy', resultOffset, codeOffset, length)
     const vBuf = this._data.code.slice(codeOffset, codeOffset + length)
     this._memory.write(resultOffset, length, vBuf)
   }
@@ -105,7 +103,6 @@ module.exports = class Env {
    * @param {Number} offset - The memory offset to load the value into
    */
   getCallValue (offset) {
-    console.log('getCallValue')
     const vBuf = this._data.value
     this._memory.write(offset, 16, vBuf)
   }
@@ -115,7 +112,6 @@ module.exports = class Env {
    * input data passed with the message call instruction or transaction.
    */
   getCallDataSize () {
-    console.log('getCallDataSize', this._data.data.length)
     return this._data.data.length
   }
 
@@ -127,7 +123,6 @@ module.exports = class Env {
    * @param {Number} length - The length of data to copy
    */
   callDataCopy (resultOffset, dataOffset, length) {
-    console.log('callDataCopy', resultOffset, dataOffset, length)
     if (length === 0) {
       return
     }
@@ -137,7 +132,6 @@ module.exports = class Env {
   }
 
   _useGas (high, low) {
-    console.log('_useGas')
     const amount = fromI64(high, low)
     this.useGas(amount)
   }
@@ -148,13 +142,12 @@ module.exports = class Env {
    * @throws VmError if gas limit is exceeded
    */
   useGas (amount) {
-    console.log('useGas')
     amount = new BN(amount)
     const gasUsed = this._results.gasUsed.add(amount)
     if (this._data.gasLimit.lt(gasUsed)) {
       this._results.exception = 0
       this._results.exceptionError = ERROR.OUT_OF_GAS
-      this._results.gasUsed = this._data.gasLimit
+      this._results.gasUsed = this._data.gasLimit.clone()
       this._results.return = Buffer.from([])
       throw new VmError(ERROR.OUT_OF_GAS)
     }
@@ -163,53 +156,76 @@ module.exports = class Env {
   }
 
   _getGasLeftHigh () {
-    console.log('_getGasLeftHigh')
-    return Math.floor(this._data.gasLeft / 4294967296)
+    return Math.floor(this._data.gasLimit.sub(this._results.gasUsed) / 4294967296)
   }
 
   _getGasLeftLow () {
-    console.log('_getGasLeftLow')
-    return this._data.gasLeft
+    return this._data.gasLimit.sub(this._results.gasUsed)
   }
 
   _call (gasHigh, gasLow, addressOffset, valueOffset, dataOffset, dataLength) {
     console.log('call')
+    throw new Error('Not implemented')
   }
 
   _callCode (gasHigh, gasLow, addressOffset, valueOffset, dataOffset, dataLength) {
     console.log('callCode')
+    throw new Error('Not implemented')
   }
 
   _callDelegate (gasHigh, gasLow, addressOffset, dataOffset, dataLength) {
     console.log('callDelegate')
+    throw new Error('Not implemented')
   }
 
   _callStatic (gasHigh, gasLow, addressOffset, dataOffset, dataLength) {
     console.log('callStatic')
+    throw new Error('Not implemented')
   }
 
   getReturnDataSize () {
     console.log('getReturnDataSize')
-    return 0
   }
 
   returnDataCopy (resultOffset, dataOffset, length) {
     console.log('returnDataCopy', resultOffset, dataOffset, length)
+    throw new Error('Not implemented')
   }
 
-  storageLoad () {
-    console.log('storage load')
+  storageLoad (pathOffset, resultOffset) {
+    const path = Buffer.from(this._memory.read(pathOffset, 32))
+
+    const address = this.getAddress()
+    const acc = this._state.get(address.toString('hex'))
+    if (typeof acc === 'undefined') {
+      throw new Error(`Account ${address.toString('hex')} not in state`)
+    }
+
+    let value = acc.storage.get(path.toString('hex'))
+    if (typeof value === 'undefined') {
+      value = ethUtil.zeros(32)
+    }
+
+    this._memory.write(resultOffset, 32, value)
   }
 
   storageStore (pathOffset, valueOffset) {
-    console.log('storage store', pathOffset, valueOffset)
     const path = Buffer.from(this._memory.read(pathOffset, 32))
     const value = Buffer.from(this._memory.read(valueOffset, 32))
-    console.log(path.toString('hex'), value.toString('hex'))
+
+    const address = this.getAddress()
+    let acc = this._state.get(address.toString('hex'))
+    if (typeof acc === 'undefined') {
+      acc = { storage: new Map() }
+      this._state.set(address.toString('hex'), acc)
+    }
+
+    acc.storage.set(path.toString('hex'), value)
   }
 
   selfDestruct () {
     console.log('selfDestruct')
+    throw new Error('Not implemented')
   }
 
   /**
@@ -220,7 +236,6 @@ module.exports = class Env {
    * @throws FinishExecution
    */
   finish (offset, length) {
-    console.log('finish', offset, length)
     let ret = Buffer.from([])
     if (length) {
       ret = Buffer.from(this._memory.read(offset, length))
@@ -249,7 +264,7 @@ module.exports = class Env {
 
     this._results.exception = 0
     this._results.exceptionError = ERROR.REVERT
-    this._results.gasUsed = this._data.gasLimit
+    this._results.gasUsed = this._data.gasLimit.clone()
     this._results.return = ret
 
     throw new VmError(ERROR.REVERT)

--- a/lib/ewasm/env.js
+++ b/lib/ewasm/env.js
@@ -25,7 +25,13 @@ module.exports = class Env {
         call: this._call.bind(this),
         callCode: this._callCode.bind(this),
         callDelegate: this._callDelegate.bind(this),
-        callStatic: this._callStatic.bind(this)
+        callStatic: this._callStatic.bind(this),
+        getBlockNumberHigh: this._getBlockNumberHigh.bind(this),
+        getBlockNumberLow: this._getBlockNumberLow.bind(this),
+        getBlockTimestampHigh: this._getBlockTimestampHigh.bind(this),
+        getBlockTimestampLow: this._getBlockTimestampLow.bind(this),
+        getBlockGasLimitHigh: this._getBlockGasLimitHigh.bind(this),
+        getBlockGasLimitLow: this._getBlockGasLimitLow.bind(this)
       }
     })
 
@@ -36,7 +42,14 @@ module.exports = class Env {
 
   get imports () {
     return {
-      ethereum: this.ethereum
+      ethereum: this.ethereum,
+      env: {
+        ethereum_getBlockCoinbase: this.getBlockCoinbase.bind(this),
+        ethereum_getBlockDifficulty: this.getBlockDifficulty.bind(this),
+        ethereum_getBlockNumber: this.transformer.exports.getBlockNumber,
+        ethereum_getBlockTimestamp: this.transformer.exports.getBlockTimestamp,
+        ethereum_getBlockGasLimit: this.transformer.exports.getBlockGasLimit
+      }
     }
   }
 
@@ -74,6 +87,38 @@ module.exports = class Env {
 
   getBalance () {
     return this._data.balance
+  }
+
+  getBlockCoinbase (resultOffset) {
+    this._memory.write(resultOffset, 20, this._data.block.coinbase)
+  }
+
+  getBlockDifficulty (resultOffset) {
+    this._memory.write(resultOffset, 32, this._data.block.difficulty.toArrayLike(Buffer, 'be', 32))
+  }
+
+  _getBlockNumberHigh () {
+    return Math.floor(this._data.block.number / 4294967296)
+  }
+
+  _getBlockNumberLow () {
+    return this._data.block.number
+  }
+
+  _getBlockTimestampHigh () {
+    return Math.floor(this._data.block.timestamp / 4294967296)
+  }
+
+  _getBlockTimestampLow () {
+    return this._data.block.timestamp
+  }
+
+  _getBlockGasLimitHigh () {
+    return Math.floor(this._data.block.gasLimit / 4294967296)
+  }
+
+  _getBlockGasLimitLow () {
+    return this._data.block.gasLimit
   }
 
   getTxGasPrice () {

--- a/lib/ewasm/env.js
+++ b/lib/ewasm/env.js
@@ -17,8 +17,14 @@ module.exports = class Env {
     // Wasm-js api doesn't yet support i64 param/return values.
     // https://github.com/WebAssembly/proposals/issues/7
     this.transformer = WebAssembly.Instance(transformerModule, {
-      'interface': {
-        'useGas': this._useGas.bind(this)
+      interface: {
+        useGas: this._useGas.bind(this),
+        getGasLeftHigh: this._getGasLeftHigh.bind(this),
+        getGasLeftLow: this._getGasLeftLow.bind(this),
+        call: this._call.bind(this),
+        callCode: this._callCode.bind(this),
+        callDelegate: this._callDelegate.bind(this),
+        callStatic: this._callStatic.bind(this)
       }
     })
   }
@@ -31,13 +37,66 @@ module.exports = class Env {
 
   get ethereum () {
     return {
+      getAddress: this.getAddress.bind(this),
+      getBalance: this.getBalance.bind(this),
+      getTxGasPrice: this.getTxGasPrice.bind(this),
+      getTxOrigin: this.getTxOrigin.bind(this),
+      getCaller: this.getCaller.bind(this),
+      getCodeSize: this.getCodeSize.bind(this),
+      codeCopy: this.codeCopy.bind(this),
       getCallValue: this.getCallValue.bind(this),
       getCallDataSize: this.getCallDataSize.bind(this),
       callDataCopy: this.callDataCopy.bind(this),
       useGas: this.transformer.exports.useGas,
+      getGasLeft: this.transformer.exports.getGasLeft,
+      call: this.transformer.exports.call,
+      callCode: this.transformer.exports.callCode,
+      callDelegate: this.transformer.exports.callDelegate,
+      callStatic: this.transformer.exports.callStatic,
+      getReturnDataSize: this.getReturnDataSize.bind(this),
+      returnDataCopy: this.returnDataCopy.bind(this),
+      storageLoad: this.storageLoad.bind(this),
+      storageStore: this.storageStore.bind(this),
+      selfDestruct: this.selfDestruct.bind(this),
       finish: this.finish.bind(this),
       revert: this.revert.bind(this)
     }
+  }
+
+  getAddress () {
+    console.log('getAddress')
+    return this._data.address
+  }
+
+  getBalance () {
+    console.log('getBalance')
+    return this._data.balance
+  }
+
+  getTxGasPrice () {
+    console.log('getTxGasPrice')
+    return this._data.gasPrice
+  }
+
+  getTxOrigin () {
+    console.log('getTxOrigin')
+    return this._data.origin
+  }
+
+  getCaller () {
+    console.log('getCaller')
+    return this._data.caller
+  }
+
+  getCodeSize () {
+    console.log('getCodeSize', this._data.code.length)
+    return this._data.code.length
+  }
+
+  codeCopy (resultOffset, codeOffset, length) {
+    console.log('codeCopy', resultOffset, codeOffset, length)
+    const vBuf = this._data.code.slice(codeOffset, codeOffset + length)
+    this._memory.write(resultOffset, length, vBuf)
   }
 
   /**
@@ -46,6 +105,7 @@ module.exports = class Env {
    * @param {Number} offset - The memory offset to load the value into
    */
   getCallValue (offset) {
+    console.log('getCallValue')
     const vBuf = this._data.value
     this._memory.write(offset, 16, vBuf)
   }
@@ -55,6 +115,7 @@ module.exports = class Env {
    * input data passed with the message call instruction or transaction.
    */
   getCallDataSize () {
+    console.log('getCallDataSize', this._data.data.length)
     return this._data.data.length
   }
 
@@ -66,11 +127,17 @@ module.exports = class Env {
    * @param {Number} length - The length of data to copy
    */
   callDataCopy (resultOffset, dataOffset, length) {
+    console.log('callDataCopy', resultOffset, dataOffset, length)
+    if (length === 0) {
+      return
+    }
+
     const data = this._data.data.slice(dataOffset, dataOffset + length)
     this._memory.write(resultOffset, length, data)
   }
 
   _useGas (high, low) {
+    console.log('_useGas')
     const amount = fromI64(high, low)
     this.useGas(amount)
   }
@@ -81,6 +148,7 @@ module.exports = class Env {
    * @throws VmError if gas limit is exceeded
    */
   useGas (amount) {
+    console.log('useGas')
     amount = new BN(amount)
     const gasUsed = this._results.gasUsed.add(amount)
     if (this._data.gasLimit.lt(gasUsed)) {
@@ -94,6 +162,56 @@ module.exports = class Env {
     this._results.gasUsed = gasUsed
   }
 
+  _getGasLeftHigh () {
+    console.log('_getGasLeftHigh')
+    return Math.floor(this._data.gasLeft / 4294967296)
+  }
+
+  _getGasLeftLow () {
+    console.log('_getGasLeftLow')
+    return this._data.gasLeft
+  }
+
+  _call (gasHigh, gasLow, addressOffset, valueOffset, dataOffset, dataLength) {
+    console.log('call')
+  }
+
+  _callCode (gasHigh, gasLow, addressOffset, valueOffset, dataOffset, dataLength) {
+    console.log('callCode')
+  }
+
+  _callDelegate (gasHigh, gasLow, addressOffset, dataOffset, dataLength) {
+    console.log('callDelegate')
+  }
+
+  _callStatic (gasHigh, gasLow, addressOffset, dataOffset, dataLength) {
+    console.log('callStatic')
+  }
+
+  getReturnDataSize () {
+    console.log('getReturnDataSize')
+    return 0
+  }
+
+  returnDataCopy (resultOffset, dataOffset, length) {
+    console.log('returnDataCopy', resultOffset, dataOffset, length)
+  }
+
+  storageLoad () {
+    console.log('storage load')
+  }
+
+  storageStore (pathOffset, valueOffset) {
+    console.log('storage store', pathOffset, valueOffset)
+    const path = Buffer.from(this._memory.read(pathOffset, 32))
+    const value = Buffer.from(this._memory.read(valueOffset, 32))
+    console.log(path.toString('hex'), value.toString('hex'))
+  }
+
+  selfDestruct () {
+    console.log('selfDestruct')
+  }
+
   /**
    * Set the returning output data for the execution.
    * This will halt the execution immediately.
@@ -102,6 +220,7 @@ module.exports = class Env {
    * @throws FinishExecution
    */
   finish (offset, length) {
+    console.log('finish', offset, length)
     let ret = Buffer.from([])
     if (length) {
       ret = Buffer.from(this._memory.read(offset, length))

--- a/lib/ewasm/memory.js
+++ b/lib/ewasm/memory.js
@@ -4,6 +4,13 @@ module.exports = class Memory {
   }
 
   write (offset, length, value) {
+    // Grow if needed
+    if (this._raw.buffer.byteLength < length) {
+      const diff = length - this._raw.buffer.byteLength
+      const pageSize = 64 * 1024
+      this._raw.grow(Math.ceil(diff / pageSize))
+    }
+
     const m = new Uint8Array(this._raw.buffer, offset, length)
     m.set(value)
   }

--- a/lib/ewasm/system/deployer.wasm
+++ b/lib/ewasm/system/deployer.wasm
@@ -1,0 +1,1 @@
+/home/s1na/dev/ewasm/runevm/target/deployer.wasm

--- a/lib/ewasm/system/runevm.wasm
+++ b/lib/ewasm/system/runevm.wasm
@@ -1,0 +1,1 @@
+/home/s1na/dev/ewasm/runevm/target/runevm.wasm

--- a/lib/ewasm/system/transform-i64.wast
+++ b/lib/ewasm/system/transform-i64.wast
@@ -5,17 +5,92 @@
 ;; have to be extended to support the full EEI interface.
 (module
   (import "interface" "useGas" (func $useGas (param i32 i32)))
+  (import "interface" "getGasLeftHigh" (func $getGasLeftHigh (result i32)))
+  (import "interface" "getGasLeftLow" (func $getGasLeftLow (result i32)))
+  (import "interface" "call" (func $call (param i32 i32 i32 i32 i32 i32) (result i32)))
+  (import "interface" "callCode" (func $callCode (param i32 i32 i32 i32 i32 i32) (result i32)))
+  (import "interface" "callDelegate" (func $callDelegate (param i32 i32 i32 i32 i32) (result i32)))
+  (import "interface" "callStatic" (func $callStatic (param i32 i32 i32 i32 i32) (result i32)))
 
   (export "useGas" (func $useGasShim))
+  (export "getGasLeft" (func $getGasLeft))
+  (export "call" (func $callShim))
+  (export "callCode" (func $callCodeShim))
+  (export "callDelegate" (func $callDelegateShim))
+  (export "callStatic" (func $callStaticShim))
 
-  ;; Use gas takes a i64 parameter `amount`. This shim takes the i64 value
-  ;; and breaks it into two 32 bit values `high` and `low` which js can natively
-  ;; support.
   (func $useGasShim
     (param $amount i64)
     (call $useGas
-      (i32.wrap/i64 (i64.shr_u (get_local $amount) (i64.const 32)))
-      (i32.wrap/i64 (get_local $amount))
+                 (i32.wrap/i64
+                   (i64.shr_u (get_local $amount) (i64.const 32)))
+                 (i32.wrap/i64 (get_local $amount)))
+  )
+
+  (func $getGasLeft
+    (result i64)
+    (call $useGas (i32.const 0) (i32.const 2))
+    (return
+      (i64.add
+        (i64.shl (i64.extend_u/i32 (call $getGasLeftHigh)) (i64.const 32))
+        (i64.extend_u/i32 (call $getGasLeftLow))))
+  )
+
+  ;; call
+  ;; (import $call "ethereum" "call" (param i32 i32 i32 i32 i32) (result i32))
+  (func $callShim
+    (param i64 i32 i32 i32 i32)
+    (result i32)
+    (call $call
+           (i32.wrap/i64
+             (i64.shr_u (get_local 0) (i64.const 32)))
+           (i32.wrap/i64 (get_local 0))
+           (get_local 1)
+           (get_local 2)
+           (get_local 3)
+           (get_local 4)
+    )
+  )
+
+  ;; callCode
+  ;; (import $callCode "ethereum" "callCode" (param i32 i32 i32 i32 i32) (result i32))
+  (func $callCodeShim
+    (param i64 i32 i32 i32 i32)
+    (result i32)
+    (call $callCode
+           (i32.wrap/i64
+             (i64.shr_u (get_local 0) (i64.const 32)))
+           (i32.wrap/i64 (get_local 0))
+           (get_local 1)
+           (get_local 2)
+           (get_local 3)
+           (get_local 4)
+    )
+  )
+
+  (func $callDelegateShim
+    (param i64 i32 i32 i32)
+    (result i32)
+    (call $callDelegate
+           (i32.wrap/i64
+             (i64.shr_u (get_local 0) (i64.const 32)))
+           (i32.wrap/i64 (get_local 0))
+           (get_local 1)
+           (get_local 2)
+           (get_local 3)
+    )
+  )
+
+  (func $callStaticShim
+    (param i64 i32 i32 i32)
+    (result i32)
+    (call $callStatic
+           (i32.wrap/i64
+             (i64.shr_u (get_local 0) (i64.const 32)))
+           (i32.wrap/i64 (get_local 0))
+           (get_local 1)
+           (get_local 2)
+           (get_local 3)
     )
   )
 )

--- a/lib/ewasm/system/transform-i64.wast
+++ b/lib/ewasm/system/transform-i64.wast
@@ -29,7 +29,9 @@
 
   (func $getGasLeft
     (result i64)
-    (call $useGas (i32.const 0) (i32.const 2))
+    ;; The line below was in the original version. Commented it
+    ;; out to conform with existing gas rules.
+    ;; (call $useGas (i32.const 0) (i32.const 2))
     (return
       (i64.add
         (i64.shl (i64.extend_u/i32 (call $getGasLeftHigh)) (i64.const 32))

--- a/lib/ewasm/system/transform-i64.wast
+++ b/lib/ewasm/system/transform-i64.wast
@@ -11,6 +11,12 @@
   (import "interface" "callCode" (func $callCode (param i32 i32 i32 i32 i32 i32) (result i32)))
   (import "interface" "callDelegate" (func $callDelegate (param i32 i32 i32 i32 i32) (result i32)))
   (import "interface" "callStatic" (func $callStatic (param i32 i32 i32 i32 i32) (result i32)))
+  (import "interface" "getBlockNumberHigh" (func $getBlockNumberHigh (result i32)))
+  (import "interface" "getBlockNumberLow" (func $getBlockNumberLow (result i32)))
+  (import "interface" "getBlockTimestampHigh" (func $getBlockTimestampHigh (result i32)))
+  (import "interface" "getBlockTimestampLow" (func $getBlockTimestampLow (result i32)))
+  (import "interface" "getBlockGasLimitHigh" (func $getBlockGasLimitHigh (result i32)))
+  (import "interface" "getBlockGasLimitLow" (func $getBlockGasLimitLow (result i32)))
 
   (export "useGas" (func $useGasShim))
   (export "getGasLeft" (func $getGasLeft))
@@ -18,6 +24,9 @@
   (export "callCode" (func $callCodeShim))
   (export "callDelegate" (func $callDelegateShim))
   (export "callStatic" (func $callStaticShim))
+  (export "getBlockNumber" (func $getBlockNumberShim))
+  (export "getBlockTimestamp" (func $getBlockTimestampShim))
+  (export "getBlockGasLimit" (func $getBlockGasLimitShim))
 
   (func $useGasShim
     (param $amount i64)
@@ -32,10 +41,10 @@
     ;; The line below was in the original version. Commented it
     ;; out to conform with existing gas rules.
     ;; (call $useGas (i32.const 0) (i32.const 2))
-    (return
-      (i64.add
-        (i64.shl (i64.extend_u/i32 (call $getGasLeftHigh)) (i64.const 32))
-        (i64.extend_u/i32 (call $getGasLeftLow))))
+    (call $toI64
+      (call $getGasLeftHigh)
+      (call $getGasLeftLow)
+    )
   )
 
   ;; call
@@ -94,5 +103,39 @@
            (get_local 2)
            (get_local 3)
     )
+  )
+
+  (func $getBlockNumberShim
+    (result i64)
+    (call $toI64
+      (call $getBlockNumberHigh)
+      (call $getBlockNumberLow)
+    )
+  )
+
+  (func $getBlockTimestampShim
+    (result i64)
+    (call $toI64
+      (call $getBlockTimestampHigh)
+      (call $getBlockTimestampLow)
+    )
+  )
+
+  (func $getBlockGasLimitShim
+    (result i64)
+    (call $toI64
+      (call $getBlockGasLimitHigh)
+      (call $getBlockGasLimitLow)
+    )
+  )
+
+  (func $toI64
+    ;; high, low -> i64
+    (param i32 i32)
+    (result i64)
+    (return
+      (i64.add
+        (i64.shl (i64.extend_u/i32 (get_local 0)) (i64.const 32))
+        (i64.extend_u/i32 (get_local 1))))
   )
 )

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "echo \"[INFO] Generic test cmd not used. See package.json for more specific test run cmds.\"",
     "testStateEwasm": "npm run build:dist && node ./tests/tester -s --fork='Constantinople' --dist --ewasm",
     "testBlockchainEwasm": "npm run build:dist && node --stack-size=1500 ./tests/tester -b --dist --ewasm --excludeDir='GeneralStateTests'",
+    "testRunevm": "npm run build:wast && node ./tests/ewasm/runevm",
     "lint": "standard",
     "prepublishOnly": "npm run lint && npm run build:dist && npm run testBuildIntegrity",
     "build:dist": "npm run build:wast && babel lib/ -d dist/ --copy-files",

--- a/tests/ewasm/runevm.js
+++ b/tests/ewasm/runevm.js
@@ -27,7 +27,7 @@ tape('Runevm', (t) => {
     st.end()
   })
 
-  require('ethereumjs-testing').getTestsFromArgs('VMTests/vmArithmeticTest', (fileName, testName, test) => {
+  require('ethereumjs-testing').getTestsFromArgs('VMTests/vmBlockInfoTest', (fileName, testName, test) => {
     t.test(`${fileName}/${testName}`, st => {
       const testcase = test
       const state = new Map()
@@ -44,8 +44,17 @@ tape('Runevm', (t) => {
         state.set(ethUtil.stripHexPrefix(addr), acc)
       }
 
+      const block = {
+        coinbase: ethUtil.toBuffer(testcase.env.currentCoinbase),
+        difficulty: new BN(ethUtil.stripHexPrefix(testcase.env.currentDifficulty), 16),
+        gasLimit: new BN(ethUtil.stripHexPrefix(testcase.env.currentGasLimit), 16),
+        number: new BN(ethUtil.stripHexPrefix(testcase.env.currentNumber), 16),
+        timestamp: new BN(ethUtil.stripHexPrefix(testcase.env.currentTimestamp), 16)
+      }
+
       const opts = {
         state: state,
+        block: block,
         address: ethUtil.toBuffer(testcase.exec.address),
         caller: ethUtil.toBuffer(testcase.exec.caller),
         code: ethUtil.toBuffer(testcase.exec.code),

--- a/tests/ewasm/runevm.js
+++ b/tests/ewasm/runevm.js
@@ -1,0 +1,86 @@
+const fs = require('fs')
+const path = require('path')
+const tape = require('tape')
+const BN = require('bn.js')
+const ethUtil = require('ethereumjs-util')
+const { Contract } = require('../../lib/ewasm')
+
+tape('Runevm', (t) => {
+  let interpreter
+
+  t.test('should execute deployer', st => {
+    const runevmCode = fs.readFileSync(path.join(__dirname, '../../lib/ewasm/system/runevm.wasm'))
+    const deployerCode = fs.readFileSync(path.join(__dirname, '../../lib/ewasm/system/deployer.wasm'))
+
+    const deployer = new Contract(deployerCode)
+    let opts = {
+      code: runevmCode
+    }
+    let res = deployer.run(opts)
+
+    t.equal(res.exception, 1)
+    t.ok(res.return.length > 0)
+
+    const interpreterCode = res.return
+    interpreter = new Contract(interpreterCode)
+
+    st.end()
+  })
+
+  require('ethereumjs-testing').getTestsFromArgs('VMTests/vmArithmeticTest', (fileName, testName, test) => {
+    t.test(`${fileName}/${testName}`, st => {
+      const testcase = test
+      const state = new Map()
+      for (const addr of Object.keys(testcase.pre)) {
+        const acc = {
+          balance: ethUtil.toBuffer(testcase.pre[addr].balance),
+          code: ethUtil.toBuffer(testcase.pre[addr].code),
+          nonce: ethUtil.toBuffer(testcase.pre[addr].nonce),
+          storage: new Map()
+        }
+        for (const k of Object.keys(testcase.pre[addr].storage)) {
+          acc.storage.set(ethUtil.stripHexPrefix(k), ethUtil.toBuffer(testcase.pre[addr].storage[k]))
+        }
+        state.set(ethUtil.stripHexPrefix(addr), acc)
+      }
+
+      const opts = {
+        state: state,
+        address: ethUtil.toBuffer(testcase.exec.address),
+        caller: ethUtil.toBuffer(testcase.exec.caller),
+        code: ethUtil.toBuffer(testcase.exec.code),
+        data: ethUtil.toBuffer(testcase.exec.data),
+        gasLimit: new BN(ethUtil.stripHexPrefix(testcase.exec.gas), 16),
+        gasPrice: new BN(ethUtil.stripHexPrefix(testcase.exec.gasPrice), 16)
+      }
+
+      const res = interpreter.run(opts)
+
+      // If exception is expected, testcase doesn't include
+      // post state
+      if ('post' in testcase) {
+        t.equal(res.exception, 1)
+        t.deepEqual(res.return, ethUtil.toBuffer(testcase.out), 'return value should match')
+        t.ok(opts.gasLimit.sub(res.gasUsed).eq(new BN(ethUtil.stripHexPrefix(testcase.gas), 16)), 'gas usage should match')
+        // TODO: check logs
+        // TODO: check callcreates
+        t.equal(testcase.callcreates.length, 0)
+
+        // Check state
+        for (const addr of Object.keys(testcase.post)) {
+          const acc = state.get(ethUtil.stripHexPrefix(addr))
+          st.ok(typeof acc !== 'undefined')
+          for (let k of Object.keys(testcase.post[addr].storage)) {
+            k = ethUtil.setLengthLeft(ethUtil.stripHexPrefix(k), 32)
+            const v = acc.storage.get(k)
+            st.deepEqual(v, testcase.post[addr].storage[k])
+          }
+        }
+      } else {
+        st.equal(res.exception, 0)
+      }
+
+      st.end()
+    })
+  }).then(() => t.end())
+})

--- a/tests/ewasm/runevm.js
+++ b/tests/ewasm/runevm.js
@@ -71,9 +71,10 @@ tape('Runevm', (t) => {
           const acc = state.get(ethUtil.stripHexPrefix(addr))
           st.ok(typeof acc !== 'undefined')
           for (let k of Object.keys(testcase.post[addr].storage)) {
-            k = ethUtil.setLengthLeft(ethUtil.stripHexPrefix(k), 32)
-            const v = acc.storage.get(k)
-            st.deepEqual(v, testcase.post[addr].storage[k])
+            const expected = testcase.post[addr].storage[k]
+            k = ethUtil.setLengthLeft(k, 32)
+            const v = acc.storage.get(k.toString('hex'))
+            st.deepEqual(v, ethUtil.setLengthLeft(expected, 32))
           }
         }
       } else {


### PR DESCRIPTION
Depends on #431.

**Summary** [runevm](https://github.com/axic/runevm) compiles parity's evm interpreter to wasm, and uses the [ewasm-rust-api](https://github.com/ewasm/ewasm-rust-api) to communicate with the Ethereum environment. This PR extends the EEI to allow running simple evm bytecodes on top of ewasm through runevm. It's currently passing the `vmArithmeticTest` suite :) To run the tests use `npm run testRunevm`. The good point about `VMTests` is that they don't explicitly require the state trie. So to simulate the state I use a simple in-memory mock object, and avoid the [sync/async problem](https://github.com/ewasm/design/blob/master/interface_questions.md) for now.

Notes:

- Not to be merged, this is an experiment with two purposes:
    1. serve as a pipline for testing runevm
    2. incrementally fill in more ewasm features in ethereumjs-vm and figure out challenges
- The runevm contract was built from the https://github.com/axic/runevm/pull/9 branch
- As in #431, this PR is heavily influenced by [ewasm-kernel](https://github.com/ewasm/ewasm-kernel)