### PR TITLE
ci: simplify dependency cache code

### DIFF
--- a/.github/workflows/block-build.yml
+++ b/.github/workflows/block-build.yml
@@ -22,32 +22,20 @@ jobs:
       matrix:
         node-version: [12]
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run coverage

--- a/.github/workflows/blockchain-build.yml
+++ b/.github/workflows/blockchain-build.yml
@@ -22,32 +22,20 @@ jobs:
       matrix:
         node-version: [12]
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run coverage

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -22,32 +22,20 @@ jobs:
       matrix:
         node-version: [12]
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run coverage
@@ -67,32 +55,20 @@ jobs:
         syncmode: ['full', 'light']
       fail-fast: false
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: 12
+          cache: 'npm'
 
       - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
-        
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
 
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run test:cli -- --network=${{matrix.network}} --syncmode=${{matrix.syncmode}} --transports rlpx

--- a/.github/workflows/common-build.yml
+++ b/.github/workflows/common-build.yml
@@ -22,32 +22,20 @@ jobs:
       matrix:
         node-version: [12]
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run coverage

--- a/.github/workflows/devp2p-build.yml
+++ b/.github/workflows/devp2p-build.yml
@@ -22,32 +22,20 @@ jobs:
       matrix:
         node-version: [12]
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run coverage

--- a/.github/workflows/e2e-hardhat.yml
+++ b/.github/workflows/e2e-hardhat.yml
@@ -18,34 +18,21 @@ jobs:
       matrix:
         node-version: [16]
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      # Use a dependency cache to speed up runs of same deps
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: |
-            **/node_modules
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Build if cache is restored
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
-
-      # Otherwise, run install (which also runs build)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
+      - run: npm i
+        working-directory: ${{github.workspace}}
 
       # Publish all packages to virtual npm registry
       # after giving each a minor version bump

--- a/.github/workflows/ethash-build.yml
+++ b/.github/workflows/ethash-build.yml
@@ -22,32 +22,20 @@ jobs:
       matrix:
         node-version: [12]
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run coverage

--- a/.github/workflows/node-versions.yml
+++ b/.github/workflows/node-versions.yml
@@ -15,13 +15,9 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
-
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
+          node-version: 12
 
       - id: set-matrix
         run: echo "::set-output name=matrix::$(npx testable-node-versions)"
@@ -34,18 +30,20 @@ jobs:
         node: ${{ fromJson(needs.get-node-versions.outputs.matrix) }}
       fail-fast: false
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node }}
-
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+
       - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      - run: npm install
+      - run: npm i
 
       - name: Test Block
         run: npm run test

--- a/.github/workflows/trie-build.yml
+++ b/.github/workflows/trie-build.yml
@@ -22,32 +22,20 @@ jobs:
       matrix:
         node-version: [12]
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run coverage
@@ -63,31 +51,20 @@ jobs:
   trie-benchmarks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: 12
+          cache: 'npm'
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
-      
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
 
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
       
       - run: npm run benchmarks | tee output.txt

--- a/.github/workflows/tx-build.yml
+++ b/.github/workflows/tx-build.yml
@@ -22,32 +22,20 @@ jobs:
       matrix:
         node-version: [12]
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run coverage

--- a/.github/workflows/util-build.yml
+++ b/.github/workflows/util-build.yml
@@ -22,32 +22,20 @@ jobs:
       matrix:
         node-version: [12]
     steps:
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run coverage

--- a/.github/workflows/vm-build.yml
+++ b/.github/workflows/vm-build.yml
@@ -17,28 +17,20 @@ jobs:
   test-vm-api:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: 12
+          cache: 'npm'
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
+      - name: Use npm v7 for workspaces support 
+        run: npm i -g npm@7
 
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run coverage
@@ -55,28 +47,20 @@ jobs:
   test-vm-state:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: 12
+          cache: 'npm'
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
+      - name: Use npm v7 for workspaces support 
+        run: npm i -g npm@7
 
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run test:state:selectedForks
@@ -84,28 +68,20 @@ jobs:
   test-vm-blockchain:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: 12
+          cache: 'npm'
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
+      - name: Use npm v7 for workspaces support 
+        run: npm i -g npm@7
 
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run test:blockchain
@@ -113,31 +89,20 @@ jobs:
   vm-benchmarks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: 12
+          cache: 'npm'
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run build:benchmarks

--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -14,28 +14,25 @@ jobs:
   test-vm-api:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: 'npm'
+
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # This is specific to Nightly test 1/2.
-      # The job needs to run with a fresh combination of lockfiles, to warm up the cache.
-      # So in this step, we remove the lockfiles
-      - run: rm package-lock.json packages/*/package-lock.json
+      # The job is meant to run with a fresh lock file
+      # to detect any possible issues with new dep versions.
+      - run: rm package-lock.json
         working-directory: ${{github.workspace}}
 
-      # This is specific to Nightly test 2/2.
-      # Here, we generate new lockfiles
-      - run: npm install
-        working-directory: ${{github.workspace}}
-
-      - run: npm run build
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run test:API
@@ -44,28 +41,25 @@ jobs:
   test-vm-state:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: 'npm'
+
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # This is specific to Nightly test 1/2.
-      # The job needs to run with a fresh combination of lockfiles, to warm up the cache.
-      # So in this step, we remove the lockfiles
-      - run: rm package-lock.json packages/*/package-lock.json
+      # The job is meant to run with a fresh lock file
+      # to detect any possible issues with new dep versions.
+      - run: rm package-lock.json
         working-directory: ${{github.workspace}}
 
