### PR TITLE
blockbuilder: allow customizable baseFeePerGas

### DIFF
--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+- BlockBuilder: allow customizable baseFeePerGas, PR [#1326](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1326)
+
 ## 5.4.1 - 2021-06-11
 
 This release comes with some additional `EIP-1559` checks and functionality:

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -72,7 +72,7 @@ export class BlockBuilder {
       gasLimit: opts.headerData?.gasLimit ?? opts.parentBlock.header.gasLimit,
     }
 
-    if (this.vm._common.isActivatedEIP(1559)) {
+    if (this.vm._common.isActivatedEIP(1559) && this.headerData.baseFeePerGas === undefined) {
       this.headerData.baseFeePerGas = opts.parentBlock.header.calcNextBaseFee()
     }
   }


### PR DESCRIPTION
This PR allows the blockbuilder to set a customizable `baseFeePerGas` if set in the `headerData`.

This was requested by hardhat to let users manipulate the base fee to test e.g. varying edge cases.