### PR TITLE
Generate receipt roots in runBlock

### DIFF
--- a/packages/vm/lib/runBlock.ts
+++ b/packages/vm/lib/runBlock.ts
@@ -171,7 +171,7 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
     const bloom = result.bloom.bitvector
     block = Block.fromBlockData({
       ...block,
-      header: { ...block.header, stateRoot, bloom },
+      header: { ...block.header, stateRoot, bloom, receiptTrie: result.receiptRoot },
     })
   } else {
     if (result.receiptRoot && !result.receiptRoot.equals(block.header.receiptTrie)) {

--- a/packages/vm/tests/api/runBlock.spec.ts
+++ b/packages/vm/tests/api/runBlock.spec.ts
@@ -1,13 +1,14 @@
 import tape from 'tape'
-import { Address, BN, rlp } from 'ethereumjs-util'
+import { Address, BN, rlp, KECCAK256_RLP } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import { Transaction } from '@ethereumjs/tx'
 import { DefaultStateManager } from '../../lib/state'
-import runBlock from '../../lib/runBlock'
+import runBlock, { RunBlockOpts } from '../../lib/runBlock'
 import { setupPreConditions, getDAOCommon } from '../util'
 import { setupVM, createAccount } from './utils'
 import VM from '../../lib/index'
+import { AfterBlockEvent } from '../../lib/runBlock'
 
 const testData = require('./testdata.json')
 
@@ -264,6 +265,46 @@ tape(
     t.end()
   }
 )
+
+async function runBlockAndGetAfterBlockEvent(
+  vm: VM,
+  runBlockOpts: RunBlockOpts
+): Promise<AfterBlockEvent> {
+  let results: AfterBlockEvent
+  function handler(event: AfterBlockEvent) {
+    results = event
+  }
+
+  try {
+    vm.once('afterBlock', handler)
+    await vm.runBlock(runBlockOpts)
+  } finally {
+    // We need this in case `runBlock` throws before emitting the event.
+    // Otherwise we'd be leaking the listener until the next call to runBlock.
+    vm.removeListener('afterBlock', handler)
+  }
+
+  return results!
+}
+
+tape('should generate a receipt root', async (t) => {
+  const vm = new VM()
+
+  // We create a block with a receiptTrie filled with 0s and no txs.
+  // Once we run it we should get a receipt trie root of for the empty receipts set,
+  // which is a well known constant.
+  const block = Block.fromBlockData({ header: { receiptTrie: Buffer.alloc(32, 0) } })
+
+  const results = await runBlockAndGetAfterBlockEvent(vm, {
+    block,
+    generate: true,
+    skipBlockValidation: true,
+  })
+
+  t.ok(results.block.header.receiptTrie.equals(KECCAK256_RLP))
+
+  t.end()
+})
 /*
 async function runWithHf(hardfork: string) {
   const vm = setupVM({ common: new Common({ chain: 'mainnet', hardfork }) })


### PR DESCRIPTION
Hey guys,

We found a bug in Hardhat network yesterday, that IMO is a bug in `ethereumjs-vm`, so I fixed it :)

I think that if a user calls `vm.runBlock` with the `generate: true`, is because they don't want to validate the block but to  modify the state and update (`generate`) the fields of the block header that can only be computed after executing the txs. If this is the actual intention, then `block.header.receiptTrie` was missing.

This PR just updates that header field, and adds a test for it.

Also, as you can see in the test, using `runBlock` with `generate: true` is really really inconvenient. I don't get why the new `Block` wasn't added to `RunBlockResult`. You can only access it with an event listener. The good news is that adding it is a backwards compatible change. Should I create a PR doing it?