### PR TITLE
util: rename bnToRlp to bnToUnpaddedBuffer

### DIFF
--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -659,7 +659,7 @@ export class BlockHeader {
     ]
 
     if (this._common.isActivatedEIP(1559)) {
-      rawItems.push(bnToUnpaddedBuffer(this.baseFeePerGas))
+      rawItems.push(bnToUnpaddedBuffer(this.baseFeePerGas!))
     }
 
     return rawItems

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -3,6 +3,7 @@ import {
   Address,
   BN,
   bnToHex,
+  bnToUnpaddedBuffer,
   ecrecover,
   ecsign,
   intToBuffer,
@@ -11,7 +12,6 @@ import {
   rlp,
   rlphash,
   toBuffer,
-  unpadBuffer,
   zeros,
 } from 'ethereumjs-util'
 import { HeaderData, JsonHeader, BlockHeaderBuffer, Blockchain, BlockOptions } from './types'
@@ -648,18 +648,18 @@ export class BlockHeader {
       this.transactionsTrie,
       this.receiptTrie,
       this.bloom,
-      unpadBuffer(toBuffer(this.difficulty)), // we unpadBuffer, because toBuffer(new BN(0)) == <Buffer 00>
-      unpadBuffer(toBuffer(this.number)),
-      unpadBuffer(toBuffer(this.gasLimit)),
-      unpadBuffer(toBuffer(this.gasUsed)),
-      unpadBuffer(toBuffer(this.timestamp)),
+      bnToUnpaddedBuffer(this.difficulty),
+      bnToUnpaddedBuffer(this.number),
+      bnToUnpaddedBuffer(this.gasLimit),
+      bnToUnpaddedBuffer(this.gasUsed),
+      bnToUnpaddedBuffer(this.timestamp),
       this.extraData,
       this.mixHash,
       this.nonce,
     ]
 
     if (this._common.isActivatedEIP(1559)) {
-      rawItems.push(unpadBuffer(toBuffer(this.baseFeePerGas)))
+      rawItems.push(bnToUnpaddedBuffer(this.baseFeePerGas))
     }
 
     return rawItems

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -1,4 +1,12 @@
-import { BN, bnToHex, bnToRlp, ecrecover, keccak256, rlp, toBuffer } from 'ethereumjs-util'
+import {
+  BN,
+  bnToHex,
+  bnToUnpaddedBuffer,
+  ecrecover,
+  keccak256,
+  rlp,
+  toBuffer,
+} from 'ethereumjs-util'
 import { BaseTransaction } from './baseTransaction'
 import {
   AccessList,
@@ -244,18 +252,18 @@ export default class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMark
    */
   raw(): FeeMarketEIP1559ValuesArray {
     return [
-      bnToRlp(this.chainId),
-      bnToRlp(this.nonce),
-      bnToRlp(this.maxPriorityFeePerGas),
-      bnToRlp(this.maxFeePerGas),
-      bnToRlp(this.gasLimit),
+      bnToUnpaddedBuffer(this.chainId),
+      bnToUnpaddedBuffer(this.nonce),
+      bnToUnpaddedBuffer(this.maxPriorityFeePerGas),
+      bnToUnpaddedBuffer(this.maxFeePerGas),
+      bnToUnpaddedBuffer(this.gasLimit),
       this.to !== undefined ? this.to.buf : Buffer.from([]),
-      bnToRlp(this.value),
+      bnToUnpaddedBuffer(this.value),
       this.data,
       this.accessList,
-      this.v !== undefined ? bnToRlp(this.v) : Buffer.from([]),
-      this.r !== undefined ? bnToRlp(this.r) : Buffer.from([]),
-      this.s !== undefined ? bnToRlp(this.s) : Buffer.from([]),
+      this.v !== undefined ? bnToUnpaddedBuffer(this.v) : Buffer.from([]),
+      this.r !== undefined ? bnToUnpaddedBuffer(this.r) : Buffer.from([]),
+      this.s !== undefined ? bnToUnpaddedBuffer(this.s) : Buffer.from([]),
     ]
   }
 
@@ -343,8 +351,8 @@ export default class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMark
       return ecrecover(
         msgHash,
         v!.addn(27), // Recover the 27 which was stripped from ecsign
-        bnToRlp(r!),
-        bnToRlp(s!)
+        bnToUnpaddedBuffer(r!),
+        bnToUnpaddedBuffer(s!)
       )
     } catch (e) {
       throw new Error('Invalid Signature')

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -1,4 +1,12 @@
-import { BN, bnToHex, bnToRlp, ecrecover, keccak256, rlp, toBuffer } from 'ethereumjs-util'
+import {
+  BN,
+  bnToHex,
+  bnToUnpaddedBuffer,
+  ecrecover,
+  keccak256,
+  rlp,
+  toBuffer,
+} from 'ethereumjs-util'
 import { BaseTransaction } from './baseTransaction'
 import {
   AccessList,
@@ -215,17 +223,17 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
    */
   raw(): AccessListEIP2930ValuesArray {
     return [
-      bnToRlp(this.chainId),
-      bnToRlp(this.nonce),
-      bnToRlp(this.gasPrice),
-      bnToRlp(this.gasLimit),
+      bnToUnpaddedBuffer(this.chainId),
+      bnToUnpaddedBuffer(this.nonce),
+      bnToUnpaddedBuffer(this.gasPrice),
+      bnToUnpaddedBuffer(this.gasLimit),
       this.to !== undefined ? this.to.buf : Buffer.from([]),
-      bnToRlp(this.value),
+      bnToUnpaddedBuffer(this.value),
       this.data,
       this.accessList,
-      this.v !== undefined ? bnToRlp(this.v) : Buffer.from([]),
-      this.r !== undefined ? bnToRlp(this.r) : Buffer.from([]),
-      this.s !== undefined ? bnToRlp(this.s) : Buffer.from([]),
+      this.v !== undefined ? bnToUnpaddedBuffer(this.v) : Buffer.from([]),
+      this.r !== undefined ? bnToUnpaddedBuffer(this.r) : Buffer.from([]),
+      this.s !== undefined ? bnToUnpaddedBuffer(this.s) : Buffer.from([]),
     ]
   }
 
@@ -311,8 +319,8 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
       return ecrecover(
         msgHash,
         yParity!.addn(27), // Recover the 27 which was stripped from ecsign
-        bnToRlp(r!),
-        bnToRlp(s!)
+        bnToUnpaddedBuffer(r!),
+        bnToUnpaddedBuffer(s!)
       )
     } catch (e) {
       throw new Error('Invalid Signature')

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -1,7 +1,7 @@
 import {
   BN,
   bnToHex,
-  bnToRlp,
+  bnToUnpaddedBuffer,
   ecrecover,
   rlp,
   rlphash,
@@ -122,15 +122,15 @@ export default class Transaction extends BaseTransaction<Transaction> {
    */
   raw(): TxValuesArray {
     return [
-      bnToRlp(this.nonce),
-      bnToRlp(this.gasPrice),
-      bnToRlp(this.gasLimit),
+      bnToUnpaddedBuffer(this.nonce),
+      bnToUnpaddedBuffer(this.gasPrice),
+      bnToUnpaddedBuffer(this.gasLimit),
       this.to !== undefined ? this.to.buf : Buffer.from([]),
-      bnToRlp(this.value),
+      bnToUnpaddedBuffer(this.value),
       this.data,
-      this.v !== undefined ? bnToRlp(this.v) : Buffer.from([]),
-      this.r !== undefined ? bnToRlp(this.r) : Buffer.from([]),
-      this.s !== undefined ? bnToRlp(this.s) : Buffer.from([]),
+      this.v !== undefined ? bnToUnpaddedBuffer(this.v) : Buffer.from([]),
+      this.r !== undefined ? bnToUnpaddedBuffer(this.r) : Buffer.from([]),
+      this.s !== undefined ? bnToUnpaddedBuffer(this.s) : Buffer.from([]),
     ]
   }
 
@@ -153,11 +153,11 @@ export default class Transaction extends BaseTransaction<Transaction> {
 
   private _getMessageToSign(withEIP155: boolean) {
     const values = [
-      bnToRlp(this.nonce),
-      bnToRlp(this.gasPrice),
-      bnToRlp(this.gasLimit),
+      bnToUnpaddedBuffer(this.nonce),
+      bnToUnpaddedBuffer(this.gasPrice),
+      bnToUnpaddedBuffer(this.gasLimit),
       this.to !== undefined ? this.to.buf : Buffer.from([]),
-      bnToRlp(this.value),
+      bnToUnpaddedBuffer(this.value),
       this.data,
     ]
 
@@ -241,8 +241,8 @@ export default class Transaction extends BaseTransaction<Transaction> {
       return ecrecover(
         msgHash,
         v!,
-        bnToRlp(r!),
-        bnToRlp(s!),
+        bnToUnpaddedBuffer(r!),
+        bnToUnpaddedBuffer(s!),
         this._signedTxImplementsEIP155() ? this.common.chainIdBN() : undefined
       )
     } catch (e) {

--- a/packages/util/src/account.ts
+++ b/packages/util/src/account.ts
@@ -12,7 +12,7 @@ import { KECCAK256_RLP, KECCAK256_NULL } from './constants'
 import { zeros, bufferToHex, toBuffer } from './bytes'
 import { keccak, keccak256, keccakFromString, rlphash } from './hash'
 import { assertIsString, assertIsHexString, assertIsBuffer } from './helpers'
-import { BNLike, BufferLike, bnToRlp, toType, TypeOutput } from './types'
+import { BNLike, BufferLike, bnToUnpaddedBuffer, toType, TypeOutput } from './types'
 
 export interface AccountData {
   nonce?: BNLike
@@ -91,7 +91,12 @@ export class Account {
    * Returns a Buffer Array of the raw Buffers for the account, in order.
    */
   raw(): Buffer[] {
-    return [bnToRlp(this.nonce), bnToRlp(this.balance), this.stateRoot, this.codeHash]
+    return [
+      bnToUnpaddedBuffer(this.nonce),
+      bnToUnpaddedBuffer(this.balance),
+      this.stateRoot,
+      this.codeHash,
+    ]
   }
 
   /**

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -67,6 +67,7 @@ export function bnToUnpaddedBuffer(value: BN): Buffer {
 
 /**
  * Deprecated alias for bnToUnpaddedBuffer()
+ * @deprecated
  */
 export function bnToRlp(value: BN): Buffer {
   return bnToUnpaddedBuffer(value)

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -55,13 +55,21 @@ export function bnToHex(value: BN): PrefixedHexString {
 }
 
 /**
- * Convert value from BN to RLP (unpadded buffer)
+ * Convert value from BN to an unpadded Buffer
+ * (useful for RLP transport)
  * @param value value to convert
  */
-export function bnToRlp(value: BN): Buffer {
+export function bnToUnpaddedBuffer(value: BN): Buffer {
   // Using `bn.toArrayLike(Buffer)` instead of `bn.toBuffer()`
   // for compatibility with browserify and similar tools
   return unpadBuffer(value.toArrayLike(Buffer))
+}
+
+/**
+ * Deprecated alias for bnToUnpaddedBuffer()
+ */
+export function bnToRlp(value: BN): Buffer {
+  return bnToUnpaddedBuffer(value)
 }
 
 /**

--- a/packages/util/test/types.spec.ts
+++ b/packages/util/test/types.spec.ts
@@ -7,6 +7,7 @@ import {
   bufferToHex,
   intToHex,
   bnToHex,
+  bnToUnpaddedBuffer,
   toBuffer,
 } from '../src'
 
@@ -120,5 +121,13 @@ tape('toType', function (t) {
       }, /^Error: A string must be provided with a 0x-prefix, given: 1$/)
       st.end()
     })
+  })
+})
+
+tape('bnToUnpaddedBuffer', function (t) {
+  t.test('should equal unpadded buffer value', function (st) {
+    st.ok(bnToUnpaddedBuffer(new BN(0)).equals(Buffer.from([])))
+    st.ok(bnToUnpaddedBuffer(new BN(100)).equals(Buffer.from('64', 'hex')))
+    st.end()
   })
 })


### PR DESCRIPTION
This PR renames `bnToRlp` to `bnToUnpaddedBuffer` to better describe its function (closes https://github.com/ethereumjs/ethereumjs-util/issues/284)

It also converts some uses of `unpadBuffer(toBuffer(bn))` to the function, and adds a test for it in the util package. `bnToRlp` is kept as a deprecated alias that can be removed in a future major version.