### PR TITLE
StateManager: fix buffer comparison in setStateRoot

### DIFF
--- a/packages/vm/lib/state/stateManager.ts
+++ b/packages/vm/lib/state/stateManager.ts
@@ -464,16 +464,11 @@ export default class DefaultStateManager implements StateManager {
 
     await this._cache.flush()
 
-    if (stateRoot === this._trie.EMPTY_TRIE_ROOT) {
-      this._trie.root = stateRoot
-      this._cache.clear()
-      this._storageTries = {}
-      return
-    }
-
-    const hasRoot = await this._trie.checkRoot(stateRoot)
-    if (!hasRoot) {
-      throw new Error('State trie does not contain state root')
+    if (!stateRoot.equals(this._trie.EMPTY_TRIE_ROOT)) {
+      const hasRoot = await this._trie.checkRoot(stateRoot)
+      if (!hasRoot) {
+        throw new Error('State trie does not contain state root')
+      }
     }
 
     this._trie.root = stateRoot


### PR DESCRIPTION
I recently noticed that `setStateRoot` had a direct buffer comparison:

`if (stateRoot === this._trie.EMPTY_TRIE_ROOT) {`

In practice this doesn't always work and should instead use `Buffer.equals()`. I added a spec test that fails without the provided fix.

This was also an opportunity to DRY (Don't-Repeat-Yourself) the code a bit.