### PR TITLE
Tx: Small fixes and improvements

### DIFF
--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -149,12 +149,14 @@ export class Block {
   }
 
   /**
-   *  Returns a Buffer Array of the raw Buffers of this block, in order.
+   * Returns a Buffer Array of the raw Buffers of this block, in order.
    */
   raw(): BlockBuffer {
     return [
       this.header.raw(),
-      this.transactions.map((tx) => <Buffer[]>tx.raw()),
+      this.transactions.map((tx) =>
+        'transactionType' in tx && tx.transactionType > 0 ? tx.serialize() : tx.raw()
+      ) as Buffer[],
       this.uncleHeaders.map((uh) => uh.raw()),
     ]
   }

--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -100,7 +100,10 @@ export interface BlockData {
 export type BlockBuffer = [BlockHeaderBuffer, TransactionsBuffer, UncleHeadersBuffer]
 export type BlockHeaderBuffer = Buffer[]
 export type BlockBodyBuffer = [TransactionsBuffer, UncleHeadersBuffer]
-export type TransactionsBuffer = Buffer[][]
+/**
+ * TransactionsBuffer can be an array of serialized txs for Typed Transactions or an array of Buffer Arrays for legacy transactions.
+ */
+export type TransactionsBuffer = Buffer[][] | Buffer[]
 export type UncleHeadersBuffer = Buffer[][]
 
 /**

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -194,8 +194,8 @@ export class Config {
     // TODO: map chainParams (and lib/util.parseParams) to new Common format
     const common =
       options.common ?? new Common({ chain: Config.CHAIN_DEFAULT, hardfork: 'chainstart' })
-    this.chainCommon = Object.assign(Object.create(Object.getPrototypeOf(common)), common)
-    this.execCommon = Object.assign(Object.create(Object.getPrototypeOf(common)), common)
+    this.chainCommon = common.copy()
+    this.execCommon = common.copy()
 
     this.discDns = this.getDnsDiscovery(options.discDns)
     this.discV4 = this.getV4Discovery(options.discV4)

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -742,4 +742,11 @@ export default class Common extends EventEmitter {
   consensusConfig(): any {
     return (<any>this._chainParams)['consensus'][this.consensusAlgorithm()]
   }
+
+  /**
+   * Returns a deep copy of this common instance.
+   */
+  copy(): Common {
+    return Object.assign(Object.create(Object.getPrototypeOf(this)), this)
+  }
 }

--- a/packages/tx/.eslintrc.js
+++ b/packages/tx/.eslintrc.js
@@ -1,7 +1,8 @@
 module.exports = {
-  extends: "@ethereumjs/eslint-config-defaults",
-  ignorePatterns: ["examples", "karma.conf.js", "test-build"],
+  extends: '@ethereumjs/eslint-config-defaults',
+  ignorePatterns: ['examples', 'karma.conf.js', 'test-build'],
   rules: {
-    "@typescript-eslint/no-unnecessary-condition": "off"
-  }
+    '@typescript-eslint/no-unnecessary-condition': 'off',
+    'no-dupe-class-members': 'off',
+  },
 }

--- a/packages/tx/examples/ropsten-tx.ts
+++ b/packages/tx/examples/ropsten-tx.ts
@@ -7,7 +7,7 @@ const txData = toBuffer(
 )
 
 const common = new Common({ chain: 'ropsten', hardfork: 'petersburg' })
