### PR TITLE
[ethereumjs/common] Remove this._hardfork override

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -133,7 +133,6 @@ export default class Common extends EventEmitter {
     this._customChains = opts.customChains ?? []
     this._chainParams = this.setChain(opts.chain)
     this.DEFAULT_HARDFORK = this._chainParams.defaultHardfork ?? 'istanbul'
-    this._hardfork = this.DEFAULT_HARDFORK
     if (opts.supportedHardforks) {
       this._supportedHardforks = opts.supportedHardforks
     }


### PR DESCRIPTION
Currently if the user wishes to override the current hardfork within the `Common` class, it isn't possible to to an override that it is applied within the constructor of `Common. This PR removes the override, allowing the hardfork to be chosen by the user.