### PR TITLE
Client: Simple message queue to handle unhandled ETH messages during handshake

### DIFF
--- a/packages/client/lib/net/peer/peer.ts
+++ b/packages/client/lib/net/peer/peer.ts
@@ -46,6 +46,13 @@ export class Peer extends events.EventEmitter {
   protected transport: string
   protected protocols: Protocol[]
   private _idle: boolean
+
+  /*
+    If the peer is in the PeerPool.
+    If true, messages are handled immediately.
+    If false, adds incoming messages to handleMessageQueue,
+    which are handled after the peer is added to the pool.
+  */
   public pooled: boolean = false
 
   // Dynamically bound protocol properties

--- a/packages/client/lib/net/peer/peer.ts
+++ b/packages/client/lib/net/peer/peer.ts
@@ -46,6 +46,7 @@ export class Peer extends events.EventEmitter {
   protected transport: string
   protected protocols: Protocol[]
   private _idle: boolean
+  public pooled: boolean = false
 
   // Dynamically bound protocol properties
   public eth: (BoundProtocol & EthProtocolMethods) | undefined
@@ -126,6 +127,15 @@ export class Peer extends events.EventEmitter {
    */
   understands(protocolName: string): boolean {
     return !!this.bound.get(protocolName)
+  }
+
+  /**
+   * Handle unhandled messages along handshake
+   */
+  handleMessageQueue() {
+    this.bound.forEach(async (bound) => {
+      bound.handleMessageQueue()
+    })
   }
 
   toString(withFullId = false): string {

--- a/packages/client/lib/net/peerpool.ts
+++ b/packages/client/lib/net/peerpool.ts
@@ -142,6 +142,7 @@ export class PeerPool extends EventEmitter {
       }
     })
     this.add(peer)
+    peer.handleMessageQueue()
   }
 
   /**
@@ -179,6 +180,7 @@ export class PeerPool extends EventEmitter {
   add(peer?: Peer) {
     if (peer && peer.id && !this.pool.get(peer.id)) {
       this.pool.set(peer.id, peer)
+      peer.pooled = true
       this.emit('added', peer)
     }
   }
@@ -191,6 +193,7 @@ export class PeerPool extends EventEmitter {
   remove(peer?: Peer) {
     if (peer && peer.id) {
       if (this.pool.delete(peer.id)) {
+        peer.pooled = false
         this.emit('removed', peer)
       }
     }

--- a/packages/client/test/integration/mocks/mockpeer.ts
+++ b/packages/client/test/integration/mocks/mockpeer.ts
@@ -23,6 +23,7 @@ export default class MockPeer extends Peer {
     super({ ...options, transport: 'mock', address: options.location })
     this.location = options.location
     this.connected = false
+    this.pooled = true
   }
 
   async connect() {

--- a/packages/client/test/net/peerpool.spec.ts
+++ b/packages/client/test/net/peerpool.spec.ts
@@ -43,6 +43,7 @@ tape('[PeerPool]', async (t) => {
     const config = new Config({ loglevel: 'error', transports: [] })
     const pool = new PeerPool({ config })
     ;(peer as any).id = 'abc'
+    ;(peer as any).handleMessageQueue = td.func()
     ;(pool as any).ban = td.func()
     pool.connected(peer)
     pool.on('message', (msg: any, proto: any, p: any) => {


### PR DESCRIPTION
Follow-up solution to initial ETH messages being lost, replaces #1236 