### PR TITLE
devp2p/client: add les v3/v4

### DIFF
--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -263,12 +263,13 @@ export class Block {
    *
    * Throws if invalid.
    *
-   * @param blockchain - validate against a @ethereumjs/blockchain
+   * @param blockchain - validate against an @ethereumjs/blockchain
+   * @param onlyHeader - if should only validate the header (skips validating txTrie and unclesHash) (default: false)
    */
-  async validate(blockchain: Blockchain): Promise<void> {
+  async validate(blockchain: Blockchain, onlyHeader: boolean = false): Promise<void> {
     await this.header.validate(blockchain)
     await this.validateUncles(blockchain)
-    await this.validateData()
+    await this.validateData(onlyHeader)
   }
   /**
    * Validates the block data, throwing if invalid.
@@ -277,21 +278,24 @@ export class Block {
    * - All transactions are valid
    * - The transactions trie is valid
    * - The uncle hash is valid
+   * @param onlyHeader if only passed the header, skip validating txTrie and unclesHash (default: false)
    */
-  async validateData(): Promise<void> {
+  async validateData(onlyHeader: boolean = false): Promise<void> {
     const txErrors = this.validateTransactions(true)
     if (txErrors.length > 0) {
       const msg = `invalid transactions: ${txErrors.join(' ')}`
       throw this.header._error(msg)
     }
 
-    const validateTxTrie = await this.validateTransactionsTrie()
-    if (!validateTxTrie) {
-      throw new Error('invalid transaction trie')
-    }
+    if (!onlyHeader) {
+      const validateTxTrie = await this.validateTransactionsTrie()
+      if (!validateTxTrie) {
+        throw new Error('invalid transaction trie')
+      }
 
-    if (!this.validateUnclesHash()) {
-      throw new Error('invalid uncle hash')
+      if (!this.validateUnclesHash()) {
+        throw new Error('invalid uncle hash')
+      }
     }
   }
 

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -877,9 +877,9 @@ export default class Blockchain implements BlockchainInterface {
             })
           : item
       const isGenesis = block.isGenesis()
+      const isHeader = item instanceof BlockHeader
 
       // we cannot overwrite the Genesis block after initializing the Blockchain
-
       if (isGenesis) {
         throw new Error('Cannot put a genesis block: create a new Blockchain')
       }
@@ -897,7 +897,7 @@ export default class Blockchain implements BlockchainInterface {
 
       if (this._validateBlocks && !isGenesis) {
         // this calls into `getBlock`, which is why we cannot lock yet
-        await block.validate(this)
+        await block.validate(this, isHeader)
       }
 
       if (this._validateConsensus) {

--- a/packages/client/lib/net/peer/rlpxpeer.ts
+++ b/packages/client/lib/net/peer/rlpxpeer.ts
@@ -15,6 +15,8 @@ const devp2pCapabilities: any = {
   eth64: Devp2pETH.eth64,
   eth65: Devp2pETH.eth65,
   les2: Devp2pLES.les2,
+  les3: Devp2pLES.les3,
+  les4: Devp2pLES.les4,
 }
 
 export interface RlpxPeerOptions extends Omit<PeerOptions, 'address' | 'transport'> {

--- a/packages/client/lib/net/protocol/boundprotocol.ts
+++ b/packages/client/lib/net/protocol/boundprotocol.ts
@@ -184,7 +184,7 @@ export class BoundProtocol extends EventEmitter {
       ;(this as any)[camel] = async (args: any[]) =>
         this.request(name, args).catch((error: Error) => {
           this.emit('error', error)
-          return []
+          return undefined
         })
     }
   }

--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -138,12 +138,12 @@ export class EthProtocol extends Protocol {
    * @return {Object}
    */
   encodeStatus(): any {
-    // TODO: add latestBlock for more precise ETH/64 forkhash switch
     return {
       networkId: this.chain.networkId.toArrayLike(Buffer),
       td: this.chain.blocks.td.toArrayLike(Buffer),
       bestHash: this.chain.blocks.latest!.hash(),
       genesisHash: this.chain.genesis.hash,
+      latestBlock: this.chain.blocks.latest!.header.number.toArrayLike(Buffer),
     }
   }
 

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -11,7 +11,7 @@ interface FullEthereumServiceOptions extends EthereumServiceOptions {
 }
 
 /**
- * Ethereum service
+ * Full Ethereum service
  * @memberof module:service
  */
 export class FullEthereumService extends EthereumService {

--- a/packages/client/lib/service/lightethereumservice.ts
+++ b/packages/client/lib/service/lightethereumservice.ts
@@ -4,15 +4,15 @@ import { LightSynchronizer } from '../sync/lightsync'
 import { LesProtocol } from '../net/protocol/lesprotocol'
 
 /**
- * Ethereum service
+ * Light Ethereum service
  * @memberof module:service
  */
 export class LightEthereumService extends EthereumService {
   public synchronizer: LightSynchronizer
 
   /**
-   * Create new ETH service
-   * @param {Object}   options constructor parameters
+   * Create new LES service
+   * @param options
    */
   constructor(options: EthereumServiceOptions) {
     super(options)
@@ -35,7 +35,6 @@ export class LightEthereumService extends EthereumService {
       new LesProtocol({
         config: this.config,
         chain: this.chain,
-        flow: this.flow,
         timeout: this.timeout,
       }),
     ]

--- a/packages/client/test/net/protocol/ethprotocol.spec.ts
+++ b/packages/client/test/net/protocol/ethprotocol.spec.ts
@@ -38,7 +38,7 @@ tape('[EthProtocol]', (t) => {
       get: () => {
         return {
           td: new BN(100),
-          latest: { hash: () => '0xaa' },
+          latest: { hash: () => '0xaa', header: { number: new BN(10) } },
         }
       },
     })
@@ -54,6 +54,7 @@ tape('[EthProtocol]', (t) => {
         td: Buffer.from('64', 'hex'),
         bestHash: '0xaa',
         genesisHash: '0xbb',
+        latestBlock: Buffer.from('0A', 'hex'),
       },
       'encode status'
     )

--- a/packages/client/test/net/protocol/lesprotocol.spec.ts
+++ b/packages/client/test/net/protocol/lesprotocol.spec.ts
@@ -70,10 +70,13 @@ tape('[LesProtocol]', (t) => {
         status.headHash === '0xaa' &&
         status.headNum.toString('hex') === '64' &&
         status.genesisHash === '0xbb' &&
+        status.forkID[0].toString('hex') === 'fc64ec04' &&
+        status.forkID[1].toString('hex') === '118c30' &&
+        status.recentTxLookup.toString('hex') === '01' &&
         status.serveHeaders === 1 &&
         status.serveChainSince === 0 &&
         status.serveStateSince === 0 &&
-        status.txRelay === 1 &&
+        //status.txRelay === 1 && TODO: uncomment with client tx pool functionality
         status['flowControl/BL'].toString('hex') === '03e8' &&
         status['flowControl/MRR'].toString('hex') === '0a' &&
         status['flowControl/MRC'][0].toString() === '2,10,10',
@@ -87,10 +90,13 @@ tape('[LesProtocol]', (t) => {
         status.headHash === '0xaa' &&
         status.headNum.toNumber() === 100 &&
         status.genesisHash === '0xbb' &&
+        status.forkID[0].toString('hex') === 'fc64ec04' &&
+        status.forkID[1].toString('hex') === '118c30' &&
+        status.recentTxLookup.toString('hex') === '01' &&
         status.serveHeaders === true &&
         status.serveChainSince === 0 &&
         status.serveStateSince === 0 &&
-        status.txRelay === true &&
+        //status.txRelay === true && TODO: uncomment with client tx pool functionality
         status.bl === 1000 &&
         status.mrr === 10 &&
         status.mrc['2'].base === 10 &&

--- a/packages/devp2p/test/integration/les-simulator.ts
+++ b/packages/devp2p/test/integration/les-simulator.ts
@@ -9,7 +9,7 @@ const GENESIS_HASH = Buffer.from(
   'hex'
 )
 
-const capabilities = [devp2p.LES.les2]
+const capabilities = [devp2p.LES.les4]
 
 const status = {
   headTd: devp2p.int2buffer(GENESIS_TD), // total difficulty in genesis block
@@ -84,7 +84,7 @@ test('LES: send valid message', async (t) => {
   opts.status0 = Object.assign({}, status)
   opts.status1 = Object.assign({}, status)
   opts.onOnceStatus0 = function (rlpxs: any, les: any) {
-    t.equal(les.getVersion(), 2, 'should use les2 as protocol version')
+    t.equal(les.getVersion(), 4, 'should use les4 as protocol version')
     les.sendMessage(devp2p.LES.MESSAGE_CODES.GET_BLOCK_HEADERS, [1, [437000, 1, 0, 0]])
     t.pass('should send GET_BLOCK_HEADERS message')
   }


### PR DESCRIPTION
This PR fixes `devp2p/examples/peer-communication-les.ts` by upgrading to les v4.

Sample run:

```
➜  examples git:(les-v4) ✗ ts-node peer-communication-les.ts
Add peer: 52.169.42.101:30303 Geth/v1.10.2-unstable-aab35600-20210322/linux-amd64/go1.16.2 (les4) (total: 1)
Add peer: 159.89.28.211:30303 Geth/v1.10.5-unstable-10eb654f-20210623/linux-amd64/go1.16.5 (les4) (total: 2)
----------------------------------------------------------------------------------------------------------
block 8845079 received: 0a3040af08dc247ad9e4290285360b9af0d58b8363c8cd1f0e0832bb2f98630a (from 52.169.42.101:30303)
----------------------------------------------------------------------------------------------------------
----------------------------------------------------------------------------------------------------------
block 8845079 received: 0a3040af08dc247ad9e4290285360b9af0d58b8363c8cd1f0e0832bb2f98630a (from 159.89.28.211:30303)
----------------------------------------------------------------------------------------------------------
```

WIP, now working on adding to the client to start light sync from genesis block.

Current challenge is finding LES peers that don't disconnect with `TOO_MANY_PEERS` (happening for me on ropsten/rinkeby/goerli). When trying the rinkeby bootstrap nodes (which the devp2p example above successfully works), getting a consistent but weird error from both peers `CLIENT_QUITTING`:

```
  devp2p:les Send GET_BLOCK_HEADERS message to 159.89.28.211:30303: c601c401328080 +1s
  devp2p:les Send GET_BLOCK_HEADERS message to 52.169.42.101:30303: c602c433328080 +1ms
  devp2p:rlpx:peer Received header 52.169.42.101:30303 +327ms
  devp2p:rlpx:peer Received body 52.169.42.101:30303 01c108 +0ms
  devp2p:rlpx:peer Received DISCONNECT (message code: 1 - 0 = 1) 52.169.42.101:30303 +0ms
  devp2p:rlpx:peer DISCONNECT reason: CLIENT_QUITTING 52.169.42.101:30303 +0ms
  devp2p:rlpx Restart connection refill .. with selector 0 peers: 1, queue size: 0, open slots: 24 +1ms
  devp2p:rlpx 52.169.42.101:30303 disconnect, reason: CLIENT_QUITTING +0ms
  devp2p:rlpx:peer Received header 159.89.28.211:30303 +82ms
  devp2p:rlpx:peer Received body 159.89.28.211:30303 01c108 +0ms
  devp2p:rlpx:peer Received DISCONNECT (message code: 1 - 0 = 1) 159.89.28.211:30303 +1ms
  devp2p:rlpx:peer DISCONNECT reason: CLIENT_QUITTING 159.89.28.211:30303 +0ms
  devp2p:rlpx 159.89.28.211:30303 disconnect, reason: CLIENT_QUITTING +0ms
```