### PR TITLE
client: update changelog

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -8,7 +8,48 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [UNRELEASED]
 
-- `libp2p` modules upgraded to latest, PR [#1027](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1027)
+**New Features**
+
+- Integrate ETH/64 Protocol into Client, PR [#1020](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1020)
+- Upgrade to eth/66 [#1331](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1331)
+- Add les v3/v4, PR [#1324](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1324)
+- Implement EIP-1459: DNS peer discovery, PR [#1070](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1070)
+- Add VM execution, PR [#1028](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1028)
+- Add 6 new RPC methods, PR [#1130](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1130)
+- "The merge" rpc scaffolding, PR [#1265](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1265)
+- eth_chainID and eth_syncing RPC implementations, PR [#1314](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1314)
+- Central event bus implementation, PR [#1187](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1187)
+- Add node discovery mode flags & define network-based defaults, PR [#1097](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1097)
+- Add debugCode CLI option to generate Block execution script, PR [#1091](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1091)
+- Local client connections for debugging, PR [#1147](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1147)
+
+**Bug Fixes**
+
+- Clique PoA fixes, PR [#1088](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1088)
+- Fix Sync Bugs and Error Messages, PR [#1075](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1075)
+- Client Network Improvements and fix `nextForkBlock` bug, PR [#1031](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1031)
+- Fix HF switching. Fix TangerineWhistle update bug (Rinkeby: Block 14182), PR [#1101](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1101)
+- Fix Goerli Clique Difficulty Bug, PR [#1103](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1103)
+- Add fix for kovan nonce, PR [#1334](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1334)
+
+**Maintenance**
+
+- Save node key for consistent enode id, PR [#1067](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1067)
+- Refactor VM execution, PR [#1068](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1068)
+- Restart rlpx server on peerpool re-bootstrap, PR [#1113](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1113)
+- Split CLI transports options for bootnodes and multiaddrs, PR [#1145](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1145)
+- Simple message queue to handle unhandled ETH messages during handshake, PR [#1237](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1237)
+- bootstrap() extraction, PR [#1222](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1222)
+- Await DPT init, PR [#1233](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1233)
+- Make fetcher more typesafe, PR [#1023](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1023)
+
+**Dependencies, CI and Docs**
+
+- Upgrade `libp2p` modules to latest, PR [#1027](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1027)
+- Add basic cli test, PR [#1165](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1165)
+- Update client diagram [#1005](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1005)
+- Fix Fetcher.ts failure on Node v14, PR [#1022](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1022)
+- Fix failing node 16 CI, PR [#1346](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1346)
 
 ## [0.0.6] - 2020-06-19
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -45,7 +45,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 **Dependencies, CI and Docs**
 
-- Upgrade `libp2p` modules to latest, PR [#1027](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1027)
+- Upgrade `libp2p` modules to js-libp2p v0.30.7 and associated modules, PR [#1027](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1027)
 - Add basic cli test, PR [#1165](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1165)
 - Update client diagram [#1005](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1005)
 - Fix Fetcher.ts failure on Node v14, PR [#1022](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1022)


### PR DESCRIPTION
This PR updates the client changelog with the changes since the last release on 2020-06-19. There were 3 pages of PRs to sort through *(phew)* I tried to compile a list of the most significant PRs and not necessarily *every one* of them.

Prep for #1365