### PR TITLE
Implement EIP3554

### DIFF
--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -344,21 +344,9 @@ export class BlockHeader {
       dif = parentDif.add(offset.mul(a))
     }
 
-    if (this._common.hardforkGteHardfork(hardfork, 'muirGlacier')) {
-      // Istanbul/Berlin difficulty bomb delay (EIP2384)
-      num.isubn(9000000)
-      if (num.ltn(0)) {
-        num = new BN(0)
-      }
-    } else if (this._common.hardforkGteHardfork(hardfork, 'constantinople')) {
-      // Constantinople difficulty bomb delay (EIP1234)
-      num.isubn(5000000)
-      if (num.ltn(0)) {
-        num = new BN(0)
-      }
-    } else if (this._common.hardforkGteHardfork(hardfork, 'byzantium')) {
-      // Byzantium difficulty bomb delay (EIP649)
-      num.isubn(3000000)
+    if (this._common.hardforkGteHardfork(hardfork, 'byzantium')) {
+      // Get delay as parameter from common
+      num.isubn(this._common.param('pow', 'difficultyBombDelay'))
       if (num.ltn(0)) {
         num = new BN(0)
       }

--- a/packages/common/src/eips/3554.json
+++ b/packages/common/src/eips/3554.json
@@ -1,0 +1,18 @@
+{
+    "name": "EIP-3554",
+    "comment": "Reduction in refunds",
+    "url": "Difficulty Bomb Delay to December 1st 2021",
+    "status": "Draft",
+    "minimumHardfork": "muirGlacier",
+    "requiredEIPs": [],
+    "gasConfig": {},
+    "gasPrices": {},
+    "vm": {},
+    "pow": {
+        "difficultyBombDelay": {
+          "v": 9500000,
+          "d": "the amount of blocks to delay the difficulty bomb with"
+        }
+      }
+  }
+  

--- a/packages/common/src/eips/index.ts
+++ b/packages/common/src/eips/index.ts
@@ -9,4 +9,5 @@ export const EIPs: eipsType = {
   2930: require('./2930.json'),
   3529: require('./3529.json'),
   3541: require('./3541.json'),
+  3554: require('./3554.json'),
 }

--- a/packages/common/src/hardforks/byzantium.json
+++ b/packages/common/src/hardforks/byzantium.json
@@ -47,6 +47,10 @@
     "minerReward": {
       "v": "3000000000000000000",
       "d": "the amount a miner get rewarded for mining a block"
+    },
+    "difficultyBombDelay": {
+      "v": 3000000,
+      "d": "the amount of blocks to delay the difficulty bomb with"
     }
   }
 }

--- a/packages/common/src/hardforks/chainstart.json
+++ b/packages/common/src/hardforks/chainstart.json
@@ -437,6 +437,10 @@
     "minerReward": {
       "v": "5000000000000000000",
       "d": "the amount a miner get rewarded for mining a block"
+    },
+    "difficultyBombDelay": {
+      "v": 0,
+      "d": "the amount of blocks to delay the difficulty bomb with"
     }
   }
 }

--- a/packages/common/src/hardforks/constantinople.json
+++ b/packages/common/src/hardforks/constantinople.json
@@ -59,6 +59,10 @@
     "minerReward": {
       "v": "2000000000000000000",
       "d": "The amount a miner gets rewarded for mining a block"
+    },
+    "difficultyBombDelay": {
+      "v": 5000000,
+      "d": "the amount of blocks to delay the difficulty bomb with"
     }
   }
 }

--- a/packages/common/src/hardforks/muirGlacier.json
+++ b/packages/common/src/hardforks/muirGlacier.json
@@ -3,5 +3,13 @@
   "comment": "HF to delay the difficulty bomb",
   "url": "https://eips.ethereum.org/EIPS/eip-2384",
   "status": "Final",
-  "eips": []
+  "gasConfig": {},
+  "gasPrices": {},
+  "vm": {},
+  "pow": {
+    "difficultyBombDelay": {
+      "v": 9000000,
+      "d": "the amount of blocks to delay the difficulty bomb with"
+    }
+  }
 }

--- a/packages/common/tests/eips.spec.ts
+++ b/packages/common/tests/eips.spec.ts
@@ -58,4 +58,16 @@ tape('[Common]: Initialization / Chain params', function (t: tape.Test) {
 
     st.end()
   })
+
+  t.test('returns the right block delay for EIP3554', function (st) {
+    for (const fork of ['muirGlacier', 'berlin']) {
+      const c = new Common({ chain: 'mainnet', hardfork: fork })
+      let delay = c.param('pow', 'difficultyBombDelay')
+      st.equal(delay, 9000000)
+      c.setEIPs([3554])
+      delay = c.param('pow', 'difficultyBombDelay')
+      st.equal(delay, 9500000)
+    }
+    st.end()
+  })
 })


### PR DESCRIPTION
This [EIP](https://eips.ethereum.org/EIPS/eip-3554) is scheduled for London (please note that the Eth1 spec is outdated, it points to an EIP where the writer is currently not available, so a new EIP was created).

This also cleanups some code in block where the delay logic was copied (>= Byzantium). It is now a parameter in Common.