### PR TITLE
VM: Refactor runTx() API tests / add Typed Transaction tests

### DIFF
--- a/packages/vm/tests/api/runTx.spec.ts
+++ b/packages/vm/tests/api/runTx.spec.ts
@@ -4,160 +4,218 @@ import { Block } from '@ethereumjs/block'
 import Common from '@ethereumjs/common'
 import { Transaction } from '@ethereumjs/tx'
 import VM from '../../lib'
-import { createAccount } from './utils'
+import { createAccount, getTransaction } from './utils'
 
-tape('runTx', (t) => {
-  const vm = new VM()
+const TRANSACTION_TYPES = [
+  {
+    type: 0,
+    name: 'legacy tx',
+  },
+  {
+    type: 1,
+    name: 'EIP2930 tx',
+  },
+]
+const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
+common.setMaxListeners(100)
 
-  t.test('should fail to run without signature', async (st) => {
-    const tx = getTransaction(false)
-    shouldFail(st, vm.runTx({ tx }), (e: Error) =>
-      st.ok(e.message.includes('not signed'), 'should fail with appropriate error')
-    )
-    st.end()
+tape('runTx() -> successful API usage', async (t) => {
+  t.test('simple run (unmodified options)', async (t) => {
+    for (const txType of TRANSACTION_TYPES) {
+      const vm = new VM({ common })
+      const tx = getTransaction(vm._common, txType.type, true)
+
+      const caller = tx.getSenderAddress()
+      const acc = createAccount()
+
+      await vm.stateManager.putAccount(caller, acc)
+
+      const res = await vm.runTx({ tx })
+      t.true(res.gasUsed.gt(new BN(0)), `should run ${txType.name} without errors`)
+    }
+    t.end()
   })
 
-  t.test('should fail without sufficient funds', async (st) => {
-    const tx = getTransaction(true)
-    shouldFail(st, vm.runTx({ tx }), (e: Error) => {
-      st.ok(e.message.toLowerCase().includes('enough funds'), 'error should include "enough funds"')
-    })
-    st.end()
+  t.test('disabled block gas limit validation (skipBlockGasLimitValidation: true)', async (t) => {
+    for (const txType of TRANSACTION_TYPES) {
+      const vm = new VM({ common })
+
+      const privateKey = Buffer.from(
+        'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
+        'hex'
+      )
+      const address = Address.fromPrivateKey(privateKey)
+      const initialBalance = new BN(10).pow(new BN(18))
+
+      const account = await vm.stateManager.getAccount(address)
+      await vm.stateManager.putAccount(
+        address,
+        Account.fromAccountData({ ...account, balance: initialBalance })
+      )
+
+      const transferCost = 21000
+      const unsignedTx = Transaction.fromTxData({
+        to: address,
+        gasLimit: transferCost,
+        gasPrice: 1,
+        nonce: 0,
+      })
+      const tx = unsignedTx.sign(privateKey)
+
+      const block = Block.fromBlockData({
+        header: { gasLimit: transferCost - 1 },
+      })
+
+      const result = await vm.runTx({
+        tx,
+        block,
+        skipBlockGasLimitValidation: true,
+      })
+
+      t.equals(
+        result.execResult.exceptionError,
+        undefined,
+        `should run ${txType.name} without errors`
+      )
+    }
+    t.end()
   })
 })
 
-tape('should run simple tx without errors', async (t) => {
-  const vm = new VM()
-  const tx = getTransaction(true)
-
-  const caller = tx.getSenderAddress()
-  const acc = createAccount()
-
-  await vm.stateManager.putAccount(caller, acc)
-
-  const res = await vm.runTx({ tx })
-  t.true(res.gasUsed.gt(new BN(0)), 'should have used some gas')
-
-  t.end()
-})
-
-tape('should fail when account balance overflows (call)', async (t) => {
-  const vm = new VM()
-  const tx = getTransaction(true, '0x01')
-
-  const caller = tx.getSenderAddress()
-  const from = createAccount()
-  await vm.stateManager.putAccount(caller, from)
-
-  const to = createAccount(new BN(0), MAX_INTEGER)
-  await vm.stateManager.putAccount(tx.to!, to)
-
-  const res = await vm.runTx({ tx })
-
-  t.equal(res.execResult!.exceptionError!.error, 'value overflow')
-  t.equal((<any>vm.stateManager)._checkpointCount, 0)
-  t.end()
-})
-
-tape('should fail when account balance overflows (create)', async (t) => {
-  const vm = new VM()
-  const tx = getTransaction(true, '0x01', true)
-
-  const caller = tx.getSenderAddress()
-  const from = createAccount()
-  await vm.stateManager.putAccount(caller, from)
-
-  const contractAddress = new Address(
-    Buffer.from('61de9dc6f6cff1df2809480882cfd3c2364b28f7', 'hex')
-  )
-  const to = createAccount(new BN(0), MAX_INTEGER)
-  await vm.stateManager.putAccount(contractAddress, to)
-
-  const res = await vm.runTx({ tx })
-
-  t.equal(res.execResult!.exceptionError!.error, 'value overflow')
-  t.equal((<any>vm.stateManager)._checkpointCount, 0)
-  t.end()
-})
-
-tape('should clear storage cache after every transaction', async (t) => {
-  const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
-  const vm = new VM({ common })
-  const privateKey = Buffer.from(
-    'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
-    'hex'
-  )
-  /* Code which is deployed here: 
-    PUSH1 01
-    PUSH1 00
-    SSTORE
-    INVALID
-  */
-  const code = Buffer.from('6001600055FE', 'hex')
-  const address = new Address(Buffer.from('00000000000000000000000000000000000000ff', 'hex'))
-  await vm.stateManager.putContractCode(address, code)
-  await vm.stateManager.putContractStorage(
-    address,
-    Buffer.from('00'.repeat(32), 'hex'),
-    Buffer.from('00'.repeat(31) + '01', 'hex')
-  )
-  const tx = Transaction.fromTxData(
-    {
-      nonce: '0x00',
-      gasPrice: 1,
-      gasLimit: 100000,
-      to: address,
-    },
-    { common }
-  ).sign(privateKey)
-
-  await vm.stateManager.putAccount(tx.getSenderAddress(), createAccount())
-
-  await vm.runTx({ tx }) // this tx will fail, but we have to ensure that the cache is cleared
-
-  t.equal((<any>vm.stateManager)._originalStorageCache.size, 0, 'storage cache should be cleared')
-  t.end()
-})
-
-tape('should be possible to disable the block gas limit validation', async (t) => {
-  const vm = new VM()
-
-  const privateKey = Buffer.from(
-    'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
-    'hex'
-  )
-  const address = Address.fromPrivateKey(privateKey)
-  const initialBalance = new BN(10).pow(new BN(18))
-
-  const account = await vm.stateManager.getAccount(address)
-  await vm.stateManager.putAccount(
-    address,
-    Account.fromAccountData({ ...account, balance: initialBalance })
-  )
-
-  const transferCost = 21000
-
-  const unsignedTx = Transaction.fromTxData({
-    to: address,
-    gasLimit: transferCost,
-    gasPrice: 1,
-    nonce: 0,
+tape('runTx() -> API usage/data errors', (t) => {
+  t.test('run without signature', async (t) => {
+    for (const txType of TRANSACTION_TYPES) {
+      const vm = new VM({ common })
+      const tx = getTransaction(vm._common, 0, false)
+      try {
+        await vm.runTx({ tx })
+      } catch (e) {
+        t.ok(e.message.includes('not signed'), `should fail for ${txType.name}`)
+      }
+    }
+    t.end()
   })
 
-  const tx = unsignedTx.sign(privateKey)
+  t.test('run with insufficient funds', async (t) => {
+    for (const txType of TRANSACTION_TYPES) {
+      const vm = new VM({ common })
+      const tx = getTransaction(vm._common, 0, true)
+      try {
+        await vm.runTx({ tx })
+      } catch (e) {
+        t.ok(e.message.toLowerCase().includes('enough funds'), `should fail for ${txType.name}`)
+      }
+    }
+    t.end()
+  })
+})
 
-  const block = Block.fromBlockData({
-    header: { gasLimit: transferCost - 1 },
+tape('runTx() -> runtime behavior', async (t) => {
+  t.test('storage cache', async (t) => {
+    for (const txType of TRANSACTION_TYPES) {
+      const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+      const vm = new VM({ common })
+      const privateKey = Buffer.from(
+        'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
+        'hex'
+      )
+      /* Code which is deployed here: 
+        PUSH1 01
+        PUSH1 00
+        SSTORE
+        INVALID
+      */
+      const code = Buffer.from('6001600055FE', 'hex')
+      const address = new Address(Buffer.from('00000000000000000000000000000000000000ff', 'hex'))
+      await vm.stateManager.putContractCode(address, code)
+      await vm.stateManager.putContractStorage(
+        address,
+        Buffer.from('00'.repeat(32), 'hex'),
+        Buffer.from('00'.repeat(31) + '01', 'hex')
+      )
+      const tx = Transaction.fromTxData(
+        {
+          nonce: '0x00',
+          gasPrice: 1,
+          gasLimit: 100000,
+          to: address,
+        },
+        { common }
+      ).sign(privateKey)
+
+      await vm.stateManager.putAccount(tx.getSenderAddress(), createAccount())
+
+      await vm.runTx({ tx }) // this tx will fail, but we have to ensure that the cache is cleared
+
+      t.equal(
+        (<any>vm.stateManager)._originalStorageCache.size,
+        0,
+        `should clear storage cache after every ${txType.name}`
+      )
+    }
+    t.end()
+  })
+})
+
+tape('runTx() -> runtime errors', async (t) => {
+  t.test('account balance overflows (call)', async (t) => {
+    for (const txType of TRANSACTION_TYPES) {
+      const vm = new VM({ common })
+      const tx = getTransaction(vm._common, 0, true, '0x01')
+
+      const caller = tx.getSenderAddress()
+      const from = createAccount()
+      await vm.stateManager.putAccount(caller, from)
+
+      const to = createAccount(new BN(0), MAX_INTEGER)
+      await vm.stateManager.putAccount(tx.to!, to)
+
+      const res = await vm.runTx({ tx })
+
+      t.equal(
+        res.execResult!.exceptionError!.error,
+        'value overflow',
+        `result should have 'value overflow' error set (${txType.name})`
+      )
+      t.equal(
+        (<any>vm.stateManager)._checkpointCount,
+        0,
+        `checkpoint count should be 0 (${txType.name})`
+      )
+    }
+    t.end()
   })
 
-  const result = await vm.runTx({
-    tx,
-    block,
-    skipBlockGasLimitValidation: true,
-  })
+  t.test('account balance overflows (create)', async (t) => {
+    for (const txType of TRANSACTION_TYPES) {
+      const vm = new VM({ common })
+      const tx = getTransaction(vm._common, 0, true, '0x01', true)
 
-  t.equals(result.execResult.exceptionError, undefined)
-  t.end()
+      const caller = tx.getSenderAddress()
+      const from = createAccount()
+      await vm.stateManager.putAccount(caller, from)
+
+      const contractAddress = new Address(
+        Buffer.from('61de9dc6f6cff1df2809480882cfd3c2364b28f7', 'hex')
+      )
+      const to = createAccount(new BN(0), MAX_INTEGER)
+      await vm.stateManager.putAccount(contractAddress, to)
+
+      const res = await vm.runTx({ tx })
+
+      t.equal(
+        res.execResult!.exceptionError!.error,
+        'value overflow',
+        `result should have 'value overflow' error set (${txType.name})`
+      )
+      t.equal(
+        (<any>vm.stateManager)._checkpointCount,
+        0,
+        `checkpoint count should be 0 (${txType.name})`
+      )
+    }
+    t.end()
+  })
 })
 
 // The following test tries to verify that running a tx
@@ -181,39 +239,3 @@ tape('should be possible to disable the block gas limit validation', async (t) =
 
   t.end()
 }) */
-
-function shouldFail(st: tape.Test, p: any, onErr: Function) {
-  p.then(() => st.fail('runTx didnt return any errors')).catch(onErr)
-}
-
-function getTransaction(sign = false, value = '0x00', createContract = false) {
-  let to: string | undefined = '0x0000000000000000000000000000000000000000'
-  let data = '0x7f7465737432000000000000000000000000000000000000000000000000000000600057'
-
-  if (createContract) {
-    to = undefined
-    data =
-      '0x6080604052348015600f57600080fd5b50603e80601d6000396000f3fe6080604052600080fdfea265627a7a723158204aed884a44fd1747efccba1447a2aa2d9a4b06dd6021c4a3bbb993021e0a909e64736f6c634300050f0032'
-  }
-
-  const txParams = {
-    nonce: 0,
-    gasPrice: 100,
-    gasLimit: 90000,
-    to,
-    value,
-    data,
-  }
-
-  const tx = Transaction.fromTxData(txParams)
-
-  if (sign) {
-    const privateKey = Buffer.from(
-      'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
-      'hex'
-    )
-    return tx.sign(privateKey)
-  }
-
-  return tx
-}

--- a/packages/vm/tests/api/utils.ts
+++ b/packages/vm/tests/api/utils.ts
@@ -3,6 +3,8 @@ import Blockchain from '@ethereumjs/blockchain'
 import VM from '../../lib/index'
 import { VMOpts } from '../../lib'
 import { Block } from '@ethereumjs/block'
+import { TransactionFactory } from '@ethereumjs/tx'
+import Common from '@ethereumjs/common'
 
 const level = require('level-mem')
 
@@ -25,4 +27,55 @@ export function setupVM(opts: VMOpts & { genesisBlock?: Block } = {}) {
   return new VM({
     ...opts,
   })
+}
+
+export function getTransaction(
+  common: Common,
+  txType = 0,
+  sign = false,
+  value = '0x00',
+  createContract = false
+) {
+  let to: string | undefined = '0x0000000000000000000000000000000000000000'
+  let data = '0x7f7465737432000000000000000000000000000000000000000000000000000000600057'
+
+  if (createContract) {
+    to = undefined
+    data =
+      '0x6080604052348015600f57600080fd5b50603e80601d6000396000f3fe6080604052600080fdfea265627a7a723158204aed884a44fd1747efccba1447a2aa2d9a4b06dd6021c4a3bbb993021e0a909e64736f6c634300050f0032'
+  }
+
+  const txParams: any = {
+    nonce: 0,
+    gasPrice: 100,
+    gasLimit: 90000,
+    to,
+    value,
+    data,
+  }
+  if (txType === 1) {
+    txParams['chainId'] = common.chainIdBN()
+    txParams['accessList'] = [
+      {
+        address: '0x0000000000000000000000000000000000000101',
+        storageKeys: [
+          '0x0000000000000000000000000000000000000000000000000000000000000000',
+          '0x00000000000000000000000000000000000000000000000000000000000060a7',
+        ],
+      },
+    ]
+    txParams['type'] = txType
+  }
+
+  const tx = TransactionFactory.fromTxData(txParams, { common })
+
+  if (sign) {
+    const privateKey = Buffer.from(
+      'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
+      'hex'
+    )
+    return tx.sign(privateKey)
+  }
+
+  return tx
 }


### PR DESCRIPTION
I've switched from TxPool to access list generation for today. 😄 

On a first round I will add some tests to `runTx()` API tests and also clean up there a bit. On a first commit 4163c40 I've removed the existing `setup()` function, I am pretty sure that this is not doing anything useful (maybe some relic which was necessary on some old structure setup) and just bloating up the code. This is also confusing to read and hinders adding more flexible test setups directly by e.g. changing the `StateManager` or `Common`. Nevertheless pushing early here, so if I've overlooked something here let me know.

Generally I will see how far I will come, I think I'll give some tests some more space on a first round, generally in need I have the impression.