### PR TITLE
VM: fix EIP1559 bug to include tx value in balance check, fix nonce check

### DIFF
--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -162,7 +162,7 @@ export class Eth {
       return from
     }
 
-    const { execResult } = await vm.runTx({ tx })
+    const { execResult } = await vm.runTx({ tx, skipNonce: true })
     return bufferToHex(execResult.returnValue)
   }
 

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+- Fix EIP1559 bug to include tx value in balance check, fix nonce check, PR [#1372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1372)
+
 ## 5.5.0 - 2021-07-08
 
 ### Finalized London HF Support

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -284,14 +284,15 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
       // EIP-1559 spec:
       // The signer must be able to afford the transaction
       // `assert balance >= gas_limit * max_fee_per_gas`
-      const cost = tx.gasLimit.mul((tx as FeeMarketEIP1559Transaction).maxFeePerGas)
+      const cost = tx.gasLimit.mul((tx as FeeMarketEIP1559Transaction).maxFeePerGas).iadd(tx.value)
       if (balance.lt(cost)) {
         throw new Error(
           `sender doesn't have enough funds to send tx. The max cost is: ${cost} and the sender's account only has: ${balance}`
         )
       }
     }
-  } else if (!opts.skipNonce) {
+  }
+  if (!opts.skipNonce) {
     if (!nonce.eq(tx.nonce)) {
       throw new Error(
         `the tx doesn't have the correct nonce. account has nonce of: ${nonce} tx has nonce of: ${tx.nonce}`

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -284,7 +284,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
       // EIP-1559 spec:
       // The signer must be able to afford the transaction
       // `assert balance >= gas_limit * max_fee_per_gas`
-      const cost = tx.gasLimit.mul((tx as FeeMarketEIP1559Transaction).maxFeePerGas).iadd(tx.value)
+      const cost = tx.gasLimit.mul((tx as FeeMarketEIP1559Transaction).maxFeePerGas).add(tx.value)
       if (balance.lt(cost)) {
         throw new Error(
           `sender doesn't have enough funds to send tx. The max cost is: ${cost} and the sender's account only has: ${balance}`

--- a/packages/vm/tests/api/EIPs/eip-1559-FeeMarket.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-1559-FeeMarket.spec.ts
@@ -117,6 +117,7 @@ tape('EIP1559 tests', (t) => {
     const results2 = await vm.runTx({
       tx: block2.transactions[0],
       block: block2,
+      skipNonce: true,
     })
 
     expectedCost = GWEI.muln(21000).muln(5)
@@ -147,6 +148,7 @@ tape('EIP1559 tests', (t) => {
     const results3 = await vm.runTx({
       tx: block3.transactions[0],
       block: block3,
+      skipNonce: true,
     })
 
     expectedCost = GWEI.muln(21000).muln(5)

--- a/packages/vm/tests/api/EIPs/eip-2930-accesslists.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-2930-accesslists.spec.ts
@@ -72,7 +72,7 @@ tape('EIP-2930 Optional Access Lists tests', (t) => {
     st.equal(gasUsed, 100, 'charge warm sload gas')
 
     trace = []
-    await vm.runTx({ tx: txnWithoutAccessList })
+    await vm.runTx({ tx: txnWithoutAccessList, skipNonce: true })
     st.ok(trace[1][0] == 'SLOAD')
     gasUsed = trace[1][1].sub(trace[2][1]).toNumber()
     st.equal(gasUsed, 2100, 'charge cold sload gas')

--- a/packages/vm/tests/api/EIPs/eip-3541.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3541.spec.ts
@@ -49,7 +49,6 @@ tape('EIP 3541 tests', (t) => {
     const tx2 = Transaction.fromTxData({
       data: '0x7FEF0000000000000000000000000000000000000000000000000000000000000060005260206000F3',
       gasLimit: 1000000,
-      nonce: 2,
     }).sign(pkey)
 
     result = await vm.runTx({ tx: tx2 })

--- a/packages/vm/tests/api/buildBlock.spec.ts
+++ b/packages/vm/tests/api/buildBlock.spec.ts
@@ -229,7 +229,16 @@ tape('BlockBuilder', async (t) => {
     }
 
     blockBuilder = await vm.buildBlock({ parentBlock: genesisBlock })
-    await blockBuilder.addTransaction(tx)
+
+    const tx2 = Transaction.fromTxData(
+      { to: Address.zero(), value: 1000, gasLimit: 21000, gasPrice: 1, nonce: 1 },
+      { common, freeze: false }
+    )
+    tx2.getSenderAddress = () => {
+      return address
+    }
+
+    await blockBuilder.addTransaction(tx2)
     await blockBuilder.revert()
 
     try {
@@ -326,7 +335,7 @@ tape('BlockBuilder', async (t) => {
       return address
     }
     const tx4 = FeeMarketEIP1559Transaction.fromTxData(
-      { to: Address.zero(), value: 1000, gasLimit: 21000, maxFeePerGas: 101 },
+      { to: Address.zero(), value: 1000, gasLimit: 21000, maxFeePerGas: 101, nonce: 1 },
       { common, freeze: false }
     )
     tx4.getSenderAddress = () => {


### PR DESCRIPTION
This PR fixes an [EIP1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) bug, where we checked:

```
			# the signer must be able to afford the transaction
			assert signer.balance >= transaction.gas_limit * transaction.max_fee_per_gas
```

However, in the EIP, the call value is first deducted from the accounts' balance, and we should thus add this to the `transaction.gas_limit * transaction.max_fee_per_gas`.

This PR also fixes a bug where nonce values are not checked at runtime.
