### PR TITLE
Remove all the debug traces from the vm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2728,9 +2728,9 @@
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
 		},
 		"node_modules/@types/secp256k1": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
-			"integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.2.tgz",
+			"integrity": "sha512-QMg+9v0bbNJ2peLuHRWxzmy0HRJIG6gFZNhaRSp7S3ggSbCCxiqQB2/ybvhXyhHOCequpNkrx7OavNhrWOsW0A==",
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -3088,15 +3088,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/micromatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-			"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
 			"dependencies": {
 				"braces": "^3.0.1",
-				"picomatch": "^2.0.5"
+				"picomatch": "^2.2.3"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=8.6"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/ms": {
@@ -4963,15 +4963,15 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.16.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-			"integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+			"version": "4.16.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
+			"integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001181",
-				"colorette": "^1.2.1",
-				"electron-to-chromium": "^1.3.649",
+				"caniuse-lite": "^1.0.30001208",
+				"colorette": "^1.2.2",
+				"electron-to-chromium": "^1.3.712",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.70"
+				"node-releases": "^1.1.71"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -6655,9 +6655,12 @@
 			"integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg=="
 		},
 		"node_modules/d3-time": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.0.0.tgz",
-			"integrity": "sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+			"integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+			"dependencies": {
+				"d3-array": "2"
+			}
 		},
 		"node_modules/d3-time-format": {
 			"version": "3.0.0",
@@ -7564,9 +7567,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.3.711",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.711.tgz",
-			"integrity": "sha512-XbklBVCDiUeho0PZQCjC25Ha6uBwqqJeyDhPLwLwfWRAo4x+FZFsmu1pPPkXT+B4MQMQoQULfyaMltDopfeiHQ=="
+			"version": "1.3.712",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.712.tgz",
+			"integrity": "sha512-3kRVibBeCM4vsgoHHGKHmPocLqtFAGTrebXxxtgKs87hNUzXrX2NuS3jnBys7IozCnw7viQlozxKkmty2KNfrw=="
 		},
 		"node_modules/elliptic": {
 			"version": "6.5.4",
@@ -13420,9 +13423,9 @@
 			}
 		},
 		"node_modules/karma-typescript/node_modules/acorn": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
-			"integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==",
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.1.tgz",
+			"integrity": "sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g==",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -13791,9 +13794,9 @@
 			}
 		},
 		"node_modules/keypair": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.2.tgz",
-			"integrity": "sha512-7zRr8fKOWp/N8xfZyZV6WG1CUvKNiNahSDI4vjJnPJD60lHtIg62dpv60yCgcM2PP8QKv4S2UkZl+8MsYmQRpw=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.3.tgz",
+			"integrity": "sha512-0wjZ2z/SfZZq01+3/8jYLd8aEShSa+aat1zyPGQY3IuKoEAp6DJGvu2zt6snELrQU9jbCkIlCyNOD7RdQbHhkQ=="
 		},
 		"node_modules/kind-of": {
 			"version": "6.0.3",
@@ -14126,56 +14129,67 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/libp2p-crypto": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.19.2.tgz",
-			"integrity": "sha512-dl/tViAyaBhJn0gTTIeZGxK0t+d+2FSN6vmjVdljYZc+pVMExjrx8p7lmX98qp/X97u7Vt+Oq9LvfjLoiERDCQ==",
+			"version": "0.19.3",
+			"resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.19.3.tgz",
+			"integrity": "sha512-6xn2JRXXsn1/wWzcvmzmkMpw0j8N1/kO01V4eTjMzFpK6cS4cxHmBN3PQzYqAw6gHbjRTzsP8E+k5+iW6/VRaA==",
 			"dependencies": {
-				"err-code": "^2.0.0",
+				"err-code": "^3.0.1",
 				"is-typedarray": "^1.0.0",
-				"iso-random-stream": "^1.1.0",
+				"iso-random-stream": "^2.0.0",
 				"keypair": "^1.0.1",
-				"multibase": "^3.0.0",
-				"multicodec": "^2.0.0",
+				"multibase": "^4.0.3",
+				"multicodec": "^3.0.1",
 				"multihashes": "^4.0.2",
-				"multihashing-async": "^2.0.1",
+				"multihashing-async": "^2.1.2",
 				"node-forge": "^0.10.0",
 				"pem-jwk": "^2.0.0",
-				"protons": "^2.0.0",
+				"protobufjs": "^6.10.2",
 				"secp256k1": "^4.0.0",
-				"uint8arrays": "^1.1.0",
+				"uint8arrays": "^2.1.4",
 				"ursa-optional": "^0.10.1"
 			},
 			"engines": {
-				"node": ">=10.0.0",
-				"npm": ">=6.0.0"
+				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/libp2p-crypto/node_modules/err-code": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+			"integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
 		},
-		"node_modules/libp2p-crypto/node_modules/multibase": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.2.tgz",
-			"integrity": "sha512-bpklWHs70LO3smJUHOjcnzGceJJvn9ui0Vau6Za0B/GBepaXswmW8Ufea0uD9pROf/qCQ4N4lZ3sf3U+SNf0tw==",
+		"node_modules/libp2p-crypto/node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"engines": {
+				"node": ">=0.8.x"
+			}
+		},
+		"node_modules/libp2p-crypto/node_modules/iso-random-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-2.0.0.tgz",
+			"integrity": "sha512-lGuIu104KfBV9ubYTSaE3GeAr6I69iggXxBHbTBc5u/XKlwlWl0LCytnkIZissaKqvxablwRD9B3ktVnmIUnEg==",
 			"dependencies": {
-				"@multiformats/base-x": "^4.0.1",
-				"web-encoding": "^1.0.6"
+				"events": "^3.3.0",
+				"readable-stream": "^3.4.0"
 			},
 			"engines": {
-				"node": ">=10.0.0",
-				"npm": ">=6.0.0"
+				"node": ">=10"
 			}
 		},
-		"node_modules/libp2p-crypto/node_modules/uint8arrays": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
-			"integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
+		"node_modules/libp2p-crypto/node_modules/multicodec": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.0.1.tgz",
+			"integrity": "sha512-Y6j3wiPojvkF/z6KFIGt84KdJdP2oILEdzc/3YbD3qQ3EerhqtYlfsZTPPNVoCCxNZZdzIpCKrdYFSav17sIrQ==",
 			"dependencies": {
-				"multibase": "^3.0.0",
-				"web-encoding": "^1.0.2"
+				"uint8arrays": "^2.1.3",
+				"varint": "^5.0.2"
 			}
+		},
+		"node_modules/libp2p-crypto/node_modules/varint": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+			"integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
 		},
 		"node_modules/libp2p-interfaces": {
 			"version": "0.8.4",
@@ -14549,22 +14563,21 @@
 			}
 		},
 		"node_modules/libp2p-tcp": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.15.3.tgz",
-			"integrity": "sha512-j9efQ0aAbcCmVnnF0UqWH1r+qjNc0TpC3bV+QJDxBIe6v92a8l3kZ04G/QkP3vmzDT5Z4ayzMGjrOAas8hJIBA==",
+			"version": "0.15.4",
+			"resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.15.4.tgz",
+			"integrity": "sha512-MqXIlqV7t9z0A1Ww9Omd2XIlndcYOAh5R6kWRZ8Vo/CITazKUC5ZGNoj23hq/aEPaX8p5XmJs2BKESg/OuhGhQ==",
 			"dependencies": {
 				"abortable-iterator": "^3.0.0",
 				"class-is": "^1.1.0",
-				"debug": "^4.1.1",
-				"err-code": "^2.0.0",
-				"libp2p-utils": "^0.2.0",
-				"mafmt": "^8.0.0",
-				"multiaddr": "^8.0.0",
+				"debug": "^4.3.1",
+				"err-code": "^3.0.1",
+				"libp2p-utils": "^0.3.0",
+				"mafmt": "^9.0.0",
+				"multiaddr": "^9.0.1",
 				"stream-to-it": "^0.2.2"
 			},
 			"engines": {
-				"node": ">=6.0.0",
-				"npm": ">=3.0.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/libp2p-tcp/node_modules/debug": {
@@ -14584,14 +14597,72 @@
 			}
 		},
 		"node_modules/libp2p-tcp/node_modules/err-code": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+			"integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
+		},
+		"node_modules/libp2p-tcp/node_modules/ip-address": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-7.1.0.tgz",
+			"integrity": "sha512-V9pWC/VJf2lsXqP7IWJ+pe3P1/HCYGBMZrrnT62niLGjAfCbeiwXMUxaeHvnVlz19O27pvXP4azs+Pj/A0x+SQ==",
+			"dependencies": {
+				"jsbn": "1.1.0",
+				"sprintf-js": "1.1.2"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/libp2p-tcp/node_modules/jsbn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+			"integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+		},
+		"node_modules/libp2p-tcp/node_modules/libp2p-utils": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.3.1.tgz",
+			"integrity": "sha512-LOVfww7a6Rhtoupl3z1ABuTEli5whY3VLTB9QntsOIwbOcX9GfmjuhqYbEDht9lVPAQl+rCUWbfDMvK121ryUg==",
+			"dependencies": {
+				"abortable-iterator": "^3.0.0",
+				"debug": "^4.3.0",
+				"err-code": "^3.0.1",
+				"ip-address": "^7.1.0",
+				"is-loopback-addr": "^1.0.0",
+				"multiaddr": "^9.0.1",
+				"private-ip": "^2.1.1"
+			}
+		},
+		"node_modules/libp2p-tcp/node_modules/mafmt": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/mafmt/-/mafmt-9.0.0.tgz",
+			"integrity": "sha512-BwKL6FJxc6R85K6gFE/pX7MVyCp0NkM2DJHg0RatxVgDlK4g9kqtfXQUt2iReSmTcgZss/Q/Bdfa2KTg4KyC+g==",
+			"dependencies": {
+				"multiaddr": "^9.0.1"
+			}
 		},
 		"node_modules/libp2p-tcp/node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"node_modules/libp2p-tcp/node_modules/multiaddr": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-9.0.1.tgz",
