### PR TITLE
VM: Generate Access Lists in runTx()

### DIFF
--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -1,4 +1,4 @@
-import { BN, AddressLike, BNLike, BufferLike } from 'ethereumjs-util'
+import { BN, AddressLike, BNLike, BufferLike, PrefixedHexString } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { default as Transaction } from './legacyTransaction'
 import { default as AccessListEIP2930Transaction } from './eip2930Transaction'
@@ -36,8 +36,8 @@ export interface TxOptions {
  */
 
 export type AccessListItem = {
-  address: string
-  storageKeys: string[]
+  address: PrefixedHexString
+  storageKeys: PrefixedHexString[]
 }
 
 /*

--- a/packages/util/src/address.ts
+++ b/packages/util/src/address.ts
@@ -90,6 +90,18 @@ export class Address {
   }
 
   /**
+   * True if address is in the address range defined
+   * by EIP-1352
+   */
+  isPrecompileOrSystemAddress(): boolean {
+    const addressBN = new BN(this.buf)
+    const rangeMin = new BN(0)
+    const rangeMax = new BN('ffff', 'hex')
+
+    return addressBN.gte(rangeMin) && addressBN.lte(rangeMax)
+  }
+
+  /**
    * Returns hex encoding of address.
    */
   toString(): string {

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -119,7 +119,8 @@ export type ToBufferInputTypes =
 
 /**
  * Attempts to turn a value into a `Buffer`.
- * Inputs supported: `Buffer`, `String`, `Number`, null/undefined, `BN` and other objects with a `toArray()` or `toBuffer()` method.
+ * Inputs supported: `Buffer`, `String` (hex-prefixed), `Number`, null/undefined, `BN` and other objects
+ * with a `toArray()` or `toBuffer()` method.
  * @param v the value
  */
 export const toBuffer = function (v: ToBufferInputTypes): Buffer {

--- a/packages/util/test/address.spec.ts
+++ b/packages/util/test/address.spec.ts
@@ -75,6 +75,14 @@ tape('Address', (t) => {
     st.end()
   })
 
+  t.test('should provide correct precompile check', (st) => {
+    const precompile = Address.fromString('0x0000000000000000000000000000000000000009')
+    st.true(precompile.isPrecompileOrSystemAddress(), 'should detect precompile address')
+    const nonPrecompile = Address.fromString('0x990ccf8a0de58091c028d6ff76bb235ee67c1c39')
+    st.false(nonPrecompile.isPrecompileOrSystemAddress(), 'should detect non-precompile address')
+    st.end()
+  })
+
   t.test('should generate address for CREATE2', (st) => {
     for (const testdata of eip1014Testdata) {
       const { address, salt, initCode, result } = testdata

--- a/packages/vm/examples/run-transactions-complete/index.ts
+++ b/packages/vm/examples/run-transactions-complete/index.ts
@@ -1,4 +1,4 @@
-import { Account, BN, toBuffer, pubToAddress, bufferToHex } from 'ethereumjs-util'
+import { Address, Account, BN, toBuffer, pubToAddress } from 'ethereumjs-util'
 import { Transaction, TxData } from '@ethereumjs/tx'
 import VM from '../..'
 
@@ -9,12 +9,11 @@ async function main() {
   // used to sign transactions and generate addresses
   const keyPair = require('./key-pair')
   const privateKey = toBuffer(keyPair.secretKey)
-
   const publicKeyBuf = toBuffer(keyPair.publicKey)
-  const address = pubToAddress(publicKeyBuf, true)
+  const address = new Address(pubToAddress(publicKeyBuf, true))
 
   console.log('---------------------')
-  console.log('Sender address: ', bufferToHex(address))
+  console.log('Sender address: ', address.toString())
 
   // Create a new account
   const acctData = {
@@ -61,7 +60,7 @@ async function runTx(vm: VM, txData: TxData, privateKey: Buffer) {
   const createdAddress = results.createdAddress
 
   if (createdAddress) {
-    console.log('address created: 0x' + createdAddress.toString('hex'))
+    console.log('address created: ' + createdAddress.toString())
     return createdAddress
   }
 }

--- a/packages/vm/karma.conf.js
+++ b/packages/vm/karma.conf.js
@@ -20,10 +20,7 @@ module.exports = function (config) {
     },
 
     karmaTypescriptConfig: {
-      compilerOptions: {
-        resolveJsonModule: true,
-        esModuleInterop: true,
-      },
+      tsconfig: './tsconfig.json',
       bundlerOptions: {
         entrypoints: /\.spec\.ts$/,
       },

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -1,7 +1,12 @@
 import { debug as createDebugLogger } from 'debug'
-import { Address, BN } from 'ethereumjs-util'
+import { Address, BN, toBuffer } from 'ethereumjs-util'
 import { Block } from '@ethereumjs/block'
-import { AccessListItem, AccessListEIP2930Transaction, TypedTransaction } from '@ethereumjs/tx'
+import {
+  AccessListItem,
+  AccessListEIP2930Transaction,
+  TypedTransaction,
+  AccessList,
+} from '@ethereumjs/tx'
 import VM from './index'
 import Bloom from './bloom'
 import { default as EVM, EVMResult } from './evm/evm'
@@ -40,6 +45,15 @@ export interface RunTxOpts {
    * agains the block's gas limit.
    */
   skipBlockGasLimitValidation?: boolean
+
+  /**
+   * If true, adds a generated EIP-2930 access list
+   * to the `RunTxResult` returned.
+   *
+   * Option works with all tx types. EIP-2929 needs to
+   * be activated (included in `berlin` HF).
+   */
+  reportAccessList?: boolean
 }
 
 /**
@@ -58,6 +72,11 @@ export interface RunTxResult extends EVMResult {
    * The amount of gas as that was refunded during the transaction (i.e. `gasUsed = totalGasConsumed - gasRefund`)
    */
   gasRefund?: BN
+
+  /**
+   * EIP-2930 access list generated for the tx (see `reportAccessList` option)
+   */
+  accessList?: AccessList
 }
 
 export interface AfterTxEvent extends RunTxResult {
@@ -111,10 +130,10 @@ export default async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxRes
     const castedTx = <AccessListEIP2930Transaction>opts.tx
 
     castedTx.AccessListJSON.forEach((accessListItem: AccessListItem) => {
-      const address = Buffer.from(accessListItem.address.slice(2), 'hex')
+      const address = toBuffer(accessListItem.address)
       state.addWarmedAddress(address)
       accessListItem.storageKeys.forEach((storageKey: string) => {
-        state.addWarmedStorage(address, Buffer.from(storageKey.slice(2), 'hex'))
+        state.addWarmedStorage(address, toBuffer(storageKey))
       })
     })
   }
@@ -123,6 +142,10 @@ export default async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxRes
     const result = await _runTx.bind(this)(opts)
     await state.commit()
     debug(`tx checkpoint committed`)
+    if (this._common.isActivatedEIP(2929) && opts.reportAccessList) {
+      result.accessList = state.clearWarmedAccounts(true)
+      console.log(result)
+    }
     return result
   } catch (e) {
     await state.revert()

--- a/packages/vm/lib/state/interface.ts
+++ b/packages/vm/lib/state/interface.ts
@@ -39,5 +39,5 @@ export interface EIP2929StateManager extends StateManager {
   isWarmedAddress(address: Buffer): boolean
   addWarmedStorage(address: Buffer, slot: Buffer): void
   isWarmedStorage(address: Buffer, slot: Buffer): boolean
-  clearWarmedAccounts(): void
+  clearWarmedAccounts(reportAccessList?: boolean): any
 }

--- a/packages/vm/lib/state/interface.ts
+++ b/packages/vm/lib/state/interface.ts
@@ -39,5 +39,5 @@ export interface EIP2929StateManager extends StateManager {
   isWarmedAddress(address: Buffer): boolean
   addWarmedStorage(address: Buffer, slot: Buffer): void
   isWarmedStorage(address: Buffer, slot: Buffer): boolean
-  clearWarmedAccounts(reportAccessList?: boolean): any
+  clearWarmedAccounts(): void
 }

--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -693,14 +693,16 @@ export default class DefaultStateManager implements StateManager {
         this._accessedStorageMerge(mergedStorage, storageMap)
       }
     }
-    const folded = mergedStorage[0]
+    const folded = new Map([...mergedStorage[0].entries()].sort())
 
     // Transfer folded map to final structure
     const accessList: AccessList = []
     folded.forEach((slots, addressStr) => {
       const address = Address.fromString(`0x${addressStr}`)
       if (!address.isPrecompileOrSystemAddress()) {
-        const storageSlots = Array.from(slots).map((s) => `0x${s}`)
+        const storageSlots = Array.from(slots)
+          .map((s) => `0x${s}`)
+          .sort()
         const accessListItem: AccessListItem = {
           address: addressStr,
           storageKeys: storageSlots,

--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -372,7 +372,7 @@ export default class DefaultStateManager implements StateManager {
     storageList: Map<string, Set<string>>[],
     storageMap: Map<string, Set<string>>
   ) {
-    const mapTarget = storageList[this._accessedStorage.length - 1]
+    const mapTarget = storageList[storageList.length - 1]
 
     if (mapTarget) {
       // Note: storageMap is always defined here per definition (TypeScript cannot infer this)
@@ -678,8 +678,8 @@ export default class DefaultStateManager implements StateManager {
    * Note: there is an edge case on accessList generation where an
    * internal call might revert without an accessList but pass if the
    * accessList is used for a tx run (so the subsequent behavior might change).
-   * This edge case is not covered by this implementation. 
-   * 
+   * This edge case is not covered by this implementation.
+   *
    * @returns - an [@ethereumjs/tx](https://github.com/ethereumjs/ethereumjs-monorepo/packages/tx) `AccessList`
    */
   generateAccessList(): AccessList {

--- a/packages/vm/tests/api/runTx.spec.ts
+++ b/packages/vm/tests/api/runTx.spec.ts
@@ -148,6 +148,24 @@ tape('runTx() -> API parameter usage/data errors', (t) => {
     t.end()
   })
 
+  t.test('simple run (reportAccessList option)', async (t) => {
+    const vm = new VM({ common })
+
+    const tx = getTransaction(vm._common, 0, true)
+
+    const caller = tx.getSenderAddress()
+    const acc = createAccount()
+    await vm.stateManager.putAccount(caller, acc)
+
+    const res = await vm.runTx({ tx, reportAccessList: true })
+    t.true(
+      res.gasUsed.gt(new BN(0)),
+      `mainnet (PoW), istanbul HF, default SM - should run without errors (${TRANSACTION_TYPES[0].name})`
+    )
+    t.true(res.accessList)
+    t.end()
+  })
+
   t.test('run without signature', async (t) => {
     for (const txType of TRANSACTION_TYPES) {
       const vm = new VM({ common })

--- a/packages/vm/tests/api/state/stateManager.spec.ts
+++ b/packages/vm/tests/api/state/stateManager.spec.ts
@@ -530,6 +530,44 @@ tape('StateManager - generateAccessList', (tester) => {
     t.end()
   })
 
+  it('one frame, unsorted slots', async (t) => {
+    const { addA, addS, gen } = getStateManagerAliases()
+    addA(a(1))
+    addS(a(1), s(2))
+    addS(a(1), s(1))
+    const json = [
+      {
+        address: 'ff00000000000000000000000000000000000001',
+        storageKeys: [
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+          '0x0000000000000000000000000000000000000000000000000000000000000002',
+        ],
+      },
+    ]
+    t.deepEqual(gen(), json)
+    t.end()
+  })
+
+  it('one frame, unsorted addresses', async (t) => {
+    const { addA, addS, gen } = getStateManagerAliases()
+    addA(a(2))
+    addS(a(2), s(1))
+    addA(a(1))
+    addS(a(1), s(1))
+    const json = [
+      {
+        address: 'ff00000000000000000000000000000000000001',
+        storageKeys: ['0x0000000000000000000000000000000000000000000000000000000000000001'],
+      },
+      {
+        address: 'ff00000000000000000000000000000000000002',
+        storageKeys: ['0x0000000000000000000000000000000000000000000000000000000000000001'],
+      },
+    ]
+    t.deepEqual(gen(), json)
+    t.end()
+  })
+
   it('one frame, more complex', async (t) => {
     const { addA, addS, gen } = getStateManagerAliases()
     addA(a(1))

--- a/packages/vm/tests/api/state/stateManager.spec.ts
+++ b/packages/vm/tests/api/state/stateManager.spec.ts
@@ -493,3 +493,231 @@ tape('StateManager - Contract storage', (tester) => {
     t.end()
   })
 })
+
+tape('StateManager - generateAccessList', (tester) => {
+  const it = tester.test
+
+  // Only use 0..9
+  function a(n: number) {
+    return Buffer.from(`ff${'00'.repeat(18)}0${n}`, 'hex')
+  }
+
+  // Only use 0..9
+  function s(n: number) {
+    return Buffer.from(`${'00'.repeat(31)}0${n}`, 'hex')
+  }
+
+  function getStateManagerAliases() {
+    const stateManager = new DefaultStateManager()
+    const addA = stateManager.addWarmedAddress.bind(stateManager)
+    const addS = stateManager.addWarmedStorage.bind(stateManager)
+    const gen = stateManager.generateAccessList.bind(stateManager)
+    const sm = stateManager
+    return { addA, addS, gen, sm }
+  }
+
+  it('one frame, simple', async (t) => {
+    const { addA, addS, gen } = getStateManagerAliases()
+    addA(a(1))
+    addS(a(1), s(1))
+    const json = [
+      {
+        address: 'ff00000000000000000000000000000000000001',
+        storageKeys: ['0x0000000000000000000000000000000000000000000000000000000000000001'],
+      },
+    ]
+    t.deepEqual(gen(), json)
+    t.end()
+  })
+
+  it('one frame, more complex', async (t) => {
+    const { addA, addS, gen } = getStateManagerAliases()
+    addA(a(1))
+    addS(a(1), s(1))
+    addA(a(2))
+    addA(a(3))
+    addS(a(3), s(1))
+    addS(a(3), s(2))
+    const json = [
+      {
+        address: 'ff00000000000000000000000000000000000001',
+        storageKeys: ['0x0000000000000000000000000000000000000000000000000000000000000001'],
+      },
+      {
+        address: 'ff00000000000000000000000000000000000002',
+        storageKeys: [],
+      },
+      {
+        address: 'ff00000000000000000000000000000000000003',
+        storageKeys: [
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+          '0x0000000000000000000000000000000000000000000000000000000000000002',
+        ],
+      },
+    ]
+    t.deepEqual(gen(), json)
+    t.end()
+  })
+
+  it('two frames, simple', async (t) => {
+    const { addA, addS, gen, sm } = getStateManagerAliases()
+    addA(a(1))
+    addS(a(1), s(1))
+    await sm.checkpoint()
+    addA(a(2))
+    addA(a(3))
+    addS(a(3), s(1))
+    addS(a(3), s(2))
+    const json = [
+      {
+        address: 'ff00000000000000000000000000000000000001',
+        storageKeys: ['0x0000000000000000000000000000000000000000000000000000000000000001'],
+      },
+      {
+        address: 'ff00000000000000000000000000000000000002',
+        storageKeys: [],
+      },
+      {
+        address: 'ff00000000000000000000000000000000000003',
+        storageKeys: [
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+          '0x0000000000000000000000000000000000000000000000000000000000000002',
+        ],
+      },
+    ]
+    t.deepEqual(gen(), json)
+    t.end()
+  })
+
+  it('two frames, same address with different storage slots', async (t) => {
+    const { addA, addS, gen, sm } = getStateManagerAliases()
+    addA(a(1))
+    addS(a(1), s(1))
+    await sm.checkpoint()
+    addA(a(1))
+    addS(a(1), s(2))
+    const json = [
+      {
+        address: 'ff00000000000000000000000000000000000001',
+        storageKeys: [
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+          '0x0000000000000000000000000000000000000000000000000000000000000002',
+        ],
+      },
+    ]
+    t.deepEqual(gen(), json)
+    t.end()
+  })
+
+  it('two frames, same address with same storage slots', async (t) => {
+    const { addA, addS, gen, sm } = getStateManagerAliases()
+    addA(a(1))
+    addS(a(1), s(1))
+    await sm.checkpoint()
+    addA(a(1))
+    addS(a(1), s(1))
+    const json = [
+      {
+        address: 'ff00000000000000000000000000000000000001',
+        storageKeys: ['0x0000000000000000000000000000000000000000000000000000000000000001'],
+      },
+    ]
+    t.deepEqual(gen(), json)
+    t.end()
+  })
+
+  it('three frames, no accesses on level two', async (t) => {
+    const { addA, addS, gen, sm } = getStateManagerAliases()
+    addA(a(1))
+    addS(a(1), s(1))
+    await sm.checkpoint()
+    await sm.checkpoint()
+    addA(a(2))
+    addS(a(2), s(2))
+    const json = [
+      {
+        address: 'ff00000000000000000000000000000000000001',
+        storageKeys: ['0x0000000000000000000000000000000000000000000000000000000000000001'],
+      },
+      {
+        address: 'ff00000000000000000000000000000000000002',
+        storageKeys: ['0x0000000000000000000000000000000000000000000000000000000000000002'],
+      },
+    ]
+    t.deepEqual(gen(), json)
+    t.end()
+  })
+
+  it('one frame, one revert frame', async (t) => {
+    const { addA, addS, gen, sm } = getStateManagerAliases()
+    await sm.checkpoint()
+    addA(a(1))
+    addS(a(1), s(1))
+    await sm.revert()
+    addA(a(2))
+    addS(a(2), s(2))
+    const json = [
+      {
+        address: 'ff00000000000000000000000000000000000001',
+        storageKeys: ['0x0000000000000000000000000000000000000000000000000000000000000001'],
+      },
+      {
+        address: 'ff00000000000000000000000000000000000002',
+        storageKeys: ['0x0000000000000000000000000000000000000000000000000000000000000002'],
+      },
+    ]
+    t.deepEqual(gen(), json)
+    t.end()
+  })
+
+  it('one frame, one revert frame, same address, different slots', async (t) => {
+    const { addA, addS, gen, sm } = getStateManagerAliases()
+    await sm.checkpoint()
+    addA(a(1))
+    addS(a(1), s(1))
+    await sm.revert()
+    addA(a(1))
+    addS(a(1), s(2))
+    const json = [
+      {
+        address: 'ff00000000000000000000000000000000000001',
+        storageKeys: [
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+          '0x0000000000000000000000000000000000000000000000000000000000000002',
+        ],
+      },
+    ]
+    t.deepEqual(gen(), json)
+    t.end()
+  })
+
+  it('one frame, two revert frames', async (t) => {
+    const { addA, addS, gen, sm } = getStateManagerAliases()
+    await sm.checkpoint()
+    await sm.checkpoint()
+    addA(a(1))
+    addS(a(1), s(1))
+    await sm.revert()
+    addA(a(2))
+    addS(a(2), s(1))
+    await sm.revert()
+    addA(a(3))
+    addS(a(3), s(1))
+    const json = [
+      {
+        address: 'ff00000000000000000000000000000000000001',
+        storageKeys: ['0x0000000000000000000000000000000000000000000000000000000000000001'],
+      },
+      {
+        address: 'ff00000000000000000000000000000000000002',
+        storageKeys: ['0x0000000000000000000000000000000000000000000000000000000000000001'],
+      },
+      {
+        address: 'ff00000000000000000000000000000000000003',
+        storageKeys: ['0x0000000000000000000000000000000000000000000000000000000000000001'],
+      },
+    ]
+    t.deepEqual(gen(), json)
+    t.end()
+  })
+})

--- a/packages/vm/tests/config.ts
+++ b/packages/vm/tests/config.ts
@@ -322,7 +322,7 @@ export function getCommon(network: string) {
 const expectedTestsFull: any = {
   BlockchainTests: {
     Chainstart: 4385,
-    Homestead: 7004,
+    Homestead: 7001,
     Dao: 0,
     TangerineWhistle: 4255,
     SpuriousDragon: 4305,


### PR DESCRIPTION
Ok, here is the access list generation PR fixing #1152. This needs significantly more tests, but this should generally do what is expected. I just tried to generate the following super-simple access list with this:

```shell
{
  gasUsed: <BN: 52f8>,
  execResult: {
    gasUsed: <BN: 0>,
    exceptionError: undefined,
    returnValue: <Buffer >,
    gasRefund: <BN: 0>
  },
  bloom: Bloom {
    bitvector: <Buffer 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ... 206 more bytes>
  },
  amountSpent: <BN: 2068e0>,
  accessList: [
    {
      address: 'be862ad9abfe6f22bcb087716c7d89a26051f74c',
      storageKeys: []
    }
  ]
}
```

Which obviously is not enough yet. 😄  Functionality for more complex AL is there but should be manually tested or optimally by adding additional test cases. 

For now I've added the functionality to `StateManger.clearWarmedAccounts()` in a non-breaking way. On a second thought along pushing I rather think it might be better and more flexible to just add a distinct method for that which can be called separately (which then still can be called somewhat along the clearing-call in our context).

I also added a new helper function `Address.isPrecompileOrSystemAddress()` to Util which checks an address to be a precompile or system address following [EIP-1352](https://eips.ethereum.org/EIPS/eip-1352).