### PR TITLE
Add backwards-compatibility test fixture and run in CI for `tx`

### DIFF
--- a/.github/workflows/vm-pr.yml
+++ b/.github/workflows/vm-pr.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: ${{github.workspace}}
 
       - run: npm run coverage
-      
+
       - uses: codecov/codecov-action@v1
         with:
           file: ${{ env.cwd }}/coverage/lcov.info
@@ -48,7 +48,7 @@ jobs:
       - run: npm run test:API
       - run: npm run test:API:browser
       - run: npm run lint
-  
+
   vm-state:
     runs-on: ubuntu-latest
     strategy:
@@ -132,9 +132,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Args to pass to the tester. Note that some have splitted the slow tests and only 
+        # Args to pass to the tester. Note that some have splitted the slow tests and only
         #   running those: these are only on forks where that is applicable (see PR #489 for numbers on these)
-        
+
         # Tests were splitted with --dir and --excludeDir to balance execution times below the 9min mark.
         args: [
           '--fork=Istanbul --dir=GeneralStateTests/stTimeConsuming --expected-test-amount=15561',
@@ -174,9 +174,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # Args to pass to the tester. Note that some have splitted the slow tests and only 
+        # Args to pass to the tester. Note that some have splitted the slow tests and only
         #   running those: these are only on forks where that is applicable (see PR #489 for numbers on these)
-        
+
         # Tests were splitted with --dir and --excludeDir to balance execution times below the 9min mark.
         args: [
           '--fork=Berlin --expected-test-amount=33',
@@ -214,6 +214,37 @@ jobs:
         working-directory: ${{github.workspace}}
 
       - run: npm run test:blockchain -- ${{ matrix.args }}
+
+  vm-backwards-compatibility:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Dependency cache
+        uses: actions/cache@v2
+        id: cache
+        with:
+          key: VM-${{ runner.os }}-12-${{ hashFiles('**/package-lock.json') }}
+          path: '**/node_modules'
+
+      # Installs root dependencies, ignoring Bootstrap All script.
+      # Bootstraps the current package only
+      - run: npm install --ignore-scripts && npm run bootstrap:vm
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: ${{github.workspace}}
+
+      # Builds current package and the ones it depends from.
+      - run: npm run build:vm
+        working-directory: ${{github.workspace}}
+
+      # Runs vm test:API with @ethereumjs/tx@3.0.2
+      - run: npm run check:compatibility -- -t vm -d tx -n @ethereumjs/tx -v "3.0.2" -s test:API
+        working-directory: ${{github.workspace}}
 
   vm-benchmarks:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test": "lerna exec npm run test --parallel",
     "coverage": "lerna run coverage --stream",
     "docs:build": "lerna run docs:build --ignore @ethereumjs/ethash",
-    "clean": "rm -rf node_modules packages/*/node_modules packages/*/test-build packages/*/dist packages/*/dist.browser packages/*/package-lock.json"
+    "clean": "rm -rf node_modules packages/*/node_modules packages/*/test-build packages/*/dist packages/*/dist.browser packages/*/package-lock.json",
+    "check:compatibility": "bash ./scripts/check-compatibility.sh"
   }
 }

