### PR TITLE
VM: Update run-solidity-contract example

### DIFF
--- a/packages/vm/examples/.gitignore
+++ b/packages/vm/examples/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/packages/vm/examples/run-solidity-contract/contracts/Greeter.sol
+++ b/packages/vm/examples/run-solidity-contract/contracts/Greeter.sol
@@ -1,10 +1,10 @@
-pragma solidity ^0.5.10;
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
 
 contract Greeter {
-
     string greeting;
 
-    constructor(string memory _greeting) public {
+    constructor(string memory _greeting) {
         greeting = _greeting;
     }
 
@@ -15,5 +15,4 @@ contract Greeter {
     function greet() public view returns (string memory) {
         return greeting;
     }
-
 }

--- a/packages/vm/examples/run-solidity-contract/package.json
+++ b/packages/vm/examples/run-solidity-contract/package.json
@@ -5,7 +5,7 @@
     "example": "ts-node index.ts"
   },
   "dependencies": {
-    "ethereumjs-abi": "^0.6.7",
-    "solc": "^0.5.10"
+    "@ethersproject/abi": "^5.0.12",
+    "solc": "^0.8.1"
   }
 }


### PR DESCRIPTION
This PR:
  * replaces `ethereumjs-abi` (deprecated) with `@ethersproject/abi` (closes #1098)
  * upgrades `solc` version
    * fixes some new warnings for contract:
      * upgrades solidity version
      * adds SPDX-License-Identifier
      * removes visibility identifier from constructor (public is default)

---

To test, `cd` into `packages/vm/examples/run-solidity-contract` and run `npm i && npm run example`

The output should look like this:

```
> run-solidity-contract@ example /Users/rg/dev/ethereumjs-monorepo/packages/vm/examples/run-solidity-contract
> ts-node index.ts

Account: 0xbe862ad9abfe6f22bcb087716c7d89a26051f74c
Set account a balance of 1 ETH
Compiling...
Compiled the contract
Deploying the contract...
Contract address: 0x61de9dc6f6cff1df2809480882cfd3c2364b28f7
Greeting: Hello, World!
Changing greeting...
Greeting: Hola, Mundo!
Everything run correctly!
```