### PR TITLE
Remove @types/bn.js from block,blockchain,trie,tx,vm packages

### DIFF
--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -42,7 +42,6 @@
     "@ethereumjs/common": "^2.1.0",
     "merkle-patricia-tree": "^4.1.0",
     "@ethereumjs/tx": "^3.0.2",
-    "@types/bn.js": "^4.11.6",
     "ethereumjs-util": "^7.0.8"
   },
   "devDependencies": {

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -51,7 +51,6 @@
     "@ethereumjs/config-typescript": "^2.0.0",
     "@ethereumjs/eslint-config-defaults": "^2.0.0",
     "@types/async": "^2.4.1",
-    "@types/bn.js": "^4.11.6",
     "@types/lru-cache": "^5.1.0",
     "@types/node": "^11.13.4",
     "@types/tape": "^4.13.0",

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -56,7 +56,6 @@
     "@ethereumjs/config-typescript": "^2.0.0",
     "@ethereumjs/eslint-config-defaults": "^2.0.0",
     "@types/benchmark": "^1.0.33",
-    "@types/bn.js": "^4.11.6",
     "@types/tape": "^4.13.0",
     "benchmark": "^2.1.4",
     "eslint": "^6.8.0",

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -38,7 +38,6 @@
     "@ethereumjs/config-coverage": "^2.0.0",
     "@ethereumjs/config-typescript": "^2.0.0",
     "@ethereumjs/eslint-config-defaults": "^2.0.0",
-    "@types/bn.js": "^4.11.6",
     "@types/minimist": "^1.2.0",
     "@types/node": "^11.13.4",
     "@types/tape": "^4.13.0",

--- a/packages/tx/src/transactionFactory.ts
+++ b/packages/tx/src/transactionFactory.ts
@@ -2,7 +2,7 @@ import Common from '@ethereumjs/common'
 import { default as LegacyTransaction } from './legacyTransaction'
 import { default as EIP2930Transaction } from './eip2930Transaction'
 import { TxOptions, Transaction, TxData } from './types'
-import BN from 'bn.js'
+import { BN } from 'ethereumjs-util'
 
 const DEFAULT_COMMON = new Common({ chain: 'mainnet' })
 

--- a/packages/vm/benchmarks/util.ts
+++ b/packages/vm/benchmarks/util.ts
@@ -1,5 +1,4 @@
-import BN = require('bn.js')
-import { Account, Address, toBuffer, bufferToInt } from 'ethereumjs-util'
+import { Account, Address, toBuffer, bufferToInt, BN } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import { StateManager, DefaultStateManager } from '../dist/state'

--- a/packages/vm/lib/evm/opcodes/EIP1283.ts
+++ b/packages/vm/lib/evm/opcodes/EIP1283.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { RunState } from './../interpreter'
 
 /**

--- a/packages/vm/lib/evm/opcodes/EIP2200.ts
+++ b/packages/vm/lib/evm/opcodes/EIP2200.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { RunState } from './../interpreter'
 import { ERROR } from '../../exceptions'
 import { adjustSstoreGasEIP2929 } from './EIP2929'

--- a/packages/vm/lib/evm/opcodes/EIP2929.ts
+++ b/packages/vm/lib/evm/opcodes/EIP2929.ts
@@ -1,5 +1,4 @@
-import BN = require('bn.js')
-import { Address } from 'ethereumjs-util'
+import { Address, BN } from 'ethereumjs-util'
 import { EIP2929StateManager } from '../../state/interface'
 import { RunState } from './../interpreter'
 

--- a/packages/vm/lib/evm/precompiles/01-ecrecover.ts
+++ b/packages/vm/lib/evm/precompiles/01-ecrecover.ts
@@ -1,5 +1,4 @@
-import BN = require('bn.js')
-import { setLengthLeft, setLengthRight, ecrecover, publicToAddress } from 'ethereumjs-util'
+import { setLengthLeft, setLengthRight, ecrecover, publicToAddress, BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')

--- a/packages/vm/lib/evm/precompiles/02-sha256.ts
+++ b/packages/vm/lib/evm/precompiles/02-sha256.ts
@@ -1,5 +1,4 @@
-import BN = require('bn.js')
-import { sha256 } from 'ethereumjs-util'
+import { sha256, BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')

--- a/packages/vm/lib/evm/precompiles/03-ripemd160.ts
+++ b/packages/vm/lib/evm/precompiles/03-ripemd160.ts
@@ -1,5 +1,4 @@
-import BN = require('bn.js')
-import { ripemd160 } from 'ethereumjs-util'
+import { ripemd160, BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')

--- a/packages/vm/lib/evm/precompiles/04-identity.ts
+++ b/packages/vm/lib/evm/precompiles/04-identity.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')

--- a/packages/vm/lib/evm/precompiles/05-modexp.ts
+++ b/packages/vm/lib/evm/precompiles/05-modexp.ts
@@ -1,5 +1,4 @@
-import BN = require('bn.js')
-import { setLengthRight } from 'ethereumjs-util'
+import { setLengthRight, BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')

--- a/packages/vm/lib/evm/precompiles/06-ecadd.ts
+++ b/packages/vm/lib/evm/precompiles/06-ecadd.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')

--- a/packages/vm/lib/evm/precompiles/07-ecmul.ts
+++ b/packages/vm/lib/evm/precompiles/07-ecmul.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')

--- a/packages/vm/lib/evm/precompiles/08-ecpairing.ts
+++ b/packages/vm/lib/evm/precompiles/08-ecpairing.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
 const assert = require('assert')

--- a/packages/vm/lib/evm/precompiles/09-blake2f.ts
+++ b/packages/vm/lib/evm/precompiles/09-blake2f.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
 import { VmError, ERROR } from '../../exceptions'

--- a/packages/vm/lib/evm/precompiles/0a-bls12-g1add.ts
+++ b/packages/vm/lib/evm/precompiles/0a-bls12-g1add.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'

--- a/packages/vm/lib/evm/precompiles/0b-bls12-g1mul.ts
+++ b/packages/vm/lib/evm/precompiles/0b-bls12-g1mul.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'

--- a/packages/vm/lib/evm/precompiles/0c-bls12-g1multiexp.ts
+++ b/packages/vm/lib/evm/precompiles/0c-bls12-g1multiexp.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'

--- a/packages/vm/lib/evm/precompiles/0d-bls12-g2add.ts
+++ b/packages/vm/lib/evm/precompiles/0d-bls12-g2add.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'

--- a/packages/vm/lib/evm/precompiles/0e-bls12-g2mul.ts
+++ b/packages/vm/lib/evm/precompiles/0e-bls12-g2mul.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'

--- a/packages/vm/lib/evm/precompiles/0f-bls12-g2multiexp.ts
+++ b/packages/vm/lib/evm/precompiles/0f-bls12-g2multiexp.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'

--- a/packages/vm/lib/evm/precompiles/10-bls12-pairing.ts
+++ b/packages/vm/lib/evm/precompiles/10-bls12-pairing.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'

--- a/packages/vm/lib/evm/precompiles/11-bls12-map-fp-to-g1.ts
+++ b/packages/vm/lib/evm/precompiles/11-bls12-map-fp-to-g1.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'

--- a/packages/vm/lib/evm/precompiles/12-bls12-map-fp2-to-g2.ts
+++ b/packages/vm/lib/evm/precompiles/12-bls12-map-fp2-to-g2.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'

--- a/packages/vm/lib/evm/precompiles/types.ts
+++ b/packages/vm/lib/evm/precompiles/types.ts
@@ -1,4 +1,4 @@
-import BN = require('bn.js')
+import { BN } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { ExecResult } from '../evm'
 import VM from '../../index'

--- a/packages/vm/lib/evm/precompiles/util/bls12_381.ts
+++ b/packages/vm/lib/evm/precompiles/util/bls12_381.ts
@@ -1,6 +1,5 @@
-const { padToEven } = require('ethereumjs-util')
+import { padToEven, BN } from 'ethereumjs-util'
 import { VmError, ERROR } from '../../../exceptions'
-import { BN } from 'ethereumjs-util'
 
 // base field modulus as described in the EIP
 const fieldModulus = new BN(

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -63,7 +63,6 @@
     "@ethereumjs/config-typescript": "^2.0.0",
     "@ethereumjs/eslint-config-defaults": "^2.0.0",
     "@types/benchmark": "^1.0.33",
-    "@types/bn.js": "^4.11.6",
     "@types/core-js": "^2.5.0",
     "@types/lru-cache": "^5.1.0",
     "@types/node": "^11.13.4",


### PR DESCRIPTION
Fixes a TS compilation failure on install relating to ethereumjs-util 7.0.9. 

PR: 
+ removes @types/bn.js as a dependency everywhere
+ imports `bn.js` via ethereumjs-util everywhere (for clarity about its source)

Idea is:
+ bn.js [is not a direct dependency in any package][1] - it always comes from ethereumjs-util
+ @types/bn.js [is a direct dependency][2] of ethereumjs-util
+ monorepo should let ethereumjs-util manage the bn types


[1]: https://github.com/ethereumjs/ethereumjs-monorepo/search?p=1&q=bn.js
[2]: https://github.com/ethereumjs/ethereumjs-util/blob/b100d13f827a3d495d3de85f3e5d6756749b514f/package.json#L88