--- a/scripts/check-compatibility.sh
+++ b/scripts/check-compatibility.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# --------------------------------------------------------------------------------------------------
+# A script to test the backwards compatibility of monorepo packages
+# with previously published monorepo package sub dependencies.
+#
+# Substitutes a current package with another version of it installed from npm
+# and runs the tests of a package which consumes it.
+#
+# The monorepo is restored to orignal state after script completes, so this script
+# can be run repeatedly for different scenarios in CI
+#
+# # USAGE
+# -t <test> the monorepo package whose tests we'd like to run (ex: vm)
+# -d <dependency> the monorepo package dependency we want to swap out (ex: tx)
+# -n <npm>    the npm package name to swap in (ex: @ethereumjs/tx)
+# -v <version> the npm package version to swap in (ex: 3.0.2)
+# -s <script> the script to "npm run" to execute the tests
+# --------------------------------------------------------------------------------------------------
+
+# Exit immediately on error
+set -o errexit
+
+if [ -z "$CI" ]; then
+
+  echo "=================================================================="
+  echo "This script temporarily alters your deps and might mess things up."
+  echo "Only run in CI or locally with 'CI=true'                          "
+  echo "=================================================================="
+
+  exit 1
+
+fi
+
+# Collect command arguments
+while getopts t:d:n:v:s: flag
+do
+    case "${flag}" in
+        t) tst=${OPTARG};;
+        d) dep=${OPTARG};;
+        n) npm=${OPTARG};;
+        v) ver=${OPTARG};;
+        s) scr=${OPTARG};;
+    esac
+done
+
+[ -z $tst ] && echo "Missing -t <test> argument" && exit 1
+[ -z $dep ] && echo "Missing -d <dependency> argument" && exit 1
+[ -z $npm ] && echo "Missing -n <npm> argument" && exit 1
+[ -z $ver ] && echo "Missing -v <version> argument" && exit 1
+[ -z $scr ] && echo "Missing -s <script> argument" && exit 1
+
+echo ">> Stashing packages/${dep} in 'stash/'"
+
+mkdir stash
+mv packages/${dep} stash
+
+echo ">> Installing and staging ${npm}@${ver}"
+
+mkdir ${dep}
+cd ${dep}
+npm init --yes
+npm install ${npm}@${ver}
+mv node_modules/${npm}/* .
+
+# Comment out by default: Injects a log line into the npm installed
+# package to verify that the substitute package is *actually* swapped in
+# for the targets tests (by looking at terminal output)
+#
+# echo ">> Injecting verification log line into line 21 of tx/dist/transaction.js"
+#
+# sed -i -e $'21 a\\\n'"console.log('>>>>> HELLO!!');"  ./dist/transaction.js
+
+echo ">> Swapping packages/${dep} with ${npm}@${ver} and re-linking"
+
+cd ..
+mv ${dep} packages
+lerna link
+
+echo ">> Executing 'npm run ${scr}' in packages/${tst}"
+
+cd packages/${tst}
+npm run ${scr}
+cd ../..
+
+echo ">> Un-stashing and relinking packages/${dep}"
+
+rm -rf packages/${dep}
+mv stash/${dep} packages
+rm -rf stash
+rm -rf ${dep}
+lerna link


### PR DESCRIPTION
#1111

> a test setup should be integrated so that some/all/selected API tests can be run with a different dependency version, e.g. by providing a different package.json file or something.

This PR's strategy is to swap an npm published version of a sub-dependency  (ex: `tx`) into the monorepo, replacing the current branch's version. Then everything is re-linked and vm API tests are run with the new version. 

Have added a shell script that can execute this process generically for any sub-dependency/target pair. It restores the monorepo to its original state after executing so in principle it can be used locally but have added an env variable safety check to dissuade people from doing this accidentally. 

It should also be possible to execute repeatedly in CI in the `vm-backwards-compatibility` job for different subpackages (mpt, etc)

Usage:
```
$ ./scripts/check-compatibility.sh [options]

> OPTIONS (all are required)
> -t <test>       monorepo package whose tests we'd like to run (ex: vm)
> -d <dependency> monorepo package dependency we want to swap out (ex: tx)
> -n <npm>        npm package name to swap in (ex: @ethereumjs/tx)
> -v <version>    npm package version to swap in (ex: 3.0.2)
> -s <script>     script to "npm run" to execute the tests
```

The script flow for this case is 
+ Move `packages/tx` to a safe place (`stash/`)
+ Create a `tx` folder in the project root, cd in and npm install @ethereumjs/tx there
+ Move the contents of `tx/node_modules/@ethereumjs/tx` out 2 levels so that the folder looks like
```
tx/
  dist/
  dist.browser/
  node_modules/
  package.json
  etc...
```
+ Move `tx/` into `packages/`
+ Re-link everything
+ Run vm tests
+ Unspool all the above