### PR TITLE
Tx: fix AccessListEIP2930Transaction constructor bug with v=0

### DIFF
--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -33,6 +33,7 @@ export abstract class BaseTransaction<TransactionObject> {
   constructor(txData: TxData, txOptions: TxOptions = {}) {
     const { nonce, gasLimit, gasPrice, to, value, data, v, r, s } = txData
     const toB = toBuffer(to)
+    const vB = toBuffer(v)
     const rB = toBuffer(r)
     const sB = toBuffer(s)
 
@@ -43,7 +44,7 @@ export abstract class BaseTransaction<TransactionObject> {
     this.value = new BN(toBuffer(value))
     this.data = toBuffer(data)
 
-    this.v = v ? new BN(toBuffer(v)) : undefined
+    this.v = vB.length > 0 ? new BN(vB) : undefined
     this.r = rB.length > 0 ? new BN(rB) : undefined
     this.s = sB.length > 0 ? new BN(sB) : undefined
 

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -33,17 +33,19 @@ export abstract class BaseTransaction<TransactionObject> {
   constructor(txData: TxData, txOptions: TxOptions = {}) {
     const { nonce, gasLimit, gasPrice, to, value, data, v, r, s } = txData
     const toB = toBuffer(to)
+    const rB = toBuffer(r)
+    const sB = toBuffer(s)
 
     this.nonce = new BN(toBuffer(nonce))
     this.gasPrice = new BN(toBuffer(gasPrice))
     this.gasLimit = new BN(toBuffer(gasLimit))
-    this.to = toB.length > 0 ? new Address(toBuffer(to)) : undefined
+    this.to = toB.length > 0 ? new Address(toB) : undefined
     this.value = new BN(toBuffer(value))
     this.data = toBuffer(data)
 
     this.v = v ? new BN(toBuffer(v)) : undefined
-    this.r = r ? new BN(toBuffer(r)) : undefined
-    this.s = s ? new BN(toBuffer(s)) : undefined
+    this.r = rB.length > 0 ? new BN(rB) : undefined
+    this.s = sB.length > 0 ? new BN(sB) : undefined
 
     this._validateCannotExceedMaxInteger({
       nonce: this.nonce,

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -32,17 +32,17 @@ export abstract class BaseTransaction<TransactionObject> {
 
   constructor(txData: TxData, txOptions: TxOptions = {}) {
     const { nonce, gasLimit, gasPrice, to, value, data, v, r, s } = txData
-    const toB = toBuffer(to)
-    const vB = toBuffer(v)
-    const rB = toBuffer(r)
-    const sB = toBuffer(s)
+    const toB = toBuffer(to === '' ? '0x' : to)
+    const vB = toBuffer(v === '' ? '0x' : v)
+    const rB = toBuffer(r === '' ? '0x' : r)
+    const sB = toBuffer(s === '' ? '0x' : s)
 
-    this.nonce = new BN(toBuffer(nonce))
-    this.gasPrice = new BN(toBuffer(gasPrice))
-    this.gasLimit = new BN(toBuffer(gasLimit))
+    this.nonce = new BN(toBuffer(nonce === '' ? '0x' : nonce))
+    this.gasPrice = new BN(toBuffer(gasPrice === '' ? '0x' : gasPrice))
+    this.gasLimit = new BN(toBuffer(gasLimit === '' ? '0x' : gasLimit))
     this.to = toB.length > 0 ? new Address(toB) : undefined
-    this.value = new BN(toBuffer(value))
-    this.data = toBuffer(data)
+    this.value = new BN(toBuffer(value === '' ? '0x' : value))
+    this.data = toBuffer(data === '' ? '0x' : data)
 
     this.v = vB.length > 0 ? new BN(vB) : undefined
     this.r = rB.length > 0 ? new BN(rB) : undefined

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -32,11 +32,12 @@ export abstract class BaseTransaction<TransactionObject> {
 
   constructor(txData: TxData, txOptions: TxOptions = {}) {
     const { nonce, gasLimit, gasPrice, to, value, data, v, r, s } = txData
+    const toB = toBuffer(to)
 
     this.nonce = new BN(toBuffer(nonce))
     this.gasPrice = new BN(toBuffer(gasPrice))
     this.gasLimit = new BN(toBuffer(gasLimit))
-    this.to = to ? new Address(toBuffer(to)) : undefined
+    this.to = toB.length > 0 ? new Address(toBuffer(to)) : undefined
     this.value = new BN(toBuffer(value))
     this.data = toBuffer(data)
 

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -122,8 +122,8 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
         data: data ?? emptyBuffer,
         accessList: accessList ?? emptyAccessList,
         v: v !== undefined ? new BN(v) : undefined, // EIP2930 supports v's with value 0 (empty Buffer)
-        r: r !== undefined && !r.equals(emptyBuffer) ? new BN(r) : undefined,
-        s: s !== undefined && !s.equals(emptyBuffer) ? new BN(s) : undefined,
+        r,
+        s,
       },
       opts
     )

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -115,11 +115,11 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
     return new AccessListEIP2930Transaction(
       {
         chainId: new BN(chainId),
-        nonce: new BN(nonce),
-        gasPrice: new BN(gasPrice),
-        gasLimit: new BN(gasLimit),
+        nonce,
+        gasPrice,
+        gasLimit,
         to: to && to.length > 0 ? new Address(to) : undefined,
-        value: new BN(value),
+        value,
         data: data ?? emptyBuffer,
         accessList: accessList ?? emptyAccessList,
         v: v !== undefined ? new BN(v) : undefined, // EIP2930 supports v's with value 0 (empty Buffer)

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -1,5 +1,4 @@
 import {
-  Address,
   BN,
   bnToHex,
   bnToRlp,
@@ -118,7 +117,7 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
         nonce,
         gasPrice,
         gasLimit,
-        to: to && to.length > 0 ? new Address(to) : undefined,
+        to,
         value,
         data: data ?? emptyBuffer,
         accessList: accessList ?? emptyAccessList,

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -23,7 +23,6 @@ import {
 } from './types'
 
 const emptyAccessList: AccessList = []
-const emptyBuffer = Buffer.from([])
 
 /**
  * Typed transaction with optional access lists
@@ -119,7 +118,7 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
         gasLimit,
         to,
         value,
-        data: data ?? emptyBuffer,
+        data,
         accessList: accessList ?? emptyAccessList,
         v: v !== undefined ? new BN(v) : undefined, // EIP2930 supports v's with value 0 (empty Buffer)
         r,

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -77,7 +77,7 @@ export default class Transaction extends BaseTransaction<Transaction> {
         to,
         value,
         data: data ?? emptyBuffer,
-        v: v !== undefined && !v.equals(emptyBuffer) ? new BN(v) : undefined,
+        v,
         r,
         s,
       },

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -67,8 +67,6 @@ export default class Transaction extends BaseTransaction<Transaction> {
 
     const [nonce, gasPrice, gasLimit, to, value, data, v, r, s] = values
 
-    const emptyBuffer = Buffer.from([])
-
     return new Transaction(
       {
         nonce,
@@ -76,7 +74,7 @@ export default class Transaction extends BaseTransaction<Transaction> {
         gasLimit,
         to,
         value,
-        data: data ?? emptyBuffer,
+        data,
         v,
         r,
         s,

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -72,11 +72,11 @@ export default class Transaction extends BaseTransaction<Transaction> {
 
     return new Transaction(
       {
-        nonce: new BN(nonce),
-        gasPrice: new BN(gasPrice),
-        gasLimit: new BN(gasLimit),
+        nonce,
+        gasPrice,
+        gasLimit,
         to: to && to.length > 0 ? new Address(to) : undefined,
-        value: new BN(value),
+        value,
         data: data ?? emptyBuffer,
         v: v !== undefined && !v.equals(emptyBuffer) ? new BN(v) : undefined,
         r: r !== undefined && !r.equals(emptyBuffer) ? new BN(r) : undefined,

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -78,8 +78,8 @@ export default class Transaction extends BaseTransaction<Transaction> {
         value,
         data: data ?? emptyBuffer,
         v: v !== undefined && !v.equals(emptyBuffer) ? new BN(v) : undefined,
-        r: r !== undefined && !r.equals(emptyBuffer) ? new BN(r) : undefined,
-        s: s !== undefined && !s.equals(emptyBuffer) ? new BN(s) : undefined,
+        r,
+        s,
       },
       opts
     )

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -1,5 +1,4 @@
 import {
-  Address,
   BN,
   bnToHex,
   bnToRlp,
@@ -75,7 +74,7 @@ export default class Transaction extends BaseTransaction<Transaction> {
         nonce,
         gasPrice,
         gasLimit,
-        to: to && to.length > 0 ? new Address(to) : undefined,
+        to,
         value,
         data: data ?? emptyBuffer,
         v: v !== undefined && !v.equals(emptyBuffer) ? new BN(v) : undefined,


### PR DESCRIPTION
Fixes #1189 

Ok, this should do it, have tested on the console and can confirm that this fixes the bug.

Have also unified the default value setting along the road since this would otherwise generally be dangerous to introduce inconsistencies and hard-to-track bugs in the future which just occur on a single constructor or so.

I have done pretty atomic commits to allow for a careful review. I have done these single transitions pretty cautiously though.