### PR TITLE
Added client rpc eth tests for unsupported block params

### DIFF
--- a/packages/client/test/rpc/eth/call.spec.ts
+++ b/packages/client/test/rpc/eth/call.spec.ts
@@ -93,10 +93,7 @@ tape(`${method}: call with unsupported block argument`, async (t) => {
     gasLimit: `0x${new BN(53000).toString(16)}`,
   }
 
-  const req = params(
-    method,
-    [{ ...estimateTxData, gas: estimateTxData.gasLimit }, 'pending']
-  )
+  const req = params(method, [{ ...estimateTxData, gas: estimateTxData.gasLimit }, 'pending'])
   const expectRes = (res: any) => {
     const msg = 'should return error if block argument is not "latest"'
     if (res.body.result.message === 'Currently only "latest" block supported') {

--- a/packages/client/test/rpc/eth/call.spec.ts
+++ b/packages/client/test/rpc/eth/call.spec.ts
@@ -74,3 +74,36 @@ tape(`${method}: call with valid arguments`, async (t) => {
   }
   baseRequest(t, server, req, 200, expectRes)
 })
+
+tape(`${method}: call with unsupported block argument`, async (t) => {
+  const blockchain = await Blockchain.create()
+
+  const client = createClient({ blockchain, includeVM: true })
+  const manager = createManager(client)
+  const server = startRPC(manager.getMethods())
+
+  // genesis address with balance
+  const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
+
+  const funcHash = '26b85ee1' // borrowed from valid test above
+  const estimateTxData = {
+    to: address.toString(),
+    from: address.toString(),
+    data: `0x${funcHash}`,
+    gasLimit: `0x${new BN(53000).toString(16)}`,
+  }
+
+  const req = params(
+    method,
+    [{ ...estimateTxData, gas: estimateTxData.gasLimit }, 'pending']
+  )
+  const expectRes = (res: any) => {
+    const msg = 'should return error if block argument is not "latest"'
+    if (res.body.result.message === 'Currently only "latest" block supported') {
+      t.pass(msg)
+    } else {
+      throw new Error(msg)
+    }
+  }
+  baseRequest(t, server, req, 200, expectRes)
+})

--- a/packages/client/test/rpc/eth/estimateGas.spec.ts
+++ b/packages/client/test/rpc/eth/estimateGas.spec.ts
@@ -93,10 +93,7 @@ tape(`${method}: call with unsupported block argument`, async (t) => {
     gasLimit: `0x${new BN(53000).toString(16)}`,
   }
 
-  const req = params(
-    method,
-    [{ ...estimateTxData, gas: estimateTxData.gasLimit }, 'pending']
-  )
+  const req = params(method, [{ ...estimateTxData, gas: estimateTxData.gasLimit }, 'pending'])
   const expectRes = (res: any) => {
     const msg = 'should return error if block argument is not "latest"'
     if (res.body.result.message === 'Currently only "latest" block supported') {

--- a/packages/client/test/rpc/eth/estimateGas.spec.ts
+++ b/packages/client/test/rpc/eth/estimateGas.spec.ts
@@ -74,3 +74,36 @@ tape(`${method}: call with valid arguments`, async (t) => {
   }
   baseRequest(t, server, req, 200, expectRes)
 })
+
+tape(`${method}: call with unsupported block argument`, async (t) => {
+  const blockchain = await Blockchain.create()
+
+  const client = createClient({ blockchain, includeVM: true })
+  const manager = createManager(client)
+  const server = startRPC(manager.getMethods())
+
+  // genesis address with balance
+  const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
+
+  const funcHash = '26b85ee1' // borrowed from valid test above
+  const estimateTxData = {
+    to: address.toString(),
+    from: address.toString(),
+    data: `0x${funcHash}`,
+    gasLimit: `0x${new BN(53000).toString(16)}`,
+  }
+
+  const req = params(
+    method,
+    [{ ...estimateTxData, gas: estimateTxData.gasLimit }, 'pending']
+  )
+  const expectRes = (res: any) => {
+    const msg = 'should return error if block argument is not "latest"'
+    if (res.body.result.message === 'Currently only "latest" block supported') {
+      t.pass(msg)
+    } else {
+      throw new Error(msg)
+    }
+  }
+  baseRequest(t, server, req, 200, expectRes)
+})

--- a/packages/client/test/rpc/eth/getBalance.spec.ts
+++ b/packages/client/test/rpc/eth/getBalance.spec.ts
@@ -3,7 +3,7 @@ import { Address, BN, toBuffer } from 'ethereumjs-util'
 import Blockchain from '@ethereumjs/blockchain'
 import { Transaction } from '@ethereumjs/tx'
 import { FullSynchronizer } from '../../../lib/sync'
-import { startRPC, createManager, createClient, params, baseRequest } from '../helpers'
+import { startRPC, createManager, createClient, params, baseRequest, baseSetup } from '../helpers'
 
 const method = 'eth_getBalance'
 
@@ -68,6 +68,38 @@ tape(`${method}: ensure balance deducts after a tx`, async (t) => {
     const msg = 'should return the correct balance'
     const resultBN = new BN(toBuffer(res.body.result))
     if (resultBN.eq(expectedNewBalance)) {
+      t.pass(msg)
+    } else {
+      throw new Error(msg)
+    }
+  }
+  baseRequest(t, server, req, 200, expectRes)
+})
+
+tape(`${method}: call with unsupported block argument`, async (t) => {
+  const blockchain = await Blockchain.create()
+
+  const client = createClient({ blockchain, includeVM: true })
+  const manager = createManager(client)
+  const server = startRPC(manager.getMethods())
+
+  const service = client.services.find((s) => s.name === 'eth')
+  const vm = (service!.synchronizer as FullSynchronizer).execution.vm
+
+  // since synchronizer.run() is not executed in the mock setup,
+  // manually run stateManager.generateCanonicalGenesis()
+  await vm.stateManager.generateCanonicalGenesis()
+
+  // genesis address with balance
+  const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
+
+  const req = params(
+    method,
+    [address.toString(), 'pending']
+  )
+  const expectRes = (res: any) => {
+    const msg = 'should return error if block argument is not "latest"'
+    if (res.body.result.message === 'Currently only "latest" block supported') {
       t.pass(msg)
     } else {
       throw new Error(msg)

--- a/packages/client/test/rpc/eth/getBalance.spec.ts
+++ b/packages/client/test/rpc/eth/getBalance.spec.ts
@@ -3,7 +3,7 @@ import { Address, BN, toBuffer } from 'ethereumjs-util'
 import Blockchain from '@ethereumjs/blockchain'
 import { Transaction } from '@ethereumjs/tx'
 import { FullSynchronizer } from '../../../lib/sync'
-import { startRPC, createManager, createClient, params, baseRequest, baseSetup } from '../helpers'
+import { startRPC, createManager, createClient, params, baseRequest } from '../helpers'
 
 const method = 'eth_getBalance'
 

--- a/packages/client/test/rpc/eth/getBalance.spec.ts
+++ b/packages/client/test/rpc/eth/getBalance.spec.ts
@@ -93,10 +93,7 @@ tape(`${method}: call with unsupported block argument`, async (t) => {
   // genesis address with balance
   const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
 
-  const req = params(
-    method,
-    [address.toString(), 'pending']
-  )
+  const req = params(method, [address.toString(), 'pending'])
   const expectRes = (res: any) => {
     const msg = 'should return error if block argument is not "latest"'
     if (res.body.result.message === 'Currently only "latest" block supported') {

--- a/packages/client/test/rpc/eth/getCode.spec.ts
+++ b/packages/client/test/rpc/eth/getCode.spec.ts
@@ -86,10 +86,7 @@ tape(`${method}: call with unsupported block argument`, async (t) => {
   // genesis address with balance
   const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
 
-  const req = params(
-    method,
-    [address.toString(), 'pending']
-  )
+  const req = params(method, [address.toString(), 'pending'])
   const expectRes = (res: any) => {
     const msg = 'should return error if block argument is not "latest"'
     if (res.body.result.message === 'Currently only "latest" block supported') {

--- a/packages/client/test/rpc/eth/getCode.spec.ts
+++ b/packages/client/test/rpc/eth/getCode.spec.ts
@@ -75,3 +75,28 @@ tape(`${method}: ensure returns correct code`, async (t) => {
   }
   baseRequest(t, server, req, 200, expectRes)
 })
+
+tape(`${method}: call with unsupported block argument`, async (t) => {
+  const blockchain = await Blockchain.create()
+
+  const client = createClient({ blockchain, includeVM: true })
+  const manager = createManager(client)
+  const server = startRPC(manager.getMethods())
+
+  // genesis address with balance
+  const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
+
+  const req = params(
+    method,
+    [address.toString(), 'pending']
+  )
+  const expectRes = (res: any) => {
+    const msg = 'should return error if block argument is not "latest"'
+    if (res.body.result.message === 'Currently only "latest" block supported') {
+      t.pass(msg)
+    } else {
+      throw new Error(msg)
+    }
+  }
+  baseRequest(t, server, req, 200, expectRes)
+})

--- a/packages/client/test/rpc/eth/getStorageAt.spec.ts
+++ b/packages/client/test/rpc/eth/getStorageAt.spec.ts
@@ -108,3 +108,18 @@ tape(`${method}: call with valid arguments (retrieve pos1)`, async (t) => {
   }
   baseRequest(t, server, req, 200, expectRes)
 })
+
+tape(`${method}: call with unsupported block argument`, async (t) => {
+  const { server, createdAddress } = await setup()
+
+  const req = params(method, [createdAddress!.toString(), '0x0', 'pending'])
+  const expectRes = (res: any) => {
+    const msg = 'should return error if block argument is not "latest"'
+    if (res.body.result.message === 'Currently only "latest" block supported') {
+      t.pass(msg)
+    } else {
+      throw new Error(msg)
+    }
+  }
+  baseRequest(t, server, req, 200, expectRes)
+})

--- a/packages/client/test/rpc/eth/getTransactionCount.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionCount.spec.ts
@@ -73,10 +73,7 @@ tape(`${method}: call with unsupported block argument`, async (t) => {
   // genesis address with balance
   const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
 
-  const req = params(
-    method,
-    [address.toString(), 'pending']
-  )
+  const req = params(method, [address.toString(), 'pending'])
   const expectRes = (res: any) => {
     const msg = 'should return error if block argument is not "latest"'
     if (res.body.result.message === 'Currently only "latest" block supported') {

--- a/packages/client/test/rpc/eth/getTransactionCount.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionCount.spec.ts
@@ -62,3 +62,28 @@ tape(`${method}: ensure count increments after a tx`, async (t) => {
   }
   baseRequest(t, server, req, 200, expectRes)
 })
+
+tape(`${method}: call with unsupported block argument`, async (t) => {
+  const blockchain = await Blockchain.create()
+
+  const client = createClient({ blockchain, includeVM: true })
+  const manager = createManager(client)
+  const server = startRPC(manager.getMethods())
+
+  // genesis address with balance
+  const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
+
+  const req = params(
+    method,
+    [address.toString(), 'pending']
+  )
+  const expectRes = (res: any) => {
+    const msg = 'should return error if block argument is not "latest"'
+    if (res.body.result.message === 'Currently only "latest" block supported') {
+      t.pass(msg)
+    } else {
+      throw new Error(msg)
+    }
+  }
+  baseRequest(t, server, req, 200, expectRes)
+})


### PR DESCRIPTION
Partially addresses #1227 for `eth` calls. In particular, added tests for unsupported `block` params (i.e. block !== `latest`). Hopefully will help out with the code coverage report.