### PR TITLE
Client: Save node key

### DIFF
--- a/.github/workflows/trie-build.yml
+++ b/.github/workflows/trie-build.yml
@@ -98,8 +98,6 @@ jobs:
           output-file-path: ${{ env.cwd }}/output.txt
           # Location of data in gh-pages branch
           benchmark-data-dir-path: dev/bench/trie
-          # Enable alert commit comment
-          comment-on-alert: true
           # GitHub API token to make a commit comment
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Push and deploy to GitHub pages branch automatically (if on master)

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -175,11 +175,14 @@ async function run() {
   }
 
   const common = new Common({ chain, hardfork: 'chainstart' })
+  const datadir = args.datadir ?? Config.DATADIR_DEFAULT
+  const key = await Config.getClientKey(datadir, common)
   const config = new Config({
     common,
     syncmode: args.syncmode,
     lightserv: args.lightserv,
-    datadir: args.datadir,
+    datadir,
+    key,
     transports: args.transports,
     bootnodes: args.bootnodes ? parseMultiaddrs(args.bootnodes) : undefined,
     multiaddrs: args.multiaddrs ? parseMultiaddrs(args.multiaddrs) : undefined,

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -294,4 +294,11 @@ export class Config {
     if (option !== undefined) return option
     return this.chainCommon.chainName() === 'mainnet'
   }
+  
+  getNetworkDir(): string {
+    const networkDirName = this.common.chainName()
+    const dataDir = `${this.datadir}/${networkDirName}`
+
+    return dataDir
+  }
 }

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -294,7 +294,7 @@ export class Config {
     if (option !== undefined) return option
     return this.chainCommon.chainName() === 'mainnet'
   }
-  
+
   getNetworkDir(): string {
     const networkDirName = this.common.chainName()
     const dataDir = `${this.datadir}/${networkDirName}`

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -1,9 +1,12 @@
 import Common from '@ethereumjs/common'
 import VM from '@ethereumjs/vm'
+import { genPrivateKey } from '@ethereumjs/devp2p'
 import Multiaddr from 'multiaddr'
 import { getLogger, Logger } from './logging'
 import { Libp2pServer, RlpxServer } from './net/server'
 import { parseTransports } from './util'
+import type { LevelUp } from 'levelup'
+const level = require('level')
 
 export interface ConfigOptions {
   /**
@@ -39,6 +42,13 @@ export interface ConfigOptions {
    * Root data directory for the blockchain
    */
   datadir?: string
+
+  /**
+   * Private key for the client.
+   * Use return value of `await Config.getClientKey(datadir, common)`
+   * If left blank, a random key will be generated and used.
+   */
+  key?: Buffer
 
   /**
    * Network transports ('rlpx' and/or 'libp2p')
@@ -172,6 +182,7 @@ export class Config {
   public readonly vm?: VM
   public readonly lightserv: boolean
   public readonly datadir: string
+  public readonly key: Buffer
   public readonly transports: string[]
   public readonly bootnodes?: Multiaddr[]
   public readonly multiaddrs?: Multiaddr[]
@@ -199,6 +210,7 @@ export class Config {
     this.bootnodes = options.bootnodes
     this.multiaddrs = options.multiaddrs
     this.datadir = options.datadir ?? Config.DATADIR_DEFAULT
+    this.key = options.key ?? genPrivateKey()
     this.rpc = options.rpc ?? Config.RPC_DEFAULT
     this.rpcport = options.rpcport ?? Config.RPCPORT_DEFAULT
     this.rpcaddr = options.rpcaddr ?? Config.RPCADDR_DEFAULT
@@ -243,14 +255,24 @@ export class Config {
           const bootnodes = this.bootnodes ?? this.chainCommon.bootstrapNodes()
           const dnsNetworks = options.dnsNetworks ?? this.chainCommon.dnsNetworks()
           return new RlpxServer({ config: this, bootnodes, dnsNetworks })
-        } else {
-          // t.name === 'libp2p'
+        } else if (t.name === 'libp2p') {
           const multiaddrs = this.multiaddrs
           const bootnodes = this.bootnodes
           return new Libp2pServer({ config: this, multiaddrs, bootnodes })
+        } else {
+          throw new Error(`unknown transport: ${t.name}`)
         }
       })
     }
+  }
+
+  /**
+   * Returns the network directory for the chain.
+   */
+  getNetworkDirectory(): string {
+    const networkDirName = this.chainCommon.chainName()
+    const dataDir = `${this.datadir}/${networkDirName}`
+    return dataDir
   }
 
   /**
@@ -258,10 +280,8 @@ export class Config {
    * based on syncmode and selected chain (subdirectory of 'datadir')
    */
   getChainDataDirectory(): string {
-    const networkDirName = this.chainCommon.chainName()
     const chainDataDirName = this.syncmode === 'light' ? 'lightchain' : 'chain'
-
-    const dataDir = `${this.datadir}/${networkDirName}/${chainDataDirName}`
+    const dataDir = `${this.getNetworkDirectory()}/${chainDataDirName}`
     return dataDir
   }
 
@@ -270,10 +290,36 @@ export class Config {
    * based selected chain (subdirectory of 'datadir')
    */
   getStateDataDirectory(): string {
-    const networkDirName = this.chainCommon.chainName()
+    return `${this.getNetworkDirectory()}/state`
+  }
 
-    const dataDir = `${this.datadir}/${networkDirName}/state`
-    return dataDir
+  /**
+   * Returns the config level db.
+   */
+  static getConfigDB(networkDir: string): LevelUp {
+    const db = level(`${networkDir}/config` as any)
+    return db
+  }
+
+  /**
+   * Gets the client private key from the config db.
+   */
+  static async getClientKey(datadir: string, common: Common) {
+    const networkDir = `${datadir}/${common.chainName()}`
+    const db = this.getConfigDB(networkDir)
+    const encodingOpts = { keyEncoding: 'utf8', valueEncoding: 'binary' }
+    const dbKey = 'config:client_key'
+    let key
+    try {
+      key = await db.get(dbKey, encodingOpts)
+    } catch (error) {
+      if (error.type === 'NotFoundError') {
+        // generate and save a new key
+        key = genPrivateKey()
+        await db.put(dbKey, key, encodingOpts)
+      }
+    }
+    return key
   }
 
   /**
@@ -293,12 +339,5 @@ export class Config {
   getV4Discovery(option: boolean | undefined): boolean {
     if (option !== undefined) return option
     return this.chainCommon.chainName() === 'mainnet'
-  }
-
-  getNetworkDir(): string {
-    const networkDirName = this.common.chainName()
-    const dataDir = `${this.datadir}/${networkDirName}`
-
-    return dataDir
   }
 }

--- a/packages/client/lib/net/server/rlpxserver.ts
+++ b/packages/client/lib/net/server/rlpxserver.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'crypto'
 import { RLPx as Devp2pRLPx, Peer as Devp2pRLPxPeer, DPT as Devp2pDPT } from '@ethereumjs/devp2p'
 import { RlpxPeer } from '../peer/rlpxpeer'
 import { Server, ServerOptions } from './server'
-import fs from 'fs'
+const fs = require('fs-extra')
 
 export interface RlpxServerOptions extends ServerOptions {
   /* Local port to listen on (default: 30303) */
@@ -73,6 +73,7 @@ export class RlpxServer extends Server {
       } else {
         const key = randomBytes(32)
         this.key = key
+        fs.ensureDirSync(dataDir)
         fs.writeFileSync(fileName, key.toString('binary'), {
           encoding: 'binary',
         })

--- a/packages/client/lib/net/server/rlpxserver.ts
+++ b/packages/client/lib/net/server/rlpxserver.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'crypto'
 import { RLPx as Devp2pRLPx, Peer as Devp2pRLPxPeer, DPT as Devp2pDPT } from '@ethereumjs/devp2p'
 import { RlpxPeer } from '../peer/rlpxpeer'
 import { Server, ServerOptions } from './server'
+import fs from 'fs'
 
 export interface RlpxServerOptions extends ServerOptions {
   /* Local port to listen on (default: 30303) */
@@ -63,6 +64,20 @@ export class RlpxServer extends Server {
    */
   constructor(options: RlpxServerOptions) {
     super(options)
+
+    if (this.key === undefined) {
+      const dataDir = this.config.getNetworkDir()
+      const fileName = dataDir + '/nodekey'
+      if (fs.existsSync(fileName)) {
+        this.key = Buffer.from(fs.readFileSync(fileName, { encoding: 'binary' }), 'binary')
+      } else {
+        const key = randomBytes(32)
+        this.key = key
+        fs.writeFileSync(fileName, key.toString('binary'), {
+          encoding: 'binary',
+        })
+      }
+    }
 
     // TODO: get the external ip from the upnp service
     this.ip = '::'

--- a/packages/client/lib/net/server/rlpxserver.ts
+++ b/packages/client/lib/net/server/rlpxserver.ts
@@ -1,8 +1,6 @@
-import { randomBytes } from 'crypto'
 import { RLPx as Devp2pRLPx, Peer as Devp2pRLPxPeer, DPT as Devp2pDPT } from '@ethereumjs/devp2p'
 import { RlpxPeer } from '../peer/rlpxpeer'
 import { Server, ServerOptions } from './server'
-const fs = require('fs-extra')
 
 export interface RlpxServerOptions extends ServerOptions {
   /* Local port to listen on (default: 30303) */
@@ -64,21 +62,6 @@ export class RlpxServer extends Server {
    */
   constructor(options: RlpxServerOptions) {
     super(options)
-
-    if (this.key === undefined) {
-      const dataDir = this.config.getNetworkDir()
-      const fileName = dataDir + '/nodekey'
-      if (fs.existsSync(fileName)) {
-        this.key = Buffer.from(fs.readFileSync(fileName, { encoding: 'binary' }), 'binary')
-      } else {
-        const key = randomBytes(32)
-        this.key = key
-        fs.ensureDirSync(dataDir)
-        fs.writeFileSync(fileName, key.toString('binary'), {
-          encoding: 'binary',
-        })
-      }
-    }
 
     // TODO: get the external ip from the upnp service
     this.ip = '::'
@@ -231,7 +214,7 @@ export class RlpxServer extends Server {
    * @private
    */
   initDpt() {
-    this.dpt = new Devp2pDPT(this.key ?? randomBytes(32), {
+    this.dpt = new Devp2pDPT(this.key, {
       refreshInterval: this.refreshInterval,
       endpoint: {
         address: '0.0.0.0',
@@ -257,7 +240,7 @@ export class RlpxServer extends Server {
    * @private
    */
   initRlpx() {
-    this.rlpx = new Devp2pRLPx(this.key ?? randomBytes(32), {
+    this.rlpx = new Devp2pRLPx(this.key, {
       dpt: this.dpt!,
       maxPeers: this.config.maxPeers,
       capabilities: RlpxPeer.capabilities(Array.from(this.protocols)),

--- a/packages/client/lib/net/server/server.ts
+++ b/packages/client/lib/net/server/server.ts
@@ -28,7 +28,7 @@ export interface ServerOptions {
  */
 export class Server extends EventEmitter {
   public config: Config
-  public key: Buffer | undefined
+  public key: Buffer
   public bootnodes: multiaddr[] = []
   public dnsNetworks: DnsNetwork[]
 
@@ -45,7 +45,7 @@ export class Server extends EventEmitter {
     super()
 
     this.config = options.config
-    this.key = options.key ? parseKey(options.key) : undefined
+    this.key = options.key ? parseKey(options.key) : this.config.key
     this.bootnodes = options.bootnodes ? parseMultiaddrs(options.bootnodes) : []
     this.dnsNetworks = options.dnsNetworks ?? []
     this.refreshInterval = options.refreshInterval ?? 30000


### PR DESCRIPTION
This PR ensures that we save the node key to disk. This is saved in the root directory of the current network. This way, we ensure that we will re-use the enode, such that we can quickly reconnect, or add our client as a bootnode. This would not be possible if it is not saved, since then our enode keeps changing every time we reboot the client.