### PR TITLE
VM: add tests for wrong transactions

### DIFF
--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 **Maintenance**
 
 - Update internal `common` usage to new Chain & Hardfork enums, PR [#1363](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1363)
+- Add tests for wrong transactions, PR [#1374](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1374)
 
 **Dependencies, CI and Docs**
 

--- a/packages/vm/tests/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/BlockchainTestsRunner.ts
@@ -126,10 +126,10 @@ export default async function runBlockchainTest(options: any, testData: any, t: 
           blockOpts: { calcDifficultyFromHeader: parentBlock.header, freeze: false },
         })
         for (const txData of raw.transactionSequence) {
-          const txRLP = Buffer.from(txData.rawBytes.slice(2), 'hex')
-          const tx = TransactionFactory.fromSerializedData(txRLP)
           const shouldFail = txData.valid == 'false'
           try {
+            const txRLP = Buffer.from(txData.rawBytes.slice(2), 'hex')
+            const tx = TransactionFactory.fromSerializedData(txRLP)
             await blockBuilder.addTransaction(tx)
             if (shouldFail) {
               t.fail('tx should fail, but did not fail')
@@ -142,7 +142,12 @@ export default async function runBlockchainTest(options: any, testData: any, t: 
             }
           }
         }
-        await vm.stateManager.revert()
+        // Have to try/catch this revert, in some cases trie is not checkpointed and we should thus not revert changes
+        try {
+          await vm.stateManager.revert()
+          // eslint-disable-next-line no-empty
+        } finally {
+        }
       }
 
       const blockRlp = Buffer.from(raw.rlp.slice(2), 'hex')

--- a/packages/vm/tests/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/BlockchainTestsRunner.ts
@@ -122,8 +122,7 @@ export default async function runBlockchainTest(options: any, testData: any, t: 
         const parentBlock = await vm.blockchain.getIteratorHead()
         const blockBuilder = await vm.buildBlock({
           parentBlock,
-          headerData: { coinbase: '0x96dc73c8b5969608c77375f085949744b5177660' },
-          blockOpts: { calcDifficultyFromHeader: parentBlock.header, freeze: false },
+          blockOpts: { calcDifficultyFromHeader: parentBlock.header },
         })
         for (const txData of raw.transactionSequence) {
           const shouldFail = txData.valid == 'false'

--- a/packages/vm/tests/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/BlockchainTestsRunner.ts
@@ -143,12 +143,7 @@ export default async function runBlockchainTest(options: any, testData: any, t: 
             }
           }
         }
-        // Have to try/catch this revert, in some cases trie is not checkpointed and we should thus not revert changes
-        try {
-          await vm.stateManager.revert()
-          // eslint-disable-next-line no-empty
-        } finally {
-        }
+        await blockBuilder.revert() // will only revert if checkpointed
       }
 
       const blockRlp = Buffer.from(raw.rlp.slice(2), 'hex')

--- a/packages/vm/tests/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/BlockchainTestsRunner.ts
@@ -118,6 +118,8 @@ export default async function runBlockchainTest(options: any, testData: any, t: 
       // Update common HF
       common.setHardforkByBlockNumber(currentBlock.toNumber())
 
+      // transactionSequence is provided when txs are expected to be rejected.
+      // To run this field we try to import them on the current state.
       if (raw.transactionSequence) {
         const parentBlock = await vm.blockchain.getIteratorHead()
         const blockBuilder = await vm.buildBlock({

--- a/packages/vm/tests/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/BlockchainTestsRunner.ts
@@ -1,11 +1,11 @@
 import * as tape from 'tape'
 import { addHexPrefix, BN, toBuffer, rlp } from 'ethereumjs-util'
-import { SecureTrie as Trie } from 'merkle-patricia-tree'
 import { Block } from '@ethereumjs/block'
 import Blockchain from '@ethereumjs/blockchain'
-import { setupPreConditions, verifyPostConditions } from './util'
 import Common from '@ethereumjs/common'
 import { TransactionFactory } from '@ethereumjs/tx'
+import { SecureTrie as Trie } from 'merkle-patricia-tree'
+import { setupPreConditions, verifyPostConditions } from './util'
 
 const level = require('level')
 const levelMem = require('level-mem')

--- a/packages/vm/tests/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/BlockchainTestsRunner.ts
@@ -5,7 +5,7 @@ import { Block } from '@ethereumjs/block'
 import Blockchain from '@ethereumjs/blockchain'
 import { setupPreConditions, verifyPostConditions } from './util'
 import Common from '@ethereumjs/common'
-import { TransactionFactory } from '../../tx/dist'
+import { TransactionFactory } from '@ethereumjs/tx'
 
 const level = require('level')
 const levelMem = require('level-mem')


### PR DESCRIPTION
We are not running all checks which are expected in `ethereum/tests`; if there is a `transactionSequence` field, try to execute the transactions on top of the last header block. This would have caught our nonce check problem in the transactions (see #1372).