### PR TITLE
Temporarily disable e2e tests (due to intermittent failures)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -17,31 +17,18 @@ jobs:
     strategy:
       matrix:
         node-version: [15]
-    steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+    # steps:
+    #   - name: Use Node.js ${{ matrix.node-version }}
+    #     uses: actions/setup-node@v1
+    #     with:
+    #       node-version: ${{ matrix.node-version }}
+    #   - uses: actions/checkout@v2
+    #     with:
+    #       submodules: recursive
 
       # Installs all dependencies, bootstrapping everything.
-      - run: npm install
+      # - run: npm install
 
-      # Publishes all packages to a virtual npm registry after giving each a minor version bump
-      - name: Publish to virtual registry
-        run: npm run e2e:publish
-
-      # This project is simple / does not require resolutions injection
-      - name: E2E Target - NoahZinsmeister/as-you-permit
-        run: |
-          git clone https://github.com/NoahZinsmeister/as-you-permit.git
-          cd as-you-permit
-          yarn
-          rm -rf dist
-          yarn remove @ethereumjs/vm
-          yarn add @ethereumjs/vm@e2e
-          yarn test --verbose
-        env:
-          URL_MAINNET: ${{ secrets.URL_MAINNET }}
+      # # Publishes all packages to a virtual npm registry after giving each a minor version bump
+      # - name: Publish to virtual registry
+      #   run: npm run e2e:publish


### PR DESCRIPTION
The current E2E test seems to be failing randomly with a build error (from the target repo's own build script)
```
'dist/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.json'
Error: ENOENT: no such file or directory, unlink 'dist/tokens/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48.json'
```

I don't think this is worth digging into because this target was POC and doesn't test much of the monorepo.

Will open a PR re-enabling when Hardhat has successfully integrated the new libraries - they have a huge test suite which touches most of the code here. 