### PR TITLE
VM, Block: large ChainID ecrecover fixes

### DIFF
--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -13,7 +13,6 @@ import {
   toBuffer,
   unpadBuffer,
   zeros,
-  bufferToInt,
 } from 'ethereumjs-util'
 import { HeaderData, JsonHeader, BlockHeaderBuffer, Blockchain, BlockOptions } from './types'
 import {
@@ -716,7 +715,7 @@ export class BlockHeader {
     }
     const r = extraSeal.slice(0, 32)
     const s = extraSeal.slice(32, 64)
-    const v = bufferToInt(extraSeal.slice(64, 65)) + 27
+    const v = new BN(extraSeal.slice(64, 65)).addn(27)
     const pubKey = ecrecover(this.cliqueSigHash(), v, r, s)
     return Address.fromPublicKey(pubKey)
   }

--- a/packages/vm/lib/evm/precompiles/01-ecrecover.ts
+++ b/packages/vm/lib/evm/precompiles/01-ecrecover.ts
@@ -21,7 +21,7 @@ export default function (opts: PrecompileInput): ExecResult {
 
   let publicKey
   try {
-    publicKey = ecrecover(msgHash, new BN(v).toNumber(), r, s)
+    publicKey = ecrecover(msgHash, new BN(v), r, s)
   } catch (e) {
     return {
       gasUsed,


### PR DESCRIPTION
Two more fixes when using ecrecover on large chain IDs:

- VM `ECRECOVER` precompile
- Block cliqueSigner() address recovery