### PR TITLE
block: Add fix for kovan nonce

### DIFF
--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -301,6 +301,7 @@ export class BlockHeader {
    */
   _validateHeaderFields() {
     const { parentHash, stateRoot, transactionsTrie, receiptTrie, mixHash, nonce } = this
+
     if (parentHash.length !== 32) {
       throw new Error(`parentHash must be 32 bytes, received ${parentHash.length} bytes`)
     }
@@ -320,7 +321,14 @@ export class BlockHeader {
     }
 
     if (nonce.length !== 8) {
-      throw new Error(`nonce must be 8 bytes, received ${nonce.length} bytes`)
+      // Hack to check for Kovan due to non-standard nonce length (65 bytes)
+      if (this._common.networkIdBN().eqn(42)) {
+        if (nonce.length !== 65) {
+          throw new Error(`nonce must be 65 bytes on kovan, received ${nonce.length} bytes`)
+        }
+      } else {
+        throw new Error(`nonce must be 8 bytes, received ${nonce.length} bytes`)
+      }
     }
   }
 


### PR DESCRIPTION
The Kovan block nonce is a hex string of 65 0s and our `block` package expects a nonce of 8 bytes in length so trying to sync Kovan with the `client` results in an error.  
```
INFO [07-06|11:00:47] Connecting to network: kovan
ERROR [07-06|11:00:47] Error: nonce must be 8 bytes, received 65 bytes
    at BlockHeader._validateHeaderFields (/home/jim/development/ethereumjs-monorepo/packages/block/src/header.ts:323:13)
    at new BlockHeader (/home/jim/development/ethereumjs-monorepo/packages/block/src/header.ts:267:10)
    at Function.fromHeaderData (/home/jim/development/ethereumjs-monorepo/packages/block/src/header.ts:77:12)
    at Function.fromBlockData (/home/jim/development/ethereumjs-monorepo/packages/block/src/block.ts:36:32)
    at Function.genesis (/home/jim/development/ethereumjs-monorepo/packages/block/src/block.ts:131:18)
    at Blockchain._init (/home/jim/development/ethereumjs-monorepo/packages/blockchain/src/index.ts:327:28)
    at Blockchain.initAndLock (/home/jim/development/ethereumjs-monorepo/packages/blockchain/src/index.ts:413:5)
    at Blockchain.getLatestHeader (/home/jim/development/ethereumjs-monorepo/packages/blockchain/src/index.ts:776:12)
    at Chain.update (/home/jim/development/ethereumjs-monorepo/packages/client/lib/blockchain/chain.ts:222:22)
    at Chain.open (/home/jim/development/ethereumjs-monorepo/packages/client/lib/blockchain/chain.ts:186:5)
```
Adds hack to `_validateHeaderData` for Kovan genesis nonce so that client can try to start syncing Kovan testnet.  

What does the team think?  Do we need to support Kovan in the client?