### PR TITLE
Make genesis params settable for any hardfork in block headers

### DIFF
--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -209,11 +209,6 @@ export class BlockHeader {
     }
 
     if (options.initWithGenesisHeader) {
-      if (this._common.hardfork() !== 'chainstart') {
-        throw new Error(
-          'Genesis parameters can only be set with a Common instance set to chainstart'
-        )
-      }
       number = new BN(0)
       if (gasLimit.eq(DEFAULT_GAS_LIMIT)) {
         gasLimit = new BN(toBuffer(this._common.genesis().gasLimit))


### PR DESCRIPTION
PR removes a restriction introduced in #863 that disallows commons with custom genesis settings unless their hardforks are set to `chainstart`. 

This is blocking integration of the `block` module in the Hardhat testrpc because they set a custom common with special gas limits, chainId, etc as an initial step on launch, but need to run on arbitrary hardforks.

https://github.com/nomiclabs/hardhat/blob/579d44a105d6a8323d270ea55876c6694c212316/packages/hardhat-core/src/internal/hardhat-network/provider/utils/makeCommon.ts#L20-L42

Perhaps this restriction should be preserved but gated behind a flag - not sure. Am opening in the simplest form for further discussion.  