### PR TITLE
eslint: rule clean up and consolidation

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -32,6 +32,7 @@ module.exports = {
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     '@typescript-eslint/no-unnecessary-condition': 'off',
+    'no-dupe-class-members': 'off',
     'prettier/prettier': 'error',
   },
   parserOptions: {

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -31,6 +31,7 @@ module.exports = {
     ],
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+    '@typescript-eslint/no-unnecessary-condition': 'off',
     'prettier/prettier': 'error',
   },
   parserOptions: {

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -29,6 +29,8 @@ module.exports = {
           }
       }
     ],
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     'prettier/prettier': 'error',
   },
   parserOptions: {

--- a/packages/block/.eslintrc.js
+++ b/packages/block/.eslintrc.js
@@ -2,6 +2,5 @@ module.exports = {
   extends: "../../config/eslint.js",
   ignorePatterns: ["test-build", "karma.conf.js"],
   rules: {
-    "@typescript-eslint/no-unnecessary-condition": "off"
   }
 }

--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-dupe-class-members */
-
 import { BaseTrie as Trie } from 'merkle-patricia-tree'
 import { BN, rlp, keccak256, KECCAK256_RLP } from 'ethereumjs-util'
 import Common from '@ethereumjs/common'

--- a/packages/blockchain/.eslintrc.js
+++ b/packages/blockchain/.eslintrc.js
@@ -1,6 +1,5 @@
 module.exports = {
   extends: "../../config/eslint.js",
   rules: {
-    "@typescript-eslint/no-unnecessary-condition": "off"
   }
 }

--- a/packages/client/.eslintrc.js
+++ b/packages/client/.eslintrc.js
@@ -4,9 +4,6 @@ module.exports = {
     project: ['./tsconfig.json', './tsconfig.browser.json', './tsconfig.eslint.json']
   },
   rules: {
-    // Many methods have been sketched in as stubs & their params trigger this.
-    // Duplicates the (more tolerant) @typescript-eslint/no-unused-vars
-    'no-unused-vars': 'off'
   },
   overrides: [
     {

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -184,6 +184,11 @@ async function run() {
     chain = args.network
   }
 
+  // TODO: map chainParams (and lib/util.parseParams) to new Common format
+  // and pass into common constructor below
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const chainParams = args.params ? await parseParams(args.params) : args.network
+
   const common = new Common({ chain, hardfork: Hardfork.Chainstart })
   const datadir = args.datadir ?? Config.DATADIR_DEFAULT
   const configDirectory = `${datadir}/${common.chainName()}/config`
@@ -214,9 +219,6 @@ async function run() {
   })
   logger = config.logger
   config.events.setMaxListeners(50)
-  // TODO: see todo below wrt resolving chain param parsing
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const chainParams = args.params ? await parseParams(args.params) : args.network
 
   const client = await runNode(config)
   const server = config.rpc ? runRpcServer(client, config) : null

--- a/packages/client/lib/net/peer/peer.ts
+++ b/packages/client/lib/net/peer/peer.ts
@@ -147,7 +147,6 @@ export class Peer extends events.EventEmitter {
       protocols: Array.from(this.bound.keys()),
       inbound: this.inbound,
     }
-    /* eslint-disable @typescript-eslint/no-unnecessary-condition */
     return Object.entries(properties)
       .filter(([, value]) => value !== undefined && value !== null && value.toString() !== '')
       .map((keyValue) => keyValue.join('='))

--- a/packages/client/lib/net/peerpool.ts
+++ b/packages/client/lib/net/peerpool.ts
@@ -147,7 +147,6 @@ export class PeerPool {
    * @emits  Event.POOL_PEER_BANNED
    */
   ban(peer: Peer, maxAge: number = 60000) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!peer.server) {
       return
     }

--- a/packages/client/lib/sync/execution/vmexecution.ts
+++ b/packages/client/lib/sync/execution/vmexecution.ts
@@ -77,7 +77,6 @@ export class VMExecution extends Execution {
     while (
       (numExecuted === undefined || numExecuted === this.NUM_BLOCKS_PER_ITERATION) &&
       !startHeadBlock.hash().equals(canonicalHead.hash()) &&
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       this.syncing
     ) {
       headBlock = undefined
@@ -171,7 +170,6 @@ export class VMExecution extends Execution {
       )
       numExecuted = (await this.vmPromise) as number
 
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (errorBlock) {
         await this.chain.blockchain.setIteratorHead('vm', (errorBlock as Block).header.parentHash)
         return 0

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -28,7 +28,6 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
       block: first,
       max: count,
     })
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!headersResult) {
       // Catch occasional null responses from peers who do not return block headers from peer.eth request
       this.config.logger.warn(
@@ -40,7 +39,6 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
     }
     const headers = headersResult[1]
     const bodiesResult = await peer!.eth!.getBlockBodies({ hashes: headers.map((h) => h.hash()) })
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!bodiesResult) {
       // Catch occasional null responses from peers who do not return block bodies from peer.eth request
       this.config.logger.warn(

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -222,7 +222,6 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
       return false
     }
     const peer = this.peer()
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (peer) {
       peer.idle = false
       this.in.remove()

--- a/packages/client/lib/util/parse.ts
+++ b/packages/client/lib/util/parse.ts
@@ -37,7 +37,6 @@ export function parseMultiaddrs(input: MultiaddrLike): multiaddr[] {
       // parse as ip:port
       const match = s.match(/^(\d+\.\d+\.\d+\.\d+):([0-9]+)$/)
       if (match) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const [_, ip, port] = match
         return multiaddr(`/ip4/${ip}/tcp/${port}`)
       }

--- a/packages/client/test/blockchain/chain.spec.ts
+++ b/packages/client/test/blockchain/chain.spec.ts
@@ -1,5 +1,6 @@
 import tape from 'tape'
 import { Block, BlockData, HeaderData } from '@ethereumjs/block'
+import Blockchain from '@ethereumjs/blockchain'
 import { BN } from 'ethereumjs-util'
 import { Chain } from '../../lib/blockchain'
 import { Config } from '../../lib/config'
@@ -8,7 +9,6 @@ import { Config } from '../../lib/config'
 // needed for karma-typescript bundling
 import * as util from 'util' // eslint-disable-line @typescript-eslint/no-unused-vars
 import { Buffer } from 'buffer' // eslint-disable-line @typescript-eslint/no-unused-vars
-import Blockchain from '@ethereumjs/blockchain'
 
 const config = new Config()
 

--- a/packages/client/test/integration/mocks/mockserver.ts
+++ b/packages/client/test/integration/mocks/mockserver.ts
@@ -84,7 +84,6 @@ export default class MockServer extends Server {
 
   disconnect(id: string) {
     const peer = this.peers[id]
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (peer) this.config.events.emit(Event.PEER_DISCONNECTED, peer)
   }
 

--- a/packages/client/test/integration/mocks/network.ts
+++ b/packages/client/test/integration/mocks/network.ts
@@ -23,8 +23,6 @@ interface ServerDetails {
 }
 export const servers: ServerDetails = {}
 
-/* eslint-disable @typescript-eslint/no-unnecessary-condition */
-
 export function createServer(location: string) {
   if (servers[location]) {
     throw new Error(`Already running a server at ${location}`)

--- a/packages/client/test/net/peer/libp2pnode.spec.ts
+++ b/packages/client/test/net/peer/libp2pnode.spec.ts
@@ -2,8 +2,7 @@ import tape from 'tape-catch'
 import td from 'testdouble'
 
 tape('[Libp2pNode]', async (t) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const libp2p = td.replace('libp2p')
+  const _libp2p = td.replace('libp2p')
   const { Libp2pNode } = await import('../../../lib/net/peer/libp2pnode')
 
   t.test('should be a libp2p bundle', (t) => {

--- a/packages/client/test/net/peer/libp2ppeer.spec.ts
+++ b/packages/client/test/net/peer/libp2ppeer.spec.ts
@@ -7,8 +7,7 @@ import { Event } from '../../../lib/types'
 import { Libp2pPeer } from '../../../lib/net/peer'
 
 tape('[Libp2pPeer]', async (t) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const PeerId = td.replace('peer-id')
+  const _PeerId = td.replace('peer-id')
 
   const Libp2pNode = td.constructor(['start', 'stop', 'dial', 'dialProtocol'] as any)
   td.replace('../../../lib/net/peer/libp2pnode', { Libp2pNode })

--- a/packages/client/test/sync/fetcher/fetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/fetcher.spec.ts
@@ -6,16 +6,13 @@ import { Job } from '../../../lib/sync/fetcher/types'
 import { Event } from '../../../lib/types'
 
 class FetcherTest extends Fetcher<any, any, any> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  process(_job: any, res: any) {
+  process(_job: any, _res: any) {
     return undefined // have to return undefined, otherwise the function return signature is void.
   }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async request(_job: any, peer: any) {
+  async request(_job: any, _peer: any) {
     return
   }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async store(store: any) {}
+  async store(_store: any) {}
 }
 
 tape('[Fetcher]', (t) => {

--- a/packages/common/.eslintrc.js
+++ b/packages/common/.eslintrc.js
@@ -2,6 +2,5 @@ module.exports = {
   extends: "../../config/eslint.js",
   ignorePatterns: ["scripts"],
   rules: {
-    "@typescript-eslint/no-unnecessary-condition": "off"
   }
 }

--- a/packages/devp2p/.eslintrc.js
+++ b/packages/devp2p/.eslintrc.js
@@ -5,7 +5,6 @@ module.exports = {
   },
   rules: {
     '@typescript-eslint/no-floating-promises': 'off',
-    '@typescript-eslint/no-unnecessary-condition': 'off',
     'no-redeclare': 'off',
     'no-undef': 'off' // temporary until fixed: 'NodeJS' is not defined
   }

--- a/packages/devp2p/src/browser/dns.ts
+++ b/packages/devp2p/src/browser/dns.ts
@@ -14,13 +14,11 @@ const errorMessage =
 
 export default class dns {
   public static promises = {
-    // eslint-disable-next-line no-unused-vars
     resolve: async function (_url: string, _recordType: string): Promise<any[]> {
       throw new Error(errorMessage)
     },
   }
 
-  // eslint-disable-next-line no-unused-vars
   static setServers(_servers: string[]): void {
     throw new Error(errorMessage)
   }

--- a/packages/devp2p/src/rlpx/ecies.ts
+++ b/packages/devp2p/src/rlpx/ecies.ts
@@ -324,7 +324,6 @@ export class ECIES {
   }
 
   parseAckEIP8(data: Buffer): void {
-    // eslint-disable-line
     const size = buffer2int(data.slice(0, 2)) + 2
     assertEq(data.length, size, 'message length different from specified size (EIP8)', debug)
     this.parseAckPlain(data.slice(2), data.slice(0, 2))

--- a/packages/ethash/.eslintrc.js
+++ b/packages/ethash/.eslintrc.js
@@ -2,6 +2,5 @@ module.exports = {
   extends: "../../config/eslint.js",
   ignorePatterns: ["examples"],
   rules: {
-    "@typescript-eslint/no-unnecessary-condition": "off"
   }
 }

--- a/packages/trie/src/baseTrie.ts
+++ b/packages/trie/src/baseTrie.ts
@@ -73,7 +73,6 @@ export class Trie {
    * Sets the current root of the `trie`
    */
   set root(value: Buffer) {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!value) {
       value = this.EMPTY_TRIE_ROOT
     }
@@ -137,7 +136,6 @@ export class Trie {
    */
   async put(key: Buffer, value: Buffer): Promise<void> {
     // If value is empty, delete
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!value || value.toString() === '') {
       return await this.del(key)
     }
@@ -408,10 +406,8 @@ export class Trie {
       stack: TrieNode[]
     ) => {
       // branchNode is the node ON the branch node not THE branch node
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (!parentNode || parentNode instanceof BranchNode) {
         // branch->?
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (parentNode) {
           stack.push(parentNode)
         }
@@ -618,12 +614,10 @@ export class Trie {
   async batch(ops: BatchDBOp[]): Promise<void> {
     for (const op of ops) {
       if (op.type === 'put') {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (!op.value) {
           throw new Error('Invalid batch db operation')
         }
         await this.put(op.key, op.value)
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       } else if (op.type === 'del') {
         await this.del(op.key)
       }

--- a/packages/trie/src/checkpointDb.ts
+++ b/packages/trie/src/checkpointDb.ts
@@ -141,7 +141,6 @@ export class CheckpointDB extends DB {
       for (const op of opStack) {
         if (op.type === 'put') {
           await this.put(op.key, op.value)
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         } else if (op.type === 'del') {
           await this.del(op.key)
         }

--- a/packages/trie/src/secure.ts
+++ b/packages/trie/src/secure.ts
@@ -33,7 +33,6 @@ export class SecureTrie extends CheckpointTrie {
    * @param value
    */
   async put(key: Buffer, val: Buffer): Promise<void> {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (!val || val.toString() === '') {
       await this.del(key)
     } else {

--- a/packages/tx/.eslintrc.js
+++ b/packages/tx/.eslintrc.js
@@ -2,7 +2,6 @@ module.exports = {
   extends: '../../config/eslint.js',
   ignorePatterns: ['examples', 'karma.conf.js', 'test-build'],
   rules: {
-    '@typescript-eslint/no-unnecessary-condition': 'off',
     'no-dupe-class-members': 'off',
   },
 }

--- a/packages/tx/.eslintrc.js
+++ b/packages/tx/.eslintrc.js
@@ -2,6 +2,5 @@ module.exports = {
   extends: '../../config/eslint.js',
   ignorePatterns: ['examples', 'karma.conf.js', 'test-build'],
   rules: {
-    'no-dupe-class-members': 'off',
   },
 }

--- a/packages/tx/src/transactionFactory.ts
+++ b/packages/tx/src/transactionFactory.ts
@@ -96,10 +96,9 @@ export default class TransactionFactory {
    * If transactionID is undefined, returns the legacy transaction class.
    * @deprecated - This method is deprecated and will be removed on the next major release
    * @param transactionID
-   * @param common - This option is not used
+   * @param _common - This option is not used
    */
-  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-  public static getTransactionClass(transactionID: number = 0, common?: Common) {
+  public static getTransactionClass(transactionID: number = 0, _common?: Common) {
     const legacyTxn = transactionID == 0 || (transactionID >= 0x80 && transactionID <= 0xff)
 
     if (legacyTxn) {

--- a/packages/vm/.eslintrc.js
+++ b/packages/vm/.eslintrc.js
@@ -3,7 +3,6 @@ module.exports = {
   ignorePatterns: ['scripts', 'benchmarks', 'examples', 'karma.conf.js'],
   rules: {
     '@typescript-eslint/no-use-before-define': 'off',
-    '@typescript-eslint/no-unnecessary-condition': 'off',
     'no-invalid-this': 'off',
     'no-restricted-syntax': 'off',
   },

--- a/packages/vm/.eslintrc.js
+++ b/packages/vm/.eslintrc.js
@@ -6,7 +6,6 @@ module.exports = {
     '@typescript-eslint/no-unnecessary-condition': 'off',
     'no-invalid-this': 'off',
     'no-restricted-syntax': 'off',
-    'no-unused-vars': ["error", { "argsIgnorePattern": "^_" }]
   },
   overrides: [
     {

--- a/packages/vm/src/evm/opcodes/codes.ts
+++ b/packages/vm/src/evm/opcodes/codes.ts
@@ -303,7 +303,6 @@ export function getOpcodesForHF(common: Common): OpcodeList {
     }
   }
 
-  /* eslint-disable-next-line no-restricted-syntax */
   for (const key in opcodeBuilder) {
     const baseFee = common.param('gasPrices', opcodeBuilder[key].name.toLowerCase())
     // explicitly verify that we have defined a base fee

--- a/packages/vm/tests/api/index.spec.ts
+++ b/packages/vm/tests/api/index.spec.ts
@@ -12,7 +12,7 @@ import testnet2 from './testdata/testnet2.json'
 // explicitly import util and buffer,
 // needed for karma-typescript bundling
 import * as util from 'util' // eslint-disable-line @typescript-eslint/no-unused-vars
-import { Buffer } from 'buffer'  // eslint-disable-line @typescript-eslint/no-unused-vars
+import { Buffer } from 'buffer' // eslint-disable-line @typescript-eslint/no-unused-vars
 
 /**
  * Tests for the main constructor API and

--- a/packages/vm/tests/api/index.spec.ts
+++ b/packages/vm/tests/api/index.spec.ts
@@ -11,10 +11,8 @@ import testnet2 from './testdata/testnet2.json'
 
 // explicitly import util and buffer,
 // needed for karma-typescript bundling
-// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-import * as util from 'util'
-// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
-import { Buffer } from 'buffer'
+import * as util from 'util' // eslint-disable-line @typescript-eslint/no-unused-vars
+import { Buffer } from 'buffer'  // eslint-disable-line @typescript-eslint/no-unused-vars
 
 /**
  * Tests for the main constructor API and


### PR DESCRIPTION
This PR does some eslint rule cleanup, bringing common rule configurations up to the root config for more consistent behavior across packages.

This PR:
* Configures `no-unused-vars` in the root eslint
* Clarifies `chainParams `todo comment
* Turns off `no-unnecessary-condition` in root config
* Turns off `no-dupe-class-members` in root config
* Cleans up unneeded disables