### PR TITLE
Add test for header error conditions

### DIFF
--- a/packages/block/test/header.spec.ts
+++ b/packages/block/test/header.spec.ts
@@ -280,11 +280,11 @@ tape('[Block]: Header functions', function (t) {
     }
     headerData.mixHash = Buffer.alloc(32)
 
-    testCase = 'show throw on invalid clique difficulty'
+    testCase = 'should throw on invalid clique difficulty'
     headerData.difficulty = new BN(3)
     header = BlockHeader.fromHeaderData(headerData, { common })
     try {
-      await header.validateCliqueDifficulty(blockchain);
+      header.validateCliqueDifficulty(blockchain)
       st.fail('should throw')
     } catch (error) {
       if (error.message.includes('difficulty for clique block must be INTURN (2) or NOTURN (1)')) {
@@ -359,34 +359,37 @@ tape('[Block]: Header functions', function (t) {
     st.end()
   })
 
-  t.test('should throw on fromRLPSerializedHeader() with header as rlp encoded string', function (st) {
-    const badHeader = function (): void {
-      let header = BlockHeader.fromRLPSerializedHeader(rlp.encode('a'))
-    }
-    st.throws(() => badHeader(), 'Invalid serialized header input. Must be array')
-    st.end();
-  })
-
-  t.test('should throw on fromValuesBuffer() call with values array with length > 15', function (st) {
-    const badHeader = function (): void {
-      const zero = Buffer.alloc(0)
-      const headerArray = []
-      for (let item = 0; item < 16; item++) {
-        headerArray.push(zero)
+  t.test(
+    'should throw on fromRLPSerializedHeader() with header as rlp encoded string',
+    function (st) {
+      const badHeader = function (): void {
+        BlockHeader.fromRLPSerializedHeader(rlp.encode('a'))
       }
-  
-      // mock header data (if set to zeros(0) header throws)
-      headerArray[0] = zeros(32) //parentHash
-      headerArray[2] = zeros(20) //coinbase
-      headerArray[3] = zeros(32) //stateRoot
-      headerArray[4] = zeros(32) //transactionsTrie
-      headerArray[5] = zeros(32) //receiptTrie
-      headerArray[13] = zeros(32) // mixHash
-      headerArray[14] = zeros(8) // nonce
-      headerArray[15] = zeros(4) // bad data
-      const header = BlockHeader.fromValuesArray(headerArray);
+      st.throws(() => badHeader(), 'invalid serialized header input. Must be array')
+      st.end()
     }
-    st.throws(() => badHeader(), 'invalid header. More values than expected were received');
-    st.end();
-  })
+  )
+
+  t.test(
+    'should throw on fromValuesBuffer() call with values array with length > 15',
+    function (st) {
+      const badHeader = function (): void {
+        const zero = Buffer.alloc(0)
+        const headerArray = Array(16).fill(Buffer.alloc(0))
+
+        // mock header data (if set to zeros(0) header throws)
+        headerArray[0] = zeros(32) //parentHash
+        headerArray[2] = zeros(20) //coinbase
+        headerArray[3] = zeros(32) //stateRoot
+        headerArray[4] = zeros(32) //transactionsTrie
+        headerArray[5] = zeros(32) //receiptTrie
+        headerArray[13] = zeros(32) // mixHash
+        headerArray[14] = zeros(8) // nonce
+        headerArray[15] = zeros(4) // bad data
+        BlockHeader.fromValuesArray(headerArray)
+      }
+      st.throws(() => badHeader(), 'invalid header. More values than expected were received')
+      st.end()
+    }
+  )
 })

--- a/packages/block/test/header.spec.ts
+++ b/packages/block/test/header.spec.ts
@@ -374,7 +374,6 @@ tape('[Block]: Header functions', function (t) {
     'should throw on fromValuesBuffer() call with values array with length > 15',
     function (st) {
       const badHeader = function (): void {
-        const zero = Buffer.alloc(0)
         const headerArray = Array(16).fill(Buffer.alloc(0))
 
         // mock header data (if set to zeros(0) header throws)

--- a/packages/block/test/poaMockchain.ts
+++ b/packages/block/test/poaMockchain.ts
@@ -1,0 +1,18 @@
+import { Address } from 'ethereumjs-util'
+import { Block, Blockchain } from '../src'
+
+// Helper class to setup a mock Blockchain
+
+export class PoaMockchain implements Blockchain {
+  private HashMap: { [key: string]: Block } = {}
+  async getBlock(hash: Buffer) {
+    return this.HashMap[hash.toString('hex')]
+  }
+  async putBlock(block: Block) {
+    this.HashMap[block.hash().toString('hex')] = block
+  }
+  cliqueActiveSigners() {
+    const signer = new Address(Buffer.from('0b90087d864e82a284dca15923f3776de6bb016f', 'hex'))
+    return [signer]
+  }
+}


### PR DESCRIPTION
Partially addresses #1232 - Add 3 new tests for error conditions in `header.ts` that are currently not covered.