### PR TITLE
Stop throwing when non-hex-prefixed addresses are passed to util `isValid..` methods

### DIFF
--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [7.1.0] - TBD
+
+- Return false (instead of throwing) for non-hex-string values in account `isValidAddress`, `isValidChecksumAddress`, `isZeroAddress` methods, PR [#1173](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1173)
+
 ## [7.0.9] - 2021-03-04
 
 This release adds support for very high `chainId` numbers exceeding `MAX_SAFE_INTEGER` (an example is the chain ID `34180983699157880` used for the ephemeral Yolov3 testnet preparing for the `berlin` hardfork, but high chain IDs might be used for things like private test networks and the like as well), see PR [#290](https://github.com/ethereumjs/ethereumjs-util/pull/290).
@@ -401,7 +405,7 @@ see PR [#170](https://github.com/ethereumjs/ethereumjs-util/pull/170).
 ## [6.0.0] - 2018-10-08
 
 - Support for `EIP-155` replay protection by adding an optional `chainId` parameter
-  to `ecsign()`, `ecrecover()`, `toRpcSig()` and `isValidSignature()`, if present the  
+  to `ecsign()`, `ecrecover()`, `toRpcSig()` and `isValidSignature()`, if present the
   new signature format relying on the `chainId` is used, see PR [#143](https://github.com/ethereumjs/ethereumjs-util/pull/143)
 - New `generateAddress2()` for `CREATE2` opcode (`EIP-1014`) address creation
   (Constantinople HF), see PR [#146](https://github.com/ethereumjs/ethereumjs-util/pull/146)

--- a/packages/util/src/account.ts
+++ b/packages/util/src/account.ts
@@ -11,7 +11,7 @@ import { stripHexPrefix } from 'ethjs-util'
 import { KECCAK256_RLP, KECCAK256_NULL } from './constants'
 import { zeros, bufferToHex, toBuffer } from './bytes'
 import { keccak, keccak256, keccakFromString, rlphash } from './hash'
-import { assertIsHexString, assertIsBuffer } from './helpers'
+import { assertIsString, assertIsHexString, assertIsBuffer } from './helpers'
 import { BNLike, BufferLike, bnToRlp, toType, TypeOutput } from './types'
 
 export interface AccountData {
@@ -122,7 +122,12 @@ export class Account {
  * Checks if the address is a valid. Accepts checksummed addresses too.
  */
 export const isValidAddress = function (hexAddress: string): boolean {
-  assertIsHexString(hexAddress)
+  try {
+    assertIsString(hexAddress)
+  } catch (e) {
+    return false
+  }
+
   return /^0x[0-9a-fA-F]{40}$/.test(hexAddress)
 }
 
@@ -299,7 +304,12 @@ export const zeroAddress = function (): string {
  * Checks if a given address is the zero address.
  */
 export const isZeroAddress = function (hexAddress: string): boolean {
-  assertIsHexString(hexAddress)
+  try {
+    assertIsString(hexAddress)
+  } catch (e) {
+    return false
+  }
+
   const zeroAddr = zeroAddress()
   return zeroAddr === hexAddress
 }

--- a/packages/util/test/account.spec.ts
+++ b/packages/util/test/account.spec.ts
@@ -633,10 +633,8 @@ tape('Utility Functions', function (t) {
         st.end()
       })
 
-      st.test('input format', function (st) {
-        st.throws(() => {
-          isValidChecksumAddress('2f015c60e0be116b1f0cd534704db9c92118fb6a')
-        }, 'Should throw when the address is not hex-prefixed')
+      st.test('Should return false if input is not hex-prefixed', function (st) {
+        st.notOk(isValidChecksumAddress('2f015c60e0be116b1f0cd534704db9c92118fb6a'))
         st.end()
       })
 
@@ -653,28 +651,9 @@ tape('Utility Functions', function (t) {
     st.test('should return false', function (st) {
       st.notOk(isValidAddress('0x2f015c60e0be116b1f0cd534704db9c92118fb6'))
       st.notOk(isValidAddress('0x2f015c60e0be116b1f0cd534704db9c92118fb6aa'))
-      st.end()
-    })
-    st.test('should throw when input is not hex prefixed', function (st) {
-      st.throws(function () {
-        isValidAddress('2f015c60e0be116b1f0cd534704db9c92118fb6a')
-      })
-      st.throws(function () {
-        isValidAddress('x2f015c60e0be116b1f0cd534704db9c92118fb6a')
-      })
-      st.throws(function () {
-        isValidAddress('0X52908400098527886E0F7030069857D2E4169EE7')
-      })
-      st.end()
-    })
-    st.test('error message should have correct format', function (st) {
-      const input = '2f015c60e0be116b1f0cd534704db9c92118fb6a'
-      try {
-        isValidAddress('2f015c60e0be116b1f0cd534704db9c92118fb6a')
-      } catch (err) {
-        st.ok(err.message.includes('only supports 0x-prefixed hex strings'))
-        st.ok(err.message.includes(input))
-      }
+      st.notOk(isValidAddress('2f015c60e0be116b1f0cd534704db9c92118fb6a'))
+      st.notOk(isValidAddress('x2f015c60e0be116b1f0cd534704db9c92118fb6a'))
+      st.notOk(isValidAddress('0X52908400098527886E0F7030069857D2E4169EE7'))
       st.end()
     })
   })

--- a/packages/util/test/bytes.spec.ts
+++ b/packages/util/test/bytes.spec.ts
@@ -47,10 +47,8 @@ tape('is zero address', function (t) {
     st.end()
   })
 
-  t.test('should throw when address is not hex-prefixed', function (st) {
-    st.throws(function () {
-      isZeroAddress('0000000000000000000000000000000000000000')
-    })
+  t.test('should return false when address is not hex-prefixed', function (st) {
+    st.equal(isZeroAddress('0000000000000000000000000000000000000000'), false)
     st.end()
   })
 })


### PR DESCRIPTION
PR changes `isValidAddress`, `isValidChecksumAddress` and `isZeroAddress` to return `false` when given a non-hex-prefixed string (or non-string) input.

This proposal comes from a Hardhat integration [review discussion][1]. 

Basic idea is that it's unexpected behavior for boolean validators like this to throw. 

[1]: https://github.com/nomiclabs/hardhat/pull/1337#discussion_r600056630
 