### PR TITLE
Client: small BN fixes

### DIFF
--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -136,7 +136,7 @@ export class EthProtocol extends Protocol {
   encodeStatus(): any {
     // TODO: add latestBlock for more precise ETH/64 forkhash switch
     return {
-      networkId: this.chain.networkId.toNumber(),
+      networkId: this.chain.networkId.toArrayLike(Buffer),
       td: this.chain.blocks.td.toArrayLike(Buffer),
       bestHash: this.chain.blocks.latest!.hash(),
       genesisHash: this.chain.genesis.hash,

--- a/packages/client/lib/net/protocol/lesprotocol.ts
+++ b/packages/client/lib/net/protocol/lesprotocol.ts
@@ -174,10 +174,10 @@ export class LesProtocol extends Protocol {
     }
 
     return {
-      networkId: this.chain.networkId.toNumber(),
+      networkId: this.chain.networkId.toArrayLike(Buffer),
       headTd: this.chain.headers.td.toArrayLike(Buffer),
       headHash: this.chain.headers.latest?.hash(),
-      headNum: this.chain.headers.latest?.number,
+      headNum: this.chain.headers.latest?.number.toArrayLike(Buffer),
       genesisHash: this.chain.genesis.hash,
       ...serveOptions,
     }

--- a/packages/client/lib/rpc/modules/admin.ts
+++ b/packages/client/lib/rpc/modules/admin.ts
@@ -43,10 +43,10 @@ export class Admin {
     // TODO version not present in reference..
     // const ethVersion = Math.max.apply(Math, this._ethProtocol.versions)
     const latestHeader = await this._chain.getLatestHeader()
-    const difficulty = latestHeader.difficulty
+    const difficulty = latestHeader.difficulty.toString()
     const genesis = bufferToHex(this._chain.genesis.hash)
     const head = bufferToHex(latestHeader.mixHash)
-    const network = this._chain.networkId.toNumber()
+    const network = this._chain.networkId.toString()
 
     const nodeInfo = {
       name: clientName,

--- a/packages/client/test/net/protocol/ethprotocol.spec.ts
+++ b/packages/client/test/net/protocol/ethprotocol.spec.ts
@@ -50,7 +50,7 @@ tape('[EthProtocol]', (t) => {
     t.deepEquals(
       p.encodeStatus(),
       {
-        networkId: 1,
+        networkId: Buffer.from('01', 'hex'),
         td: Buffer.from('64', 'hex'),
         bestHash: '0xaa',
         genesisHash: '0xbb',

--- a/packages/client/test/net/protocol/lesprotocol.spec.ts
+++ b/packages/client/test/net/protocol/lesprotocol.spec.ts
@@ -65,10 +65,10 @@ tape('[LesProtocol]', (t) => {
     })
     let status = p.encodeStatus()
     t.ok(
-      status.networkId === 1 &&
+      status.networkId.toString('hex') === '01' &&
         status.headTd.toString('hex') === '64' &&
         status.headHash === '0xaa' &&
-        status.headNum.toNumber() === 100 &&
+        status.headNum.toString('hex') === '64' &&
         status.genesisHash === '0xbb' &&
         status.serveHeaders === 1 &&
         status.serveChainSince === 0 &&


### PR DESCRIPTION
This PR is a follow-up to #1150 that fixes some BN cases where toNumber should not be used in case of large number network ids like yolov3.