### PR TITLE
New Releases VM v5.4.1, Tx v3.2.1, Common v2.3.1

### DIFF
--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@ethereumjs/common": "^2.3.1",
     "merkle-patricia-tree": "^4.2.0",
-    "@ethereumjs/tx": "^3.2.0",
+    "@ethereumjs/tx": "^3.2.1",
     "ethereumjs-util": "^7.0.10"
   },
   "devDependencies": {

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -32,7 +32,7 @@
     "test:browser": "npm run test:browser:build && karma start karma.conf.js"
   },
   "dependencies": {
-    "@ethereumjs/common": "^2.3.0",
+    "@ethereumjs/common": "^2.3.1",
     "merkle-patricia-tree": "^4.2.0",
     "@ethereumjs/tx": "^3.2.0",
     "ethereumjs-util": "^7.0.10"

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -30,7 +30,7 @@
   "author": "mjbecze <mjbecze@gmail.com>",
   "dependencies": {
     "@ethereumjs/block": "^3.3.0",
-    "@ethereumjs/common": "^2.3.0",
+    "@ethereumjs/common": "^2.3.1",
     "@ethereumjs/ethash": "^1.0.0",
     "debug": "^2.2.0",
     "ethereumjs-util": "^7.0.10",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@ethereumjs/block": "^3.3.0",
     "@ethereumjs/blockchain": "^5.3.0",
-    "@ethereumjs/common": "^2.3.0",
+    "@ethereumjs/common": "^2.3.1",
     "@ethereumjs/devp2p": "^4.0.0",
     "@ethereumjs/tx": "^3.2.0",
     "@ethereumjs/vm": "^5.4.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -49,7 +49,7 @@
     "@ethereumjs/blockchain": "^5.3.0",
     "@ethereumjs/common": "^2.3.1",
     "@ethereumjs/devp2p": "^4.0.0",
-    "@ethereumjs/tx": "^3.2.0",
+    "@ethereumjs/tx": "^3.2.1",
     "@ethereumjs/vm": "^5.4.0",
     "merkle-patricia-tree": "^4.2.0",
     "chalk": "^2.4.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -50,7 +50,7 @@
     "@ethereumjs/common": "^2.3.1",
     "@ethereumjs/devp2p": "^4.0.0",
     "@ethereumjs/tx": "^3.2.1",
-    "@ethereumjs/vm": "^5.4.0",
+    "@ethereumjs/vm": "^5.4.1",
     "merkle-patricia-tree": "^4.2.0",
     "chalk": "^2.4.2",
     "ethereumjs-util": "^7.0.10",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.3.1 - 2021-06-11
+
+Small feature release.
+
+- Added static helper method `Common.isSupportedChainId()`to check if a chain is natively supported by the Common version installed, PR [#1281](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1281)
+- Added support for the `calaveras` ephemeral developer test network (preparing for the `london` HF), PR [#1286](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1286)
+
 ## 2.3.0 - 2021-05-26
 
 ### London HF Support

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -95,9 +95,10 @@ Supported chains:
 - `rinkeby`
 - `kovan`
 - `goerli`
-- `yolov3`
-- `aleut`
-- `baikal`
+- `yolov3` (retired)
+- `aleut` (retired)
+- `baikal` (retired)
+- `calaveras`
 - Private/custom chain parameters
 
 The following chain-specific parameters are provided:

--- a/packages/common/docs/classes/index.default.md
+++ b/packages/common/docs/classes/index.default.md
@@ -85,6 +85,7 @@ Common class to access chain and hardfork parameters
 - [setHardforkByBlockNumber](index.default.md#sethardforkbyblocknumber)
 - [setMaxListeners](index.default.md#setmaxlisteners)
 - [forCustomChain](index.default.md#forcustomchain)
+- [isSupportedChainId](index.default.md#issupportedchainid)
 - [listenerCount](index.default.md#listenercount)
 - [once](index.default.md#once)
 
@@ -104,7 +105,7 @@ Common class to access chain and hardfork parameters
 
 Overrides: EventEmitter.constructor
 
-Defined in: [packages/common/src/index.ts:116](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L116)
+Defined in: [packages/common/src/index.ts:126](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L126)
 
 ## Properties
 
@@ -142,7 +143,7 @@ Internal helper function to calculate a fork hash
 
 Fork hash as hex string
 
-Defined in: [packages/common/src/index.ts:613](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L613)
+Defined in: [packages/common/src/index.ts:623](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L623)
 
 ___
 
@@ -163,7 +164,7 @@ Internal helper function to choose between hardfork set and hardfork provided as
 
 Hardfork chosen to be used
 
-Defined in: [packages/common/src/index.ts:228](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L228)
+Defined in: [packages/common/src/index.ts:238](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L238)
 
 ___
 
@@ -183,7 +184,7 @@ Internal helper function, returns the params for the given hardfork for the chai
 
 Dictionary with hardfork params
 
-Defined in: [packages/common/src/index.ts:242](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L242)
+Defined in: [packages/common/src/index.ts:252](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L252)
 
 ___
 
@@ -203,7 +204,7 @@ Internal helper function to check if a hardfork is set to be supported by the li
 
 True if hardfork is supported
 
-Defined in: [packages/common/src/index.ts:255](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L255)
+Defined in: [packages/common/src/index.ts:265](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L265)
 
 ___
 
@@ -224,7 +225,7 @@ Returns the latest active hardfork name for chain or block or throws if unavaila
 
 Hardfork name
 
-Defined in: [packages/common/src/index.ts:524](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L524)
+Defined in: [packages/common/src/index.ts:534](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L534)
 
 ___
 
@@ -245,7 +246,7 @@ Returns the active hardfork switches for the current chain
 
 Array with hardfork arrays
 
-Defined in: [packages/common/src/index.ts:505](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L505)
+Defined in: [packages/common/src/index.ts:515](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L515)
 
 ___
 
@@ -266,7 +267,7 @@ Alias to hardforkIsActiveOnBlock when hardfork is set
 
 True if HF is active on block number
 
-Defined in: [packages/common/src/index.ts:437](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L437)
+Defined in: [packages/common/src/index.ts:447](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L447)
 
 ___
 
@@ -299,7 +300,7 @@ Returns bootstrap nodes for the current chain
 
 Dict with bootstrap nodes
 
-Defined in: [packages/common/src/index.ts:688](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L688)
+Defined in: [packages/common/src/index.ts:698](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L698)
 
 ___
 
@@ -315,7 +316,7 @@ Returns the Id of current chain
 
 chain Id
 
-Defined in: [packages/common/src/index.ts:713](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L713)
+Defined in: [packages/common/src/index.ts:723](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L723)
 
 ___
 
@@ -329,7 +330,7 @@ Returns the Id of current chain
 
 chain Id
 
-Defined in: [packages/common/src/index.ts:721](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L721)
+Defined in: [packages/common/src/index.ts:731](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L731)
 
 ___
 
@@ -343,7 +344,7 @@ Returns the name of current chain
 
 chain name (lower case)
 
-Defined in: [packages/common/src/index.ts:729](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L729)
+Defined in: [packages/common/src/index.ts:739](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L739)
 
 ___
 
@@ -358,7 +359,7 @@ e.g. "ethash" for "pow" consensus type or
 
 **Returns:** *string*
 
-Defined in: [packages/common/src/index.ts:772](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L772)
+Defined in: [packages/common/src/index.ts:782](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L782)
 
 ___
 
@@ -378,7 +379,7 @@ aura: -
 
 **Returns:** *any*
 
-Defined in: [packages/common/src/index.ts:787](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L787)
+Defined in: [packages/common/src/index.ts:797](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L797)
 
 ___
 
@@ -391,7 +392,7 @@ Possible values: "pow"|"poa"
 
 **Returns:** *string*
 
-Defined in: [packages/common/src/index.ts:762](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L762)
+Defined in: [packages/common/src/index.ts:772](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L772)
 
 ___
 
@@ -403,7 +404,7 @@ Returns a deep copy of this common instance.
 
 **Returns:** [*default*](index.default.md)
 
-Defined in: [packages/common/src/index.ts:794](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L794)
+Defined in: [packages/common/src/index.ts:804](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L804)
 
 ___
 
@@ -417,7 +418,7 @@ Returns DNS networks for the current chain
 
 Array of DNS ENR urls
 
-Defined in: [packages/common/src/index.ts:696](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L696)
+Defined in: [packages/common/src/index.ts:706](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L706)
 
 ___
 
@@ -431,7 +432,7 @@ Returns the active EIPs
 
 List of EIPs
 
-Defined in: [packages/common/src/index.ts:754](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L754)
+Defined in: [packages/common/src/index.ts:764](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L764)
 
 ___
 
@@ -480,7 +481,7 @@ Returns an eth/64 compliant fork hash (EIP-2124)
 
 **Returns:** *any*
 
-Defined in: [packages/common/src/index.ts:643](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L643)
+Defined in: [packages/common/src/index.ts:653](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L653)
 
 ___
 
@@ -494,7 +495,7 @@ Returns the Genesis parameters of current chain
 
 Genesis dictionary
 
-Defined in: [packages/common/src/index.ts:672](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L672)
+Defined in: [packages/common/src/index.ts:682](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L682)
 
 ___
 
@@ -514,7 +515,7 @@ Returns the hardfork based on the block number provided
 
 The name of the HF
 
-Defined in: [packages/common/src/index.ts:194](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L194)
+Defined in: [packages/common/src/index.ts:204](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L204)
 
 ___
 
@@ -547,7 +548,7 @@ Alias to hardforkGteHardfork when hardfork is set
 
 True if hardfork set is greater than hardfork provided
 
-Defined in: [packages/common/src/index.ts:480](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L480)
+Defined in: [packages/common/src/index.ts:490](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L490)
 
 ___
 
@@ -561,7 +562,7 @@ Returns the hardfork set
 
 Hardfork name
 
-Defined in: [packages/common/src/index.ts:704](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L704)
+Defined in: [packages/common/src/index.ts:714](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L714)
 
 ___
 
@@ -583,7 +584,7 @@ Returns the hardfork change block for hardfork provided or set
 
 Block number
 
-Defined in: [packages/common/src/index.ts:539](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L539)
+Defined in: [packages/common/src/index.ts:549](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L549)
 
 ___
 
@@ -603,7 +604,7 @@ Returns the hardfork change block for hardfork provided or set
 
 Block number
 
-Defined in: [packages/common/src/index.ts:548](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L548)
+Defined in: [packages/common/src/index.ts:558](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L558)
 
 ___
 
@@ -621,7 +622,7 @@ ___
 
 Array with hardfork data (name, block, forkHash)
 
-Defined in: [packages/common/src/index.ts:661](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L661)
+Defined in: [packages/common/src/index.ts:671](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L671)
 
 ___
 
@@ -643,7 +644,7 @@ Sequence based check if given or set HF1 is greater than or equal HF2
 
 True if HF1 gte HF2
 
-Defined in: [packages/common/src/index.ts:448](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L448)
+Defined in: [packages/common/src/index.ts:458](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L458)
 
 ___
 
@@ -665,7 +666,7 @@ Checks if set or provided hardfork is active on block number
 
 True if HF is active on block number
 
-Defined in: [packages/common/src/index.ts:416](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L416)
+Defined in: [packages/common/src/index.ts:426](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L426)
 
 ___
 
@@ -686,7 +687,7 @@ Checks if given or set hardfork is active on the chain
 
 True if hardfork is active on the chain
 
-Defined in: [packages/common/src/index.ts:490](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L490)
+Defined in: [packages/common/src/index.ts:500](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L500)
 
 ___
 
@@ -700,7 +701,7 @@ Returns the hardforks for current chain
 
 Array with arrays of hardforks
 
-Defined in: [packages/common/src/index.ts:680](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L680)
+Defined in: [packages/common/src/index.ts:690](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L690)
 
 ___
 
@@ -723,7 +724,7 @@ by the `eips` constructor option
 
 **Returns:** *boolean*
 
-Defined in: [packages/common/src/index.ts:394](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L394)
+Defined in: [packages/common/src/index.ts:404](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L404)
 
 ___
 
@@ -744,7 +745,7 @@ True if block number provided is the hardfork (given or set) change block
 
 True if blockNumber is HF block
 
-Defined in: [packages/common/src/index.ts:559](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L559)
+Defined in: [packages/common/src/index.ts:569](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L569)
 
 ___
 
@@ -765,7 +766,7 @@ True if block number provided is the hardfork change block following the hardfor
 
 True if blockNumber is HF block
 
-Defined in: [packages/common/src/index.ts:601](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L601)
+Defined in: [packages/common/src/index.ts:611](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L611)
 
 ___
 
@@ -817,7 +818,7 @@ Returns the Id of current network
 
 network Id
 
-Defined in: [packages/common/src/index.ts:738](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L738)
+Defined in: [packages/common/src/index.ts:748](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L748)
 
 ___
 
@@ -831,7 +832,7 @@ Returns the Id of current network
 
 network Id
 
-Defined in: [packages/common/src/index.ts:746](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L746)
+Defined in: [packages/common/src/index.ts:756](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L756)
 
 ___
 
@@ -853,7 +854,7 @@ Returns the change block for the next hardfork after the hardfork provided or se
 
 Block number or null if not available
 
-Defined in: [packages/common/src/index.ts:571](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L571)
+Defined in: [packages/common/src/index.ts:581](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L581)
 
 ___
 
@@ -873,7 +874,7 @@ Returns the change block for the next hardfork after the hardfork provided or se
 
 Block number or null if not available
 
-Defined in: [packages/common/src/index.ts:581](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L581)
+Defined in: [packages/common/src/index.ts:591](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L591)
 
 ___
 
@@ -955,7 +956,7 @@ a change on the respective parameter.
 
 The value requested or `null` if not found
 
-Defined in: [packages/common/src/index.ts:304](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L304)
+Defined in: [packages/common/src/index.ts:314](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L314)
 
 ___
 
@@ -975,7 +976,7 @@ Returns a parameter for the hardfork active on block number
 
 **Returns:** *any*
 
-Defined in: [packages/common/src/index.ts:379](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L379)
+Defined in: [packages/common/src/index.ts:389](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L389)
 
 ___
 
@@ -997,7 +998,7 @@ Returns a parameter corresponding to an EIP
 
 The value requested or `null` if not found
 
-Defined in: [packages/common/src/index.ts:357](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L357)
+Defined in: [packages/common/src/index.ts:367](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L367)
 
 ___
 
@@ -1019,7 +1020,7 @@ Returns the parameter corresponding to a hardfork
 
 The value requested or `null` if not found
 
-Defined in: [packages/common/src/index.ts:324](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L324)
+Defined in: [packages/common/src/index.ts:334](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L334)
 
 ___
 
@@ -1132,7 +1133,7 @@ Sets the chain
 
 The dictionary with parameters set as chain
 
-Defined in: [packages/common/src/index.ts:144](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L144)
+Defined in: [packages/common/src/index.ts:154](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L154)
 
 ___
 
@@ -1150,7 +1151,7 @@ Sets the active EIPs
 
 **Returns:** *void*
 
-Defined in: [packages/common/src/index.ts:270](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L270)
+Defined in: [packages/common/src/index.ts:280](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L280)
 
 ___
 
@@ -1168,7 +1169,7 @@ Sets the hardfork to get params for
 
 **Returns:** *void*
 
-Defined in: [packages/common/src/index.ts:170](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L170)
+Defined in: [packages/common/src/index.ts:180](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L180)
 
 ___
 
@@ -1188,7 +1189,7 @@ Sets a new hardfork based on the block number provided
 
 The name of the HF set
 
-Defined in: [packages/common/src/index.ts:216](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L216)
+Defined in: [packages/common/src/index.ts:226](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L226)
 
 ___
 
@@ -1229,6 +1230,26 @@ params from [[baseChain]] except the ones overridden in [[customChainParams]].
 **Returns:** [*default*](index.default.md)
 
 Defined in: [packages/common/src/index.ts:80](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L80)
+
+___
+
+### isSupportedChainId
+
+▸ `Static` **isSupportedChainId**(`chainId`: *BN*): *boolean*
+
+Static method to determine if a chainId is supported as a standard chain
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `chainId` | *BN* | BN id (`1`) of a standard chain |
+
+**Returns:** *boolean*
+
+boolean
+
+Defined in: [packages/common/src/index.ts:103](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L103)
 
 ___
 

--- a/packages/common/docs/modules/genesisstates.md
+++ b/packages/common/docs/modules/genesisstates.md
@@ -27,7 +27,7 @@ Returns the genesis state by network ID
 
 Dictionary with genesis accounts
 
-Defined in: [packages/common/src/genesisStates/index.ts:29](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/genesisStates/index.ts#L29)
+Defined in: [packages/common/src/genesisStates/index.ts:31](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/genesisStates/index.ts#L31)
 
 ___
 
@@ -47,4 +47,4 @@ Returns the genesis state by network name
 
 Dictionary with genesis accounts
 
-Defined in: [packages/common/src/genesisStates/index.ts:38](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/genesisStates/index.ts#L38)
+Defined in: [packages/common/src/genesisStates/index.ts:40](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/genesisStates/index.ts#L40)

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/common",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Resources common to all Ethereum implementations",
   "license": "MIT",
   "keywords": [

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -64,7 +64,7 @@
     "@ethereumjs/config-coverage": "^2.0.0",
     "@ethereumjs/config-typescript": "^2.0.0",
     "@ethereumjs/eslint-config-defaults": "^2.0.0",
-    "@ethereumjs/tx": "^3.2.0",
+    "@ethereumjs/tx": "^3.2.1",
     "@types/async": "^2.4.1",
     "@types/chalk": "^2.2.0",
     "@types/debug": "^4.1.4",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -39,7 +39,7 @@
     "test": "tape -r ts-node/register ./test/index.ts"
   },
   "dependencies": {
-    "@ethereumjs/common": "^2.3.0",
+    "@ethereumjs/common": "^2.3.1",
     "@types/bl": "^2.1.0",
     "@types/k-bucket": "^5.0.0",
     "@types/lru-cache": "^5.1.0",

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -22,7 +22,7 @@ This has been done in PR [#1292](https://github.com/ethereumjs/ethereumjs-monore
 
 ### More Intelligent Default Chain Instantiation
 
-We tried to get more intelligent on the instation with a default chain if no `Common` is provided. On older versions of the library `mainnet` was the default fallback here. For typed tx the chain ID is also provided as a data parameter along instantiation. This chain ID parameter is now taken for the internal `Common` and therefore the internal chain setting. Same for signed EIP-155 respecting legacy txs, there the chain ID is now extracted from the `v` parameter provided and the internal `Common` initialized accordingly. For unsigned or non-EIP-1559 legacy txs the chain for `Common` still defaults back to `mainnet`.
+We tried to get more intelligent on the instantiation with a default chain if no `Common` is provided. On older versions of the library `mainnet` was the default fallback here. For typed txs the chain ID is also provided as a data parameter along instantiation. This chain ID parameter is now used for the internal `Common` and therefore the internal chain setting. Same for signed EIP-155 respecting legacy txs, there the chain ID is now extracted from the `v` parameter provided and initialized with the internal `Common` accordingly. For unsigned or non-EIP-1559 legacy txs the chain for `Common` still defaults back to `mainnet`.
 
 Both these changes with the new default HF rules and the more intelligent chain ID instantiation now allows for an e.g. `EIP-155` tx instantiation without a Common (and generally for a safer non-Common tx instantiation) like this:
 
@@ -50,7 +50,7 @@ const txData = {
 const tx = FeeMarketEIP1559Transaction.fromTxData(txData)
 ```
 
-Note that depending on your usage context it might still be a good idea to instantiate with `Common` since you then have a deterministic state setup, explicitly know what rule set your tx is operating on and are safe towards eventual future behavioral changes (e.g. on a default HF update along a major version tx library bump).
+Note that depending on your usage context it might still be a good idea to instantiate with `Common` since you then have a deterministic state setup, explicitly know what rule set your tx is operating on, and are safe towards eventual future behavioral changes (e.g. on a default HF update along a major version tx library bump).
 
 ### Signing Txs with a Hardware Wallet
 

--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -37,7 +37,7 @@ This library supports the following transaction types ([EIP-2718](https://eips.e
 - `AccessListEIP2930Transaction` ([EIP-2930](https://eips.ethereum.org/EIPS/eip-2930), optional access lists)
 - `Transaction`, the Ethereum standard tx up to `berlin`, now referred to as legacy txs with the introduction of tx types
 
-Please note that for now you have to manually set the `hardfork` in `Common` to `berlin` to allow for typed tx instantiation, since the current `Common` release series v2 (tx type support introduced with `v2.2.0`) still defaults to `istanbul` for backwards-compatibility reasons.
+Please note that up to `v3.2.0` you mandatorily had to use a `Common` instance for typed tx instantiation and set the `hardfork` in `Common` to minimally `berlin` (`EIP-2930`) respectively `london` (`EIP-1559`) to allow for typed tx instantiation, since the current `Common` release series v2 (tx type support introduced with `v2.2.0`) still defaults to `istanbul` for backwards-compatibility reasons (also see tx default HF section below).
 
 #### Gas Fee Market Transactions (EIP-1559)
 
@@ -198,10 +198,11 @@ _getFakeTransaction(txParams: TxParams): Transaction {
 
 ## Chain and Hardfork Support
 
-The `Transaction` constructor receives a parameter of an [`@ethereumjs/common`](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common) object that lets you specify the chain and hardfork to be used. The chain defaults to `mainnet`. 
+The `Transaction` constructor receives a parameter of an [`@ethereumjs/common`](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common) object that lets you specify the chain and hardfork to be used. If there is no `Common` provided the chain ID provided as a paramter on typed tx or the chain ID derived from the `v` value on signed EIP-155 conforming legacy txs will be taken (introduced in `v3.2.1`). In other cases the chain defaults to `mainnet`.
 
+Base default HF (determined by `Common`): `istanbul`
 
-Current default HF (determined by `Common`): `istanbul`
+Starting with `v3.2.1` the tx library now deviates from the default HF for typed tx using the following rule: "The default HF is the default HF from `Common` if the tx type is active on that HF. Otherwise it is set to the first greater HF where the tx is active."
 
 ### Supported Hardforks
 

--- a/packages/tx/docs/classes/basetransaction.basetransaction-1.md
+++ b/packages/tx/docs/classes/basetransaction.basetransaction-1.md
@@ -72,7 +72,7 @@ It is therefore not recommended to use directly.
 
 ### constructor
 
-\+ **new BaseTransaction**<TransactionObject\>(`txData`: [*TxData*](../modules/types.md#txdata) \| [*AccessListEIP2930TxData*](../interfaces/types.accesslisteip2930txdata.md) \| [*FeeMarketEIP1559TxData*](../interfaces/types.feemarketeip1559txdata.md), `txOptions?`: [*TxOptions*](../interfaces/types.txoptions.md)): [*BaseTransaction*](basetransaction.basetransaction-1.md)<TransactionObject\>
+\+ **new BaseTransaction**<TransactionObject\>(`txData`: [*TxData*](../modules/types.md#txdata) \| [*AccessListEIP2930TxData*](../interfaces/types.accesslisteip2930txdata.md) \| [*FeeMarketEIP1559TxData*](../interfaces/types.feemarketeip1559txdata.md)): [*BaseTransaction*](basetransaction.basetransaction-1.md)<TransactionObject\>
 
 #### Type parameters
 
@@ -82,14 +82,13 @@ It is therefore not recommended to use directly.
 
 #### Parameters
 
-| Name | Type | Default value |
-| :------ | :------ | :------ |
-| `txData` | [*TxData*](../modules/types.md#txdata) \| [*AccessListEIP2930TxData*](../interfaces/types.accesslisteip2930txdata.md) \| [*FeeMarketEIP1559TxData*](../interfaces/types.feemarketeip1559txdata.md) | - |
-| `txOptions` | [*TxOptions*](../interfaces/types.txoptions.md) | {} |
+| Name | Type |
+| :------ | :------ |
+| `txData` | [*TxData*](../modules/types.md#txdata) \| [*AccessListEIP2930TxData*](../interfaces/types.accesslisteip2930txdata.md) \| [*FeeMarketEIP1559TxData*](../interfaces/types.feemarketeip1559txdata.md) |
 
 **Returns:** [*BaseTransaction*](basetransaction.basetransaction-1.md)<TransactionObject\>
 
-Defined in: [baseTransaction.ts:42](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L42)
+Defined in: [baseTransaction.ts:61](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L61)
 
 ## Properties
 
@@ -97,7 +96,7 @@ Defined in: [baseTransaction.ts:42](https://github.com/ethereumjs/ethereumjs-mon
 
 • `Readonly` **common**: *default*
 
-Defined in: [baseTransaction.ts:38](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L38)
+Defined in: [baseTransaction.ts:43](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L43)
 
 ___
 
@@ -129,7 +128,7 @@ ___
 
 • `Optional` `Readonly` **r**: *BN*
 
-Defined in: [baseTransaction.ts:41](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L41)
+Defined in: [baseTransaction.ts:40](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L40)
 
 ___
 
@@ -137,7 +136,7 @@ ___
 
 • `Optional` `Readonly` **s**: *BN*
 
-Defined in: [baseTransaction.ts:42](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L42)
+Defined in: [baseTransaction.ts:41](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L41)
 
 ___
 
@@ -153,7 +152,7 @@ ___
 
 • `Optional` `Readonly` **v**: *BN*
 
-Defined in: [baseTransaction.ts:40](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L40)
+Defined in: [baseTransaction.ts:39](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L39)
 
 ___
 
@@ -175,7 +174,7 @@ Alias for `type`
 
 **Returns:** *number*
 
-Defined in: [baseTransaction.ts:82](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L82)
+Defined in: [baseTransaction.ts:96](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L96)
 
 ___
 
@@ -189,7 +188,7 @@ Note: legacy txs will return tx type `0`.
 
 **Returns:** *number*
 
-Defined in: [baseTransaction.ts:91](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L91)
+Defined in: [baseTransaction.ts:105](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L105)
 
 ## Methods
 
@@ -201,7 +200,7 @@ The minimum amount of gas the tx must have (DataFee + TxFee + Creation Fee)
 
 **Returns:** *BN*
 
-Defined in: [baseTransaction.ts:119](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L119)
+Defined in: [baseTransaction.ts:133](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L133)
 
 ___
 
@@ -213,7 +212,7 @@ The amount of gas paid for the data in this tx
 
 **Returns:** *BN*
 
-Defined in: [baseTransaction.ts:130](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L130)
+Defined in: [baseTransaction.ts:144](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L144)
 
 ___
 
@@ -229,7 +228,7 @@ ___
 
 **Returns:** *Buffer* \| *Buffer*[]
 
-Defined in: [baseTransaction.ts:167](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L167)
+Defined in: [baseTransaction.ts:181](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L181)
 
 ▸ `Abstract` **getMessageToSign**(`hashMessage?`: ``true``): *Buffer*
 
@@ -241,7 +240,7 @@ Defined in: [baseTransaction.ts:167](https://github.com/ethereumjs/ethereumjs-mo
 
 **Returns:** *Buffer*
 
-Defined in: [baseTransaction.ts:168](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L168)
+Defined in: [baseTransaction.ts:182](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L182)
 
 ___
 
@@ -251,7 +250,7 @@ ___
 
 **Returns:** *Buffer*
 
-Defined in: [baseTransaction.ts:172](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L172)
+Defined in: [baseTransaction.ts:186](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L186)
 
 ___
 
@@ -263,7 +262,7 @@ Returns the sender's address
 
 **Returns:** *Address*
 
-Defined in: [baseTransaction.ts:207](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L207)
+Defined in: [baseTransaction.ts:221](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L221)
 
 ___
 
@@ -275,7 +274,7 @@ Returns the public key of the sender
 
 **Returns:** *Buffer*
 
-Defined in: [baseTransaction.ts:214](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L214)
+Defined in: [baseTransaction.ts:228](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L228)
 
 ___
 
@@ -287,7 +286,7 @@ The up front amount that an account must have for this transaction to be valid
 
 **Returns:** *BN*
 
-Defined in: [baseTransaction.ts:144](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L144)
+Defined in: [baseTransaction.ts:158](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L158)
 
 ___
 
@@ -297,7 +296,7 @@ ___
 
 **Returns:** *Buffer*
 
-Defined in: [baseTransaction.ts:170](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L170)
+Defined in: [baseTransaction.ts:184](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L184)
 
 ___
 
@@ -307,7 +306,7 @@ ___
 
 **Returns:** *boolean*
 
-Defined in: [baseTransaction.ts:174](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L174)
+Defined in: [baseTransaction.ts:188](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L188)
 
 ___
 
@@ -319,7 +318,7 @@ Returns a Buffer Array of the raw Buffers of this transaction, in order.
 
 **Returns:** [*TxValuesArray*](../modules/types.md#txvaluesarray) \| [*AccessListEIP2930ValuesArray*](../modules/types.md#accesslisteip2930valuesarray) \| [*FeeMarketEIP1559ValuesArray*](../modules/types.md#feemarketeip1559valuesarray)
 
-Defined in: [baseTransaction.ts:156](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L156)
+Defined in: [baseTransaction.ts:170](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L170)
 
 ___
 
@@ -331,7 +330,7 @@ Returns the encoding of the transaction.
 
 **Returns:** *Buffer*
 
-Defined in: [baseTransaction.ts:161](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L161)
+Defined in: [baseTransaction.ts:175](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L175)
 
 ___
 
@@ -355,7 +354,7 @@ const signedTx = tx.sign(privateKey)
 
 **Returns:** TransactionObject
 
-Defined in: [baseTransaction.ts:225](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L225)
+Defined in: [baseTransaction.ts:239](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L239)
 
 ___
 
@@ -367,7 +366,7 @@ If the tx's `to` is to the creation address
 
 **Returns:** *boolean*
 
-Defined in: [baseTransaction.ts:149](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L149)
+Defined in: [baseTransaction.ts:163](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L163)
 
 ___
 
@@ -379,7 +378,7 @@ Returns an object with the JSON representation of the transaction
 
 **Returns:** [*JsonTx*](../interfaces/types.jsontx.md)
 
-Defined in: [baseTransaction.ts:237](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L237)
+Defined in: [baseTransaction.ts:251](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L251)
 
 ___
 
@@ -392,7 +391,7 @@ Checks if the transaction has the minimum amount of gas required
 
 **Returns:** *boolean*
 
-Defined in: [baseTransaction.ts:99](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L99)
+Defined in: [baseTransaction.ts:113](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L113)
 
 ▸ **validate**(`stringError`: ``false``): *boolean*
 
@@ -404,7 +403,7 @@ Defined in: [baseTransaction.ts:99](https://github.com/ethereumjs/ethereumjs-mon
 
 **Returns:** *boolean*
 
-Defined in: [baseTransaction.ts:100](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L100)
+Defined in: [baseTransaction.ts:114](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L114)
 
 ▸ **validate**(`stringError`: ``true``): *string*[]
 
@@ -416,7 +415,7 @@ Defined in: [baseTransaction.ts:100](https://github.com/ethereumjs/ethereumjs-mo
 
 **Returns:** *string*[]
 
-Defined in: [baseTransaction.ts:101](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L101)
+Defined in: [baseTransaction.ts:115](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L115)
 
 ___
 
@@ -428,4 +427,4 @@ Determines if the signature is valid
 
 **Returns:** *boolean*
 
-Defined in: [baseTransaction.ts:194](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L194)
+Defined in: [baseTransaction.ts:208](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L208)

--- a/packages/tx/docs/classes/eip1559transaction.default.md
+++ b/packages/tx/docs/classes/eip1559transaction.default.md
@@ -93,7 +93,7 @@ varying data types.
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip1559Transaction.ts:153](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L153)
+Defined in: [eip1559Transaction.ts:164](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L164)
 
 ## Properties
 
@@ -101,7 +101,7 @@ Defined in: [eip1559Transaction.ts:153](https://github.com/ethereumjs/ethereumjs
 
 • `Readonly` **AccessListJSON**: [*AccessList*](../modules/types.md#accesslist)
 
-Defined in: [eip1559Transaction.ts:26](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L26)
+Defined in: [eip1559Transaction.ts:27](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L27)
 
 ___
 
@@ -109,7 +109,7 @@ ___
 
 • `Readonly` **accessList**: [*AccessListBuffer*](../modules/types.md#accesslistbuffer)
 
-Defined in: [eip1559Transaction.ts:25](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L25)
+Defined in: [eip1559Transaction.ts:26](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L26)
 
 ___
 
@@ -117,7 +117,7 @@ ___
 
 • `Readonly` **chainId**: *BN*
 
-Defined in: [eip1559Transaction.ts:24](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L24)
+Defined in: [eip1559Transaction.ts:25](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L25)
 
 ___
 
@@ -125,9 +125,9 @@ ___
 
 • `Readonly` **common**: *default*
 
-Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md).[common](basetransaction.basetransaction-1.md#common)
+Overrides: [BaseTransaction](basetransaction.basetransaction-1.md).[common](basetransaction.basetransaction-1.md#common)
 
-Defined in: [baseTransaction.ts:38](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L38)
+Defined in: [eip1559Transaction.ts:31](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L31)
 
 ___
 
@@ -155,7 +155,7 @@ ___
 
 • `Readonly` **maxFeePerGas**: *BN*
 
-Defined in: [eip1559Transaction.ts:28](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L28)
+Defined in: [eip1559Transaction.ts:29](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L29)
 
 ___
 
@@ -163,7 +163,7 @@ ___
 
 • `Readonly` **maxPriorityFeePerGas**: *BN*
 
-Defined in: [eip1559Transaction.ts:27](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L27)
+Defined in: [eip1559Transaction.ts:28](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L28)
 
 ___
 
@@ -183,7 +183,7 @@ ___
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md).[r](basetransaction.basetransaction-1.md#r)
 
-Defined in: [baseTransaction.ts:41](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L41)
+Defined in: [baseTransaction.ts:40](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L40)
 
 ___
 
@@ -193,7 +193,7 @@ ___
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md).[s](basetransaction.basetransaction-1.md#s)
 
-Defined in: [baseTransaction.ts:42](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L42)
+Defined in: [baseTransaction.ts:41](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L41)
 
 ___
 
@@ -213,7 +213,7 @@ ___
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md).[v](basetransaction.basetransaction-1.md#v)
 
-Defined in: [baseTransaction.ts:40](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L40)
+Defined in: [baseTransaction.ts:39](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L39)
 
 ___
 
@@ -237,7 +237,7 @@ EIP-2930 alias for `r`
 
 **Returns:** *undefined* \| *BN*
 
-Defined in: [eip1559Transaction.ts:35](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L35)
+Defined in: [eip1559Transaction.ts:46](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L46)
 
 ___
 
@@ -251,7 +251,7 @@ EIP-2930 alias for `s`
 
 **Returns:** *undefined* \| *BN*
 
-Defined in: [eip1559Transaction.ts:44](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L44)
+Defined in: [eip1559Transaction.ts:55](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L55)
 
 ___
 
@@ -265,7 +265,7 @@ Alias for `type`
 
 **Returns:** *number*
 
-Defined in: [baseTransaction.ts:82](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L82)
+Defined in: [baseTransaction.ts:96](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L96)
 
 ___
 
@@ -279,7 +279,7 @@ Note: legacy txs will return tx type `0`.
 
 **Returns:** *number*
 
-Defined in: [baseTransaction.ts:91](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L91)
+Defined in: [baseTransaction.ts:105](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L105)
 
 ___
 
@@ -293,7 +293,7 @@ EIP-2930 alias for `v`
 
 **Returns:** *undefined* \| *BN*
 
-Defined in: [eip1559Transaction.ts:53](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L53)
+Defined in: [eip1559Transaction.ts:64](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L64)
 
 ## Methods
 
@@ -313,7 +313,7 @@ Defined in: [eip1559Transaction.ts:53](https://github.com/ethereumjs/ethereumjs-
 
 Overrides: BaseTransaction.\_processSignature
 
-Defined in: [eip1559Transaction.ts:354](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L354)
+Defined in: [eip1559Transaction.ts:362](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L362)
 
 ___
 
@@ -327,7 +327,7 @@ The minimum amount of gas the tx must have (DataFee + TxFee + Creation Fee)
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:119](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L119)
+Defined in: [baseTransaction.ts:133](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L133)
 
 ___
 
@@ -341,7 +341,7 @@ The amount of gas paid for the data in this tx
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip1559Transaction.ts:221](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L221)
+Defined in: [eip1559Transaction.ts:229](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L229)
 
 ___
 
@@ -369,7 +369,7 @@ const serializedMessage = tx.getMessageToSign(false) // use this for the HW wall
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip1559Transaction.ts:290](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L290)
+Defined in: [eip1559Transaction.ts:298](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L298)
 
 ▸ **getMessageToSign**(`hashMessage?`: ``true``): *Buffer*
 
@@ -383,7 +383,7 @@ Defined in: [eip1559Transaction.ts:290](https://github.com/ethereumjs/ethereumjs
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip1559Transaction.ts:291](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L291)
+Defined in: [eip1559Transaction.ts:299](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L299)
 
 ___
 
@@ -397,7 +397,7 @@ Computes a sha3-256 hash which can be used to verify the signature
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip1559Transaction.ts:319](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L319)
+Defined in: [eip1559Transaction.ts:327](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L327)
 
 ___
 
@@ -411,7 +411,7 @@ Returns the sender's address
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:207](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L207)
+Defined in: [baseTransaction.ts:221](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L221)
 
 ___
 
@@ -425,7 +425,7 @@ Returns the public key of the sender
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip1559Transaction.ts:326](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L326)
+Defined in: [eip1559Transaction.ts:334](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L334)
 
 ___
 
@@ -445,7 +445,7 @@ The up front amount that an account must have for this transaction to be valid
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip1559Transaction.ts:231](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L231)
+Defined in: [eip1559Transaction.ts:239](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L239)
 
 ___
 
@@ -462,7 +462,7 @@ Use `getMessageToSign()` to get a tx hash for the purpose of signing.
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip1559Transaction.ts:308](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L308)
+Defined in: [eip1559Transaction.ts:316](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L316)
 
 ___
 
@@ -474,7 +474,7 @@ ___
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:174](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L174)
+Defined in: [baseTransaction.ts:188](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L188)
 
 ___
 
@@ -493,7 +493,7 @@ Use `serialize()` to add to block data for `Block.fromValuesArray()`.
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip1559Transaction.ts:245](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L245)
+Defined in: [eip1559Transaction.ts:253](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L253)
 
 ___
 
@@ -506,7 +506,7 @@ Returns the serialized encoding of the EIP-1559 transaction.
 Format: `0x02 || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data,
 accessList, signatureYParity, signatureR, signatureS])`
 
-Note that in contrast to the legacy tx serialization format this in not
+Note that in contrast to the legacy tx serialization format this is not
 valid RLP any more due to the raw tx type preceeding and concatenated to
 the RLP encoding of the values.
 
@@ -514,7 +514,7 @@ the RLP encoding of the values.
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip1559Transaction.ts:272](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L272)
+Defined in: [eip1559Transaction.ts:280](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L280)
 
 ___
 
@@ -540,7 +540,7 @@ const signedTx = tx.sign(privateKey)
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:225](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L225)
+Defined in: [baseTransaction.ts:239](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L239)
 
 ___
 
@@ -554,7 +554,7 @@ If the tx's `to` is to the creation address
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:149](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L149)
+Defined in: [baseTransaction.ts:163](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L163)
 
 ___
 
@@ -568,7 +568,7 @@ Returns an object with the JSON representation of the transaction
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip1559Transaction.ts:381](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L381)
+Defined in: [eip1559Transaction.ts:389](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L389)
 
 ___
 
@@ -583,7 +583,7 @@ Checks if the transaction has the minimum amount of gas required
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:99](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L99)
+Defined in: [baseTransaction.ts:113](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L113)
 
 ▸ **validate**(`stringError`: ``false``): *boolean*
 
@@ -597,7 +597,7 @@ Defined in: [baseTransaction.ts:99](https://github.com/ethereumjs/ethereumjs-mon
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:100](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L100)
+Defined in: [baseTransaction.ts:114](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L114)
 
 ▸ **validate**(`stringError`: ``true``): *string*[]
 
@@ -611,7 +611,7 @@ Defined in: [baseTransaction.ts:100](https://github.com/ethereumjs/ethereumjs-mo
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:101](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L101)
+Defined in: [baseTransaction.ts:115](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L115)
 
 ___
 
@@ -625,7 +625,7 @@ Determines if the signature is valid
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:194](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L194)
+Defined in: [baseTransaction.ts:208](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L208)
 
 ___
 
@@ -650,7 +650,7 @@ in favor of the `fromSerializedTx()` constructor
 
 **Returns:** [*default*](eip1559transaction.default.md)
 
-Defined in: [eip1559Transaction.ts:104](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L104)
+Defined in: [eip1559Transaction.ts:115](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L115)
 
 ___
 
@@ -672,7 +672,7 @@ accessList, signatureYParity, signatureR, signatureS])`
 
 **Returns:** [*default*](eip1559transaction.default.md)
 
-Defined in: [eip1559Transaction.ts:77](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L77)
+Defined in: [eip1559Transaction.ts:88](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L88)
 
 ___
 
@@ -698,7 +698,7 @@ Notes:
 
 **Returns:** [*default*](eip1559transaction.default.md)
 
-Defined in: [eip1559Transaction.ts:67](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L67)
+Defined in: [eip1559Transaction.ts:78](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L78)
 
 ___
 
@@ -720,4 +720,4 @@ accessList, signatureYParity, signatureR, signatureS]`
 
 **Returns:** [*default*](eip1559transaction.default.md)
 
-Defined in: [eip1559Transaction.ts:114](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L114)
+Defined in: [eip1559Transaction.ts:125](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip1559Transaction.ts#L125)

--- a/packages/tx/docs/classes/eip2930transaction.default.md
+++ b/packages/tx/docs/classes/eip2930transaction.default.md
@@ -92,7 +92,7 @@ varying data types.
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip2930Transaction.ts:141](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L141)
+Defined in: [eip2930Transaction.ts:152](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L152)
 
 ## Properties
 
@@ -100,7 +100,7 @@ Defined in: [eip2930Transaction.ts:141](https://github.com/ethereumjs/ethereumjs
 
 • `Readonly` **AccessListJSON**: [*AccessList*](../modules/types.md#accesslist)
 
-Defined in: [eip2930Transaction.ts:27](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L27)
+Defined in: [eip2930Transaction.ts:28](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L28)
 
 ___
 
@@ -108,7 +108,7 @@ ___
 
 • `Readonly` **accessList**: [*AccessListBuffer*](../modules/types.md#accesslistbuffer)
 
-Defined in: [eip2930Transaction.ts:26](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L26)
+Defined in: [eip2930Transaction.ts:27](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L27)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 • `Readonly` **chainId**: *BN*
 
-Defined in: [eip2930Transaction.ts:25](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L25)
+Defined in: [eip2930Transaction.ts:26](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L26)
 
 ___
 
@@ -124,9 +124,9 @@ ___
 
 • `Readonly` **common**: *default*
 
-Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md).[common](basetransaction.basetransaction-1.md#common)
+Overrides: [BaseTransaction](basetransaction.basetransaction-1.md).[common](basetransaction.basetransaction-1.md#common)
 
-Defined in: [baseTransaction.ts:38](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L38)
+Defined in: [eip2930Transaction.ts:31](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L31)
 
 ___
 
@@ -154,7 +154,7 @@ ___
 
 • `Readonly` **gasPrice**: *BN*
 
-Defined in: [eip2930Transaction.ts:28](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L28)
+Defined in: [eip2930Transaction.ts:29](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L29)
 
 ___
 
@@ -174,7 +174,7 @@ ___
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md).[r](basetransaction.basetransaction-1.md#r)
 
-Defined in: [baseTransaction.ts:41](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L41)
+Defined in: [baseTransaction.ts:40](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L40)
 
 ___
 
@@ -184,7 +184,7 @@ ___
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md).[s](basetransaction.basetransaction-1.md#s)
 
-Defined in: [baseTransaction.ts:42](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L42)
+Defined in: [baseTransaction.ts:41](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L41)
 
 ___
 
@@ -204,7 +204,7 @@ ___
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md).[v](basetransaction.basetransaction-1.md#v)
 
-Defined in: [baseTransaction.ts:40](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L40)
+Defined in: [baseTransaction.ts:39](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L39)
 
 ___
 
@@ -228,7 +228,7 @@ EIP-2930 alias for `r`
 
 **Returns:** *undefined* \| *BN*
 
-Defined in: [eip2930Transaction.ts:35](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L35)
+Defined in: [eip2930Transaction.ts:46](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L46)
 
 ___
 
@@ -242,7 +242,7 @@ EIP-2930 alias for `s`
 
 **Returns:** *undefined* \| *BN*
 
-Defined in: [eip2930Transaction.ts:44](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L44)
+Defined in: [eip2930Transaction.ts:55](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L55)
 
 ___
 
@@ -256,7 +256,7 @@ Alias for `type`
 
 **Returns:** *number*
 
-Defined in: [baseTransaction.ts:82](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L82)
+Defined in: [baseTransaction.ts:96](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L96)
 
 ___
 
@@ -270,7 +270,7 @@ Note: legacy txs will return tx type `0`.
 
 **Returns:** *number*
 
-Defined in: [baseTransaction.ts:91](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L91)
+Defined in: [baseTransaction.ts:105](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L105)
 
 ___
 
@@ -284,7 +284,7 @@ EIP-2930 alias for `v`
 
 **Returns:** *undefined* \| *BN*
 
-Defined in: [eip2930Transaction.ts:53](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L53)
+Defined in: [eip2930Transaction.ts:64](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L64)
 
 ## Methods
 
@@ -304,7 +304,7 @@ Defined in: [eip2930Transaction.ts:53](https://github.com/ethereumjs/ethereumjs-
 
 Overrides: BaseTransaction.\_processSignature
 
-Defined in: [eip2930Transaction.ts:322](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L322)
+Defined in: [eip2930Transaction.ts:330](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L330)
 
 ___
 
@@ -318,7 +318,7 @@ The minimum amount of gas the tx must have (DataFee + TxFee + Creation Fee)
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:119](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L119)
+Defined in: [baseTransaction.ts:133](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L133)
 
 ___
 
@@ -332,7 +332,7 @@ The amount of gas paid for the data in this tx
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip2930Transaction.ts:195](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L195)
+Defined in: [eip2930Transaction.ts:203](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L203)
 
 ___
 
@@ -360,7 +360,7 @@ const serializedMessage = tx.getMessageToSign(false) // use this for the HW wall
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip2930Transaction.ts:260](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L260)
+Defined in: [eip2930Transaction.ts:268](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L268)
 
 ___
 
@@ -374,7 +374,7 @@ Computes a sha3-256 hash which can be used to verify the signature
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip2930Transaction.ts:287](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L287)
+Defined in: [eip2930Transaction.ts:295](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L295)
 
 ___
 
@@ -388,7 +388,7 @@ Returns the sender's address
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:207](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L207)
+Defined in: [baseTransaction.ts:221](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L221)
 
 ___
 
@@ -402,7 +402,7 @@ Returns the public key of the sender
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip2930Transaction.ts:294](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L294)
+Defined in: [eip2930Transaction.ts:302](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L302)
 
 ___
 
@@ -416,7 +416,7 @@ The up front amount that an account must have for this transaction to be valid
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip2930Transaction.ts:204](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L204)
+Defined in: [eip2930Transaction.ts:212](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L212)
 
 ___
 
@@ -433,7 +433,7 @@ Use `getMessageToSign()` to get a tx hash for the purpose of signing.
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip2930Transaction.ts:276](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L276)
+Defined in: [eip2930Transaction.ts:284](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L284)
 
 ___
 
@@ -445,7 +445,7 @@ ___
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:174](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L174)
+Defined in: [baseTransaction.ts:188](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L188)
 
 ___
 
@@ -464,7 +464,7 @@ Use `serialize()` to add to block data for `Block.fromValuesArray()`.
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip2930Transaction.ts:216](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L216)
+Defined in: [eip2930Transaction.ts:224](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L224)
 
 ___
 
@@ -477,7 +477,7 @@ Returns the serialized encoding of the EIP-2930 transaction.
 Format: `0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
 signatureYParity (v), signatureR (r), signatureS (s)])`
 
-Note that in contrast to the legacy tx serialization format this in not
+Note that in contrast to the legacy tx serialization format this is not
 valid RLP any more due to the raw tx type preceeding and concatenated to
 the RLP encoding of the values.
 
@@ -485,7 +485,7 @@ the RLP encoding of the values.
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip2930Transaction.ts:242](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L242)
+Defined in: [eip2930Transaction.ts:250](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L250)
 
 ___
 
@@ -511,7 +511,7 @@ const signedTx = tx.sign(privateKey)
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:225](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L225)
+Defined in: [baseTransaction.ts:239](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L239)
 
 ___
 
@@ -525,7 +525,7 @@ If the tx's `to` is to the creation address
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:149](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L149)
+Defined in: [baseTransaction.ts:163](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L163)
 
 ___
 
@@ -539,7 +539,7 @@ Returns an object with the JSON representation of the transaction
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [eip2930Transaction.ts:348](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L348)
+Defined in: [eip2930Transaction.ts:356](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L356)
 
 ___
 
@@ -554,7 +554,7 @@ Checks if the transaction has the minimum amount of gas required
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:99](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L99)
+Defined in: [baseTransaction.ts:113](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L113)
 
 ▸ **validate**(`stringError`: ``false``): *boolean*
 
@@ -568,7 +568,7 @@ Defined in: [baseTransaction.ts:99](https://github.com/ethereumjs/ethereumjs-mon
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:100](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L100)
+Defined in: [baseTransaction.ts:114](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L114)
 
 ▸ **validate**(`stringError`: ``true``): *string*[]
 
@@ -582,7 +582,7 @@ Defined in: [baseTransaction.ts:100](https://github.com/ethereumjs/ethereumjs-mo
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:101](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L101)
+Defined in: [baseTransaction.ts:115](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L115)
 
 ___
 
@@ -596,7 +596,7 @@ Determines if the signature is valid
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:194](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L194)
+Defined in: [baseTransaction.ts:208](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L208)
 
 ___
 
@@ -621,7 +621,7 @@ in favor of the `fromSerializedTx()` constructor
 
 **Returns:** [*default*](eip2930transaction.default.md)
 
-Defined in: [eip2930Transaction.ts:104](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L104)
+Defined in: [eip2930Transaction.ts:115](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L115)
 
 ___
 
@@ -643,7 +643,7 @@ signatureYParity (v), signatureR (r), signatureS (s)])`
 
 **Returns:** [*default*](eip2930transaction.default.md)
 
-Defined in: [eip2930Transaction.ts:77](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L77)
+Defined in: [eip2930Transaction.ts:88](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L88)
 
 ___
 
@@ -669,7 +669,7 @@ Notes:
 
 **Returns:** [*default*](eip2930transaction.default.md)
 
-Defined in: [eip2930Transaction.ts:67](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L67)
+Defined in: [eip2930Transaction.ts:78](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L78)
 
 ___
 
@@ -691,4 +691,4 @@ signatureYParity (v), signatureR (r), signatureS (s)]`
 
 **Returns:** [*default*](eip2930transaction.default.md)
 
-Defined in: [eip2930Transaction.ts:114](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L114)
+Defined in: [eip2930Transaction.ts:125](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/eip2930Transaction.ts#L125)

--- a/packages/tx/docs/classes/legacytransaction.default.md
+++ b/packages/tx/docs/classes/legacytransaction.default.md
@@ -82,7 +82,7 @@ varying data types.
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [legacyTransaction.ts:90](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L90)
+Defined in: [legacyTransaction.ts:93](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L93)
 
 ## Properties
 
@@ -90,9 +90,9 @@ Defined in: [legacyTransaction.ts:90](https://github.com/ethereumjs/ethereumjs-m
 
 • `Readonly` **common**: *default*
 
-Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md).[common](basetransaction.basetransaction-1.md#common)
+Overrides: [BaseTransaction](basetransaction.basetransaction-1.md).[common](basetransaction.basetransaction-1.md#common)
 
-Defined in: [baseTransaction.ts:38](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L38)
+Defined in: [legacyTransaction.ts:23](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L23)
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 • `Readonly` **gasPrice**: *BN*
 
-Defined in: [legacyTransaction.ts:20](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L20)
+Defined in: [legacyTransaction.ts:21](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L21)
 
 ___
 
@@ -140,7 +140,7 @@ ___
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md).[r](basetransaction.basetransaction-1.md#r)
 
-Defined in: [baseTransaction.ts:41](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L41)
+Defined in: [baseTransaction.ts:40](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L40)
 
 ___
 
@@ -150,7 +150,7 @@ ___
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md).[s](basetransaction.basetransaction-1.md#s)
 
-Defined in: [baseTransaction.ts:42](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L42)
+Defined in: [baseTransaction.ts:41](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L41)
 
 ___
 
@@ -170,7 +170,7 @@ ___
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md).[v](basetransaction.basetransaction-1.md#v)
 
-Defined in: [baseTransaction.ts:40](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L40)
+Defined in: [baseTransaction.ts:39](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L39)
 
 ___
 
@@ -194,7 +194,7 @@ Alias for `type`
 
 **Returns:** *number*
 
-Defined in: [baseTransaction.ts:82](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L82)
+Defined in: [baseTransaction.ts:96](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L96)
 
 ___
 
@@ -208,7 +208,7 @@ Note: legacy txs will return tx type `0`.
 
 **Returns:** *number*
 
-Defined in: [baseTransaction.ts:91](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L91)
+Defined in: [baseTransaction.ts:105](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L105)
 
 ## Methods
 
@@ -222,7 +222,7 @@ The minimum amount of gas the tx must have (DataFee + TxFee + Creation Fee)
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:119](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L119)
+Defined in: [baseTransaction.ts:133](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L133)
 
 ___
 
@@ -236,7 +236,7 @@ The amount of gas paid for the data in this tx
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:130](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L130)
+Defined in: [baseTransaction.ts:144](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L144)
 
 ___
 
@@ -266,7 +266,7 @@ const serializedMessage = rlp.encode(message) // use this for the HW wallet inpu
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [legacyTransaction.ts:188](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L188)
+Defined in: [legacyTransaction.ts:191](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L191)
 
 ▸ **getMessageToSign**(`hashMessage?`: ``true``): *Buffer*
 
@@ -280,7 +280,7 @@ Defined in: [legacyTransaction.ts:188](https://github.com/ethereumjs/ethereumjs-
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [legacyTransaction.ts:189](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L189)
+Defined in: [legacyTransaction.ts:192](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L192)
 
 ___
 
@@ -294,7 +294,7 @@ Computes a sha3-256 hash which can be used to verify the signature
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [legacyTransaction.ts:219](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L219)
+Defined in: [legacyTransaction.ts:222](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L222)
 
 ___
 
@@ -308,7 +308,7 @@ Returns the sender's address
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:207](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L207)
+Defined in: [baseTransaction.ts:221](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L221)
 
 ___
 
@@ -322,7 +322,7 @@ Returns the public key of the sender
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [legacyTransaction.ts:228](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L228)
+Defined in: [legacyTransaction.ts:231](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L231)
 
 ___
 
@@ -336,7 +336,7 @@ The up front amount that an account must have for this transaction to be valid
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [legacyTransaction.ts:202](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L202)
+Defined in: [legacyTransaction.ts:205](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L205)
 
 ___
 
@@ -353,7 +353,7 @@ Use `getMessageToSign()` to get a tx hash for the purpose of signing.
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [legacyTransaction.ts:212](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L212)
+Defined in: [legacyTransaction.ts:215](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L215)
 
 ___
 
@@ -365,7 +365,7 @@ ___
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:174](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L174)
+Defined in: [baseTransaction.ts:188](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L188)
 
 ___
 
@@ -385,7 +385,7 @@ representation have a look at the `getMessageToSign()` method.
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [legacyTransaction.ts:123](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L123)
+Defined in: [legacyTransaction.ts:126](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L126)
 
 ___
 
@@ -405,7 +405,7 @@ EIP-155 compliant representation use the `getMessageToSign()` method.
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [legacyTransaction.ts:146](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L146)
+Defined in: [legacyTransaction.ts:149](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L149)
 
 ___
 
@@ -431,7 +431,7 @@ const signedTx = tx.sign(privateKey)
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:225](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L225)
+Defined in: [baseTransaction.ts:239](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L239)
 
 ___
 
@@ -445,7 +445,7 @@ If the tx's `to` is to the creation address
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:149](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L149)
+Defined in: [baseTransaction.ts:163](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L163)
 
 ___
 
@@ -459,7 +459,7 @@ Returns an object with the JSON representation of the transaction.
 
 Overrides: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [legacyTransaction.ts:285](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L285)
+Defined in: [legacyTransaction.ts:288](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L288)
 
 ___
 
@@ -474,7 +474,7 @@ Checks if the transaction has the minimum amount of gas required
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:99](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L99)
+Defined in: [baseTransaction.ts:113](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L113)
 
 ▸ **validate**(`stringError`: ``false``): *boolean*
 
@@ -488,7 +488,7 @@ Defined in: [baseTransaction.ts:99](https://github.com/ethereumjs/ethereumjs-mon
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:100](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L100)
+Defined in: [baseTransaction.ts:114](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L114)
 
 ▸ **validate**(`stringError`: ``true``): *string*[]
 
@@ -502,7 +502,7 @@ Defined in: [baseTransaction.ts:100](https://github.com/ethereumjs/ethereumjs-mo
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:101](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L101)
+Defined in: [baseTransaction.ts:115](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L115)
 
 ___
 
@@ -516,7 +516,7 @@ Determines if the signature is valid
 
 Inherited from: [BaseTransaction](basetransaction.basetransaction-1.md)
 
-Defined in: [baseTransaction.ts:194](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L194)
+Defined in: [baseTransaction.ts:208](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/baseTransaction.ts#L208)
 
 ___
 
@@ -539,7 +539,7 @@ in favor of the `fromSerializedTx()` constructor
 
 **Returns:** [*default*](legacytransaction.default.md)
 
-Defined in: [legacyTransaction.ts:56](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L56)
+Defined in: [legacyTransaction.ts:59](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L59)
 
 ___
 
@@ -560,7 +560,7 @@ Format: `rlp([nonce, gasPrice, gasLimit, to, value, data, v, r, s])`
 
 **Returns:** [*default*](legacytransaction.default.md)
 
-Defined in: [legacyTransaction.ts:39](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L39)
+Defined in: [legacyTransaction.ts:42](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L42)
 
 ___
 
@@ -584,7 +584,7 @@ Notes:
 
 **Returns:** [*default*](legacytransaction.default.md)
 
-Defined in: [legacyTransaction.ts:30](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L30)
+Defined in: [legacyTransaction.ts:33](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L33)
 
 ___
 
@@ -605,4 +605,4 @@ Format: `[nonce, gasPrice, gasLimit, to, value, data, v, r, s]`
 
 **Returns:** [*default*](legacytransaction.default.md)
 
-Defined in: [legacyTransaction.ts:65](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L65)
+Defined in: [legacyTransaction.ts:68](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/legacyTransaction.ts#L68)

--- a/packages/tx/docs/classes/transactionfactory.default.md
+++ b/packages/tx/docs/classes/transactionfactory.default.md
@@ -33,7 +33,7 @@ This method returns the right transaction.
 
 **Returns:** [*TypedTransaction*](../modules/types.md#typedtransaction)
 
-Defined in: [transactionFactory.ts:97](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/transactionFactory.ts#L97)
+Defined in: [transactionFactory.ts:83](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/transactionFactory.ts#L83)
 
 ___
 
@@ -52,7 +52,7 @@ This method tries to decode serialized data.
 
 **Returns:** [*TypedTransaction*](../modules/types.md#typedtransaction)
 
-Defined in: [transactionFactory.ts:51](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/transactionFactory.ts#L51)
+Defined in: [transactionFactory.ts:49](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/transactionFactory.ts#L49)
 
 ___
 
@@ -71,7 +71,7 @@ Create a transaction from a `txData` object
 
 **Returns:** [*TypedTransaction*](../modules/types.md#typedtransaction)
 
-Defined in: [transactionFactory.ts:24](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/transactionFactory.ts#L24)
+Defined in: [transactionFactory.ts:22](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/transactionFactory.ts#L22)
 
 ___
 
@@ -86,11 +86,11 @@ If transactionID is undefined, returns the legacy transaction class.
 
 #### Parameters
 
-| Name | Type | Default value |
-| :------ | :------ | :------ |
-| `transactionID` | *number* | 0 |
-| `common?` | *default* | - |
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `transactionID` | *number* | 0 |  |
+| `common?` | *default* | - | This option is not used |
 
 **Returns:** *typeof* [*default*](eip1559transaction.default.md) \| *typeof* [*default*](eip2930transaction.default.md) \| *typeof* [*default*](legacytransaction.default.md)
 
-Defined in: [transactionFactory.ts:115](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/transactionFactory.ts#L115)
+Defined in: [transactionFactory.ts:102](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/src/transactionFactory.ts#L102)

--- a/packages/tx/docs/interfaces/types.accesslisteip2930txdata.md
+++ b/packages/tx/docs/interfaces/types.accesslisteip2930txdata.md
@@ -55,7 +55,7 @@ ___
 
 ### data
 
-• `Optional` **data**: *string* \| *number* \| *BN* \| *Buffer* \| *Uint8Array* \| *number*[] \| TransformableToBuffer
+• `Optional` **data**: *string* \| *number* \| *BN* \| *Buffer* \| *number*[] \| *Uint8Array* \| TransformableToBuffer
 
 This will contain the data of the message or the init of a contract.
 

--- a/packages/tx/docs/interfaces/types.feemarketeip1559txdata.md
+++ b/packages/tx/docs/interfaces/types.feemarketeip1559txdata.md
@@ -59,7 +59,7 @@ ___
 
 ### data
 
-• `Optional` **data**: *string* \| *number* \| *BN* \| *Buffer* \| *Uint8Array* \| *number*[] \| TransformableToBuffer
+• `Optional` **data**: *string* \| *number* \| *BN* \| *Buffer* \| *number*[] \| *Uint8Array* \| TransformableToBuffer
 
 This will contain the data of the message or the init of a contract.
 

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -32,7 +32,7 @@
     "test:browser": "npm run test:browser:build && karma start karma.conf.js"
   },
   "dependencies": {
-    "@ethereumjs/common": "^2.3.0",
+    "@ethereumjs/common": "^2.3.1",
     "ethereumjs-util": "^7.0.10"
   },
   "devDependencies": {

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/tx",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A simple module for creating, manipulating and signing Ethereum transactions",
   "license": "MPL-2.0",
   "author": "mjbecze <mb@ethdev.com>",

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.4.1 - 2021-06-11
+
+This release comes with some additional `EIP-1559` checks and functionality:
+
+- Additional 1559 check in `VM.runTx()` that the tx sender balance must be >= gas_limit * max_fee_per_gas, PR [#1272](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1272)
+- Additional 1559 check in `VM.runTx()` to ensure that the user was willing to at least pay the base fee (`transaction.max_fee_per_gas >= block.base_fee_per_gas`), PR [#1276](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1276)
+- 1559 support for the BlockBuilder (`VM.buildBlock()`) by setting the new block's `baseFeePerGas` to `parentBlock.header.calcNextBaseFee()`, PR [#1280](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1280)
+
 ## 5.4.0 - 2021-05-26
 
 ### London HF Support

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@ethereumjs/block": "^3.3.0",
     "@ethereumjs/blockchain": "^5.3.0",
-    "@ethereumjs/common": "^2.3.0",
+    "@ethereumjs/common": "^2.3.1",
     "@ethereumjs/tx": "^3.2.0",
     "merkle-patricia-tree": "^4.2.0",
     "async-eventemitter": "^0.2.4",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -48,7 +48,7 @@
     "@ethereumjs/block": "^3.3.0",
     "@ethereumjs/blockchain": "^5.3.0",
     "@ethereumjs/common": "^2.3.1",
-    "@ethereumjs/tx": "^3.2.0",
+    "@ethereumjs/tx": "^3.2.1",
     "merkle-patricia-tree": "^4.2.0",
     "async-eventemitter": "^0.2.4",
     "core-js-pure": "^3.0.1",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/vm",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "An Ethereum VM implementation",
   "license": "MPL-2.0",
   "author": "mjbecze <mjbecze@gmail.com>",


### PR DESCRIPTION
Ok, a new round of releases integrating the latest EIP-1559 spec changes and updating on tx library usability and generally integrating user feedback. ~Still WIP, VM is still missing.~

I very much anticipate a relatively narrow cadence of follow-up releases in the next weeks on approaching the `london` HF (so at least every two weeks, eventually also more on a weekly basis), so no worry if some feature or fix hasn't made this yet in this release.

We generally should release here soon since there are features/fixes both HardHat and Web3.js are waiting for to integrate.