### PR TITLE
trie: remove use of deprecated setRoot

### DIFF
--- a/packages/trie/CHANGELOG.md
+++ b/packages/trie/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+**New Features**
+
+**Bug Fixes**
+
+**Maintenance**
+
+- Remove use of deprecated setRoot, PR [#1376](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1376)
+
+**Dependencies, CI and Docs**
+
 ## 4.2.0 - 2021-05-20
 
 ### Changed Delete Behavior: NO Default Node Deletes

--- a/packages/trie/src/baseTrie.ts
+++ b/packages/trie/src/baseTrie.ts
@@ -65,13 +65,18 @@ export class Trie {
     this._deleteFromDB = deleteFromDB
 
     if (root) {
-      this.setRoot(root)
+      this.root = root
     }
   }
 
   /** Sets the current root of the `trie` */
   set root(value: Buffer) {
-    this.setRoot(value)
+    /* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */
+    if (!value) {
+      value = this.EMPTY_TRIE_ROOT
+    }
+    assert(value.length === 32, 'Invalid root length. Roots are 32 bytes')
+    this._root = value
   }
 
   /** Gets the current root of the `trie` */

--- a/packages/trie/src/baseTrie.ts
+++ b/packages/trie/src/baseTrie.ts
@@ -69,13 +69,21 @@ export class Trie {
     }
   }
 
-  /** Sets the current root of the `trie` */
+  /**
+   * Sets the current root of the `trie`
+   */
   set root(value: Buffer) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!value) {
+      value = this.EMPTY_TRIE_ROOT
+    }
     assert(value.length === 32, 'Invalid root length. Roots are 32 bytes')
     this._root = value
   }
 
-  /** Gets the current root of the `trie` */
+  /**
+   * Gets the current root of the `trie`
+   */
   get root(): Buffer {
     return this._root
   }

--- a/packages/trie/src/baseTrie.ts
+++ b/packages/trie/src/baseTrie.ts
@@ -70,13 +70,11 @@ export class Trie {
   }
 
   /** Sets the current root of the `trie` */
-  set root(value: Buffer) {
-    /* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */
-    if (!value) {
-      value = this.EMPTY_TRIE_ROOT
-    }
-    assert(value.length === 32, 'Invalid root length. Roots are 32 bytes')
-    this._root = value
+  set root(value: Buffer | undefined) {
+    if (value) {
+      assert(value.length === 32, 'Invalid root length. Roots are 32 bytes')
+      this._root = value
+    } else this._root = this.EMPTY_TRIE_ROOT
   }
 
   /** Gets the current root of the `trie` */
@@ -92,11 +90,7 @@ export class Trie {
    * @deprecated
    */
   setRoot(value?: Buffer) {
-    if (!value) {
-      value = this.EMPTY_TRIE_ROOT
-    }
-    assert(value.length === 32, 'Invalid root length. Roots are 32 bytes')
-    this._root = value
+    this.root = value
   }
 
   /**

--- a/packages/trie/src/baseTrie.ts
+++ b/packages/trie/src/baseTrie.ts
@@ -71,12 +71,8 @@ export class Trie {
 
   /** Sets the current root of the `trie` */
   set root(value: Buffer) {
-    try {
-      assert(value.length === 32, 'Invalid root length. Roots are 32 bytes')
-      this._root = value
-    } catch {
-      this._root = this.EMPTY_TRIE_ROOT
-    }
+    assert(value.length === 32, 'Invalid root length. Roots are 32 bytes')
+    this._root = value
   }
 
   /** Gets the current root of the `trie` */
@@ -91,8 +87,8 @@ export class Trie {
    * @param value
    * @deprecated
    */
-  setRoot(value: Buffer) {
-    this.root = value
+  setRoot(value?: Buffer) {
+    this.root = value ?? this.EMPTY_TRIE_ROOT
   }
 
   /**

--- a/packages/trie/src/baseTrie.ts
+++ b/packages/trie/src/baseTrie.ts
@@ -70,11 +70,13 @@ export class Trie {
   }
 
   /** Sets the current root of the `trie` */
-  set root(value: Buffer | undefined) {
-    if (value) {
+  set root(value: Buffer) {
+    try {
       assert(value.length === 32, 'Invalid root length. Roots are 32 bytes')
       this._root = value
-    } else this._root = this.EMPTY_TRIE_ROOT
+    } catch {
+      this._root = this.EMPTY_TRIE_ROOT
+    }
   }
 
   /** Gets the current root of the `trie` */
@@ -89,7 +91,7 @@ export class Trie {
    * @param value
    * @deprecated
    */
-  setRoot(value?: Buffer) {
+  setRoot(value: Buffer) {
     this.root = value
   }
 


### PR DESCRIPTION
Small change to remove internal use of deprecated `setRoot` method in `trie` package