### PR TITLE
Client: Warning on not possible further block execution

### DIFF
--- a/packages/blockchain/test/index.ts
+++ b/packages/blockchain/test/index.ts
@@ -335,15 +335,16 @@ tape('blockchain test', (t) => {
     st.end()
   })
 
-  t.test('should iterate through 25 blocks', async (st) => {
+  t.test('should iterate through 24 blocks', async (st) => {
     const { blockchain, blocks, error } = await generateBlockchain(25)
     st.error(error, 'no error')
     let i = 0
-    await blockchain.iterator('test', (block: Block) => {
+    const iterated = await blockchain.iterator('test', (block: Block) => {
       if (block.hash().equals(blocks[i + 1].hash())) {
         i++
       }
     })
+    st.equals(iterated, 24)
     st.equals(i, 24)
     st.end()
   })
@@ -354,7 +355,7 @@ tape('blockchain test', (t) => {
       const { blockchain, blocks, error } = await generateBlockchain(25)
       st.error(error, 'no error')
       let i = 0
-      await blockchain.iterator(
+      const iterated = await blockchain.iterator(
         'test',
         (block: Block) => {
           if (block.hash().equals(blocks[i + 1].hash())) {
@@ -363,6 +364,7 @@ tape('blockchain test', (t) => {
         },
         5
       )
+      st.equals(iterated, 5)
       st.equals(i, 5)
       st.end()
     }
@@ -374,7 +376,7 @@ tape('blockchain test', (t) => {
       const { blockchain, blocks, error } = await generateBlockchain(25)
       st.error(error, 'no error')
       let i = 0
-      await blockchain
+      const iterated = await blockchain
         .iterator(
           'test',
           (block: Block) => {
@@ -387,6 +389,7 @@ tape('blockchain test', (t) => {
         .catch(() => {
           st.fail('Promise cannot throw when running 0 blocks')
         })
+      st.equals(iterated, 0)
       st.equals(i, 0)
       st.end()
     }

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -19,7 +19,7 @@ export class FullSynchronizer extends Synchronizer {
   public runningBlocks: boolean
 
   private stopSyncing: boolean
-  private vmPromise?: Promise<number>
+  private vmPromise?: Promise<void | number>
 
   constructor(options: SynchronizerOptions) {
     super(options)
@@ -76,7 +76,7 @@ export class FullSynchronizer extends Synchronizer {
       while (!newHead.equals(oldHead) && !this.stopSyncing) {
         oldHead = newHead
         this.vmPromise = this.vm.runBlockchain(this.vm.blockchain, 1)
-        const numExecuted = await this.vmPromise
+        const numExecuted = (await this.vmPromise) as number
         if (numExecuted === 0) {
           this.config.logger.warn(
             `No blocks executed past chain head hash=${short(

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -19,7 +19,7 @@ export class FullSynchronizer extends Synchronizer {
   public runningBlocks: boolean
 
   private stopSyncing: boolean
-  private vmPromise?: Promise<void>
+  private vmPromise?: Promise<number>
 
   constructor(options: SynchronizerOptions) {
     super(options)
@@ -76,7 +76,16 @@ export class FullSynchronizer extends Synchronizer {
       while (!newHead.equals(oldHead) && !this.stopSyncing) {
         oldHead = newHead
         this.vmPromise = this.vm.runBlockchain(this.vm.blockchain, 1)
-        await this.vmPromise
+        const numExecuted = await this.vmPromise
+        if (numExecuted === 0) {
+          this.config.logger.warn(
+            `No blocks executed past chain head hash=${short(
+              newHead
+            )} number=${newHeadBlock.header.number.toNumber()}`
+          )
+          this.runningBlocks = false
+          return
+        }
         const headBlock = await this.vm.blockchain.getHead()
         newHead = headBlock.hash()
         if (blockCounter === 0) {

--- a/packages/vm/lib/index.ts
+++ b/packages/vm/lib/index.ts
@@ -272,7 +272,7 @@ export default class VM extends AsyncEventEmitter {
    *
    * @param blockchain -  An [@ethereumjs/blockchain](https://github.com/ethereumjs/ethereumjs-vm/tree/master/packages/blockchain) object to process
    */
-  async runBlockchain(blockchain?: Blockchain, maxBlocks?: number): Promise<number> {
+  async runBlockchain(blockchain?: Blockchain, maxBlocks?: number): Promise<void | number> {
     await this.init()
     return runBlockchain.bind(this)(blockchain, maxBlocks)
   }

--- a/packages/vm/lib/index.ts
+++ b/packages/vm/lib/index.ts
@@ -272,7 +272,7 @@ export default class VM extends AsyncEventEmitter {
    *
    * @param blockchain -  An [@ethereumjs/blockchain](https://github.com/ethereumjs/ethereumjs-vm/tree/master/packages/blockchain) object to process
    */
-  async runBlockchain(blockchain?: Blockchain, maxBlocks?: number): Promise<void> {
+  async runBlockchain(blockchain?: Blockchain, maxBlocks?: number): Promise<number> {
     await this.init()
     return runBlockchain.bind(this)(blockchain, maxBlocks)
   }

--- a/packages/vm/lib/runBlockchain.ts
+++ b/packages/vm/lib/runBlockchain.ts
@@ -9,7 +9,7 @@ export default async function runBlockchain(
   this: VM,
   blockchain?: Blockchain,
   maxBlocks?: number
-): Promise<number> {
+): Promise<void | number> {
   let headBlock: Block
   let parentState: Buffer
 

--- a/packages/vm/lib/runBlockchain.ts
+++ b/packages/vm/lib/runBlockchain.ts
@@ -5,13 +5,17 @@ import VM from './index'
 /**
  * @ignore
  */
-export default async function runBlockchain(this: VM, blockchain?: Blockchain, maxBlocks?: number) {
+export default async function runBlockchain(
+  this: VM,
+  blockchain?: Blockchain,
+  maxBlocks?: number
+): Promise<number> {
   let headBlock: Block
   let parentState: Buffer
 
   blockchain = blockchain || this.blockchain
 
-  await blockchain.iterator(
+  return await blockchain.iterator(
     'vm',
     async (block: Block, reorg: boolean) => {
       // determine starting state for block run


### PR DESCRIPTION
My own client (blockchain) DB is currently in a state where block execution is not further done due to a somewhat inconsistent db state. In the client this gets noticeable by the execution messages not further showing up, there are only the block import logs displayed.

I could identify the root cause of the no-execution behavior: in the `Blockchain` iterator function there is no [block found](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/blockchain/src/index.ts#L769) in the DB following the current iterator head. Therefore no blocks are executed. I have no idea though how and when the blockchain DB got into this state. I do know though that I've been there (in this state) a couple of times before with block execution stopping.

This PR is approaching this on a low level by not changing any logic or behavior but as a first step providing feedback when block execution is not further processing. For this it:

- Expands the `Blockchain.iterator()` interface to allow for a `number` value to be returned (so now allowing `Promise<void | number>`, keeping `void` is for backwards compatibility) and changing our own interface implementation in the blockchain class to return the number of blocks which have been actually iterated. This will likely generally be useful for a number of use cases.
- The `VM.runBlockchain()` method now similarly also returns the number of iterated blocks
- This allows in the client to give an instant warning feedback message together with the current latest head hash and number and stop further block execution

Output looks like this:

![image](https://user-images.githubusercontent.com/931137/105213557-24a0e400-5b4f-11eb-920f-772872e4a69f.png)

This should allow to better tracing/debugging this in the future and there is now a clear consumer feedback if this behavior occurs.

We might want to decide if we want to further act upon this case, a possibility would be to set the latest blockchain head to the VM iterator head, so that sync will restart from there. I hesitated to directly integrate since it is not clear what corrupted the DB in the first place. We can decide this independently from this PR though.