### PR TITLE
VM/Client: fix HF switching. Fix TangerineWhistle update bug.

### DIFF
--- a/packages/client/lib/sync/execution/vmexecution.ts
+++ b/packages/client/lib/sync/execution/vmexecution.ts
@@ -49,6 +49,7 @@ export class VMExecution extends Execution {
     const blockNumber = headBlock.header.number.toNumber()
     this.config.execCommon.setHardforkByBlockNumber(blockNumber)
     this.hardfork = this.config.execCommon.hardfork()
+    this.vm._updateOpcodes()
     this.config.logger.info(`Initializing VM execution hardfork=${this.hardfork}`)
   }
 
@@ -112,6 +113,7 @@ export class VMExecution extends Execution {
                 `Execution hardfork switch on block number=${blockNumber} hash=${hash} old=${this.hardfork} new=${hardfork}`
               )
               this.hardfork = this.config.execCommon.setHardforkByBlockNumber(blockNumber)
+              this.vm._updateOpcodes()
             }
             await this.vm.runBlock({ block, root: parentState })
             txCounter += block.transactions.length

--- a/packages/vm/lib/evm/opcodes/codes.ts
+++ b/packages/vm/lib/evm/opcodes/codes.ts
@@ -191,11 +191,27 @@ const opcodes = {
 
 // Array of hard forks in order. These changes are repeatedly applied to `opcodes` until the hard fork is in the future based upon the common
 // TODO: All gas price changes should be moved to common
+// If the base gas cost of any of the operations change, then these should also be added to this list.
+// If there are context variables changed (such as "warm slot reads") which are not the base gas fees,
+// Then this does not have to be added.
 const hardforkOpcodes = [
   {
     hardforkName: 'homestead',
     opcodes: {
       0xf4: { name: 'DELEGATECALL', isAsync: true }, // EIP 7
+    },
+  },
+  {
+    hardforkName: 'tangerineWhistle',
+    opcodes: {
+      0x54: { name: 'SLOAD', isAsync: true },
+      0xf1: { name: 'CALL', isAsync: true },
+      0xf2: { name: 'CALLCODE', isAsync: true },
+      0x3b: { name: 'EXTCODESIZE', isAsync: true },
+      0x3c: { name: 'EXTCODECOPY', isAsync: true },
+      0xf4: { name: 'DELEGATECALL', isAsync: true }, // EIP 7
+      0xff: { name: 'SELFDESTRUCT', isAsync: true },
+      0x31: { name: 'BALANCE', isAsync: true },
     },
   },
   {


### PR DESCRIPTION
Closes #1090. Cherry-picked from #1094.

Very nasty bug. There are two problems:

(1) Client does not update the opcodes of VM when we change hard forks. In practice, some stuff happens though: if we update a context variable which we were already using (like tx data gas cost for nonzero data) then this is used (as we dynamically fetch this from the current Common). However, if a HF introduces new opcodes, then these are not added to VM and are thus not accessible. 

(2) We never updated TangerineWhistle gas cost changes in the first place. If you instantiate a Common with Chainstart, then switch to TangerineWhistle, and even called `_updateOpcodes()` before, then gas costs are *not* updated in the VM.

(Side note: also weird that tests did not cover this. On the other hand, there are not that many tests where we check HF switching).