### PR TITLE
VM: New Release v5.4.2

### DIFF
--- a/packages/blockchain/src/db/manager.ts
+++ b/packages/blockchain/src/db/manager.ts
@@ -8,12 +8,12 @@ import {
   BlockBodyBuffer,
 } from '@ethereumjs/block'
 import Common from '@ethereumjs/common'
+import { CliqueLatestSignerStates, CliqueLatestVotes, CliqueLatestBlockSigners } from '../clique'
 import Cache from './cache'
 import { DatabaseKey, DBOp, DBTarget, DBOpData } from './operation'
 
+// eslint-disable-next-line implicit-dependencies/no-implicit
 import type { LevelUp } from 'levelup'
-import { CliqueLatestSignerStates, CliqueLatestVotes, CliqueLatestBlockSigners } from '../clique'
-
 const level = require('level-mem')
 
 /**

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -20,6 +20,7 @@ import {
 
 const debug = createDebugLogger('blockchain:clique')
 
+// eslint-disable-next-line implicit-dependencies/no-implicit
 import type { LevelUp } from 'levelup'
 const level = require('level-mem')
 

--- a/packages/client/lib/blockchain/chain.ts
+++ b/packages/client/lib/blockchain/chain.ts
@@ -2,8 +2,9 @@ import { EventEmitter } from 'events'
 import { Block, BlockHeader } from '@ethereumjs/block'
 import Blockchain from '@ethereumjs/blockchain'
 import { BN, toBuffer } from 'ethereumjs-util'
-import type { LevelUp } from 'levelup'
 import { Config } from '../config'
+// eslint-disable-next-line implicit-dependencies/no-implicit
+import type { LevelUp } from 'levelup'
 
 /**
  * The options that the Blockchain constructor can receive.

--- a/packages/client/lib/client.ts
+++ b/packages/client/lib/client.ts
@@ -1,8 +1,9 @@
 import events from 'events'
-import { LevelUp } from 'levelup'
 import { MultiaddrLike } from './types'
 import { Config } from './config'
 import { FullEthereumService, LightEthereumService } from './service'
+// eslint-disable-next-line implicit-dependencies/no-implicit
+import type { LevelUp } from 'levelup'
 
 export interface EthereumClientOptions {
   /* Client configuration */

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -5,6 +5,7 @@ import Multiaddr from 'multiaddr'
 import { getLogger, Logger } from './logging'
 import { Libp2pServer, RlpxServer } from './net/server'
 import { parseTransports } from './util'
+// eslint-disable-next-line implicit-dependencies/no-implicit
 import type { LevelUp } from 'levelup'
 const level = require('level')
 

--- a/packages/client/lib/net/server/libp2pserver.ts
+++ b/packages/client/lib/net/server/libp2pserver.ts
@@ -1,4 +1,5 @@
 import PeerId from 'peer-id'
+// eslint-disable-next-line implicit-dependencies/no-implicit
 import crypto from 'libp2p-crypto'
 import multiaddr from 'multiaddr'
 import { Libp2pConnection as Connection } from '../../types'

--- a/packages/client/lib/service/ethereumservice.ts
+++ b/packages/client/lib/service/ethereumservice.ts
@@ -1,8 +1,9 @@
-import { LevelUp } from 'levelup'
 import { FlowControl } from '../net/protocol/flowcontrol'
 import { Chain } from '../blockchain'
 import { Service, ServiceOptions } from './service'
 import { Synchronizer } from '../sync'