+			"integrity": "sha512-fubxMjVoRPcz3GYBb63Z6ADCY6BoqezbnL2o8owDcfYqhwW61oFtIlsZGiNKIVC2Fk1Od5rf/3z34QSGJFT/uA==",
+			"dependencies": {
+				"cids": "^1.0.0",
+				"dns-over-http-resolver": "^1.0.0",
+				"err-code": "^3.0.1",
+				"is-ip": "^3.1.0",
+				"multibase": "^4.0.2",
+				"uint8arrays": "^2.1.3",
+				"varint": "^6.0.0"
+			}
+		},
+		"node_modules/libp2p-tcp/node_modules/sprintf-js": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
 		},
 		"node_modules/libp2p-utils": {
 			"version": "0.2.3",
@@ -14634,19 +14705,19 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/libp2p-websockets": {
-			"version": "0.15.4",
-			"resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.15.4.tgz",
-			"integrity": "sha512-CoZ9zeCEUDFDdUGzKz6YXx+BTnQzl9D1rxWS7+6wzO9uasDrxn8etigbXP7DbToGAGTQnrhEry6xNX4NI3CPdQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.15.5.tgz",
+			"integrity": "sha512-pD/J5lp4QM8oyQKjLcnnfwwcNbCRDG33+C4njQ7MUKuD5MphF1s2U0z8FiAlTtyNVflYX82dhTYgI4cPzmoBeA==",
 			"dependencies": {
 				"abortable-iterator": "^3.0.0",
 				"class-is": "^1.1.0",
-				"debug": "^4.2.0",
+				"debug": "^4.3.1",
 				"err-code": "^3.0.1",
-				"ipfs-utils": "^6.0.1",
+				"ipfs-utils": "^6.0.6",
 				"it-ws": "^4.0.0",
-				"libp2p-utils": "^0.2.1",
-				"mafmt": "^8.0.1",
-				"multiaddr": "^8.1.1",
+				"libp2p-utils": "^0.3.0",
+				"mafmt": "^9.0.0",
+				"multiaddr": "^9.0.1",
 				"multiaddr-to-uri": "^6.0.0",
 				"p-defer": "^3.0.0",
 				"p-timeout": "^4.1.0"
@@ -14673,10 +14744,68 @@
 			"resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
 			"integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
 		},
+		"node_modules/libp2p-websockets/node_modules/ip-address": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-7.1.0.tgz",
+			"integrity": "sha512-V9pWC/VJf2lsXqP7IWJ+pe3P1/HCYGBMZrrnT62niLGjAfCbeiwXMUxaeHvnVlz19O27pvXP4azs+Pj/A0x+SQ==",
+			"dependencies": {
+				"jsbn": "1.1.0",
+				"sprintf-js": "1.1.2"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/libp2p-websockets/node_modules/jsbn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+			"integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+		},
+		"node_modules/libp2p-websockets/node_modules/libp2p-utils": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.3.1.tgz",
+			"integrity": "sha512-LOVfww7a6Rhtoupl3z1ABuTEli5whY3VLTB9QntsOIwbOcX9GfmjuhqYbEDht9lVPAQl+rCUWbfDMvK121ryUg==",
+			"dependencies": {
+				"abortable-iterator": "^3.0.0",
+				"debug": "^4.3.0",
+				"err-code": "^3.0.1",
+				"ip-address": "^7.1.0",
+				"is-loopback-addr": "^1.0.0",
+				"multiaddr": "^9.0.1",
+				"private-ip": "^2.1.1"
+			}
+		},
+		"node_modules/libp2p-websockets/node_modules/mafmt": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/mafmt/-/mafmt-9.0.0.tgz",
+			"integrity": "sha512-BwKL6FJxc6R85K6gFE/pX7MVyCp0NkM2DJHg0RatxVgDlK4g9kqtfXQUt2iReSmTcgZss/Q/Bdfa2KTg4KyC+g==",
+			"dependencies": {
+				"multiaddr": "^9.0.1"
+			}
+		},
 		"node_modules/libp2p-websockets/node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"node_modules/libp2p-websockets/node_modules/multiaddr": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-9.0.1.tgz",
+			"integrity": "sha512-fubxMjVoRPcz3GYBb63Z6ADCY6BoqezbnL2o8owDcfYqhwW61oFtIlsZGiNKIVC2Fk1Od5rf/3z34QSGJFT/uA==",
+			"dependencies": {
+				"cids": "^1.0.0",
+				"dns-over-http-resolver": "^1.0.0",
+				"err-code": "^3.0.1",
+				"is-ip": "^3.1.0",
+				"multibase": "^4.0.2",
+				"uint8arrays": "^2.1.3",
+				"varint": "^6.0.0"
+			}
+		},
+		"node_modules/libp2p-websockets/node_modules/sprintf-js": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
 		},
 		"node_modules/libp2p/node_modules/debug": {
 			"version": "4.3.1",
@@ -18350,9 +18479,9 @@
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"node_modules/picomatch": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+			"integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
 			"engines": {
 				"node": ">=8.6"
 			},
@@ -23008,15 +23137,15 @@
 			}
 		},
 		"node_modules/ts-loader/node_modules/micromatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-			"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
 			"dependencies": {
 				"braces": "^3.0.1",
-				"picomatch": "^2.0.5"
+				"picomatch": "^2.2.3"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=8.6"
 			}
 		},
 		"node_modules/ts-loader/node_modules/to-regex-range": {
@@ -23298,9 +23427,9 @@
 			}
 		},
 		"node_modules/typedoc/node_modules/marked": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
-			"integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
+			"integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA==",
 			"bin": {
 				"marked": "bin/marked"
 			},
@@ -23329,9 +23458,9 @@
 			}
 		},
 		"node_modules/ua-parser-js": {
-			"version": "0.7.27",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.27.tgz",
-			"integrity": "sha512-eXMaRYK2skomGocoX0x9sBXzx5A1ZVQgXfrW4mTc8dT0zS7olEcyfudAzRC5tIIRgLxQ69B6jut3DI+n5hslPA==",
+			"version": "0.7.28",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+			"integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -27539,9 +27668,9 @@
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
 		},
 		"@types/secp256k1": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
-			"integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.2.tgz",
+			"integrity": "sha512-QMg+9v0bbNJ2peLuHRWxzmy0HRJIG6gFZNhaRSp7S3ggSbCCxiqQB2/ybvhXyhHOCequpNkrx7OavNhrWOsW0A==",
 			"requires": {
 				"@types/node": "*"
 			}
@@ -27770,12 +27899,12 @@
 					}
 				},
 				"micromatch": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
 					"requires": {
 						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
+						"picomatch": "^2.2.3"
 					}
 				},
 				"ms": {
@@ -29365,15 +29494,15 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.16.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.3.tgz",
-			"integrity": "sha512-vIyhWmIkULaq04Gt93txdh+j02yX/JzlyhLYbV3YQCn/zvES3JnY7TifHHvvr1w5hTDluNKMkV05cs4vy8Q7sw==",
+			"version": "4.16.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.4.tgz",
+			"integrity": "sha512-d7rCxYV8I9kj41RH8UKYnvDYCRENUlHRgyXy/Rhr/1BaeLGfiCptEdFE8MIrvGfWbBFNjVYx76SQWvNX1j+/cQ==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001181",
-				"colorette": "^1.2.1",
-				"electron-to-chromium": "^1.3.649",
+				"caniuse-lite": "^1.0.30001208",
+				"colorette": "^1.2.2",
+				"electron-to-chromium": "^1.3.712",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.70"
+				"node-releases": "^1.1.71"
 			}
 		},
 		"bs58": {
@@ -30776,9 +30905,12 @@
 			"integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg=="
 		},
 		"d3-time": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.0.0.tgz",
-			"integrity": "sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q=="
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+			"integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+			"requires": {
+				"d3-array": "2"
+			}
 		},
 		"d3-time-format": {
 			"version": "3.0.0",
@@ -31544,9 +31676,9 @@
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.711",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.711.tgz",
-			"integrity": "sha512-XbklBVCDiUeho0PZQCjC25Ha6uBwqqJeyDhPLwLwfWRAo4x+FZFsmu1pPPkXT+B4MQMQoQULfyaMltDopfeiHQ=="
+			"version": "1.3.712",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.712.tgz",
+			"integrity": "sha512-3kRVibBeCM4vsgoHHGKHmPocLqtFAGTrebXxxtgKs87hNUzXrX2NuS3jnBys7IozCnw7viQlozxKkmty2KNfrw=="
 		},
 		"elliptic": {
 			"version": "6.5.4",
@@ -36339,9 +36471,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.0.tgz",
-					"integrity": "sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA=="
+					"version": "8.1.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.1.1.tgz",
+					"integrity": "sha512-xYiIVjNuqtKXMxlRMDc6mZUhXehod4a3gbZ1qRlM7icK4EbxUFNLhWoPblCvFtB2Y9CIqHP3CF/rdxLItaQv8g=="
 				},
 				"acorn-walk": {
 					"version": "8.0.2",
@@ -36458,9 +36590,9 @@
 			}
 		},
 		"keypair": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.2.tgz",
