### PR TITLE
codecov: configure threshold for patch status check

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,9 @@ coverage:
       default:
         target: auto
         threshold: 2%
-        base: auto 
+    patch:
+      default:
+        target: auto
+        threshold: 5%
 comment:
-  layout: 'reach, flags'        
+  layout: 'reach, flags'

--- a/packages/client/codecov.yml
+++ b/packages/client/codecov.yml
@@ -1,7 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: auto
-        threshold: 2%
-        base: auto

--- a/packages/devp2p/codecov.yml
+++ b/packages/devp2p/codecov.yml
@@ -1,7 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: auto
-        threshold: 2%
-        base: auto 

--- a/packages/trie/codecov.yml
+++ b/packages/trie/codecov.yml
@@ -1,7 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: auto
-        threshold: 2%
-        base: auto 

--- a/packages/util/codecov.yml
+++ b/packages/util/codecov.yml
@@ -1,7 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: auto
-        threshold: 2%
-        base: auto


### PR DESCRIPTION
This PR:
* Configures the threshold for the codecov `patch` status check to `5%` ([docs link](https://docs.codecov.io/docs/commit-status#patch-status))
* Removes duplicate `codecov.yml` files, preferring one at the top level of the monorepo
* Removes deprecated `base` property