### PR TITLE
Update run-solidity-contract readme instructions

### DIFF
--- a/packages/vm/examples/run-solidity-contract/README.md
+++ b/packages/vm/examples/run-solidity-contract/README.md
@@ -15,10 +15,9 @@ The example does these things:
 
 ## Installation
 
-1. Run `npm install` in the root of this project
-1. Run `npm install` in this directory
+1. Run `npm i` in the root of this project
+1. Run `npm i` in this directory
 
 ## Running the example
 
-1. Run `npm run build:dist` in the root of this project
 1. Run `npm run example` in this directory


### PR DESCRIPTION
This PR updates the readme instructions for `run-solidity-contract`  removing the old `npm run build:dist` step since the monorepo packages are now automatically built post-install following `npm i` on root.