### PR TITLE
VM: Improve buildBlock test performance

### DIFF
--- a/packages/vm/tests/api/buildBlock.spec.ts
+++ b/packages/vm/tests/api/buildBlock.spec.ts
@@ -1,10 +1,18 @@
 import tape from 'tape'
-import { Account, Address } from 'ethereumjs-util'
+import { Account, Address, BN } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
-import VM from '../../lib'
 import { Block } from '@ethereumjs/block'
 import { Transaction } from '@ethereumjs/tx'
 import Blockchain from '@ethereumjs/blockchain'
+import VM from '../../lib'
+import { createAccount } from './utils'
+
+const addBalance = async (vm: VM, address: Address, balance = new BN(100000000)) => {
+  const account = createAccount(new BN(0), balance)
+  await vm.stateManager.checkpoint()
+  await vm.stateManager.putAccount(address, account)
+  await vm.stateManager.commit()
+}
 
 tape('BlockBuilder', async (t) => {
   t.test('should build a valid block', async (st) => {
@@ -12,7 +20,10 @@ tape('BlockBuilder', async (t) => {
     const genesisBlock = Block.genesis({ header: { gasLimit: 50000 } }, { common })
     const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
     const vm = await VM.create({ common, blockchain })
-    await vm.stateManager.generateCanonicalGenesis()
+
+    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
+    await addBalance(vm, address)
+
     const vmCopy = vm.copy()
 
     const blockBuilder = await vm.buildBlock({
@@ -26,8 +37,6 @@ tape('BlockBuilder', async (t) => {
       { to: Address.zero(), value: 1000, gasLimit: 21000, gasPrice: 1 },
       { common, freeze: false }
     )
-    // set `from` to a genesis address with existing balance
-    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
     tx.getSenderAddress = () => {
       return address
     }
@@ -73,7 +82,9 @@ tape('BlockBuilder', async (t) => {
     const genesisBlock = Block.genesis({ header: { gasLimit: 50000 } }, { common })
     const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
     const vm = await VM.create({ common, blockchain })
-    await vm.stateManager.generateCanonicalGenesis()
+
+    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
+    await addBalance(vm, address)
 
     const root0 = await vm.stateManager.getStateRoot()
 
@@ -84,8 +95,6 @@ tape('BlockBuilder', async (t) => {
       { to: Address.zero(), value: 1000, gasLimit: 21000, gasPrice: 1 },
       { common, freeze: false }
     )
-    // set `from` to a genesis address with existing balance
-    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
     tx.getSenderAddress = () => {
       return address
     }
@@ -107,7 +116,9 @@ tape('BlockBuilder', async (t) => {
     const genesisBlock = Block.genesis({ header: { gasLimit: 50000 } }, { common })
     const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
     const vm = await VM.create({ common, blockchain })
-    await vm.stateManager.generateCanonicalGenesis()
+
+    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
+    await addBalance(vm, address)
 
     const blockBuilder = await vm.buildBlock({
       parentBlock: genesisBlock,
@@ -119,8 +130,6 @@ tape('BlockBuilder', async (t) => {
       { to: Address.zero(), value: 1000, gasLimit: 21000, gasPrice: 1 },
       { common, freeze: false }
     )
-    // set `from` to a genesis address with existing balance
-    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
     tx.getSenderAddress = () => {
       return address
     }
@@ -195,7 +204,9 @@ tape('BlockBuilder', async (t) => {
     const genesisBlock = Block.genesis({ header: { gasLimit: 50000 } }, { common })
     const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
     const vm = await VM.create({ common, blockchain })
-    await vm.stateManager.generateCanonicalGenesis()
+
+    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
+    await addBalance(vm, address)
 
     let blockBuilder = await vm.buildBlock({
       parentBlock: genesisBlock,
@@ -206,8 +217,6 @@ tape('BlockBuilder', async (t) => {
       { to: Address.zero(), value: 1000, gasLimit: 21000, gasPrice: 1 },
       { common, freeze: false }
     )
-    // set `from` to a genesis address with existing balance
-    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
     tx.getSenderAddress = () => {
       return address
     }

--- a/packages/vm/tests/api/buildBlock.spec.ts
+++ b/packages/vm/tests/api/buildBlock.spec.ts
@@ -1,18 +1,11 @@
 import tape from 'tape'
-import { Account, Address, BN } from 'ethereumjs-util'
+import { Account, Address } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import { Transaction } from '@ethereumjs/tx'
 import Blockchain from '@ethereumjs/blockchain'
 import VM from '../../lib'
-import { createAccount } from './utils'
-
-const addBalance = async (vm: VM, address: Address, balance = new BN(100000000)) => {
-  const account = createAccount(new BN(0), balance)
-  await vm.stateManager.checkpoint()
-  await vm.stateManager.putAccount(address, account)
-  await vm.stateManager.commit()
-}
+import { setBalance } from './utils'
 
 tape('BlockBuilder', async (t) => {
   t.test('should build a valid block', async (st) => {
@@ -22,7 +15,7 @@ tape('BlockBuilder', async (t) => {
     const vm = await VM.create({ common, blockchain })
 
     const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
-    await addBalance(vm, address)
+    await setBalance(vm, address)
 
     const vmCopy = vm.copy()
 
@@ -84,7 +77,7 @@ tape('BlockBuilder', async (t) => {
     const vm = await VM.create({ common, blockchain })
 
     const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
-    await addBalance(vm, address)
+    await setBalance(vm, address)
 
     const root0 = await vm.stateManager.getStateRoot()
 
@@ -118,7 +111,7 @@ tape('BlockBuilder', async (t) => {
     const vm = await VM.create({ common, blockchain })
 
     const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
-    await addBalance(vm, address)
+    await setBalance(vm, address)
 
     const blockBuilder = await vm.buildBlock({
       parentBlock: genesisBlock,
@@ -206,7 +199,7 @@ tape('BlockBuilder', async (t) => {
     const vm = await VM.create({ common, blockchain })
 
     const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
-    await addBalance(vm, address)
+    await setBalance(vm, address)
 
     let blockBuilder = await vm.buildBlock({
       parentBlock: genesisBlock,

--- a/packages/vm/tests/api/runBlock.spec.ts
+++ b/packages/vm/tests/api/runBlock.spec.ts
@@ -9,6 +9,7 @@ import { setupPreConditions, getDAOCommon } from '../util'
 import { setupVM, createAccount } from './utils'
 import testnet from './testdata/testnet.json'
 import VM from '../../lib/index'
+import { setBalance } from './utils'
 
 const testData = require('./testdata/blockchain.json')
 const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
@@ -379,12 +380,12 @@ tape('runBlock() -> tx types', async (t) => {
   t.test('legacy tx', async (t) => {
     const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
     const vm = setupVM({ common })
-    await vm.stateManager.generateCanonicalGenesis()
+
+    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
+    await setBalance(vm, address)
 
     const tx = Transaction.fromTxData({ gasLimit: 53000, value: 1 }, { common, freeze: false })
 
-    // set `from` to a genesis address with existing balance
-    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
     tx.getSenderAddress = () => {
       return address
     }
@@ -396,15 +397,15 @@ tape('runBlock() -> tx types', async (t) => {
   t.test('access list tx', async (t) => {
     const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
     const vm = setupVM({ common })
-    await vm.stateManager.generateCanonicalGenesis()
+
+    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
+    await setBalance(vm, address)
 
     const tx = AccessListEIP2930Transaction.fromTxData(
       { gasLimit: 53000, value: 1, v: 1, r: 1, s: 1 },
       { common, freeze: false }
     )
 
-    // set `from` to a genesis address with existing balance
-    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
     tx.getSenderAddress = () => {
       return address
     }

--- a/packages/vm/tests/api/utils.ts
+++ b/packages/vm/tests/api/utils.ts
@@ -1,4 +1,4 @@
-import { Account, BN } from 'ethereumjs-util'
+import { Account, Address, BN } from 'ethereumjs-util'
 import Blockchain from '@ethereumjs/blockchain'
 import VM from '../../lib/index'
 import { VMOpts } from '../../lib'
@@ -10,6 +10,13 @@ const level = require('level-mem')
 
 export function createAccount(nonce: BN = new BN(0), balance: BN = new BN(0xfff384)) {
   return new Account(nonce, balance)
+}
+
+export async function setBalance(vm: VM, address: Address, balance = new BN(100000000)) {
+  const account = createAccount(new BN(0), balance)
+  await vm.stateManager.checkpoint()
+  await vm.stateManager.putAccount(address, account)
+  await vm.stateManager.commit()
 }
 
 export function setupVM(opts: VMOpts & { genesisBlock?: Block } = {}) {


### PR DESCRIPTION
This PR improves the test performance for `buildBlock.spec.ts` after seeing that it was running very slow in karma.

The bottleneck was `vm.stateManager.generateCanonicalGenesis()` which I was using to set up addresses with balances to use for txs. Instead I am now just adding balance to the specific accounts needed, which drastically reduced the execution time.