-			"integrity": "sha512-7zRr8fKOWp/N8xfZyZV6WG1CUvKNiNahSDI4vjJnPJD60lHtIg62dpv60yCgcM2PP8QKv4S2UkZl+8MsYmQRpw=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/keypair/-/keypair-1.0.3.tgz",
+			"integrity": "sha512-0wjZ2z/SfZZq01+3/8jYLd8aEShSa+aat1zyPGQY3IuKoEAp6DJGvu2zt6snELrQU9jbCkIlCyNOD7RdQbHhkQ=="
 		},
 		"kind-of": {
 			"version": "6.0.3",
@@ -36753,48 +36885,58 @@
 			}
 		},
 		"libp2p-crypto": {
-			"version": "0.19.2",
-			"resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.19.2.tgz",
-			"integrity": "sha512-dl/tViAyaBhJn0gTTIeZGxK0t+d+2FSN6vmjVdljYZc+pVMExjrx8p7lmX98qp/X97u7Vt+Oq9LvfjLoiERDCQ==",
+			"version": "0.19.3",
+			"resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.19.3.tgz",
+			"integrity": "sha512-6xn2JRXXsn1/wWzcvmzmkMpw0j8N1/kO01V4eTjMzFpK6cS4cxHmBN3PQzYqAw6gHbjRTzsP8E+k5+iW6/VRaA==",
 			"requires": {
-				"err-code": "^2.0.0",
+				"err-code": "^3.0.1",
 				"is-typedarray": "^1.0.0",
-				"iso-random-stream": "^1.1.0",
+				"iso-random-stream": "^2.0.0",
 				"keypair": "^1.0.1",
-				"multibase": "^3.0.0",
-				"multicodec": "^2.0.0",
+				"multibase": "^4.0.3",
+				"multicodec": "^3.0.1",
 				"multihashes": "^4.0.2",
-				"multihashing-async": "^2.0.1",
+				"multihashing-async": "^2.1.2",
 				"node-forge": "^0.10.0",
 				"pem-jwk": "^2.0.0",
-				"protons": "^2.0.0",
+				"protobufjs": "^6.10.2",
 				"secp256k1": "^4.0.0",
-				"uint8arrays": "^1.1.0",
+				"uint8arrays": "^2.1.4",
 				"ursa-optional": "^0.10.1"
 			},
 			"dependencies": {
 				"err-code": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-					"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+					"integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
 				},
-				"multibase": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/multibase/-/multibase-3.1.2.tgz",
-					"integrity": "sha512-bpklWHs70LO3smJUHOjcnzGceJJvn9ui0Vau6Za0B/GBepaXswmW8Ufea0uD9pROf/qCQ4N4lZ3sf3U+SNf0tw==",
+				"events": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+					"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+				},
+				"iso-random-stream": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/iso-random-stream/-/iso-random-stream-2.0.0.tgz",
+					"integrity": "sha512-lGuIu104KfBV9ubYTSaE3GeAr6I69iggXxBHbTBc5u/XKlwlWl0LCytnkIZissaKqvxablwRD9B3ktVnmIUnEg==",
 					"requires": {
-						"@multiformats/base-x": "^4.0.1",
-						"web-encoding": "^1.0.6"
+						"events": "^3.3.0",
+						"readable-stream": "^3.4.0"
 					}
 				},
-				"uint8arrays": {
-					"version": "1.1.0",
-					"resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
-					"integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
+				"multicodec": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/multicodec/-/multicodec-3.0.1.tgz",
+					"integrity": "sha512-Y6j3wiPojvkF/z6KFIGt84KdJdP2oILEdzc/3YbD3qQ3EerhqtYlfsZTPPNVoCCxNZZdzIpCKrdYFSav17sIrQ==",
 					"requires": {
-						"multibase": "^3.0.0",
-						"web-encoding": "^1.0.2"
+						"uint8arrays": "^2.1.3",
+						"varint": "^5.0.2"
 					}
+				},
+				"varint": {
+					"version": "5.0.2",
+					"resolved": "https://registry.npmjs.org/varint/-/varint-5.0.2.tgz",
+					"integrity": "sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow=="
 				}
 			}
 		},
@@ -37111,17 +37253,17 @@
 			}
 		},
 		"libp2p-tcp": {
-			"version": "0.15.3",
-			"resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.15.3.tgz",
-			"integrity": "sha512-j9efQ0aAbcCmVnnF0UqWH1r+qjNc0TpC3bV+QJDxBIe6v92a8l3kZ04G/QkP3vmzDT5Z4ayzMGjrOAas8hJIBA==",
+			"version": "0.15.4",
+			"resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.15.4.tgz",
+			"integrity": "sha512-MqXIlqV7t9z0A1Ww9Omd2XIlndcYOAh5R6kWRZ8Vo/CITazKUC5ZGNoj23hq/aEPaX8p5XmJs2BKESg/OuhGhQ==",
 			"requires": {
 				"abortable-iterator": "^3.0.0",
 				"class-is": "^1.1.0",
-				"debug": "^4.1.1",
-				"err-code": "^2.0.0",
-				"libp2p-utils": "^0.2.0",
-				"mafmt": "^8.0.0",
-				"multiaddr": "^8.0.0",
+				"debug": "^4.3.1",
+				"err-code": "^3.0.1",
+				"libp2p-utils": "^0.3.0",
+				"mafmt": "^9.0.0",
+				"multiaddr": "^9.0.1",
 				"stream-to-it": "^0.2.2"
 			},
 			"dependencies": {
@@ -37134,14 +37276,69 @@
 					}
 				},
 				"err-code": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
-					"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA=="
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
+					"integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
+				},
+				"ip-address": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-7.1.0.tgz",
+					"integrity": "sha512-V9pWC/VJf2lsXqP7IWJ+pe3P1/HCYGBMZrrnT62niLGjAfCbeiwXMUxaeHvnVlz19O27pvXP4azs+Pj/A0x+SQ==",
+					"requires": {
+						"jsbn": "1.1.0",
+						"sprintf-js": "1.1.2"
+					}
+				},
+				"jsbn": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+					"integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+				},
+				"libp2p-utils": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.3.1.tgz",
+					"integrity": "sha512-LOVfww7a6Rhtoupl3z1ABuTEli5whY3VLTB9QntsOIwbOcX9GfmjuhqYbEDht9lVPAQl+rCUWbfDMvK121ryUg==",
+					"requires": {
+						"abortable-iterator": "^3.0.0",
+						"debug": "^4.3.0",
+						"err-code": "^3.0.1",
+						"ip-address": "^7.1.0",
+						"is-loopback-addr": "^1.0.0",
+						"multiaddr": "^9.0.1",
+						"private-ip": "^2.1.1"
+					}
+				},
+				"mafmt": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/mafmt/-/mafmt-9.0.0.tgz",
+					"integrity": "sha512-BwKL6FJxc6R85K6gFE/pX7MVyCp0NkM2DJHg0RatxVgDlK4g9kqtfXQUt2iReSmTcgZss/Q/Bdfa2KTg4KyC+g==",
+					"requires": {
+						"multiaddr": "^9.0.1"
+					}
 				},
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				},
+				"multiaddr": {
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-9.0.1.tgz",
+					"integrity": "sha512-fubxMjVoRPcz3GYBb63Z6ADCY6BoqezbnL2o8owDcfYqhwW61oFtIlsZGiNKIVC2Fk1Od5rf/3z34QSGJFT/uA==",
+					"requires": {
+						"cids": "^1.0.0",
+						"dns-over-http-resolver": "^1.0.0",
+						"err-code": "^3.0.1",
+						"is-ip": "^3.1.0",
+						"multibase": "^4.0.2",
+						"uint8arrays": "^2.1.3",
+						"varint": "^6.0.0"
+					}
+				},
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
 				}
 			}
 		},
@@ -37180,19 +37377,19 @@
 			}
 		},
 		"libp2p-websockets": {
-			"version": "0.15.4",
-			"resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.15.4.tgz",
-			"integrity": "sha512-CoZ9zeCEUDFDdUGzKz6YXx+BTnQzl9D1rxWS7+6wzO9uasDrxn8etigbXP7DbToGAGTQnrhEry6xNX4NI3CPdQ==",
+			"version": "0.15.5",
+			"resolved": "https://registry.npmjs.org/libp2p-websockets/-/libp2p-websockets-0.15.5.tgz",
+			"integrity": "sha512-pD/J5lp4QM8oyQKjLcnnfwwcNbCRDG33+C4njQ7MUKuD5MphF1s2U0z8FiAlTtyNVflYX82dhTYgI4cPzmoBeA==",
 			"requires": {
 				"abortable-iterator": "^3.0.0",
 				"class-is": "^1.1.0",
-				"debug": "^4.2.0",
+				"debug": "^4.3.1",
 				"err-code": "^3.0.1",
-				"ipfs-utils": "^6.0.1",
+				"ipfs-utils": "^6.0.6",
 				"it-ws": "^4.0.0",
-				"libp2p-utils": "^0.2.1",
-				"mafmt": "^8.0.1",
-				"multiaddr": "^8.1.1",
+				"libp2p-utils": "^0.3.0",
+				"mafmt": "^9.0.0",
+				"multiaddr": "^9.0.1",
 				"multiaddr-to-uri": "^6.0.0",
 				"p-defer": "^3.0.0",
 				"p-timeout": "^4.1.0"
@@ -37211,10 +37408,65 @@
 					"resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
 					"integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA=="
 				},
+				"ip-address": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-7.1.0.tgz",
+					"integrity": "sha512-V9pWC/VJf2lsXqP7IWJ+pe3P1/HCYGBMZrrnT62niLGjAfCbeiwXMUxaeHvnVlz19O27pvXP4azs+Pj/A0x+SQ==",
+					"requires": {
+						"jsbn": "1.1.0",
+						"sprintf-js": "1.1.2"
+					}
+				},
+				"jsbn": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+					"integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+				},
+				"libp2p-utils": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.3.1.tgz",
+					"integrity": "sha512-LOVfww7a6Rhtoupl3z1ABuTEli5whY3VLTB9QntsOIwbOcX9GfmjuhqYbEDht9lVPAQl+rCUWbfDMvK121ryUg==",
+					"requires": {
+						"abortable-iterator": "^3.0.0",
+						"debug": "^4.3.0",
+						"err-code": "^3.0.1",
+						"ip-address": "^7.1.0",
+						"is-loopback-addr": "^1.0.0",
+						"multiaddr": "^9.0.1",
+						"private-ip": "^2.1.1"
+					}
+				},
+				"mafmt": {
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/mafmt/-/mafmt-9.0.0.tgz",
+					"integrity": "sha512-BwKL6FJxc6R85K6gFE/pX7MVyCp0NkM2DJHg0RatxVgDlK4g9kqtfXQUt2iReSmTcgZss/Q/Bdfa2KTg4KyC+g==",
+					"requires": {
+						"multiaddr": "^9.0.1"
+					}
+				},
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				},
+				"multiaddr": {
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-9.0.1.tgz",
+					"integrity": "sha512-fubxMjVoRPcz3GYBb63Z6ADCY6BoqezbnL2o8owDcfYqhwW61oFtIlsZGiNKIVC2Fk1Od5rf/3z34QSGJFT/uA==",
+					"requires": {
+						"cids": "^1.0.0",
+						"dns-over-http-resolver": "^1.0.0",
+						"err-code": "^3.0.1",
+						"is-ip": "^3.1.0",
+						"multibase": "^4.0.2",
+						"uint8arrays": "^2.1.3",
+						"varint": "^6.0.0"
+					}
+				},
+				"sprintf-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
 				}
 			}
 		},
