### PR TITLE
VM, Common: updated EIP checks / added EIP-2565, EIP-2929 to Berlin HF

### DIFF
--- a/.github/workflows/vm-pr.yml
+++ b/.github/workflows/vm-pr.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       matrix:
         fork: [
-          'MuirGlacier',
+          'Berlin',
           'Istanbul'
         ]
       fail-fast: false
@@ -137,7 +137,9 @@ jobs:
         # Tests were splitted with --dir and --excludeDir to balance execution times below the 9min mark.
         args: [
           '--fork=Istanbul --dir=GeneralStateTests/stTimeConsuming --expected-test-amount=15561',
-          '--fork=Istanbul --excludeDir=stTimeConsuming --expected-test-amount=19817'
+          '--fork=Istanbul --excludeDir=stTimeConsuming --expected-test-amount=19817',
+          '--fork=Berlin --dir=GeneralStateTests/stTimeConsuming',
+          '--fork=Berlin --excludeDir=stTimeConsuming'
         ]
       fail-fast: false
     steps:

--- a/packages/common/src/hardforks/berlin.json
+++ b/packages/common/src/hardforks/berlin.json
@@ -3,5 +3,5 @@
   "comment": "HF targeted for July 2020 following the Muir Glacier HF",
   "url": "https://eips.ethereum.org/EIPS/eip-2070",
   "status": "Draft",
-  "eips": [ 2315 ]
+  "eips": [ 2315, 2565, 2929 ]
 }

