### PR TITLE
Trie: new deleteFromDB option (default: false)

### DIFF
--- a/packages/trie/src/baseTrie.ts
+++ b/packages/trie/src/baseTrie.ts
@@ -39,24 +39,30 @@ export type FoundNodeFunction = (
  * The API for the base and the secure interface are about the same.
  */
 export class Trie {
-  /** The backend DB */
-  db: DB
   /** The root for an empty trie */
   EMPTY_TRIE_ROOT: Buffer
-  private _root: Buffer
   protected lock: Semaphore
+
+  /** The backend DB */
+  db: DB
+  private _root: Buffer
+  private _deleteFromDB: boolean
 
   /**
    * test
    * @param db - A [levelup](https://github.com/Level/levelup) instance. By default (if the db is `null` or
    * left undefined) creates an in-memory [memdown](https://github.com/Level/memdown) instance.
    * @param root - A `Buffer` for the root of a previously stored trie
+   * @param deleteFromDB - Delete nodes from DB on delete operations (disallows switching to an older state root) (default: `false`)
    */
-  constructor(db?: LevelUp | null, root?: Buffer) {
+  constructor(db?: LevelUp | null, root?: Buffer, deleteFromDB: boolean = false) {
     this.EMPTY_TRIE_ROOT = KECCAK256_RLP
     this.lock = new Semaphore(1)
+
     this.db = db ? new DB(db) : new DB()
     this._root = this.EMPTY_TRIE_ROOT
+    this._deleteFromDB = deleteFromDB
+
     if (root) {
       this.setRoot(root)
     }
@@ -382,7 +388,7 @@ export class Trie {
   }
 
   /**
-   * Deletes a node from the database.
+   * Deletes a node from the trie.
    * @private
    */
   async _deleteNode(k: Buffer, stack: TrieNode[]): Promise<void> {
@@ -566,11 +572,13 @@ export class Trie {
       // is applied twice (performance)
       const hashRoot = keccak(rlpNode)
 
-      if (remove && this.isCheckpoint) {
-        opStack.push({
-          type: 'del',
-          key: hashRoot,
-        })
+      if (remove) {
+        if (this._deleteFromDB) {
+          opStack.push({
+            type: 'del',
+            key: hashRoot,
+          })
+        }
       } else {
         opStack.push({
           type: 'put',
@@ -586,7 +594,8 @@ export class Trie {
   }
 
   /**
-   * The given hash of operations (key additions or deletions) are executed on the DB
+   * The given hash of operations (key additions or deletions) are executed on the trie
+   * (delete operations are only executed on DB with `deleteFromDB` set to `true`)
    * @example
    * const ops = [
    *    { type: 'del', key: Buffer.from('father') }

--- a/packages/trie/src/baseTrie.ts
+++ b/packages/trie/src/baseTrie.ts
@@ -569,10 +569,17 @@ export class Trie {
   ): Buffer | (EmbeddedNode | null)[] {
     const rlpNode = node.serialize()
 
-    // TODO: analyze why this length check is here, 2021-04-29
-    // If removed various tests fail. However this prevents certain delete operations
-    // when deleteFromDB is activated
-    // Related test: `index.spec.ts`, "setting back state root (deleteFromDB)"
+    /**
+     * TODO: analyze why this length check is here, 2021-04-29
+     *
+     * Hint from https://eth.wiki/fundamentals/patricia-tree:
+     * "When one node is referenced inside another node, what is included is H(rlp.encode(x)),
+     * where H(x) = sha3(x) if len(x) >= 32 else x and rlp.encode is the RLP encoding function."
+     *
+     * If removed various tests fail. However this prevents certain delete operations
+     * when deleteFromDB is activated.
+     * Related test: `index.spec.ts`, "setting back state root (deleteFromDB)"
+     */
     if (rlpNode.length >= 32 || topLevel) {
       // Do not use TrieNode.hash() here otherwise serialize()
       // is applied twice (performance)

--- a/packages/trie/src/baseTrie.ts
+++ b/packages/trie/src/baseTrie.ts
@@ -123,7 +123,8 @@ export class Trie {
   }
 
   /**
-   * Stores a given `value` at the given `key`.
+   * Stores a given `value` at the given `key` or do a delete if `value` is empty
+   * (delete operations are only executed on DB with `deleteFromDB` set to `true`)
    * @param key
    * @param value
    * @returns A Promise that resolves once value is stored.
@@ -149,7 +150,8 @@ export class Trie {
   }
 
   /**
-   * Deletes a value given a `key`.
+   * Deletes a value given a `key` from the trie
+   * (delete operations are only executed on DB with `deleteFromDB` set to `true`)
    * @param key
    * @returns A Promise that resolves once value is deleted.
    */
@@ -567,6 +569,10 @@ export class Trie {
   ): Buffer | (EmbeddedNode | null)[] {
     const rlpNode = node.serialize()
 
+    // TODO: analyze why this length check is here, 2021-04-29
+    // If removed various tests fail. However this prevents certain delete operations
+    // when deleteFromDB is activated
+    // Related test: `index.spec.ts`, "setting back state root (deleteFromDB)"
     if (rlpNode.length >= 32 || topLevel) {
       // Do not use TrieNode.hash() here otherwise serialize()
       // is applied twice (performance)

--- a/packages/trie/src/baseTrie.ts
+++ b/packages/trie/src/baseTrie.ts
@@ -569,17 +569,6 @@ export class Trie {
   ): Buffer | (EmbeddedNode | null)[] {
     const rlpNode = node.serialize()
 
-    /**
-     * TODO: analyze why this length check is here, 2021-04-29
-     *
-     * Hint from https://eth.wiki/fundamentals/patricia-tree:
-     * "When one node is referenced inside another node, what is included is H(rlp.encode(x)),
-     * where H(x) = sha3(x) if len(x) >= 32 else x and rlp.encode is the RLP encoding function."
-     *
-     * If removed various tests fail. However this prevents certain delete operations
-     * when deleteFromDB is activated.
-     * Related test: `index.spec.ts`, "setting back state root (deleteFromDB)"
-     */
     if (rlpNode.length >= 32 || topLevel) {
       // Do not use TrieNode.hash() here otherwise serialize()
       // is applied twice (performance)

--- a/packages/trie/test/index.spec.ts
+++ b/packages/trie/test/index.spec.ts
@@ -289,3 +289,44 @@ tape('it should create the genesis state root from ethereum', function (tester) 
     t.end()
   })
 })
+
+tape('setting back state root (deleteFromDB)', async (t) => {
+  const k1 = Buffer.from('1')
+  const v1 = Buffer.from('value1')
+  const k2 = Buffer.from('2')
+  const v2 = Buffer.from('value2')
+
+  const rootAfterK1 = Buffer.from(
+    'd7ad4d901f5ecbf1940c67129b2bc24e46dadb3d4f806f6e9b927fdbddc567c7',
+    'hex'
+  )
+
+  const trieSetups = [
+    {
+      trie: new BaseTrie(undefined, undefined, false),
+      expected: v1,
+      msg: 'should return v1 when setting back the state root when deleteFromDB=false',
+    },
+    {
+      trie: new BaseTrie(undefined, undefined, true),
+      expected: null,
+      msg: 'should return null when setting back the state root when deleteFromDB=true',
+    },
+  ]
+
+  for (const s of trieSetups) {
+    await s.trie.put(k1, v1)
+    await s.trie.put(k2, v2)
+    await s.trie.del(k1)
+    t.equal(
+      await s.trie.get(k1),
+      null,
+      'should return null on latest state root independently from deleteFromDB setting'
+    )
+
+    s.trie.root = rootAfterK1
+    t.deepEqual(await s.trie.get(k1), s.expected, s.msg)
+  }
+
+  t.end()
+})

--- a/packages/trie/test/index.spec.ts
+++ b/packages/trie/test/index.spec.ts
@@ -157,53 +157,69 @@ tape('simple save and retrieve', function (tester) {
 
 tape('testing deletion cases', function (tester) {
   const it = tester.test
-  const trie = new CheckpointTrie()
+  const trieSetupWithoutDBDelete = {
+    trie: new CheckpointTrie(),
+    msg: 'without DB delete',
+  }
+  const trieSetupWithDBDelete = {
+    trie: new CheckpointTrie(undefined, undefined, true),
+    msg: 'with DB delete',
+  }
+  const trieSetups = [trieSetupWithoutDBDelete, trieSetupWithDBDelete]
 
   it('should delete from a branch->branch-branch', async function (t) {
-    await trie.put(Buffer.from([11, 11, 11]), Buffer.from('first'))
-    await trie.put(Buffer.from([12, 22, 22]), Buffer.from('create the first branch'))
-    await trie.put(Buffer.from([12, 34, 44]), Buffer.from('create the last branch'))
+    for (const trieSetup of trieSetups) {
+      await trieSetup.trie.put(Buffer.from([11, 11, 11]), Buffer.from('first'))
+      await trieSetup.trie.put(Buffer.from([12, 22, 22]), Buffer.from('create the first branch'))
+      await trieSetup.trie.put(Buffer.from([12, 34, 44]), Buffer.from('create the last branch'))
 
-    await trie.del(Buffer.from([12, 22, 22]))
-    const val = await trie.get(Buffer.from([12, 22, 22]))
-    t.equal(null, val)
+      await trieSetup.trie.del(Buffer.from([12, 22, 22]))
+      const val = await trieSetup.trie.get(Buffer.from([12, 22, 22]))
+      t.equal(null, val, trieSetup.msg)
+    }
     t.end()
   })
 
   it('should delete from a branch->branch-extension', async function (t) {
-    await trie.put(Buffer.from([11, 11, 11]), Buffer.from('first'))
-    await trie.put(Buffer.from([12, 22, 22]), Buffer.from('create the first branch'))
-    await trie.put(Buffer.from([12, 33, 33]), Buffer.from('create the middle branch'))
-    await trie.put(Buffer.from([12, 34, 44]), Buffer.from('create the last branch'))
+    for (const trieSetup of trieSetups) {
+      await trieSetup.trie.put(Buffer.from([11, 11, 11]), Buffer.from('first'))
+      await trieSetup.trie.put(Buffer.from([12, 22, 22]), Buffer.from('create the first branch'))
+      await trieSetup.trie.put(Buffer.from([12, 33, 33]), Buffer.from('create the middle branch'))
+      await trieSetup.trie.put(Buffer.from([12, 34, 44]), Buffer.from('create the last branch'))
 
-    await trie.del(Buffer.from([12, 22, 22]))
-    const val = await trie.get(Buffer.from([12, 22, 22]))
-    t.equal(null, val)
+      await trieSetup.trie.del(Buffer.from([12, 22, 22]))
+      const val = await trieSetup.trie.get(Buffer.from([12, 22, 22]))
+      t.equal(null, val, trieSetup.msg)
+    }
     t.end()
   })
 
   it('should delete from a extension->branch-extension', async function (t) {
-    await trie.put(Buffer.from([11, 11, 11]), Buffer.from('first'))
-    await trie.put(Buffer.from([12, 22, 22]), Buffer.from('create the first branch'))
-    await trie.put(Buffer.from([12, 33, 33]), Buffer.from('create the middle branch'))
-    await trie.put(Buffer.from([12, 34, 44]), Buffer.from('create the last branch'))
+    for (const trieSetup of trieSetups) {
+      await trieSetup.trie.put(Buffer.from([11, 11, 11]), Buffer.from('first'))
+      await trieSetup.trie.put(Buffer.from([12, 22, 22]), Buffer.from('create the first branch'))
+      await trieSetup.trie.put(Buffer.from([12, 33, 33]), Buffer.from('create the middle branch'))
+      await trieSetup.trie.put(Buffer.from([12, 34, 44]), Buffer.from('create the last branch'))
 
-    // delete the middle branch
-    await trie.del(Buffer.from([11, 11, 11]))
-    const val = await trie.get(Buffer.from([11, 11, 11]))
-    t.equal(null, val)
+      // delete the middle branch
+      await trieSetup.trie.del(Buffer.from([11, 11, 11]))
+      const val = await trieSetup.trie.get(Buffer.from([11, 11, 11]))
+      t.equal(null, val, trieSetup.msg)
+    }
     t.end()
   })
 
   it('should delete from a extension->branch-branch', async function (t) {
-    await trie.put(Buffer.from([11, 11, 11]), Buffer.from('first'))
-    await trie.put(Buffer.from([12, 22, 22]), Buffer.from('create the first branch'))
-    await trie.put(Buffer.from([12, 33, 33]), Buffer.from('create the middle branch'))
-    await trie.put(Buffer.from([12, 34, 44]), Buffer.from('create the last branch'))
-    // delete the middle branch
-    await trie.del(Buffer.from([11, 11, 11]))
-    const val = await trie.get(Buffer.from([11, 11, 11]))
-    t.equal(null, val)
+    for (const trieSetup of trieSetups) {
+      await trieSetup.trie.put(Buffer.from([11, 11, 11]), Buffer.from('first'))
+      await trieSetup.trie.put(Buffer.from([12, 22, 22]), Buffer.from('create the first branch'))
+      await trieSetup.trie.put(Buffer.from([12, 33, 33]), Buffer.from('create the middle branch'))
+      await trieSetup.trie.put(Buffer.from([12, 34, 44]), Buffer.from('create the last branch'))
+      // delete the middle branch
+      await trieSetup.trie.del(Buffer.from([11, 11, 11]))
+      const val = await trieSetup.trie.get(Buffer.from([11, 11, 11]))
+      t.equal(null, val, trieSetup.msg)
+    }
     t.end()
   })
 })

--- a/packages/trie/test/index.spec.ts
+++ b/packages/trie/test/index.spec.ts
@@ -292,12 +292,14 @@ tape('it should create the genesis state root from ethereum', function (tester) 
 
 tape('setting back state root (deleteFromDB)', async (t) => {
   const k1 = Buffer.from('1')
-  const v1 = Buffer.from('value1')
+  // Testing with longer value due to `rlpNode.length >= 32` check in `_formatNode()`
+  // see TODO note over there
+  const v1 = Buffer.from('this-is-some-longer-value-to-test-the-delete-operation-value1')
   const k2 = Buffer.from('2')
-  const v2 = Buffer.from('value2')
+  const v2 = Buffer.from('this-is-some-longer-value-to-test-the-delete-operation-value2')
 
   const rootAfterK1 = Buffer.from(
-    'd7ad4d901f5ecbf1940c67129b2bc24e46dadb3d4f806f6e9b927fdbddc567c7',
+    '809e75931f394603657e113eb7244794f35b8d326cff99407111d600722e9425',
     'hex'
   )
 

--- a/packages/trie/test/index.spec.ts
+++ b/packages/trie/test/index.spec.ts
@@ -292,8 +292,11 @@ tape('it should create the genesis state root from ethereum', function (tester) 
 
 tape('setting back state root (deleteFromDB)', async (t) => {
   const k1 = Buffer.from('1')
-  // Testing with longer value due to `rlpNode.length >= 32` check in `_formatNode()`
-  // see TODO note over there
+  /* Testing with longer value due to `rlpNode.length >= 32` check in `_formatNode()`
+   * Reasoning from https://eth.wiki/fundamentals/patricia-tree:
+   * "When one node is referenced inside another node, what is included is `H(rlp.encode(x))`,
+   * where `H(x) = sha3(x) if len(x) >= 32 else x`"
+   */
   const v1 = Buffer.from('this-is-some-longer-value-to-test-the-delete-operation-value1')
   const k2 = Buffer.from('2')
   const v2 = Buffer.from('this-is-some-longer-value-to-test-the-delete-operation-value2')


### PR DESCRIPTION
Fixes #1210 

I am coming more and more to the conclusion that this might be the only change we need. We shouldn't comment out stuff (or remove) directly in the DB manager to let people the freedom to delete themselves if they wish, this is what would be expected from the direct DB class.

Some historical reference in between: `_formatNode` has been moved from `CheckpointTrie` to `BaseTrie` [here](https://github.com/ethereumjs/merkle-patricia-tree/commit/40b02ee1c84f5dcda7c1f295699b1244fdbaf22f#diff-a21bc7ca183ffb0c3fc3c310436fe3ceb155b33debfda6e132ae2afb42724a8e).

All Trie delete operations - both from `del()` and from `batch()` - are routed through this `_formatNode` method, so this should shield all possible high-level trie deletes.

I am unsure about the default setting of a potential new option `deleteFromDB`. My tendency is to switch to this keep-behavior to shield users from an unwanted delete behavior. However I am not sure about the side effects. This *will* lead to larger state growth - also e.g. in our client - if used for continuous trie operations. This would be an argument to start with remaining the delete-behavior (so set `deleteFromDB` to `true` by default) but then instantiate the default trie in the VM with `false`.

Hmm, very much unsure about these decisions.

Nevertheless this is my proposal what I would currently have a tendency towards.