### PR TITLE
Client: Aleut initial connection reliability test fix

### DIFF
--- a/packages/client/lib/net/peer/libp2ppeer.ts
+++ b/packages/client/lib/net/peer/libp2ppeer.ts
@@ -29,7 +29,7 @@ export interface Libp2pPeerOptions extends Omit<PeerOptions, 'address' | 'transp
  *
  * new Libp2pPeer({ id, multiaddrs, protocols })
  *   .on('error', (err) => console.log('Error: ', err))
- *   .on('connected', () => console.log('Connected'))
+ *   .on('bound', () => console.log('Bound'))
  *   .on('disconnected', (reason) => console.log('Disconnected: ', reason))
  *   .connect()
  */
@@ -67,7 +67,7 @@ export class Libp2pPeer extends Peer {
       await node.dial(ma)
       await this.bindProtocols(node, ma)
     }
-    this.emit('connected')
+    this.emit('bound')
   }
 
   /**
@@ -110,6 +110,5 @@ export class Libp2pPeer extends Peer {
       })
     )
     this.server = server
-    this.connected = true
   }
 }

--- a/packages/client/lib/net/peer/rlpxpeer.ts
+++ b/packages/client/lib/net/peer/rlpxpeer.ts
@@ -42,7 +42,7 @@ export interface RlpxPeerOptions extends Omit<PeerOptions, 'address' | 'transpor
  *
  * new RlpxPeer({ id, host, port, protocols })
  *   .on('error', (err) => console.log('Error:', err))
- *   .on('connected', () => console.log('Connected'))
+ *   .on('bound', () => console.log('Bound'))
  *   .on('disconnected', (reason) => console.log('Disconnected:', reason))
  *   .connect()
  */
@@ -117,7 +117,7 @@ export class RlpxPeer extends Peer {
     this.rlpx.once('peer:added', async (rlpxPeer: Devp2pRlpxPeer) => {
       try {
         await this.bindProtocols(rlpxPeer)
-        this.emit('connected')
+        this.emit('bound')
       } catch (error) {
         this.emit('error', error)
       }
@@ -167,6 +167,5 @@ export class RlpxPeer extends Peer {
         }
       })
     )
-    this.connected = true
   }
 }

--- a/packages/client/lib/net/peerpool.ts
+++ b/packages/client/lib/net/peerpool.ts
@@ -147,7 +147,7 @@ export class PeerPool extends EventEmitter {
           this.add(peer)
         }
         await bound.handshake(bound.sender)
-      } catch(error) {
+      } catch (error) {
         this.ban(peer)
         peer.emit('error', error)
       }

--- a/packages/client/lib/net/protocol/boundprotocol.ts
+++ b/packages/client/lib/net/protocol/boundprotocol.ts
@@ -27,7 +27,7 @@ export class BoundProtocol extends EventEmitter {
   public name: string
   private protocol: Protocol
   private peer: Peer
-  private sender: Sender
+  public sender: Sender
   private versions: number[]
   private timeout: number
   private _status: any

--- a/packages/client/lib/net/protocol/protocol.ts
+++ b/packages/client/lib/net/protocol/protocol.ts
@@ -176,7 +176,6 @@ export class Protocol extends EventEmitter {
       peer: peer,
       sender: sender,
     })
-    await bound.handshake(sender)
     //@ts-ignore TODO: evaluate this line
     peer[this.name] = bound
     return bound

--- a/packages/client/lib/net/server/libp2pserver.ts
+++ b/packages/client/lib/net/server/libp2pserver.ts
@@ -70,7 +70,7 @@ export class Libp2pServer extends Server {
           const peer = this.peers.get(peerId.toB58String())
           if (peer) {
             await peer.accept(p, stream, this)
-            this.emit('connected', peer)
+            this.emit('bound', peer)
           }
         })
       })
@@ -83,7 +83,7 @@ export class Libp2pServer extends Server {
       const peer = this.createPeer(peerId)
       await peer.bindProtocols(this.node as Libp2pNode, peerId, this)
       this.config.logger.debug(`Peer discovered: ${peer}`)
-      this.emit('connected', peer)
+      this.emit('bound', peer)
     })
     this.node.connectionManager.on('peer:connect', (connection: Connection) => {
       const [peerId, multiaddr] = this.getPeerInfo(connection)

--- a/packages/client/lib/net/server/rlpxserver.ts
+++ b/packages/client/lib/net/server/rlpxserver.ts
@@ -263,7 +263,7 @@ export class RlpxServer extends Server {
           await peer.accept(rlpxPeer, this)
           this.peers.set(peer.id, peer)
           this.config.logger.debug(`Peer connected: ${peer}`)
-          this.emit('connected', peer)
+          this.emit('bound', peer)
         } catch (error) {
           this.error(error)
         }


### PR DESCRIPTION
Ok, I was at least able to track down the connection reliability problems on Aleut, so the non-response to the `GET_BLOCK_HEADERS` message from the Nethermind client. This is *not* due to the early bootstrap but happens after due to the time interval between the peer handshake triggered in protocol binding `BoundProtocol` and the final setup and addition of the peer to the peerpool.

I tested refactoring out the handshake and add later in `PeerPool`. This *does* reliably solve the Aleut connection problem, so connection starts immediately with this. However the solution has too many side effects, errors are now not shielded properly any more and generally mainnet is not working any more with this solution. Lol. It is also not desirable likely to add peers to the pool *before* the handshake completes, since this would cause a lot of add-ban bouncing.

Anyhow. At least one step closer.

We might also want to pursue another approach, like buffering ETH requests if peer connection is still build up (maybe we add another flag to the `Peer` class) and then do the response once ready.