### PR TITLE
Update ethereum-tests submodule to 8.0.0 / Remove EIP-2315 from berlin

### DIFF
--- a/packages/common/src/chains/goerli.json
+++ b/packages/common/src/chains/goerli.json
@@ -70,8 +70,8 @@
     },
     {
       "name": "berlin",
-      "block": null,
-      "forkHash": null
+      "block": 4460644,
+      "forkHash": "0x757a1c47"
     }
   ],
   "bootstrapNodes": [

--- a/packages/common/src/chains/mainnet.json
+++ b/packages/common/src/chains/mainnet.json
@@ -72,8 +72,8 @@
     },
     {
       "name": "berlin",
-      "block": null,
-      "forkHash": null
+      "block": 12244000,
+      "forkHash": "0xeb440f6"
     }
   ],
   "bootstrapNodes": [

--- a/packages/common/src/chains/rinkeby.json
+++ b/packages/common/src/chains/rinkeby.json
@@ -70,8 +70,8 @@
     },
     {
       "name": "berlin",
-      "block": null,
-      "forkHash": null
+      "block": 8290928,
+      "forkHash": "0x6910c8bd"
     }
   ],
   "bootstrapNodes": [

--- a/packages/common/src/chains/ropsten.json
+++ b/packages/common/src/chains/ropsten.json
@@ -72,8 +72,8 @@
     },
     {
       "name": "berlin",
-      "block": null,
-      "forkHash": null
+      "block": 9812189,
+      "forkHash": "0xa157d377"
     }
   ],
   "bootstrapNodes": [

--- a/packages/common/src/hardforks/berlin.json
+++ b/packages/common/src/hardforks/berlin.json
@@ -3,5 +3,5 @@
   "comment": "HF targeted for July 2020 following the Muir Glacier HF",
   "url": "https://eips.ethereum.org/EIPS/eip-2070",
   "status": "Draft",
-  "eips": [ 2315, 2565, 2929, 2718, 2930 ]
+  "eips": [ 2565, 2929, 2718, 2930 ]
 }

