### PR TITLE
Devp2p: fix a peer data processing bug

### DIFF
--- a/packages/devp2p/src/rlpx/peer.ts
+++ b/packages/devp2p/src/rlpx/peer.ts
@@ -512,8 +512,8 @@ export class Peer extends EventEmitter {
   _onSocketData(data: Buffer) {
     if (this._closed) return
     this._socketData.append(data)
-    while (this._socketData.length >= this._nextPacketSize) {
-      try {
+    try {
+      while (this._socketData.length >= this._nextPacketSize) {
         switch (this._state) {
           case 'Auth':
             this._handleAuth()
@@ -528,11 +528,11 @@ export class Peer extends EventEmitter {
             this._handleBody()
             break
         }
-      } catch (err) {
-        this.disconnect(DISCONNECT_REASONS.SUBPROTOCOL_ERROR)
-        debug(`Error on peer socket data handling: ${err}`)
-        this.emit('error', err)
       }
+    } catch (err) {
+      this.disconnect(DISCONNECT_REASONS.SUBPROTOCOL_ERROR)
+      debug(`Error on peer socket data handling: ${err}`)
+      this.emit('error', err)
     }
   }
 


### PR DESCRIPTION
This PR fixes a critical devp2p bug where peer data processing stays in an endless while loop on retrieval of malformed data, code change should be relatively self-explanatory, so if an error is thrown "early enough" before the data is consumed the loop will be executed ever and ever again (while the peer is disconnected anyhow).

Stumbled upon this in the client where the following error has been hammered out in an endless fashion on some malformed peer data:

```shell
ERROR [01-19|18:55:59] AssertionError [ERR_ASSERTION]: should have valid tag: c9994806780c34bf140355955ad1d2f5aeb38a61cea495379a435931d8bf7e6e / 176a38c21a95454505a8d05627c9975ce84673da8903b33fe48b80b082595cc0
    at new AssertionError (internal/assert/assertion_error.js:447:11)
    at Object.assertEq (/ethereumjs-vm/packages/devp2p/dist/util.js:73:15)
    at ECIES._decryptMessage (/EthereumJS/ethereumjs-vm/packages/devp2p/dist/rlpx/ecies.js:126:16)
    at ECIES.parseAuthPlain (/EthereumJS/ethereumjs-vm/packages/devp2p/dist/rlpx/ecies.js:197:32)
    at ECIES.parseAuthEIP8 (/EthereumJS/ethereumjs-vm/packages/devp2p/dist/rlpx/ecies.js:236:14)
    at Peer._handleAuth (/EthereumJS/ethereumjs-vm/packages/devp2p/dist/rlpx/peer.js:238:32)
    at Peer._onSocketData (/EthereumJS/ethereumjs-vm/packages/devp2p/dist/rlpx/peer.js:443:30)
    at Socket.emit (events.js:314:20)
    at addChunk (_stream_readable.js:297:12)
    at readableAddChunk (_stream_readable.js:272:9)
```

I think I already had this in other occasions before as well.

This might also solve some client "hanging" situations - so this behavior might have also been occurred together with the error not propagated through as an output for the client log, so the situation just looked as if the client just hangs. That's just an assumption though, we'll eventually see.