--- a/packages/vm/lib/evm/evm.ts
+++ b/packages/vm/lib/evm/evm.ts
@@ -137,7 +137,7 @@ export default class EVM {
   async executeMessage(message: Message): Promise<EVMResult> {
     await this._vm._emit('beforeMessage', message)
 
-    if (!message.to && this._vm._common.eips().includes(2929)) {
+    if (!message.to && this._vm._common.isActivatedEIP(2929)) {
       // eslint-disable-next-line prettier/prettier
       (<any>this._state).addWarmedAddress((await this._generateAddress(message)).buf)
     }

--- a/packages/vm/lib/evm/opcodes/EIP2929.ts
+++ b/packages/vm/lib/evm/opcodes/EIP2929.ts
@@ -11,7 +11,7 @@ import { RunState } from './../interpreter'
  * @param {BN}       address
  */
 export function accessAddressEIP2929(runState: RunState, address: Address, baseFee?: number) {
-  if (!runState._common.eips().includes(2929)) return
+  if (!runState._common.isActivatedEIP(2929)) return
 
   const addressStr = address.buf
 
@@ -41,7 +41,7 @@ export function accessAddressEIP2929(runState: RunState, address: Address, baseF
  * @param {Buffer} key (to storage slot)
  */
 export function accessStorageEIP2929(runState: RunState, key: Buffer, isSstore: boolean) {
-  if (!runState._common.eips().includes(2929)) return
+  if (!runState._common.isActivatedEIP(2929)) return
 
   const baseFee = !isSstore ? runState._common.param('gasPrices', 'sload') : 0
   const address = runState.eei.getAddress().buf
@@ -73,7 +73,7 @@ export function adjustSstoreGasEIP2929(
   defaultCost: number,
   costName: string
 ): number {
-  if (!runState._common.eips().includes(2929)) return defaultCost
+  if (!runState._common.isActivatedEIP(2929)) return defaultCost
 
   const address = runState.eei.getAddress().buf
   const warmRead = runState._common.param('gasPrices', 'warmstorageread')

--- a/packages/vm/lib/evm/precompiles/05-modexp.ts
+++ b/packages/vm/lib/evm/precompiles/05-modexp.ts
@@ -100,7 +100,7 @@ export default function (opts: PrecompileInput): ExecResult {
   const mStart = eEnd
   const mEnd = mStart.add(mLen)
 
-  if (!opts._common.eips().includes(2565)) {
+  if (!opts._common.isActivatedEIP(2565)) {
     gasUsed = adjustedELen.mul(multComplexity(maxLen)).divn(Gquaddivisor)
   } else {
     gasUsed = adjustedELen.mul(multComplexityEIP2565(maxLen)).divn(Gquaddivisor)

--- a/packages/vm/lib/index.ts
+++ b/packages/vm/lib/index.ts
@@ -216,7 +216,7 @@ export default class VM extends AsyncEventEmitter {
 
     this._selectHardforkByBlockNumber = opts.selectHardforkByBlockNumber ?? false
 
-    if (this._common.eips().includes(2537)) {
+    if (this._common.isActivatedEIP(2537)) {
       if (IS_BROWSER) {
         throw new Error('EIP-2537 is currently not supported in browsers')
       } else {
@@ -250,7 +250,7 @@ export default class VM extends AsyncEventEmitter {
       await this.stateManager.commit()
     }
 
-    if (this._common.eips().includes(2537)) {
+    if (this._common.isActivatedEIP(2537)) {
       if (IS_BROWSER) {
         throw new Error('EIP-2537 is currently not supported in browsers')
       } else {

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -89,7 +89,7 @@ export default async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxRes
   const state: any = this.stateManager
 
   // Ensure we start with a clear warmed accounts Map
-  if (this._common.eips().includes(2929)) {
+  if (this._common.isActivatedEIP(2929)) {
     state.clearWarmedAccounts()
   }
 
@@ -107,7 +107,7 @@ export default async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxRes
     debug(`tx checkpoint reverted`)
     throw e
   } finally {
-    if (this._common.eips().includes(2929)) {
+    if (this._common.isActivatedEIP(2929)) {
       state.clearWarmedAccounts()
     }
   }
@@ -134,7 +134,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   const caller = tx.getSenderAddress()
   debug(`New tx run hash=${opts.tx.hash().toString('hex')} sender=${caller.toString()}`)
 
-  if (this._common.eips().includes(2929)) {
+  if (this._common.isActivatedEIP(2929)) {
     // Add origin and precompiles to warm addresses
     getActivePrecompiles(this._common).forEach((address: Address) =>
       state.addWarmedAddress(address.buf)

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -19,7 +19,7 @@
     "docs:build": "typedoc --options typedoc.js",
     "test:state": "ts-node ./tests/tester --state",
     "test:state:allForks": "echo 'Chainstart Homestead dao TangerineWhistle SpuriousDragon Byzantium Constantinople Petersburg Istanbul MuirGlacier Berlin ByzantiumToConstantinopleFixAt5 EIP158ToByzantiumAt5 FrontierToHomesteadAt5 HomesteadToDaoAt5 HomesteadToEIP150At5' | xargs -n1 | xargs -I v1 npm run test:state -- --fork=v1 --verify-test-amount-alltests",
-    "test:state:selectedForks": "echo 'Homestead TangerineWhistle SpuriousDragon Petersburg' | xargs -n1 | xargs -I v1 npm run test:state -- --fork=v1 --verify-test-amount-alltests",
+    "test:state:selectedForks": "echo 'Homestead TangerineWhistle SpuriousDragon Petersburg Berlin' | xargs -n1 | xargs -I v1 npm run test:state -- --fork=v1 --verify-test-amount-alltests",
     "test:state:slow": "npm run test:state -- --runSkipped=slow",
     "test:buildIntegrity": "npm run test:state -- --test='stackOverflow'",
     "test:blockchain": "node -r ts-node/register --stack-size=1500 ./tests/tester --blockchain",


### PR DESCRIPTION
This PR is to get an in-between overview on where we are with the berlin test runs - still excluding EIP-2718 and EIP-2930 - PR is branched off from #1124.

@jochem-brouwer feel free to merge this one in if useful or we can otherwise merge post #1124 merge, as you like.