### PR TITLE
Common: Add new isActivatedEIP() method

### DIFF
--- a/packages/common/src/eips/2315.json
+++ b/packages/common/src/eips/2315.json
@@ -4,7 +4,7 @@
   "comment": "Simple subroutines for the EVM",
   "url": "https://eips.ethereum.org/EIPS/eip-2315",
   "status": "Draft",
-  "minimumHardfork": "berlin",
+  "minimumHardfork": "istanbul",
   "gasConfig": {},
   "gasPrices": {
     "beginsub": {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -371,6 +371,30 @@ export default class Common extends EventEmitter {
   }
 
   /**
+   * Checks if an EIP is activated by either being included in the EIPs
+   * manually passed in with the `eips` constructor option or in a
+   * hardfork currently being active
+   *
+   * Note: this method only works for EIPs being supported
+   * by the `eips` constructor option
+   * @param eip
+   */
+  isActivatedEIP(eip: number): boolean {
+    if (this.eips().includes(eip)) {
+      return true
+    }
+    for (const hfChanges of HARDFORK_CHANGES) {
+      const hf = hfChanges[1]
+      if (this.gteHardfork(hf['name']) && 'eips' in hf) {
+        if (hf['eips'].includes(eip)) {
+          return true
+        }
+      }
+    }
+    return false
+  }
+
+  /**
    * Checks if set or provided hardfork is active on block number
    * @param hardfork Hardfork name or null (for HF set)
    * @param blockNumber

--- a/packages/common/tests/eips.spec.ts
+++ b/packages/common/tests/eips.spec.ts
@@ -32,4 +32,16 @@ tape('[Common]: Initialization / Chain params', function (t: tape.Test) {
 
     st.end()
   })
+
+  t.test('isActivatedEIP()', function (st) {
+    let c = new Common({ chain: 'rinkeby', hardfork: 'istanbul' })
+    st.equal(c.isActivatedEIP(2315), false, 'istanbul, eips: [] -> false (EIP-2315)')
+    c = new Common({ chain: 'rinkeby', hardfork: 'istanbul', eips: [2315] })
+    st.equal(c.isActivatedEIP(2315), true, 'istanbul, eips: [2315] -> true (EIP-2315)')
+    c = new Common({ chain: 'rinkeby', hardfork: 'berlin' })
+    st.equal(c.isActivatedEIP(2315), true, 'berlin, eips: [] -> true (EIP-2315)')
+    st.equal(c.isActivatedEIP(2537), false, 'berlin, eips: [] -> false (EIP-2537)')
+
+    st.end()
+  })
 })


### PR DESCRIPTION
This PR adds a new method `Common.isActivatedEIP()`. This method is meant to replace manual calls like `this._vm._common.eips().includes(2929)` (see e.g. [here](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1124/files#diff-5989b042ba2babcc01da3488dea79edfec7ea66c41dde9d04cf6332d204fae2dR276)) which will break once such an EIP moves to a HF.

After merging all these calls - particularly in the VM - should be replaced with the functionality from here.

Note that the current terminology around the term "active" in the `Common` library is very unfortunate (I once introduced myself). Other methods like `activeHardforks()` take "active" as "being a part of the chain" - if activated or not. I therefor for now used the terminology "activated" to differentiate here at least a bit. I will add a note to the major-release-note planning, these old "active" names should be replaced with something less ambiguous.

For now all this should work out.