### PR TITLE
return value of type never|BNLike is assignable to a variable of type BNLike

### DIFF
--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -184,7 +184,7 @@ export interface FeeMarketEIP1559TxData extends AccessListEIP2930TxData {
   /**
    * The transaction's gas price.
    */
-  gasPrice?: never
+  gasPrice?: never | BNLike
   /**
    * The maximum inclusion fee per gas (this fee is given to the miner)
    */


### PR DESCRIPTION
The set of never is an empty set.

The empty set is a subset of every set .viz Given a set U, the union of U and the empty set is just U.

Given that no values are assignable to a variable of type never saying:

````
 gasPrice?: never 
````

Can result in bugs/miscellaneous limitations/errors.  Example: [gasprice](https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-core/src/internal/core/providers/accounts.ts#:~:text=gasPrice%3A%20undefined%2C) 

Hence suggesting
````
 gasPrice?: never | BNLike
````

Which gives gasPrice assignability to a variable of type BNLike