### PR TITLE
vm: fix generateStateRoot

### DIFF
--- a/packages/vm/lib/runBlock.ts
+++ b/packages/vm/lib/runBlock.ts
@@ -162,7 +162,7 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
   // header values against the current block.
   if (generateStateRoot) {
     const bloom = result.bloom.bitvector
-    block = Block.fromBlockData({
+    opts.block = block = Block.fromBlockData({
       ...block,
       header: { ...block.header, stateRoot, bloom },
     })


### PR DESCRIPTION
Now, when `generate` in `RunBlockOpts` of `runBlock` is true, the stateRoot in block.header will not change.

The source code is like this:
```js
export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<RunBlockResult> {
  //...
  let { block } = opts
  const generateStateRoot = !!opts.generate
  //...
  if (generateStateRoot) {
    const bloom = result.bloom.bitvector
    block = Block.fromBlockData({
      ...block,
      header: { ...block.header, stateRoot, bloom },
    })
  }
  //...
}
```

The logic looks similar to this:

```js
var obj = {
    a: 1
}

const func = ({ obj }) => {
    obj = {
        ...obj,
        a: 2
    }
}

func({ obj })

// value: 1
console.log('value:', obj.a)
```