### PR TITLE
VM: New Release v5.4.2

### DIFF
--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.4.2 - 2021-07-06
+
+- BlockBuilder: allow customizable baseFeePerGas, PR [#1326](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1326)
+
 ## 5.4.1 - 2021-06-11
 
 This release comes with some additional `EIP-1559` checks and functionality:

--- a/packages/vm/lib/buildBlock.ts
+++ b/packages/vm/lib/buildBlock.ts
@@ -72,7 +72,7 @@ export class BlockBuilder {
       gasLimit: opts.headerData?.gasLimit ?? opts.parentBlock.header.gasLimit,
     }
 
-    if (this.vm._common.isActivatedEIP(1559)) {
+    if (this.vm._common.isActivatedEIP(1559) && this.headerData.baseFeePerGas === undefined) {
       this.headerData.baseFeePerGas = opts.parentBlock.header.calcNextBaseFee()
     }
   }


### PR DESCRIPTION
This is for a time critical in-between VM release requested by Hardhat (@alcuadrado @@fvictorio) since #1327 is taking more time than anticipated. Single change is the "allow customizable baseFeePerGas" change in the block builder from 487b472 (#1326).

PR is not for merge. I branched of 26de933 (merge commit from the latest releases PR #1295) and re-added this one small change manually and added release notes.

Instead this is just to check if CI passes. If it does I will do the release locally, then close here and adopt the CHANGELOG from the upcoming releases in #1327 accordingly.