### PR TITLE
VM: Add vm.buildBlock() and BlockBuilder API

### DIFF
--- a/packages/block/test/clique.spec.ts
+++ b/packages/block/test/clique.spec.ts
@@ -80,19 +80,15 @@ tape('[Header]: Clique PoA Functionality', function (t) {
   t.test('Signing', function (st) {
     const cliqueSigner = A.privateKey
 
-    let header = BlockHeader.fromHeaderData(
-      { number: 1, extraData: Buffer.alloc(97) },
-      { common, freeze: false, cliqueSigner }
-    )
+    let header = BlockHeader.fromHeaderData({ number: 1 }, { common, freeze: false, cliqueSigner })
 
     st.equal(header.extraData.length, 97)
     st.ok(header.cliqueVerifySignature([A.address]), 'should verify signature')
     st.ok(header.cliqueSigner().equals(A.address), 'should recover the correct signer address')
 
     header = BlockHeader.fromHeaderData({}, { common })
-    st.deepEqual(
-      header.cliqueSigner(),
-      Address.zero(),
+    st.ok(
+      header.cliqueSigner().equals(Address.zero()),
       'should return zero address on default block'
     )
 

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+## New Block Builder
+
+This release includes a new Block Builder API for creating new blocks on top of the current state by adding transactions one at a time.
+
+It can be used like the following:
+
+```typescript
+const blockBuilder = await vm.buildBlock({ parentBlock, blockData, blockOpts })
+const txResult = await blockBuilder.addTransaction(tx)
+// reset the state with `blockBuilder.revert()`
+const block = await blockBuilder.build()
+```
+
+When the block is built it becomes fully executed in the vm and its blockchain.
+
 ## 5.2.0 - 2021-03-18
 
 ### Berlin HF Support

--- a/packages/vm/karma.conf.js
+++ b/packages/vm/karma.conf.js
@@ -20,10 +20,7 @@ module.exports = function (config) {
     },
 
     karmaTypescriptConfig: {
-      compilerOptions: {
-        resolveJsonModule: true,
-        esModuleInterop: true,
-      },
+      tsconfig: './tsconfig.json',
       bundlerOptions: {
         entrypoints: /\.spec\.ts$/,
       },

--- a/packages/vm/lib/buildBlock.ts
+++ b/packages/vm/lib/buildBlock.ts
@@ -71,7 +71,7 @@ export class BlockBuilder {
   /**
    * Throws if the block has already been built or reverted.
    */
-  checkStatus() {
+  private checkStatus() {
     if (this.built) {
       throw new Error('Block has already been built')
     }

--- a/packages/vm/lib/buildBlock.ts
+++ b/packages/vm/lib/buildBlock.ts
@@ -1,0 +1,250 @@
+import { Address, BN, toBuffer } from 'ethereumjs-util'
+import { encode } from 'rlp'
+import { BaseTrie as Trie } from 'merkle-patricia-tree'
+import { TypedTransaction } from '@ethereumjs/tx'
+import { Block, BlockOptions, HeaderData } from '@ethereumjs/block'
+import VM from '.'
+import { RunTxResult } from './runTx'
+import Bloom from './bloom'
+import { generateTxReceipt, calculateMinerReward, rewardAccount } from './runBlock'
+
+/**
+ * Options for building a block.
+ */
+export interface BuildBlockOpts {
+  /**
+   * The parent block
+   */
+  parentBlock: Block
+
+  /**
+   * The block header data to use.
+   * Defaults used for any values not provided.
+   */
+  headerData?: HeaderData
+
+  /**
+   * The block options to use.
+   */
+  blockOpts?: BlockOptions
+}
+
+/**
+ * Options for sealing a block.
+ */
+export interface SealBlockOpts {
+  /**
+   * For PoW, the nonce.
+   * Overrides the value passed in the constructor.
+   */
+  nonce?: Buffer
+
+  /**
+   * For PoW, the mixHash.
+   * Overrides the value passed in the constructor.
+   */
+  mixHash?: Buffer
+
+  /**
+   * For PoW, the difficulty.
+   * Overrides the value passed in the constructor.
+   */
+  difficulty?: BN
+
+  /**
+   * For PoA, the private key for the clique signer.
+   * Overrides the value passed in the constructor.
+   * If not provided, the block will not be sealed.
+   */
+  cliqueSigner?: Buffer
+}
+
+export class BlockBuilder {
+  private readonly vm: VM
+  private blockOpts: BlockOptions
+  private headerData: HeaderData
+  private transactions: TypedTransaction[] = []
+  private transactionResults: RunTxResult[] = []
+  private checkpointed = false
+  private reverted = false
+  private built = false
+
+  constructor(vm: VM, opts: BuildBlockOpts) {
+    this.vm = vm
+    this.blockOpts = { ...opts.blockOpts, common: this.vm._common }
+
+    this.headerData = {
+      ...opts.headerData,
+      parentHash: opts.headerData?.parentHash ?? opts.parentBlock.hash(),
+      number: opts.headerData?.number ?? opts.parentBlock.header.number.addn(1),
+      gasLimit: opts.headerData?.gasLimit ?? opts.parentBlock.header.gasLimit,
+    }
+  }
+
+  /**
+   * Throws if the block has already been built or reverted.
+   */
+  checkStatus() {
+    if (this.built) {
+      throw new Error('Block has already been built, please use a new BlockBuilder')
+    }
+    if (this.reverted) {
+      throw new Error('State has already been reverted, please use a new BlockBuilder')
+    }
+  }
+
+  /**
+   * Returns the cumulative gas used by the transactions added to the block.
+   */
+  gasUsed(): BN {
+    return this.transactionResults.reduce(
+      (accumulator: BN, result: RunTxResult) => accumulator.iadd(result.gasUsed),
+      new BN(0)
+    )
+  }
+
+  /**
+   * Calculates and returns the transactionsTrie for the block.
+   */
+  private async transactionsTrie() {
+    const trie = new Trie()
+    for (const [i, tx] of this.transactions.entries()) {
+      await trie.put(encode(i), tx.serialize())
+    }
+    return trie.root
+  }
+
+  /**
+   * Calculates and returns the logs bloom for the block.
+   */
+  private bloom() {
+    const bloom = new Bloom()
+    for (const txResult of this.transactionResults) {
+      // Combine blooms via bitwise OR
+      bloom.or(txResult.bloom)
+    }
+    return bloom.bitvector
+  }
+
+  /**
+   * Calculates and returns the receiptTrie for the block.
+   */
+  private async receiptTrie() {
+    const gasUsed = new BN(0)
+    const receiptTrie = new Trie()
+    for (const [i, txResult] of this.transactionResults.entries()) {
+      const tx = this.transactions[i]
+      gasUsed.iadd(txResult.gasUsed)
+      const { encodedReceipt } = await generateTxReceipt.bind(this.vm)(tx, txResult, gasUsed)
+      await receiptTrie.put(encode(i), encodedReceipt)
+    }
+    return receiptTrie.root
+  }
+
+  /**
+   * Rewards the miner.
+   */
+  private async rewardMiner() {
+    const minerReward = new BN(this.vm._common.param('pow', 'minerReward'))
+    const reward = calculateMinerReward(minerReward, 0)
+    const coinbase = this.headerData.coinbase
+      ? new Address(toBuffer(this.headerData.coinbase))
+      : Address.zero()
+    await rewardAccount(this.vm.stateManager, coinbase, reward)
+  }
+
+  /**
+   * Run and add a transaction to the block being built.
+   * Please note that this modifies the state of the VM.
+   * Throws if the transaction's gasLimit is greater than
+   * the remaining gas in the block.
+   */
+  async addTransaction(tx: TypedTransaction) {
+    this.checkStatus()
+
+    if (!this.checkpointed) {
+      await this.vm.stateManager.checkpoint()
+      this.checkpointed = true
+    }
+
+    // According to the Yellow Paper, a transaction's gas limit
+    // cannot be greater than the remaining gas in the block
+    const blockGasLimit = new BN(toBuffer(this.headerData.gasLimit))
+    const blockGasRemaining = blockGasLimit.sub(this.gasUsed())
+    if (tx.gasLimit.gt(blockGasRemaining)) {
+      throw new Error('tx has a higher gas limit than the remaining gas in the block')
+    }
+
+    const result = await this.vm.runTx({ tx })
+    this.transactions.push(tx)
+    this.transactionResults.push(result)
+    return result
+  }
+
+  /**
+   * Reverts the checkpoint on the StateManager to reset the state from any transactions that have been run.
+   */
+  async revert() {
+    this.checkStatus()
+    if (this.checkpointed) {
+      await this.vm.stateManager.revert()
+      this.reverted = true
+    }
+  }
+
+  /**
+   * This method returns the finalized block.
+   * It also:
+   *  - Assigns the reward for miner
+   *  - Commits the checkpoint on the StateManager
+   *  - Sets the tip of the VM's blockchain to this block
+   * Optionally seals the block with params:
+   *  - PoW: nonce, mixHash, and difficulty validated with the block number by ethash
+   *  - PoA: seals the block with the private key of the clique signer if provided
+   */
+  async build(sealOpts?: SealBlockOpts) {
+    this.checkStatus()
+    const blockOpts = this.blockOpts
+    const consensusType = this.vm._common.consensusType()
+
+    await this.rewardMiner()
+    await this.vm.stateManager.commit()
+
+    const stateRoot = await this.vm.stateManager.getStateRoot(false)
+    const transactionsTrie = await this.transactionsTrie()
+    const receiptTrie = await this.receiptTrie()
+    const bloom = this.bloom()
+    const gasUsed = this.gasUsed()
+    const timestamp = this.headerData.timestamp ?? Date.now()
+
+    const headerData = {
+      ...this.headerData,
+      stateRoot,
+      transactionsTrie,
+      receiptTrie,
+      bloom,
+      gasUsed,
+      timestamp,
+    }
+
+    if (consensusType === 'pow') {
+      headerData.nonce = sealOpts?.nonce ?? headerData.nonce
+      headerData.mixHash = sealOpts?.mixHash ?? headerData.mixHash
+      headerData.difficulty = sealOpts?.difficulty ?? headerData.difficulty
+    } else if (consensusType === 'poa') {
+      blockOpts.cliqueSigner = sealOpts?.cliqueSigner ?? blockOpts.cliqueSigner
+    } else {
+      throw new Error(`Unsupported consensus type: ${consensusType}`)
+    }
+
+    const blockData = { header: headerData, transactions: this.transactions }
+    const block = Block.fromBlockData(blockData, blockOpts)
+    await this.vm.blockchain.putBlock(block)
+    this.built = true
+    return block
+  }
+}
+
+export default async function buildBlock(this: VM, opts: BuildBlockOpts): Promise<BlockBuilder> {
+  return new BlockBuilder(this, opts)
+}

--- a/packages/vm/lib/buildBlock.ts
+++ b/packages/vm/lib/buildBlock.ts
@@ -80,10 +80,10 @@ export class BlockBuilder {
    */
   checkStatus() {
     if (this.built) {
-      throw new Error('Block has already been built, please use a new BlockBuilder')
+      throw new Error('Block has already been built')
     }
     if (this.reverted) {
-      throw new Error('State has already been reverted, please use a new BlockBuilder')
+      throw new Error('State has already been reverted')
     }
   }
 

--- a/packages/vm/lib/buildBlock.ts
+++ b/packages/vm/lib/buildBlock.ts
@@ -215,7 +215,7 @@ export class BlockBuilder {
     const receiptTrie = await this.receiptTrie()
     const bloom = this.bloom()
     const gasUsed = this.gasUsed()
-    const timestamp = this.headerData.timestamp ?? Date.now()
+    const timestamp = this.headerData.timestamp ?? Date.now() / 1000
 
     const headerData = {
       ...this.headerData,

--- a/packages/vm/lib/buildBlock.ts
+++ b/packages/vm/lib/buildBlock.ts
@@ -136,7 +136,7 @@ export class BlockBuilder {
   }
 
   /**
-   * Rewards the miner.
+   * Adds the block miner reward to the coinbase account.
    */
   private async rewardMiner() {
     const minerReward = new BN(this.vm._common.param('pow', 'minerReward'))
@@ -169,9 +169,13 @@ export class BlockBuilder {
       throw new Error('tx has a higher gas limit than the remaining gas in the block')
     }
 
-    const result = await this.vm.runTx({ tx })
+    const block = Block.fromBlockData({ header: this.headerData, transactions: this.transactions })
+
+    const result = await this.vm.runTx({ tx, block })
+
     this.transactions.push(tx)
     this.transactionResults.push(result)
+
     return result
   }
 

--- a/packages/vm/lib/buildBlock.ts
+++ b/packages/vm/lib/buildBlock.ts
@@ -46,12 +46,6 @@ export interface SealBlockOpts {
   mixHash?: Buffer
 
   /**
-   * For PoW, the difficulty.
-   * Overrides the value passed in the constructor.
-   */
-  difficulty?: BN
-
-  /**
    * For PoA, the private key for the clique signer.
    * Overrides the value passed in the constructor.
    * If not provided, the block will not be sealed.
@@ -199,7 +193,7 @@ export class BlockBuilder {
    *  - Commits the checkpoint on the StateManager
    *  - Sets the tip of the VM's blockchain to this block
    * Optionally seals the block with params:
-   *  - PoW: nonce, mixHash, and difficulty validated with the block number by ethash
+   *  - PoW: nonce and mixHash validated with the block number by ethash
    *  - PoA: seals the block with the private key of the clique signer if provided
    */
   async build(sealOpts?: SealBlockOpts) {
@@ -230,7 +224,6 @@ export class BlockBuilder {
     if (consensusType === 'pow') {
       headerData.nonce = sealOpts?.nonce ?? headerData.nonce
       headerData.mixHash = sealOpts?.mixHash ?? headerData.mixHash
-      headerData.difficulty = sealOpts?.difficulty ?? headerData.difficulty
     } else if (consensusType === 'poa') {
       blockOpts.cliqueSigner = sealOpts?.cliqueSigner ?? blockOpts.cliqueSigner
     } else {

--- a/packages/vm/lib/index.ts
+++ b/packages/vm/lib/index.ts
@@ -7,6 +7,7 @@ import { default as runCode, RunCodeOpts } from './runCode'
 import { default as runCall, RunCallOpts } from './runCall'
 import { default as runTx, RunTxOpts, RunTxResult } from './runTx'
 import { default as runBlock, RunBlockOpts, RunBlockResult } from './runBlock'
+import { default as buildBlock, BuildBlockOpts, BlockBuilder } from './buildBlock'
 import { EVMResult, ExecResult } from './evm/evm'
 import { OpcodeList, getOpcodesForHF } from './evm/opcodes'
 import { precompiles } from './evm/precompiles'
@@ -328,6 +329,25 @@ export default class VM extends AsyncEventEmitter {
   async runCode(opts: RunCodeOpts): Promise<ExecResult> {
     await this.init()
     return runCode.bind(this)(opts)
+  }
+
+  /**
+   * Build a block on top of the current state
+   * by adding one transaction at a time.
+   *
+   * Creates a checkpoint on the StateManager and modifies the state
+   * as transactions are run. The checkpoint is committed on `build()`
+   * or discarded with `revert()`.
+   *
+   * @param {BuildBlockOpts} opts
+   * @returns An instance of [[BlockBuilder]] with methods:
+   * - `addTransaction(tx): RunTxResult`
+   * - `build(sealOpts): Block`
+   * - `revert()`
+   */
+  async buildBlock(opts: BuildBlockOpts): Promise<BlockBuilder> {
+    await this.init()
+    return buildBlock.bind(this)(opts)
   }
 
   /**

--- a/packages/vm/lib/runBlock.ts
+++ b/packages/vm/lib/runBlock.ts
@@ -212,10 +212,11 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
     const receiptTrie = result.receiptRoot
     const transactionsTrie = await _genTxTrie(block)
     const generatedFields = { stateRoot, bloom, gasUsed, receiptTrie, transactionsTrie }
-    block = Block.fromBlockData({
+    const blockData = {
       ...block,
       header: { ...block.header, ...generatedFields },
-    })
+    }
+    block = Block.fromBlockData(blockData, { common: this._common })
   } else {
     if (result.receiptRoot && !result.receiptRoot.equals(block.header.receiptTrie)) {
       debug(

--- a/packages/vm/tests/api/buildBlock.spec.ts
+++ b/packages/vm/tests/api/buildBlock.spec.ts
@@ -17,6 +17,7 @@ tape('BlockBuilder', async (t) => {
 
     const blockBuilder = await vm.buildBlock({
       parentBlock: genesisBlock,
+      headerData: { coinbase: '0x96dc73c8b5969608c77375f085949744b5177660' },
       blockOpts: { calcDifficultyFromHeader: genesisBlock.header, freeze: false },
     })
 

--- a/packages/vm/tests/api/buildBlock.spec.ts
+++ b/packages/vm/tests/api/buildBlock.spec.ts
@@ -57,11 +57,12 @@ tape('BlockBuilder', async (t) => {
     const tx = Transaction.fromTxData({ gasLimit }, { common })
     try {
       await blockBuilder.addTransaction(tx)
+      st.fail('should throw error')
     } catch (error) {
       if (error.message.includes('tx has a higher gas limit than the remaining gas in the block')) {
-        st.pass('error thrown')
+        st.pass('correct error thrown')
       } else {
-        st.fail('should throw')
+        st.fail('wrong error thrown')
       }
     }
     st.end()

--- a/packages/vm/tests/api/buildBlock.spec.ts
+++ b/packages/vm/tests/api/buildBlock.spec.ts
@@ -1,0 +1,111 @@
+import tape from 'tape'
+import { Address } from 'ethereumjs-util'
+import Common from '@ethereumjs/common'
+import VM from '../../lib'
+import { Block } from '@ethereumjs/block'
+import { Transaction } from '@ethereumjs/tx'
+import Blockchain from '@ethereumjs/blockchain'
+
+tape('BlockBuilder', async (t) => {
+  t.test('should build a valid block', async (st) => {
+    const common = new Common({ chain: 'mainnet' })
+    const genesisBlock = Block.genesis({ header: { gasLimit: 50000 } }, { common })
+    const blockchain = await Blockchain.create({ genesisBlock, validateConsensus: false })
+    const vm = await VM.create({ common, blockchain })
+    await vm.stateManager.generateCanonicalGenesis()
+    const vmCopy = vm.copy()
+
+    const blockBuilder = await vm.buildBlock({
+      parentBlock: genesisBlock,
+      blockOpts: { calcDifficultyFromHeader: genesisBlock.header, freeze: false },
+    })
+
+    // Set up tx
+    const tx = Transaction.fromTxData(
+      { to: Address.zero(), value: 1000, gasLimit: 21000, gasPrice: 1 },
+      { common, freeze: false }
+    )
+    // set `from` to a genesis address with existing balance
+    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
+    tx.getSenderAddress = () => {
+      return address
+    }
+
+    await blockBuilder.addTransaction(tx)
+    const block = await blockBuilder.build()
+
+    // block should successfully execute with VM.runBlock and have same outputs
+    block.transactions[0].getSenderAddress = () => {
+      return address
+    }
+    const result = await vmCopy.runBlock({ block })
+    st.ok(result.gasUsed.eq(block.header.gasUsed))
+    st.ok(result.receiptRoot.equals(block.header.receiptTrie))
+    st.ok(result.stateRoot.equals(block.header.stateRoot))
+    st.ok(result.logsBloom.equals(block.header.bloom))
+    st.end()
+  })
+
+  t.test('should throw if adding a transaction exceeds the block gas limit', async (st) => {
+    const common = new Common({ chain: 'mainnet' })
+    const vm = await VM.create({ common })
+    const genesis = Block.genesis({}, { common })
+
+    const blockBuilder = await vm.buildBlock({ parentBlock: genesis })
+    const gasLimit = genesis.header.gasLimit.addn(1)
+    const tx = Transaction.fromTxData({ gasLimit }, { common })
+    try {
+      await blockBuilder.addTransaction(tx)
+    } catch (error) {
+      if (error.message.includes('tx has a higher gas limit than the remaining gas in the block')) {
+        st.pass('error thrown')
+      } else {
+        st.fail('should throw')
+      }
+    }
+    st.end()
+  })
+
+  t.test('should revert the VM state if reverted', async (st) => {
+    const common = new Common({ chain: 'mainnet' })
+    const genesisBlock = Block.genesis({ header: { gasLimit: 50000 } }, { common })
+    const blockchain = await Blockchain.create({ genesisBlock, validateConsensus: false })
+    const vm = await VM.create({ common, blockchain })
+    await vm.stateManager.generateCanonicalGenesis()
+
+    const root0 = await vm.stateManager.getStateRoot()
+
+    const blockBuilder = await vm.buildBlock({ parentBlock: genesisBlock })
+
+    // Set up tx
+    const tx = Transaction.fromTxData(
+      { to: Address.zero(), value: 1000, gasLimit: 21000, gasPrice: 1 },
+      { common, freeze: false }
+    )
+    // set `from` to a genesis address with existing balance
+    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
+    tx.getSenderAddress = () => {
+      return address
+    }
+
+    await blockBuilder.addTransaction(tx)
+
+    const root1 = await vm.stateManager.getStateRoot(true)
+    st.ok(!root0.equals(root1), 'state root should change after adding a tx')
+
+    await blockBuilder.revert()
+    const root2 = await vm.stateManager.getStateRoot()
+
+    st.ok(root2.equals(root0), 'state root should revert to before the tx was run')
+    st.end()
+  })
+  t.test('should correctly seal a PoW block', (st) => {
+    st.end()
+  })
+  t.test('should correctly seal a PoA block', (st) => {
+    st.end()
+  })
+  t.test('should throw on invalid PoW', (st) => {
+    st.end()
+  })
+})

--- a/packages/vm/tests/api/runBlock.spec.ts
+++ b/packages/vm/tests/api/runBlock.spec.ts
@@ -1,12 +1,12 @@
 import tape from 'tape'
-import { Address, BN, rlp } from 'ethereumjs-util'
+import { Address, BN, rlp, KECCAK256_RLP } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import { Transaction } from '@ethereumjs/tx'
-import { PostByzantiumTxReceipt, PreByzantiumTxReceipt } from '../../lib/runBlock'
+import { RunBlockOpts, AfterBlockEvent } from '../../lib/runBlock'
+import { setupPreConditions, getDAOCommon } from '../util'
 import { setupVM, createAccount } from './utils'
 import testnet from './testdata/testnet.json'
-import { setupPreConditions, getDAOCommon } from '../util'
 import VM from '../../lib/index'
 
 const testData = require('./testdata/blockchain.json')
@@ -262,6 +262,53 @@ tape('runBlock() -> runtime behavior', async (t) => {
   })
 })
 
+async function runBlockAndGetAfterBlockEvent(
+  vm: VM,
+  runBlockOpts: RunBlockOpts
+): Promise<AfterBlockEvent> {
+  let results: AfterBlockEvent
+  function handler(event: AfterBlockEvent) {
+    results = event
+  }
+
+  try {
+    vm.once('afterBlock', handler)
+    await vm.runBlock(runBlockOpts)
+  } finally {
+    // We need this in case `runBlock` throws before emitting the event.
+    // Otherwise we'd be leaking the listener until the next call to runBlock.
+    vm.removeListener('afterBlock', handler)
+  }
+
+  return results!
+}
+
+tape('should correctly reflect generated fields', async (t) => {
+  const vm = new VM()
+
+  // We create a block with a receiptTrie and transactionsTrie
+  // filled with 0s and no txs. Once we run it we should
+  // get a receipt trie root of for the empty receipts set,
+  // which is a well known constant.
+  const buffer32Zeros = Buffer.alloc(32, 0)
+  const block = Block.fromBlockData({
+    header: { receiptTrie: buffer32Zeros, transactionsTrie: buffer32Zeros, gasUsed: new BN(1) },
+  })
+
+  const results = await runBlockAndGetAfterBlockEvent(vm, {
+    block,
+    generate: true,
+    skipBlockValidation: true,
+  })
+
+  t.ok(results.block.header.receiptTrie.equals(KECCAK256_RLP))
+  t.ok(results.block.header.transactionsTrie.equals(KECCAK256_RLP))
+  t.ok(results.block.header.gasUsed.eqn(0))
+
+  t.end()
+})
+
+/*
 async function runWithHf(hardfork: string) {
   const vm = setupVM({ common: new Common({ chain: 'mainnet', hardfork }) })
 
@@ -299,3 +346,4 @@ tape('runBlock() -> API return values', async (t) => {
     t.end()
   })
 })
+*/

--- a/packages/vm/tests/api/runBlock.spec.ts
+++ b/packages/vm/tests/api/runBlock.spec.ts
@@ -3,7 +3,12 @@ import { Address, BN, rlp, KECCAK256_RLP } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import { Transaction } from '@ethereumjs/tx'
-import { RunBlockOpts, AfterBlockEvent } from '../../lib/runBlock'
+import {
+  PreByzantiumTxReceipt,
+  PostByzantiumTxReceipt,
+  RunBlockOpts,
+  AfterBlockEvent,
+} from '../../lib/runBlock'
 import { setupPreConditions, getDAOCommon } from '../util'
 import { setupVM, createAccount } from './utils'
 import testnet from './testdata/testnet.json'
@@ -308,7 +313,6 @@ tape('should correctly reflect generated fields', async (t) => {
   t.end()
 })
 
-/*
 async function runWithHf(hardfork: string) {
   const vm = setupVM({ common: new Common({ chain: 'mainnet', hardfork }) })
 
@@ -346,4 +350,3 @@ tape('runBlock() -> API return values', async (t) => {
     t.end()
   })
 })
-*/


### PR DESCRIPTION
This PR adds `vm.buildBlock()` for building a block and adding transactions one at a time. 

It can be used like so:

```typescript
const blockBuilder = await vm.buildBlock({ parentBlock })
const txResult = await blockBuilder.addTransaction(tx)
const block = await blockBuilder.build()
```

It creates a checkpoint on the StateManager and modifies the state as transactions are run. The checkpoint is committed on `build()` or discarded with `revert()`.

Closes #1018.

This PR also:
* includes fixes for `runBlock` with `generate: true` by setting the header fields for gasUsed, logs bloom, receiptTrie, and transactionsTrie. (closes #1037)
* moves the tx receipt generation logic in `runBlock` to a function inside the same file called `generateTxReceipt`, which is then exported and used in BlockBuilder for generating the receiptTrie.

WIP, still finishing some last spec tests but sharing for initial review.