### PR TITLE
Chain & HF enum usage

### DIFF
--- a/packages/block/README.md
+++ b/packages/block/README.md
@@ -63,8 +63,8 @@ To instantiate an EIP-1559 block the hardfork parameter on the `Common` instance
 
 ```typescript
 import { Block } from 'ethereumjs-block'
-import Common from '@ethereumjs/common'
-const common = new Common({ chain: 'mainnet', hardfork: 'london' })
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
 const block = Block.fromBlockData({
   header: {
     //...,
@@ -85,8 +85,8 @@ An Ethash/PoW block can be instantiated as follows:
 
 ```typescript
 import { Block } from '@ethereumjs/block'
-import Common from '@ethereumjs/common'
-const common = new Common({ chain: 'mainnet' })
+import Common, { Chain } from '@ethereumjs/common'
+const common = new Common({ chain: Chain.Mainnet })
 console.log(common.consensusType()) // 'pow'
 console.log(common.consensusAlgorithm()) // 'ethash'
 const block = Block.fromBlockData({}, { common })
@@ -102,8 +102,8 @@ A clique block can be instantiated as follows:
 
 ```typescript
 import { Block } from '@ethereumjs/block'
-import Common from '@ethereumjs/common'
-const common = new Common({ chain: 'goerli' })
+import Common, { Chain } from '@ethereumjs/common'
+const common = new Common({ chain: Chain.Goerli })
 console.log(common.consensusType()) // 'poa'
 console.log(common.consensusAlgorithm()) // 'clique'
 const block = Block.fromBlockData({}, { common })

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -1,4 +1,4 @@
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import {
   Address,
   BN,
@@ -202,9 +202,9 @@ export class BlockHeader {
     if (options.common) {
       this._common = options.common.copy()
     } else {
-      const chain = 'mainnet' // default
+      const chain = Chain.Mainnet // default
       if (options.initWithGenesisHeader) {
-        this._common = new Common({ chain, hardfork: 'chainstart' })
+        this._common = new Common({ chain, hardfork: Hardfork.Chainstart })
       } else {
         // This initializes on the Common default hardfork
         this._common = new Common({ chain })

--- a/packages/block/test/block.spec.ts
+++ b/packages/block/test/block.spec.ts
@@ -469,7 +469,7 @@ tape('[Block]: block functions', function (t) {
       const blockchain = new Mockchain()
 
       const common = new Common({ chain: Chain.Mainnet })
-      common.setHardfork('berlin')
+      common.setHardfork(Hardfork.Berlin)
 
       const mainnetForkBlock = common.hardforkBlockBN('london')
       const rootBlock = Block.fromBlockData({
@@ -491,7 +491,7 @@ tape('[Block]: block functions', function (t) {
         common
       )
       await blockchain.putBlock(preForkBlock)
-      common.setHardfork('london')
+      common.setHardfork(Hardfork.London)
       const forkBlock = createBlock(preForkBlock, 'forkBlock', [], common)
       await blockchain.putBlock(forkBlock)
       const uncleFork = createBlock(forkBlock, 'uncleFork', [], common)

--- a/packages/block/test/block.spec.ts
+++ b/packages/block/test/block.spec.ts
@@ -63,7 +63,7 @@ tape('[Block]: block functions', function (t) {
 
   t.test('should initialize with null parameters without throwing', function (st) {
     st.doesNotThrow(function () {
-      const common = new Common({ chain: 'ropsten' })
+      const common = new Common({ chain: Chain.Ropsten })
       const opts = { common }
       Block.fromBlockData({}, opts)
       st.end()
@@ -72,7 +72,7 @@ tape('[Block]: block functions', function (t) {
   t.test(
     'should throw when trying to initialize with uncle headers on a PoA network',
     function (st) {
-      const common = new Common({ chain: 'rinkeby' })
+      const common = new Common({ chain: Chain.Rinkeby })
       const uncleBlock = Block.fromBlockData(
         { header: { extraData: Buffer.alloc(117) } },
         { common }
@@ -100,7 +100,7 @@ tape('[Block]: block functions', function (t) {
   })
 
   t.test('should test block validation on poa chain', async function (st) {
-    const common = new Common({ chain: 'goerli', hardfork: 'chainstart' })
+    const common = new Common({ chain: Chain.Goerli, hardfork: Hardfork.Chainstart })
     const blockchain = new Mockchain()
     const block = blockFromRpc(testDataFromRpcGoerli, [], { common })
 
@@ -158,7 +158,7 @@ tape('[Block]: block functions', function (t) {
   })
 
   t.test('should test transaction validation with legacy tx in london', async function (st) {
-    const common = new Common({ chain: 'goerli', hardfork: 'london' })
+    const common = new Common({ chain: Chain.Goerli, hardfork: Hardfork.London })
     const blockRlp = testData.blocks[0].rlp
     const block = Block.fromRLPSerializedBlock(blockRlp, { common, freeze: false })
     await testTransactionValidation(st, block)
@@ -449,7 +449,7 @@ tape('[Block]: block functions', function (t) {
   })
 
   t.test('should test isGenesis (ropsten)', function (st) {
-    const common = new Common({ chain: 'ropsten' })
+    const common = new Common({ chain: Chain.Ropsten })
     const block = Block.fromBlockData({ header: { number: 1 } }, { common })
     st.notEqual(block.isGenesis(), true)
     const genesisBlock = Block.fromBlockData({ header: { number: 0 } }, { common })
@@ -471,7 +471,7 @@ tape('[Block]: block functions', function (t) {
   })
 
   t.test('should test genesis hashes (ropsten)', function (st) {
-    const common = new Common({ chain: 'ropsten', hardfork: 'chainstart' })
+    const common = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Chainstart })
     const genesis = Block.genesis({}, { common })
     st.strictEqual(
       genesis.hash().toString('hex'),
@@ -482,7 +482,7 @@ tape('[Block]: block functions', function (t) {
   })
 
   t.test('should test genesis hashes (rinkeby)', function (st) {
-    const common = new Common({ chain: 'rinkeby', hardfork: 'chainstart' })
+    const common = new Common({ chain: Chain.Rinkeby, hardfork: Hardfork.Chainstart })
     const genesis = Block.genesis({}, { common })
     st.strictEqual(
       genesis.hash().toString('hex'),
@@ -493,7 +493,7 @@ tape('[Block]: block functions', function (t) {
   })
 
   t.test('should test genesis parameters (ropsten)', function (st) {
-    const common = new Common({ chain: 'ropsten', hardfork: 'chainstart' })
+    const common = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Chainstart })
     const genesis = Block.genesis({}, { common })
     const ropstenStateRoot = '217b0bbcfb72e2d57e28f33cb361b9983513177755dc3f33ce3e7022ed62b77b'
     st.strictEqual(
@@ -532,7 +532,7 @@ tape('[Block]: block functions', function (t) {
     // Set block number from test block to mainnet DAO fork block 1920000
     blockData[0][8] = Buffer.from('1D4C00', 'hex')
 
-    const common = new Common({ chain: 'mainnet', hardfork: 'dao' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Dao })
     st.throws(
       function () {
         Block.fromValuesArray(blockData, { common })
@@ -553,7 +553,7 @@ tape('[Block]: block functions', function (t) {
   t.test(
     'should set canonical difficulty if I provide a calcDifficultyFromHeader header',
     function (st) {
-      const common = new Common({ chain: 'mainnet', hardfork: 'chainstart' })
+      const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
       const genesis = Block.genesis({}, { common })
 
       const nextBlockHeaderData = {

--- a/packages/block/test/clique.spec.ts
+++ b/packages/block/test/clique.spec.ts
@@ -1,10 +1,10 @@
 import tape from 'tape'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { BlockHeader } from '../src/header'
 import { Address } from 'ethereumjs-util'
 
 tape('[Header]: Clique PoA Functionality', function (t) {
-  const common = new Common({ chain: 'rinkeby', hardfork: 'chainstart' })
+  const common = new Common({ chain: Chain.Rinkeby, hardfork: Hardfork.Chainstart })
 
   t.test('Header Data', function (st) {
     let header = BlockHeader.fromHeaderData({ number: 1 })

--- a/packages/block/test/difficulty.spec.ts
+++ b/packages/block/test/difficulty.spec.ts
@@ -1,6 +1,6 @@
 import tape from 'tape'
 import { BN, toBuffer, bufferToInt } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 import { Block } from '../src'
 
 function isHexPrefixed(str: string) {
@@ -42,7 +42,7 @@ tape('[Header]: difficulty tests', (t) => {
     /* eslint-disable-next-line no-restricted-syntax */
     for (const testName in testData) {
       const test = testData[testName]
-      const common = new Common({ chain: 'mainnet', hardfork: hardfork })
+      const common = new Common({ chain: Chain.Mainnet, hardfork: hardfork })
       const parentBlock = Block.fromBlockData(
         {
           header: {

--- a/packages/block/test/eip1559block.spec.ts
+++ b/packages/block/test/eip1559block.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { BlockHeader } from '../src/header'
 import { BN } from 'ethereumjs-util'
 import { Mockchain } from './mockchain'
@@ -12,8 +12,8 @@ const eip1559BaseFee = require('./testdata/eip1559baseFee.json')
 
 const common = new Common({
   eips: [1559],
-  chain: 'mainnet',
-  hardfork: 'london',
+  chain: Chain.Mainnet,
+  hardfork: Hardfork.London,
 })
 
 const blockchain1 = new Mockchain()
@@ -42,7 +42,7 @@ tape('EIP1559 tests', function (t) {
 
   t.test('Header -> Initialization', async function (st) {
     try {
-      const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+      const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
       BlockHeader.fromHeaderData(
         {
           number: new BN(1),

--- a/packages/block/test/from-rpc.spec.ts
+++ b/packages/block/test/from-rpc.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { Transaction } from '@ethereumjs/tx'
 import blockFromRpc from '../src/from-rpc'
 import blockHeaderFromRpc from '../src/header-from-rpc'
@@ -79,7 +79,7 @@ tape('[fromRPC]:', function (t) {
   )
 
   t.test('should create a block from london hardfork', function (st) {
-    const common = new Common({ chain: 'goerli', hardfork: 'london' })
+    const common = new Common({ chain: Chain.Goerli, hardfork: Hardfork.London })
     const block = blockFromRpc(testDataFromRpcGoerliLondon, [], { common })
     st.equal(
       `0x${block.header.baseFeePerGas?.toString(16)}`,

--- a/packages/block/test/header.spec.ts
+++ b/packages/block/test/header.spec.ts
@@ -1,6 +1,6 @@
 import tape from 'tape'
 import { Address, BN, zeros, KECCAK256_RLP, KECCAK256_RLP_ARRAY, rlp } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { BlockHeader } from '../src/header'
 import { Block } from '../src'
 import { Mockchain } from './mockchain'
@@ -39,7 +39,7 @@ tape('[Block]: Header functions', function (t) {
   })
 
   t.test('Initialization -> fromHeaderData()', function (st) {
-    const common = new Common({ chain: 'ropsten', hardfork: 'chainstart' })
+    const common = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Chainstart })
     let header = BlockHeader.genesis(undefined, { common })
     st.ok(header.hash().toString('hex'), 'genesis block should initialize')
     st.equal(header._common.hardfork(), 'chainstart', 'should initialize with correct HF provided')
@@ -140,7 +140,7 @@ tape('[Block]: Header functions', function (t) {
   })
 
   t.test('Initialization -> Clique Blocks', function (st) {
-    const common = new Common({ chain: 'rinkeby', hardfork: 'chainstart' })
+    const common = new Common({ chain: Chain.Rinkeby, hardfork: Hardfork.Chainstart })
     let header = BlockHeader.genesis(undefined, { common })
     st.ok(header.hash().toString('hex'), 'genesis block should initialize')
 
@@ -153,7 +153,7 @@ tape('[Block]: Header functions', function (t) {
   t.test('should validate extraData', async function (st) {
     // PoW
     let blockchain = new Mockchain()
-    let common = new Common({ chain: 'mainnet', hardfork: 'chainstart' })
+    let common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
     let genesis = Block.genesis({}, { common })
     await blockchain.putBlock(genesis)
 
@@ -199,7 +199,7 @@ tape('[Block]: Header functions', function (t) {
 
     // PoA
     blockchain = new Mockchain()
-    common = new Common({ chain: 'rinkeby', hardfork: 'chainstart' })
+    common = new Common({ chain: Chain.Rinkeby, hardfork: Hardfork.Chainstart })
     genesis = Block.genesis({}, { common })
     await blockchain.putBlock(genesis)
 
@@ -264,7 +264,7 @@ tape('[Block]: Header functions', function (t) {
   t.test('header validation -> poa checks', async function (st) {
     const headerData = testData.blocks[0].blockHeader
 
-    const common = new Common({ chain: 'goerli' })
+    const common = new Common({ chain: Chain.Goerli })
     const blockchain = new Mockchain()
 
     const block = Block.fromRLPSerializedBlock(testData.genesisRLP, { common })
@@ -408,7 +408,7 @@ tape('[Block]: Header functions', function (t) {
   })
 
   t.test('should test genesis parameters (ropsten)', function (st) {
-    const common = new Common({ chain: 'ropsten', hardfork: 'chainstart' })
+    const common = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Chainstart })
     const genesis = BlockHeader.genesis({}, { common })
     const ropstenStateRoot = '217b0bbcfb72e2d57e28f33cb361b9983513177755dc3f33ce3e7022ed62b77b'
     st.strictEqual(genesis.stateRoot.toString('hex'), ropstenStateRoot, 'genesis stateRoot match')
@@ -416,7 +416,7 @@ tape('[Block]: Header functions', function (t) {
   })
 
   t.test('should test hash() function', function (st) {
-    let common = new Common({ chain: 'mainnet', hardfork: 'chainstart' })
+    let common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
     let header = BlockHeader.fromHeaderData(blocksMainnet[0]['header'], { common })
     st.equal(
       header.hash().toString('hex'),
@@ -424,7 +424,7 @@ tape('[Block]: Header functions', function (t) {
       'correct PoW hash (mainnet block 1)'
     )
 
-    common = new Common({ chain: 'goerli', hardfork: 'chainstart' })
+    common = new Common({ chain: Chain.Goerli, hardfork: Hardfork.Chainstart })
     header = BlockHeader.fromHeaderData(blocksGoerli[0]['header'], { common })
     st.equal(
       header.hash().toString('hex'),

--- a/packages/block/test/header.spec.ts
+++ b/packages/block/test/header.spec.ts
@@ -44,7 +44,7 @@ tape('[Block]: Header functions', function (t) {
     st.ok(header.hash().toString('hex'), 'genesis block should initialize')
     st.equal(header._common.hardfork(), 'chainstart', 'should initialize with correct HF provided')
 
-    common.setHardfork('byzantium')
+    common.setHardfork(Hardfork.Byzantium)
     st.equal(
       header._common.hardfork(),
       'chainstart',

--- a/packages/block/test/util.ts
+++ b/packages/block/test/util.ts
@@ -1,4 +1,4 @@
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 import { BN, rlp, keccak256 } from 'ethereumjs-util'
 import { Block, BlockHeader } from '../src'
 
@@ -15,7 +15,7 @@ function createBlock(
   common?: Common
 ): Block {
   uncles = uncles ?? []
-  common = common ?? new Common({ chain: 'mainnet' })
+  common = common ?? new Common({ chain: Chain.Mainnet })
 
   if (extraData.length > 32) {
     throw new Error('extra data graffiti must be 32 bytes or less')

--- a/packages/blockchain/README.md
+++ b/packages/blockchain/README.md
@@ -25,12 +25,13 @@ This module performs write operations. Making a backup of your data before tryin
 
 ```typescript
 import Blockchain from '@ethereumjs/blockchain'
+import Common, { Chain } from '@ethereumjs/common'
 
 const level = require('level')
 
 const gethDbPath = './chaindata' // Add your own path here. It will get modified, see remarks.
 
