### PR TITLE
vm: add tx receipt to RunTxResult, allow BlockBuilder to build a block with zero txs

### DIFF
--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -1,6 +1,6 @@
 import { AddressLike, BNLike, BufferLike } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
-import { TxData, JsonTx } from '@ethereumjs/tx'
+import { AccessListEIP2930TxData, TxData, JsonTx } from '@ethereumjs/tx'
 import { Block } from './block'
 import { BlockHeader } from './header'
 
@@ -93,7 +93,7 @@ export interface BlockData {
    * Header data for the block
    */
   header?: HeaderData
-  transactions?: Array<TxData>
+  transactions?: Array<TxData | AccessListEIP2930TxData>
   uncleHeaders?: Array<HeaderData>
 }
 

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -47,7 +47,7 @@ export abstract class BaseTransaction<TransactionObject> {
     } else {
       this._type = 0
     }
-    
+
     const toB = toBuffer(to === '' ? '0x' : to)
     const vB = toBuffer(v === '' ? '0x' : v)
     const rB = toBuffer(r === '' ? '0x' : r)

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -8,7 +8,13 @@ import {
   ecsign,
   publicToAddress,
 } from 'ethereumjs-util'
-import { TxData, TxOptions, JsonTx, AccessListEIP2930ValuesArray } from './types'
+import {
+  TxData,
+  TxOptions,
+  JsonTx,
+  AccessListEIP2930ValuesArray,
+  AccessListEIP2930TxData,
+} from './types'
 
 /**
  * This base class will likely be subject to further
@@ -18,6 +24,8 @@ import { TxData, TxOptions, JsonTx, AccessListEIP2930ValuesArray } from './types
  * It is therefore not recommended to use directly.
  */
 export abstract class BaseTransaction<TransactionObject> {
+  private readonly _type: number
+
   public readonly nonce: BN
   public readonly gasLimit: BN
   public readonly gasPrice: BN
@@ -30,8 +38,16 @@ export abstract class BaseTransaction<TransactionObject> {
   public readonly r?: BN
   public readonly s?: BN
 
-  constructor(txData: TxData, txOptions: TxOptions = {}) {
+  constructor(txData: TxData | AccessListEIP2930TxData, txOptions: TxOptions = {}) {
     const { nonce, gasLimit, gasPrice, to, value, data, v, r, s } = txData
+
+    const type = (txData as AccessListEIP2930TxData).type
+    if (type !== undefined) {
+      this._type = new BN(toBuffer(type)).toNumber()
+    } else {
+      this._type = 0
+    }
+    
     const toB = toBuffer(to === '' ? '0x' : to)
     const vB = toBuffer(v === '' ? '0x' : v)
     const rB = toBuffer(r === '' ? '0x' : r)
@@ -59,9 +75,40 @@ export abstract class BaseTransaction<TransactionObject> {
   }
 
   /**
-   * Checks if the transaction has the minimum amount of gas required
-   * (DataFee + TxFee + Creation Fee).
+   * Returns the transaction type
    */
+  get transactionType(): number {
+    return this._type
+  }
+
+  /**
+   * Alias for `transactionType`
+   */
+  get type() {
+    return this.transactionType
+  }
+
+  /**
+   * EIP-2930 alias for `r`
+   */
+  get senderR() {
+    return this.r
+  }
+
+  /**
+   * EIP-2930 alias for `s`
+   */
+  get senderS() {
+    return this.s
+  }
+
+  /**
+   * EIP-2930 alias for `v`
+   */
+  get yParity() {
+    return this.v
+  }
+
   /**
    * Checks if the transaction has the minimum amount of gas required
    * (DataFee + TxFee + Creation Fee).

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -38,6 +38,11 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
   get transactionType(): number {
     return 1
   }
+  
+  // Alias for transactionType
+  get type() {
+    return this.transactionType
+  }
 
   // EIP-2930 alias for `s`
   get senderS() {

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -35,30 +35,6 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
   public readonly accessList: AccessListBuffer
   public readonly AccessListJSON: AccessList
 
-  get transactionType(): number {
-    return 1
-  }
-
-  // Alias for transactionType
-  get type() {
-    return this.transactionType
-  }
-
-  // EIP-2930 alias for `s`
-  get senderS() {
-    return this.s
-  }
-
-  // EIP-2930 alias for `r`
-  get senderR() {
-    return this.r
-  }
-
-  // EIP-2930 alias for `v`
-  get yParity() {
-    return this.v
-  }
-
   /**
    * Instantiate a transaction from a data dictionary
    */
@@ -143,7 +119,7 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
   public constructor(txData: AccessListEIP2930TxData, opts: TxOptions = {}) {
     const { chainId, accessList } = txData
 
-    super(txData, opts)
+    super({ ...txData, type: 1 }, opts)
 
     // EIP-2718 check is done in Common
     if (!this.common.isActivatedEIP(2930)) {

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -38,7 +38,7 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
   get transactionType(): number {
     return 1
   }
-  
+
   // Alias for transactionType
   get type() {
     return this.transactionType

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -15,10 +15,6 @@ import { BaseTransaction } from './baseTransaction'
  * An Ethereum non-typed (legacy) transaction
  */
 export default class Transaction extends BaseTransaction<Transaction> {
-  get transactionType(): number {
-    return 0
-  }
-
   /**
    * Instantiate a transaction from a data dictionary
    */

--- a/packages/tx/src/transactionFactory.ts
+++ b/packages/tx/src/transactionFactory.ts
@@ -1,4 +1,4 @@
-import { BN } from 'ethereumjs-util'
+import { BN, toBuffer } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { default as Transaction } from './legacyTransaction'
 import { default as AccessListEIP2930Transaction } from './eip2930Transaction'
@@ -25,7 +25,7 @@ export default class TransactionFactory {
       // Assume legacy transaction
       return Transaction.fromTxData(<TxData>txData, txOptions)
     } else {
-      const txType = new BN(txData.type).toNumber()
+      const txType = new BN(toBuffer(txData.type)).toNumber()
       return TransactionFactory.getTransactionClass(txType, common).fromTxData(
         <AccessListEIP2930TxData>txData,
         txOptions

--- a/packages/tx/test/eip2930.spec.ts
+++ b/packages/tx/test/eip2930.spec.ts
@@ -19,7 +19,12 @@ const chainId = new BN(1)
 
 tape('[AccessListEIP2930Transaction]', function (t) {
   t.test('Initialization / Getter', function (t) {
-    t.ok(AccessListEIP2930Transaction.fromTxData({}, { common }), 'should initialize correctly')
+    const tx = AccessListEIP2930Transaction.fromTxData({}, { common })
+    t.ok(tx, 'should initialize correctly')
+    t.ok(
+      AccessListEIP2930Transaction.fromTxData(tx, { common }),
+      'should initialize correctly from its own data'
+    )
 
     const nonEIP2930Common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
     t.throws(() => {

--- a/packages/vm/lib/buildBlock.ts
+++ b/packages/vm/lib/buildBlock.ts
@@ -204,7 +204,9 @@ export class BlockBuilder {
       await this.rewardMiner()
     }
 
-    await this.vm.stateManager.commit()
+    if (this.checkpointed) {
+      await this.vm.stateManager.commit()
+    }
 
     const stateRoot = await this.vm.stateManager.getStateRoot(false)
     const transactionsTrie = await this.transactionsTrie()

--- a/packages/vm/lib/buildBlock.ts
+++ b/packages/vm/lib/buildBlock.ts
@@ -204,11 +204,7 @@ export class BlockBuilder {
       await this.rewardMiner()
     }
 
-    if (this.checkpointed) {
-      await this.vm.stateManager.commit()
-    }
-
-    const stateRoot = await this.vm.stateManager.getStateRoot(false)
+    const stateRoot = await this.vm.stateManager.getStateRoot(true)
     const transactionsTrie = await this.transactionsTrie()
     const receiptTrie = await this.receiptTrie()
     const bloom = this.bloom()
@@ -233,7 +229,13 @@ export class BlockBuilder {
     const blockData = { header: headerData, transactions: this.transactions }
     const block = Block.fromBlockData(blockData, blockOpts)
     await this.vm.blockchain.putBlock(block)
+
     this.built = true
+    if (this.checkpointed) {
+      await this.vm.stateManager.commit()
+      this.checkpointed = false
+    }
+
     return block
   }
 }

--- a/packages/vm/lib/runBlock.ts
+++ b/packages/vm/lib/runBlock.ts
@@ -1,17 +1,16 @@
 import { debug as createDebugLogger } from 'debug'
 import { encode } from 'rlp'
 import { BaseTrie as Trie } from 'merkle-patricia-tree'
-import { Account, Address, BN } from 'ethereumjs-util'
+import { Account, Address, BN, intToBuffer } from 'ethereumjs-util'
 import { Block } from '@ethereumjs/block'
 import VM from './index'
 import Bloom from './bloom'
 import { StateManager } from './state'
-
-import * as DAOConfig from './config/dao_fork_accounts_config.json'
-import { Log } from './evm/types'
 import { short } from './evm/opcodes'
 import type { TypedTransaction } from '@ethereumjs/tx'
 import type { RunTxResult } from './runTx'
+import type { TxReceipt } from './types'
+import * as DAOConfig from './config/dao_fork_accounts_config.json'
 
 const debug = createDebugLogger('vm:block')
 
@@ -61,7 +60,7 @@ export interface RunBlockResult {
   /**
    * Receipts generated for transactions in the block
    */
-  receipts: (PreByzantiumTxReceipt | PostByzantiumTxReceipt | EIP2930Receipt)[]
+  receipts: TxReceipt[]
   /**
    * Results of executing the transactions in the block
    */
@@ -83,49 +82,6 @@ export interface RunBlockResult {
    */
   receiptRoot: Buffer
 }
-
-/**
- * Abstract interface with common transaction receipt fields
- */
-interface TxReceipt {
-  /**
-   * Gas used
-   */
-  gasUsed: Buffer
-  /**
-   * Bloom bitvector
-   */
-  bitvector: Buffer
-  /**
-   * Logs emitted
-   */
-  logs: Log[]
-}
-
-/**
- * Pre-Byzantium receipt type with a field
- * for the intermediary state root
- */
-export interface PreByzantiumTxReceipt extends TxReceipt {
-  /**
-   * Intermediary state root
-   */
-  stateRoot: Buffer
-}
-
-/**
- * Receipt type for Byzantium and beyond replacing the intermediary
- * state root field with a status code field (EIP-658)
- */
-export interface PostByzantiumTxReceipt extends TxReceipt {
-  /**
-   * Status of transaction, `1` if successful, `0` if an exception occured
-   */
-  status: 0 | 1
-}
-
-// EIP290Receipt, which has the same fields as PostByzantiumTxReceipt
-export interface EIP2930Receipt extends PostByzantiumTxReceipt {}
 
 export interface AfterBlockEvent extends RunBlockResult {
   // The block which just finished processing
@@ -334,9 +290,13 @@ async function applyTransactions(this: VM, block: Block, opts: RunBlockOpts) {
 
     // Run the tx through the VM
     const { skipBalance, skipNonce } = opts
+
+    // Construct a block with the current gasUsed for accurate tx receipt generation
+    const blockWithGasUsed = Block.fromBlockData({ ...block, header: { ...block.header, gasUsed } })
+
     const txRes = await this.runTx({
       tx,
-      block,
+      block: blockWithGasUsed,
       skipBalance,
       skipNonce,
     })
@@ -346,18 +306,13 @@ async function applyTransactions(this: VM, block: Block, opts: RunBlockOpts) {
     // Add to total block gas usage
     gasUsed = gasUsed.add(txRes.gasUsed)
     debug(`Add tx gas used (${txRes.gasUsed}) to total block gas usage (-> ${gasUsed})`)
+
     // Combine blooms via bitwise OR
     bloom.or(txRes.bloom)
 
-    const { txReceipt, encodedReceipt, receiptLog } = await generateTxReceipt.bind(this)(
-      tx,
-      txRes,
-      gasUsed
-    )
-    debug(receiptLog)
-    receipts.push(txReceipt)
-
     // Add receipt to trie to later calculate receipt root
+    receipts.push(txRes.receipt)
+    const encodedReceipt = encodeReceipt(tx, txRes.receipt)
     await receiptTrie.put(encode(txIdx), encodedReceipt)
   }
 
@@ -420,66 +375,17 @@ export async function rewardAccount(
 }
 
 /**
- * Generates the tx receipt and returns { txReceipt, encodedReceipt, receiptLog }
+ * Returns the encoded tx receipt.
  */
-export async function generateTxReceipt(
-  this: VM,
-  tx: TypedTransaction,
-  txRes: RunTxResult,
-  blockGasUsed: BN
-) {
-  const abstractTxReceipt: TxReceipt = {
-    gasUsed: blockGasUsed.toArrayLike(Buffer),
-    bitvector: txRes.bloom.bitvector,
-    logs: txRes.execResult.logs || [],
-  }
-
-  let txReceipt
-  let encodedReceipt
-
-  let receiptLog = `Generate tx receipt transactionType=${
-    'transactionType' in tx ? tx.transactionType : 'NaN'
-  } gasUsed=${blockGasUsed.toString()} bitvector=${short(abstractTxReceipt.bitvector)} (${
-    abstractTxReceipt.bitvector.length
-  } bytes) logs=${abstractTxReceipt.logs.length}`
+export function encodeReceipt(tx: TypedTransaction, receipt: TxReceipt) {
+  const encoded = encode(Object.values(receipt))
 
   if (!('transactionType' in tx) || tx.transactionType === 0) {
-    // Legacy transaction
-    if (this._common.gteHardfork('byzantium')) {
-      // Post-Byzantium
-      txReceipt = {
-        status: txRes.execResult.exceptionError ? 0 : 1, // Receipts have a 0 as status on error
-        ...abstractTxReceipt,
-      } as PostByzantiumTxReceipt
-      const statusInfo = txRes.execResult.exceptionError ? 'error' : 'ok'
-      receiptLog += ` status=${txReceipt.status} (${statusInfo}) (>= Byzantium)`
-    } else {
-      // Pre-Byzantium
-      const stateRoot = await this.stateManager.getStateRoot(true)
-      txReceipt = {
-        stateRoot: stateRoot,
-        ...abstractTxReceipt,
-      } as PreByzantiumTxReceipt
-      receiptLog += ` stateRoot=${txReceipt.stateRoot.toString('hex')} (< Byzantium)`
-    }
-    encodedReceipt = encode(Object.values(txReceipt))
-  } else if ('transactionType' in tx && tx.transactionType === 1) {
-    // EIP2930 Transaction
-    txReceipt = {
-      status: txRes.execResult.exceptionError ? 0 : 1,
-      ...abstractTxReceipt,
-    } as EIP2930Receipt
-    encodedReceipt = Buffer.concat([Buffer.from('01', 'hex'), encode(Object.values(txReceipt))])
-  } else {
-    throw new Error(
-      `Unsupported transaction type ${'transactionType' in tx ? tx.transactionType : 'NaN'}`
-    )
+    return encoded
   }
-  return {
-    txReceipt,
-    encodedReceipt,
-    receiptLog,
-  }
+
+  const type = intToBuffer(tx.transactionType)
+  return Buffer.concat([type, encoded])
 }
 
 // apply the DAO fork changes to the VM

--- a/packages/vm/lib/runBlock.ts
+++ b/packages/vm/lib/runBlock.ts
@@ -292,7 +292,7 @@ async function applyTransactions(this: VM, block: Block, opts: RunBlockOpts) {
     const { skipBalance, skipNonce } = opts
 
     // Construct a block with the current gasUsed for accurate tx receipt generation
-    const blockWithGasUsed = Block.fromBlockData({ ...block, header: { ...block.header, gasUsed } })
+    const blockWithGasUsed = Block.fromBlockData({ ...block, header: { ...block.header, gasUsed } }, { common: this._common })
 
     const txRes = await this.runTx({
       tx,

--- a/packages/vm/lib/runBlock.ts
+++ b/packages/vm/lib/runBlock.ts
@@ -292,7 +292,10 @@ async function applyTransactions(this: VM, block: Block, opts: RunBlockOpts) {
     const { skipBalance, skipNonce } = opts
 
     // Construct a block with the current gasUsed for accurate tx receipt generation
-    const blockWithGasUsed = Block.fromBlockData({ ...block, header: { ...block.header, gasUsed } }, { common: this._common })
+    const blockWithGasUsed = Block.fromBlockData(
+      { ...block, header: { ...block.header, gasUsed } },
+      { common: this._common }
+    )
 
     const txRes = await this.runTx({
       tx,

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -410,6 +410,12 @@ function txLogsBloom(logs?: any[]): Bloom {
 
 /**
  * Returns the tx receipt.
+ * @param this The vm instance
+ * @param tx The transaction
+ * @param txResult The tx result
+ * @param blockGasUsed The amount of gas used in the block up until this tx
+ * @param debug If provided, the debug log message will be run as the first
+ * parameter of this function, i.e. debug(log)
  */
 export async function generateTxReceipt(
   this: VM,

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -371,7 +371,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
 
   // Generate the tx receipt
   const blockGasUsed = block.header.gasUsed.add(results.gasUsed)
-  results.receipt = await generateTxReceipt.bind(this)(tx, results, blockGasUsed, debug)
+  results.receipt = await generateTxReceipt.bind(this)(tx, results, blockGasUsed)
 
   /**
    * The `afterTx` event
@@ -421,8 +421,7 @@ export async function generateTxReceipt(
   this: VM,
   tx: TypedTransaction,
   txResult: RunTxResult,
-  blockGasUsed: BN,
-  debug?: Function
+  blockGasUsed: BN
 ): Promise<TxReceipt> {
   const baseReceipt: BaseTxReceipt = {
     gasUsed: blockGasUsed.toArrayLike(Buffer),
@@ -468,9 +467,6 @@ export async function generateTxReceipt(
     )
   }
 
-  if (debug) {
-    debug(log)
-  }
-
+  debug(log)
   return receipt
 }

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -414,8 +414,6 @@ function txLogsBloom(logs?: any[]): Bloom {
  * @param tx The transaction
  * @param txResult The tx result
  * @param blockGasUsed The amount of gas used in the block up until this tx
- * @param debug If provided, the debug log message will be run as the first
- * parameter of this function, i.e. debug(log)
  */
 export async function generateTxReceipt(
   this: VM,

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -15,6 +15,13 @@ import Message from './evm/message'
 import TxContext from './evm/txContext'
 import { getActivePrecompiles } from './evm/precompiles'
 import { EIP2929StateManager } from './state/interface'
+import type {
+  TxReceipt,
+  BaseTxReceipt,
+  PreByzantiumTxReceipt,
+  PostByzantiumTxReceipt,
+  EIP2930Receipt,
+} from './types'
 
 const debug = createDebugLogger('vm:tx')
 const debugGas = createDebugLogger('vm:tx:gas')
@@ -24,7 +31,11 @@ const debugGas = createDebugLogger('vm:tx:gas')
  */
 export interface RunTxOpts {
   /**
-   * The `@ethereumjs/block` the `tx` belongs to. If omitted a default blank block will be used.
+   * The `@ethereumjs/block` the `tx` belongs to.
+   * If omitted, a default blank block will be used.
+   * To obtain an accurate `TxReceipt`, please pass a block
+   * with the header field `gasUsed` set to the value
+   * prior to this tx being run.
    */
   block?: Block
   /**
@@ -67,10 +78,17 @@ export interface RunTxResult extends EVMResult {
    * Bloom filter resulted from transaction
    */
   bloom: Bloom
+
   /**
    * The amount of ether used by this transaction
    */
   amountSpent: BN
+
+  /**
+   * The tx receipt
+   */
+  receipt: TxReceipt
+
   /**
    * The amount of gas as that was refunded during the transaction (i.e. `gasUsed = totalGasConsumed - gasRefund`)
    */
@@ -285,9 +303,11 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // Generate the bloom for the tx
   results.bloom = txLogsBloom(results.execResult.logs)
   debug(`Generated tx bloom with logs=${results.execResult.logs?.length}`)
+
   // Caculate the total gas used
   results.gasUsed.iadd(basefee)
   debugGas(`tx add baseFee ${basefee} to gasUsed (-> ${results.gasUsed})`)
+
   // Process any gas refund
   // TODO: determine why the gasRefund from execResult is not used here directly
   let gasRefund = evm._refund
@@ -349,6 +369,10 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   await state.cleanupTouchedAccounts()
   state.clearOriginalStorageCache()
 
+  // Generate the tx receipt
+  const blockGasUsed = block.header.gasUsed.add(results.gasUsed)
+  results.receipt = await generateTxReceipt.bind(this)(tx, results, blockGasUsed, debug)
+
   /**
    * The `afterTx` event
    *
@@ -382,4 +406,65 @@ function txLogsBloom(logs?: any[]): Bloom {
     }
   }
   return bloom
+}
+
+/**
+ * Returns the tx receipt.
+ */
+export async function generateTxReceipt(
+  this: VM,
+  tx: TypedTransaction,
+  txResult: RunTxResult,
+  blockGasUsed: BN,
+  debug?: Function
+): Promise<TxReceipt> {
+  const baseReceipt: BaseTxReceipt = {
+    gasUsed: blockGasUsed.toArrayLike(Buffer),
+    bitvector: txResult.bloom.bitvector,
+    logs: txResult.execResult.logs ?? [],
+  }
+
+  let receipt
+  let log = `Generate tx receipt transactionType=${
+    'transactionType' in tx ? tx.transactionType : 'NaN'
+  } gasUsed=${blockGasUsed.toString()} bitvector=${short(baseReceipt.bitvector)} (${
+    baseReceipt.bitvector.length
+  } bytes) logs=${baseReceipt.logs.length}`
+
+  if (!('transactionType' in tx) || tx.transactionType === 0) {
+    // Legacy transaction
+    if (this._common.gteHardfork('byzantium')) {
+      // Post-Byzantium
+      receipt = {
+        status: txResult.execResult.exceptionError ? 0 : 1, // Receipts have a 0 as status on error
+        ...baseReceipt,
+      } as PostByzantiumTxReceipt
+      const statusInfo = txResult.execResult.exceptionError ? 'error' : 'ok'
+      log += ` status=${receipt.status} (${statusInfo}) (>= Byzantium)`
+    } else {
+      // Pre-Byzantium
+      const stateRoot = await this.stateManager.getStateRoot(true)
+      receipt = {
+        stateRoot: stateRoot,
+        ...baseReceipt,
+      } as PreByzantiumTxReceipt
+      log += ` stateRoot=${receipt.stateRoot.toString('hex')} (< Byzantium)`
+    }
+  } else if ('transactionType' in tx && tx.transactionType === 1) {
+    // EIP2930 Transaction
+    receipt = {
+      status: txResult.execResult.exceptionError ? 0 : 1,
+      ...baseReceipt,
+    } as EIP2930Receipt
+  } else {
+    throw new Error(
+      `Unsupported transaction type ${'transactionType' in tx ? tx.transactionType : 'NaN'}`
+    )
+  }
+
+  if (debug) {
+    debug(log)
+  }
+
+  return receipt
 }

--- a/packages/vm/lib/types.ts
+++ b/packages/vm/lib/types.ts
@@ -1,0 +1,46 @@
+import { Log } from './evm/types'
+
+export type TxReceipt = PreByzantiumTxReceipt | PostByzantiumTxReceipt | EIP2930Receipt
+
+/**
+ * Abstract interface with common transaction receipt fields
+ */
+export interface BaseTxReceipt {
+  /**
+   * Gas used
+   */
+  gasUsed: Buffer
+  /**
+   * Bloom bitvector
+   */
+  bitvector: Buffer
+  /**
+   * Logs emitted
+   */
+  logs: Log[]
+}
+
+/**
+ * Pre-Byzantium receipt type with a field
+ * for the intermediary state root
+ */
+export interface PreByzantiumTxReceipt extends BaseTxReceipt {
+  /**
+   * Intermediary state root
+   */
+  stateRoot: Buffer
+}
+
+/**
+ * Receipt type for Byzantium and beyond replacing the intermediary
+ * state root field with a status code field (EIP-658)
+ */
+export interface PostByzantiumTxReceipt extends BaseTxReceipt {
+  /**
+   * Status of transaction, `1` if successful, `0` if an exception occured
+   */
+  status: 0 | 1
+}
+
+// EIP290Receipt, which has the same fields as PostByzantiumTxReceipt
+export interface EIP2930Receipt extends PostByzantiumTxReceipt {}

--- a/packages/vm/tests/api/runBlock.spec.ts
+++ b/packages/vm/tests/api/runBlock.spec.ts
@@ -3,12 +3,8 @@ import { Address, BN, rlp, KECCAK256_RLP } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import { Transaction } from '@ethereumjs/tx'
-import {
-  PreByzantiumTxReceipt,
-  PostByzantiumTxReceipt,
-  RunBlockOpts,
-  AfterBlockEvent,
-} from '../../lib/runBlock'
+import { RunBlockOpts, AfterBlockEvent } from '../../lib/runBlock'
+import type { PreByzantiumTxReceipt, PostByzantiumTxReceipt } from '../../lib/types'
 import { setupPreConditions, getDAOCommon } from '../util'
 import { setupVM, createAccount } from './utils'
 import testnet from './testdata/testnet.json'

--- a/packages/vm/tests/api/runBlock.spec.ts
+++ b/packages/vm/tests/api/runBlock.spec.ts
@@ -2,7 +2,7 @@ import tape from 'tape'
 import { Address, BN, rlp, KECCAK256_RLP } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
-import { Transaction } from '@ethereumjs/tx'
+import { AccessListEIP2930Transaction, Transaction, TypedTransaction } from '@ethereumjs/tx'
 import { RunBlockOpts, AfterBlockEvent } from '../../lib/runBlock'
 import type { PreByzantiumTxReceipt, PostByzantiumTxReceipt } from '../../lib/types'
 import { setupPreConditions, getDAOCommon } from '../util'
@@ -343,6 +343,73 @@ tape('runBlock() -> API return values', async (t) => {
       'should return correct pre-Byzantium receipt format'
     )
 
+    t.end()
+  })
+})
+
+tape('runBlock() -> tx types', async (t) => {
+  async function simpleRun(vm: VM, transactions: TypedTransaction[]) {
+    const common = vm._common
+
+    const blockRlp = testData.blocks[0].rlp
+    const block = Block.fromRLPSerializedBlock(blockRlp, { common, freeze: false })
+
+    //@ts-ignore overwrite transactions
+    block.transactions = transactions
+
+    //@ts-ignore
+    await setupPreConditions(vm.stateManager._trie, testData)
+
+    const res = await vm.runBlock({
+      block,
+      skipBlockValidation: true,
+      generate: true,
+    })
+
+    t.ok(
+      res.gasUsed.eq(
+        res.receipts
+          .map((r) => r.gasUsed)
+          .reduce((prevValue: BN, currValue: Buffer) => prevValue.add(new BN(currValue)), new BN(0))
+      ),
+      "gas used should equal transaction's total gasUsed"
+    )
+  }
+
+  t.test('legacy tx', async (t) => {
+    const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
+    const vm = setupVM({ common })
+    await vm.stateManager.generateCanonicalGenesis()
+
+    const tx = Transaction.fromTxData({ gasLimit: 53000, value: 1 }, { common, freeze: false })
+
+    // set `from` to a genesis address with existing balance
+    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
+    tx.getSenderAddress = () => {
+      return address
+    }
+
+    await simpleRun(vm, [tx])
+    t.end()
+  })
+
+  t.test('access list tx', async (t) => {
+    const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
+    const vm = setupVM({ common })
+    await vm.stateManager.generateCanonicalGenesis()
+
+    const tx = AccessListEIP2930Transaction.fromTxData(
+      { gasLimit: 53000, value: 1, v: 1, r: 1, s: 1 },
+      { common, freeze: false }
+    )
+
+    // set `from` to a genesis address with existing balance
+    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
+    tx.getSenderAddress = () => {
+      return address
+    }
+
+    await simpleRun(vm, [tx])
     t.end()
   })
 })

--- a/packages/vm/tests/api/runTx.spec.ts
+++ b/packages/vm/tests/api/runTx.spec.ts
@@ -2,7 +2,7 @@ import tape from 'tape'
 import { Account, Address, BN, MAX_INTEGER } from 'ethereumjs-util'
 import { Block } from '@ethereumjs/block'
 import Common from '@ethereumjs/common'
-import { Transaction } from '@ethereumjs/tx'
+import { Transaction, TransactionFactory } from '@ethereumjs/tx'
 import VM from '../../lib'
 import { createAccount, getTransaction } from './utils'
 
@@ -196,7 +196,7 @@ tape('runTx() -> API parameter usage/data errors', (t) => {
 tape('runTx() -> runtime behavior', async (t) => {
   t.test('storage cache', async (t) => {
     for (const txType of TRANSACTION_TYPES) {
-      const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+      const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
       const vm = new VM({ common })
       const privateKey = Buffer.from(
         'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
@@ -225,9 +225,9 @@ tape('runTx() -> runtime behavior', async (t) => {
       if (txType.type === 1) {
         txParams['chainId'] = common.chainIdBN()
         txParams['accessList'] = []
-        txParams['type'] = txType
+        txParams['type'] = txType.type
       }
-      const tx = Transaction.fromTxData(txParams, { common }).sign(privateKey)
+      const tx = TransactionFactory.fromTxData(txParams, { common }).sign(privateKey)
 
       await vm.stateManager.putAccount(tx.getSenderAddress(), createAccount())
 

--- a/packages/vm/tests/api/types.spec.ts
+++ b/packages/vm/tests/api/types.spec.ts
@@ -1,0 +1,43 @@
+import tape from 'tape'
+import Common from '@ethereumjs/common'
+import {
+  AccessListEIP2930Transaction,
+  AccessListEIP2930TxData,
+  Transaction,
+  TxData,
+} from '@ethereumjs/tx'
+import { Block, BlockData } from '@ethereumjs/block'
+
+tape('[Types]', function (t) {
+  t.test('should ensure that the actual objects can be safely used as their data types', (st) => {
+    type RequiredExceptOptionals<TypeT, OptionalFieldsT extends keyof TypeT> = Required<
+      Omit<TypeT, OptionalFieldsT>
+    > &
+      Pick<TypeT, OptionalFieldsT>
+
+    const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
+
+    // Block
+    const block: Required<BlockData> = Block.fromBlockData({}, { common })
+    st.ok(block, 'block')
+
+    // Transactions
+    type OptionalTxFields = 'to' | 'r' | 's' | 'v'
+
+    // Legacy tx
+    const legacyTx: RequiredExceptOptionals<TxData, OptionalTxFields> = Transaction.fromTxData(
+      {},
+      { common }
+    )
+    st.ok(legacyTx, 'legacy tx')
+
+    // Access List tx
+    const accessListTx: RequiredExceptOptionals<
+      AccessListEIP2930TxData,
+      OptionalTxFields
+    > = AccessListEIP2930Transaction.fromTxData({}, { common })
+    st.ok(accessListTx, 'accessList tx')
+
+    st.end()
+  })
+})

--- a/packages/vm/tests/api/types.spec.ts
+++ b/packages/vm/tests/api/types.spec.ts
@@ -10,6 +10,11 @@ import { Block, BlockData } from '@ethereumjs/block'
 
 tape('[Types]', function (t) {
   t.test('should ensure that the actual objects can be safely used as their data types', (st) => {
+    // Dev note:
+    // This test was written by @alcuadrado after discovering
+    // issues in creating an object from its own data. It will
+    // ensure that the classes can be initialized from their own data. 
+
     type RequiredExceptOptionals<TypeT, OptionalFieldsT extends keyof TypeT> = Required<
       Omit<TypeT, OptionalFieldsT>
     > &

--- a/packages/vm/tests/api/types.spec.ts
+++ b/packages/vm/tests/api/types.spec.ts
@@ -13,7 +13,7 @@ tape('[Types]', function (t) {
     // Dev note:
     // This test was written by @alcuadrado after discovering
     // issues in creating an object from its own data. It will
-    // ensure that the classes can be initialized from their own data. 
+    // ensure that the classes can be initialized from their own data.
 
     type RequiredExceptOptionals<TypeT, OptionalFieldsT extends keyof TypeT> = Required<
       Omit<TypeT, OptionalFieldsT>


### PR DESCRIPTION
This PR:
* Adds `receipt` to `RunTxResult`
  * Moves the tx receipt generation logic from `runBlock` to `runTx`
  * Requested by @alcuadrado
* Fixes `BlockBuilder` to allow building a block with zero txs
* `AccessListEIP2930Transaction`: adds alias `type` for `transactionType` so it can be interpreted correctly when passed to `fromTxData`
* `TransactionFactory`: For extra safety, adds `toBuffer` on `txData.type` in case a 0x-prefixed hex string is passed in
* Adds types test from @alcuadrado to ensure that the actual objects can be safely used as their data types
* Adds test cases for legacy and access list transactions to `runBlock`
* `BlockBuilder`: Moves the `stateManager.commit` to after putting the block in blockchain in case it throws on validating