-const tx = Transaction.fromRlpSerializedTx(txData, { common })
+const tx = Transaction.fromSerializedTx(txData, { common })
 
 if (
   tx.validate() &&

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -37,14 +37,12 @@ export abstract class BaseTransaction<TransactionObject> {
     this.r = r ? new BN(toBuffer(r)) : undefined
     this.s = s ? new BN(toBuffer(s)) : undefined
 
-    const validateCannotExceedMaxInteger = {
+    this._validateCannotExceedMaxInteger({
       nonce: this.nonce,
       gasPrice: this.gasPrice,
       gasLimit: this.gasLimit,
       value: this.value,
-    }
-
-    this._validateExceedsMaxInteger(validateCannotExceedMaxInteger)
+    })
 
     this.common = txOptions.common?.copy() ?? new Common({ chain: 'mainnet' })
   }
@@ -192,9 +190,9 @@ export abstract class BaseTransaction<TransactionObject> {
   // Accept the v,r,s values from the `sign` method, and convert this into a TransactionObject
   protected abstract _processSignature(v: number, r: Buffer, s: Buffer): TransactionObject
 
-  protected _validateExceedsMaxInteger(validateCannotExceedMaxInteger: { [key: string]: BN }) {
-    for (const [key, value] of Object.entries(validateCannotExceedMaxInteger)) {
-      if (value && value.gt(MAX_INTEGER)) {
+  protected _validateCannotExceedMaxInteger(values: { [key: string]: BN | undefined }) {
+    for (const [key, value] of Object.entries(values)) {
+      if (value?.gt(MAX_INTEGER)) {
         throw new Error(`${key} cannot exceed MAX_INTEGER, given ${value}`)
       }
     }

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -46,10 +46,7 @@ export abstract class BaseTransaction<TransactionObject> {
 
     this._validateExceedsMaxInteger(validateCannotExceedMaxInteger)
 
-    this.common =
-      (txOptions.common &&
-        Object.assign(Object.create(Object.getPrototypeOf(txOptions.common)), txOptions.common)) ??
-      new Common({ chain: 'mainnet' })
+    this.common = txOptions.common?.copy() ?? new Common({ chain: 'mainnet' })
   }
 
   /**

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -8,7 +8,7 @@ import {
   ecsign,
   publicToAddress,
 } from 'ethereumjs-util'
-import { TxData, TxOptions, JsonTx } from './types'
+import { TxData, TxOptions, JsonTx, AccessListEIP2930ValuesArray } from './types'
 
 export abstract class BaseTransaction<TransactionObject> {
   public readonly nonce: BN
@@ -114,7 +114,7 @@ export abstract class BaseTransaction<TransactionObject> {
   /**
    * Returns a Buffer Array of the raw Buffers of this transaction, in order.
    */
-  abstract raw(): Buffer[]
+  abstract raw(): Buffer[] | AccessListEIP2930ValuesArray
 
   /**
    * Returns the encoding of the transaction.

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -61,11 +61,8 @@ export abstract class BaseTransaction<TransactionObject> {
    * (DataFee + TxFee + Creation Fee).
    */
   validate(): boolean
-  /* eslint-disable-next-line no-dupe-class-members */
   validate(stringError: false): boolean
-  /* eslint-disable-next-line no-dupe-class-members */
   validate(stringError: true): string[]
-  /* eslint-disable-next-line no-dupe-class-members */
   validate(stringError: boolean = false): boolean | string[] {
     const errors = []
 
@@ -185,13 +182,8 @@ export abstract class BaseTransaction<TransactionObject> {
     if (privateKey.length !== 32) {
       throw new Error('Private key must be 32 bytes in length.')
     }
-
     const msgHash = this.getMessageToSign()
-
-    // Only `v` is reassigned.
-    /* eslint-disable-next-line prefer-const */
-    let { v, r, s } = ecsign(msgHash, privateKey)
-
+    const { v, r, s } = ecsign(msgHash, privateKey)
     return this._processSignature(v, r, s)
   }
 

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -112,19 +112,9 @@ export abstract class BaseTransaction<TransactionObject> {
   }
 
   /**
-   * Returns the raw `Buffer[]` (Transaction) or `Buffer` (typed transaction).
-   * This is the data which is found in the transactions of the block body.
-   *
-   * Note that if you want to use this function in a tx type independent way
-   * to then use the raw data output for tx instantiation with
-   * `Tx.fromValuesArray()` you should set the `asList` parameter to `true` -
-   * which is ignored on a legacy tx but provides the correct format on
-   * a typed tx.
-   *
-   * To prepare a tx to be added as block data with `Block.fromValuesArray()`
-   * just use the plain `raw()` method.
+   * Returns a Buffer Array of the raw Buffers of this transaction, in order.
    */
-  abstract raw(asList: boolean): Buffer[] | Buffer
+  abstract raw(): Buffer[]
 
   /**
    * Returns the encoding of the transaction.

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -108,7 +108,7 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
 
     const [chainId, nonce, gasPrice, gasLimit, to, value, data, accessList, v, r, s] = <
       AccessListEIP2930ValuesArray
-      >values
+    >values
     const emptyBuffer = Buffer.from([])
 
     return new AccessListEIP2930Transaction(

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -82,12 +82,12 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
 
   /**
    * Instantiate a transaction from the serialized tx.
-   * (alias of fromSerializedTx())
+   * (alias of `fromSerializedTx()`)
    *
    * Note: This means that the Buffer should start with 0x01.
    *
    * @deprecated this constructor alias is deprecated and will be removed
-   * in favor of the from SerializedTx() constructor
+   * in favor of the `fromSerializedTx() constructor
    */
   public static fromRlpSerializedTx(serialized: Buffer, opts: TxOptions = {}) {
     return AccessListEIP2930Transaction.fromSerializedTx(serialized, opts)

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -87,7 +87,7 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
    * Note: This means that the Buffer should start with 0x01.
    *
    * @deprecated this constructor alias is deprecated and will be removed
-   * in favor of the `fromSerializedTx() constructor
+   * in favor of the `fromSerializedTx()` constructor
    */
   public static fromRlpSerializedTx(serialized: Buffer, opts: TxOptions = {}) {
     return AccessListEIP2930Transaction.fromSerializedTx(serialized, opts)
@@ -143,7 +143,7 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
       throw new Error('EIP-2930 not enabled on Common')
     }
 
-    // check the type of AccessList. If it's a JSON-type, we have to convert it to a buffer.
+    // check the type of AccessList. If it's a JSON-type, we have to convert it to a Buffer.
     let usedAccessList
     if (accessList && isAccessList(accessList)) {
       this.AccessListJSON = accessList

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -108,15 +108,6 @@ export default class Transaction extends BaseTransaction<Transaction> {
 
   /**
    * Returns a Buffer Array of the raw Buffers of this transaction, in order.
-   *
-   * Note that if you want to use this function in a tx type independent way
-   * to then use the raw data output for tx instantiation with
-   * `Tx.fromValuesArray()` you should set the `asList` parameter to `true` -
-   * which is ignored on a legacy tx but provides the correct format on
-   * a typed tx.
-   *
-   * To prepare a tx to be added as block data with `Block.fromValuesArray()`
-   * just use the plain `raw()` method.
    */
   raw(): Buffer[] {
     return [

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -42,10 +42,10 @@ export default class Transaction extends BaseTransaction<Transaction> {
 
   /**
    * Instantiate a transaction from the serialized tx.
-   * (alias of fromSerializedTx())
+   * (alias of `fromSerializedTx()`)
    *
    * @deprecated this constructor alias is deprecated and will be removed
-   * in favor of the from SerializedTx() constructor
+   * in favor of the `fromSerializedTx()` constructor
    */
   public static fromRlpSerializedTx(serialized: Buffer, opts: TxOptions = {}) {
     return Transaction.fromSerializedTx(serialized, opts)

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -96,16 +96,7 @@ export default class Transaction extends BaseTransaction<Transaction> {
   public constructor(txData: TxData, opts: TxOptions = {}) {
     super(txData, opts)
 
-    const validateCannotExceedMaxInteger = {
-      r: this.r ?? new BN(0),
-      s: this.s ?? new BN(0),
-    }
-
-    this._validateExceedsMaxInteger(validateCannotExceedMaxInteger)
-
-    if (this.v) {
-      this._validateTxV(this.v)
-    }
+    this._validateCannotExceedMaxInteger({ r: this.r, s: this.s })
 
     this._validateTxV(this.v)
 

--- a/packages/tx/src/transactionFactory.ts
+++ b/packages/tx/src/transactionFactory.ts
@@ -63,9 +63,9 @@ export default class TransactionFactory {
         )
       }
 
-      return AccessListEIP2930Transaction.fromRlpSerializedTx(rawData, txOptions)
+      return AccessListEIP2930Transaction.fromSerializedTx(rawData, txOptions)
     } else {
-      return Transaction.fromRlpSerializedTx(rawData, txOptions)
+      return Transaction.fromSerializedTx(rawData, txOptions)
     }
   }
 

--- a/packages/tx/src/transactionFactory.ts
+++ b/packages/tx/src/transactionFactory.ts
@@ -74,15 +74,22 @@ export default class TransactionFactory {
    * A Buffer[] (Legacy Transaction)
    * This method returns the right transaction.
    *
-   * @param rawData - Either a Buffer or a Buffer[]
+   * @param data - A Buffer or Buffer[]
    * @param txOptions - The transaction options
    */
-  public static fromBlockBodyData(rawData: Buffer | Buffer[], txOptions: TxOptions = {}) {
-    if (Buffer.isBuffer(rawData)) {
-      return this.fromRawData(rawData, txOptions)
-    } else if (Array.isArray(rawData)) {
-      // It is a legacy transaction
-      return Transaction.fromValuesArray(rawData, txOptions)
+  public static fromBlockBodyData(data: Buffer | Buffer[], txOptions: TxOptions = {}) {
+    if (Buffer.isBuffer(data)) {
+      return this.fromSerializedData(data, txOptions)
+    } else if (Array.isArray(data)) {
+      if (data.length === 6 || data.length === 9) {
+        // It is a legacy transaction
+        return Transaction.fromValuesArray(data, txOptions)
+      } else if (data.length === 8 || data.length === 11) {
+        // It is an Access List Transaction
+        return AccessListEIP2930Transaction.fromValuesArray(data, txOptions)
+      } else {
+        throw new Error('Cannot decode transaction: unknown array length')
+      }
     } else {
       throw new Error('Cannot decode transaction: unknown type input')
     }

--- a/packages/tx/src/transactionFactory.ts
+++ b/packages/tx/src/transactionFactory.ts
@@ -81,15 +81,8 @@ export default class TransactionFactory {
     if (Buffer.isBuffer(data)) {
       return this.fromSerializedData(data, txOptions)
     } else if (Array.isArray(data)) {
-      if (data.length === 6 || data.length === 9) {
-        // It is a legacy transaction
-        return Transaction.fromValuesArray(data, txOptions)
-      } else if (data.length === 8 || data.length === 11) {
-        // It is an Access List Transaction
-        return AccessListEIP2930Transaction.fromValuesArray(data, txOptions)
-      } else {
-        throw new Error('Cannot decode transaction: unknown array length')
-      }
+      // It is a legacy transaction
+      return Transaction.fromValuesArray(data, txOptions)
     } else {
       throw new Error('Cannot decode transaction: unknown type input')
     }

--- a/packages/tx/src/transactionFactory.ts
+++ b/packages/tx/src/transactionFactory.ts
@@ -34,37 +34,37 @@ export default class TransactionFactory {
   }
 
   /**
-   * This method tries to decode `raw` data. It is somewhat equivalent to `fromSerializedTx`, however it could be that the data is not directly RLP-encoded (it is a Typed Transaction)
+   * This method tries to decode serialized data.
    *
-   * @param rawData - The raw data buffer
+   * @param data - The data Buffer
    * @param txOptions - The transaction options
    */
-  public static fromRawData(rawData: Buffer, txOptions: TxOptions = {}): TypedTransaction {
+  public static fromSerializedData(data: Buffer, txOptions: TxOptions = {}): TypedTransaction {
     const common = txOptions.common ?? DEFAULT_COMMON
-    if (rawData[0] <= 0x7f) {
+    if (data[0] <= 0x7f) {
       // It is an EIP-2718 Typed Transaction
       if (!common.isActivatedEIP(2718)) {
         throw new Error('Common support for TypedTransactions (EIP-2718) not activated')
       }
       // Determine the type.
       let EIP: number
-      switch (rawData[0]) {
+      switch (data[0]) {
         case 1:
           EIP = 2930
           break
         default:
-          throw new Error(`TypedTransaction with ID ${rawData[0]} unknown`)
+          throw new Error(`TypedTransaction with ID ${data[0]} unknown`)
       }
 
       if (!common.isActivatedEIP(EIP)) {
         throw new Error(
-          `Cannot create TypedTransaction with ID ${rawData[0]}: EIP ${EIP} not activated`
+          `Cannot create TypedTransaction with ID ${data[0]}: EIP ${EIP} not activated`
         )
       }
 
-      return AccessListEIP2930Transaction.fromSerializedTx(rawData, txOptions)
+      return AccessListEIP2930Transaction.fromSerializedTx(data, txOptions)
     } else {
-      return Transaction.fromSerializedTx(rawData, txOptions)
+      return Transaction.fromSerializedTx(data, txOptions)
     }
   }
 

--- a/packages/tx/src/transactionFactory.ts
+++ b/packages/tx/src/transactionFactory.ts
@@ -1,8 +1,8 @@
+import { BN } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { default as Transaction } from './legacyTransaction'
 import { default as AccessListEIP2930Transaction } from './eip2930Transaction'
 import { TxOptions, TypedTransaction, TxData, AccessListEIP2930TxData } from './types'
-import { BN } from 'ethereumjs-util'
 
 const DEFAULT_COMMON = new Common({ chain: 'mainnet' })
 
@@ -13,7 +13,7 @@ export default class TransactionFactory {
   /**
    * Create a transaction from a `txData` object
    *
-   * @param txData - The transaction data. The `type` field will determine which transaction type is returned (if undefined, create a Transaction)
+   * @param txData - The transaction data. The `type` field will determine which transaction type is returned (if undefined, creates a legacy transaction)
    * @param txOptions - Options to pass on to the constructor of the transaction
    */
   public static fromTxData(
@@ -22,7 +22,7 @@ export default class TransactionFactory {
   ): TypedTransaction {
     const common = txOptions.common ?? DEFAULT_COMMON
     if (!('type' in txData) || txData.type === undefined) {
-      // Assume Transaction
+      // Assume legacy transaction
       return Transaction.fromTxData(<TxData>txData, txOptions)
     } else {
       const txType = new BN(txData.type).toNumber()
@@ -34,8 +34,7 @@ export default class TransactionFactory {
   }
 
   /**
-   * This method tries to decode `raw` data. It is somewhat equivalent to `fromRlpSerializedTx`.
-   * However, it could be that the data is not directly RLP-encoded (it is a Typed Transaction)
+   * This method tries to decode `raw` data. It is somewhat equivalent to `fromSerializedTx`, however it could be that the data is not directly RLP-encoded (it is a Typed Transaction)
    *
    * @param rawData - The raw data buffer
    * @param txOptions - The transaction options
@@ -72,7 +71,7 @@ export default class TransactionFactory {
   /**
    * When decoding a BlockBody, in the transactions field, a field is either:
    * A Buffer (a TypedTransaction - encoded as TransactionType || rlp(TransactionPayload))
-   * A Buffer[] (Transaction)
+   * A Buffer[] (Legacy Transaction)
    * This method returns the right transaction.
    *
    * @param rawData - Either a Buffer or a Buffer[]
@@ -82,7 +81,7 @@ export default class TransactionFactory {
     if (Buffer.isBuffer(rawData)) {
       return this.fromRawData(rawData, txOptions)
     } else if (Array.isArray(rawData)) {
-      // It is a Transaction
+      // It is a legacy transaction
       return Transaction.fromValuesArray(rawData, txOptions)
     } else {
       throw new Error('Cannot decode transaction: unknown type input')
@@ -91,7 +90,7 @@ export default class TransactionFactory {
 
   /**
    * This helper method allows one to retrieve the class which matches the transactionID
-   * If transactionID is undefined, return the Transaction class.
+   * If transactionID is undefined, returns the legacy transaction class.
    *
    * @param transactionID
    * @param common

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -1,4 +1,4 @@
-import { AddressLike, BNLike, BufferLike } from 'ethereumjs-util'
+import { BN, AddressLike, BNLike, BufferLike } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { default as Transaction } from './legacyTransaction'
 import { default as AccessListEIP2930Transaction } from './eip2930Transaction'
@@ -128,6 +128,23 @@ export interface AccessListEIP2930TxData extends TxData {
   type?: BNLike
 }
 
+/**
+ * Buffer values array for EIP2930 transaction
+ */
+export type AccessListEIP2930ValuesArray = [
+  Buffer,
+  Buffer,
+  Buffer,
+  Buffer,
+  Buffer,
+  Buffer,
+  Buffer,
+  AccessListBuffer,
+  Buffer?,
+  Buffer?,
+  Buffer?
+]
+
 type JsonAccessListItem = { address: string; storageKeys: string[] }
 
 /**
@@ -147,3 +164,11 @@ export interface JsonTx {
   accessList?: JsonAccessListItem[]
   type?: string
 }
+
+/**
+ * A const defining secp256k1n/2
+ */
+export const N_DIV_2 = new BN(
+  '7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0',
+  16
+)

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -31,15 +31,21 @@ export interface TxOptions {
   freeze?: boolean
 }
 
+/*
+ * Access List types
+ */
+
 export type AccessListItem = {
   address: string
   storageKeys: string[]
 }
 
+/*
+ * An Access List as a tuple of [address: Buffer, storageKeys: Buffer[]]
+ */
 export type AccessListBufferItem = [Buffer, Buffer[]]
-
-export type AccessList = AccessListItem[]
 export type AccessListBuffer = AccessListBufferItem[]
+export type AccessList = AccessListItem[]
 
 export function isAccessListBuffer(
   input: AccessListBuffer | AccessList

--- a/packages/tx/test/base.spec.ts
+++ b/packages/tx/test/base.spec.ts
@@ -89,10 +89,10 @@ tape('[BaseTransaction]', function (t) {
         `${txType.name}: tx should not be frozen when freeze deactivated in options`
       )
 
-      tx = txType.class.fromValuesArray(txType.values, { common })
+      tx = txType.class.fromValuesArray(txType.values as any, { common })
       st.ok(Object.isFrozen(tx), `${txType.name}: tx should be frozen by default`)
 
-      tx = txType.class.fromValuesArray(txType.values, { common, freeze: false })
+      tx = txType.class.fromValuesArray(txType.values as any, { common, freeze: false })
       st.ok(
         !Object.isFrozen(tx),
         `${txType.name}: tx should not be frozen when freeze deactivated in options`

--- a/packages/tx/test/base.spec.ts
+++ b/packages/tx/test/base.spec.ts
@@ -121,7 +121,7 @@ tape('[BaseTransaction]', function (t) {
     for (const txType of txTypes) {
       txType.txs.forEach(function (tx: any) {
         st.ok(
-          txType.class.fromValuesArray(tx.raw(true), { common }),
+          txType.class.fromValuesArray(tx.raw(), { common }),
           `${txType.name}: should do roundtrip raw() -> fromValuesArray()`
         )
       })

--- a/packages/tx/test/base.spec.ts
+++ b/packages/tx/test/base.spec.ts
@@ -80,10 +80,10 @@ tape('[BaseTransaction]', function (t) {
       tx = txType.class.fromTxData({}, { common, freeze: false })
       const rlpData = tx.serialize()
 
-      tx = txType.class.fromRlpSerializedTx(rlpData, { common })
+      tx = txType.class.fromSerializedTx(rlpData, { common })
       st.ok(Object.isFrozen(tx), `${txType.name}: tx should be frozen by default`)
 
-      tx = txType.class.fromRlpSerializedTx(rlpData, { common, freeze: false })
+      tx = txType.class.fromSerializedTx(rlpData, { common, freeze: false })
       st.ok(
         !Object.isFrozen(tx),
         `${txType.name}: tx should not be frozen when freeze deactivated in options`
@@ -105,12 +105,12 @@ tape('[BaseTransaction]', function (t) {
     for (const txType of txTypes) {
       txType.txs.forEach(function (tx: any) {
         st.ok(
-          txType.class.fromRlpSerializedTx(tx.serialize(), { common }),
-          `${txType.name}: should do roundtrip serialize() -> fromRlpSerializedTx()`
+          txType.class.fromSerializedTx(tx.serialize(), { common }),
+          `${txType.name}: should do roundtrip serialize() -> fromSerializedTx()`
         )
         st.ok(
           txType.class.fromSerializedTx(tx.serialize(), { common }),
-          `${txType.name}: should do roundtrip serialize() -> fromRlpSerializedTx()`
+          `${txType.name}: should do roundtrip serialize() -> fromSerializedTx()`
         )
       })
     }

--- a/packages/tx/test/legacy.spec.ts
+++ b/packages/tx/test/legacy.spec.ts
@@ -55,7 +55,7 @@ tape('[Transaction]', function (t) {
       const privKey = Buffer.from(txFixtures[0].privateKey, 'hex')
       tx = tx.sign(privKey)
       const serialized = tx.serialize()
-      st.throws(() => Transaction.fromRlpSerializedTx(serialized))
+      st.throws(() => Transaction.fromSerializedTx(serialized))
       st.end()
     }
   )
@@ -131,7 +131,7 @@ tape('[Transaction]', function (t) {
     const s1 = tx.serialize()
 
     const s1Rlp = toBuffer('0x' + s1.toString('hex'))
-    const tx2 = Transaction.fromRlpSerializedTx(s1Rlp)
+    const tx2 = Transaction.fromSerializedTx(s1Rlp)
     const s2 = tx2.serialize()
 
     st.ok(s1.equals(s2))
@@ -182,7 +182,7 @@ tape('[Transaction]', function (t) {
     "getMessageToSign(), getSenderPublicKey() (implicit call) -> verify EIP155 signature based on Vitalik's tests",
     function (st) {
       txFixturesEip155.forEach(function (tx) {
-        const pt = Transaction.fromRlpSerializedTx(toBuffer(tx.rlp))
+        const pt = Transaction.fromSerializedTx(toBuffer(tx.rlp))
         st.equal(pt.getMessageToSign().toString('hex'), tx.hash)
         st.equal('0x' + pt.serialize().toString('hex'), tx.rlp)
         st.equal(pt.getSenderAddress().toString(), '0x' + tx.sender)
@@ -359,7 +359,7 @@ tape('[Transaction]', function (t) {
 
     const serialized = tx.serialize()
 
-    const reTx = Transaction.fromRlpSerializedTx(serialized, { common })
+    const reTx = Transaction.fromSerializedTx(serialized, { common })
     st.equal(reTx.verifySignature(), true)
     st.equal(reTx.common.chainId(), 42)
 
@@ -394,11 +394,11 @@ tape('[Transaction]', function (t) {
     const rawSigned = tx.serialize()
     st.ok(tx.isSigned())
 
-    tx = Transaction.fromRlpSerializedTx(rawUnsigned)
+    tx = Transaction.fromSerializedTx(rawUnsigned)
     st.notOk(tx.isSigned())
     tx = tx.sign(privateKey)
     st.ok(tx.isSigned())
-    tx = Transaction.fromRlpSerializedTx(rawSigned)
+    tx = Transaction.fromSerializedTx(rawSigned)
     st.ok(tx.isSigned())
 
     const signedValues = (rlp.decode(rawSigned) as any) as Buffer[]

--- a/packages/tx/test/transactionFactory.spec.ts
+++ b/packages/tx/test/transactionFactory.spec.ts
@@ -86,7 +86,7 @@ tape('[TransactionFactory]: Basic functions', function (t) {
 
   t.test('should decode raw block body data', function (st) {
     const rawLegacy = simpleSignedTransaction.raw()
-    const rawEIP2930 = simpleSignedAccessListEIP2930Transaction.raw()
+    const rawEIP2930 = simpleSignedAccessListEIP2930Transaction.serialize()
 
     const legacyTx = TransactionFactory.fromBlockBodyData(rawLegacy)
     const eip2930Tx = TransactionFactory.fromBlockBodyData(rawEIP2930, { common: EIP2930Common })

--- a/packages/tx/test/transactionFactory.spec.ts
+++ b/packages/tx/test/transactionFactory.spec.ts
@@ -26,12 +26,12 @@ const simpleSignedTransaction = simpleUnsignedTransaction.sign(pKey)
 tape('[TransactionFactory]: Basic functions', function (t) {
   t.test('should return the right type', function (st) {
     const serialized = simpleUnsignedAccessListEIP2930Transaction.serialize()
-    const factoryTx = TransactionFactory.fromRawData(serialized, { common: EIP2930Common })
+    const factoryTx = TransactionFactory.fromSerializedData(serialized, { common: EIP2930Common })
     st.equals(factoryTx.constructor.name, AccessListEIP2930Transaction.name)
 
     const legacyTx = Transaction.fromTxData({})
     const serializedLegacyTx = legacyTx.serialize()
-    const factoryLegacyTx = TransactionFactory.fromRawData(serializedLegacyTx, {})
+    const factoryLegacyTx = TransactionFactory.fromSerializedData(serializedLegacyTx, {})
     st.equals(factoryLegacyTx.constructor.name, Transaction.name)
 
     st.end()
@@ -41,7 +41,10 @@ tape('[TransactionFactory]: Basic functions', function (t) {
     'should throw when trying to create EIP-2718 typed transactions when not allowed in Common',
     function (st) {
       st.throws(() => {
-        TransactionFactory.fromRawData(simpleUnsignedAccessListEIP2930Transaction.serialize(), {})
+        TransactionFactory.fromSerializedData(
+          simpleUnsignedAccessListEIP2930Transaction.serialize(),
+          {}
+        )
       })
       st.end()
     }
@@ -53,7 +56,7 @@ tape('[TransactionFactory]: Basic functions', function (t) {
       st.throws(() => {
         const serialized = simpleUnsignedAccessListEIP2930Transaction.serialize()
         serialized[0] = 2 // edit the transaction type
-        TransactionFactory.fromRawData(serialized, { common: EIP2930Common })
+        TransactionFactory.fromSerializedData(serialized, { common: EIP2930Common })
       })
       st.end()
     }

--- a/packages/tx/test/transactionRunner.ts
+++ b/packages/tx/test/transactionRunner.ts
@@ -46,7 +46,7 @@ tape('TransactionTests', (t) => {
               const rawTx = toBuffer(testData.rlp)
               const hardfork = forkNameMap[forkName]
               const common = new Common({ chain: 1, hardfork })
-              const tx = Transaction.fromRlpSerializedTx(rawTx, { common })
+              const tx = Transaction.fromSerializedTx(rawTx, { common })
 
               const sender = tx.getSenderAddress().toString()
               const hash = tx.hash().toString('hex')


### PR DESCRIPTION
This PR applies a few small fixes and improvements to the new tx library with EIP2718 and 2930 support:

* `AccessListEIP2930Transaction` - removes `asList` parameter in `raw()`, preferring to use `serialize()`
* `TransactionFactory` - for clarity, renames `fromRawData` to `fromSerializedData`
* For clarity, renames `_validateExceedsMaxInteger(validateCannotExceedMaxInteger)` to `_validateCannotExceedMaxInteger(values)`
* Renames internal usage of `fromRlpSerializedTx` to `fromSerializedTx`
* Introduces `common.copy()` for easier deep copy functionality.