### PR TITLE
client: add basic cli test

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -56,3 +56,37 @@ jobs:
         if: ${{ matrix.node-version == 12 }}
 
       - run: npm run lint
+  test-client-cli:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        network: ['rinkeby', 'goerli']
+        syncmode: ['full', 'light']
+      fail-fast: false
+    steps:
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      
+      - name: Dependency cache
+        uses: actions/cache@v2
+        id: cache
+        with:
+          key: Client-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
+          path: '**/node_modules'
+
+      # Installs root dependencies, ignoring Bootstrap All script.
+      # Bootstraps the current package only
+      - run: npm install --ignore-scripts && npm run bootstrap:client
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: ${{github.workspace}}
+
+      # Builds current package and the ones it depends from.
+      - run: npm run build:client
+        working-directory: ${{github.workspace}}
+
+      - run: npm run test:cli -- --network=${{matrix.network}} --syncmode=${{matrix.syncmode}}

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -89,4 +89,4 @@ jobs:
       - run: npm run build:client
         working-directory: ${{github.workspace}}
 
-      - run: npm run test:cli -- --network=${{matrix.network}} --syncmode=${{matrix.syncmode}}
+      - run: npm run test:cli -- --network=${{matrix.network}} --syncmode=${{matrix.syncmode}} --transports rlpx

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -40,8 +40,9 @@
     "lint:fix": "../../config/cli/lint-fix.sh",
     "tape": "tape -r ts-node/register",
     "test": "npm run test:unit && npm run test:integration && npm run test:browser",
-    "test:unit": "npm run tape -- 'test/!(integration)/**/*.spec.ts' 'test/*.spec.ts'",
+    "test:unit": "npm run tape -- 'test/!(integration|cli)/**/*.spec.ts' 'test/*.spec.ts'",
     "test:integration": "npm run tape -- 'test/integration/**/*.spec.ts'",
+    "test:cli": "npm run tape -- 'test/cli/*.spec.ts'",
     "test:browser": "karma start karma.conf.js"
   },
   "dependencies": {

--- a/packages/client/test/cli/cli.spec.ts
+++ b/packages/client/test/cli/cli.spec.ts
@@ -1,0 +1,61 @@
+import { spawn } from 'child_process'
+import tape from 'tape'
+
+// get args for --network and --syncmode
+const cliArgs = process.argv.filter(
+  (arg) => arg.startsWith('--network') || arg.startsWith('--syncmode')
+)
+
+tape('[CLI]', (t) => {
+  t.test('should begin downloading blocks', { timeout: 260000 }, (t) => {
+    const file = require.resolve('../../dist/bin/cli.js')
+    const child = spawn(process.execPath, [file, ...cliArgs])
+
+    let hasEnded = false
+
+    const timeout = setTimeout(() => {
+      t.fail('timed out before finishing')
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
+      end()
+    }, 240000)
+
+    const end = () => {
+      clearTimeout(timeout)
+      if (!hasEnded) {
+        hasEnded = true
+        child.kill('SIGINT')
+        t.end()
+      }
+    }
+
+    child.stdout.on('data', (data) => {
+      const message = data.toString()
+
+      // log message for easier debugging
+      // eslint-disable-next-line no-console
+      console.log(message)
+
+      if (message.toLowerCase().includes('error')) {
+        t.fail(message)
+        return end()
+      }
+      if (message.includes('Imported')) {
+        t.pass('successfully imported blocks or headers')
+        return end()
+      }
+    })
+
+    child.stderr.on('data', (data) => {
+      const message = data.toString()
+      t.fail(`stderr: ${message}`)
+      end()
+    })
+
+    child.on('close', (code) => {
+      if (code > 0) {
+        t.fail(`child process exited with code ${code}`)
+        end()
+      }
+    })
+  })
+})


### PR DESCRIPTION
This PR adds a basic cli test that spins up the client, imports a block from a peer, and finishes.

The Github Action is specified with a matrix of `network` and `syncmode`.