### PR TITLE
Client, VM -> Rinkeby: Fix consensus error on block 14182 (invalid receipt trie)

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -88,6 +88,11 @@ const args = require('yargs')
       describe: 'EIP-1459 ENR tree urls to query for peer discovery targets',
       array: true,
     },
+    debugCode: {
+      describe: 'Generate code for local debugging (internal usage mostly)',
+      boolean: true,
+      default: Config.DEBUGCODE_DEFAULT,
+    },
   })
   .locale('en_EN').argv
 
@@ -168,6 +173,7 @@ async function run() {
     maxPeers: args.maxPeers,
     dnsAddr: args.dnsAddr,
     dnsNetworks: args.dnsNetworks,
+    debugCode: args.debugCode,
   })
   logger = config.logger
 

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -114,6 +114,15 @@ export interface ConfigOptions {
    * EIP-1459 ENR Tree urls to query via DNS for peer discovery
    */
   dnsNetworks?: string[]
+
+  /**
+   * Generate code for local debugging, currently providing a
+   * code snippet which can be used to run blocks on the
+   * EthereumJS VM on execution errors
+   *
+   * (meant to be used internally for the most part)
+   */
+  debugCode?: boolean
 }
 
 export class Config {
@@ -129,6 +138,7 @@ export class Config {
   public static readonly MINPEERS_DEFAULT = 1
   public static readonly MAXPEERS_DEFAULT = 25
   public static readonly DNSADDR_DEFAULT = '8.8.8.8'
+  public static readonly DEBUGCODE_DEFAULT = false
 
   public readonly logger: Logger
   public readonly syncmode: string
@@ -143,6 +153,7 @@ export class Config {
   public readonly minPeers: number
   public readonly maxPeers: number
   public readonly dnsAddr: string
+  public readonly debugCode: boolean
 
   public readonly chainCommon: Common
   public readonly execCommon: Common
@@ -162,6 +173,7 @@ export class Config {
     this.minPeers = options.minPeers ?? Config.MINPEERS_DEFAULT
     this.maxPeers = options.maxPeers ?? Config.MAXPEERS_DEFAULT
     this.dnsAddr = options.dnsAddr ?? Config.DNSADDR_DEFAULT
+    this.debugCode = options.debugCode ?? Config.DEBUGCODE_DEFAULT
 
     // TODO: map chainParams (and lib/util.parseParams) to new Common format
     const common =

--- a/packages/client/lib/sync/execution/vmexecution.ts
+++ b/packages/client/lib/sync/execution/vmexecution.ts
@@ -4,6 +4,7 @@ import VM from '@ethereumjs/vm'
 import { DefaultStateManager } from '@ethereumjs/vm/dist/state'
 import { SecureTrie as Trie } from '@ethereumjs/trie'
 import { Block } from '@ethereumjs/block'
+import { debugCodeReplayBlock } from '../../util/debug'
 
 export class VMExecution extends Execution {
   public vm: VM
@@ -155,6 +156,9 @@ export class VMExecution extends Execution {
             this.config.logger.warn(
               `Execution of block number=${blockNumber} hash=${hash} hardfork=${this.hardfork} failed`
             )
+            if (this.config.debugCode) {
+              await debugCodeReplayBlock(this, block)
+            }
             this.emit('error', error)
             errorBlock = block
           }

--- a/packages/client/lib/util/debug.ts
+++ b/packages/client/lib/util/debug.ts
@@ -1,0 +1,65 @@
+import { Block } from '@ethereumjs/block'
+import { VMExecution } from '../sync/execution'
+
+/**
+ * Generates a code snippet which can be used to replay an erraneous block
+ * locally in the VM
+ *
+ * @param block
+ */
+export async function debugCodeReplayBlock(execution: VMExecution, block: Block) {
+  const code = `
+/**
+ * Script for locally executing a block in the EthereumJS VM,
+ * meant to be used from packages/vm directory within the
+ * https://github.com/ethereumjs/ethereumjs-monorepo repository.
+ * 
+ * Block: ${block.header.number}
+ * Hardfork: ${execution.hardfork}
+ * 
+ * Run with: DEBUG=vm:*:*,vm:*,-vm:ops:* ts-node [SCRIPT_NAME].ts
+ * 
+ */
+
+const level = require('level')
+import Common from '@ethereumjs/common'
+import { Block } from '@ethereumjs/block'
+import VM from './lib'
+import { SecureTrie as Trie } from '@ethereumjs/trie'
+import { DefaultStateManager } from './lib/state'
+import Blockchain from '@ethereumjs/blockchain'
+
+const main = async () => {
+  const common = new Common({ chain: '${execution.config.execCommon.chainName()}', hardfork: '${
+    execution.hardfork
+  }' })
+  const block = Block.fromRLPSerializedBlock(Buffer.from('${block
+    .serialize()
+    .toString('hex')}', 'hex'), { common })
+
+  const stateDB = level('${execution.config.getStateDataDirectory()}')
+  const trie = new Trie(stateDB)
+  const stateManager = new DefaultStateManager({ trie, common })
+  // Ensure we run on the right root
+  stateManager.setStateRoot(Buffer.from('${(
+    await execution.vm.stateManager.getStateRoot(true)
+  ).toString('hex')}', 'hex'))
+
+
+  const chainDB = level('${execution.config.getChainDataDirectory()}')
+  const blockchain = await Blockchain.create({
+    db: chainDB,
+    common,
+    validateBlocks: true,
+    validateConsensus: false,
+  })
+  const vm = new VM({ stateManager, blockchain, common })
+
+  await vm.runBlock({ block })
+}
+
+main()
+    `
+
+  execution.config.logger.info(code)
+}

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -176,7 +176,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
       .hash()
       .toString('hex')} with caller=${caller.toString()} gasLimit=${gasLimit} to=${
       to ? to.toString() : ''
-    } value=${value} data=0x${data.toString('hex')}`
+    } value=${value} data=0x${short(data)}`
   )
   const results = (await evm.executeMessage(message)) as RunTxResult
   debug('-'.repeat(100))


### PR DESCRIPTION
Fixing #1090 

I will actually not start working on new consensus bugs without adding a new meaningful debug tool. 😂

This one from this first commit 8d0afb7 is actually super-handy: it adds a new CLI option (mainly for internal usage, but of course also can be leveraged by consumers) `debugCode` which generates a dynamic script on a VM block execution failure. 

So this can be run with:

```shell
npm run client:start -- --network=rinkeby --debugCode
```

Script looks something like this and will be logged out to the console:

```typescript
/**
 * Script for locally executing a block in the EthereumJS VM,
 * meant to be used from packages/vm directory within the
 * https://github.com/ethereumjs/ethereumjs-monorepo repository.
 *
 * Block: 14182
 * Hardfork: spuriousDragon
 *
 * Run with: DEBUG=vm:*:*,vm:*,-vm:ops:* ts-node [SCRIPT_NAME].ts
 *
 */

const level = require('level')
import Common from '@ethereumjs/common'
import { Block } from '@ethereumjs/block'
import VM from './lib'
import { SecureTrie as Trie } from '@ethereumjs/trie'
import { DefaultStateManager } from './lib/state'
import Blockchain from '@ethereumjs/blockchain'

const main = async () => {
  const common = new Common({ chain: 'rinkeby', hardfork: 'spuriousDragon' })
  const block = Block.fromRLPSerializedBlock(Buffer.from('f91692f9025ba0b477241819c2222f...', 'hex'), { common })

  const stateDB = level('/Ethereum/ethereumjs/rinkeby/state')
  const trie = new Trie(stateDB)
  const stateManager = new DefaultStateManager({ trie, common })
  // Ensure we run on the right root
  stateManager.setStateRoot(Buffer.from('135fae6d4909a072d77707a797769afc72f6239a72173e0f411c7700af66ac26', 'hex'))


  const chainDB = level('/Ethereum/ethereumjs/rinkeby/chain')
  const blockchain = await Blockchain.create({
    db: chainDB,
    common,
    validateBlocks: true,
    validateConsensus: false,
  })
  const vm = new VM({ stateManager, blockchain, common })

  await vm.runBlock({ block })
}

main()
```

The script works out of the box, has all the correct values filled in (HFs, directories, block RLP) and can directly be copied over into the VM folder and then executed to reliably reproduce the error locally. 😄 