+// eslint-disable-next-line implicit-dependencies/no-implicit
+import type { LevelUp } from 'levelup'
 
 export interface EthereumServiceOptions extends ServiceOptions {
   /* Blockchain */

--- a/packages/client/lib/sync/execution/execution.ts
+++ b/packages/client/lib/sync/execution/execution.ts
@@ -1,7 +1,8 @@
 import { EventEmitter } from 'events'
 import { Config } from '../../config'
-import { LevelUp } from 'levelup'
 import { Chain } from '../../blockchain'
+// eslint-disable-next-line implicit-dependencies/no-implicit
+import type { LevelUp } from 'levelup'
 
 export interface ExecutionOptions {
   /* Config */

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -4,7 +4,8 @@ import { Peer } from '../net/peer/peer'
 import { FlowControl } from '../net/protocol'
 import { Config } from '../config'
 import { Chain } from '../blockchain'
-import { LevelUp } from 'levelup'
+// eslint-disable-next-line implicit-dependencies/no-implicit
+import type { LevelUp } from 'levelup'
 
 export interface SynchronizerOptions {
   /* Config */

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -81,6 +81,7 @@
     "nyc": "^14.0.0",
     "prettier": "^2.0.5",
     "tape": "^4.10.1",
+    "testdouble": "^3.8.2",
     "ts-node": "^8.8.2",
     "typedoc": "^0.20.34",
     "typedoc-plugin-markdown": "^3.6.0",

--- a/packages/ethash/src/index.ts
+++ b/packages/ethash/src/index.ts
@@ -9,6 +9,7 @@ import {
   getFullSize,
   getSeed,
 } from './util'
+// eslint-disable-next-line implicit-dependencies/no-implicit
 import type { LevelUp } from 'levelup'
 import type { Block, BlockHeader } from '@ethereumjs/block'
 const xor = require('buffer-xor')

--- a/packages/trie/src/baseTrie.ts
+++ b/packages/trie/src/baseTrie.ts
@@ -1,5 +1,4 @@
 import Semaphore from 'semaphore-async-await'
-import { LevelUp } from 'levelup'
 import { keccak, KECCAK256_RLP } from 'ethereumjs-util'
 import { DB, BatchDBOp, PutBatch } from './db'
 import { TrieReadStream as ReadStream } from './readStream'
@@ -16,6 +15,8 @@ import {
   EmbeddedNode,
   Nibbles,
 } from './trieNode'
+// eslint-disable-next-line implicit-dependencies/no-implicit
+import type { LevelUp } from 'levelup'
 const assert = require('assert')
 
 export type Proof = Buffer[]

--- a/packages/trie/src/checkpointDb.ts
+++ b/packages/trie/src/checkpointDb.ts
@@ -1,5 +1,6 @@
-import { LevelUp } from 'levelup'
 import { DB, BatchDBOp, ENCODING_OPTS } from './db'
+// eslint-disable-next-line implicit-dependencies/no-implicit
+import type { LevelUp } from 'levelup'
 
 export type Checkpoint = {
   // We cannot use a Buffer => Buffer map directly. If you create two Buffers with the same internal value,

--- a/packages/trie/src/db.ts
+++ b/packages/trie/src/db.ts
@@ -1,4 +1,5 @@
-import { LevelUp } from 'levelup'
+// eslint-disable-next-line implicit-dependencies/no-implicit
+import type { LevelUp } from 'levelup'
 const level = require('level-mem')
 
 export const ENCODING_OPTS = { keyEncoding: 'binary', valueEncoding: 'binary' }

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.4.2 - 2021-07-06
+
+- BlockBuilder: allow customizable baseFeePerGas, PR [#1326](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1326)
+
 ## 5.4.1 - 2021-06-11
 
 This release comes with some additional `EIP-1559` checks and functionality:

--- a/packages/vm/lib/buildBlock.ts
+++ b/packages/vm/lib/buildBlock.ts
@@ -72,7 +72,7 @@ export class BlockBuilder {
       gasLimit: opts.headerData?.gasLimit ?? opts.parentBlock.header.gasLimit,
     }
 
-    if (this.vm._common.isActivatedEIP(1559)) {
+    if (this.vm._common.isActivatedEIP(1559) && this.headerData.baseFeePerGas === undefined) {
       this.headerData.baseFeePerGas = opts.parentBlock.header.calcNextBaseFee()
     }
   }


### PR DESCRIPTION
This is for a time critical in-between VM release requested by Hardhat (@alcuadrado @@fvictorio) since #1327 is taking more time than anticipated. Single change is the "allow customizable baseFeePerGas" change in the block builder from 487b472 (#1326).

PR is not for merge. I branched of 26de933 (merge commit from the latest releases PR #1295) and re-added this one small change manually and added release notes.

Instead this is just to check if CI passes. If it does I will do the release locally, then close here and adopt the CHANGELOG from the upcoming releases in #1327 accordingly.

Replaces #1332 