--- a/packages/common/tests/eips.spec.ts
+++ b/packages/common/tests/eips.spec.ts
@@ -52,7 +52,8 @@ tape('[Common]: Initialization / Chain params', function (t: tape.Test) {
     c = new Common({ chain: 'rinkeby', hardfork: 'istanbul', eips: [2315] })
     st.equal(c.isActivatedEIP(2315), true, 'istanbul, eips: [2315] -> true (EIP-2315)')
     c = new Common({ chain: 'rinkeby', hardfork: 'berlin' })
-    st.equal(c.isActivatedEIP(2315), true, 'berlin, eips: [] -> true (EIP-2315)')
+    st.equal(c.isActivatedEIP(2929), true, 'berlin, eips: [] -> true (EIP-2929)')
+    st.equal(c.isActivatedEIP(2315), false, 'berlin, eips: [] -> true (EIP-2315)')
     st.equal(c.isActivatedEIP(2537), false, 'berlin, eips: [] -> false (EIP-2537)')
 
     st.end()

--- a/packages/common/tests/hardforks.spec.ts
+++ b/packages/common/tests/hardforks.spec.ts
@@ -34,7 +34,8 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     st.equal(c.getHardforkByBlockNumber(1150000), 'homestead', msg)
     st.equal(c.getHardforkByBlockNumber(1400000), 'homestead', msg)
     st.equal(c.getHardforkByBlockNumber(9200000), 'muirGlacier', msg)
-    st.equal(c.getHardforkByBlockNumber(999999999999), 'muirGlacier', msg)
+    st.equal(c.getHardforkByBlockNumber(12244000), 'berlin', msg)
+    st.equal(c.getHardforkByBlockNumber(999999999999), 'berlin', msg)
 
     msg = 'should set HF correctly'
 
@@ -42,8 +43,8 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     st.equal(c.setHardforkByBlockNumber(1149999), 'chainstart', msg)
     st.equal(c.setHardforkByBlockNumber(1150000), 'homestead', msg)
     st.equal(c.setHardforkByBlockNumber(1400000), 'homestead', msg)
-    st.equal(c.setHardforkByBlockNumber(9200000), 'muirGlacier', msg)
-    st.equal(c.setHardforkByBlockNumber(999999999999), 'muirGlacier', msg)
+    st.equal(c.setHardforkByBlockNumber(12244000), 'berlin', msg)
+    st.equal(c.setHardforkByBlockNumber(999999999999), 'berlin', msg)
 
     c = new Common({ chain: 'ropsten' })
     st.equal(c.setHardforkByBlockNumber(0), 'tangerineWhistle', msg)
@@ -107,8 +108,8 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     msg = 'should return correct next HF (rinkeby: byzantium -> constantinople)'
     st.equal(c.nextHardforkBlock('byzantium'), 3660663, msg)
 
-    msg = 'should return null if next HF is not available (rinkeby: istanbul -> berlin)'
-    st.equal(c.nextHardforkBlock('istanbul'), null, msg)
+    msg = 'should return null if next HF is not available (rinkeby: berlin -> london)'
+    st.equal(c.nextHardforkBlock('berlin'), null, msg)
 
     msg =
       'should work correctly along the need to skip several forks (ropsten: chainstart -> (homestead) -> (dao) -> (tangerineWhistle) -> spuriousDragon)'
@@ -142,8 +143,8 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
 
   t.test('activeHardforks()', function (st: tape.Test) {
     let c = new Common({ chain: 'ropsten' })
-    let msg = 'should return 9 active hardforks for Ropsten'
-    st.equal(c.activeHardforks().length, 9, msg)
+    let msg = 'should return 10 active hardforks for Ropsten'
+    st.equal(c.activeHardforks().length, 10, msg)
 
     msg = 'should return the correct HF data for Ropsten'
     st.equal(c.activeHardforks()[3]['name'], 'spuriousDragon', msg)
@@ -169,24 +170,24 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     st.equal(c.activeHardforks(null, { onlySupported: true }).length, 2, msg)
 
     c = new Common({ chain: 'mainnet' })
-    msg = 'should return 10 active HFs for mainnet'
-    st.equal(c.activeHardforks().length, 10, msg)
+    msg = 'should return 11 active HFs for mainnet'
+    st.equal(c.activeHardforks().length, 11, msg)
 
     c = new Common({ chain: 'rinkeby' })
-    msg = 'should return 8 active HFs for rinkeby'
-    st.equal(c.activeHardforks().length, 8, msg)
+    msg = 'should return 9 active HFs for rinkeby'
+    st.equal(c.activeHardforks().length, 9, msg)
 
     c = new Common({ chain: 'goerli' })
-    msg = 'should return 8 active HFs for goerli'
-    st.equal(c.activeHardforks().length, 8, msg)
+    msg = 'should return 9 active HFs for goerli'
+    st.equal(c.activeHardforks().length, 9, msg)
 
     st.end()
   })
 
   t.test('activeHardfork()', function (st: tape.Test) {
     let c = new Common({ chain: 'ropsten' })
-    let msg = 'should return muirGlacier as latest active HF for Ropsten'
-    st.equal(c.activeHardfork(), 'muirGlacier', msg)
+    let msg = 'should return berlin as latest active HF for Ropsten'
+    st.equal(c.activeHardfork(), 'berlin', msg)
 
     msg = 'should return spuriousDragon as latest active HF for Ropsten for block 10'
     st.equal(c.activeHardfork(10), 'spuriousDragon', msg)
@@ -199,8 +200,8 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     st.equal(c.activeHardfork(null, { onlySupported: true }), 'spuriousDragon', msg)
 
     c = new Common({ chain: 'rinkeby' })
-    msg = 'should return Istanbul as latest active HF for Rinkeby'
-    st.equal(c.activeHardfork(), 'istanbul', msg)
+    msg = 'should return berlin as latest active HF for Rinkeby'
+    st.equal(c.activeHardfork(), 'berlin', msg)
 
     st.end()
   })

--- a/packages/common/tests/params.spec.ts
+++ b/packages/common/tests/params.spec.ts
@@ -14,8 +14,6 @@ tape('[Common]: Parameter access for param(), paramByHardfork()', function (t: t
     st.equal(c.param('gasPrices', 'ecAdd'), 150, msg)
     c.setHardfork('muirGlacier')
     st.equal(c.param('gasPrices', 'ecAdd'), 150, msg)
-    c.setHardfork('berlin')
-    st.equal(c.param('gasPrices', 'beginsub'), 2, msg)
 
     msg = 'Should return null for non-existing value'
     st.equal(c.param('gasPrices', 'notexistingvalue'), null, msg)

--- a/packages/vm/lib/evm/opcodes/codes.ts
+++ b/packages/vm/lib/evm/opcodes/codes.ts
@@ -240,12 +240,15 @@ const hardforkOpcodes = [
       0x47: { name: 'SELFBALANCE', isAsync: false }, // EIP 1884
     },
   },
+]
+
+const eipOpcodes = [
   {
-    hardforkName: 'berlin',
+    eip: 2315,
     opcodes: {
-      0x5c: { name: 'BEGINSUB', isAsync: false }, // EIP 2315
-      0x5d: { name: 'RETURNSUB', isAsync: false }, // EIP 2315
-      0x5e: { name: 'JUMPSUB', isAsync: false }, // EIP 2315
+      0x5c: { name: 'BEGINSUB', isAsync: false },
+      0x5d: { name: 'RETURNSUB', isAsync: false },
+      0x5e: { name: 'JUMPSUB', isAsync: false },
     },
   },
 ]
@@ -286,6 +289,11 @@ export function getOpcodesForHF(common: Common): OpcodeList {
   for (let fork = 0; fork < hardforkOpcodes.length; fork++) {
     if (common.gteHardfork(hardforkOpcodes[fork].hardforkName)) {
       opcodeBuilder = { ...opcodeBuilder, ...hardforkOpcodes[fork].opcodes }
+    }
+  }
+  for (const eipOps of eipOpcodes) {
+    if (common.isActivatedEIP(eipOps.eip)) {
+      opcodeBuilder = { ...opcodeBuilder, ...eipOps.opcodes }
     }
   }
 

--- a/packages/vm/lib/index.ts
+++ b/packages/vm/lib/index.ts
@@ -40,8 +40,9 @@ export interface VMOpts {
    *
    * ### Supported EIPs
    *
+   * - [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) - VM simple subroutines
    * - [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) (`experimental`) - BLS12-381 precompiles
-   * - [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929) (`experimental`) - Gas cost increases for state access opcodes
+   * - [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929) - Gas cost increases for state access opcodes
    *
    * *Annotations:*
    *
@@ -163,7 +164,7 @@ export default class VM extends AsyncEventEmitter {
 
     if (opts.common) {
       //EIPs
-      const supportedEIPs = [2537, 2565, 2718, 2929, 2930]
+      const supportedEIPs = [2315, 2537, 2565, 2718, 2929, 2930]
       for (const eip of opts.common.eips()) {
         if (!supportedEIPs.includes(eip)) {
           throw new Error(`${eip} is not supported by the VM`)

--- a/packages/vm/tests/api/EIPs/eip-2315.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-2315.spec.ts
@@ -4,7 +4,7 @@ import VM from '../../../lib'
 import Common from '@ethereumjs/common'
 
 tape('Berlin: EIP 2315 tests', (t) => {
-  const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
+  const common = new Common({ chain: 'mainnet', hardfork: 'berlin', eips: [2315] })
 
   const runTest = async function (test: any, st: tape.Test) {
     let i = 0

--- a/packages/vm/tests/api/opcodes.spec.ts
+++ b/packages/vm/tests/api/opcodes.spec.ts
@@ -4,6 +4,7 @@ import VM from '../../lib'
 
 tape('VM -> getActiveOpcodes()', (t) => {
   const CHAINID = 0x46 //istanbul opcode
+  const BEGINSUB = 0x5c // EIP-2315 opcode
 
   t.test('should not expose opcodes from a follow-up HF (istanbul -> petersburg)', (st) => {
     const common = new Common({ chain: 'mainnet', hardfork: 'petersburg' })
@@ -31,6 +32,26 @@ tape('VM -> getActiveOpcodes()', (t) => {
       vm.getActiveOpcodes().get(CHAINID)!.name,
       'CHAINID',
       'istanbul opcode exposed (HF: > istanbul (muirGlacier)'
+    )
+
+    st.end()
+  })
+
+  t.test('should expose opcodes when EIP is active', (st) => {
+    let common = new Common({ chain: 'mainnet', hardfork: 'istanbul', eips: [2315] })
+    let vm = new VM({ common })
+    st.equal(
+      vm.getActiveOpcodes().get(BEGINSUB)!.name,
+      'BEGINSUB',
+      'EIP-2315 opcode BEGINSUB exposed (EIP-2315 activated)'
+    )
+
+    common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    vm = new VM({ common })
+    st.equal(
+      vm.getActiveOpcodes().get(BEGINSUB),
+      undefined,
+      'EIP-2315 opcode BEGINSUB not exposed (EIP-2315 not activated)'
     )
 
     st.end()


### PR DESCRIPTION
This is a simple PR which updates the `ethereum-tests` submodule to the `Berlin` release [8.0.0](https://github.com/ethereum/tests/releases/tag/8.0.0) with a removed `EIP-2315` HF. `EIP-2315` is also removed here in `Common` in the `berlin` HF definition file.

I originally also wanted to add the block numbers for `berlin` along this PR. But I don't trust these numbers yet since the `Ropsten` HF would be so close and there is no corresponding `go-ethereum` release out yet, see also https://github.com/ethereum/pm/issues/248#issuecomment-792573651.