-      # This is specific to Nightly test 2/2.
-      # Here, we generate new lockfiles
-      - run: npm install
-        working-directory: ${{github.workspace}}
-
-      - run: npm run build
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run test:state:allForks
@@ -73,38 +67,25 @@ jobs:
   test-vm-blockchain:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: 'npm'
+
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # This is specific to Nightly test 1/2.
-      # The job needs to run with a fresh combination of lockfiles, to warm up the cache.
-      # So in this step, we remove the lockfiles
-      - run: rm package-lock.json packages/*/package-lock.json
+      # The job is meant to run with a fresh lock file
+      # to detect any possible issues with new dep versions.
+      - run: rm package-lock.json
         working-directory: ${{github.workspace}}
 
-      # This is specific to Nightly test 2/2.
-      # Here, we generate new lockfiles
-      - run: npm install
-        working-directory: ${{github.workspace}}
-
-      # This is specific to Nightly test 3/2.
-      # In the case lockfiles a.re not so fresh, use information from cache
-      - name: Dependency cache.
-      # We need this to save cache afterwards, so other jobs can benefit from it.
-        uses: actions/cache@v2
-        id: cache
-        with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
-
-      - run: npm run build
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run test:blockchain:allForks
@@ -113,28 +94,25 @@ jobs:
   test-vm-slow:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: 'npm'
+
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
-      
-      # This is specific to Nightly test 1/2.
-      # The job needs to run with a fresh combination of lockfiles, to warm up the cache.
-      # So in this step, we remove the lockfiles
-      - run: rm package-lock.json packages/*/package-lock.json
+
+      # The job is meant to run with a fresh lock file
+      # to detect any possible issues with new dep versions.
+      - run: rm package-lock.json
         working-directory: ${{github.workspace}}
 
-      # This is specific to Nightly test 2/2.
-      # Here, we generate new lockfiles
-      - run: npm install
-        working-directory: ${{github.workspace}}
-
-      - run: npm run build
+      - run: npm i
         working-directory: ${{github.workspace}}
       
       - run: npm run test:state:slow

--- a/.github/workflows/vm-pr.yml
+++ b/.github/workflows/vm-pr.yml
@@ -14,31 +14,20 @@ jobs:
   vm-api:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-12-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: 12
+          cache: 'npm'
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run coverage
@@ -64,31 +53,20 @@ jobs:
         ]
       fail-fast: false
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-12-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: 12
+          cache: 'npm'
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run test:state -- --fork=${{ matrix.fork }} --verify-test-amount-alltests
@@ -113,30 +91,20 @@ jobs:
         ]
       fail-fast: false
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          key: cache-${{ runner.os }}-12-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: 'npm'
+
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run test:state -- --fork=${{ matrix.fork }} --verify-test-amount-alltests
@@ -159,30 +127,20 @@ jobs:
         ]
       fail-fast: false
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
-        with:
-          key: cache-${{ runner.os }}-12-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: 'npm'
+
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run test:blockchain -- ${{ matrix.args }}
@@ -207,31 +165,20 @@ jobs:
         ]
       fail-fast: false
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-12-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
+          node-version: 12
+          cache: 'npm'
 
-      - name: Update to npm v7 for workspaces support 
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'true'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run test:blockchain -- ${{ matrix.args }}
@@ -239,31 +186,20 @@ jobs:
   vm-benchmarks:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
       - uses: actions/checkout@v2
         with:
           submodules: recursive
 
-      - name: Dependency cache
-        uses: actions/cache@v2
-        id: cache
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
         with:
-          key: cache-${{ runner.os }}-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          path: '**/node_modules'
-          
-      - name: Update to npm v7 for workspaces support 
+          node-version: 12
+          cache: 'npm'
+
+      - name: Use npm v7 for workspaces support 
         run: npm i -g npm@7
 
-      # Installs dependencies and builds all packages (if cache hit failed)
-      - run: npm install
-        if: steps.cache.outputs.cache-hit != 'true'
-        working-directory: ${{github.workspace}}
-
-      # Builds fresh packages (if cache hit succeeded)
-      - run: npm run build --workspaces
-        if: steps.cache.outputs.cache-hit == 'false'
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run build:benchmarks

--- a/scripts/check-npm-version.sh
+++ b/scripts/check-npm-version.sh
@@ -7,13 +7,11 @@
 # Exit immediately on error
 set -o errexit
 
-NPM_MAJOR_V=$(npm -v | grep -o [0-9]*)
+NPM_MAJOR_V=$(npm -v | grep -Eo '^[0-9]+')
 
-# Remove all new line, carriage return, tab characters
-# from the string, to allow integer comparison
-NPM_MAJOR_V="${NPM_MAJOR_V//[$'\t\r\n ']}"
-
-if [ "$NPM_MAJOR_V" -ge 7 ]; then
-  echo 'npm >=v7 satisfied'; else
+if [[ "$NPM_MAJOR_V" -ge 7 ]]
+then
+  echo 'npm >=v7 satisfied'
+else
   echo 'npm version 7 or greater is required for workspaces support. Please update with "npm i -g npm@7"' && exit 1
 fi


### PR DESCRIPTION
Thanks to @alcuadrado for [mentioning](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1395#discussion_r687059092) that the latest version of `actions/setup-node` has [caching](https://github.com/actions/setup-node#caching-packages-dependencies) capabilities, this really simplifies our ci scripts!