-const common = new Common({ chain: 'ropsten' })
+const common = new Common({ chain: Chain.Ropsten })
 const db = level(gethDbPath)
 // Use the safe static constructor which awaits the init method
 const blockchain = Blockchain.create({ common, db })

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -324,7 +324,7 @@ export default class Blockchain implements BlockchainInterface {
 
     if (!genesisBlock) {
       const common = this._common.copy()
-      common.setHardfork('chainstart')
+      common.setHardfork(Hardfork.Chainstart)
       genesisBlock = Block.genesis({}, { common })
     }
 

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -3,7 +3,7 @@ import Semaphore from 'semaphore-async-await'
 import { Address, BN, rlp } from 'ethereumjs-util'
 import { Block, BlockData, BlockHeader } from '@ethereumjs/block'
 import Ethash from '@ethereumjs/ethash'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { DBManager } from './db/manager'
 import { DBOp, DBSetBlockOrHeader, DBSetTD, DBSetHashToNumber, DBSaveLookups } from './db/helpers'
 import { DBTarget } from './db/operation'
@@ -248,8 +248,8 @@ export default class Blockchain implements BlockchainInterface {
     if (opts.common) {
       this._common = opts.common
     } else {
-      const DEFAULT_CHAIN = 'mainnet'
-      const DEFAULT_HARDFORK = 'chainstart'
+      const DEFAULT_CHAIN = Chain.Mainnet
+      const DEFAULT_HARDFORK = Hardfork.Chainstart
       this._common = new Common({
         chain: DEFAULT_CHAIN,
         hardfork: DEFAULT_HARDFORK,

--- a/packages/blockchain/test/clique.spec.ts
+++ b/packages/blockchain/test/clique.spec.ts
@@ -1,5 +1,5 @@
 import { Block } from '@ethereumjs/block'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { Address, BN } from 'ethereumjs-util'
 import tape from 'tape'
 import Blockchain from '../src'
@@ -7,7 +7,7 @@ import { CLIQUE_NONCE_AUTH, CLIQUE_NONCE_DROP } from '../src/clique'
 
 tape('Clique: Initialization', (t) => {
   t.test('should initialize a clique blockchain', async (st) => {
-    const common = new Common({ chain: 'rinkeby', hardfork: 'chainstart' })
+    const common = new Common({ chain: Chain.Rinkeby, hardfork: Hardfork.Chainstart })
     const blockchain = new Blockchain({ common })
 
     const head = await blockchain.getHead()
@@ -21,7 +21,7 @@ tape('Clique: Initialization', (t) => {
     st.end()
   })
 
-  const COMMON = new Common({ chain: 'rinkeby', hardfork: 'chainstart' })
+  const COMMON = new Common({ chain: Chain.Rinkeby, hardfork: Hardfork.Chainstart })
   const EXTRA_DATA = Buffer.alloc(97)
   const GAS_LIMIT = 8000000
 

--- a/packages/blockchain/test/index.spec.ts
+++ b/packages/blockchain/test/index.spec.ts
@@ -1,5 +1,5 @@
 import { BN } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { Block, BlockHeader, BlockOptions } from '@ethereumjs/block'
 import tape from 'tape'
 import Blockchain from '../src'
@@ -20,7 +20,7 @@ tape('blockchain test', (t) => {
   })
 
   t.test('should initialize correctly', async (st) => {
-    const common = new Common({ chain: 'ropsten' })
+    const common = new Common({ chain: Chain.Ropsten })
     let blockchain = new Blockchain({ common })
 
     const head = await blockchain.getHead()
@@ -47,7 +47,7 @@ tape('blockchain test', (t) => {
   })
 
   t.test('should initialize correctly with Blockchain.fromBlocksData()', async (st) => {
-    const common = new Common({ chain: 'mainnet' })
+    const common = new Common({ chain: Chain.Mainnet })
     const blockchain = await Blockchain.fromBlocksData(blocksData, {
       validateBlocks: true,
       validateConsensus: false,
@@ -61,7 +61,7 @@ tape('blockchain test', (t) => {
   })
 
   t.test('should only initialize with supported consensus validation options', (st) => {
-    let common = new Common({ chain: 'mainnet' })
+    let common = new Common({ chain: Chain.Mainnet })
     st.doesNotThrow(() => {
       new Blockchain({ common, validateConsensus: true })
     })
@@ -69,7 +69,7 @@ tape('blockchain test', (t) => {
       new Blockchain({ common, validateBlocks: true })
     })
 
-    common = new Common({ chain: 'goerli' })
+    common = new Common({ chain: Chain.Goerli })
     st.doesNotThrow(() => {
       new Blockchain({ common, validateConsensus: true })
     })
@@ -121,7 +121,7 @@ tape('blockchain test', (t) => {
   t.test('should add 12 blocks, one at a time', async (st) => {
     const blocks: Block[] = []
     const gasLimit = 8000000
-    const common = new Common({ chain: 'ropsten' })
+    const common = new Common({ chain: Chain.Ropsten })
 
     const genesisBlock = Block.genesis({ header: { gasLimit } }, { common })
     blocks.push(genesisBlock)
@@ -532,7 +532,7 @@ tape('blockchain test', (t) => {
 
     await blockchain.putBlocks(blocks.slice(1))
 
-    const common = new Common({ chain: 'mainnet', hardfork: 'chainstart' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
     const headerData = {
       number: 15,
       parentHash: blocks[14].hash(),
@@ -557,7 +557,7 @@ tape('blockchain test', (t) => {
     const { blockchain, blocks, error } = await generateBlockchain(15)
     st.error(error, 'no error')
 
-    const common = new Common({ chain: 'mainnet', hardfork: 'chainstart' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
     const headerData = {
       number: 15,
       parentHash: blocks[14].hash(),
@@ -745,7 +745,7 @@ tape('blockchain test', (t) => {
 
   t.test('should get latest', async (st) => {
     const gasLimit = 8000000
-    const common = new Common({ chain: 'mainnet', hardfork: 'chainstart' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
     const opts: BlockOptions = { common }
 
     const genesisBlock = Block.genesis({ header: { gasLimit } }, opts)
@@ -805,7 +805,7 @@ tape('blockchain test', (t) => {
   })
 
   t.test('mismatched chains', async (st) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'chainstart' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
     const gasLimit = 8000000
 
     const genesisBlock = Block.genesis({ header: { gasLimit } }, { common })
@@ -828,7 +828,7 @@ tape('blockchain test', (t) => {
       genesisBlock,
       Block.fromBlockData(blockData1, { common, calcDifficultyFromHeader: genesisBlock.header }),
       Block.fromBlockData(blockData2, {
-        common: new Common({ chain: 'ropsten', hardfork: 'chainstart' }),
+        common: new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Chainstart }),
         calcDifficultyFromHeader: genesisBlock.header,
       }),
     ]
@@ -860,8 +860,8 @@ tape('blockchain test', (t) => {
 tape('initialization tests', (t) => {
   t.test('should read genesis from database', async (st) => {
     const common = new Common({
-      chain: 'ropsten',
-      hardfork: 'chainstart',
+      chain: Chain.Ropsten,
+      hardfork: Hardfork.Chainstart,
     })
     const genesisHash = Block.genesis({}, { common }).hash()
     const blockchain = new Blockchain({ common })

--- a/packages/blockchain/test/reorg.spec.ts
+++ b/packages/blockchain/test/reorg.spec.ts
@@ -1,4 +1,4 @@
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import { Address, BN } from 'ethereumjs-util'
 import tape from 'tape'
@@ -18,7 +18,7 @@ tape('reorg tests', (t) => {
   t.test(
     'should correctly reorg the chain if the total difficulty is higher on a lower block number than the current head block',
     async (st) => {
-      const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
+      const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.MuirGlacier })
       const blockchain = new Blockchain({
         validateBlocks: true,
         validateConsensus: false,
@@ -90,7 +90,7 @@ tape('reorg tests', (t) => {
   t.test(
     'should correctly reorg a poa chain and remove blocks from clique snapshots',
     async (st) => {
-      const common = new Common({ chain: 'goerli', hardfork: 'chainstart' })
+      const common = new Common({ chain: Chain.Goerli, hardfork: Hardfork.Chainstart })
       const genesisBlock = Block.genesis({}, { common })
       const blockchain = new Blockchain({
         validateBlocks: false,

--- a/packages/blockchain/test/util.ts
+++ b/packages/blockchain/test/util.ts
@@ -1,6 +1,6 @@
 import { BN, rlp } from 'ethereumjs-util'
 import { Block, BlockHeader } from '@ethereumjs/block'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import Blockchain from '../src'
 const level = require('level-mem')
 
@@ -8,7 +8,7 @@ export const generateBlocks = (numberOfBlocks: number, existingBlocks?: Block[])
   const blocks = existingBlocks ? existingBlocks : []
 
   const gasLimit = 8000000
-  const common = new Common({ chain: 'mainnet', hardfork: 'chainstart' })
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
   const opts = { common }
 
   if (blocks.length === 0) {
@@ -70,7 +70,7 @@ export const generateConsecutiveBlock = (
   if (difficultyChangeFactor > 1) {
     difficultyChangeFactor = 1
   }
-  const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.MuirGlacier })
   const tmpHeader = BlockHeader.fromHeaderData({
     number: parentBlock.header.number.addn(1),
     timestamp: parentBlock.header.timestamp.addn(10 + -difficultyChangeFactor * 9),

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env client
 
 import { Server as RPCServer } from 'jayson/promise'
-import Common from '@ethereumjs/common'
+import Common, { Hardfork } from '@ethereumjs/common'
 import { parseParams, parseMultiaddrs } from '../lib/util'
 import EthereumClient from '../lib/client'
 import { Config } from '../lib/config'
@@ -184,7 +184,7 @@ async function run() {
     chain = args.network
   }
 
-  const common = new Common({ chain, hardfork: 'chainstart' })
+  const common = new Common({ chain, hardfork: Hardfork.Chainstart })
   const datadir = args.datadir ?? Config.DATADIR_DEFAULT
   const configDirectory = `${datadir}/${common.chainName()}/config`
   fs.ensureDirSync(configDirectory)

--- a/packages/client/browser/index.ts
+++ b/packages/client/browser/index.ts
@@ -1,4 +1,4 @@
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 
 // Blockchain
 export * from '../lib/blockchain/chain'
@@ -48,7 +48,7 @@ import { getLogger } from './logging'
 export async function createClient(args: any) {
   const logger = getLogger({ loglevel: args.loglevel ?? 'info' })
   const datadir = args.datadir ?? Config.DATADIR_DEFAULT
-  const common = new Common({ chain: args.network ?? 'mainnet' })
+  const common = new Common({ chain: args.network ?? Chain.Mainnet })
   const key = await Config.getClientKey(datadir, common)
   const config = new Config({
     common,

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -1,4 +1,4 @@
-import Common from '@ethereumjs/common'
+import Common, { Hardfork } from '@ethereumjs/common'
 import VM from '@ethereumjs/vm'
 import { genPrivateKey } from '@ethereumjs/devp2p'
 import Multiaddr from 'multiaddr'
@@ -252,7 +252,7 @@ export class Config {
 
     // TODO: map chainParams (and lib/util.parseParams) to new Common format
     const common =
-      options.common ?? new Common({ chain: Config.CHAIN_DEFAULT, hardfork: 'chainstart' })
+      options.common ?? new Common({ chain: Config.CHAIN_DEFAULT, hardfork: Hardfork.Chainstart })
     this.chainCommon = common.copy()
     this.execCommon = common.copy()
 

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -1,3 +1,4 @@
+import { Hardfork } from '@ethereumjs/common'
 import { Transaction, TransactionFactory } from '@ethereumjs/tx'
 import {
   Account,
@@ -471,8 +472,8 @@ export class Eth {
     try {
       const common = this.client.config.chainCommon.copy()
       // TODO: generalize with a new Common.latestSupportedHardfork() method or similar
-      // Alternative: common.setHardfork('lastest')
-      common.setHardfork('london')
+      // Alternative: common.setHardfork('latest')
+      common.setHardfork(Hardfork.London)
       const tx = TransactionFactory.fromSerializedData(toBuffer(serializedTx), { common })
       if (!tx.isSigned()) {
         return {

--- a/packages/client/test/config.spec.ts
+++ b/packages/client/test/config.spec.ts
@@ -1,6 +1,6 @@
 import tape from 'tape-catch'
 import { Config } from '../lib/config'
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 
 tape('[Config]', (t) => {
   t.test('Initialization with default parameters', (t) => {
@@ -28,7 +28,7 @@ tape('[Config]', (t) => {
   })
 
   t.test('peer discovery default mainnet setting', (t) => {
-    const common = new Common({ chain: 'mainnet' })
+    const common = new Common({ chain: Chain.Mainnet })
     const config = new Config({ common })
     t.equal(config.discDns, false, 'disables DNS peer discovery for mainnet')
     t.equal(config.discV4, true, 'enables DNS peer discovery for mainnet')
@@ -38,7 +38,7 @@ tape('[Config]', (t) => {
   t.test('peer discovery default testnet settings', (t) => {
     let config
 
-    for (const chain of ['rinkeby', 'goerli', 'ropsten']) {
+    for (const chain of [Chain.Rinkeby, Chain.Goerli, Chain.Ropsten]) {
       const common = new Common({ chain })
       config = new Config({ common })
       t.equal(config.discDns, true, `enables DNS peer discovery for ${chain}`)
@@ -50,12 +50,12 @@ tape('[Config]', (t) => {
   t.test('--discDns=true/false', (t) => {
     let common, config, chain
 
-    chain = 'mainnet'
+    chain = Chain.Mainnet
     common = new Common({ chain })
     config = new Config({ common, discDns: true })
     t.equal(config.discDns, true, `default discDns setting can be overridden to true`)
 
-    chain = 'rinkeby'
+    chain = Chain.Rinkeby
     common = new Common({ chain })
     config = new Config({ common, discDns: false })
     t.equal(config.discDns, false, `default discDns setting can be overridden to false`)
@@ -65,12 +65,12 @@ tape('[Config]', (t) => {
   t.test('--discV4=true/false', (t) => {
     let common, config, chain
 
-    chain = 'mainnet'
+    chain = Chain.Mainnet
     common = new Common({ chain })
     config = new Config({ common, discV4: false })
     t.equal(config.discDns, false, `default discV4 setting can be overridden to false`)
 
-    chain = 'rinkeby'
+    chain = Chain.Rinkeby
     common = new Common({ chain })
     config = new Config({ common, discV4: true })
     t.equal(config.discDns, true, `default discV4 setting can be overridden to true`)

--- a/packages/client/test/rpc/eth/chainId.spec.ts
+++ b/packages/client/test/rpc/eth/chainId.spec.ts
@@ -1,6 +1,6 @@
 import tape from 'tape'
 import { BN } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 import { baseSetup, params, baseRequest, createClient, createManager, startRPC } from '../helpers'
 
 const method = 'eth_chainId'
@@ -33,7 +33,7 @@ tape(`${method}: returns 1 for Mainnet`, (t) => {
 
 tape(`${method}: returns 3 for Ropsten`, (t) => {
   const manager = createManager(
-    createClient({ opened: true, commonChain: new Common({ chain: 'ropsten' }) })
+    createClient({ opened: true, commonChain: new Common({ chain: Chain.Ropsten }) })
   )
   const server = startRPC(manager.getMethods())
 
@@ -47,7 +47,7 @@ tape(`${method}: returns 3 for Ropsten`, (t) => {
 
 tape(`${method}: returns 42 for Kovan`, (t) => {
   const manager = createManager(
-    createClient({ opened: true, commonChain: new Common({ chain: 'kovan' }) })
+    createClient({ opened: true, commonChain: new Common({ chain: Chain.Kovan }) })
   )
   const server = startRPC(manager.getMethods())
 

--- a/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
+++ b/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
@@ -1,6 +1,6 @@
 import tape from 'tape'
 import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { toBuffer } from 'ethereumjs-util'
 import { baseSetup, params, baseRequest, createClient, createManager, startRPC } from '../helpers'
 
@@ -51,7 +51,7 @@ tape(`${method}: call with unsigned tx`, (t) => {
   // Mainnet EIP-1559 tx
   const txData =
     '0x02f90108018001018402625a0094cccccccccccccccccccccccccccccccccccccccc830186a0b8441a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f85bf859940000000000000000000000000000000000000101f842a00000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000060a701a0afb6e247b1c490e284053c87ab5f6b59e219d51f743f7a4d83e400782bc7e4b9a0479a268e0e0acd4de3f1e28e4fac2a6b32a4195e8dfa9d19147abe8807aa6f64'
-  const common = new Common({ chain: 'mainnet', hardfork: 'london' })
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
   const tx = FeeMarketEIP1559Transaction.fromSerializedTx(toBuffer(txData), {
     common,
     freeze: false,

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -1,7 +1,7 @@
 import tape from 'tape'
 import { Server as RPCServer, HttpServer } from 'jayson/promise'
 import VM from '@ethereumjs/vm'
-import Common from '@ethereumjs/common'
+import Common, { Chain as ChainEnum } from '@ethereumjs/common'
 import { RPCManager as Manager } from '../../lib/rpc'
 import { getLogger } from '../../lib/logging'
 import { Config } from '../../lib/config'
@@ -31,7 +31,7 @@ export function createManager(client: EthereumClient) {
 }
 
 export function createClient(clientOpts: any = {}) {
-  const common = clientOpts.commonChain ?? new Common({ chain: 'mainnet' })
+  const common = clientOpts.commonChain ?? new Common({ chain: ChainEnum.Mainnet })
   const config = new Config({ transports: [], common })
   const blockchain = clientOpts.blockchain ?? ((<any>mockBlockchain()) as Blockchain)
 

--- a/packages/client/test/rpc/net/version.spec.ts
+++ b/packages/client/test/rpc/net/version.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 import { startRPC, createManager, createClient, baseSetup, params, baseRequest } from '../helpers'
 
 const method = 'net_version'
@@ -29,7 +29,7 @@ function compareResult(t: any, result: any, chainId: any) {
 
 tape(`${method}: call on ropsten`, (t) => {
   const manager = createManager(
-    createClient({ opened: true, commonChain: new Common({ chain: 'ropsten' }) })
+    createClient({ opened: true, commonChain: new Common({ chain: Chain.Ropsten }) })
   )
   const server = startRPC(manager.getMethods())
 
@@ -54,7 +54,7 @@ tape(`${method}: call on mainnet`, (t) => {
 
 tape(`${method}: call on rinkeby`, (t) => {
   const manager = createManager(
-    createClient({ opened: true, commonChain: new Common({ chain: 'rinkeby' }) })
+    createClient({ opened: true, commonChain: new Common({ chain: Chain.Rinkeby }) })
   )
   const server = startRPC(manager.getMethods())
 
@@ -68,7 +68,7 @@ tape(`${method}: call on rinkeby`, (t) => {
 
 tape(`${method}: call on kovan`, (t) => {
   const manager = createManager(
-    createClient({ opened: true, commonChain: new Common({ chain: 'kovan' }) })
+    createClient({ opened: true, commonChain: new Common({ chain: Chain.Kovan }) })
   )
   const server = startRPC(manager.getMethods())
 
@@ -82,7 +82,7 @@ tape(`${method}: call on kovan`, (t) => {
 
 tape(`${method}: call on goerli`, (t) => {
   const manager = createManager(
-    createClient({ opened: true, commonChain: new Common({ chain: 'goerli' }) })
+    createClient({ opened: true, commonChain: new Common({ chain: Chain.Goerli }) })
   )
   const server = startRPC(manager.getMethods())
 

--- a/packages/client/test/sync/execution/vmexecution.spec.ts
+++ b/packages/client/test/sync/execution/vmexecution.spec.ts
@@ -7,7 +7,7 @@ import { VMExecution } from '../../../lib/sync/execution/vmexecution'
 import blocksDataMainnet from './../../testdata/blocks_mainnet.json'
 import blocksDataGoerli from './../../testdata/blocks_goerli.json'
 import testnet from './../../testdata/testnet.json'
-import Common from '@ethereumjs/common'
+import Common, { Chain as ChainEnum, Hardfork } from '@ethereumjs/common'
 
 tape('[VMExecution]', async (t) => {
   t.test('Initialization', async (t) => {
@@ -64,7 +64,7 @@ tape('[VMExecution]', async (t) => {
   })
 
   t.test('Block execution / Hardforks PoA (goerli)', async (t) => {
-    const common = new Common({ chain: 'goerli', hardfork: 'chainstart' })
+    const common = new Common({ chain: ChainEnum.Goerli, hardfork: Hardfork.Chainstart })
     let blockchain = new Blockchain({
       validateBlocks: true,
       validateConsensus: false,

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -21,7 +21,7 @@ All parameters can be accessed through the `Common` class which can be required 
 main package and instantiated either with just the `chain` (e.g. 'mainnet') or the `chain`
 together with a specific `hardfork` provided.
 
-If no hardfork is provided the common is initialized with the default hardfork.
+If no hardfork is provided, the common is initialized with the default hardfork.
 
 Current `DEFAULT_HARDFORK`: `istanbul`
 
@@ -60,6 +60,18 @@ const c = new Common({
 This will e.g. throw an error when a param is requested for an unsupported hardfork and
 like this prevents unpredicted behaviour.
 
+For an improved developer experience, there are `Chain` and `Hardfork` enums available:
+
+```typescript
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
+
+// Chain provided by Chain enum
+const c = new Common({ chain: Chain.Mainnet })
+
+// Chain provided by Chain enum, hardfork provided by Hardfork enum
+const c = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Byzantium })
+```
+
 # API
 
 See the API documentation for a full list of functions for accessing specific chain and
@@ -88,14 +100,22 @@ The `chain` can be set in the constructor like this:
 const c = new Common({ chain: 'ropsten' })
 ```
 
+Or optionally with the `Chain` enum:
+
+```typescript
+import Common, { Chain } from '@ethereumjs/common'
+
+const c = new Common({ chain: Chain.Ropsten })
+```
+
 Supported chains:
 
-- `mainnet`
-- `ropsten`
-- `rinkeby`
-- `kovan`
-- `goerli`
-- `calaveras`
+- `mainnet` (`Chain.Mainnet`)
+- `ropsten` (`Chain.Ropsten`)
+- `rinkeby` (`Chain.Rinkeby`)
+- `kovan` (`Chain.Kovan`)
+- `goerli` (`Chain.Goerli`)
+- `calaveras` (`Chain.Calaveras`)
 - Private/custom chain parameters
 
 The following chain-specific parameters are provided:
@@ -167,23 +187,34 @@ The `hardfork` can be set in constructor like this:
 const c = new Common({ chain: 'ropsten', hardfork: 'byzantium' })
 ```
 
+Or optionally with the `Hardfork` enum:
+
+```typescript
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
+
+const c = new Common({
+  chain: Chain.Ropsten,
+  hardfork: Hardfork.Byzantium,
+})
+```
+
 ### Active Hardforks
 
 There are currently parameter changes by the following past and future hardfork by the
 library supported:
 
-- `chainstart`
-- `homestead`
-- `dao`
-- `tangerineWhistle`
-- `spuriousDragon`
-- `byzantium`
-- `constantinople`
-- `petersburg` (aka `constantinopleFix`, apply together with `constantinople`)
-- `istanbul` (`DEFAULT_HARDFORK` (`v2.0.0` release series))
-- `muirGlacier`
-- `berlin` (since `v2.2.0`)
-- `london` (since `v2.4.0`)
+- `chainstart` (`Hardfork.Chainstart`)
+- `homestead` (`Hardfork.Homestead`)
+- `dao` (`Hardfork.Dao`)
+- `tangerineWhistle` (`Hardfork.TangerineWhistle`)
+- `spuriousDragon` (`Hardfork.SpuriousDragon`)
+- `byzantium` (`Hardfork.Byzantium`)
+- `constantinople` (`Hardfork.Constantinople`)
+- `petersburg` (`Hardfork.Petersburg`) (aka `constantinopleFix`, apply together with `constantinople`)
+- `istanbul` (`Hardfork.Instanbul`) (`DEFAULT_HARDFORK` (`v2.0.0` release series))
+- `muirGlacier` (`Hardfork.MuirGlacier`)
+- `berlin` (`Hardfork.Berlin`) (since `v2.2.0`)
+- `london` (`Hardfork.London`) (since `v2.4.0`)
 
 ### Future Hardforks
 
@@ -212,7 +243,7 @@ Starting with the `v2.0.0` release of the library, EIPs are now native citizens 
 and can be activated like this:
 
 ```typescript
-const c = new Common({ chain: 'mainnet', eips: [2537] })
+const c = new Common({ chain: Chain.Mainnet, eips: [2537] })
 ```
 
 The following EIPs are currently supported:

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -62,9 +62,9 @@ export enum Hardfork {
 
 interface BaseOpts {
   /**
-   * String identifier ('byzantium') for hardfork
+   * String identifier ('byzantium') for hardfork or {@link Hardfork} enum.
    *
-   * Default: `istanbul`
+   * Default: Hardfork.Istanbul
    */
   hardfork?: string | Hardfork
   /**
@@ -87,8 +87,9 @@ interface BaseOpts {
  */
 export interface CommonOpts extends BaseOpts {
   /**
-   * Chain name ('mainnet') or id (1), either from a chain directly supported
-   * or a custom chain passed in via {@link CommonOpts.customChains}
+   * Chain name ('mainnet'), id (1), or {@link Chain} enum,
+   * either from a chain directly supported or a custom chain
+   * passed in via {@link CommonOpts.customChains}.
    */
   chain: string | number | Chain | BN | object
   /**
@@ -110,8 +111,8 @@ export interface CommonOpts extends BaseOpts {
  */
 export interface CustomCommonOpts extends BaseOpts {
   /**
-   * The name (`mainnet`) or id (`1`) of a standard chain used to base the custom
-   * chain params on.
+   * The name (`mainnet`), id (`1`), or {@link Chain} enum of
+   * a standard chain used to base the custom chain params on.
    */
   baseChain?: string | number | Chain | BN
 }
@@ -327,7 +328,7 @@ export default class Common extends EventEmitter {
 
   /**
    * Sets the hardfork to get params for
-   * @param hardfork String identifier (e.g. 'byzantium')
+   * @param hardfork String identifier (e.g. 'byzantium') or {@link Hardfork} enum
    */
   setHardfork(hardfork: string | Hardfork): void {
     if (!this._isSupportedHardfork(hardfork)) {

--- a/packages/common/tests/customChains.spec.ts
+++ b/packages/common/tests/customChains.spec.ts
@@ -106,7 +106,11 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
     const mainnetCommon = new Common({ chain: Chain.Mainnet })
 
     const customChainParams = { name: 'custom', chainId: 123, networkId: 678 }
-    const customChainCommon = Common.forCustomChain('mainnet', customChainParams, Hardfork.Byzantium)
+    const customChainCommon = Common.forCustomChain(
+      'mainnet',
+      customChainParams,
+      Hardfork.Byzantium
+    )
 
     // From custom chain params
     st.equal(customChainCommon.chainName(), customChainParams.name)
@@ -143,7 +147,11 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
   })
 
   t.test('customChains parameter: initialization', (st) => {
-    let c = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium, customChains: [testnet] })
+    let c = new Common({
+      chain: Chain.Mainnet,
+      hardfork: Hardfork.Byzantium,
+      customChains: [testnet],
+    })
     st.equal(c.chainName(), 'mainnet', 'customChains, chain set to supported chain')
     st.equal(c.hardforkBlock(), 4370000, 'customChains, chain set to supported chain')
 

--- a/packages/common/tests/customChains.spec.ts
+++ b/packages/common/tests/customChains.spec.ts
@@ -1,6 +1,6 @@
 import tape from 'tape'
 import { BN } from '../../util/dist'
-import Common, { CustomChain } from '../src/'
+import Common, { Chain, CustomChain, Hardfork } from '../src/'
 import testnet from './data/testnet.json'
 import testnet2 from './data/testnet2.json'
 import testnet3 from './data/testnet3.json'
@@ -9,7 +9,7 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
   t.test(
     'chain -> object: should provide correct access to private network chain parameters',
     function (st: tape.Test) {
-      const c = new Common({ chain: testnet, hardfork: 'byzantium' })
+      const c = new Common({ chain: testnet, hardfork: Hardfork.Byzantium })
       st.equal(c.chainName(), 'testnet', 'should initialize with chain name')
       st.equal(c.chainId(), 12345, 'should return correct chain Id')
       st.ok(c.chainIdBN().eqn(12345), 'should return correct chain Id')
@@ -45,10 +45,10 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
   )
 
   t.test('custom() -> base functionality', function (st: tape.Test) {
-    const mainnetCommon = new Common({ chain: 'mainnet' })
+    const mainnetCommon = new Common({ chain: Chain.Mainnet })
 
     const customChainParams = { name: 'custom', chainId: 123, networkId: 678 }
-    const customChainCommon = Common.custom(customChainParams, { hardfork: 'byzantium' })
+    const customChainCommon = Common.custom(customChainParams, { hardfork: Hardfork.Byzantium })
 
     // From custom chain params
     st.equal(customChainCommon.chainName(), customChainParams.name)
@@ -103,10 +103,10 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
   })
 
   t.test('forCustomChain() (deprecated) -> base functionality', function (st: tape.Test) {
-    const mainnetCommon = new Common({ chain: 'mainnet' })
+    const mainnetCommon = new Common({ chain: Chain.Mainnet })
 
     const customChainParams = { name: 'custom', chainId: 123, networkId: 678 }
-    const customChainCommon = Common.forCustomChain('mainnet', customChainParams, 'byzantium')
+    const customChainCommon = Common.forCustomChain('mainnet', customChainParams, Hardfork.Byzantium)
 
     // From custom chain params
     st.equal(customChainCommon.chainName(), customChainParams.name)
@@ -143,7 +143,7 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
   })
 
   t.test('customChains parameter: initialization', (st) => {
-    let c = new Common({ chain: 'mainnet', hardfork: 'byzantium', customChains: [testnet] })
+    let c = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium, customChains: [testnet] })
     st.equal(c.chainName(), 'mainnet', 'customChains, chain set to supported chain')
     st.equal(c.hardforkBlock(), 4370000, 'customChains, chain set to supported chain')
 
@@ -151,12 +151,12 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
     st.equal(c.chainName(), 'testnet', 'customChains, chain switched to custom chain')
     st.equal(c.hardforkBlock(), 4, 'customChains, chain switched to custom chain')
 
-    c = new Common({ chain: 'testnet', hardfork: 'byzantium', customChains: [testnet] })
+    c = new Common({ chain: 'testnet', hardfork: Hardfork.Byzantium, customChains: [testnet] })
     st.equal(c.chainName(), 'testnet', 'customChains, chain initialized with custom chain')
     st.equal(c.hardforkBlock(), 4, 'customChains, chain initialized with custom chain')
 
     const customChains = [testnet, testnet2, testnet3]
-    c = new Common({ chain: 'testnet2', hardfork: 'istanbul', customChains })
+    c = new Common({ chain: 'testnet2', hardfork: Hardfork.Istanbul, customChains })
     st.equal(c.chainName(), 'testnet2', 'customChains, chain initialized with custom chain')
     st.equal(c.hardforkBlock(), 10, 'customChains, chain initialized with custom chain')
 

--- a/packages/common/tests/eips.spec.ts
+++ b/packages/common/tests/eips.spec.ts
@@ -1,21 +1,21 @@
 import tape from 'tape'
-import Common from '../src/'
+import Common, { Chain, Hardfork } from '../src/'
 
 tape('[Common/EIPs]: Initialization / Chain params', function (t: tape.Test) {
   t.test('Correct initialization', function (st: tape.Test) {
     let eips = [2537, 2929]
-    const c = new Common({ chain: 'mainnet', eips })
+    const c = new Common({ chain: Chain.Mainnet, eips })
     st.equal(c.eips(), eips, 'should initialize with supported EIP')
 
     eips = [2718, 2929, 2930]
-    new Common({ chain: 'mainnet', eips, hardfork: 'istanbul' })
+    new Common({ chain: Chain.Mainnet, eips, hardfork: Hardfork.Istanbul })
     st.pass('Should not throw when initializing with a consistent EIP list')
 
     eips = [2930]
     const msg =
       'should throw when initializing with an EIP with required EIPs not being activated along'
     const f = () => {
-      new Common({ chain: 'mainnet', eips, hardfork: 'istanbul' })
+      new Common({ chain: Chain.Mainnet, eips, hardfork: Hardfork.Istanbul })
     }
     st.throws(f, msg)
 
@@ -27,7 +27,7 @@ tape('[Common/EIPs]: Initialization / Chain params', function (t: tape.Test) {
     const eips = [UNSUPPORTED_EIP]
     const msg = 'should throw on an unsupported EIP'
     const f = () => {
-      new Common({ chain: 'mainnet', eips })
+      new Common({ chain: Chain.Mainnet, eips })
     }
     st.throws(f, /not supported$/, msg)
 
@@ -38,7 +38,7 @@ tape('[Common/EIPs]: Initialization / Chain params', function (t: tape.Test) {
     eips = [ 2537, ]
     msg = 'should throw on not meeting minimum hardfork requirements'
     f = () => {
-      new Common({ chain: 'mainnet', hardfork: 'byzantium', eips })
+      new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium, eips })
     }
     st.throws(f, /minimumHardfork/, msg)
     */
@@ -47,11 +47,11 @@ tape('[Common/EIPs]: Initialization / Chain params', function (t: tape.Test) {
   })
 
   t.test('isActivatedEIP()', function (st) {
-    let c = new Common({ chain: 'rinkeby', hardfork: 'istanbul' })
+    let c = new Common({ chain: Chain.Rinkeby, hardfork: Hardfork.Istanbul })
     st.equal(c.isActivatedEIP(2315), false, 'istanbul, eips: [] -> false (EIP-2315)')
-    c = new Common({ chain: 'rinkeby', hardfork: 'istanbul', eips: [2315] })
+    c = new Common({ chain: Chain.Rinkeby, hardfork: Hardfork.Istanbul, eips: [2315] })
     st.equal(c.isActivatedEIP(2315), true, 'istanbul, eips: [2315] -> true (EIP-2315)')
-    c = new Common({ chain: 'rinkeby', hardfork: 'berlin' })
+    c = new Common({ chain: Chain.Rinkeby, hardfork: Hardfork.Berlin })
     st.equal(c.isActivatedEIP(2929), true, 'berlin, eips: [] -> true (EIP-2929)')
     st.equal(c.isActivatedEIP(2315), false, 'berlin, eips: [] -> true (EIP-2315)')
     st.equal(c.isActivatedEIP(2537), false, 'berlin, eips: [] -> false (EIP-2537)')

--- a/packages/common/tests/hardforks.spec.ts
+++ b/packages/common/tests/hardforks.spec.ts
@@ -60,7 +60,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
       st.equal(hardfork, 'byzantium', 'should send correct hardforkChanged event')
       st.end()
     })
-    c.setHardfork('byzantium')
+    c.setHardfork(Hardfork.Byzantium)
   })
 
   t.test('hardforkBlock()', function (st: tape.Test) {

--- a/packages/common/tests/hardforks.spec.ts
+++ b/packages/common/tests/hardforks.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import Common from '../src/'
+import Common, { Chain, Hardfork } from '../src/'
 
 tape('[Common]: Hardfork logic', function (t: tape.Test) {
   t.test('Hardfork access', function (st: tape.Test) {
@@ -18,7 +18,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     let c
 
     for (const hardfork of supportedHardforks) {
-      c = new Common({ chain: 'mainnet', hardfork: hardfork })
+      c = new Common({ chain: Chain.Mainnet, hardfork: hardfork })
       st.equal(c.hardfork(), hardfork, hardfork)
     }
 
@@ -26,7 +26,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
   })
 
   t.test('getHardforkByBlockNumber() / setHardforkByBlockNumber()', function (st: tape.Test) {
-    let c = new Common({ chain: 'mainnet' })
+    let c = new Common({ chain: Chain.Mainnet })
     let msg = 'should get HF correctly'
 
     st.equal(c.getHardforkByBlockNumber(0), 'chainstart', msg)
@@ -48,14 +48,14 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     st.equal(c.setHardforkByBlockNumber(12965000), 'london', msg)
     st.equal(c.setHardforkByBlockNumber(999999999999), 'london', msg)
 
-    c = new Common({ chain: 'ropsten' })
+    c = new Common({ chain: Chain.Ropsten })
     st.equal(c.setHardforkByBlockNumber(0), 'tangerineWhistle', msg)
 
     st.end()
   })
 
   t.test('setHardfork(): hardforkChanged event', function (st) {
-    const c = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    const c = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     c.on('hardforkChanged', (hardfork: string) => {
       st.equal(hardfork, 'byzantium', 'should send correct hardforkChanged event')
       st.end()
@@ -64,15 +64,15 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
   })
 
   t.test('hardforkBlock()', function (st: tape.Test) {
-    let c = new Common({ chain: 'ropsten' })
+    let c = new Common({ chain: Chain.Ropsten })
     let msg = 'should return the correct HF change block for byzantium (provided)'
     st.equal(c.hardforkBlock('byzantium'), 1700000, msg)
 
-    c = new Common({ chain: 'ropsten', hardfork: 'byzantium' })
+    c = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Byzantium })
     msg = 'should return the correct HF change block for byzantium (set)'
     st.equal(c.hardforkBlock(), 1700000, msg)
 
-    c = new Common({ chain: 'ropsten', hardfork: 'istanbul' })
+    c = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Istanbul })
     msg = 'should return the correct HF change block for istanbul (set)'
     st.equal(c.hardforkBlock(), 6485846, msg)
 
@@ -80,14 +80,14 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
   })
 
   t.test('isHardforkBlock()', function (st: tape.Test) {
-    let c = new Common({ chain: 'ropsten' })
+    let c = new Common({ chain: Chain.Ropsten })
     let msg = 'should return true for HF change block for byzantium (provided)'
     st.equal(c.isHardforkBlock(1700000, 'byzantium'), true, msg)
 
     msg = 'should return false for another block for byzantium (provided)'
     st.equal(c.isHardforkBlock(1700001, 'byzantium'), false, msg)
 
-    c = new Common({ chain: 'ropsten', hardfork: 'byzantium' })
+    c = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Byzantium })
     msg = 'should return true for HF change block for byzantium (set)'
     st.equal(c.isHardforkBlock(1700000), true, msg)
 
@@ -98,7 +98,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
   })
 
   t.test('nextHardforkBlock()', function (st: tape.Test) {
-    let c = new Common({ chain: 'rinkeby', hardfork: 'chainstart' })
+    let c = new Common({ chain: Chain.Rinkeby, hardfork: Hardfork.Chainstart })
     let msg =
       'should work with HF set / return correct next HF block for chainstart (rinkeby: chainstart -> homestead)'
     st.equal(c.nextHardforkBlock(), 1, msg)
@@ -115,16 +115,16 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
 
     msg =
       'should work correctly along the need to skip several forks (ropsten: chainstart -> (homestead) -> (dao) -> (tangerineWhistle) -> spuriousDragon)'
-    c = new Common({ chain: 'ropsten', hardfork: 'chainstart' })
+    c = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Chainstart })
     st.equal(c.nextHardforkBlock(), 10, msg)
 
     st.end()
   })
 
   t.test('isNextHardforkBlock()', function (st: tape.Test) {
-    const c = new Common({ chain: 'rinkeby', hardfork: 'chainstart' })
+    const c = new Common({ chain: Chain.Rinkeby, hardfork: Hardfork.Chainstart })
     let msg =
-      'should work with HF set / return true fro correct next HF block for chainstart (rinkeby: chainstart -> homestead)'
+      'should work with HF set / return true for correct next HF block for chainstart (rinkeby: chainstart -> homestead)'
     st.equal(c.isNextHardforkBlock(1), true, msg)
 
     msg =
@@ -137,14 +137,14 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     msg = 'should return false for a block number too low (rinkeby: byzantium -> constantinople)'
     st.equal(c.isNextHardforkBlock(124, 'byzantium'), false, msg)
 
-    msg = 'should return false for a block number too hight (rinkeby: byzantium -> constantinople)'
+    msg = 'should return false for a block number too high (rinkeby: byzantium -> constantinople)'
     st.equal(c.isNextHardforkBlock(605948938, 'byzantium'), false, msg)
 
     st.end()
   })
 
   t.test('activeHardforks()', function (st: tape.Test) {
-    let c = new Common({ chain: 'ropsten' })
+    let c = new Common({ chain: Chain.Ropsten })
     let msg = 'should return correct number of active hardforks for Ropsten'
     st.equal(c.activeHardforks().length, 11, msg)
 
@@ -158,28 +158,28 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     st.equal(c.activeHardforks(10).length, 4, msg)
 
     c = new Common({
-      chain: 'ropsten',
+      chain: Chain.Ropsten,
       supportedHardforks: ['spuriousDragon', 'byzantium', 'constantinople'],
     })
     msg = 'should return 3 active HFs when restricted to supported HFs'
     st.equal(c.activeHardforks(null, { onlySupported: true }).length, 3, msg)
 
     c = new Common({
-      chain: 'ropsten',
+      chain: Chain.Ropsten,
       supportedHardforks: ['spuriousDragon', 'byzantium', 'dao'],
     })
     msg = 'should return 2 active HFs when restricted to supported HFs'
     st.equal(c.activeHardforks(null, { onlySupported: true }).length, 2, msg)
 
-    c = new Common({ chain: 'mainnet' })
+    c = new Common({ chain: Chain.Mainnet })
     msg = 'should return correct number of active HFs for mainnet'
     st.equal(c.activeHardforks().length, 12, msg)
 
-    c = new Common({ chain: 'rinkeby' })
+    c = new Common({ chain: Chain.Rinkeby })
     msg = 'should return correct number of active HFs for rinkeby'
     st.equal(c.activeHardforks().length, 10, msg)
 
-    c = new Common({ chain: 'goerli' })
+    c = new Common({ chain: Chain.Goerli })
     msg = 'should return correct number of active HFs for goerli'
     st.equal(c.activeHardforks().length, 10, msg)
 
@@ -187,7 +187,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
   })
 
   t.test('activeHardfork()', function (st: tape.Test) {
-    let c = new Common({ chain: 'ropsten' })
+    let c = new Common({ chain: Chain.Ropsten })
     let msg = 'should return correct latest active HF for Ropsten'
     st.equal(c.activeHardfork(), 'london', msg)
 
@@ -195,13 +195,13 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     st.equal(c.activeHardfork(10), 'spuriousDragon', msg)
 
     c = new Common({
-      chain: 'ropsten',
+      chain: Chain.Ropsten,
       supportedHardforks: ['tangerineWhistle', 'spuriousDragon'],
     })
     msg = 'should return spuriousDragon as latest active HF for Ropsten with limited supported HFs'
     st.equal(c.activeHardfork(null, { onlySupported: true }), 'spuriousDragon', msg)
 
-    c = new Common({ chain: 'rinkeby' })
+    c = new Common({ chain: Chain.Rinkeby })
     msg = 'should return correct latest active HF for Rinkeby'
     st.equal(c.activeHardfork(), 'london', msg)
 
@@ -209,7 +209,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
   })
 
   t.test('hardforkIsActiveOnBlock() / activeOnBlock()', function (st: tape.Test) {
-    let c = new Common({ chain: 'ropsten' })
+    let c = new Common({ chain: Chain.Ropsten })
     let msg = 'Ropsten, byzantium (provided), 1700000 -> true'
     st.equal(c.hardforkIsActiveOnBlock('byzantium', 1700000), true, msg)
 
@@ -219,7 +219,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     msg = 'Ropsten, byzantium (provided), 1699999 -> false'
     st.equal(c.hardforkIsActiveOnBlock('byzantium', 1699999), false, msg)
 
-    c = new Common({ chain: 'ropsten', hardfork: 'byzantium' })
+    c = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Byzantium })
     msg = 'Ropsten, byzantium (set), 1700000 -> true'
     st.equal(c.hardforkIsActiveOnBlock(null, 1700000), true, msg)
 
@@ -236,7 +236,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
   })
 
   t.test('hardforkGteHardfork()', function (st: tape.Test) {
-    let c = new Common({ chain: 'ropsten' })
+    let c = new Common({ chain: Chain.Ropsten })
     let msg = 'Ropsten, constantinople >= byzantium (provided) -> true'
     st.equal(c.hardforkGteHardfork('constantinople', 'byzantium'), true, msg)
 
@@ -255,7 +255,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     msg = 'Ropsten, spuriousDragon >= byzantium (provided) -> false'
     st.equal(c.hardforkGteHardfork('spuriousDragon', 'byzantium'), false, msg)
 
-    c = new Common({ chain: 'ropsten', hardfork: 'byzantium' })
+    c = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Byzantium })
     msg = 'Ropsten, byzantium (set) >= spuriousDragon -> true'
     st.equal(c.hardforkGteHardfork(null, 'spuriousDragon'), true, msg)
 
@@ -275,7 +275,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
   })
 
   t.test('hardforkGteHardfork() ropsten', function (st: tape.Test) {
-    const c = new Common({ chain: 'ropsten' })
+    const c = new Common({ chain: Chain.Ropsten })
     const msg = 'ropsten, spuriousDragon >= muirGlacier (provided) -> false'
     st.equal(c.hardforkGteHardfork('spuriousDragon', 'muirGlacier'), false, msg)
 
@@ -283,7 +283,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
   })
 
   t.test('hardforkIsActiveOnChain()', function (st: tape.Test) {
-    let c = new Common({ chain: 'ropsten' })
+    let c = new Common({ chain: Chain.Ropsten })
     let msg = 'should return true for byzantium (provided) on Ropsten'
     st.equal(c.hardforkIsActiveOnChain('byzantium'), true, msg)
 
@@ -302,12 +302,12 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     msg = 'should not throw with unsupported Hf (provided) and onlySupported set to false'
     st.doesNotThrow(f, /unsupported hardfork$/, msg)
 
-    c = new Common({ chain: 'ropsten', hardfork: 'byzantium' })
+    c = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Byzantium })
     msg = 'should return true for byzantium (set) on Ropsten'
     st.equal(c.hardforkIsActiveOnChain(), true, msg)
 
     c = new Common({
-      chain: 'ropsten',
+      chain: Chain.Ropsten,
       supportedHardforks: ['byzantium', 'constantinople'],
     })
     f = function () {
@@ -320,7 +320,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
   })
 
   t.test('_calcForkHash()', function (st: tape.Test) {
-    let c = new Common({ chain: 'mainnet' })
+    let c = new Common({ chain: Chain.Mainnet })
     let msg = 'should calc correctly for chainstart (only genesis)'
     st.equal(c._calcForkHash('chainstart'), '0xfc64ec04', msg)
 
@@ -347,14 +347,14 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
   })
 
   t.test('forkHash()', function (st: tape.Test) {
-    let c = new Common({ chain: 'mainnet', hardfork: 'byzantium' })
+    let c = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium })
     let msg = 'should provide correct forkHash for HF set'
     st.equal(c.forkHash(), '0xa00bc324', msg)
 
     msg = 'should provide correct forkHash for HF provided'
     st.equal(c.forkHash('spuriousDragon'), '0x3edd5b10', msg)
 
-    c = new Common({ chain: 'kovan' })
+    c = new Common({ chain: Chain.Kovan })
     const f = () => {
       c.forkHash('london')
     }
@@ -365,7 +365,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
   })
 
   t.test('hardforkForForkHash()', function (st: tape.Test) {
-    const c = new Common({ chain: 'mainnet' })
+    const c = new Common({ chain: Chain.Mainnet })
 
     let msg = 'should return the correct HF array for a matching forkHash'
     const res = c.hardforkForForkHash('0x3edd5b10')

--- a/packages/common/tests/params.spec.ts
+++ b/packages/common/tests/params.spec.ts
@@ -1,9 +1,9 @@
 import tape from 'tape'
-import Common from '../src/'
+import Common, { Chain, Hardfork } from '../src/'
 
 tape('[Common]: Parameter access for param(), paramByHardfork()', function (t: tape.Test) {
   t.test('Basic usage', function (st: tape.Test) {
-    const c = new Common({ chain: 'mainnet', eips: [2537] })
+    const c = new Common({ chain: Chain.Mainnet, eips: [2537] })
     let msg = 'Should return correct value when HF directly provided'
     st.equal(c.paramByHardfork('gasPrices', 'ecAdd', 'byzantium'), 500, msg)
 
@@ -32,7 +32,7 @@ tape('[Common]: Parameter access for param(), paramByHardfork()', function (t: t
   })
 
   t.test('Error cases for param(), paramByHardfork()', function (st: tape.Test) {
-    let c = new Common({ chain: 'mainnet' })
+    let c = new Common({ chain: Chain.Mainnet })
 
     let f = function () {
       c.paramByHardfork('gasPrizes', 'ecAdd', 'byzantium')
@@ -44,9 +44,9 @@ tape('[Common]: Parameter access for param(), paramByHardfork()', function (t: t
     st.equal(c.param('gasPrices', 'ecAdd'), 500, 'Should return correct value for HF set in class')
 
     c = new Common({
-      chain: 'mainnet',
-      hardfork: 'byzantium',
-      supportedHardforks: ['byzantium', 'constantinople'],
+      chain: Chain.Mainnet,
+      hardfork: Hardfork.Byzantium,
+      supportedHardforks: [Hardfork.Byzantium, Hardfork.Constantinople],
     })
     f = function () {
       c.paramByHardfork('gasPrices', 'expByte', 'spuriousDragon')
@@ -64,7 +64,7 @@ tape('[Common]: Parameter access for param(), paramByHardfork()', function (t: t
   })
 
   t.test('Parameter updates', function (st: tape.Test) {
-    const c = new Common({ chain: 'mainnet' })
+    const c = new Common({ chain: Chain.Mainnet })
 
     let msg = 'Should return correct value for chain start'
     st.equal(c.paramByHardfork('pow', 'minerReward', 'chainstart'), '5000000000000000000', msg)
@@ -82,7 +82,7 @@ tape('[Common]: Parameter access for param(), paramByHardfork()', function (t: t
   })
 
   t.test('Access by block number, paramByBlock()', function (st: tape.Test) {
-    const c = new Common({ chain: 'mainnet', hardfork: 'byzantium' })
+    const c = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium })
     let msg = 'Should correctly translate block numbers into HF states (updated value)'
     st.equal(c.paramByBlock('pow', 'minerReward', 4370000), '3000000000000000000', msg)
 
@@ -94,7 +94,7 @@ tape('[Common]: Parameter access for param(), paramByHardfork()', function (t: t
   })
 
   t.test('EIP param access, paramByEIP()', function (st: tape.Test) {
-    const c = new Common({ chain: 'mainnet' })
+    const c = new Common({ chain: Chain.Mainnet })
 
     let msg = 'Should return null for non-existing value'
     st.equal(c.paramByEIP('gasPrices', 'notexistingvalue', 2537), null, msg)
@@ -118,8 +118,8 @@ tape('[Common]: Parameter access for param(), paramByHardfork()', function (t: t
   })
 
   t.test('returns the right block delay for EIP3554', function (st) {
-    for (const fork of ['muirGlacier', 'berlin']) {
-      const c = new Common({ chain: 'mainnet', hardfork: fork })
+    for (const fork of [Hardfork.MuirGlacier, Hardfork.Berlin]) {
+      const c = new Common({ chain: Chain.Mainnet, hardfork: fork })
       let delay = c.param('pow', 'difficultyBombDelay')
       st.equal(delay, 9000000)
       c.setEIPs([3554])

--- a/packages/common/tests/params.spec.ts
+++ b/packages/common/tests/params.spec.ts
@@ -8,11 +8,11 @@ tape('[Common]: Parameter access for param(), paramByHardfork()', function (t: t
     st.equal(c.paramByHardfork('gasPrices', 'ecAdd', 'byzantium'), 500, msg)
 
     msg = 'Should return correct value for HF set in class'
-    c.setHardfork('byzantium')
+    c.setHardfork(Hardfork.Byzantium)
     st.equal(c.param('gasPrices', 'ecAdd'), 500, msg)
-    c.setHardfork('istanbul')
+    c.setHardfork(Hardfork.Istanbul)
     st.equal(c.param('gasPrices', 'ecAdd'), 150, msg)
-    c.setHardfork('muirGlacier')
+    c.setHardfork(Hardfork.MuirGlacier)
     st.equal(c.param('gasPrices', 'ecAdd'), 150, msg)
 
     msg = 'Should return null for non-existing value'
@@ -40,7 +40,7 @@ tape('[Common]: Parameter access for param(), paramByHardfork()', function (t: t
     let msg = 'Should throw when called with non-existing topic'
     st.throws(f, /Topic gasPrizes not defined$/, msg)
 
-    c.setHardfork('byzantium')
+    c.setHardfork(Hardfork.Byzantium)
     st.equal(c.param('gasPrices', 'ecAdd'), 500, 'Should return correct value for HF set in class')
 
     c = new Common({

--- a/packages/devp2p/README.md
+++ b/packages/devp2p/README.md
@@ -157,7 +157,7 @@ Instantiate an [@ethereumjs/common](https://github.com/ethereumjs/ethereumjs-mon
 instance with the network you want to connect to:
 
 ```typescript
-const common = new Common({ chain: 'mainnet' })
+const common = new Common({ chain: Chain.Mainnet })
 ```
 
 Create your `RLPx` object, e.g.:

--- a/packages/devp2p/examples/peer-communication-les.ts
+++ b/packages/devp2p/examples/peer-communication-les.ts
@@ -1,6 +1,6 @@
 import * as devp2p from '../src/index'
 import { LES, Peer } from '../src/index'
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 import { TypedTransaction } from '@ethereumjs/tx'
 import { Block, BlockHeader } from '@ethereumjs/block'
 import ms from 'ms'
@@ -16,7 +16,7 @@ const GENESIS_HASH = Buffer.from(
   'hex'
 )
 
-const common = new Common({ chain: 'rinkeby' })
+const common = new Common({ chain: Chain.Rinkeby })
 const bootstrapNodes = common.bootstrapNodes()
 const BOOTNODES = bootstrapNodes.map((node: any) => {
   return {

--- a/packages/devp2p/examples/peer-communication.ts
+++ b/packages/devp2p/examples/peer-communication.ts
@@ -4,7 +4,7 @@ import LRUCache from 'lru-cache'
 import ms from 'ms'
 import chalk from 'chalk'
 import * as rlp from 'rlp'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { TypedTransaction, TransactionFactory } from '@ethereumjs/tx'
 import { Block, BlockHeader } from '@ethereumjs/block'
 import * as devp2p from '../src/index'
@@ -12,7 +12,7 @@ import { ETH, Peer } from '../src/index'
 
 const PRIVATE_KEY = randomBytes(32)
 
-const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
 const bootstrapNodes = common.bootstrapNodes()
 const BOOTNODES = bootstrapNodes.map((node: any) => {
   return {

--- a/packages/devp2p/examples/simple.ts
+++ b/packages/devp2p/examples/simple.ts
@@ -1,10 +1,10 @@
 import chalk from 'chalk'
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 import { DPT } from '../src/index'
 
 const PRIVATE_KEY = 'd772e3d6a001a38064dd23964dd2836239fa0e6cec8b28972a87460a17210fe9'
 
-const config = new Common({ chain: 'mainnet' })
+const config = new Common({ chain: Chain.Mainnet })
 const bootstrapNodes = config.bootstrapNodes()
 const BOOTNODES = bootstrapNodes.map((node: any) => {
   return {

--- a/packages/devp2p/test/integration/eth-simulator.ts
+++ b/packages/devp2p/test/integration/eth-simulator.ts
@@ -1,7 +1,7 @@
 import test from 'tape'
 import * as devp2p from '../../src'
 import * as util from './util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { ETH } from '../../src'
 
 const GENESIS_TD = 17179869184
@@ -44,8 +44,8 @@ test('ETH: send status message (NetworkId mismatch)', async (t) => {
     t.end()
   }
 
-  const c1 = new Common({ chain: 'mainnet' })
-  const c2 = new Common({ chain: 'ropsten' })
+  const c1 = new Common({ chain: Chain.Mainnet })
+  const c2 = new Common({ chain: Chain.Ropsten })
   util.twoPeerMsgExchange(t, opts, capabilities, [c1, c2])
 })
 
@@ -112,7 +112,7 @@ test('ETH: should use latest protocol version on default', async (t) => {
 
 test('ETH -> Eth64 -> sendStatus(): should throw on non-matching latest block provided', async (t) => {
   const cap = [devp2p.ETH.eth65]
-  const common = new Common({ chain: 'mainnet', hardfork: 'byzantium' })
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium })
   const status0: any = Object.assign({}, status)
   status0['latestBlock'] = 100000 // lower than Byzantium fork block 4370000
 
@@ -139,7 +139,7 @@ test('ETH: send not-allowed eth64', async (t) => {
 test('ETH -> Eth64 -> ForkId validation 1a)', async (t) => {
   const opts: any = {}
   const cap = [devp2p.ETH.eth64]
-  const common = new Common({ chain: 'mainnet', hardfork: 'byzantium' })
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium })
   const status0: any = Object.assign({}, status)
   // Take a latest block > next mainnet fork block (constantinople)
   // to trigger validation condition

--- a/packages/devp2p/test/integration/les-simulator.ts
+++ b/packages/devp2p/test/integration/les-simulator.ts
@@ -1,5 +1,5 @@
 import test from 'tape'
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 import * as devp2p from '../../src'
 import * as util from './util'
 
@@ -58,8 +58,8 @@ test('LES: send status message (NetworkId mismatch)', async (t) => {
     t.end()
   }
 
-  const c1 = new Common({ chain: 'mainnet' })
-  const c2 = new Common({ chain: 'ropsten' })
+  const c1 = new Common({ chain: Chain.Mainnet })
+  const c2 = new Common({ chain: Chain.Ropsten })
   util.twoPeerMsgExchange(t, opts, capabilities, [c1, c2])
 })
 

--- a/packages/devp2p/test/integration/util.ts
+++ b/packages/devp2p/test/integration/util.ts
@@ -1,6 +1,6 @@
 import { Test } from 'tape'
 import { DPT, ETH, RLPx, genPrivateKey } from '../../src'
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 import testdata from '../testdata.json'
 
 export const localhost = '127.0.0.1'
@@ -68,7 +68,7 @@ export function getTestRLPXs(
     capabilities = [ETH.eth66, ETH.eth65, ETH.eth64, ETH.eth63, ETH.eth62]
   }
   if (!common) {
-    common = new Common({ chain: 'mainnet' })
+    common = new Common({ chain: Chain.Mainnet })
   }
   const dpts = getTestDPTs(numRLPXs)
 

--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -68,10 +68,10 @@ Please note that up to `v3.2.0` you mandatorily had to use a `Common` instance f
 This is the recommended tx type starting with the activation of the `london` HF, see the following code snipped for an example on how to instantiate:
 
 ```typescript
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
 
-const common = new Common({ chain: 'mainnet', hardfork: 'london' })
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
 
 const txData = {
   "data": "0x1a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
@@ -101,10 +101,10 @@ const tx = FeeMarketEIP1559Transaction.fromTxData(txData, { common })
 This transaction type has been introduced along the `berlin` HF. See the following code snipped for an example on how to instantiate:
 
 ```typescript
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { AccessListEIP2930Transaction } from '@ethereumjs/tx'
 
-const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
 
 const txData = {
   "data": "0x1a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
@@ -145,7 +145,7 @@ Legacy transaction are still valid transaction within Ethereum `mainnet` but wil
 See this [example script](./examples/transactions.ts) or the following code example on how to use.
 
 ```typescript
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 import { Transaction } from '@ethereumjs/tx'
 
 const txParams = {
@@ -157,7 +157,7 @@ const txParams = {
   data: '0x7f7465737432000000000000000000000000000000000000000000000000000000600057',
 }
 
-const common = new Common({ chain: 'mainnet' })
+const common = new Common({ chain: Chain.Mainnet })
 const tx = Transaction.fromTxData(txParams, { common })
 
 const privateKey = Buffer.from(
@@ -175,10 +175,10 @@ const serializedTx = signedTx.serialize()
 If you only know on runtime which tx type will be used within your code or if you want to keep your code transparent to tx types, this library comes with a `TransactionFactory` for your convenience which can be used as follows:
 
 ```typescript
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { TransactionFactory } from '@ethereumjs/tx'
 
-const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
 
 const txData = {} // Use data from the different tx type examples
 const tx = TransactionFactory.fromTxData(txData, { common })

--- a/packages/tx/examples/ropsten-tx.ts
+++ b/packages/tx/examples/ropsten-tx.ts
@@ -1,12 +1,12 @@
 import { Transaction } from '../src'
 import { toBuffer } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 
 const txData = toBuffer(
   '0xf9010b82930284d09dc30083419ce0942d18de92e0f9aee1a29770c3b15c6cf8ac5498e580b8a42f43f4fb0000000000000000000000000000000000000000000000000000016b78998da900000000000000000000000000000000000000000000000000000000000cb1b70000000000000000000000000000000000000000000000000000000000000fa00000000000000000000000000000000000000000000000000000000001363e4f00000000000000000000000000000000000000000000000000000000000186a029a0fac36e66d329af0e831b2e61179b3ec8d7c7a8a2179e303cfed3364aff2bc3e4a07cb73d56e561ccbd838818dd3dea5fa0b5158577ffc61c0e6ec1f0ed55716891',
 )
 
-const common = new Common({ chain: 'ropsten', hardfork: 'petersburg' })
+const common = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Petersburg })
 const tx = Transaction.fromSerializedTx(txData, { common })
 
 if (

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -1,4 +1,4 @@
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import {
   Address,
   BN,
@@ -58,7 +58,7 @@ export abstract class BaseTransaction<TransactionObject> {
    *
    * @hidden
    */
-  protected DEFAULT_CHAIN = 'mainnet'
+  protected DEFAULT_CHAIN = Chain.Mainnet
 
   /**
    * The default HF if the tx type is active on that HF
@@ -66,7 +66,7 @@ export abstract class BaseTransaction<TransactionObject> {
    *
    * @hidden
    */
-  protected DEFAULT_HARDFORK = 'istanbul'
+  protected DEFAULT_HARDFORK: string | Hardfork = Hardfork.Istanbul
 
   constructor(txData: TxData | AccessListEIP2930TxData | FeeMarketEIP1559TxData) {
     const { nonce, gasLimit, to, value, data, v, r, s, type } = txData

--- a/packages/tx/test/base.spec.ts
+++ b/packages/tx/test/base.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import {
   Transaction,
   AccessListEIP2930Transaction,
@@ -13,7 +13,7 @@ import { privateToPublic, BN, toBuffer } from 'ethereumjs-util'
 
 tape('[BaseTransaction]', function (t) {
   // EIP-2930 is not enabled in Common by default (2021-03-06)
-  const common = new Common({ chain: 'mainnet', hardfork: 'london' })
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
 
   const legacyFixtures: TxsJsonEntry[] = require('./json/txs.json')
   const legacyTxs: BaseTransaction<Transaction>[] = []
@@ -87,8 +87,8 @@ tape('[BaseTransaction]', function (t) {
       st.ok(Object.isFrozen(tx), `${txType.name}: tx should be frozen by default`)
 
       const initCommon = new Common({
-        chain: 'mainnet',
-        hardfork: 'london',
+        chain: Chain.Mainnet,
+        hardfork: Hardfork.London,
       })
       tx = txType.class.fromTxData({}, { common: initCommon })
       st.equal(

--- a/packages/tx/test/base.spec.ts
+++ b/packages/tx/test/base.spec.ts
@@ -97,7 +97,7 @@ tape('[BaseTransaction]', function (t) {
         `${txType.name}: should initialize with correct HF provided`
       )
 
-      initCommon.setHardfork('byzantium')
+      initCommon.setHardfork(Hardfork.Byzantium)
       st.equal(
         tx.common.hardfork(),
         'london',

--- a/packages/tx/test/eip1559.spec.ts
+++ b/packages/tx/test/eip1559.spec.ts
@@ -1,4 +1,4 @@
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { BN, rlp, TWO_POW256 } from 'ethereumjs-util'
 import tape from 'tape'
 import { FeeMarketEIP1559Transaction } from '../src'
@@ -6,8 +6,8 @@ import { FeeMarketEIP1559Transaction } from '../src'
 const testdata = require('./json/eip1559.json') // Source: Besu
 
 const common = new Common({
-  chain: 'rinkeby',
-  hardfork: 'london',
+  chain: Chain.Rinkeby,
+  hardfork: Hardfork.London,
 })
 
 const validAddress = Buffer.from('01'.repeat(20), 'hex')

--- a/packages/tx/test/legacy.spec.ts
+++ b/packages/tx/test/legacy.spec.ts
@@ -1,7 +1,7 @@
 import tape from 'tape'
 import { Buffer } from 'buffer'
 import { BN, rlp, toBuffer, bufferToHex, intToBuffer, unpadBuffer } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { Transaction, TxData } from '../src'
 import { TxsJsonEntry, VitaliksTestsDataEntry } from './types'
 
@@ -12,7 +12,7 @@ tape('[Transaction]', function (t) {
   const transactions: Transaction[] = []
 
   t.test('Initialization', function (st) {
-    const nonEIP2930Common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    const nonEIP2930Common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     st.ok(
       Transaction.fromTxData({}, { common: nonEIP2930Common }),
       'should initialize on a pre-Berlin Harfork (EIP-2930 not activated)'
@@ -78,13 +78,13 @@ tape('[Transaction]', function (t) {
   t.test(
     'Initialization -> throws when creating a a transaction with incompatible chainid and v value',
     function (st) {
-      let common = new Common({ chain: 42, hardfork: 'petersburg' })
+      let common = new Common({ chain: 42, hardfork: Hardfork.Petersburg })
       let tx = Transaction.fromTxData({}, { common })
       st.ok(tx.common.chainIdBN().eqn(42))
       const privKey = Buffer.from(txFixtures[0].privateKey, 'hex')
       tx = tx.sign(privKey)
       const serialized = tx.serialize()
-      common = new Common({ chain: 'mainnet', hardfork: 'petersburg' })
+      common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Petersburg })
       st.throws(() => Transaction.fromSerializedTx(serialized, { common }))
       st.end()
     }
@@ -94,7 +94,7 @@ tape('[Transaction]', function (t) {
     'Initialization -> throws if v is set to an EIP155-encoded value incompatible with the chain id',
     function (st) {
       st.throws(() => {
-        const common = new Common({ chain: 42, hardfork: 'petersburg' })
+        const common = new Common({ chain: 42, hardfork: Hardfork.Petersburg })
         Transaction.fromTxData({ v: new BN(1) }, { common })
       })
       st.end()
@@ -125,7 +125,7 @@ tape('[Transaction]', function (t) {
   })
 
   t.test('getDataFee() -> should return correct data fee for istanbul', function (st) {
-    const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     let tx = Transaction.fromTxData({}, { common })
     st.equals(tx.getDataFee().toNumber(), 0)
 
@@ -170,8 +170,8 @@ tape('[Transaction]', function (t) {
 
   t.test('hash() / getMessageToSign(true) / getMessageToSign(false)', function (st) {
     const common = new Common({
-      chain: 'mainnet',
-      hardfork: 'tangerineWhistle',
+      chain: Chain.Mainnet,
+      hardfork: Hardfork.TangerineWhistle,
     })
     const tx = Transaction.fromValuesArray(txFixtures[3].raw.map(toBuffer), {
       common,
@@ -263,7 +263,7 @@ tape('[Transaction]', function (t) {
   t.test(
     'sign(), getSenderPublicKey() (implicit call) -> EIP155 hashing when singing',
     function (st) {
-      const common = new Common({ chain: 1, hardfork: 'petersburg' })
+      const common = new Common({ chain: 1, hardfork: Hardfork.Petersburg })
       txFixtures.slice(0, 3).forEach(function (txData) {
         const tx = Transaction.fromValuesArray(txData.raw.slice(0, 6).map(toBuffer), {
           common,
@@ -330,8 +330,8 @@ tape('[Transaction]', function (t) {
       const fixtureTxSignedWithEIP155 = Transaction.fromTxData(txData).sign(privateKey)
 
       const common = new Common({
-        chain: 'mainnet',
-        hardfork: 'tangerineWhistle',
+        chain: Chain.Mainnet,
+        hardfork: Hardfork.TangerineWhistle,
       })
 
       const fixtureTxSignedWithoutEIP155 = Transaction.fromTxData(txData, {
@@ -381,7 +381,7 @@ tape('[Transaction]', function (t) {
   )
 
   t.test('sign(), verifySignature(): sign tx with chainId specified in params', function (st) {
-    const common = new Common({ chain: 42, hardfork: 'petersburg' })
+    const common = new Common({ chain: 42, hardfork: Hardfork.Petersburg })
     let tx = Transaction.fromTxData({}, { common })
     st.ok(tx.common.chainIdBN().eqn(42))
 

--- a/packages/tx/test/transactionFactory.spec.ts
+++ b/packages/tx/test/transactionFactory.spec.ts
@@ -1,4 +1,4 @@
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { BN } from 'ethereumjs-util'
 import tape from 'tape'
 import {
@@ -9,8 +9,8 @@ import {
 } from '../src'
 
 const common = new Common({
-  chain: 'mainnet',
-  hardfork: 'london',
+  chain: Chain.Mainnet,
+  hardfork: Hardfork.London,
 })
 
 const pKey = Buffer.from('4646464646464646464646464646464646464646464646464646464646464646', 'hex')
@@ -71,7 +71,7 @@ tape('[TransactionFactory]: Basic functions', function (t) {
   t.test('fromSerializedData() -> error cases', function (st) {
     for (const txType of txTypes) {
       if (txType.eip2718) {
-        const unsupportedCommon = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+        const unsupportedCommon = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
         st.throws(() => {
           TransactionFactory.fromSerializedData(txType.unsigned.serialize(), {
             common: unsupportedCommon,
@@ -132,7 +132,7 @@ tape('[TransactionFactory]: Basic functions', function (t) {
   })
 
   t.test('fromTxData() -> error cases', function (st) {
-    const unsupportedCommon = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    const unsupportedCommon = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     st.throws(() => {
       TransactionFactory.fromTxData({ type: 1 }, { common: unsupportedCommon })
     })

--- a/packages/tx/test/typedTxsAndEIP2930.spec.ts
+++ b/packages/tx/test/typedTxsAndEIP2930.spec.ts
@@ -1,4 +1,4 @@
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { Address, BN, bufferToHex, privateToAddress } from 'ethereumjs-util'
 import tape from 'tape'
 import {
@@ -17,8 +17,8 @@ const N_DIV_2_PLUS_1 = new BN(
 )
 
 const common = new Common({
-  chain: 'mainnet',
-  hardfork: 'london',
+  chain: Chain.Mainnet,
+  hardfork: Hardfork.London,
 })
 
 const txTypes = [
@@ -62,7 +62,7 @@ tape(
           'should initialize Common with chain ID provided (unsupported chain ID)'
         )
 
-        const nonEIP2930Common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+        const nonEIP2930Common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
         t.throws(() => {
           txType.class.fromTxData({}, { common: nonEIP2930Common })
         }, `should throw on a pre-Berlin Harfork (EIP-2930 not activated) (${txType.name})`)

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -19,10 +19,10 @@ Note: this `README` reflects the state of the library from `v5.0.0` onwards. See
 
 ```typescript
 import { BN } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '@ethereumjs/vm'
 
-const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
 const vm = new VM({ common })
 
 const STOP = '00'
@@ -97,9 +97,9 @@ The following is a simple example for a block run on `Goerli`:
 
 ```typescript
 import VM from '@ethereumjs/vm'
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 
-const common = new Common({ chain: 'goerli' })
+const common = new Common({ chain: Chain.Goerli })
 const hardforkByBlockNumber = true
 const vm = new VM({ common, hardforkByBlockNumber })
 
@@ -132,10 +132,10 @@ A specific hardfork VM ruleset can be activated by passing in the hardfork
 along the `Common` instance:
 
 ```typescript
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '@ethereumjs/vm'
 
-const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
 const vm = new VM({ common })
 ```
 
@@ -145,10 +145,10 @@ It is possible to individually activate EIP support in the VM by instantiate the
 with the respective EIPs, e.g.:
 
 ```typescript
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 import VM from '@ethereumjs/vm'
 
-const common = new Common({ chain: 'mainnet', eips: [2537] })
+const common = new Common({ chain: Chain.Mainnet, eips: [2537] })
 const vm = new VM({ common })
 ```
 

--- a/packages/vm/benchmarks/mainnetBlocks.ts
+++ b/packages/vm/benchmarks/mainnetBlocks.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs'
 import Benchmark = require('benchmark')
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import blockFromRPC from '@ethereumjs/block/dist/from-rpc'
 import VM from '../dist'
@@ -26,7 +26,7 @@ export async function mainnetBlocks(suite?: Benchmark.Suite, numSamples?: number
   console.log(`Number of blocks to sample: ${numSamples}`)
   data = data.slice(0, numSamples)
 
-  const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.MuirGlacier })
 
   for (const blockData of data) {
     const block = blockFromRPC(blockData.block, [], { common })

--- a/packages/vm/examples/decode-opcodes/index.ts
+++ b/packages/vm/examples/decode-opcodes/index.ts
@@ -1,7 +1,7 @@
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { getOpcodesForHF } from '../../src/evm/opcodes'
 
-const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
 const opcodes = getOpcodesForHF(common)
 
 const data =

--- a/packages/vm/src/index.ts
+++ b/packages/vm/src/index.ts
@@ -1,7 +1,7 @@
 import { SecureTrie as Trie } from 'merkle-patricia-tree'
 import { Account, Address } from 'ethereumjs-util'
 import Blockchain from '@ethereumjs/blockchain'
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 import { StateManager, DefaultStateManager } from './state/index'
 import { default as runCode, RunCodeOpts } from './runCode'
 import { default as runCall, RunCallOpts } from './runCall'
@@ -191,7 +191,7 @@ export default class VM extends AsyncEventEmitter {
 
       this._common = opts.common
     } else {
-      const DEFAULT_CHAIN = 'mainnet'
+      const DEFAULT_CHAIN = Chain.Mainnet
       const supportedHardforks = [
         'chainstart',
         'homestead',

--- a/packages/vm/src/state/stateManager.ts
+++ b/packages/vm/src/state/stateManager.ts
@@ -11,7 +11,7 @@ import {
   unpadBuffer,
 } from 'ethereumjs-util'
 import { encode, decode } from 'rlp'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { genesisStateByName } from '@ethereumjs/common/dist/genesisStates'
 import { StateManager, StorageDump } from './interface'
 import Cache from './cache'
@@ -81,7 +81,7 @@ export default class DefaultStateManager implements StateManager {
   constructor(opts: DefaultStateManagerOpts = {}) {
     let common = opts.common
     if (!common) {
-      common = new Common({ chain: 'mainnet', hardfork: 'petersburg' })
+      common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Petersburg })
     }
     this._common = common
 

--- a/packages/vm/tests/GeneralStateTestsRunner.ts
+++ b/packages/vm/tests/GeneralStateTestsRunner.ts
@@ -1,7 +1,7 @@
 import * as tape from 'tape'
 import { SecureTrie as Trie } from 'merkle-patricia-tree'
 import { Account, BN, toBuffer } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 import { setupPreConditions, makeTx, makeBlockFromEnv } from './util'
 import { InterpreterStep } from '../src/evm/interpreter'
 
@@ -70,7 +70,7 @@ async function runTestCase(options: any, testData: any, t: tape.Test) {
 
   const eips: number[] = []
 
-  const common = new Common({ chain: 'mainnet', hardfork, eips })
+  const common = new Common({ chain: Chain.Mainnet, hardfork, eips })
 
   const vm = new VM({ state, common })
 

--- a/packages/vm/tests/api/EIPs/eip-1559-FeeMarket.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-1559-FeeMarket.spec.ts
@@ -1,7 +1,7 @@
 import tape from 'tape'
 import { Address, BN, privateToAddress, setLengthLeft } from 'ethereumjs-util'
 import VM from '../../../src'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import {
   AccessListEIP2930Transaction,
   FeeMarketEIP1559Transaction,
@@ -14,8 +14,8 @@ const GWEI = new BN('1000000000')
 
 const common = new Common({
   eips: [1559, 2718, 2930],
-  chain: 'mainnet',
-  hardfork: 'london',
+  chain: Chain.Mainnet,
+  hardfork: Hardfork.London,
 })
 
 // Small hack to hack in the activation block number

--- a/packages/vm/tests/api/EIPs/eip-2315.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-2315.spec.ts
@@ -1,10 +1,10 @@
 import tape from 'tape'
 import { BN } from 'ethereumjs-util'
 import VM from '../../../src'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 
 tape('Berlin: EIP 2315 tests', (t) => {
-  const common = new Common({ chain: 'mainnet', hardfork: 'berlin', eips: [2315] })
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin, eips: [2315] })
 
   const runTest = async function (test: any, st: tape.Test) {
     let i = 0

--- a/packages/vm/tests/api/EIPs/eip-2537-BLS.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-2537-BLS.spec.ts
@@ -1,6 +1,6 @@
 import tape from 'tape'
 import { Address, BN, bufferToHex } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../../src'
 import { isRunningInKarma } from '../../util'
 import { getPrecompile } from '../../../src/evm/precompiles'
@@ -20,7 +20,7 @@ tape('EIP-2537 BLS tests', (t) => {
       st.skip('BLS does not work in karma')
       return st.end()
     }
-    const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.MuirGlacier })
     const vm = new VM({ common: common })
 
     for (const address of precompiles) {
@@ -51,7 +51,7 @@ tape('EIP-2537 BLS tests', (t) => {
       st.skip('BLS does not work in karma')
       return st.end()
     }
-    const common = new Common({ chain: 'mainnet', hardfork: 'byzantium', eips: [2537] })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium, eips: [2537] })
     const vm = new VM({ common: common })
 
     for (const address of precompiles) {
@@ -89,7 +89,7 @@ tape('EIP-2537 BLS tests', (t) => {
       st.skip('BLS does not work in karma')
       return st.end()
     }
-    const common = new Common({ chain: 'mainnet', hardfork: 'berlin', eips: [2537] })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin, eips: [2537] })
     const vm = new VM({ common: common })
     const address = new Address(Buffer.from('000000000000000000000000000000000000000f', 'hex'))
     const BLS12G2MultiExp = getPrecompile(address, common)

--- a/packages/vm/tests/api/EIPs/eip-2565-modexp-gas-cost.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-2565-modexp-gas-cost.spec.ts
@@ -1,6 +1,6 @@
 import tape from 'tape'
 import { Address, BN } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../../src'
 
 // See https://github.com/holiman/go-ethereum/blob/2c99023b68c573ba24a5b01db13e000bd9b82417/core/vm/testdata/precompiles/modexp_eip2565.json
@@ -8,7 +8,7 @@ const testData = require('../testdata/eip-2565.json')
 
 tape('EIP-2565 ModExp gas cost tests', (t) => {
   t.test('Test return data, gas cost and execution status against testdata', async (st) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'byzantium', eips: [2565] })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium, eips: [2565] })
     const vm = new VM({ common: common })
 
     for (const test of testData) {

--- a/packages/vm/tests/api/EIPs/eip-2929.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-2929.spec.ts
@@ -1,7 +1,7 @@
 import tape from 'tape'
 import { Account, Address, BN } from 'ethereumjs-util'
 import VM from '../../../src'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { Transaction } from '@ethereumjs/tx'
 
 // Test cases source: https://gist.github.com/holiman/174548cad102096858583c6fbbb0649a
@@ -12,7 +12,7 @@ tape('EIP 2929: gas cost tests', (t) => {
     'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
     'hex'
   )
-  const common = new Common({ chain: 'mainnet', hardfork: 'berlin', eips: [2929] })
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin, eips: [2929] })
 
   const runTest = async function (test: any, st: tape.Test) {
     let i = 0
@@ -74,7 +74,7 @@ tape('EIP 2929: gas cost tests', (t) => {
       Buffer.from('00000000000000000000000000000000000000ff', 'hex')
     )
 
-    const common = new Common({ chain: 'mainnet', hardfork: 'berlin', eips: [2929] })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin, eips: [2929] })
     const vm = new VM({ common })
 
     await vm.stateManager.putContractCode(contractAddress, Buffer.from(code, 'hex')) // setup the contract code

--- a/packages/vm/tests/api/EIPs/eip-2930-accesslists.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-2930-accesslists.spec.ts
@@ -1,13 +1,13 @@
 import tape from 'tape'
 import { Account, Address, BN, bufferToHex } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../../src'
 import { AccessListEIP2930Transaction } from '@ethereumjs/tx'
 
 const common = new Common({
   eips: [2718, 2929, 2930],
-  chain: 'mainnet',
-  hardfork: 'berlin',
+  chain: Chain.Mainnet,
+  hardfork: Hardfork.Berlin,
 })
 
 const validAddress = Buffer.from('00000000000000000000000000000000000000ff', 'hex')

--- a/packages/vm/tests/api/EIPs/eip-3198-BaseFee.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3198-BaseFee.spec.ts
@@ -1,7 +1,7 @@
 import tape from 'tape'
 import { Address, BN, privateToAddress } from 'ethereumjs-util'
 import VM from '../../../src'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { FeeMarketEIP1559Transaction, TypedTransaction } from '@ethereumjs/tx'
 import { Block } from '@ethereumjs/block'
 import { InterpreterStep } from '../../../src/evm/interpreter'
@@ -11,8 +11,8 @@ const ETHER = GWEI.mul(GWEI)
 
 const common = new Common({
   eips: [1559, 2718, 2930, 3198],
-  chain: 'mainnet',
-  hardfork: 'london',
+  chain: Chain.Mainnet,
+  hardfork: Hardfork.London,
 })
 
 // Small hack to hack in the activation block number

--- a/packages/vm/tests/api/EIPs/eip-3529.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3529.spec.ts
@@ -1,7 +1,7 @@
 import tape from 'tape'
 import { Address, BN } from 'ethereumjs-util'
 import VM from '../../../src'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { InterpreterStep } from '../../../src/evm/interpreter'
 import { EIP2929StateManager } from '../../../src/state/interface'
 import { Transaction } from '@ethereumjs/tx'
@@ -109,7 +109,7 @@ const testCases = [
 ]
 
 tape('EIP-3529 tests', (t) => {
-  const common = new Common({ chain: 'mainnet', hardfork: 'berlin', eips: [3529] })
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin, eips: [3529] })
 
   t.test('should verify EIP test cases', async (st) => {
     const vm = new VM({ common })

--- a/packages/vm/tests/api/EIPs/eip-3541.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3541.spec.ts
@@ -1,6 +1,6 @@
 import tape from 'tape'
 import VM from '../../../src'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { Transaction } from '@ethereumjs/tx'
 import { InterpreterStep } from '../../../src/evm/interpreter'
 import { Address } from 'ethereumjs-util'
@@ -8,8 +8,8 @@ import { Address } from 'ethereumjs-util'
 const pkey = Buffer.from('20'.repeat(32), 'hex')
 
 tape('EIP 3541 tests', (t) => {
-  const common = new Common({ chain: 'mainnet', hardfork: 'berlin', eips: [3541] })
-  const commonNoEIP3541 = new Common({ chain: 'mainnet', hardfork: 'berlin', eips: [] })
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin, eips: [3541] })
+  const commonNoEIP3541 = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin, eips: [] })
 
   t.test('deposit 0xEF code if 3541 is active', async (st) => {
     // put 0xEF contract

--- a/packages/vm/tests/api/buildBlock.spec.ts
+++ b/packages/vm/tests/api/buildBlock.spec.ts
@@ -1,6 +1,6 @@
 import tape from 'tape'
 import { Account, Address } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import { Transaction, FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
 import Blockchain from '@ethereumjs/blockchain'
@@ -9,7 +9,7 @@ import { setBalance } from './utils'
 
 tape('BlockBuilder', async (t) => {
   t.test('should build a valid block', async (st) => {
-    const common = new Common({ chain: 'mainnet' })
+    const common = new Common({ chain: Chain.Mainnet })
     const genesisBlock = Block.genesis({ header: { gasLimit: 50000 } }, { common })
     const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
     const vm = await VM.create({ common, blockchain })
@@ -50,7 +50,7 @@ tape('BlockBuilder', async (t) => {
   })
 
   t.test('should throw if adding a transaction exceeds the block gas limit', async (st) => {
-    const common = new Common({ chain: 'mainnet' })
+    const common = new Common({ chain: Chain.Mainnet })
     const vm = await VM.create({ common })
     const genesis = Block.genesis({}, { common })
 
@@ -71,7 +71,7 @@ tape('BlockBuilder', async (t) => {
   })
 
   t.test('should revert the VM state if reverted', async (st) => {
-    const common = new Common({ chain: 'mainnet' })
+    const common = new Common({ chain: Chain.Mainnet })
     const genesisBlock = Block.genesis({ header: { gasLimit: 50000 } }, { common })
     const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
     const vm = await VM.create({ common, blockchain })
@@ -105,7 +105,7 @@ tape('BlockBuilder', async (t) => {
   })
 
   t.test('should correctly seal a PoW block', async (st) => {
-    const common = new Common({ chain: 'mainnet' })
+    const common = new Common({ chain: Chain.Mainnet })
     const genesisBlock = Block.genesis({ header: { gasLimit: 50000 } }, { common })
     const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
     const vm = await VM.create({ common, blockchain })
@@ -154,7 +154,7 @@ tape('BlockBuilder', async (t) => {
       ),
     }
 
-    const common = new Common({ chain: 'rinkeby' })
+    const common = new Common({ chain: Chain.Rinkeby })
     // extraData: [vanity, activeSigner, seal]
     const extraData = Buffer.concat([Buffer.alloc(32), signer.address.toBuffer(), Buffer.alloc(65)])
     const cliqueSigner = signer.privateKey
@@ -193,7 +193,7 @@ tape('BlockBuilder', async (t) => {
   })
 
   t.test('should throw if block already built or reverted', async (st) => {
-    const common = new Common({ chain: 'mainnet' })
+    const common = new Common({ chain: Chain.Mainnet })
     const genesisBlock = Block.genesis({ header: { gasLimit: 50000 } }, { common })
     const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
     const vm = await VM.create({ common, blockchain })
@@ -247,7 +247,7 @@ tape('BlockBuilder', async (t) => {
   })
 
   t.test('should build a block without any txs', async (st) => {
-    const common = new Common({ chain: 'mainnet' })
+    const common = new Common({ chain: Chain.Mainnet })
     const genesisBlock = Block.genesis({ header: { gasLimit: 50000 } }, { common })
     const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
     const vm = await VM.create({ common, blockchain })
@@ -270,7 +270,7 @@ tape('BlockBuilder', async (t) => {
   })
 
   t.test('should build a 1559 block with legacy and 1559 txs', async (st) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'london', eips: [1559] })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London, eips: [1559] })
     const genesisBlock = Block.genesis(
       { header: { gasLimit: 50000, baseFeePerGas: 100 } },
       { common }

--- a/packages/vm/tests/api/evm/precompiles/06-ecadd.spec.ts
+++ b/packages/vm/tests/api/evm/precompiles/06-ecadd.spec.ts
@@ -1,12 +1,12 @@
 import tape from 'tape'
 import { Address, BN } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../../../src'
 import { getPrecompile } from '../../../../src/evm/precompiles'
 
 tape('Precompiles: ECADD', (t) => {
   t.test('ECADD', async (st) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'petersburg' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Petersburg })
     const vm = new VM({ common: common })
     const address = new Address(Buffer.from('0000000000000000000000000000000000000006', 'hex'))
     const ECADD = getPrecompile(address, common)

--- a/packages/vm/tests/api/evm/precompiles/07-ecmul.spec.ts
+++ b/packages/vm/tests/api/evm/precompiles/07-ecmul.spec.ts
@@ -1,12 +1,12 @@
 import tape from 'tape'
 import { Address, BN } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../../../src'
 import { getPrecompile } from '../../../../src/evm/precompiles'
 
 tape('Precompiles: ECMUL', (t) => {
   t.test('ECMUL', async (st) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'petersburg' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Petersburg })
     const vm = new VM({ common: common })
     const address = new Address(Buffer.from('0000000000000000000000000000000000000007', 'hex'))
     const ECMUL = getPrecompile(address, common)

--- a/packages/vm/tests/api/evm/precompiles/08-ecpairing.spec.ts
+++ b/packages/vm/tests/api/evm/precompiles/08-ecpairing.spec.ts
@@ -1,12 +1,12 @@
 import tape from 'tape'
 import { Address, BN } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../../../src'
 import { getPrecompile } from '../../../../src/evm/precompiles'
 
 tape('Precompiles: ECPAIRING', (t) => {
   t.test('ECPAIRING', async (st) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'petersburg' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Petersburg })
     const vm = new VM({ common: common })
     const address = new Address(Buffer.from('0000000000000000000000000000000000000008', 'hex'))
     const ECPAIRING = getPrecompile(address, common)

--- a/packages/vm/tests/api/evm/precompiles/hardfork.spec.ts
+++ b/packages/vm/tests/api/evm/precompiles/hardfork.spec.ts
@@ -1,6 +1,6 @@
 import tape from 'tape'
 import { Address, BN } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../../../src'
 import { getPrecompile } from '../../../../src/evm/precompiles'
 
@@ -11,7 +11,7 @@ tape('Precompiles: hardfork availability', (t) => {
     )
 
     // ECPAIR was introduced in Byzantium; check if available from Byzantium.
-    const commonByzantium = new Common({ chain: 'mainnet', hardfork: 'byzantium' })
+    const commonByzantium = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium })
 
     let ECPAIRING = getPrecompile(ECPAIR_Address, commonByzantium)
 
@@ -32,7 +32,7 @@ tape('Precompiles: hardfork availability', (t) => {
     st.assert(result.gasUsed.toNumber() == 100000) // check that we are using gas (if address would contain no code we use 0 gas)
 
     // Check if ECPAIR is available in future hard forks.
-    const commonPetersburg = new Common({ chain: 'mainnet', hardfork: 'petersburg' })
+    const commonPetersburg = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Petersburg })
     ECPAIRING = getPrecompile(ECPAIR_Address, commonPetersburg)
 
     if (!ECPAIRING) {
@@ -52,7 +52,7 @@ tape('Precompiles: hardfork availability', (t) => {
     st.assert(result.gasUsed.toNumber() == 100000)
 
     // Check if ECPAIR is not available in Homestead.
-    const commonHomestead = new Common({ chain: 'mainnet', hardfork: 'homestead' })
+    const commonHomestead = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Homestead })
     ECPAIRING = getPrecompile(ECPAIR_Address, commonHomestead)
 
     if (ECPAIRING != undefined) {

--- a/packages/vm/tests/api/index.spec.ts
+++ b/packages/vm/tests/api/index.spec.ts
@@ -156,7 +156,9 @@ tape('VM -> state (deprecated), blockchain', (t) => {
   })
 
   t.test('should pass the correct Common object when copying the VM', async (st) => {
-    const vm = setupVM({ common: new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Byzantium }) })
+    const vm = setupVM({
+      common: new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Byzantium }),
+    })
     await vm.init()
 
     st.equal(vm._common.chainName(), 'ropsten')

--- a/packages/vm/tests/api/index.spec.ts
+++ b/packages/vm/tests/api/index.spec.ts
@@ -1,7 +1,7 @@
 import tape from 'tape'
 import { KECCAK256_RLP } from 'ethereumjs-util'
 import { SecureTrie as Trie } from 'merkle-patricia-tree'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { DefaultStateManager } from '../../src/state'
 import VM from '../../src'
 import { isRunningInKarma } from '../util'
@@ -69,7 +69,7 @@ tape('VM -> basic instantiation / boolean switches', (t) => {
 
 tape('VM -> common (chain, HFs, EIPs)', (t) => {
   t.test('should accept a common object as option', async (st) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
 
     const vm = await VM.create({ common })
     st.equal(vm._common, common)
@@ -78,13 +78,13 @@ tape('VM -> common (chain, HFs, EIPs)', (t) => {
   })
 
   t.test('should only accept valid chain and fork', async (st) => {
-    let common = new Common({ chain: 'ropsten', hardfork: 'byzantium' })
+    let common = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Byzantium })
     let vm = new VM({ common })
     await vm.init()
     st.equal((vm.stateManager as DefaultStateManager)._common.param('gasPrices', 'ecAdd'), 500)
 
     try {
-      common = new Common({ chain: 'mainchain', hardfork: 'homestead' })
+      common = new Common({ chain: 'mainchain', hardfork: Hardfork.Homestead })
       vm = new VM({ common })
       st.fail('should have failed for invalid chain')
     } catch (e) {
@@ -99,7 +99,7 @@ tape('VM -> common (chain, HFs, EIPs)', (t) => {
       st.skip('BLS does not work in karma')
       return st.end()
     }
-    const common = new Common({ chain: 'mainnet', eips: [2537] })
+    const common = new Common({ chain: Chain.Mainnet, eips: [2537] })
     st.doesNotThrow(() => {
       new VM({ common })
     })
@@ -122,7 +122,7 @@ tape('VM -> common (chain, HFs, EIPs)', (t) => {
     'should accept a custom chain config (Common customChains constructor option)',
     async (st) => {
       const customChains = [testnet, testnet2]
-      const common = new Common({ chain: 'testnet2', hardfork: 'berlin', customChains })
+      const common = new Common({ chain: 'testnet2', hardfork: Hardfork.Berlin, customChains })
 
       const vm = await VM.create({ common })
       st.equal(vm._common, common)
@@ -156,7 +156,7 @@ tape('VM -> state (deprecated), blockchain', (t) => {
   })
 
   t.test('should pass the correct Common object when copying the VM', async (st) => {
-    const vm = setupVM({ common: new Common({ chain: 'ropsten', hardfork: 'byzantium' }) })
+    const vm = setupVM({ common: new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Byzantium }) })
     await vm.init()
 
     st.equal(vm._common.chainName(), 'ropsten')

--- a/packages/vm/tests/api/istanbul/eip-1108.spec.ts
+++ b/packages/vm/tests/api/istanbul/eip-1108.spec.ts
@@ -1,12 +1,12 @@
 import tape from 'tape'
 import { Address, BN } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../../src'
 import { getPrecompile } from '../../../src/evm/precompiles'
 
 tape('Istanbul: EIP-1108 tests', (t) => {
   t.test('ECADD', async (st) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     const vm = new VM({ common })
     const address = new Address(Buffer.from('0000000000000000000000000000000000000006', 'hex'))
     const ECADD = getPrecompile(address, common)
@@ -23,7 +23,7 @@ tape('Istanbul: EIP-1108 tests', (t) => {
   })
 
   t.test('ECMUL', async (st) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     const vm = new VM({ common })
     const address = new Address(Buffer.from('0000000000000000000000000000000000000007', 'hex'))
     const ECMUL = getPrecompile(address, common)
@@ -40,7 +40,7 @@ tape('Istanbul: EIP-1108 tests', (t) => {
   })
 
   t.test('ECPAIRING', async (st) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     const vm = new VM({ common })
     const address = new Address(Buffer.from('0000000000000000000000000000000000000008', 'hex'))
     const ECPAIRING = getPrecompile(address, common)

--- a/packages/vm/tests/api/istanbul/eip-1344.spec.ts
+++ b/packages/vm/tests/api/istanbul/eip-1344.spec.ts
@@ -1,13 +1,13 @@
 import tape from 'tape'
 import { BN } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../../src'
 import { ERROR } from '../../../src/exceptions'
 
 const testCases = [
-  { chain: 'mainnet', hardfork: 'istanbul', chainId: new BN(1) },
-  { chain: 'mainnet', hardfork: 'constantinople', err: ERROR.INVALID_OPCODE },
-  { chain: 'ropsten', hardfork: 'istanbul', chainId: new BN(3) },
+  { chain: Chain.Mainnet, hardfork: Hardfork.Istanbul, chainId: new BN(1) },
+  { chain: Chain.Mainnet, hardfork: Hardfork.Constantinople, err: ERROR.INVALID_OPCODE },
+  { chain: Chain.Ropsten, hardfork: Hardfork.Istanbul, chainId: new BN(3) },
 ]
 
 // CHAINID PUSH8 0x00 MSTORE8 PUSH8 0x01 PUSH8 0x00 RETURN

--- a/packages/vm/tests/api/istanbul/eip-152.spec.ts
+++ b/packages/vm/tests/api/istanbul/eip-152.spec.ts
@@ -1,6 +1,6 @@
 import tape from 'tape'
 import { BN } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../../src'
 import { default as blake2f, F } from '../../../src/evm/precompiles/09-blake2f'
 import { ERROR } from '../../../src/exceptions'
@@ -79,7 +79,7 @@ tape('Istanbul: EIP-152', (t) => {
       return st.end()
     }
 
-    const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     const vm = new VM({ common })
 
     for (const testCase of failingTestCases) {

--- a/packages/vm/tests/api/istanbul/eip-1884.spec.ts
+++ b/packages/vm/tests/api/istanbul/eip-1884.spec.ts
@@ -1,13 +1,13 @@
 import tape from 'tape'
 import { Address, BN } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../../src'
 import { ERROR } from '../../../src/exceptions'
 import { createAccount } from '../utils'
 
 const testCases = [
-  { chain: 'mainnet', hardfork: 'istanbul', selfbalance: '0xf1' },
-  { chain: 'mainnet', hardfork: 'constantinople', err: ERROR.INVALID_OPCODE },
+  { chain: Chain.Mainnet, hardfork: Hardfork.Istanbul, selfbalance: '0xf1' },
+  { chain: Chain.Mainnet, hardfork: Hardfork.Constantinople, err: ERROR.INVALID_OPCODE },
 ]
 
 // SELFBALANCE PUSH8 0x00 MSTORE8 PUSH8 0x01 PUSH8 0x00 RETURN

--- a/packages/vm/tests/api/istanbul/eip-2200.spec.ts
+++ b/packages/vm/tests/api/istanbul/eip-2200.spec.ts
@@ -1,6 +1,6 @@
 import tape from 'tape'
 import { Address, BN } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../../src'
 import { ERROR } from '../../../src/exceptions'
 import { createAccount } from '../utils'
@@ -40,7 +40,7 @@ tape('Istanbul: EIP-2200', async (t) => {
     const addr = new Address(Buffer.from('00000000000000000000000000000000000000ff', 'hex'))
     const key = new BN(0).toArrayLike(Buffer, 'be', 32)
     for (const testCase of testCases) {
-      const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+      const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
       const vm = new VM({ common })
 
       const account = createAccount(new BN(0), new BN(0))

--- a/packages/vm/tests/api/muirGlacier/index.spec.ts
+++ b/packages/vm/tests/api/muirGlacier/index.spec.ts
@@ -1,11 +1,11 @@
 import tape from 'tape'
 import { KECCAK256_RLP } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../../src'
 
 tape('General MuirGlacier VM tests', (t) => {
   t.test('should accept muirGlacier harfork option for supported chains', (st) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.MuirGlacier })
     const vm = new VM({ common })
     st.ok(vm.stateManager)
     st.deepEqual((<any>vm.stateManager)._trie.root, KECCAK256_RLP, 'it has default trie')

--- a/packages/vm/tests/api/opcodes.spec.ts
+++ b/packages/vm/tests/api/opcodes.spec.ts
@@ -61,14 +61,14 @@ tape('VM -> getActiveOpcodes()', (t) => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     const vm = new VM({ common })
 
-    common.setHardfork('byzantium')
+    common.setHardfork(Hardfork.Byzantium)
     st.equal(
       vm.getActiveOpcodes().get(CHAINID),
       undefined,
       'opcode not exposed after HF change (-> < istanbul)'
     )
 
-    common.setHardfork('istanbul')
+    common.setHardfork(Hardfork.Istanbul)
     st.equal(
       vm.getActiveOpcodes().get(CHAINID)!.name,
       'CHAINID',

--- a/packages/vm/tests/api/opcodes.spec.ts
+++ b/packages/vm/tests/api/opcodes.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../src'
 
 tape('VM -> getActiveOpcodes()', (t) => {
@@ -7,7 +7,7 @@ tape('VM -> getActiveOpcodes()', (t) => {
   const BEGINSUB = 0x5c // EIP-2315 opcode
 
   t.test('should not expose opcodes from a follow-up HF (istanbul -> petersburg)', (st) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'petersburg' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Petersburg })
     const vm = new VM({ common })
     st.equal(
       vm.getActiveOpcodes().get(CHAINID),
@@ -18,7 +18,7 @@ tape('VM -> getActiveOpcodes()', (t) => {
   })
 
   t.test('should expose opcodes when HF is active (>= istanbul)', (st) => {
-    let common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    let common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     let vm = new VM({ common })
     st.equal(
       vm.getActiveOpcodes().get(CHAINID)!.name,
@@ -26,7 +26,7 @@ tape('VM -> getActiveOpcodes()', (t) => {
       'istanbul opcode exposed (HF: istanbul)'
     )
 
-    common = new Common({ chain: 'mainnet', hardfork: 'muirGlacier' })
+    common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.MuirGlacier })
     vm = new VM({ common })
     st.equal(
       vm.getActiveOpcodes().get(CHAINID)!.name,
@@ -38,7 +38,7 @@ tape('VM -> getActiveOpcodes()', (t) => {
   })
 
   t.test('should expose opcodes when EIP is active', (st) => {
-    let common = new Common({ chain: 'mainnet', hardfork: 'istanbul', eips: [2315] })
+    let common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul, eips: [2315] })
     let vm = new VM({ common })
     st.equal(
       vm.getActiveOpcodes().get(BEGINSUB)!.name,
@@ -46,7 +46,7 @@ tape('VM -> getActiveOpcodes()', (t) => {
       'EIP-2315 opcode BEGINSUB exposed (EIP-2315 activated)'
     )
 
-    common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     vm = new VM({ common })
     st.equal(
       vm.getActiveOpcodes().get(BEGINSUB),
@@ -58,7 +58,7 @@ tape('VM -> getActiveOpcodes()', (t) => {
   })
 
   t.test('should update opcodes on a hardfork change', async (st) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     const vm = new VM({ common })
 
     common.setHardfork('byzantium')

--- a/packages/vm/tests/api/runBlock.spec.ts
+++ b/packages/vm/tests/api/runBlock.spec.ts
@@ -1,6 +1,6 @@
 import tape from 'tape'
 import { Address, BN, rlp, KECCAK256_RLP, Account } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import {
   AccessListEIP2930Transaction,
@@ -18,7 +18,7 @@ import VM from '../../src/index'
 import { setBalance } from './utils'
 
 const testData = require('./testdata/blockchain.json')
-const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
 
 tape('runBlock() -> successful API parameter usage', async (t) => {
   async function simpleRun(vm: VM) {
@@ -122,7 +122,7 @@ tape('runBlock() -> successful API parameter usage', async (t) => {
 
   t.test('PoW block, Common custom chain (Common customChains constructor option)', async (t) => {
     const customChains = [testnet]
-    const common = new Common({ chain: 'testnet', hardfork: 'berlin', customChains })
+    const common = new Common({ chain: 'testnet', hardfork: Hardfork.Berlin, customChains })
     const vm = setupVM({ common })
     await simpleRun(vm)
     t.end()
@@ -130,14 +130,14 @@ tape('runBlock() -> successful API parameter usage', async (t) => {
 
   t.test('hardforkByBlockNumber option', async (t) => {
     const common1 = new Common({
-      chain: 'mainnet',
-      hardfork: 'muirGlacier',
+      chain: Chain.Mainnet,
+      hardfork: Hardfork.MuirGlacier,
     })
 
     // Have to use an unique common, otherwise the HF will be set to muirGlacier and then will not change back to chainstart.
     const common2 = new Common({
-      chain: 'mainnet',
-      hardfork: 'chainstart',
+      chain: Chain.Mainnet,
+      hardfork: Hardfork.Chainstart,
     })
 
     const privateKey = Buffer.from(
@@ -322,7 +322,7 @@ tape('runBlock() -> runtime behavior', async (t) => {
   })
 
   t.test('should allocate to correct clique beneficiary', async (t) => {
-    const common = new Common({ chain: 'goerli' })
+    const common = new Common({ chain: Chain.Goerli })
     const vm = setupVM({ common })
 
     const signer = {
@@ -416,7 +416,7 @@ tape('should correctly reflect generated fields', async (t) => {
 })
 
 async function runWithHf(hardfork: string) {
-  const vm = setupVM({ common: new Common({ chain: 'mainnet', hardfork }) })
+  const vm = setupVM({ common: new Common({ chain: Chain.Mainnet, hardfork }) })
 
   const blockRlp = testData.blocks[0].rlp
   const block = Block.fromRLPSerializedBlock(blockRlp)
@@ -488,7 +488,7 @@ tape('runBlock() -> tx types', async (t) => {
   }
 
   t.test('legacy tx', async (t) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
     const vm = setupVM({ common })
 
     const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
@@ -505,7 +505,7 @@ tape('runBlock() -> tx types', async (t) => {
   })
 
   t.test('access list tx', async (t) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
     const vm = setupVM({ common })
 
     const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
@@ -525,7 +525,7 @@ tape('runBlock() -> tx types', async (t) => {
   })
 
   t.test('fee market tx', async (t) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'london' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
     const vm = setupVM({ common })
 
     const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')

--- a/packages/vm/tests/api/runBlockchain.spec.ts
+++ b/packages/vm/tests/api/runBlockchain.spec.ts
@@ -1,7 +1,7 @@
 import tape from 'tape'
 import { BN, toBuffer } from 'ethereumjs-util'
 import { Block } from '@ethereumjs/block'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import Blockchain from '@ethereumjs/blockchain'
 import { setupVM } from './utils'
 import { setupPreConditions } from '../util'
@@ -14,7 +14,7 @@ Error.stackTraceLimit = 100
 
 tape('runBlockchain', (t) => {
   const blockchainDB = level()
-  const common = new Common({ chain: 'goerli', hardfork: 'chainstart' })
+  const common = new Common({ chain: Chain.Goerli, hardfork: Hardfork.Chainstart })
 
   t.test('should run without a blockchain parameter', async (st) => {
     const vm = setupVM({ common })
@@ -57,7 +57,7 @@ tape('runBlockchain', (t) => {
 
   // TODO: test has been moved over from index.spec.ts, check for redundancy
   t.test('should run blockchain with mocked runBlock', async (st) => {
-    const common = new Common({ chain: 'ropsten' })
+    const common = new Common({ chain: Chain.Ropsten })
     const genesisRlp = Buffer.from(testData.genesisRLP.slice(2), 'hex')
     const genesisBlock = Block.fromRLPSerializedBlock(genesisRlp, { common })
 
@@ -88,7 +88,7 @@ tape('runBlockchain', (t) => {
 
   // TODO: test has been moved over from index.spec.ts, check for redundancy
   t.test('should run blockchain with blocks', async (st) => {
-    const common = new Common({ chain: 'ropsten' })
+    const common = new Common({ chain: Chain.Ropsten })
 
     const genesisRlp = toBuffer(testData.genesisRLP)
     const genesisBlock = Block.fromRLPSerializedBlock(genesisRlp, { common })
@@ -115,7 +115,7 @@ tape('runBlockchain', (t) => {
   t.test('should run with valid and invalid blocks', async (st) => {
     const blockchainDB = level()
 
-    const common = new Common({ chain: 'mainnet', hardfork: 'chainstart' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
     const genesisBlock = Block.genesis(undefined, { common })
     const blockchain = new Blockchain({
       db: blockchainDB,

--- a/packages/vm/tests/api/runCall.spec.ts
+++ b/packages/vm/tests/api/runCall.spec.ts
@@ -85,7 +85,9 @@ tape('Byzantium cannot access Constantinople opcodes', async (t) => {
     Buffer.from('00000000000000000000000000000000000000ff', 'hex')
   ) // contract address
   // setup the vm
-  const vmByzantium = new VM({ common: new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium }) })
+  const vmByzantium = new VM({
+    common: new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium }),
+  })
   const vmConstantinople = new VM({
     common: new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Constantinople }),
   })

--- a/packages/vm/tests/api/runCall.spec.ts
+++ b/packages/vm/tests/api/runCall.spec.ts
@@ -1,6 +1,6 @@
 import tape from 'tape'
 import { Address, BN, keccak256, padToEven } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../src'
 
 // Non-protected Create2Address generator. Does not check if buffers have the right padding.
@@ -25,7 +25,7 @@ tape('Constantinople: EIP-1014 CREATE2 creates the right contract address', asyn
     Buffer.from('00000000000000000000000000000000000000ff', 'hex')
   ) // contract address
   // setup the vm
-  const common = new Common({ chain: 'mainnet', hardfork: 'constantinople' })
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Constantinople })
   const vm = new VM({ common })
   const code = '3460008080F560005260206000F3'
   /*
@@ -85,9 +85,9 @@ tape('Byzantium cannot access Constantinople opcodes', async (t) => {
     Buffer.from('00000000000000000000000000000000000000ff', 'hex')
   ) // contract address
   // setup the vm
-  const vmByzantium = new VM({ common: new Common({ chain: 'mainnet', hardfork: 'byzantium' }) })
+  const vmByzantium = new VM({ common: new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium }) })
   const vmConstantinople = new VM({
-    common: new Common({ chain: 'mainnet', hardfork: 'constantinople' }),
+    common: new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Constantinople }),
   })
   const code = '600160011B00'
   /*
@@ -130,7 +130,7 @@ tape('Ensure that precompile activation creates non-empty accounts', async (t) =
     Buffer.from('00000000000000000000000000000000000000ff', 'hex')
   ) // contract address
   // setup the vm
-  const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
   const vmNotActivated = new VM({ common: common })
   const vmActivated = new VM({ common: common, activatePrecompiles: true })
   const code = '6000808080347300000000000000000000000000000000000000045AF100'
@@ -176,7 +176,7 @@ tape('Ensure that Istanbul sstoreCleanRefundEIP2200 gas is applied correctly', a
   const caller = new Address(Buffer.from('00000000000000000000000000000000000000ee', 'hex')) // caller addres
   const address = new Address(Buffer.from('00000000000000000000000000000000000000ff', 'hex'))
   // setup the vm
-  const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
   const vm = new VM({ common: common })
   const code = '61000260005561000160005500'
   /*

--- a/packages/vm/tests/api/runTx.spec.ts
+++ b/packages/vm/tests/api/runTx.spec.ts
@@ -1,7 +1,7 @@
 import tape from 'tape'
 import { Account, Address, BN, MAX_INTEGER } from 'ethereumjs-util'
 import { Block } from '@ethereumjs/block'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { Transaction, TransactionFactory, FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
 import VM from '../../src'
 import { createAccount, getTransaction } from './utils'
@@ -20,7 +20,7 @@ const TRANSACTION_TYPES = [
     name: 'EIP1559 tx',
   },
 ]
-const common = new Common({ chain: 'mainnet', hardfork: 'london' })
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
 common.setMaxListeners(100)
 
 tape('runTx() -> successful API parameter usage', async (t) => {
@@ -38,11 +38,11 @@ tape('runTx() -> successful API parameter usage', async (t) => {
   }
 
   t.test('simple run (unmodified options)', async (t) => {
-    let common = new Common({ chain: 'mainnet', hardfork: 'london' })
+    let common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
     let vm = new VM({ common })
     await simpleRun(vm, 'mainnet (PoW), london HF, default SM - should run without errors')
 
-    common = new Common({ chain: 'rinkeby', hardfork: 'london' })
+    common = new Common({ chain: Chain.Rinkeby, hardfork: Hardfork.London })
     vm = new VM({ common })
     await simpleRun(vm, 'rinkeby (PoA), london HF, default SM - should run without errors')
 
@@ -50,7 +50,7 @@ tape('runTx() -> successful API parameter usage', async (t) => {
   })
 
   t.test('should use passed in blockGasUsed to generate tx receipt', async (t) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     const vm = new VM({ common })
 
     const tx = getTransaction(vm._common, 0, true)
@@ -69,7 +69,7 @@ tape('runTx() -> successful API parameter usage', async (t) => {
   })
 
   t.test('Legacy Transaction with HF set to pre-Berlin', async (t) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     const vm = new VM({ common })
 
     const tx = getTransaction(vm._common, 0, true)
@@ -169,10 +169,10 @@ tape('runTx() -> successful API parameter usage', async (t) => {
 
 tape('runTx() -> API parameter usage/data errors', (t) => {
   t.test('Typed Transaction with HF set to pre-Berlin', async (t) => {
-    const common = new Common({ chain: 'mainnet', hardfork: 'istanbul' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     const vm = new VM({ common })
 
-    const tx = getTransaction(new Common({ chain: 'mainnet', hardfork: 'berlin' }), 1, true)
+    const tx = getTransaction(new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin }), 1, true)
 
     const caller = tx.getSenderAddress()
     const acc = createAccount()
@@ -281,7 +281,7 @@ tape('runTx() -> API parameter usage/data errors', (t) => {
 tape('runTx() -> runtime behavior', async (t) => {
   t.test('storage cache', async (t) => {
     for (const txType of TRANSACTION_TYPES) {
-      const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
+      const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
       const vm = new VM({ common })
       const privateKey = Buffer.from(
         'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',

--- a/packages/vm/tests/api/runTx.spec.ts
+++ b/packages/vm/tests/api/runTx.spec.ts
@@ -172,7 +172,11 @@ tape('runTx() -> API parameter usage/data errors', (t) => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     const vm = new VM({ common })
 
-    const tx = getTransaction(new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin }), 1, true)
+    const tx = getTransaction(
+      new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin }),
+      1,
+      true
+    )
 
     const caller = tx.getSenderAddress()
     const acc = createAccount()

--- a/packages/vm/tests/api/state/stateManager.spec.ts
+++ b/packages/vm/tests/api/state/stateManager.spec.ts
@@ -10,7 +10,7 @@ import {
   unpadBuffer,
   zeros,
 } from 'ethereumjs-util'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { DefaultStateManager } from '../../../src/state'
 import { createAccount } from '../utils'
 import { isRunningInKarma } from '../../util'
@@ -194,7 +194,7 @@ tape('StateManager', (t) => {
       st.skip('skip slow test when running in karma')
       return st.end()
     }
-    const common = new Common({ chain: 'mainnet', hardfork: 'petersburg' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Petersburg })
     const expectedStateRoot = Buffer.from(common.genesis().stateRoot.slice(2), 'hex')
     const stateManager = new StateManager({ common: common })
 
@@ -209,10 +209,10 @@ tape('StateManager', (t) => {
   })
 
   t.test('should generate the genesis state root correctly for all other chains', async (st) => {
-    const chains = ['ropsten', 'rinkeby', 'kovan', 'goerli']
+    const chains = [Chain.Ropsten, Chain.Rinkeby, Chain.Kovan, Chain.Goerli]
 
     for (const chain of chains) {
-      const common = new Common({ chain: chain, hardfork: 'petersburg' })
+      const common = new Common({ chain: chain, hardfork: Hardfork.Petersburg })
       const expectedStateRoot = Buffer.from(common.genesis().stateRoot.slice(2), 'hex')
       const stateManager = new DefaultStateManager({ common: common })
 
@@ -247,7 +247,7 @@ tape('StateManager', (t) => {
 
   t.test('should pass Common object when copying the state manager', (st) => {
     const stateManager = new DefaultStateManager({
-      common: new Common({ chain: 'goerli', hardfork: 'byzantium' }),
+      common: new Common({ chain: Chain.Goerli, hardfork: Hardfork.Byzantium }),
     })
 
     st.equal(stateManager._common.chainName(), 'goerli')

--- a/packages/vm/tests/api/types.spec.ts
+++ b/packages/vm/tests/api/types.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import {
   AccessListEIP2930Transaction,
   AccessListEIP2930TxData,
@@ -20,7 +20,7 @@ tape('[Types]', function (t) {
     > &
       Pick<TypeT, OptionalFieldsT>
 
-    const common = new Common({ chain: 'mainnet', hardfork: 'berlin' })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
 
     // Block
     const block: Required<BlockData> = Block.fromBlockData({}, { common })

--- a/packages/vm/tests/config.ts
+++ b/packages/vm/tests/config.ts
@@ -1,4 +1,4 @@
-import Common from '@ethereumjs/common'
+import Common, { Chain } from '@ethereumjs/common'
 
 /**
  * Default hardfork rules to run tests against
@@ -251,7 +251,7 @@ export function getCommon(network: string) {
     const hfName = normalHardforks.reduce((previousValue, currentValue) =>
       currentValue.toLowerCase() == networkLowercase ? currentValue : previousValue
     )
-    const mainnetCommon = new Common({ chain: 'mainnet', hardfork: hfName })
+    const mainnetCommon = new Common({ chain: Chain.Mainnet, hardfork: hfName })
     const hardforks = mainnetCommon.hardforks()
     const testHardforks = []
     for (const hf of hardforks) {
@@ -290,7 +290,7 @@ export function getCommon(network: string) {
       throw new Error('network not supported: ' + network)
     }
     const mainnetCommon = new Common({
-      chain: 'mainnet',
+      chain: Chain.Mainnet,
       hardfork: transitionForks.finalSupportedFork,
     })
     const hardforks = mainnetCommon.hardforks()

--- a/packages/vm/tests/util.ts
+++ b/packages/vm/tests/util.ts
@@ -15,7 +15,7 @@ import {
   TxOptions,
 } from '@ethereumjs/tx'
 import { Block, BlockHeader, BlockOptions } from '@ethereumjs/block'
-import Common from '@ethereumjs/common'
+import Common, { Chain, Hardfork } from '@ethereumjs/common'
 
 export function dumpState(state: any, cb: Function) {
   function readAccounts(state: any) {
@@ -382,7 +382,7 @@ export function isRunningInKarma() {
  */
 export function getDAOCommon(activationBlock: number) {
   // here: get the default fork list of mainnet and only edit the DAO fork block (thus copy the rest of the "default" hardfork settings)
-  const defaultDAOCommon = new Common({ chain: 'mainnet', hardfork: 'dao' })
+  const defaultDAOCommon = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Dao })
   // retrieve the hard forks list from defaultCommon...
   const forks = defaultDAOCommon.hardforks()
   const editedForks = []


### PR DESCRIPTION
Second stage of work for #702. Updates usage of `common` package throughout monorepo to use new `Chain` and `Hardfork` enums.

My methodology was to use the global search term `new Common` and go package by package, so it's possible I may have missed some spots, but I tried to be as comprehensive as possible.