@@ -40219,9 +40471,9 @@
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"picomatch": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
+			"integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg=="
 		},
 		"pify": {
 			"version": "4.0.1",
@@ -43928,12 +44180,12 @@
 					}
 				},
 				"micromatch": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
 					"requires": {
 						"braces": "^3.0.1",
-						"picomatch": "^2.0.5"
+						"picomatch": "^2.2.3"
 					}
 				},
 				"to-regex-range": {
@@ -44126,9 +44378,9 @@
 					}
 				},
 				"marked": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/marked/-/marked-2.0.1.tgz",
-					"integrity": "sha512-5+/fKgMv2hARmMW7DOpykr2iLhl0NgjyELk5yn92iE7z8Se1IS9n3UsFm86hFXIkvMBmVxki8+ckcpjBeyo/hw=="
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/marked/-/marked-2.0.3.tgz",
+					"integrity": "sha512-5otztIIcJfPc2qGTN8cVtOJEjNJZ0jwa46INMagrYfk0EvqtRuEHLsEe0LrFS0/q+ZRKT0+kXK7P2T1AN5lWRA=="
 				},
 				"universalify": {
 					"version": "2.0.0",
@@ -44156,9 +44408,9 @@
 			"integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w=="
 		},
 		"ua-parser-js": {
-			"version": "0.7.27",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.27.tgz",
-			"integrity": "sha512-eXMaRYK2skomGocoX0x9sBXzx5A1ZVQgXfrW4mTc8dT0zS7olEcyfudAzRC5tIIRgLxQ69B6jut3DI+n5hslPA=="
+			"version": "0.7.28",
+			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
+			"integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
 		},
 		"uglify-js": {
 			"version": "3.13.3",

--- a/packages/vm/lib/evm/eei.ts
+++ b/packages/vm/lib/evm/eei.ts
@@ -1,4 +1,3 @@
-import { debug as createDebugLogger } from 'debug'
 import { Account, Address, BN } from 'ethereumjs-util'
 import { Block } from '@ethereumjs/block'
 import Blockchain from '@ethereumjs/blockchain'
@@ -8,8 +7,6 @@ import { VmError, ERROR } from '../exceptions'
 import Message from './message'
 import EVM, { EVMResult } from './evm'
 import { Log } from './types'
-
-const debugGas = createDebugLogger('vm:eei:gas')
 
 function trap(err: ERROR) {
   throw new VmError(err)
@@ -87,12 +84,12 @@ export default class EEI {
   /**
    * Subtracts an amount from the gas counter.
    * @param amount - Amount of gas to consume
-   * @param context - Usage context for debugging
+   * @param _context - Deprecated: this param doesn't do anything now.
    * @throws if out of gas
    */
-  useGas(amount: BN, context?: string): void {
+  // eslint-disable-next-line no-unused-vars
+  useGas(amount: BN, _context?: string): void {
     this._gasLeft.isub(amount)
-    debugGas(`${context ? context + ': ' : ''}used ${amount} gas (-> ${this._gasLeft})`)
     if (this._gasLeft.ltn(0)) {
       this._gasLeft = new BN(0)
       trap(ERROR.OUT_OF_GAS)
@@ -102,20 +99,20 @@ export default class EEI {
   /**
    * Adds a positive amount to the gas counter.
    * @param amount - Amount of gas refunded
-   * @param context - Usage context for debugging
+   * @param _context - Deprecated: this param doesn't do anything now.
    */
-  refundGas(amount: BN, context?: string): void {
-    debugGas(`${context ? context + ': ' : ''}refund ${amount} gas (-> ${this._evm._refund})`)
+  // eslint-disable-next-line no-unused-vars
+  refundGas(amount: BN, _context?: string): void {
     this._evm._refund.iadd(amount)
   }
 
   /**
    * Reduces amount of gas to be refunded by a positive value.
    * @param amount - Amount to subtract from gas refunds
-   * @param context - Usage context for debugging
+   * @param _context - Deprecated: this param doesn't do anything now.
    */
-  subRefund(amount: BN, context?: string): void {
-    debugGas(`${context ? context + ': ' : ''}sub gas refund ${amount} (-> ${this._evm._refund})`)
+  // eslint-disable-next-line no-unused-vars
+  subRefund(amount: BN, _context?: string): void {
     this._evm._refund.isub(amount)
     if (this._evm._refund.ltn(0)) {
       this._evm._refund = new BN(0)
@@ -508,7 +505,7 @@ export default class EEI {
     }
 
     // this should always be safe
-    this.useGas(results.gasUsed, 'CALL, STATICCALL, DELEGATECALL, CALLCODE')
+    this.useGas(results.gasUsed)
 
     // Set return value
     if (
@@ -565,7 +562,7 @@ export default class EEI {
     }
 
     // this should always be safe
-    this.useGas(results.gasUsed, 'CREATE')
+    this.useGas(results.gasUsed)
 
     // Set return buffer in case revert happened
     if (

--- a/packages/vm/lib/evm/evm.ts
+++ b/packages/vm/lib/evm/evm.ts
@@ -1,4 +1,3 @@
-import { debug as createDebugLogger } from 'debug'
 import {
   Account,
   Address,
@@ -15,12 +14,8 @@ import { getPrecompile, PrecompileFunc } from './precompiles'
 import TxContext from './txContext'
 import Message from './message'
 import EEI from './eei'
-import { short } from './opcodes/util'
 import { Log } from './types'
 import { default as Interpreter, InterpreterOpts, RunState } from './interpreter'
-
-const debug = createDebugLogger('vm:evm')
-const debugGas = createDebugLogger('vm:evm:gas')
 
 /**
  * Result of executing a message via the [[EVM]].
@@ -143,31 +138,14 @@ export default class EVM {
     }
 
     await this._state.checkpoint()
-    debug('-'.repeat(100))
-    debug(`message checkpoint`)
 
     let result
-    debug(
-      `New message caller=${message.caller.toString()} gasLimit=${message.gasLimit.toString()} to=${
-        message.to ? message.to.toString() : ''
-      } value=${message.value.toString()} delegatecall=${message.delegatecall ? 'yes' : 'no'}`
-    )
     if (message.to) {
-      debug(`Message CALL execution (to: ${message.to.toString()})`)
       result = await this._executeCall(message)
     } else {
-      debug(`Message CREATE execution (to undefined)`)
       result = await this._executeCreate(message)
     }
-    debug(
-      `Received message results gasUsed=${result.gasUsed} execResult: [ gasUsed=${
-        result.gasUsed
-      } exceptionError=${
-        result.execResult.exceptionError ? result.execResult.exceptionError.toString() : ''
-      } returnValue=${short(
-        result.execResult.returnValue
-      )} gasRefund=${result.execResult.gasRefund?.toString()} ]`
-    )
+
     // TODO: Move `gasRefund` to a tx-level result object
     // instead of `ExecResult`.
     result.execResult.gasRefund = this._refund.clone()
@@ -177,16 +155,13 @@ export default class EVM {
       if (this._vm._common.gteHardfork('homestead') || err.error != ERROR.CODESTORE_OUT_OF_GAS) {
         result.execResult.logs = []
         await this._state.revert()
-        debug(`message checkpoint reverted`)
       } else {
         // we are in chainstart and the error was the code deposit error
         // we do like nothing happened.
         await this._state.commit()
-        debug(`message checkpoint committed`)
       }
     } else {
       await this._state.commit()
-      debug(`message checkpoint committed`)
     }
 
     await this._vm._emit('afterMessage', result)
@@ -217,11 +192,9 @@ export default class EVM {
     let exit = false
     if (!message.code || message.code.length === 0) {
       exit = true
-      debug(`Exit early on no code`)
     }
     if (errorMessage) {
       exit = true
-      debug(`Exit early on value tranfer overflowed`)
     }
     if (exit) {
       return {
@@ -236,14 +209,12 @@ export default class EVM {
 
     let result: ExecResult
     if (message.isCompiled) {
-      debug(`Run precompile`)
       result = await this.runPrecompile(
         message.code as PrecompileFunc,
         message.data,
         message.gasLimit
       )
     } else {
-      debug(`Start bytecode processing...`)
       result = await this.runInterpreter(message)
     }
 
@@ -261,12 +232,10 @@ export default class EVM {
     message.code = message.data
     message.data = Buffer.alloc(0)
     message.to = await this._generateAddress(message)
-    debug(`Generated CREATE contract address ${message.to.toString()}`)
     let toAccount = await this._state.getAccount(message.to)
 
     // Check for collision
     if ((toAccount.nonce && toAccount.nonce.gtn(0)) || !toAccount.codeHash.equals(KECCAK256_NULL)) {
-      debug(`Returning on address collision`)
       return {
         gasUsed: message.gasLimit,
         createdAddress: message.to,
@@ -304,11 +273,9 @@ export default class EVM {
     let exit = false
     if (!message.code || message.code.length === 0) {
       exit = true
-      debug(`Exit early on no code`)
     }
     if (errorMessage) {
       exit = true
-      debug(`Exit early on value tranfer overflowed`)
     }
     if (exit) {
       return {
@@ -322,7 +289,6 @@ export default class EVM {
       }
     }
 
-    debug(`Start bytecode processing...`)
     let result = await this.runInterpreter(message)
 
     // fee for size of the return value
@@ -333,9 +299,6 @@ export default class EVM {
         this._vm._common.param('gasPrices', 'createData')
       )
       totalGas = totalGas.add(returnFee)
-      debugGas(
-        `Add return value size fee (${returnFee.toString()} to gas used (-> ${totalGas.toString()}))`
-      )
     }
 
     // Check for SpuriousDragon EIP-170 code size limit
@@ -355,11 +318,9 @@ export default class EVM {
       result.gasUsed = totalGas
     } else {
       if (this._vm._common.gteHardfork('homestead')) {
-        debug(`Not enough gas or code size not allowed (>= Homestead)`)
         result = { ...result, ...OOGResult(message.gasLimit) }
       } else {
         // we are in Frontier
-        debug(`Not enough gas or code size not allowed (Frontier)`)
         if (totalGas.sub(returnFee).lte(message.gasLimit)) {
           // we cannot pay the code deposit fee (but the deposit code actually did run)
           result = { ...result, ...COOGResult(totalGas.sub(returnFee)) }
@@ -373,7 +334,6 @@ export default class EVM {
     // Save code if a new contract was created
     if (!result.exceptionError && result.returnValue && result.returnValue.toString() !== '') {
       await this._state.putContractCode(message.to, result.returnValue)
-      debug(`Code saved on new contract creation`)
     } else if (CodestoreOOG) {
       // This only happens at Frontier. But, let's do a sanity check;
       if (!this._vm._common.gteHardfork('homestead')) {
@@ -512,9 +472,6 @@ export default class EVM {
   async _reduceSenderBalance(account: Account, message: Message): Promise<void> {
     account.balance.isub(message.value)
     const result = this._state.putAccount(message.caller, account)
-    debug(
-      `Reduced sender (${message.caller.toString()}) balance (-> ${account.balance.toString()})`
-    )
     return result
   }
 
@@ -526,7 +483,6 @@ export default class EVM {
     toAccount.balance = newBalance
     // putAccount as the nonce may have changed for contract creation
     const result = this._state.putAccount(message.to, toAccount)
-    debug(`Added toAccount (${message.to.toString()}) balance (-> ${toAccount.balance.toString()})`)
     return result
   }
 

--- a/packages/vm/lib/evm/interpreter.ts
+++ b/packages/vm/lib/evm/interpreter.ts
@@ -1,4 +1,3 @@
-import { debug as createDebugLogger } from 'debug'
 import { Account, Address, BN } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { StateManager } from '../state/index'
@@ -65,9 +64,6 @@ export default class Interpreter {
   _state: StateManager
   _runState: RunState
   _eei: EEI
-
-  // Opcode debuggers (e.g. { 'push': [debug Object], 'sstore': [debug Object], ...})
-  private opDebuggers: any = {}
 
   constructor(vm: any, eei: EEI) {
     this._vm = vm // TODO: remove when not needed
@@ -142,7 +138,7 @@ export default class Interpreter {
     }
 
     // Reduce opcode's base fee
-    this._eei.useGas(new BN(opInfo.fee), `${opInfo.name} (base fee)`)
+    this._eei.useGas(new BN(opInfo.fee))
     // Advance program counter
     this._runState.programCounter++
 
@@ -190,27 +186,6 @@ export default class Interpreter {
       memoryWordCount: this._runState.memoryWordCount,
       codeAddress: this._eei._env.codeAddress,
     }
-
-    // Create opTrace for debug functionality
-    let hexStack = []
-    hexStack = eventObj.stack.map((item: any) => {
-      return '0x' + new BN(item).toString(16, 0)
-    })
-
-    const name = eventObj.opcode.name
-    const opTrace = {
-      pc: eventObj.pc,
-      op: name,
-      gas: '0x' + eventObj.gasLeft.toString('hex'),
-      gasCost: '0x' + eventObj.opcode.fee.toString(16),
-      stack: hexStack,
-      depth: eventObj.depth,
-    }
-
-    if (!(name in this.opDebuggers)) {
-      this.opDebuggers[name] = createDebugLogger(`vm:ops:${name}`)
-    }
-    this.opDebuggers[name](JSON.stringify(opTrace))
 
     /**
      * The `step` event for trace output

--- a/packages/vm/lib/evm/opcodes/EIP1283.ts
+++ b/packages/vm/lib/evm/opcodes/EIP1283.ts
@@ -12,10 +12,7 @@ export function updateSstoreGasEIP1283(runState: RunState, found: any, value: Bu
   const { original, current } = found
   if (current.equals(value)) {
     // If current value equals new value (this is a no-op), 200 gas is deducted.
-    runState.eei.useGas(
-      new BN(runState._common.param('gasPrices', 'netSstoreNoopGas')),
-      'EIP-1283 -> netSstoreNoopGas'
-    )
+    runState.eei.useGas(new BN(runState._common.param('gasPrices', 'netSstoreNoopGas')))
     return
   }
   // If current value does not equal new value
@@ -23,39 +20,24 @@ export function updateSstoreGasEIP1283(runState: RunState, found: any, value: Bu
     // If original value equals current value (this storage slot has not been changed by the current execution context)
     if (original.length === 0) {
       // If original value is 0, 20000 gas is deducted.
-      return runState.eei.useGas(
-        new BN(runState._common.param('gasPrices', 'netSstoreInitGas')),
-        'EIP-1283 -> netSstoreInitGas'
-      )
+      return runState.eei.useGas(new BN(runState._common.param('gasPrices', 'netSstoreInitGas')))
     }
     if (value.length === 0) {
       // If new value is 0, add 15000 gas to refund counter.
-      runState.eei.refundGas(
-        new BN(runState._common.param('gasPrices', 'netSstoreClearRefund')),
-        'EIP-1283 -> netSstoreClearRefund'
-      )
+      runState.eei.refundGas(new BN(runState._common.param('gasPrices', 'netSstoreClearRefund')))
     }
     // Otherwise, 5000 gas is deducted.
-    return runState.eei.useGas(
-      new BN(runState._common.param('gasPrices', 'netSstoreCleanGas')),
-      'EIP-1283 -> netSstoreCleanGas'
-    )
+    return runState.eei.useGas(new BN(runState._common.param('gasPrices', 'netSstoreCleanGas')))
   }
   // If original value does not equal current value (this storage slot is dirty), 200 gas is deducted. Apply both of the following clauses.
   if (original.length !== 0) {
     // If original value is not 0
     if (current.length === 0) {
       // If current value is 0 (also means that new value is not 0), remove 15000 gas from refund counter. We can prove that refund counter will never go below 0.
-      runState.eei.subRefund(
-        new BN(runState._common.param('gasPrices', 'netSstoreClearRefund')),
-        'EIP-1283 -> netSstoreClearRefund'
-      )
+      runState.eei.subRefund(new BN(runState._common.param('gasPrices', 'netSstoreClearRefund')))
     } else if (value.length === 0) {
       // If new value is 0 (also means that current value is not 0), add 15000 gas to refund counter.
-      runState.eei.refundGas(
-        new BN(runState._common.param('gasPrices', 'netSstoreClearRefund')),
-        'EIP-1283 -> netSstoreClearRefund'
-      )
+      runState.eei.refundGas(new BN(runState._common.param('gasPrices', 'netSstoreClearRefund')))
     }
   }
   if (original.equals(value)) {
@@ -63,19 +45,12 @@ export function updateSstoreGasEIP1283(runState: RunState, found: any, value: Bu
     if (original.length === 0) {
       // If original value is 0, add 19800 gas to refund counter.
       runState.eei.refundGas(
-        new BN(runState._common.param('gasPrices', 'netSstoreResetClearRefund')),
-        'EIP-1283 -> netSstoreResetClearRefund'
+        new BN(runState._common.param('gasPrices', 'netSstoreResetClearRefund'))
       )
     } else {
       // Otherwise, add 4800 gas to refund counter.
-      runState.eei.refundGas(
-        new BN(runState._common.param('gasPrices', 'netSstoreResetRefund')),
-        'EIP-1283 -> netSstoreResetRefund'
-      )
+      runState.eei.refundGas(new BN(runState._common.param('gasPrices', 'netSstoreResetRefund')))
     }
   }
-  return runState.eei.useGas(
-    new BN(runState._common.param('gasPrices', 'netSstoreDirtyGas')),
-    'EIP-1283 -> netSstoreDirtyGas'
-  )
+  return runState.eei.useGas(new BN(runState._common.param('gasPrices', 'netSstoreDirtyGas')))
 }

--- a/packages/vm/lib/evm/opcodes/EIP2200.ts
+++ b/packages/vm/lib/evm/opcodes/EIP2200.ts
@@ -24,43 +24,35 @@ export function updateSstoreGasEIP2200(runState: RunState, found: any, value: Bu
   if (current.equals(value)) {
     const sstoreNoopCost = runState._common.param('gasPrices', 'sstoreNoopGasEIP2200')
     return runState.eei.useGas(
-      new BN(adjustSstoreGasEIP2929(runState, key, sstoreNoopCost, 'noop')),
-      'EIP-2200 -> sstoreNoopGasEIP2200'
+      new BN(adjustSstoreGasEIP2929(runState, key, sstoreNoopCost, 'noop'))
     )
   }
   if (original.equals(current)) {
     // Create slot
     if (original.length === 0) {
       return runState.eei.useGas(
-        new BN(runState._common.param('gasPrices', 'sstoreInitGasEIP2200')),
-        'EIP-2200 -> sstoreInitGasEIP2200'
+        new BN(runState._common.param('gasPrices', 'sstoreInitGasEIP2200'))
       )
     }
     // Delete slot
     if (value.length === 0) {
       runState.eei.refundGas(
-        new BN(runState._common.param('gasPrices', 'sstoreClearRefundEIP2200')),
-        'EIP-2200 -> sstoreClearRefundEIP2200'
+        new BN(runState._common.param('gasPrices', 'sstoreClearRefundEIP2200'))
       )
     }
     // Write existing slot
-    return runState.eei.useGas(
-      new BN(runState._common.param('gasPrices', 'sstoreCleanGasEIP2200')),
-      'EIP-2200 -> sstoreCleanGasEIP2200'
-    )
+    return runState.eei.useGas(new BN(runState._common.param('gasPrices', 'sstoreCleanGasEIP2200')))
   }
   if (original.length > 0) {
     if (current.length === 0) {
       // Recreate slot
       runState.eei.subRefund(
-        new BN(runState._common.param('gasPrices', 'sstoreClearRefundEIP2200')),
-        'EIP-2200 -> sstoreClearRefundEIP2200'
+        new BN(runState._common.param('gasPrices', 'sstoreClearRefundEIP2200'))
       )
     } else if (value.length === 0) {
       // Delete slot
       runState.eei.refundGas(
-        new BN(runState._common.param('gasPrices', 'sstoreClearRefundEIP2200')),
-        'EIP-2200 -> sstoreClearRefundEIP2200'
+        new BN(runState._common.param('gasPrices', 'sstoreClearRefundEIP2200'))
       )
     }
   }
@@ -69,21 +61,16 @@ export function updateSstoreGasEIP2200(runState: RunState, found: any, value: Bu
       // Reset to original non-existent slot
       const sstoreInitRefund = runState._common.param('gasPrices', 'sstoreInitRefundEIP2200')
       runState.eei.refundGas(
-        new BN(adjustSstoreGasEIP2929(runState, key, sstoreInitRefund, 'initRefund')),
-        'EIP-2200 -> initRefund'
+        new BN(adjustSstoreGasEIP2929(runState, key, sstoreInitRefund, 'initRefund'))
       )
     } else {
       // Reset to original existing slot
       const sstoreCleanRefund = runState._common.param('gasPrices', 'sstoreCleanRefundEIP2200')
       runState.eei.refundGas(
-        new BN(adjustSstoreGasEIP2929(runState, key, sstoreCleanRefund, 'cleanRefund')),
-        'EIP-2200 -> cleanRefund'
+        new BN(adjustSstoreGasEIP2929(runState, key, sstoreCleanRefund, 'cleanRefund'))
       )
     }
   }
   // Dirty update
-  return runState.eei.useGas(
-    new BN(runState._common.param('gasPrices', 'sstoreDirtyGasEIP2200')),
-    'EIP-2200 -> sstoreDirtyGasEIP2200'
-  )
+  return runState.eei.useGas(new BN(runState._common.param('gasPrices', 'sstoreDirtyGasEIP2200')))
 }

--- a/packages/vm/lib/evm/opcodes/EIP2929.ts
+++ b/packages/vm/lib/evm/opcodes/EIP2929.ts
@@ -27,17 +27,11 @@ export function accessAddressEIP2929(
     // CREATE, CREATE2 opcodes have the address warmed for free.
     // selfdestruct beneficiary address reads are charged an *additional* cold access
     if (chargeGas) {
-      runState.eei.useGas(
-        new BN(runState._common.param('gasPrices', 'coldaccountaccess')),
-        'EIP-2929 -> coldaccountaccess'
-      )
+      runState.eei.useGas(new BN(runState._common.param('gasPrices', 'coldaccountaccess')))
     }
     // Warm: (selfdestruct beneficiary address reads are not charged when warm)
   } else if (chargeGas && !isSelfdestruct) {
-    runState.eei.useGas(
-      new BN(runState._common.param('gasPrices', 'warmstorageread')),
-      'EIP-2929 -> warmstorageread'
-    )
+    runState.eei.useGas(new BN(runState._common.param('gasPrices', 'warmstorageread')))
   }
 }
 
@@ -59,15 +53,9 @@ export function accessStorageEIP2929(runState: RunState, key: Buffer, isSstore: 
   if (slotIsCold) {
     // eslint-disable-next-line prettier/prettier
     (<EIP2929StateManager>runState.stateManager).addWarmedStorage(address, key)
-    runState.eei.useGas(
-      new BN(runState._common.param('gasPrices', 'coldsload')),
-      'EIP-2929 -> coldsload'
-    )
+    runState.eei.useGas(new BN(runState._common.param('gasPrices', 'coldsload')))
   } else if (!isSstore) {
-    runState.eei.useGas(
-      new BN(runState._common.param('gasPrices', 'warmstorageread')),
-      'EIP-2929 -> warmstorageread'
-    )
+    runState.eei.useGas(new BN(runState._common.param('gasPrices', 'warmstorageread')))
   }
 }
 

--- a/packages/vm/lib/evm/opcodes/functions.ts
+++ b/packages/vm/lib/evm/opcodes/functions.ts
@@ -181,7 +181,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       }
       const gasPrice = runState._common.param('gasPrices', 'expByte')
       const amount = new BN(byteLength).muln(gasPrice)
-      runState.eei.useGas(amount, 'EXP opcode')
+      runState.eei.useGas(amount)
 
       if (base.isZero()) {
         runState.stack.push(new BN(0))
@@ -389,8 +389,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       }
       // copy fee
       runState.eei.useGas(
-        new BN(runState._common.param('gasPrices', 'sha3Word')).imul(divCeil(length, new BN(32))),
-        'SHA3 opcode'
+        new BN(runState._common.param('gasPrices', 'sha3Word')).imul(divCeil(length, new BN(32)))
       )
       const r = new BN(keccak256(data))
       runState.stack.push(r)
@@ -471,8 +470,7 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       subMemUsage(runState, memOffset, dataLength)
       runState.eei.useGas(
-        new BN(runState._common.param('gasPrices', 'copy')).imul(divCeil(dataLength, new BN(32))),
-        'CALLDATACOPY opcode'
+        new BN(runState._common.param('gasPrices', 'copy')).imul(divCeil(dataLength, new BN(32)))
       )
 
       const data = getDataSlice(runState.eei.getCallData(), dataOffset, dataLength)
@@ -497,8 +495,7 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       subMemUsage(runState, memOffset, length)
       runState.eei.useGas(
-        new BN(runState._common.param('gasPrices', 'copy')).imul(divCeil(length, new BN(32))),
-        'CODECOPY opcode'
+        new BN(runState._common.param('gasPrices', 'copy')).imul(divCeil(length, new BN(32)))
       )
 
       const data = getDataSlice(runState.eei.getCode(), codeOffset, length)
@@ -531,8 +528,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       accessAddressEIP2929(runState, address)
       // copy fee
       runState.eei.useGas(
-        new BN(runState._common.param('gasPrices', 'copy')).imul(divCeil(length, new BN(32))),
-        'EXTCODECOPY opcode'
+        new BN(runState._common.param('gasPrices', 'copy')).imul(divCeil(length, new BN(32)))
       )
 
       const code = await runState.eei.getExternalCode(addressBN)
@@ -585,8 +581,7 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       subMemUsage(runState, memOffset, length)
       runState.eei.useGas(
-        new BN(runState._common.param('gasPrices', 'copy')).mul(divCeil(length, new BN(32))),
-        'RETURNDATACOPY opcode'
+        new BN(runState._common.param('gasPrices', 'copy')).mul(divCeil(length, new BN(32)))
       )
 
       const data = getDataSlice(runState.eei.getReturnData(), returnDataOffset, length)
@@ -921,8 +916,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       runState.eei.useGas(
         new BN(runState._common.param('gasPrices', 'logTopic'))
           .imuln(topicsCount)
-          .iadd(memLength.muln(runState._common.param('gasPrices', 'logData'))),
-        'LOG opcode'
+          .iadd(memLength.muln(runState._common.param('gasPrices', 'logData')))
       )
 
       runState.eei.log(mem, topicsCount, topicsBuf)
@@ -970,8 +964,7 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       // Deduct gas costs for hashing
       runState.eei.useGas(
-        new BN(runState._common.param('gasPrices', 'sha3Word')).imul(divCeil(length, new BN(32))),
-        'CREATE2 opcode'
+        new BN(runState._common.param('gasPrices', 'sha3Word')).imul(divCeil(length, new BN(32)))
       )
       let gasLimit = new BN(runState.eei.getGasLeft())
       gasLimit = maxCallGas(gasLimit, runState.eei.getGasLeft(), runState) // CREATE2 is only available after TangerineWhistle (Constantinople introduced this opcode)
@@ -1013,10 +1006,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       accessAddressEIP2929(runState, toAddress)
 
       if (!value.isZero()) {
-        runState.eei.useGas(
-          new BN(runState._common.param('gasPrices', 'callValueTransfer')),
-          'CALL opcode -> callValueTransfer'
-        )
+        runState.eei.useGas(new BN(runState._common.param('gasPrices', 'callValueTransfer')))
       }
 
       let data = Buffer.alloc(0)
@@ -1028,18 +1018,12 @@ export const handlers: Map<number, OpHandler> = new Map([
         // We are at or after Spurious Dragon
         // Call new account gas: account is DEAD and we transfer nonzero value
         if ((await runState.eei.isAccountEmpty(toAddress)) && !value.isZero()) {
-          runState.eei.useGas(
-            new BN(runState._common.param('gasPrices', 'callNewAccount')),
-            'CALL opcode -> callNewAccount (>= SpuriousDragon)'
-          )
+          runState.eei.useGas(new BN(runState._common.param('gasPrices', 'callNewAccount')))
         }
       } else if (!(await runState.eei.accountExists(toAddress))) {
         // We are before Spurious Dragon and the account does not exist.
         // Call new account gas: account does not exist (it is not in the state trie, not even as an "empty" account)
-        runState.eei.useGas(
-          new BN(runState._common.param('gasPrices', 'callNewAccount')),
-          'CALL opcode -> callNewAccount (< SpuriousDragon)'
-        )
+        runState.eei.useGas(new BN(runState._common.param('gasPrices', 'callNewAccount')))
       }
 
       const gasLimit = maxCallGas(currentGasLimit, runState.eei.getGasLeft(), runState)
@@ -1080,10 +1064,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       accessAddressEIP2929(runState, toAddress)
 
       if (!value.isZero()) {
-        runState.eei.useGas(
-          new BN(runState._common.param('gasPrices', 'callValueTransfer')),
-          'CALLCODE opcode -> callValueTransfer'
-        )
+        runState.eei.useGas(new BN(runState._common.param('gasPrices', 'callValueTransfer')))
       }
       const gasLimit = maxCallGas(currentGasLimit, runState.eei.getGasLeft(), runState)
       // note that TangerineWhistle or later this cannot happen (it could have ran out of gas prior to getting here though)
@@ -1230,10 +1211,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         }
       }
       if (deductGas) {
-        runState.eei.useGas(
-          new BN(runState._common.param('gasPrices', 'callNewAccount')),
-          ' opcode'
-        )
+        runState.eei.useGas(new BN(runState._common.param('gasPrices', 'callNewAccount')))
       }
 
       accessAddressEIP2929(runState, selfdestructToAddress, true, true)

--- a/packages/vm/lib/evm/opcodes/util.ts
+++ b/packages/vm/lib/evm/opcodes/util.ts
@@ -222,7 +222,7 @@ export function subMemUsage(runState: RunState, offset: BN, length: BN) {
   const cost = words.mul(fee).add(words.mul(words).div(quadCoeff))
 
   if (cost.gt(runState.highestMemCost)) {
-    runState.eei.useGas(cost.sub(runState.highestMemCost), 'subMemUsage')
+    runState.eei.useGas(cost.sub(runState.highestMemCost))
     runState.highestMemCost = cost
   }
 
@@ -259,20 +259,11 @@ export function writeCallOutput(runState: RunState, outOffset: BN, outLength: BN
 export function updateSstoreGas(runState: RunState, found: any, value: Buffer, keyBuf: Buffer) {
   const sstoreResetCost = runState._common.param('gasPrices', 'sstoreReset')
   if ((value.length === 0 && !found.length) || (value.length !== 0 && found.length)) {
-    runState.eei.useGas(
-      new BN(adjustSstoreGasEIP2929(runState, keyBuf, sstoreResetCost, 'reset')),
-      'updateSstoreGas'
-    )
+    runState.eei.useGas(new BN(adjustSstoreGasEIP2929(runState, keyBuf, sstoreResetCost, 'reset')))
   } else if (value.length === 0 && found.length) {
-    runState.eei.useGas(
-      new BN(adjustSstoreGasEIP2929(runState, keyBuf, sstoreResetCost, 'reset')),
-      'updateSstoreGas'
-    )
-    runState.eei.refundGas(
-      new BN(runState._common.param('gasPrices', 'sstoreRefund')),
-      'updateSstoreGas'
-    )
+    runState.eei.useGas(new BN(adjustSstoreGasEIP2929(runState, keyBuf, sstoreResetCost, 'reset')))
+    runState.eei.refundGas(new BN(runState._common.param('gasPrices', 'sstoreRefund')))
   } else if (value.length !== 0 && !found.length) {
-    runState.eei.useGas(new BN(runState._common.param('gasPrices', 'sstoreSet')), 'updateSstoreGas')
+    runState.eei.useGas(new BN(runState._common.param('gasPrices', 'sstoreSet')))
   }
 }

--- a/packages/vm/lib/runBlock.ts
+++ b/packages/vm/lib/runBlock.ts
@@ -1,4 +1,3 @@
-import { debug as createDebugLogger } from 'debug'
 import { encode } from 'rlp'
 import { BaseTrie as Trie } from 'merkle-patricia-tree'
 import { Account, Address, BN, intToBuffer } from 'ethereumjs-util'
@@ -18,8 +17,6 @@ import * as DAOConfig from './config/dao_fork_accounts_config.json'
 // update your imports to the new types file.
 import { PreByzantiumTxReceipt, PostByzantiumTxReceipt, EIP2930Receipt } from './types'
 export { PreByzantiumTxReceipt, PostByzantiumTxReceipt, EIP2930Receipt }
-
-const debug = createDebugLogger('vm:block')
 
 /* DAO account list */
 const DAOAccountList = DAOConfig.DAOAccounts
@@ -116,18 +113,9 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
   if (this._hardforkByBlockNumber) {
     this._common.setHardforkByBlockNumber(block.header.number.toNumber())
   }
-  debug('-'.repeat(100))
-  debug(
-    `Running block hash=${block
-      .hash()
-      .toString(
-        'hex'
-      )} number=${block.header.number.toNumber()} hardfork=${this._common.hardfork()}`
-  )
 
   // Set state root if provided
   if (root) {
-    debug(`Set provided state root ${root.toString('hex')}`)
     await state.setStateRoot(root)
   }
 
@@ -136,33 +124,22 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
     this._common.hardforkIsActiveOnChain('dao') &&
     block.header.number.eq(this._common.hardforkBlockBN('dao'))
   ) {
-    debug(`Apply DAO hardfork`)
     await _applyDAOHardfork(state)
   }
 
   // Checkpoint state
   await state.checkpoint()
-  debug(`block checkpoint`)
 
   let result
   try {
     result = await applyBlock.bind(this)(block, opts)
-    debug(
-      `Received block results gasUsed=${result.gasUsed} bloom=${short(result.bloom.bitvector)} (${
-        result.bloom.bitvector.length
-      } bytes) receiptRoot=${result.receiptRoot.toString('hex')} receipts=${
-        result.receipts.length
-      } txResults=${result.results.length}`
-    )
   } catch (err) {
     await state.revert()
-    debug(`block checkpoint reverted`)
     throw err
   }
 
   // Persist state
   await state.commit()
-  debug(`block checkpoint committed`)
 
   const stateRoot = await state.getStateRoot(false)
 
@@ -182,31 +159,15 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
     block = Block.fromBlockData(blockData, { common: this._common })
   } else {
     if (result.receiptRoot && !result.receiptRoot.equals(block.header.receiptTrie)) {
-      debug(
-        `Invalid receiptTrie received=${result.receiptRoot.toString(
-          'hex'
-        )} expected=${block.header.receiptTrie.toString('hex')}`
-      )
       throw new Error('invalid receiptTrie')
     }
     if (!result.bloom.bitvector.equals(block.header.bloom)) {
-      debug(
-        `Invalid bloom received=${result.bloom.bitvector.toString(
-          'hex'
-        )} expected=${block.header.bloom.toString('hex')}`
-      )
       throw new Error('invalid bloom')
     }
     if (!result.gasUsed.eq(block.header.gasUsed)) {
-      debug(`Invalid gasUsed received=${result.gasUsed} expected=${block.header.gasUsed}`)
       throw new Error('invalid gasUsed')
     }
     if (!stateRoot.equals(block.header.stateRoot)) {
-      debug(
-        `Invalid stateRoot received=${stateRoot.toString(
-          'hex'
-        )} expected=${block.header.stateRoot.toString('hex')}`
-      )
       throw new Error('invalid block stateRoot')
     }
   }
@@ -230,13 +191,6 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
    * @property {AfterBlockEvent} result emits the results of processing a block
    */
   await this._emit('afterBlock', afterBlockEvent)
-  debug(
-    `Running block finished hash=${block
-      .hash()
-      .toString(
-        'hex'
-      )} number=${block.header.number.toNumber()} hardfork=${this._common.hardfork()}`
-  )
 
   return results
 }
@@ -255,12 +209,10 @@ async function applyBlock(this: VM, block: Block, opts: RunBlockOpts) {
     if (block.header.gasLimit.gte(new BN('8000000000000000', 16))) {
       throw new Error('Invalid block with gas limit greater than (2^63 - 1)')
     } else {
-      debug(`Validate block`)
       await block.validate(this.blockchain)
     }
   }
   // Apply transactions
-  debug(`Apply transactions`)
   const blockResults = await applyTransactions.bind(this)(block, opts)
   // Pay ommers and miners
   if (this._common.consensusType() === 'pow') {
@@ -311,11 +263,9 @@ async function applyTransactions(this: VM, block: Block, opts: RunBlockOpts) {
       skipNonce,
     })
     txResults.push(txRes)
-    debug('-'.repeat(100))
 
     // Add to total block gas usage
     gasUsed = gasUsed.add(txRes.gasUsed)
-    debug(`Add tx gas used (${txRes.gasUsed}) to total block gas usage (-> ${gasUsed})`)
 
     // Combine blooms via bitwise OR
     bloom.or(txRes.bloom)
@@ -340,20 +290,17 @@ async function applyTransactions(this: VM, block: Block, opts: RunBlockOpts) {
  * the updated balances of their accounts to state.
  */
 async function assignBlockRewards(this: VM, block: Block): Promise<void> {
-  debug(`Assign block rewards`)
   const state = this.stateManager
   const minerReward = new BN(this._common.param('pow', 'minerReward'))
   const ommers = block.uncleHeaders
   // Reward ommers
   for (const ommer of ommers) {
     const reward = calculateOmmerReward(ommer.number, block.header.number, minerReward)
-    const account = await rewardAccount(state, ommer.coinbase, reward)
-    debug(`Add uncle reward ${reward} to account ${ommer.coinbase} (-> ${account.balance})`)
+    await rewardAccount(state, ommer.coinbase, reward)
   }
   // Reward miner
   const reward = calculateMinerReward(minerReward, ommers.length)
-  const account = await rewardAccount(state, block.header.coinbase, reward)
-  debug(`Add miner reward ${reward} to account ${block.header.coinbase} (-> ${account.balance})`)
+  await rewardAccount(state, block.header.coinbase, reward)
 }
 
 function calculateOmmerReward(ommerBlockNumber: BN, blockNumber: BN, minerReward: BN): BN {

--- a/packages/vm/lib/runTx.ts
+++ b/packages/vm/lib/runTx.ts
@@ -1,4 +1,3 @@
-import { debug as createDebugLogger } from 'debug'
 import { Address, BN, toBuffer } from 'ethereumjs-util'
 import { Block } from '@ethereumjs/block'
 import {
@@ -10,7 +9,6 @@ import {
 import VM from './index'
 import Bloom from './bloom'
 import { default as EVM, EVMResult } from './evm/evm'
-import { short } from './evm/opcodes/util'
 import Message from './evm/message'
 import TxContext from './evm/txContext'
 import { getActivePrecompiles } from './evm/precompiles'
@@ -22,9 +20,6 @@ import type {
   PostByzantiumTxReceipt,
   EIP2930Receipt,
 } from './types'
-
-const debug = createDebugLogger('vm:tx')
-const debugGas = createDebugLogger('vm:tx:gas')
 
 /**
  * Options for the `runTx` method.
@@ -140,8 +135,6 @@ export default async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxRes
   }
 
   await state.checkpoint()
-  debug('-'.repeat(100))
-  debug(`tx checkpoint`)
 
   // Is it an Access List transaction?
   if (
@@ -174,7 +167,6 @@ export default async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxRes
   try {
     const result = await _runTx.bind(this)(opts)
     await state.commit()
-    debug(`tx checkpoint committed`)
     if (this._common.isActivatedEIP(2929) && opts.reportAccessList) {
       const { tx } = opts
       // Do not include sender address in access list
@@ -186,7 +178,6 @@ export default async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxRes
     return result
   } catch (e) {
     await state.revert()
-    debug(`tx checkpoint reverted`)
     throw e
   } finally {
     if (this._common.isActivatedEIP(2929)) {
@@ -214,7 +205,6 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   await this._emit('beforeTx', tx)
 
   const caller = tx.getSenderAddress()
-  debug(`New tx run hash=${opts.tx.hash().toString('hex')} sender=${caller.toString()}`)
 
   if (this._common.isActivatedEIP(2929)) {
     // Add origin and precompiles to warm addresses
@@ -235,7 +225,6 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
     throw new Error('base fee exceeds gas limit')
   }
   gasLimit.isub(basefee)
-  debugGas(`Subtracting base fee (${basefee}) from gasLimit (-> ${gasLimit})`)
 
   // Check from account's balance and nonce
   let fromAccount = await state.getAccount(caller)
@@ -261,9 +250,6 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   const txCost = tx.gasLimit.mul(tx.gasPrice)
   fromAccount.balance.isub(txCost)
   await state.putAccount(caller, fromAccount)
-  debug(
-    `Update fromAccount (caller) nonce (-> ${fromAccount.nonce}) and balance(-> ${fromAccount.balance})`
-  )
 
   /*
    * Execute message
@@ -278,35 +264,17 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
     data,
   })
   const evm = new EVM(this, txContext, block)
-  debug(
-    `Running tx=0x${tx
-      .hash()
-      .toString('hex')} with caller=${caller.toString()} gasLimit=${gasLimit} to=${
-      to ? to.toString() : ''
-    } value=${value} data=0x${short(data)}`
-  )
+
   const results = (await evm.executeMessage(message)) as RunTxResult
-  debug('-'.repeat(100))
-  debug(
-    `Received tx results gasUsed=${results.gasUsed} execResult: [ gasUsed=${
-      results.gasUsed
-    } exceptionError=${
-      results.execResult.exceptionError ? results.execResult.exceptionError.error : ''
-    } returnValue=${short(results.execResult.returnValue)} gasRefund=${
-      results.execResult.gasRefund
-    } ]`
-  )
 
   /*
    * Parse results
    */
   // Generate the bloom for the tx
   results.bloom = txLogsBloom(results.execResult.logs)
-  debug(`Generated tx bloom with logs=${results.execResult.logs?.length}`)
 
   // Caculate the total gas used
   results.gasUsed.iadd(basefee)
-  debugGas(`tx add baseFee ${basefee} to gasUsed (-> ${results.gasUsed})`)
 
   // Process any gas refund
   // TODO: determine why the gasRefund from execResult is not used here directly
@@ -316,9 +284,6 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
       gasRefund = results.gasUsed.divn(2)
     }
     results.gasUsed.isub(gasRefund)
-    debug(`Subtract tx gasRefund (${gasRefund}) from gasUsed (-> ${results.gasUsed})`)
-  } else {
-    debug(`No tx gasRefund`)
   }
   results.amountSpent = results.gasUsed.mul(tx.gasPrice)
 
@@ -328,9 +293,6 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   const txCostDiff = txCost.sub(actualTxCost)
   fromAccount.balance.iadd(txCostDiff)
   await state.putAccount(caller, fromAccount)
-  debug(
-    `Refunded txCostDiff (${txCostDiff}) to fromAccount (caller) balance (-> ${fromAccount.balance})`
-  )
 
   // Update miner's balance
   let miner
@@ -353,7 +315,6 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // the state.putAccount function puts this into the "touched" accounts. This will thus be removed when
   // we clean the touched accounts below in case we are in a fork >= SpuriousDragon
   await state.putAccount(miner, minerAccount)
-  debug(`tx update miner account (${miner.toString()}) balance (-> ${minerAccount.balance})`)
 
   /*
    * Cleanup accounts
@@ -363,7 +324,6 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
     for (const k of keys) {
       const address = new Address(Buffer.from(k, 'hex'))
       await state.deleteAccount(address)
-      debug(`tx selfdestruct on address=${address.toString()}`)
     }
   }
   await state.cleanupTouchedAccounts()
@@ -382,7 +342,6 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
    */
   const event: AfterTxEvent = { transaction: tx, ...results }
   await this._emit('afterTx', event)
-  debug(`tx run finished hash=${opts.tx.hash().toString('hex')} sender=${caller.toString()}`)
 
   return results
 }
@@ -428,11 +387,6 @@ export async function generateTxReceipt(
   }
 
   let receipt
-  let log = `Generate tx receipt transactionType=${
-    'transactionType' in tx ? tx.transactionType : 'NaN'
-  } gasUsed=${blockGasUsed.toString()} bitvector=${short(baseReceipt.bitvector)} (${
-    baseReceipt.bitvector.length
-  } bytes) logs=${baseReceipt.logs.length}`
 
   if (!('transactionType' in tx) || tx.transactionType === 0) {
     // Legacy transaction
@@ -442,8 +396,6 @@ export async function generateTxReceipt(
         status: txResult.execResult.exceptionError ? 0 : 1, // Receipts have a 0 as status on error
         ...baseReceipt,
       } as PostByzantiumTxReceipt
-      const statusInfo = txResult.execResult.exceptionError ? 'error' : 'ok'
-      log += ` status=${receipt.status} (${statusInfo}) (>= Byzantium)`
     } else {
       // Pre-Byzantium
       const stateRoot = await this.stateManager.getStateRoot(true)
@@ -451,7 +403,6 @@ export async function generateTxReceipt(
         stateRoot: stateRoot,
         ...baseReceipt,
       } as PreByzantiumTxReceipt
-      log += ` stateRoot=${receipt.stateRoot.toString('hex')} (< Byzantium)`
     }
   } else if ('transactionType' in tx && tx.transactionType === 1) {
     // EIP2930 Transaction
@@ -465,6 +416,5 @@ export async function generateTxReceipt(
     )
   }
 
-  debug(log)
   return receipt
 }

--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -1,5 +1,4 @@
 const Set = require('core-js-pure/es/set')
-import { debug as createDebugLogger } from 'debug'
 import { SecureTrie as Trie } from 'merkle-patricia-tree'
 import {
   Account,
@@ -16,10 +15,7 @@ import { genesisStateByName } from '@ethereumjs/common/dist/genesisStates'
 import { StateManager, StorageDump } from './interface'
 import Cache from './cache'
 import { getActivePrecompiles, ripemdPrecompileAddress } from '../evm/precompiles'
-import { short } from '../evm/opcodes'
 import { AccessList, AccessListItem } from '@ethereumjs/tx'
-
-const debug = createDebugLogger('vm:state')
 
 type AddressHex = string
 
@@ -113,11 +109,6 @@ export default class DefaultStateManager implements StateManager {
    * @param account - The account to store
    */
   async putAccount(address: Address, account: Account): Promise<void> {
-    debug(
-      `Save account address=${address} nonce=${account.nonce} balance=${account.balance} contract=${
-        account.isContract() ? 'yes' : 'no'
-      } empty=${account.isEmpty() ? 'yes' : 'no'}`
-    )
     this._cache.put(address, account)
     this.touchAccount(address)
   }
@@ -127,7 +118,6 @@ export default class DefaultStateManager implements StateManager {
    * @param address - Address of the account which should be deleted
    */
   async deleteAccount(address: Address) {
-    debug(`Delete account ${address}`)
     this._cache.del(address)
     this.touchAccount(address)
   }
@@ -159,7 +149,6 @@ export default class DefaultStateManager implements StateManager {
     await this._trie.db.put(codeHash, value)
 
     const account = await this.getAccount(address)
-    debug(`Update codeHash (-> ${short(codeHash)}) for account ${address}`)
     account.codeHash = codeHash
     await this.putAccount(address, account)
   }
@@ -330,11 +319,9 @@ export default class DefaultStateManager implements StateManager {
       if (value && value.length) {
         // format input
         const encodedValue = encode(value)
-        debug(`Update contract storage for account ${address} to ${short(value)}`)
         await storageTrie.put(key, encodedValue)
       } else {
         // deleting a value
-        debug(`Delete contract storage for account`)
         await storageTrie.del(key)
       }
       done()
@@ -557,7 +544,6 @@ export default class DefaultStateManager implements StateManager {
       throw new Error('Cannot create genesis state with uncommitted checkpoints')
     }
 
-    debug(`Save genesis state into the state trie`)
     const addresses = Object.keys(initState)
     for (const address of addresses) {
       const balance = new BN(toBuffer(initState[address]))
@@ -737,7 +723,6 @@ export default class DefaultStateManager implements StateManager {
         const empty = await this.accountIsEmpty(address)
         if (empty) {
           this._cache.del(address)
-          debug(`Cleanup touched account address=${address.toString()} (>= SpuriousDragon)`)
         }
       }
     }


### PR DESCRIPTION
We are receiving complains from our users about the release candidate version we published running >6x slower than our previous version. 

The main difference between these versions is that the RC version uses v5, instead of v4, making it the first consumer of v5.

This performance regression is aligned with that @jochem-brouwer reported when experimenting with removing the traces and running the standard tests, so I instructed one of our users to remove them from their `node_modules`, and not only the performance regression was gone, but the test run actually faster.

This PR removes all the debug traces from the VM. I didn't remove them from other packages to keep the PR small, and because we don't use them, so it's not as urgent.

@holgerd77, do you think we can get this published today? We really need to publish a final version of our Berlin support on Wednesday, or otherwise there won't be any way to test smart contracts against Berlin, and we can't publish something with a regression this significant.