### PR TITLE
Blockchain: if passed header only validate header

### DIFF
--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -823,7 +823,11 @@ export default class Blockchain implements BlockchainInterface {
 
       if (this._validateBlocks && !isGenesis) {
         // this calls into `getBlock`, which is why we cannot lock yet
-        await block.validate(this)
+        if (item instanceof BlockHeader) {
+          await block.header.validate(this)
+        } else {
+          await block.validate(this)
+        }
       }
 
       if (this._validateConsensus) {


### PR DESCRIPTION
This PR adds some logic to `blockchain._putBlockOrHeader` where if a header is passed in then it will only validate the header and not the entire block since the additional data needed would be missing (txs, uncles). This was discovered when trying to sync the client on rinkeby in light mode.