### PR TITLE
Block, Tx: always copy Common on instantiation / Fix HF consistency bugs

### DIFF
--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -25,7 +25,11 @@ export class Block {
     // parse transactions
     const transactions = []
     for (const txData of txsData || []) {
-      const tx = Transaction.fromTxData(txData, opts as TxOptions)
+      const tx = Transaction.fromTxData(txData, {
+        ...opts,
+        // Use header common in case of hardforkByBlockNumber being activated
+        common: header._common,
+      } as TxOptions)
       transactions.push(tx)
     }
 
@@ -34,7 +38,10 @@ export class Block {
     for (const uhData of uhsData || []) {
       const uh = BlockHeader.fromHeaderData(uhData, {
         ...opts,
-        // Disable this option here (all other options carried over), since this overwrites the provided Difficulty to an incorrect value
+        // Use header common in case of hardforkByBlockNumber being activated
+        common: header._common,
+        // Disable this option here (all other options carried over), since this overwrites
+        // the provided Difficulty to an incorrect value
         calcDifficultyFromHeader: undefined,
       })
       uncleHeaders.push(uh)
@@ -65,7 +72,13 @@ export class Block {
     // parse transactions
     const transactions = []
     for (const txData of txsData || []) {
-      transactions.push(Transaction.fromValuesArray(txData, opts))
+      transactions.push(
+        Transaction.fromValuesArray(txData, {
+          ...opts,
+          // Use header common in case of hardforkByBlockNumber being activated
+          common: header._common,
+        })
+      )
     }
 
     // parse uncle headers
@@ -74,6 +87,8 @@ export class Block {
       uncleHeaders.push(
         BlockHeader.fromValuesArray(uncleHeaderData, {
           ...opts,
+          // Use header common in case of hardforkByBlockNumber being activated
+          common: header._common,
           // Disable this option here (all other options carried over), since this overwrites the provided Difficulty to an incorrect value
           calcDifficultyFromHeader: undefined,
         })

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -688,6 +688,10 @@ export class BlockHeader {
   cliqueSigner(): Address {
     this._requireClique('cliqueSigner')
     const extraSeal = this.cliqueExtraSeal()
+    // Reasonable default for default blocks
+    if (extraSeal.length === 0) {
+      return Address.zero()
+    }
     const r = extraSeal.slice(0, 32)
     const s = extraSeal.slice(32, 64)
     const v = bufferToInt(extraSeal.slice(64, 65)) + 27

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -173,7 +173,10 @@ export class BlockHeader {
     options: BlockOptions = {}
   ) {
     if (options.common) {
-      this._common = options.common
+      this._common = Object.assign(
+        Object.create(Object.getPrototypeOf(options.common)),
+        options.common
+      )
     } else {
       const chain = 'mainnet' // default
       if (options.initWithGenesisHeader) {

--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -12,6 +12,9 @@ import { BlockHeader } from './header'
 export interface BlockOptions {
   /**
    * A Common object defining the chain and the hardfork a block/block header belongs to.
+   * 
+   * Object will be internally copied so that tx behavior don't incidentally
+   * change on future HF changes.
    *
    * Default: `Common` object set to `mainnet` and the HF currently defined as the default
    * hardfork in the `Common` class.

--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -12,7 +12,7 @@ import { BlockHeader } from './header'
 export interface BlockOptions {
   /**
    * A Common object defining the chain and the hardfork a block/block header belongs to.
-   * 
+   *
    * Object will be internally copied so that tx behavior don't incidentally
    * change on future HF changes.
    *

--- a/packages/block/test/clique.spec.ts
+++ b/packages/block/test/clique.spec.ts
@@ -80,7 +80,7 @@ tape('[Header]: Clique PoA Functionality', function (t) {
   t.test('Signing', function (st) {
     const cliqueSigner = A.privateKey
 
-    const header = BlockHeader.fromHeaderData(
+    let header = BlockHeader.fromHeaderData(
       { number: 1, extraData: Buffer.alloc(97) },
       { common, freeze: false, cliqueSigner }
     )
@@ -88,6 +88,13 @@ tape('[Header]: Clique PoA Functionality', function (t) {
     st.equal(header.extraData.length, 97)
     st.ok(header.cliqueVerifySignature([A.address]), 'should verify signature')
     st.ok(header.cliqueSigner().equals(A.address), 'should recover the correct signer address')
+
+    header = BlockHeader.fromHeaderData({}, { common })
+    st.deepEqual(
+      header.cliqueSigner(),
+      Address.zero(),
+      'should return zero address on default block'
+    )
 
     st.end()
   })

--- a/packages/block/test/header.spec.ts
+++ b/packages/block/test/header.spec.ts
@@ -41,6 +41,14 @@ tape('[Block]: Header functions', function (t) {
     const common = new Common({ chain: 'ropsten', hardfork: 'chainstart' })
     let header = BlockHeader.genesis(undefined, { common })
     st.ok(header.hash().toString('hex'), 'genesis block should initialize')
+    st.equal(header._common.hardfork(), 'chainstart', 'should initialize with correct HF provided')
+
+    common.setHardfork('byzantium')
+    st.equal(
+      header._common.hardfork(),
+      'chainstart',
+      'should stay on correct HF if outer common HF changes'
+    )
 
     header = BlockHeader.fromHeaderData({}, { common })
     st.ok(header.hash().toString('hex'), 'default block should initialize')

--- a/packages/blockchain/src/db/manager.ts
+++ b/packages/blockchain/src/db/manager.ts
@@ -167,7 +167,7 @@ export class DBManager {
       }
     }
     const blockData = [header, ...body] as BlockBuffer
-    const opts = { common: this._common }
+    const opts = { common: this._common, hardforkByBlockNumber: true }
     return Block.fromValuesArray(blockData, opts)
   }
 
@@ -184,7 +184,7 @@ export class DBManager {
    */
   async getHeader(blockHash: Buffer, blockNumber: BN) {
     const encodedHeader = await this.get(DBTarget.Header, { blockHash, blockNumber })
-    const opts = { common: this._common }
+    const opts = { common: this._common, hardforkByBlockNumber: true }
     return BlockHeader.fromRLPSerializedHeader(encodedHeader, opts)
   }
 

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -202,7 +202,10 @@ export default class Blockchain implements BlockchainInterface {
   public static async fromBlocksData(blocksData: BlockData[], opts: BlockchainOptions = {}) {
     const blockchain = await Blockchain.create(opts)
     for (const blockData of blocksData) {
-      const block = Block.fromBlockData(blockData, { common: blockchain._common, hardforkByBlockNumber: true })
+      const block = Block.fromBlockData(blockData, {
+        common: blockchain._common,
+        hardforkByBlockNumber: true,
+      })
       await blockchain.putBlock(block)
     }
     return blockchain
@@ -794,7 +797,10 @@ export default class Blockchain implements BlockchainInterface {
     await this.runWithLock<void>(async () => {
       const block =
         item instanceof BlockHeader
-          ? new Block(item, undefined, undefined, { common: this._common })
+          ? new Block(item, undefined, undefined, {
+              common: this._common,
+              hardforkByBlockNumber: true,
+            })
           : item
       const isGenesis = block.isGenesis()
 

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -202,11 +202,7 @@ export default class Blockchain implements BlockchainInterface {
   public static async fromBlocksData(blocksData: BlockData[], opts: BlockchainOptions = {}) {
     const blockchain = await Blockchain.create(opts)
     for (const blockData of blocksData) {
-      const common = Object.assign(
-        Object.create(Object.getPrototypeOf(blockchain._common)),
-        blockchain._common
-      )
-      const block = Block.fromBlockData(blockData, { common, hardforkByBlockNumber: true })
+      const block = Block.fromBlockData(blockData, { common: blockchain._common, hardforkByBlockNumber: true })
       await blockchain.putBlock(block)
     }
     return blockchain

--- a/packages/client/lib/blockchain/chain.ts
+++ b/packages/client/lib/blockchain/chain.ts
@@ -267,7 +267,10 @@ export class Chain extends EventEmitter {
     }
     await this.open()
     blocks = blocks.map((b: Block) =>
-      Block.fromValuesArray(b.raw(), { common: this.config.chainCommon })
+      Block.fromValuesArray(b.raw(), {
+        common: this.config.chainCommon,
+        hardforkByBlockNumber: true,
+      })
     )
     await this.blockchain.putBlocks(blocks)
     await this.update()
@@ -302,7 +305,10 @@ export class Chain extends EventEmitter {
     }
     await this.open()
     headers = headers.map((h) =>
-      BlockHeader.fromValuesArray(h.raw(), { common: this.config.chainCommon })
+      BlockHeader.fromValuesArray(h.raw(), {
+        common: this.config.chainCommon,
+        hardforkByBlockNumber: true,
+      })
     )
     await this.blockchain.putHeaders(headers)
     await this.update()

--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -63,14 +63,14 @@ export class EthProtocol extends Protocol {
       name: 'BlockHeaders',
       code: 0x04,
       encode: (headers: BlockHeader[]) => headers.map((h) => h.raw()),
-      decode: (headers: BlockHeaderBuffer[]) =>
-        headers.map((h) =>
+      decode: (headers: BlockHeaderBuffer[]) => {
+        return headers.map((h) =>
           BlockHeader.fromValuesArray(h, {
-            /* eslint-disable-next-line no-invalid-this */
-            common: this.config.chainCommon,
             hardforkByBlockNumber: true,
+            common: this.config.chainCommon, // eslint-disable-line no-invalid-this
           })
-        ),
+        )
+      },
     },
     {
       name: 'GetBlockBodies',

--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -64,8 +64,13 @@ export class EthProtocol extends Protocol {
       code: 0x04,
       encode: (headers: BlockHeader[]) => headers.map((h) => h.raw()),
       decode: (headers: BlockHeaderBuffer[]) =>
-        /* eslint-disable-next-line no-invalid-this */
-        headers.map((h) => BlockHeader.fromValuesArray(h, { common: this.config.chainCommon })),
+        headers.map((h) =>
+          BlockHeader.fromValuesArray(h, {
+            /* eslint-disable-next-line no-invalid-this */
+            common: this.config.chainCommon,
+            hardforkByBlockNumber: true,
+          })
+        ),
     },
     {
       name: 'GetBlockBodies',

--- a/packages/client/lib/net/protocol/lesprotocol.ts
+++ b/packages/client/lib/net/protocol/lesprotocol.ts
@@ -91,13 +91,12 @@ export class LesProtocol extends Protocol {
       decode: ([reqId, bv, headers]: any) => ({
         reqId: new BN(reqId),
         bv: new BN(bv),
-        headers: headers.map((h: BlockHeaderBuffer) =>
-          BlockHeader.fromValuesArray(h, {
-            /* eslint-disable-next-line no-invalid-this */
-            common: this.config.chainCommon,
+        headers: headers.map((h: BlockHeaderBuffer) => {
+          return BlockHeader.fromValuesArray(h, {
             hardforkByBlockNumber: true,
+            common: this.config.chainCommon, // eslint-disable-line no-invalid-this
           })
-        ),
+        }),
       }),
     },
   ]

--- a/packages/client/lib/net/protocol/lesprotocol.ts
+++ b/packages/client/lib/net/protocol/lesprotocol.ts
@@ -92,8 +92,11 @@ export class LesProtocol extends Protocol {
         reqId: new BN(reqId),
         bv: new BN(bv),
         headers: headers.map((h: BlockHeaderBuffer) =>
-          /* eslint-disable-next-line no-invalid-this */
-          BlockHeader.fromValuesArray(h, { common: this.config.chainCommon })
+          BlockHeader.fromValuesArray(h, {
+            /* eslint-disable-next-line no-invalid-this */
+            common: this.config.chainCommon,
+            hardforkByBlockNumber: true,
+          })
         ),
       }),
     },

--- a/packages/client/lib/sync/execution/vmexecution.ts
+++ b/packages/client/lib/sync/execution/vmexecution.ts
@@ -152,7 +152,9 @@ export class VMExecution extends Execution {
             // error can repeatedly processed for debugging
             const blockNumber = block.header.number.toNumber()
             const hash = short(block.hash())
-            this.config.logger.warn(`Execution of block number=${blockNumber} hash=${hash} failed`)
+            this.config.logger.warn(
+              `Execution of block number=${blockNumber} hash=${hash} hardfork=${this.hardfork} failed`
+            )
             this.emit('error', error)
             errorBlock = block
           }

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -53,6 +53,7 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
     const blocks: Block[] = bodies.map(([txsData, unclesData]: BlockBodyBuffer, i: number) =>
       Block.fromValuesArray([headers[i].raw(), txsData, unclesData], {
         common: this.config.chainCommon,
+        hardforkByBlockNumber: true,
       })
     )
     return blocks

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -1,4 +1,4 @@
-import { Block, BlockBodyBuffer } from '@ethereumjs/block'
+import { Block, BlockBodyBuffer, BlockBuffer } from '@ethereumjs/block'
 import { Peer } from '../../net/peer'
 import { EthProtocolMethods } from '../../net/protocol'
 import { Job } from './types'
@@ -50,12 +50,14 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
     const bodies: BlockBodyBuffer[] = <BlockBodyBuffer[]>(
       await peer!.eth!.getBlockBodies(headers.map((h) => h.hash()))
     )
-    const blocks: Block[] = bodies.map(([txsData, unclesData]: BlockBodyBuffer, i: number) =>
-      Block.fromValuesArray([headers[i].raw(), txsData, unclesData], {
+    const blocks: Block[] = bodies.map(([txsData, unclesData]: BlockBodyBuffer, i: number) => {
+      const opts = {
         common: this.config.chainCommon,
         hardforkByBlockNumber: true,
-      })
-    )
+      }
+      const values: BlockBuffer = [headers[i].raw(), txsData, unclesData]
+      return Block.fromValuesArray(values, opts)
+    })
     return blocks
   }
 

--- a/packages/tx/src/transaction.ts
+++ b/packages/tx/src/transaction.ts
@@ -110,7 +110,7 @@ export default class Transaction {
     }
 
     if (opts?.common) {
-      this.common = opts.common
+      this.common = Object.assign(Object.create(Object.getPrototypeOf(opts.common)), opts.common)
     } else {
       const DEFAULT_CHAIN = 'mainnet'
       this.common = new Common({ chain: DEFAULT_CHAIN })

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -8,6 +8,9 @@ export interface TxOptions {
   /**
    * A Common object defining the chain and hardfork for the transaction.
    *
+   * Object will be internally copied so that tx behavior don't incidentally
+   * change on future HF changes.
+   *
    * Default: `Common` object set to `mainnet` and the default hardfork as defined in the `Common` class.
    *
    * Current default hardfork: `istanbul`

--- a/packages/tx/test/api.ts
+++ b/packages/tx/test/api.ts
@@ -24,6 +24,13 @@ tape('[Transaction]: Basic functions', function (t) {
     st.equal(tx.common.hardfork(), 'istanbul', 'should initialize with correct default HF')
     st.ok(Object.isFrozen(tx), 'tx should be frozen by default')
 
+    const common = new Common({ chain: 'mainnet', hardfork: 'spuriousDragon' })
+    tx = Transaction.fromTxData({}, { common })
+    st.equal(tx.common.hardfork(), 'spuriousDragon', 'should initialize with correct HF provided')
+
+    common.setHardfork('byzantium')
+    st.equal(tx.common.hardfork(), 'spuriousDragon', 'should stay on correct HF if outer common HF changes')
+
     tx = Transaction.fromTxData({}, { freeze: false })
     st.ok(!Object.isFrozen(tx), 'tx should not be frozen when freeze deactivated in options')
 

--- a/packages/tx/test/api.ts
+++ b/packages/tx/test/api.ts
@@ -29,7 +29,11 @@ tape('[Transaction]: Basic functions', function (t) {
     st.equal(tx.common.hardfork(), 'spuriousDragon', 'should initialize with correct HF provided')
 
     common.setHardfork('byzantium')
-    st.equal(tx.common.hardfork(), 'spuriousDragon', 'should stay on correct HF if outer common HF changes')
+    st.equal(
+      tx.common.hardfork(),
+      'spuriousDragon',
+      'should stay on correct HF if outer common HF changes'
+    )
 
     tx = Transaction.fromTxData({}, { freeze: false })
     st.ok(!Object.isFrozen(tx), 'tx should not be frozen when freeze deactivated in options')

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -177,12 +177,12 @@ The following loggers are currently available:
 
 | Logger | Description |
 | - | - |
+| `vm:block` | Block operations (run txs, generating receipts, block rewards,...)
 | `vm:tx` | Transaction operations (account updates, checkpointing,...) |
 | `vm:tx:gas` | Transaction gas logger |
 | `vm:evm` | EVM control flow, CALL or CREATE message execution |
 | `vm:evm:gas` | EVM gas logger |
 | `vm:state`| StateManager logger |
-| `vm:state:root`| Updates on the state root |
 | `vm:ops` | Opcode traces |
 | `vm:ops:[Lower-case opcode name]` | Traces on a specific opcode |
 
@@ -200,10 +200,10 @@ Run all loggers currently available:
 DEBUG=vm:*,vm:*:* ts-node test.ts
 ```
 
-Excluding the state root logger:
+Excluding the state logger:
 
 ```shell
-DEBUG=vm:*,vm:*:*,-vm:state:root ts-node test.ts
+DEBUG=vm:*,vm:*:*,-vm:state ts-node test.ts
 ```
 
 Run some specific loggers including a logger specifically logging the `SSTORE` executions from the VM (this is from the screenshot above):

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -181,6 +181,8 @@ The following loggers are currently available:
 | `vm:tx:gas` | Transaction gas logger |
 | `vm:evm` | EVM control flow, CALL or CREATE message execution |
 | `vm:evm:gas` | EVM gas logger |
+| `vm:state`| StateManager logger |
+| `vm:state:root`| Updates on the state root |
 | `vm:ops` | Opcode traces |
 | `vm:ops:[Lower-case opcode name]` | Traces on a specific opcode |
 
@@ -196,6 +198,12 @@ Run all loggers currently available:
 
 ```shell
 DEBUG=vm:*,vm:*:* ts-node test.ts
+```
+
+Excluding the state root logger:
+
+```shell
+DEBUG=vm:*,vm:*:*,-vm:state:root ts-node test.ts
 ```
 
 Run some specific loggers including a logger specifically logging the `SSTORE` executions from the VM (this is from the screenshot above):

--- a/packages/vm/lib/evm/eei.ts
+++ b/packages/vm/lib/evm/eei.ts
@@ -262,7 +262,13 @@ export default class EEI {
   getBlockCoinbase(): BN {
     let coinbase: Address
     if (this._common.consensusAlgorithm() === 'clique') {
-      coinbase = this._env.block.header.cliqueSigner()
+      // Backwards-compatibilty check
+      // TODO: can be removed along VM v5 release
+      if ('cliqueSigner' in this._env.block.header) {
+        coinbase = this._env.block.header.cliqueSigner()
+      } else {
+        coinbase = Address.zero()
+      }
     } else {
       coinbase = this._env.block.header.coinbase
     }

--- a/packages/vm/lib/evm/evm.ts
+++ b/packages/vm/lib/evm/evm.ts
@@ -209,8 +209,16 @@ export default class EVM {
 
     // Load code
     await this._loadCode(message)
-    if (!message.code || message.code.length === 0 || errorMessage) {
-      debug(`Exit early on no code or value tranfer overflowed`)
+    let exit = false
+    if (!message.code || message.code.length === 0) {
+      exit = true
+      debug(`Exit early on no code`)
+    }
+    if (errorMessage) {
+      exit = true
+      debug(`Exit early on value tranfer overflowed`)
+    }
+    if (exit) {
       return {
         gasUsed: new BN(0),
         execResult: {
@@ -287,8 +295,16 @@ export default class EVM {
       errorMessage = e
     }
 
-    if (!message.code || message.code.length === 0 || errorMessage) {
-      debug(`Exit early on no code or value tranfer overflowed`)
+    let exit = false
+    if (!message.code || message.code.length === 0) {
+      exit = true
+      debug(`Exit early on no code`)
+    }
+    if (errorMessage) {
+      exit = true
+      debug(`Exit early on value tranfer overflowed`)
+    }
+    if (exit) {
       return {
         gasUsed: new BN(0),
         createdAddress: message.to,

--- a/packages/vm/lib/evm/evm.ts
+++ b/packages/vm/lib/evm/evm.ts
@@ -494,7 +494,9 @@ export default class EVM {
   async _reduceSenderBalance(account: Account, message: Message): Promise<void> {
     account.balance.isub(message.value)
     const result = this._state.putAccount(message.caller, account)
-    debug(`Reduce sender (${message.caller.toString()}) balance (-> ${account.balance.toString()})`)
+    debug(
+      `Reduced sender (${message.caller.toString()}) balance (-> ${account.balance.toString()})`
+    )
     return result
   }
 
@@ -506,7 +508,7 @@ export default class EVM {
     toAccount.balance = newBalance
     // putAccount as the nonce may have changed for contract creation
     const result = this._state.putAccount(message.to, toAccount)
-    debug(`Add toAccount (${message.to.toString()}) balance (-> ${toAccount.balance.toString()})`)
+    debug(`Added toAccount (${message.to.toString()}) balance (-> ${toAccount.balance.toString()})`)
     return result
   }
 

--- a/packages/vm/lib/runBlock.ts
+++ b/packages/vm/lib/runBlock.ts
@@ -334,7 +334,7 @@ async function applyTransactions(this: VM, block: Block, opts: RunBlockOpts) {
     let txReceipt
     let receiptLog = `Generate tx receipt gasUsed=${gasUsed} bitvector=${short(
       abstractTxReceipt.bitvector
-    )} (${abstractTxReceipt.bitvector.length} bytes) logs=${abstractTxReceipt.logs.length} `
+    )} (${abstractTxReceipt.bitvector.length} bytes) logs=${abstractTxReceipt.logs.length}`
     if (this._common.gteHardfork('byzantium')) {
       txReceipt = {
         status: txRes.execResult.exceptionError ? 0 : 1, // Receipts have a 0 as status on error

--- a/packages/vm/lib/runBlock.ts
+++ b/packages/vm/lib/runBlock.ts
@@ -1,3 +1,4 @@
+import { debug as createDebugLogger } from 'debug'
 import { encode } from 'rlp'
 import { BaseTrie as Trie } from '@ethereumjs/trie'
 import { Account, Address, BN } from 'ethereumjs-util'
@@ -9,9 +10,11 @@ import { StateManager } from './state'
 
 import * as DAOConfig from './config/dao_fork_accounts_config.json'
 import { Log } from './evm/types'
+import { short } from './evm/opcodes'
+
+const debug = createDebugLogger('vm:block')
 
 /* DAO account list */
-
 const DAOAccountList = DAOConfig.DAOAccounts
 const DAORefundContract = DAOConfig.DAORefundContract
 
@@ -135,9 +138,18 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
       this._updateOpcodes()
     }
   }
+  debug('-'.repeat(100))
+  debug(
+    `Running blog hash=${block
+      .hash()
+      .toString(
+        'hex'
+      )} number=${block.header.number.toNumber()} hardfork=${this._common.hardfork()}`
+  )
 
   // Set state root if provided
   if (root) {
+    debug(`Set provided state root ${root.toString('hex')}`)
     await state.setStateRoot(root)
   }
 
@@ -146,22 +158,33 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
     this._common.hardforkIsActiveOnChain('dao') &&
     block.header.number.eq(new BN(this._common.hardforkBlock('dao')))
   ) {
+    debug(`Apply DAO hardfork`)
     await _applyDAOHardfork(state)
   }
 
   // Checkpoint state
   await state.checkpoint()
+  debug(`block checkpoint`)
 
   let result
   try {
     result = await applyBlock.bind(this)(block, opts)
+    debug(
+      `Received block results gasUsed=${result.gasUsed} bloom=${short(result.bloom.bitvector)} (${
+        result.bloom.bitvector.length
+      } bytes) receiptRoot=${result.receiptRoot.toString('hex')} receipts=${
+        result.receipts.length
+      } txResults=${result.results.length}`
+    )
   } catch (err) {
     await state.revert()
+    debug(`block checkpoint reverted`)
     throw err
   }
 
   // Persist state
   await state.commit()
+  debug(`block checkpoint committed`)
 
   const stateRoot = await state.getStateRoot(false)
 
@@ -176,15 +199,31 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
     })
   } else {
     if (result.receiptRoot && !result.receiptRoot.equals(block.header.receiptTrie)) {
+      debug(
+        `Invalid receiptTrie received=${result.receiptRoot.toString(
+          'hex'
+        )} expected=${block.header.receiptTrie.toString('hex')}`
+      )
       throw new Error('invalid receiptTrie')
     }
     if (!result.bloom.bitvector.equals(block.header.bloom)) {
+      debug(
+        `Invalid bloom received=${result.bloom.bitvector.toString(
+          'hex'
+        )} expected=${block.header.bloom.toString('hex')}`
+      )
       throw new Error('invalid bloom')
     }
     if (!result.gasUsed.eq(block.header.gasUsed)) {
+      debug(`Invalid gasUsed received=${result.gasUsed} expected=${block.header.gasUsed}`)
       throw new Error('invalid gasUsed')
     }
     if (!stateRoot.equals(block.header.stateRoot)) {
+      debug(
+        `Invalid stateRoot received=${stateRoot.toString(
+          'hex'
+        )} expected=${block.header.stateRoot.toString('hex')}`
+      )
       throw new Error('invalid block stateRoot')
     }
   }
@@ -205,6 +244,13 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
    * @property {AfterBlockEvent} result emits the results of processing a block
    */
   await this._emit('afterBlock', afterBlockEvent)
+  debug(
+    `Running blog finished hash=${block
+      .hash()
+      .toString(
+        'hex'
+      )} number=${block.header.number.toNumber()} hardfork=${this._common.hardfork()}`
+  )
 
   return { receipts, results }
 }
@@ -223,16 +269,18 @@ async function applyBlock(this: VM, block: Block, opts: RunBlockOpts) {
     if (block.header.gasLimit.gte(new BN('8000000000000000', 16))) {
       throw new Error('Invalid block with gas limit greater than (2^63 - 1)')
     } else {
+      debug(`Validate block`)
       await block.validate(this.blockchain)
     }
   }
   // Apply transactions
-  const txResults = await applyTransactions.bind(this)(block, opts)
+  debug(`Apply transactions`)
+  const blockResults = await applyTransactions.bind(this)(block, opts)
   // Pay ommers and miners
   if (this._common.consensusType() === 'pow') {
     await assignBlockRewards.bind(this)(block)
   }
-  return txResults
+  return blockResults
 }
 
 /**
@@ -270,9 +318,11 @@ async function applyTransactions(this: VM, block: Block, opts: RunBlockOpts) {
       skipNonce,
     })
     txResults.push(txRes)
+    debug('-'.repeat(100))
 
     // Add to total block gas usage
     gasUsed = gasUsed.add(txRes.gasUsed)
+    debug(`Add tx gas used (${txRes.gasUsed}) to total block gas usage (-> ${gasUsed})`)
     // Combine blooms via bitwise OR
     bloom.or(txRes.bloom)
 
@@ -282,18 +332,25 @@ async function applyTransactions(this: VM, block: Block, opts: RunBlockOpts) {
       logs: txRes.execResult.logs || [],
     }
     let txReceipt
+    let receiptLog = `Generate tx receipt gasUsed=${gasUsed} bitvector=${short(
+      abstractTxReceipt.bitvector
+    )} (${abstractTxReceipt.bitvector.length} bytes) logs=${abstractTxReceipt.logs.length} `
     if (this._common.gteHardfork('byzantium')) {
       txReceipt = {
         status: txRes.execResult.exceptionError ? 0 : 1, // Receipts have a 0 as status on error
         ...abstractTxReceipt,
       } as PostByzantiumTxReceipt
+      const statusInfo = txRes.execResult.exceptionError ? 'error' : 'ok'
+      receiptLog += ` status=${txReceipt.status} (${statusInfo}) (>= Byzantium)`
     } else {
       const stateRoot = await this.stateManager.getStateRoot(true)
       txReceipt = {
         stateRoot: stateRoot,
         ...abstractTxReceipt,
       } as PreByzantiumTxReceipt
+      receiptLog += ` stateRoot=${txReceipt.stateRoot.toString('hex')} (< Byzantium)`
     }
+    debug(receiptLog)
 
     receipts.push(txReceipt)
 
@@ -315,17 +372,20 @@ async function applyTransactions(this: VM, block: Block, opts: RunBlockOpts) {
  * the updated balances of their accounts to state.
  */
 async function assignBlockRewards(this: VM, block: Block): Promise<void> {
+  debug(`Assign block rewards`)
   const state = this.stateManager
   const minerReward = new BN(this._common.param('pow', 'minerReward'))
   const ommers = block.uncleHeaders
   // Reward ommers
   for (const ommer of ommers) {
     const reward = calculateOmmerReward(ommer.number, block.header.number, minerReward)
-    await rewardAccount(state, ommer.coinbase, reward)
+    const account = await rewardAccount(state, ommer.coinbase, reward)
+    debug(`Add uncle reward ${reward} to account ${ommer.coinbase} (-> ${account.balance})`)
   }
   // Reward miner
   const reward = calculateMinerReward(minerReward, ommers.length)
-  await rewardAccount(state, block.header.coinbase, reward)
+  const account = await rewardAccount(state, block.header.coinbase, reward)
+  debug(`Add miner reward ${reward} to account ${block.header.coinbase} (-> ${account.balance})`)
 }
 
 function calculateOmmerReward(ommerBlockNumber: BN, blockNumber: BN, minerReward: BN): BN {
@@ -345,10 +405,11 @@ function calculateMinerReward(minerReward: BN, ommersNum: number): BN {
   return reward
 }
 
-async function rewardAccount(state: StateManager, address: Address, reward: BN): Promise<void> {
+async function rewardAccount(state: StateManager, address: Address, reward: BN): Promise<Account> {
   const account = await state.getAccount(address)
   account.balance.iadd(reward)
   await state.putAccount(address, account)
+  return account
 }
 
 // apply the DAO fork changes to the VM

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -224,7 +224,18 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   )
 
   // Update miner's balance
-  const miner = block.header.coinbase
+  let miner
+  if (this._common.consensusType() === 'pow') {
+    miner = block.header.coinbase
+  } else {
+    // Backwards-compatibilty check
+    // TODO: can be removed along VM v5 release
+    if ('cliqueSigner' in block.header) {
+      miner = block.header.cliqueSigner()
+    } else {
+      miner = Address.zero()
+    }
+  }
   const minerAccount = await state.getAccount(miner)
   // add the amount spent on gas to the miner's account
   minerAccount.balance.iadd(results.amountSpent)

--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -16,8 +16,10 @@ import { genesisStateByName } from '@ethereumjs/common/dist/genesisStates'
 import { StateManager, StorageDump } from './interface'
 import Cache from './cache'
 import { ripemdPrecompileAddress } from '../evm/precompiles'
+import { short } from '../evm/opcodes'
 
 const debug = createDebugLogger('vm:state')
+const debugRoot = createDebugLogger('vm:state:root')
 
 type AddressHex = string
 
@@ -95,6 +97,7 @@ export default class DefaultStateManager implements StateManager {
    * @param account - The account to store
    */
   async putAccount(address: Address, account: Account): Promise<void> {
+    debug(`Save account ${address}`)
     this._cache.put(address, account)
     this.touchAccount(address)
   }
@@ -104,6 +107,7 @@ export default class DefaultStateManager implements StateManager {
    * @param address - Address of the account which should be deleted
    */
   async deleteAccount(address: Address) {
+    debug(`Delete account ${address}`)
     this._cache.del(address)
     this.touchAccount(address)
   }
@@ -135,6 +139,7 @@ export default class DefaultStateManager implements StateManager {
     await this._trie.db.put(codeHash, value)
 
     const account = await this.getAccount(address)
+    debug(`Update codeHash (-> ${short(codeHash)}) for account ${address}`)
     account.codeHash = codeHash
     await this.putAccount(address, account)
   }
@@ -305,9 +310,11 @@ export default class DefaultStateManager implements StateManager {
       if (value && value.length) {
         // format input
         const encodedValue = encode(value)
+        debug(`Update contract storage for account ${address} to ${short(value)}`)
         await storageTrie.put(key, encodedValue)
       } else {
         // deleting a value
+        debug(`Delete contract storage for account`)
         await storageTrie.del(key)
       }
       done()
@@ -416,6 +423,7 @@ export default class DefaultStateManager implements StateManager {
     await this._cache.flush()
 
     if (stateRoot === this._trie.EMPTY_TRIE_ROOT) {
+      debugRoot(`Set state root to empty`)
       this._trie.root = stateRoot
       this._cache.clear()
       this._storageTries = {}
@@ -427,6 +435,7 @@ export default class DefaultStateManager implements StateManager {
       throw new Error('State trie does not contain state root')
     }
 
+    debugRoot(`Set new state root (-> ${stateRoot.toString('hex')})`)
     this._trie.root = stateRoot
     this._cache.clear()
     this._storageTries = {}
@@ -495,6 +504,7 @@ export default class DefaultStateManager implements StateManager {
       throw new Error('Cannot create genesis state with uncommitted checkpoints')
     }
 
+    debug(`Save genesis state into the state trie`)
     const addresses = Object.keys(initState)
     for (const address of addresses) {
       const balance = new BN(toBuffer(initState[address]))

--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -96,7 +96,11 @@ export default class DefaultStateManager implements StateManager {
    * @param account - The account to store
    */
   async putAccount(address: Address, account: Account): Promise<void> {
-    debug(`Save account ${address}`)
+    debug(
+      `Save account address=${address} nonce=${account.nonce} balance=${account.balance} contract=${
+        account.isContract() ? 'yes' : 'no'
+      } empty=${account.isEmpty() ? 'yes' : 'no'}`
+    )
     this._cache.put(address, account)
     this.touchAccount(address)
   }

--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -19,7 +19,6 @@ import { ripemdPrecompileAddress } from '../evm/precompiles'
 import { short } from '../evm/opcodes'
 
 const debug = createDebugLogger('vm:state')
-const debugRoot = createDebugLogger('vm:state:root')
 
 type AddressHex = string
 
@@ -423,7 +422,6 @@ export default class DefaultStateManager implements StateManager {
     await this._cache.flush()
 
     if (stateRoot === this._trie.EMPTY_TRIE_ROOT) {
-      debugRoot(`Set state root to empty`)
       this._trie.root = stateRoot
       this._cache.clear()
       this._storageTries = {}
@@ -435,7 +433,6 @@ export default class DefaultStateManager implements StateManager {
       throw new Error('State trie does not contain state root')
     }
 
-    debugRoot(`Set new state root (-> ${stateRoot.toString('hex')})`)
     this._trie.root = stateRoot
     this._cache.clear()
     this._storageTries = {}

--- a/packages/vm/tests/api/runBlock.spec.ts
+++ b/packages/vm/tests/api/runBlock.spec.ts
@@ -114,7 +114,7 @@ tape('should fail when tx gas limit higher than block gas limit', async (t) => {
 tape('should correctly use the selectHardforkByBlockNumber option', async (t) => {
   const common1 = new Common({
     chain: 'mainnet',
-    hardfork: 'chainstart',
+    hardfork: 'muirGlacier',
   })
 
   // Have to use an unique common, otherwise the HF will be set to muirGlacier and then will not change back to chainstart.


### PR DESCRIPTION
I think we can safe us from a load of problems when the `Common` instance in block and tx is just copied over. After months of thinking about this I am pretty much sure this is the right thing to do. Both txs and blocks just DO have a certain HF state - and if this is attached to an outer `Common` which - e.g. in the case of our client with `chainCommon` - might move on or change, this will lead to consistency problems if the respective Tx or Block objects are still around.

PR was triggered when running the client on Rinkeby which broke at bloke 55 with:

![image](https://user-images.githubusercontent.com/931137/107381165-e152e900-6aee-11eb-8fd4-76dc4dca6cf3.png)

This is now fixed with this PR - as always replaced by another error though (`Invalid receipt trie`). Original root cause was the block being executed on the wrong HF though.

I think these `Common`-copy-fix can go in as a bug fix, this will very much rather help prevent unexpected behavior within the community using the library, maybe there might be some rather unintended use cases (which should rather be discouraged) of the library where this might break, but I am pretty sure the benefits weight significantly more here.

In the client as well as in the blockchain library I then switched to `hardforkByBlockNumber` block and header instantiations. This should once and for all - together with the change from above - free us from all consistency problems in this regard.

I also fixed bugs along the way in `Block` where the tx objects have been instantiated with the wrong HF in the static constructors when the `hardforkByBlockNumber` option has been used for block instantiation.

Note that this PR is targeted towards the `client-block-poa-fixes` branch.