### PR TITLE
Client: split CLI transports options for bootnodes and multiaddrs

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -213,7 +213,7 @@ listener. The second client will use libp2p to connect to the first client.
 Run the first client and start downloading blocks:
 
 ```
-ethereumjs --syncmode full --lightserv true  --datadir first --network rinkeby --transports rlpx libp2p:multiaddrs=/ip4/127.0.0.1/tcp/50505/ws
+ethereumjs --syncmode full --lightserv true  --datadir first --network rinkeby --transports rlpx libp2p --multiaddrs /ip4/127.0.0.1/tcp/50505/ws
 ```
 
 Output:
@@ -230,10 +230,10 @@ Copy the libp2p URL from the output. In this example, the url is `/ip4/127.0.0.1
 Wait until a few thousand blocks are downloaded and then run the second client in a new terminal, using the url above to connect to the first client:
 
 <pre>
-ethereumjs --syncmode light --network rinkeby --datadir second --transports libp2p:multiaddrs=/ip4/0.0.0.0/tcp/50506,bootnodes=<b>/ip4/127.0.0.1/tcp/50505/ws/p2p/QmYAuYxw6QX1x5aafs6g3bUrPbMDifP5pDun3N9zbVLpEa</b>
+ethereumjs --syncmode light --network rinkeby --datadir second --transports libp2p --multiaddrs /ip4/0.0.0.0/tcp/50506 --bootnodes=<b>/ip4/127.0.0.1/tcp/50505/ws/p2p/QmYAuYxw6QX1x5aafs6g3bUrPbMDifP5pDun3N9zbVLpEa</b>
 </pre>
 
-Notice that we have to run the second client on port 50506 using the `multiaddrs=/ip4/0.0.0.0/tcp/50506` libp2p option to avoid port conflicts.
+Notice that we have to run the second client on port 50506 using the `--multiaddrs /ip4/0.0.0.0/tcp/50506` libp2p option to avoid port conflicts.
 
 ### Example 2: Light sync from within a browser
 

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -2,7 +2,7 @@
 
 import { Server as RPCServer } from 'jayson/promise'
 import Common from '@ethereumjs/common'
-import { parseParams } from '../lib/util'
+import { parseParams, parseMultiaddrs } from '../lib/util'
 import EthereumClient from '../lib/client'
 import { Config } from '../lib/config'
 import { Logger } from '../lib/logging'
@@ -44,6 +44,14 @@ const args = require('yargs')
     transports: {
       describe: 'Network transports',
       default: Config.TRANSPORTS_DEFAULT,
+      array: true,
+    },
+    bootnodes: {
+      describe: 'Network bootnodes',
+      array: true,
+    },
+    multiaddrs: {
+      describe: 'Network multiaddrs',
       array: true,
     },
     rpc: {
@@ -173,6 +181,8 @@ async function run() {
     lightserv: args.lightserv,
     datadir: args.datadir,
     transports: args.transports,
+    bootnodes: args.bootnodes ? parseMultiaddrs(args.bootnodes) : undefined,
+    multiaddrs: args.multiaddrs ? parseMultiaddrs(args.multiaddrs) : undefined,
     rpc: args.rpc,
     rpcport: args.rpcport,
     rpcaddr: args.rpcaddr,
@@ -203,4 +213,5 @@ async function run() {
   })
 }
 
-run().catch((err) => logger!.error(err))
+// eslint-disable-next-line no-console
+run().catch((err) => logger?.error(err) ?? console.error(err))

--- a/packages/client/lib/util/parse.ts
+++ b/packages/client/lib/util/parse.ts
@@ -5,6 +5,9 @@ import { SecureTrie as Trie } from 'merkle-patricia-tree'
 import { Account, BN, keccak, rlp, toBuffer, unpadBuffer, isHexPrefixed } from 'ethereumjs-util'
 import { MultiaddrLike } from '../types'
 
+/**
+ * Parses multiaddrs and bootnodes to multiaddr format.
+ */
 export function parseMultiaddrs(input: MultiaddrLike): multiaddr[] {
   if (!input) {
     return []


### PR DESCRIPTION
This PR splits the CLI transports options for bootnodes and multiaddrs. Closes https://github.com/ethereumjs/ethereumjs-monorepo/issues/1069.