### PR TITLE
common: remove dao hardfork from chains when not applied

### DIFF
--- a/packages/common/src/chains/calaveras.json
+++ b/packages/common/src/chains/calaveras.json
@@ -34,11 +34,6 @@
         "forkHash": "0xe34c4aff"
       },
       {
-        "name": "dao",
-        "block": null,
-        "forkHash": "0xe34c4aff"
-      },
-      {
         "name": "tangerineWhistle",
         "block": 0,
         "forkHash": "0xe34c4aff"

--- a/packages/common/src/chains/goerli.json
+++ b/packages/common/src/chains/goerli.json
@@ -34,11 +34,6 @@
       "forkHash": "0xa3f5ab08"
     },
     {
-      "name": "dao",
-      "block": null,
-      "forkHash": "0xa3f5ab08"
-    },
-    {
       "name": "tangerineWhistle",
       "block": 0,
       "forkHash": "0xa3f5ab08"

--- a/packages/common/src/chains/kovan.json
+++ b/packages/common/src/chains/kovan.json
@@ -31,11 +31,6 @@
       "forkHash": "0x010ffe56"
     },
     {
-      "name": "dao",
-      "block": null,
-      "forkHash": "0x010ffe56"
-    },
-    {
       "name": "tangerineWhistle",
       "block": 0,
       "forkHash": "0x010ffe56"

--- a/packages/common/src/chains/rinkeby.json
+++ b/packages/common/src/chains/rinkeby.json
@@ -34,11 +34,6 @@
       "forkHash": "0x60949295"
     },
     {
-      "name": "dao",
-      "block": null,
-      "forkHash": null
-    },
-    {
       "name": "tangerineWhistle",
       "block": 2,
       "forkHash": "0x8bde40dd"

--- a/packages/common/src/chains/ropsten.json
+++ b/packages/common/src/chains/ropsten.json
@@ -31,11 +31,6 @@
       "forkHash": "0x30c7ddbc"
     },
     {
-      "name": "dao",
-      "block": null,
-      "forkHash": null
-    },
-    {
       "name": "tangerineWhistle",
       "block": 0,
       "forkHash": "0x30c7ddbc"

--- a/packages/common/tests/chains.spec.ts
+++ b/packages/common/tests/chains.spec.ts
@@ -111,7 +111,7 @@ tape('[Common/Chains]: Initialization / Chain params', function (t: tape.Test) {
     c = new Common({ chain: 'rinkeby' })
     hash = '0x6341fd3daf94b748c72ced5a5b26028f2474f5f00d824504e4fa37a75767e177'
     st.equal(c.genesis().hash, hash, 'should return correct genesis hash')
-    st.equal(c.hardforks()[3]['block'], 2, 'should return correct hardfork data')
+    st.equal(c.hardforks()[3]['block'], 3, 'should return correct hardfork data')
     st.equal(typeof c.bootstrapNodes()[0].port, 'number', 'should return a port as number')
     st.equal(c.consensusType(), 'poa', 'should return correct consensus type')
     st.equal(c.consensusAlgorithm(), 'clique', 'should return correct consensus algorithm')

--- a/packages/common/tests/hardforks.spec.ts
+++ b/packages/common/tests/hardforks.spec.ts
@@ -354,9 +354,9 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     msg = 'should provide correct forkHash for HF provided'
     st.equal(c.forkHash('spuriousDragon'), '0x3edd5b10', msg)
 
-    c = new Common({ chain: 'ropsten' })
+    c = new Common({ chain: 'kovan' })
     const f = () => {
-      c.forkHash('dao')
+      c.forkHash('london')
     }
     msg = 'should throw when called on non-applied or future HF'
     st.throws(f, /No fork hash calculation possible/, msg)


### PR DESCRIPTION
Per the comment here https://github.com/ethereumjs/ethereumjs-monorepo/pull/1329#issuecomment-872002349, this PR cleans up the "type 1" `null` HFs (i.e. the `dao` HF) when not applied to a particular chain.

Please note the change in `hardforks.spec.ts` still provides a valid test as long as `london` remains unimplemented for `kovan`. If and when `kovan` gets the London HF, that test will fail.