### PR TITLE
MPT: New Release v4.1.0

### DIFF
--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/ethereumjs/ethereumjs-vm/tree/master/packages/block#readme",
   "dependencies": {
     "@ethereumjs/common": "^2.0.0",
-    "merkle-patricia-tree": "^4.0.0",
+    "merkle-patricia-tree": "^4.1.0",
     "@ethereumjs/tx": "^3.0.0",
     "@types/bn.js": "^4.11.6",
     "ethereumjs-util": "^7.0.8"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -55,7 +55,7 @@
     "@ethereumjs/blockchain": "^5.0.0",
     "@ethereumjs/common": "^2.0.0",
     "@ethereumjs/devp2p": "^3.0.3",
-    "merkle-patricia-tree": "^4.0.0",
+    "merkle-patricia-tree": "^4.1.0",
     "@ethereumjs/vm": "^5.0.0",
     "chalk": "^2.4.2",
     "ethereumjs-util": "^7.0.8",

--- a/packages/trie/CHANGELOG.md
+++ b/packages/trie/CHANGELOG.md
@@ -6,11 +6,26 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
+## 4.1.0 - 2021-02-16
 
-## New features
+This release comes with a reworked checkpointing mechanism (PR [#1030](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1030) and subsequently PR [#1035](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1035)). Instead of copying over the whole DB on checkpoints the operations in between checkpoints are now recorded in memory and either applied in batch on a `Trie.checkpoint()` call or discarded along a `Trie.revert()`. This more fine-grained operational mode leads to a substantial performance gain (up to 50x) when working with larger tries.
 
-There is a new exported `WalkController` class. Also, `trie.walkTrie()` is now a public method. Using the `WalkController`, one can create own custom ways to traverse the trie. [#135](https://github.com/ethereumjs/merkle-patricia-tree/pull/135)
+Another performance related bug has been fixed along PR [#127](https://github.com/ethereumjs/merkle-patricia-tree/pull/127) removing an unnecessary double-serialization call on nodes. This gives a general performance gain of 10-20% on putting new values in a trie.
+
+Other changes:
+
+## New Features
+
+A new exported `WalkController` class has been added and `trie.walkTrie()` has been made a public method along. This allows for creating own custom ways to traverse a trie. PR [#135](https://github.com/ethereumjs/merkle-patricia-tree/pull/135)
+
+### Refactoring, Development and Documentation
+
+- Better `Trie` code documentation, PR [#125](https://github.com/ethereumjs/merkle-patricia-tree/pull/125)
+- Internal `Trie` function reordering & partial retwrite, PR [#125](https://github.com/ethereumjs/merkle-patricia-tree/pull/125)
+- Added simple integrated profiling, PR [#128](https://github.com/ethereumjs/merkle-patricia-tree/pull/128)
+- Reworked benchmarking to be based on `benchmark.js`, basic CI integration, PR [#130](https://github.com/ethereumjs/merkle-patricia-tree/pull/130)
+- Upgrade to `ethereumjs-config` `2.0` libs for linting and formatting, PR [#133](https://github.com/ethereumjs/merkle-patricia-tree/pull/133)
+- Switched coverage from `coverall` to `codecov`, PR [#137](https://github.com/ethereumjs/merkle-patricia-tree/pull/137)
 
 ## [4.0.0] - 2020-04-17
 

--- a/packages/trie/README.md
+++ b/packages/trie/README.md
@@ -12,8 +12,6 @@ This is an implementation of the modified merkle patricia tree as specified in t
 
 The only backing store supported is LevelDB through the `levelup` module.
 
-Note: this `README` reflects the state of the library from `v5.0.0` (UNRELEASED) onwards. See `README` from the [standalone repository](https://github.com/ethereumjs/merkle-patricia-tree) for an introduction on the last preceeding release.
-
 # INSTALL
 
 `npm install merkle-patricia-tree`

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "merkle-patricia-tree",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "This is an implementation of the modified merkle patricia tree as specified in Ethereum's yellow paper.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/trie/src/baseTrie.ts
+++ b/packages/trie/src/baseTrie.ts
@@ -58,13 +58,13 @@ export class Trie {
     this.db = db ? new DB(db) : new DB()
     this._root = this.EMPTY_TRIE_ROOT
     if (root) {
-      this._setRoot(root)
+      this.setRoot(root)
     }
   }
 
   /** Sets the current root of the `trie` */
   set root(value: Buffer) {
-    this._setRoot(value)
+    this.setRoot(value)
   }
 
   /** Gets the current root of the `trie` */
@@ -72,7 +72,14 @@ export class Trie {
     return this._root
   }
 
-  _setRoot(value?: Buffer) {
+  /**
+   * This method is deprecated.
+   * Please use `Trie.root(value)` instead.
+   * 
+   * @param value 
+   * @deprecated
+   */
+  setRoot(value?: Buffer) {
     if (!value) {
       value = this.EMPTY_TRIE_ROOT
     }

--- a/packages/trie/src/baseTrie.ts
+++ b/packages/trie/src/baseTrie.ts
@@ -75,8 +75,8 @@ export class Trie {
   /**
    * This method is deprecated.
    * Please use `Trie.root(value)` instead.
-   * 
-   * @param value 
+   *
+   * @param value
    * @deprecated
    */
   setRoot(value?: Buffer) {

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -46,7 +46,7 @@
     "@ethereumjs/block": "^3.0.0",
     "@ethereumjs/blockchain": "^5.0.0",
     "@ethereumjs/common": "^2.0.0",
-    "merkle-patricia-tree": "^4.0.0",
+    "merkle-patricia-tree": "^4.1.0",
     "@ethereumjs/tx": "^3.0.0",
     "async-eventemitter": "^0.2.4",
     "core-js-pure": "^3.0.1",


### PR DESCRIPTION
MPT release with the new checkpointing mechanism and other CI and docs related changes (see CHANGELOG).

Please notice that I reverted a `Trie.setRoot()` -> `Trie._setRoot()` rename (introduced by myself) from https://github.com/ethereumjs/merkle-patricia-tree/pull/125 and switched to deprecating instead. This seemed to dangerous to me on retrospective regarding introducing a breaking change. Have instead added to #1024.