### PR TITLE
Two small fixes (adds missing flow param to LesProtocol, fixes txRelay typo)

### DIFF
--- a/packages/client/lib/service/lightethereumservice.ts
+++ b/packages/client/lib/service/lightethereumservice.ts
@@ -31,7 +31,14 @@ export class LightEthereumService extends EthereumService {
    * Returns all protocols required by this service
    */
   get protocols(): LesProtocol[] {
-    return [new LesProtocol({ config: this.config, chain: this.chain, timeout: this.timeout })]
+    return [
+      new LesProtocol({
+        config: this.config,
+        chain: this.chain,
+        flow: this.flow,
+        timeout: this.timeout,
+      }),
+    ]
   }
 
   /**

--- a/packages/devp2p/src/les/index.ts
+++ b/packages/devp2p/src/les/index.ts
@@ -124,7 +124,7 @@ export class LES extends EventEmitter {
     if (status['serveHeaders']) sStr += `, serveHeaders active`
     if (status['serveChainSince']) sStr += `, ServeCS: ${buffer2int(status['serveChainSince'])}`
     if (status['serveStateSince']) sStr += `, ServeSS: ${buffer2int(status['serveStateSince'])}`
-    if (status['txRelax']) sStr += `, txRelay active`
+    if (status['txRelay']) sStr += `, txRelay active`
     if (status['flowControl/BL']) sStr += `, flowControl/BL set`
     if (status['flowControl/MRR']) sStr += `, flowControl/MRR set`
     if (status['flowControl/MRC']) sStr += `, flowControl/MRC set`
@@ -221,7 +221,7 @@ export namespace LES {
     serveHeaders: Buffer
     serveChainSince: Buffer
     serveStateSince: Buffer
-    txRelax: Buffer
+    txRelay: Buffer
     'flowControl/BL': Buffer
     'flowControl/MRR': Buffer
     'flowControl/MRC': Buffer


### PR DESCRIPTION
This PR addresses two small fixes I noticed while using les in the client:

1. LightEthereumService: adds missing FlowControl param to LesProtocol init
2. devp2p: fixes txRelay typo in status string