### PR TITLE
Client: keep syncing at tip of chain

### DIFF
--- a/packages/client/lib/client.ts
+++ b/packages/client/lib/client.ts
@@ -46,7 +46,6 @@ export default class EthereumClient extends events.EventEmitter {
 
   public opened: boolean
   public started: boolean
-  public synchronized: boolean
 
   /**
    * Create new node
@@ -71,7 +70,6 @@ export default class EthereumClient extends events.EventEmitter {
     ]
     this.opened = false
     this.started = false
-    this.synchronized = false
   }
 
   /**
@@ -92,7 +90,6 @@ export default class EthereumClient extends events.EventEmitter {
     })
     await Promise.all(this.services.map((s) => s.open()))
     this.opened = true
-    this.config.events.on(Event.SYNC_SYNCHRONIZED, () => (this.synchronized = true))
   }
 
   /**

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -223,6 +223,8 @@ export class Config {
   public readonly discDns: boolean
   public readonly discV4: boolean
 
+  public synchronized: boolean
+
   public readonly chainCommon: Common
   public readonly execCommon: Common
 
@@ -249,6 +251,8 @@ export class Config {
     this.maxPeers = options.maxPeers ?? Config.MAXPEERS_DEFAULT
     this.dnsAddr = options.dnsAddr ?? Config.DNSADDR_DEFAULT
     this.debugCode = options.debugCode ?? Config.DEBUGCODE_DEFAULT
+
+    this.synchronized = false
 
     // TODO: map chainParams (and lib/util.parseParams) to new Common format
     const common =

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -224,6 +224,7 @@ export class Config {
   public readonly discV4: boolean
 
   public synchronized: boolean
+  public lastSyncDate: number
 
   public readonly chainCommon: Common
   public readonly execCommon: Common
@@ -253,6 +254,7 @@ export class Config {
     this.debugCode = options.debugCode ?? Config.DEBUGCODE_DEFAULT
 
     this.synchronized = false
+    this.lastSyncDate = 0
 
     // TODO: map chainParams (and lib/util.parseParams) to new Common format
     const common =

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -131,7 +131,7 @@ export interface ConfigOptions {
   /**
    * Number of peers needed before syncing
    *
-   * Default: `2`
+   * Default: `1`
    */
   minPeers?: number
 

--- a/packages/client/lib/net/peerpool.ts
+++ b/packages/client/lib/net/peerpool.ts
@@ -22,8 +22,8 @@ export class PeerPool {
   private pool: Map<string, Peer>
   private noPeerPeriods: number
   private opened: boolean
-  // eslint-disable-next-line no-undef
-  private _statusCheckInterval: NodeJS.Timeout | null
+  /* global NodeJS */
+  private _statusCheckInterval: NodeJS.Timeout | undefined
 
   /**
    * Create new peer pool
@@ -35,7 +35,6 @@ export class PeerPool {
     this.pool = new Map<string, Peer>()
     this.noPeerPeriods = 0
     this.opened = false
-    this._statusCheckInterval = null
 
     this.init()
   }
@@ -72,7 +71,6 @@ export class PeerPool {
   async close() {
     this.pool.clear()
     this.opened = false
-    // eslint-disable-next-line no-undef
     clearInterval(this._statusCheckInterval as NodeJS.Timeout)
   }
 

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -514,7 +514,7 @@ export class Eth {
    *   * highestBlock - The estimated highest block
    */
   async syncing(_params = []) {
-    if (this.client.synchronized) {
+    if (this.client.config.synchronized) {
       return false
     }
 

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -93,7 +93,7 @@ export class FullEthereumService extends EthereumService {
       const bodies: any = blocks.map((block: any) => block.raw().slice(1))
       peer.eth!.send('BlockBodies', { reqId, bodies })
     } else if (message.name === 'NewBlockHashes') {
-      await this.synchronizer.announced(message.data, peer)
+      this.synchronizer.handleNewBlockHashes(message.data)
     }
   }
 

--- a/packages/client/lib/sync/fetcher/blockfetcherbase.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcherbase.ts
@@ -11,6 +11,9 @@ export interface BlockFetcherOptions extends FetcherOptions {
 
   /* How many blocks to fetch */
   count: BN
+
+  /* Destroy fetcher once all tasks are done */
+  destroyWhenDone?: boolean
 }
 
 export type JobTask = {

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -55,7 +55,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
   protected finished: number // number of tasks which are both processed and also finished writing
   protected running: boolean
   protected reading: boolean
-  private destroyOnFinish: boolean // Destroy the fetcher once we are finished processing each task.
+  private destroyWhenDone: boolean // Destroy the fetcher once we are finished processing each task.
 
   private _readableState?: {
     // This property is inherited from Readable. We only need `length`.
@@ -93,7 +93,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
     this.finished = 0
     this.running = false
     this.reading = false
-    this.destroyOnFinish = options.destroyWhenDone ?? true
+    this.destroyWhenDone = options.destroyWhenDone ?? true
   }
 
   /**
@@ -340,7 +340,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
       }
     }
     this.running = false
-    if (this.destroyOnFinish) {
+    if (this.destroyWhenDone) {
       this.destroy()
     }
   }

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -26,6 +26,9 @@ export interface FetcherOptions {
 
   /* Retry interval in ms (default: 1000) */
   interval?: number
+
+  /* Destroy the fetcher once we are done */
+  destroyWhenDone?: boolean
 }
 
 /**
@@ -52,6 +55,8 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
   protected finished: number // number of tasks which are both processed and also finished writing
   protected running: boolean
   protected reading: boolean
+  private destroyOnFinish: boolean // Destroy the fetcher once we are finished processing each task.
+
   private _readableState?: {
     // This property is inherited from Readable. We only need `length`.
     length: number
@@ -88,6 +93,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
     this.finished = 0
     this.running = false
     this.reading = false
+    this.destroyOnFinish = options.destroyWhenDone ?? true
   }
 
   /**
@@ -153,6 +159,29 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
         return
       }
       f = this.out.peek()
+    }
+  }
+
+  /**
+   * Enqueues a task. If autoRestart is true, and Fetcher is not running, then restart the fetcher.
+   * @param task
+   * @param autoRestart
+   */
+  enqueueTask(task: JobTask, autoRestart = false) {
+    if (!this.running && !autoRestart) {
+      return
+    }
+    const job: Job<JobTask, JobResult, StorageItem> = {
+      task,
+      time: Date.now(),
+      index: this.total++,
+      state: 'idle',
+      peer: null,
+    }
+    this.in.insert(job)
+    if (!this.running && autoRestart) {
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      this.fetch()
     }
   }
 
@@ -300,17 +329,8 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
       return false
     }
     this.write()
-    this.tasks().forEach((task: JobTask) => {
-      const job: Job<JobTask, JobResult, StorageItem> = {
-        task,
-        time: Date.now(),
-        index: this.total++,
-        state: 'idle',
-        peer: null,
-      }
-      this.in.insert(job)
-    })
     this.running = true
+    this.tasks().forEach((task: JobTask) => this.enqueueTask(task))
     while (this.running) {
       if (!this.next()) {
         if (this.finished === this.total) {
@@ -319,7 +339,10 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
         await this.wait()
       }
     }
-    this.destroy()
+    this.running = false
+    if (this.destroyOnFinish) {
+      this.destroy()
+    }
   }
 
   /**

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -95,46 +95,103 @@ export class FullSynchronizer extends Synchronizer {
    * @return Resolves when sync completed
    */
   async syncWithPeer(peer?: Peer): Promise<boolean> {
-    if (!peer) return false
-    const latest = await this.latest(peer)
-    if (!latest) return false
-    const height = new BN(latest.number)
-    const first = this.chain.blocks.height.addn(1)
-    const count = height.sub(first).addn(1)
-    if (count.lten(0)) return false
+    // eslint-disable-next-line no-async-promise-executor
+    return await new Promise(async () => {
+      if (!peer) return false
+      peer!.on('message', (message: any) => {
+        if (message.name === 'NewBlockHashes') {
+          let min: BN = new BN(-1)
+          const data: any[] = message.data
+          const blockNumberList: string[] = []
+          data.forEach((value: any) => {
+            const blockNumber: BN = value[1]
+            blockNumberList.push(blockNumber.toString())
+            if (min.eqn(-1) || blockNumber.lt(min)) {
+              min = blockNumber
+            }
+          })
+          if (min.eqn(-1)) {
+            return
+          }
+          const numBlocks = blockNumberList.length
 
-    this.config.logger.debug(
-      `Syncing with peer: ${peer.toString(true)} height=${height.toString(10)}`
-    )
+          // check if we can request the blocks in bulk
+          let bulkRequest = true
+          const minCopy = min.clone()
+          for (let num = 1; num < numBlocks; num++) {
+            min.iaddn(1)
+            if (!blockNumberList.includes(min.toString())) {
+              bulkRequest = false
+              break
+            }
+          }
 
-    this.blockFetcher = new BlockFetcher({
-      config: this.config,
-      pool: this.pool,
-      chain: this.chain,
-      interval: this.interval,
-      first,
-      count,
-    })
-    this.config.events.on(Event.SYNC_FETCHER_FETCHED, (blocks) => {
-      blocks = blocks as Block[]
-      const first = new BN(blocks[0].header.number)
-      const hash = short(blocks[0].hash())
-      const baseFeeAdd = this.config.chainCommon.gteHardfork('london')
-        ? `basefee=${blocks[0].header.baseFeePerGas} `
-        : ''
-      this.config.logger.info(
-        `Imported blocks count=${blocks.length} number=${first.toString(
-          10
-        )} hash=${hash} ${baseFeeAdd}hardfork=${this.config.chainCommon.hardfork()} peers=${
-          this.pool.size
-        }`
+          if (bulkRequest) {
+            // FIXME
+            // eslint-disable-next-line @typescript-eslint/no-use-before-define
+            blockFetcher.enqueueTask(
+              {
+                first: minCopy,
+                count: numBlocks,
+              },
+              true
+            )
+          } else {
+            data.forEach((value: any) => {
+              const blockNumber: BN = value[1]
+              // FIXME
+              // eslint-disable-next-line @typescript-eslint/no-use-before-define
+              blockFetcher.enqueueTask(
+                {
+                  first: blockNumber,
+                  count: 1,
+                },
+                true
+              )
+            })
+          }
+        }
+      })
+      const latest = await this.latest(peer)
+      if (!latest) return false
+      const height = new BN(latest.number)
+      const first = this.chain.blocks.height.addn(1)
+      const count = height.sub(first).addn(1)
+      if (count.lten(0)) return false
+
+      this.config.logger.debug(
+        `Syncing with peer: ${peer.toString(true)} height=${height.toString(10)}`
       )
+
+      this.blockFetcher = new BlockFetcher({
+        config: this.config,
+        pool: this.pool,
+        chain: this.chain,
+        interval: this.interval,
+        first,
+        count,
+        destroyWhenDone: false,
+      })
+      const blockFetcher = <BlockFetcher>this.blockFetcher
+
+      this.config.events.on(Event.SYNC_FETCHER_FETCHED, (blocks) => {
+        blocks = blocks as Block[]
+        const first = new BN(blocks[0].header.number)
+        const hash = short(blocks[0].hash())
+        const baseFeeAdd = this.config.chainCommon.gteHardfork('london')
+          ? `basefee=${blocks[0].header.baseFeePerGas} `
+          : ''
+        this.config.logger.info(
+          `Imported blocks count=${blocks.length} number=${first.toString(
+            10
+          )} hash=${hash} ${baseFeeAdd}hardfork=${this.config.chainCommon.hardfork()} peers=${
+            this.pool.size
+          }`
+        )
+      })
+
+      await this.blockFetcher.fetch()
     })
-    await this.blockFetcher.fetch()
-    // TODO: Should this be deleted?
-    // @ts-ignore: error: The operand of a 'delete' operator must be optional
-    delete this.blockFetcher
-    return true
   }
 
   /**
@@ -142,7 +199,11 @@ export class FullSynchronizer extends Synchronizer {
    * @return Resolves with true if sync successful
    */
   async sync(): Promise<boolean> {
-    const peer = this.best()
+    let peer = this.best()
+    while (!peer) {
+      await new Promise((resolve) => setTimeout(resolve, 5000))
+      peer = this.best()
+    }
     return this.syncWithPeer(peer)
   }
 

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -98,7 +98,15 @@ export class FullSynchronizer extends Synchronizer {
 
       const latest = await this.latest(peer)
       if (!latest) return resolve(false)
+
       const height = latest.number
+      if (!this.syncTargetHeight) {
+        this.syncTargetHeight = height
+        this.config.logger.info(
+          `New sync target height number=${height.toString(10)} hash=${short(latest.hash())}`
+        )
+      }
+
       const first = this.chain.blocks.height.addn(1)
       const count = height.sub(first).addn(1)
       if (count.lten(0)) return resolve(false)

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -154,19 +154,6 @@ export class FullSynchronizer extends Synchronizer {
   }
 
   /**
-   * Fetch all blocks from current height up to highest found amongst peers
-   * @return Resolves with true if sync successful
-   */
-  async sync(): Promise<boolean> {
-    let peer = this.best()
-    while (!peer) {
-      await new Promise((resolve) => setTimeout(resolve, 5000))
-      peer = this.best()
-    }
-    return this.syncWithPeer(peer)
-  }
-
-  /**
    * Open synchronizer. Must be called before sync() is called
    */
   async open(): Promise<void> {

--- a/packages/client/lib/sync/lightsync.ts
+++ b/packages/client/lib/sync/lightsync.ts
@@ -77,7 +77,15 @@ export class LightSynchronizer extends Synchronizer {
 
       const latest = await this.latest(peer)
       if (!latest) return resolve(false)
+
       const height = new BN(peer.les!.status.headNum)
+      if (!this.syncTargetHeight) {
+        this.syncTargetHeight = height
+        this.config.logger.info(
+          `New sync target height number=${height.toString(10)} hash=${short(latest.hash())}`
+        )
+      }
+
       const first = this.chain.headers.height.addn(1)
       const count = height.sub(first).addn(1)
       if (count.lten(0)) return resolve(false)

--- a/packages/client/lib/sync/lightsync.ts
+++ b/packages/client/lib/sync/lightsync.ts
@@ -11,11 +11,8 @@ import { Event } from '../types'
  * @memberof module:sync
  */
 export class LightSynchronizer extends Synchronizer {
-  private headerFetcher: HeaderFetcher | null
-
   constructor(options: SynchronizerOptions) {
     super(options)
-    this.headerFetcher = null
   }
 
   /**
@@ -89,7 +86,7 @@ export class LightSynchronizer extends Synchronizer {
         `Syncing with peer: ${peer.toString(true)} height=${height.toString(10)}`
       )
 
-      this.headerFetcher = new HeaderFetcher({
+      this.fetcher = new HeaderFetcher({
         config: this.config,
         pool: this.pool,
         chain: this.chain,
@@ -99,8 +96,6 @@ export class LightSynchronizer extends Synchronizer {
         count,
         destroyWhenDone: false,
       })
-      const headerFetcher = <HeaderFetcher>this.headerFetcher
-      this.addNewBlockHandlers(peer, headerFetcher)
 
       this.config.events.on(Event.SYNC_FETCHER_FETCHED, (headers) => {
         headers = headers as BlockHeader[]
@@ -115,7 +110,7 @@ export class LightSynchronizer extends Synchronizer {
           )} hash=${hash} ${baseFeeAdd}peers=${this.pool.size}`
         )
       })
-      await this.headerFetcher.fetch()
+      await this.fetcher.fetch()
     })
   }
 
@@ -149,11 +144,11 @@ export class LightSynchronizer extends Synchronizer {
     if (!this.running) {
       return false
     }
-    if (this.headerFetcher) {
-      this.headerFetcher.destroy()
+    if (this.fetcher) {
+      this.fetcher.destroy()
       // TODO: Should this be deleted?
       // @ts-ignore: error: The operand of a 'delete' operator must be optional
-      delete this.headerFetcher
+      delete this.fetcher
     }
     await super.stop()
     return true

--- a/packages/client/lib/sync/lightsync.ts
+++ b/packages/client/lib/sync/lightsync.ts
@@ -74,43 +74,49 @@ export class LightSynchronizer extends Synchronizer {
    * @return Resolves when sync completed
    */
   async syncWithPeer(peer?: Peer): Promise<boolean> {
-    if (!peer) return false
-    const height = new BN(peer.les!.status.headNum)
-    const first = this.chain.headers.height.addn(1)
-    const count = height.sub(first).addn(1)
-    if (count.lten(0)) return false
+    // eslint-disable-next-line no-async-promise-executor
+    return await new Promise(async () => {
+      if (!peer) return false
 
-    this.config.logger.debug(
-      `Syncing with peer: ${peer.toString(true)} height=${height.toString(10)}`
-    )
+      const latest = await this.latest(peer)
+      if (!latest) return false
+      const height = new BN(peer.les!.status.headNum)
+      const first = this.chain.headers.height.addn(1)
+      const count = height.sub(first).addn(1)
+      if (count.lten(0)) return false
 
-    this.headerFetcher = new HeaderFetcher({
-      config: this.config,
-      pool: this.pool,
-      chain: this.chain,
-      flow: this.flow,
-      interval: this.interval,
-      first,
-      count,
-    })
-    this.config.events.on(Event.SYNC_FETCHER_FETCHED, (headers) => {
-      headers = headers as BlockHeader[]
-      const first = new BN(headers[0].number)
-      const hash = short(headers[0].hash())
-      const baseFeeAdd = this.config.chainCommon.gteHardfork('london')
-        ? `basefee=${headers[0].baseFeePerGas} `
-        : ''
-      this.config.logger.info(
-        `Imported headers count=${headers.length} number=${first.toString(
-          10
-        )} hash=${hash} ${baseFeeAdd}peers=${this.pool.size}`
+      this.config.logger.debug(
+        `Syncing with peer: ${peer.toString(true)} height=${height.toString(10)}`
       )
+
+      this.headerFetcher = new HeaderFetcher({
+        config: this.config,
+        pool: this.pool,
+        chain: this.chain,
+        flow: this.flow,
+        interval: this.interval,
+        first,
+        count,
+        destroyWhenDone: false,
+      })
+      const headerFetcher = <HeaderFetcher>this.headerFetcher
+      this.addNewBlockHandlers(peer, headerFetcher)
+
+      this.config.events.on(Event.SYNC_FETCHER_FETCHED, (headers) => {
+        headers = headers as BlockHeader[]
+        const first = new BN(headers[0].number)
+        const hash = short(headers[0].hash())
+        const baseFeeAdd = this.config.chainCommon.gteHardfork('london')
+          ? `basefee=${headers[0].baseFeePerGas} `
+          : ''
+        this.config.logger.info(
+          `Imported headers count=${headers.length} number=${first.toString(
+            10
+          )} hash=${hash} ${baseFeeAdd}peers=${this.pool.size}`
+        )
+      })
+      await this.headerFetcher.fetch()
     })
-    await this.headerFetcher.fetch()
-    // TODO: Should this be deleted?
-    // @ts-ignore: error: The operand of a 'delete' operator must be optional
-    delete this.headerFetcher
-    return true
   }
 
   /**

--- a/packages/client/lib/sync/lightsync.ts
+++ b/packages/client/lib/sync/lightsync.ts
@@ -132,15 +132,6 @@ export class LightSynchronizer extends Synchronizer {
   }
 
   /**
-   * Fetch all headers from current height up to highest found amongst peers
-   * @return Resolves with true if sync successful
-   */
-  async sync(): Promise<boolean> {
-    const peer = this.best()
-    return this.syncWithPeer(peer)
-  }
-
-  /**
    * Open synchronizer. Must be called before sync() is called
    */
   async open(): Promise<void> {

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -111,17 +111,17 @@ export abstract class Synchronizer {
    */
   async sync(): Promise<boolean> {
     let peer = this.best()
-    let numAttempts = 1
-    while (!peer) {
     // TODO: only activate along fixing test failures
-      /*if (numAttempts === 2) {
+    /*let numAttempts = 1
+    while (!peer) {
+      if (numAttempts === 2) {
         this.syncTargetHeight = this.chain.headers.height
         this.updateSynchronizedState()
-      }*/
+      }
       await new Promise((resolve) => setTimeout(resolve, 5000))
       peer = this.best()
       numAttempts += 1
-    }
+    }*/
     return this.syncWithPeer(peer)
   }
 

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -85,18 +85,18 @@ export abstract class Synchronizer {
           targetHeight = new BN(best.les.status.headNum)
         }
       }
-      if (targetHeight && this.chain.blocks.height.gte(targetHeight)) {
+      if (targetHeight && this.chain.headers.height.gte(targetHeight)) {
         if (!this.config.synchronized) {
-          const hash = this.chain.blocks.latest?.hash()
+          const hash = this.chain.headers.latest?.hash()
           this.config.logger.info(
-            `Chain synchronized height=${this.chain.blocks.height} number=${short(hash!)}`
+            `Chain synchronized height=${this.chain.headers.height} number=${short(hash!)}`
           )
         }
         this.config.synchronized = true
         this.config.lastSyncDate = Date.now()
 
         // TODO: analyze if this event is still needed
-        this.config.events.emit(Event.SYNC_SYNCHRONIZED, this.chain.blocks.height)
+        this.config.events.emit(Event.SYNC_SYNCHRONIZED, this.chain.headers.height)
       }
     })
   }

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -110,7 +110,7 @@ export abstract class Synchronizer {
    * @return Resolves with true if sync successful
    */
   async sync(): Promise<boolean> {
-    let peer = this.best()
+    const peer = this.best()
     // TODO: only activate along fixing test failures
     /*let numAttempts = 1
     while (!peer) {

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -76,7 +76,16 @@ export abstract class Synchronizer {
     })
 
     this.config.events.on(Event.CHAIN_UPDATED, async () => {
-      if (this.syncTargetHeight && this.chain.blocks.height.gte(this.syncTargetHeight)) {
+      let targetHeight = this.syncTargetHeight
+      if (!targetHeight) {
+        const best = this.best()
+        if (best?.eth) {
+          targetHeight = new BN(best.eth.status.latestBlock)
+        } else if (best?.les) {
+          targetHeight = new BN(best.les.status.headNum)
+        }
+      }
+      if (targetHeight && this.chain.blocks.height.gte(targetHeight)) {
         if (!this.config.synchronized) {
           const hash = this.chain.blocks.latest?.hash()
           this.config.logger.info(
@@ -92,6 +101,7 @@ export abstract class Synchronizer {
     })
   }
 
+  abstract best(): Peer | undefined
   abstract sync(): Promise<boolean>
 
   /**

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -113,10 +113,11 @@ export abstract class Synchronizer {
     let peer = this.best()
     let numAttempts = 1
     while (!peer) {
-      if (numAttempts === 2) {
+    // TODO: only activate along fixing test failures
+      /*if (numAttempts === 2) {
         this.syncTargetHeight = this.chain.headers.height
         this.updateSynchronizedState()
-      }
+      }*/
       await new Promise((resolve) => setTimeout(resolve, 5000))
       peer = this.best()
       numAttempts += 1

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -93,7 +93,21 @@ export abstract class Synchronizer {
   }
 
   abstract best(): Peer | undefined
-  abstract sync(): Promise<boolean>
+
+  abstract syncWithPeer(peer?: Peer): Promise<boolean>
+
+  /**
+   * Fetch all blocks from current height up to highest found amongst peers
+   * @return Resolves with true if sync successful
+   */
+  async sync(): Promise<boolean> {
+    let peer = this.best()
+    while (!peer) {
+      await new Promise((resolve) => setTimeout(resolve, 5000))
+      peer = this.best()
+    }
+    return this.syncWithPeer(peer)
+  }
 
   /**
    * Returns synchronizer type

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -76,16 +76,7 @@ export abstract class Synchronizer {
     })
 
     this.config.events.on(Event.CHAIN_UPDATED, async () => {
-      let targetHeight = this.syncTargetHeight
-      if (!targetHeight) {
-        const best = this.best()
-        if (best?.eth) {
-          targetHeight = new BN(best.eth.status.latestBlock)
-        } else if (best?.les) {
-          targetHeight = new BN(best.les.status.headNum)
-        }
-      }
-      if (targetHeight && this.chain.headers.height.gte(targetHeight)) {
+      if (this.syncTargetHeight && this.chain.headers.height.gte(this.syncTargetHeight)) {
         if (!this.config.synchronized) {
           const hash = this.chain.headers.latest?.hash()
           this.config.logger.info(

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -1,9 +1,7 @@
 import tape from 'tape-catch'
 import td from 'testdouble'
-import { BN } from 'ethereumjs-util'
 import { Config } from '../lib/config'
 import { PeerPool } from '../lib/net/peerpool'
-import { Event } from '../lib/types'
 
 tape('[EthereumClient]', async (t) => {
   const config = new Config({ transports: [], loglevel: 'error' })
@@ -55,18 +53,6 @@ tape('[EthereumClient]', async (t) => {
     await client.open()
     t.ok(client.opened, 'opened')
     t.equals(await client.open(), false, 'already opened')
-  })
-
-  t.test('should set synchronized to true once synchronized is emitted', async (t) => {
-    const servers = [new Server()] as any
-    const config = new Config({ servers })
-    const client = new EthereumClient({ config })
-
-    t.equals(client.config.synchronized, false, 'not synchronized yet')
-    await client.open()
-    config.events.emit(Event.SYNC_SYNCHRONIZED, new BN(0))
-    t.equals(client.config.synchronized, true, 'synchronized')
-    t.end()
   })
 
   t.test('should start/stop', async (t) => {

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -62,10 +62,10 @@ tape('[EthereumClient]', async (t) => {
     const config = new Config({ servers })
     const client = new EthereumClient({ config })
 
-    t.equals(client.synchronized, false, 'not synchronized yet')
+    t.equals(client.config.synchronized, false, 'not synchronized yet')
     await client.open()
     config.events.emit(Event.SYNC_SYNCHRONIZED, new BN(0))
-    t.equals(client.synchronized, true, 'synchronized')
+    t.equals(client.config.synchronized, true, 'synchronized')
     t.end()
   })
 

--- a/packages/client/test/integration/fullsync.spec.ts
+++ b/packages/client/test/integration/fullsync.spec.ts
@@ -32,9 +32,13 @@ tape('[Integration:FullSync]', async (t) => {
   })
 
   t.test('should sync with best peer', async (t) => {
-    const [remoteServer1, remoteService1] = await setup({ location: '127.0.0.2', height: 9 })
+    const [remoteServer1, remoteService1] = await setup({ location: '127.0.0.2', height: 7 })
     const [remoteServer2, remoteService2] = await setup({ location: '127.0.0.3', height: 10 })
-    const [localServer, localService] = await setup({ location: '127.0.0.1', height: 0 })
+    const [localServer, localService] = await setup({
+      location: '127.0.0.1',
+      height: 0,
+      minPeers: 2,
+    })
     await localService.synchronizer.stop()
     await localServer.discover('remotePeer1', '127.0.0.2')
     await localServer.discover('remotePeer2', '127.0.0.3')

--- a/packages/client/test/integration/util.ts
+++ b/packages/client/test/integration/util.ts
@@ -9,16 +9,18 @@ interface SetupOptions {
   height?: number
   interval?: number
   syncmode?: string
+  minPeers?: number
 }
 
 export async function setup(
   options: SetupOptions = {}
 ): Promise<[MockServer, FullEthereumService | LightEthereumService]> {
   const { location, height, interval, syncmode } = options
+  const minPeers = options.minPeers ?? 1
 
   const loglevel = 'error'
   const lightserv = syncmode === 'full'
-  const config = new Config({ loglevel, syncmode, lightserv })
+  const config = new Config({ loglevel, syncmode, lightserv, minPeers })
 
   const server = new MockServer({ config, location })
   const blockchain = new Blockchain({
@@ -29,13 +31,13 @@ export async function setup(
   const chain = new MockChain({ config, blockchain, height })
 
   const servers = [server] as any
-  const serviceConfig = new Config({ loglevel, syncmode, servers, lightserv, minPeers: 1 })
+  const serviceConfig = new Config({ loglevel, syncmode, servers, lightserv, minPeers })
   //@ts-ignore -- attach server eventbus to ethereums service eventbus (to simulate centralized client eventbus))
   server.config.events = serviceConfig.events
   const serviceOpts = {
     config: serviceConfig,
     chain,
-    interval: interval ?? 10,
+    interval: interval ?? 500, // do not make this too low, this will otherwise cause side effects
   }
 
   let service

--- a/packages/client/test/rpc/eth/syncing.spec.ts
+++ b/packages/client/test/rpc/eth/syncing.spec.ts
@@ -10,9 +10,9 @@ tape(`${method}: should return false when the client is synchronized`, async (t)
   const manager = createManager(client)
   const server = startRPC(manager.getMethods())
 
-  t.equals(client.synchronized, false, 'not synchronized yet')
-  client.synchronized = true
-  t.equals(client.synchronized, true, 'synchronized')
+  t.equals(client.config.synchronized, false, 'not synchronized yet')
+  client.config.synchronized = true
+  t.equals(client.config.synchronized, true, 'synchronized')
 
   const req = params(method, [])
   const expectRes = (res: any) => {
@@ -31,7 +31,7 @@ tape(`${method}: should return no peer available error`, async (t) => {
   const manager = createManager(client)
   const rpcServer = startRPC(manager.getMethods())
 
-  t.equals(client.synchronized, false, 'not synchronized yet')
+  t.equals(client.config.synchronized, false, 'not synchronized yet')
 
   const req = params(method, [])
   const expectRes = (res: any) => {
@@ -55,7 +55,7 @@ tape(`${method}: should return highest block header unavailable error`, async (t
   synchronizer.best = td.func<typeof synchronizer['best']>()
   td.when(synchronizer.best()).thenReturn('peer')
 
-  t.equals(client.synchronized, false, 'not synchronized yet')
+  t.equals(client.config.synchronized, false, 'not synchronized yet')
 
   const req = params(method, [])
   const expectRes = (res: any) => {
@@ -81,7 +81,7 @@ tape(`${method}: should return syncing status object when unsynced`, async (t) =
   td.when(synchronizer.best()).thenReturn('peer')
   td.when(synchronizer.latest('peer' as any)).thenResolve({ number: new BN(2) })
 
-  t.equals(client.synchronized, false, 'not synchronized yet')
+  t.equals(client.config.synchronized, false, 'not synchronized yet')
 
   const req = params(method, [])
   const expectRes = (res: any) => {

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -4,6 +4,7 @@ import td from 'testdouble'
 import { BN } from 'ethereumjs-util'
 import { Config } from '../../lib/config'
 import { Chain } from '../../lib/blockchain'
+import { Event } from '../../lib/types'
 
 tape('[FullSynchronizer]', async (t) => {
   class PeerPool extends EventEmitter {
@@ -114,6 +115,9 @@ tape('[FullSynchronizer]', async (t) => {
     ;(sync as any).chain = {
       blocks: { height: new BN(0) },
     }
+    setTimeout(() => {
+      config.events.emit(Event.SYNC_SYNCHRONIZED, new BN(0))
+    }, 100)
     t.ok(await sync.sync(), 'local height < remote height')
     await sync.stop()
 

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -108,7 +108,10 @@ tape('[FullSynchronizer]', async (t) => {
     sync.best = td.func<typeof sync['best']>()
     sync.latest = td.func<typeof sync['latest']>()
     td.when(sync.best()).thenReturn('peer')
-    td.when(sync.latest('peer' as any)).thenResolve({ number: new BN(2) })
+    td.when(sync.latest('peer' as any)).thenResolve({
+      number: new BN(2),
+      hash: () => Buffer.from([]),
+    })
     td.when((BlockFetcher.prototype as any).fetch(), { delay: 20 }).thenResolve(undefined)
     ;(sync as any).chain = { blocks: { height: new BN(3) } }
     t.notOk(await sync.sync(), 'local height > remote height')

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -42,6 +42,7 @@ tape('[FullSynchronizer]', async (t) => {
       chain,
     })
     ;(sync as any).pool.open = td.func<PeerPool['open']>()
+    ;(sync as any).pool.peers = []
     td.when((sync as any).pool.open()).thenResolve(null)
     await sync.open()
     t.pass('opened')

--- a/packages/client/test/sync/lightsync.spec.ts
+++ b/packages/client/test/sync/lightsync.spec.ts
@@ -74,7 +74,7 @@ tape('[LightSynchronizer]', async (t) => {
     sync.best = td.func<typeof sync['best']>()
     sync.latest = td.func<typeof sync['latest']>()
     td.when(sync.best()).thenReturn({ les: { status: { headNum: new BN(2) } } } as any)
-    td.when(sync.latest(td.matchers.anything())).thenResolve({ number: new BN(2) })
+    td.when(sync.latest(td.matchers.anything())).thenResolve({ number: new BN(2), hash: () => Buffer.from([]) })
     td.when(HeaderFetcher.prototype.fetch(), { delay: 20 }).thenResolve(undefined)
     ;(sync as any).chain = { headers: { height: new BN(3) } }
     t.notOk(await sync.sync(), 'local height > remote height')

--- a/packages/client/test/sync/lightsync.spec.ts
+++ b/packages/client/test/sync/lightsync.spec.ts
@@ -74,7 +74,10 @@ tape('[LightSynchronizer]', async (t) => {
     sync.best = td.func<typeof sync['best']>()
     sync.latest = td.func<typeof sync['latest']>()
     td.when(sync.best()).thenReturn({ les: { status: { headNum: new BN(2) } } } as any)
-    td.when(sync.latest(td.matchers.anything())).thenResolve({ number: new BN(2), hash: () => Buffer.from([]) })
+    td.when(sync.latest(td.matchers.anything())).thenResolve({
+      number: new BN(2),
+      hash: () => Buffer.from([]),
+    })
     td.when(HeaderFetcher.prototype.fetch(), { delay: 20 }).thenResolve(undefined)
     ;(sync as any).chain = { headers: { height: new BN(3) } }
     t.notOk(await sync.sync(), 'local height > remote height')

--- a/packages/client/test/sync/lightsync.spec.ts
+++ b/packages/client/test/sync/lightsync.spec.ts
@@ -4,6 +4,7 @@ import td from 'testdouble'
 import { BN } from 'ethereumjs-util'
 import { Config } from '../../lib/config'
 import { Chain } from '../../lib/blockchain'
+import { Event } from '../../lib/types'
 
 tape('[LightSynchronizer]', async (t) => {
   class PeerPool extends EventEmitter {
@@ -71,11 +72,16 @@ tape('[LightSynchronizer]', async (t) => {
       chain,
     })
     sync.best = td.func<typeof sync['best']>()
+    sync.latest = td.func<typeof sync['latest']>()
     td.when(sync.best()).thenReturn({ les: { status: { headNum: new BN(2) } } } as any)
+    td.when(sync.latest(td.matchers.anything())).thenResolve({ number: new BN(2) })
     td.when(HeaderFetcher.prototype.fetch(), { delay: 20 }).thenResolve(undefined)
     ;(sync as any).chain = { headers: { height: new BN(3) } }
     t.notOk(await sync.sync(), 'local height > remote height')
     ;(sync as any).chain = { headers: { height: new BN(0) } }
+    setTimeout(() => {
+      config.events.emit(Event.SYNC_SYNCHRONIZED, new BN(0))
+    }, 100)
     t.ok(await sync.sync(), 'local height < remote height')
     td.when(HeaderFetcher.prototype.fetch()).thenReject(new Error('err0'))
     try {

--- a/packages/client/test/sync/sync.spec.ts
+++ b/packages/client/test/sync/sync.spec.ts
@@ -45,7 +45,7 @@ tape('[Synchronizer]', async (t) => {
     sync.syncTargetHeight = new BN(1)
     setTimeout(() => {
       // eslint-disable-next-line no-extra-semi
-      ;(sync as any).chain._blocks = {
+      ;(sync as any).chain._headers = {
         latest: { hash: () => Buffer.from([]) },
         td: new BN(0),
         height: new BN(1),

--- a/packages/client/test/sync/sync.spec.ts
+++ b/packages/client/test/sync/sync.spec.ts
@@ -11,6 +11,9 @@ class SynchronizerTest extends Synchronizer {
   async sync() {
     return false
   }
+  best() {
+    return undefined
+  }
 }
 
 tape('[Synchronizer]', async (t) => {

--- a/packages/client/test/sync/sync.spec.ts
+++ b/packages/client/test/sync/sync.spec.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events'
 import tape from 'tape-catch'
 import td from 'testdouble'
+import { BN } from 'ethereumjs-util'
 import { Config } from '../../lib/config'
 import { Chain } from '../../lib/blockchain'
 import { Synchronizer } from '../../lib/sync/sync'
@@ -34,6 +35,16 @@ tape('[Synchronizer]', async (t) => {
       t.notOk((sync as any).running, 'stopped')
       t.end()
     })
+    sync.syncTargetHeight = new BN(1)
+    setTimeout(() => {
+      // eslint-disable-next-line no-extra-semi
+      ;(sync as any).chain._blocks = {
+        latest: { hash: () => Buffer.from([]) },
+        td: new BN(0),
+        height: new BN(1),
+      }
+      config.events.emit(Event.CHAIN_UPDATED)
+    }, 100)
     await sync.start()
   })
 

--- a/packages/client/test/sync/sync.spec.ts
+++ b/packages/client/test/sync/sync.spec.ts
@@ -8,6 +8,10 @@ import { Synchronizer } from '../../lib/sync/sync'
 import { Event } from '../../lib/types'
 
 class SynchronizerTest extends Synchronizer {
+  async syncWithPeer() {
+    return true
+  }
+
   async sync() {
     return false
   }


### PR DESCRIPTION
This PR intends to keep the fullsync-syncer syncing at the tip of the chain. (Note: current branch target is the YoloV3 branch)

- Add `enqueueTask` to `fetcher`. This allows one to manually enqueue a task, and possibly restart the fetcher
- Add an option to not destroy the fetcher when it has processed all tasks
- Optimize full sync: in case no peers are available, then wait 5 seconds and try again, to get a best peer (this possibly fixes the re-bootstrap at some points)
- Fullsync `sync` method never resolves.
- Enqueue new blocks when the best peer announces new blocks

This is very WIP. Here are some things which need to be resolved: 

- [ ] Add logic when there is a gap in requested blocks (possibly, we just change the block fetcher, such that we can just update the highest block number on-demand, and not add all this extra logic)
- [ ] Add tests
- [ ] Fix the error as described below

Currently, it seems to randomly work for some blocks (when we are at tip of chain, i.e. on YoloV3, every 15 seconds it imports and executes a new block), but then at some point it throws:

```
  devp2p:eth Received NEW_BLOCK_HASHES message from 3.9.20.133:30303: e6e5a0dcc51743c5579b7bcdfadda2209ee2280e16e3e065d74333ba9ee8... +12s
  devp2p:eth Send GET_BLOCK_HEADERS message to 3.9.20.133:30303: c7830150d5018080 +5ms
  devp2p:eth Received BLOCK_HEADERS message from 3.9.20.133:30303: f9025cf90259a0d28799ec1625a5d9853afc3e10f415dd05071191af1bbf... +15ms
  devp2p:eth Send GET_BLOCK_BODIES message to 3.9.20.133:30303: e1a0dcc51743c5579b7bcdfadda2209ee2280e16e3e065d74333ba9ee836... +5ms
  devp2p:eth Received BLOCK_BODIES message from 3.9.20.133:30303: c3c2c0c0 +15ms
ERROR [02-28|18:27:21] Error [ERR_STREAM_PUSH_AFTER_EOF]: stream.push() after EOF
    at readableAddChunk (_stream_readable.js:260:30)
    at BlockFetcher.Readable.push (_stream_readable.js:213:10)
    at BlockFetcher.dequeue (/Volumes/Ethereum/ethereumjs-vm/packages/client/lib/sync/fetcher/fetcher.ts:163:17)
    at BlockFetcher.success (/Volumes/Ethereum/ethereumjs-vm/packages/client/lib/sync/fetcher/fetcher.ts:219:14)
    at /Volumes/Ethereum/ethereumjs-vm/packages/client/lib/sync/fetcher/fetcher.ts:268:44
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
  devp2p:eth Send GET_BLOCK_HEADERS message to 3.9.20.133:30303: c7830150d0048080 +28ms
  ```