### PR TITLE
Client: Calaveras Sync Improvements + Working Branch

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -77,6 +77,11 @@ const args = require('yargs')
       choices: ['error', 'warn', 'info', 'debug'],
       default: Config.LOGLEVEL_DEFAULT,
     },
+    maxPerRequest: {
+      describe: 'Max items per block or header request',
+      number: true,
+      default: Config.MAXPERREQUEST_DEFAULT,
+    },
     minPeers: {
       describe: 'Peers needed before syncing',
       number: true,
@@ -197,6 +202,7 @@ async function run() {
     rpcport: args.rpcport,
     rpcaddr: args.rpcaddr,
     loglevel: args.loglevel,
+    maxPerRequest: args.maxPerRequest,
     minPeers: args.minPeers,
     maxPeers: args.maxPeers,
     dnsAddr: args.dnsAddr,

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -121,7 +121,7 @@ export interface ConfigOptions {
 
   /**
    * Max items per block or header request
-   * 
+   *
    * Default: `50``
    */
   maxPerRequest?: number

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -120,6 +120,13 @@ export interface ConfigOptions {
   logger?: Logger
 
   /**
+   * Max items per block or header request
+   * 
+   * Default: `50``
+   */
+  maxPerRequest?: number
+
+  /**
    * Number of peers needed before syncing
    *
    * Default: `2`
@@ -180,6 +187,7 @@ export class Config {
   public static readonly RPCPORT_DEFAULT = 8545
   public static readonly RPCADDR_DEFAULT = 'localhost'
   public static readonly LOGLEVEL_DEFAULT = 'info'
+  public static readonly MAXPERREQUEST_DEFAULT = 50
   public static readonly MINPEERS_DEFAULT = 1
   public static readonly MAXPEERS_DEFAULT = 25
   public static readonly DNSADDR_DEFAULT = '8.8.8.8'
@@ -199,6 +207,7 @@ export class Config {
   public readonly rpcport: number
   public readonly rpcaddr: string
   public readonly loglevel: string
+  public readonly maxPerRequest: number
   public readonly minPeers: number
   public readonly maxPeers: number
   public readonly dnsAddr: string
@@ -225,6 +234,7 @@ export class Config {
     this.rpcport = options.rpcport ?? Config.RPCPORT_DEFAULT
     this.rpcaddr = options.rpcaddr ?? Config.RPCADDR_DEFAULT
     this.loglevel = options.loglevel ?? Config.LOGLEVEL_DEFAULT
+    this.maxPerRequest = options.maxPerRequest ?? Config.MAXPERREQUEST_DEFAULT
     this.minPeers = options.minPeers ?? Config.MINPEERS_DEFAULT
     this.maxPeers = options.maxPeers ?? Config.MAXPEERS_DEFAULT
     this.dnsAddr = options.dnsAddr ?? Config.DNSADDR_DEFAULT

--- a/packages/client/lib/sync/execution/vmexecution.ts
+++ b/packages/client/lib/sync/execution/vmexecution.ts
@@ -182,8 +182,11 @@ export class VMExecution extends Execution {
         const firstHash = short(startHeadBlock.hash())
         const lastNumber = endHeadBlock.header.number.toNumber()
         const lastHash = short(endHeadBlock.hash())
+        const baseFeeAdd = this.config.execCommon.gteHardfork('london')
+          ? `basefee=${endHeadBlock.header.baseFeePerGas} `
+          : ''
         this.config.logger.info(
-          `Executed blocks count=${numExecuted} first=${firstNumber} hash=${firstHash} hardfork=${this.hardfork} last=${lastNumber} hash=${lastHash} with txs=${txCounter}`
+          `Executed blocks count=${numExecuted} first=${firstNumber} hash=${firstHash} ${baseFeeAdd}hardfork=${this.hardfork} last=${lastNumber} hash=${lastHash} with txs=${txCounter}`
         )
       } else {
         this.config.logger.warn(

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -49,11 +49,9 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
    * @return {*} results of processing job or undefined if job not finished
    */
   process(job: Job<JobTask, Block[], Block>, result: Block[]) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (result && result.length === job.task.count) {
+    if (result.length === job.task.count) {
       return result
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    } else if (result && result.length > 0 && result.length < job.task.count) {
+    } else if (result.length > 0 && result.length < job.task.count) {
       // Adopt the start block/header number from the remaining jobs
       // if the number of the results provided is lower than the expected count
       const lengthDiff = job.task.count - result.length
@@ -69,9 +67,8 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
         this.in.insert(job)
       }
       return result
-    } else {
-      return
     }
+    return
   }
 
   /**

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -23,7 +23,7 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
    */
   tasks(): JobTask[] {
     const { first, count } = this
-    const max = this.maxPerRequest
+    const max = this.config.maxPerRequest
     const tasks: JobTask[] = []
     while (count.gten(max)) {
       tasks.push({ first: first.clone(), count: max })

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -18,25 +18,6 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
   }
 
   /**
-   * Generate list of tasks to fetch
-   * @return {Object[]} tasks
-   */
-  tasks(): JobTask[] {
-    const { first, count } = this
-    const max = this.config.maxPerRequest
-    const tasks: JobTask[] = []
-    while (count.gten(max)) {
-      tasks.push({ first: first.clone(), count: max })
-      first.iaddn(max)
-      count.isubn(max)
-    }
-    if (count.gtn(0)) {
-      tasks.push({ first: first.clone(), count: count.toNumber() })
-    }
-    return tasks
-  }
-
-  /**
    * Requests blocks associated with this job
    * @param job
    */

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -52,8 +52,26 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (result && result.length === job.task.count) {
       return result
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    } else if (result && result.length > 0 && result.length < job.task.count) {
+      // Adopt the start block/header number from the remaining jobs
+      // if the number of the results provided is lower than the expected count
+      const lengthDiff = job.task.count - result.length
+      const adoptedJobs = []
+      while (this.in.length > 0) {
+        const job = this.in.remove()
+        if (job) {
+          job.task.first = job.task.first.subn(lengthDiff)
+          adoptedJobs.push(job)
+        }
+      }
+      for (const job of adoptedJobs) {
+        this.in.insert(job)
+      }
+      return result
+    } else {
+      return
     }
-    return
   }
 
   /**

--- a/packages/client/lib/sync/fetcher/blockfetcherbase.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcherbase.ts
@@ -35,7 +35,6 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
     super(options)
 
     this.chain = options.chain
-    this.maxPerRequest = options.maxPerRequest ?? 50
     this.first = options.first
     this.count = options.count
   }

--- a/packages/client/lib/sync/fetcher/blockfetcherbase.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcherbase.ts
@@ -45,7 +45,7 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
    */
   tasks(): JobTask[] {
     const { first, count } = this
-    const max = this.maxPerRequest
+    const max = this.config.maxPerRequest
     const tasks: JobTask[] = []
     while (count.gten(max)) {
       tasks.push({ first: first.clone(), count: max })

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -24,9 +24,6 @@ export interface FetcherOptions {
   /* Max write queue size (default: 16) */
   maxQueue?: number
 
-  /* Max items per request (default: 50) */
-  maxPerRequest?: number
-
   /* Retry interval in ms (default: 1000) */
   interval?: number
 }
@@ -48,7 +45,6 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
   protected interval: number
   protected banTime: number
   protected maxQueue: number
-  protected maxPerRequest: number
   protected in: QHeap<Job<JobTask, JobResult, StorageItem>>
   protected out: QHeap<Job<JobTask, JobResult, StorageItem>>
   protected total: number
@@ -74,7 +70,6 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
     this.interval = options.interval ?? 1000
     this.banTime = options.banTime ?? 60000
     this.maxQueue = options.maxQueue ?? 16
-    this.maxPerRequest = options.maxPerRequest ?? 50
 
     this.in = new Heap({
       comparBefore: (

--- a/packages/client/lib/sync/fetcher/headerfetcher.ts
+++ b/packages/client/lib/sync/fetcher/headerfetcher.ts
@@ -35,7 +35,7 @@ export class HeaderFetcher extends BlockFetcherBase<BlockHeaderResult, BlockHead
    */
   async request(job: Job<JobTask, BlockHeaderResult, BlockHeader>) {
     const { task, peer } = job
-    if (this.flow.maxRequestCount(peer!, 'GetBlockHeaders') < this.maxPerRequest) {
+    if (this.flow.maxRequestCount(peer!, 'GetBlockHeaders') < this.config.maxPerRequest) {
       // we reached our request limit. try with a different peer.
       return
     }

--- a/packages/client/lib/sync/fetcher/headerfetcher.ts
+++ b/packages/client/lib/sync/fetcher/headerfetcher.ts
@@ -54,12 +54,10 @@ export class HeaderFetcher extends BlockFetcherBase<BlockHeaderResult, BlockHead
    */
   process(job: Job<JobTask, BlockHeaderResult, BlockHeader>, result: BlockHeaderResult) {
     this.flow.handleReply(job.peer!, result.bv.toNumber())
-    const headers = result.headers
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (headers && headers.length === job.task.count) {
+    const { headers } = result
+    if (headers.length === job.task.count) {
       return headers
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    } else if (headers && headers.length > 0 && headers.length < job.task.count) {
+    } else if (headers.length > 0 && headers.length < job.task.count) {
       // Adopt the start block/header number from the remaining jobs
       // if the number of the results provided is lower than the expected count
       const lengthDiff = job.task.count - headers.length
@@ -75,9 +73,8 @@ export class HeaderFetcher extends BlockFetcherBase<BlockHeaderResult, BlockHead
         this.in.insert(job)
       }
       return headers
-    } else {
-      return
     }
+    return
   }
 
   /**

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -125,10 +125,15 @@ export class FullSynchronizer extends Synchronizer {
       .on('fetched', (blocks: Block[]) => {
         const first = new BN(blocks[0].header.number)
         const hash = short(blocks[0].hash())
+        const baseFeeAdd = this.config.chainCommon.gteHardfork('london')
+          ? `basefee=${blocks[0].header.baseFeePerGas} `
+          : ''
         this.config.logger.info(
           `Imported blocks count=${blocks.length} number=${first.toString(
             10
-          )} hash=${hash} hardfork=${this.config.chainCommon.hardfork()} peers=${this.pool.size}`
+          )} hash=${hash} ${baseFeeAdd}hardfork=${this.config.chainCommon.hardfork()} peers=${
+            this.pool.size
+          }`
         )
       })
     await this.blockFetcher.fetch()

--- a/packages/client/lib/sync/lightsync.ts
+++ b/packages/client/lib/sync/lightsync.ts
@@ -87,10 +87,13 @@ export class LightSynchronizer extends Synchronizer {
       .on('fetched', (headers: BlockHeader[]) => {
         const first = new BN(headers[0].number)
         const hash = short(headers[0].hash())
+        const baseFeeAdd = this.config.chainCommon.gteHardfork('london')
+          ? `basefee=${headers[0].baseFeePerGas} `
+          : ''
         this.config.logger.info(
           `Imported headers count=${headers.length} number=${first.toString(
             10
-          )} hash=${hash} peers=${this.pool.size}`
+          )} hash=${hash} ${baseFeeAdd}peers=${this.pool.size}`
         )
       })
     await this.headerFetcher.fetch()

--- a/packages/client/test/integration/fullsync.spec.ts
+++ b/packages/client/test/integration/fullsync.spec.ts
@@ -38,7 +38,11 @@ tape('[Integration:FullSync]', async (t) => {
     await localServer.discover('remotePeer1', '127.0.0.2')
     await localServer.discover('remotePeer2', '127.0.0.3')
     localService.on('synchronized', async () => {
-      t.equals(localService.chain.blocks.height.toNumber(), 10, 'synced with best peer')
+      // This event may fire twice
+      if (!localService.chain.blocks.height.eqn(10)) {
+        return
+      }
+      t.ok(localService.chain.blocks.height.eqn(10), 'synced with best peer')
       await destroy(localServer, localService)
       await destroy(remoteServer1, remoteService1)
       await destroy(remoteServer2, remoteService2)

--- a/packages/client/test/integration/lightsync.spec.ts
+++ b/packages/client/test/integration/lightsync.spec.ts
@@ -66,7 +66,11 @@ tape('[Integration:LightSync]', async (t) => {
     await localServer.discover('remotePeer1', '127.0.0.2')
     await localServer.discover('remotePeer2', '127.0.0.3')
     localService.on('synchronized', async () => {
-      t.equals(localService.chain.headers.height.toNumber(), 10, 'synced with best peer')
+      // This event may fire twice
+      if (!localService.chain.headers.height.eqn(10)) {
+        return
+      }
+      t.ok(localService.chain.headers.height.eqn(10), 'synced with best peer')
       await destroy(localServer, localService)
       await destroy(remoteServer1, remoteService1)
       await destroy(remoteServer2, remoteService2)

--- a/packages/client/test/sync/fetcher/blockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/blockfetcher.spec.ts
@@ -21,7 +21,7 @@ tape('[BlockFetcher]', async (t) => {
   const { BlockFetcher } = await import('../../../lib/sync/fetcher/blockfetcher')
 
   t.test('should start/stop', async (t) => {
-    const config = new Config({ loglevel: 'error', transports: [] })
+    const config = new Config({ maxPerRequest: 5, loglevel: 'error', transports: [] })
     const pool = new PeerPool() as any
     const chain = new Chain({ config })
     const fetcher = new BlockFetcher({
@@ -30,7 +30,6 @@ tape('[BlockFetcher]', async (t) => {
       chain,
       first: new BN(1),
       count: new BN(10),
-      maxPerRequest: 5,
       timeout: 5,
     })
     fetcher.next = () => false


### PR DESCRIPTION
Related: #1306 

Working branch to sync with the [Calaveras](https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/client-integration-testnets/calaveras.md) network, also coming with some calaveras related improvements (feel free to directly push on this branch or in doubt make a PR towards the branch if you have got things to add).

First thing I added here is an official `maxPerRequest` CLI option, then we don't always have to monkey-patch if running with a `50` maxPerRequest setting doesn't work but can just run `npm run client:start -- --network=calaveras --maxPerRequest=1`.

The option should be generally useful (so: not just a monkey-patch-ease option 🙂) since it will be likely useful for peopel to play a bit with this, this will likely allow to get to somewhat higher download rates if adjusted due to the specific network and ones own internet connection speed and things like that.