### PR TITLE
Fix missing sources for source maps

### DIFF
--- a/packages/account/package.json
+++ b/packages/account/package.json
@@ -5,7 +5,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist",
+    "src"
   ],
   "repository": {
     "type": "git",

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "ethereumjs-config-build",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist",
+    "src"
   ],
   "scripts": {
     "prepublishOnly": "npm run lint && npm run test && npm run build",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -5,7 +5,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "ethereumjs-config-build",

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "ethereumjs-config-build",

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "ethereumjs-config-build",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist",
+    "lib"
   ],
   "scripts": {
     "build": "ethereumjs-config-build",


### PR DESCRIPTION
I've fixed #902 issue by adding proper file record into `package.json` files.

What has been done:

- Changed `package.json#files` record for all packages.
- Unified `package.json#files` record to be `dist` instead of `dist/**/*`.