### PR TITLE
Add fullsync integration test with merge fork set

### DIFF
--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -342,7 +342,7 @@ export class BlockHeader {
     }
 
     // Check for constant values for PoS blocks
-    if (this._common.consensusType() === ConsensusType.ProofOfStake) {
+    if (this._common.consensusType() === ConsensusType.ProofOfStake && this.number >= this._common.hardforks().filter((hf: any) => hf.name === 'merge').block) {
       let error = false
       let errorMsg = ''
 

--- a/packages/client/lib/blockchain/chain.ts
+++ b/packages/client/lib/blockchain/chain.ts
@@ -270,6 +270,7 @@ export class Chain {
       return
     }
     await this.open()
+    
     blocks = blocks.map((b: Block) =>
       Block.fromValuesArray(b.raw(), {
         common: this.config.chainCommon,

--- a/packages/client/test/integration/chains/testnet.json
+++ b/packages/client/test/integration/chains/testnet.json
@@ -1,0 +1,88 @@
+{
+    "name": "mainnet",
+    "chainId": 1,
+    "networkId": 1,
+    "defaultHardfork": "london",
+    "consensus": {
+      "type": "pow",
+      "algorithm": "ethash"
+    },
+    "comment": "Private test network",
+    "url": "[TESTNET_URL]",
+    "genesis": {
+      "hash": "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
+      "timestamp": null,
+      "gasLimit": 5000,
+      "difficulty": 17179869184,
+      "nonce": "0x0000000000000042",
+      "extraData": "0x11bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82fa",
+      "stateRoot": "0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544"
+    },
+    "hardforks": [
+      {
+        "name": "chainstart",
+        "block": 0
+      },
+      {
+        "name": "homestead",
+        "block": 1
+      },
+      {
+        "name": "tangerineWhistle",
+        "block": 2
+      },
+      {
+        "name": "spuriousDragon",
+        "block": 3
+      },
+      {
+        "name": "byzantium",
+        "block": 4
+    },
+    {
+      "name": "constantinople",
+      "block": 5
+    },
+    {
+      "name": "petersburg",
+      "block": 6
+    },
+    {
+      "name": "istanbul",
+      "block": 7
+    },
+    {
+      "name": "muirGlacier",
+      "block": 8
+    },
+    {
+      "name": "berlin",
+      "block": 9
+    }, 
+    {
+      "name": "london",
+      "block": 10
+    },
+    {
+      "name": "theMerge",
+      "block": 11
+    }
+    ],
+    "bootstrapNodes": [
+      {
+        "ip": "10.0.0.1",
+        "port": 30303,
+        "id": "11000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "location": "",
+        "comment": ""
+      },
+      {
+        "ip": "10.0.0.2",
+        "port": 30303,
+        "id": "22000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+        "location": "",
+        "comment": ""
+      }
+    ]
+  }
+  

--- a/packages/client/test/integration/chains/testnet.json
+++ b/packages/client/test/integration/chains/testnet.json
@@ -64,7 +64,7 @@
       "block": 10
     },
     {
-      "name": "theMerge",
+      "name": "merge",
       "block": 11
     }
     ],

--- a/packages/client/test/integration/mergeSync.spec.ts
+++ b/packages/client/test/integration/mergeSync.spec.ts
@@ -1,0 +1,29 @@
+import Common, { Hardfork } from '@ethereumjs/common'
+import tape from 'tape'
+import { Event } from '../../lib/types'
+import { setup, destroy } from './util'
+import testnet from './chains/testnet.json'
+tape('[Integration:MergeSync]', async (t) => {
+  t.test('should sync blocks on a chain with the merge', async (t) => {
+    const common = new Common({ chain: testnet, hardfork: Hardfork.Chainstart })
+      const [remoteServer, remoteService] = await setup({
+        location: '127.0.0.2',
+        height: 20,
+        common: common,
+      })
+      const [localServer, localService] = await setup({
+        location: '127.0.0.1',
+        height: 0,
+        common: common,
+      })
+      await localService.synchronizer.stop()
+      await localServer.discover('remotePeer1', '127.0.0.2')
+      localService.config.events.on(Event.SYNC_SYNCHRONIZED, async () => {
+        t.equals(localService.chain.blocks.height.toNumber(), 20, 'synced')
+        await destroy(localServer, localService)
+        await destroy(remoteServer, remoteService)
+        t.end()
+      })
+      await localService.synchronizer.start()
+  })
+})

--- a/packages/client/test/integration/mergeSync.spec.ts
+++ b/packages/client/test/integration/mergeSync.spec.ts
@@ -5,7 +5,7 @@ import { setup, destroy } from './util'
 import testnet from './chains/testnet.json'
 tape('[Integration:MergeSync]', async (t) => {
   t.test('should sync blocks on a chain with the merge', async (t) => {
-    const common = new Common({ chain: testnet })
+    const common = new Common({ chain: testnet, hardfork: Hardfork.Merge })
       const [remoteServer, remoteService] = await setup({
         location: '127.0.0.2',
         height: 15,

--- a/packages/client/test/integration/mergeSync.spec.ts
+++ b/packages/client/test/integration/mergeSync.spec.ts
@@ -5,13 +5,13 @@ import { setup, destroy } from './util'
 import testnet from './chains/testnet.json'
 tape('[Integration:MergeSync]', async (t) => {
   t.test('should sync blocks on a chain with the merge', async (t) => {
-    const common = new Common({ chain: testnet, hardfork: Hardfork.Chainstart })
+    const common = new Common({ chain: testnet })
       const [remoteServer, remoteService] = await setup({
         location: '127.0.0.2',
-        height: 20,
+        height: 15,
         common: common,
       })
-      const [localServer, localService] = await setup({
+    const [localServer, localService] = await setup({
         location: '127.0.0.1',
         height: 0,
         common: common,
@@ -19,7 +19,7 @@ tape('[Integration:MergeSync]', async (t) => {
       await localService.synchronizer.stop()
       await localServer.discover('remotePeer1', '127.0.0.2')
       localService.config.events.on(Event.SYNC_SYNCHRONIZED, async () => {
-        t.equals(localService.chain.blocks.height.toNumber(), 20, 'synced')
+        t.equals(localService.chain.blocks.height.toNumber(), 15, 'synced')
         await destroy(localServer, localService)
         await destroy(remoteServer, remoteService)
         t.end()

--- a/packages/client/test/integration/mocks/mockchain.ts
+++ b/packages/client/test/integration/mocks/mockchain.ts
@@ -23,11 +23,13 @@ export default class MockChain extends Chain {
 
   async build() {
     const blocks: Block[] = []
+    const mergeBlockNumber = this.config.chainCommon.hardforkBlockBN('theMerge')?.toNumber();
+    
     for (let number = 0; number < this.height; number++) {
       const block = Block.fromBlockData({
         header: {
           number: number + 1,
-          difficulty: 1,
+          difficulty: mergeBlockNumber ? 0 : 1,
           parentHash: number ? blocks[number - 1].hash() : (this.genesis as any).hash,
         },
       })

--- a/packages/client/test/integration/mocks/mockchain.ts
+++ b/packages/client/test/integration/mocks/mockchain.ts
@@ -35,6 +35,11 @@ export default class MockChain extends Chain {
       })
       blocks.push(block)
     }
-    await this.putBlocks(blocks)
+    try {
+      await this.putBlocks(blocks)
+    }
+    catch (err) {
+      console.log(err);
+    }
   }
 }

--- a/packages/client/test/integration/mocks/mockchain.ts
+++ b/packages/client/test/integration/mocks/mockchain.ts
@@ -1,4 +1,5 @@
 import { Block } from '@ethereumjs/block'
+import { BN } from '../../../../util/dist'
 import { Chain, ChainOptions } from '../../../lib/blockchain'
 
 interface MockChainOptions extends ChainOptions {
@@ -24,12 +25,11 @@ export default class MockChain extends Chain {
   async build() {
     const blocks: Block[] = []
     const mergeBlockNumber = this.config.chainCommon.hardforkBlockBN('merge')?.toNumber();
-    
     for (let number = 0; number < this.height; number++) {
       const block = Block.fromBlockData({
         header: {
           number: number + 1,
-          difficulty: mergeBlockNumber ? 0 : 1,
+          difficulty: number > 10 ? 0 : new BN(1),
           parentHash: number ? blocks[number - 1].hash() : (this.genesis as any).hash,
         },
       })

--- a/packages/client/test/integration/mocks/mockchain.ts
+++ b/packages/client/test/integration/mocks/mockchain.ts
@@ -23,7 +23,7 @@ export default class MockChain extends Chain {
 
   async build() {
     const blocks: Block[] = []
-    const mergeBlockNumber = this.config.chainCommon.hardforkBlockBN('theMerge')?.toNumber();
+    const mergeBlockNumber = this.config.chainCommon.hardforkBlockBN('merge')?.toNumber();
     
     for (let number = 0; number < this.height; number++) {
       const block = Block.fromBlockData({

--- a/packages/client/test/integration/util.ts
+++ b/packages/client/test/integration/util.ts
@@ -23,7 +23,7 @@ export async function setup(
   const config = new Config({ loglevel, syncmode, lightserv, common })
 
   const server = new MockServer({ config, location })
-  const blockchain = new Blockchain({
+  const blockchain = await Blockchain.create({
     validateBlocks: false,
     validateConsensus: false,
   })

--- a/packages/client/test/integration/util.ts
+++ b/packages/client/test/integration/util.ts
@@ -3,22 +3,24 @@ import { FullEthereumService, LightEthereumService } from '../../lib/service'
 import MockServer from './mocks/mockserver'
 import MockChain from './mocks/mockchain'
 import Blockchain from '@ethereumjs/blockchain'
+import Common from '@ethereumjs/common'
 
 interface SetupOptions {
   location?: string
   height?: number
   interval?: number
   syncmode?: string
+  common?: Common
 }
 
 export async function setup(
   options: SetupOptions = {}
 ): Promise<[MockServer, FullEthereumService | LightEthereumService]> {
-  const { location, height, interval, syncmode } = options
+  const { location, height, interval, syncmode, common } = options
 
   const loglevel = 'error'
   const lightserv = syncmode === 'full'
-  const config = new Config({ loglevel, syncmode, lightserv })
+  const config = new Config({ loglevel, syncmode, lightserv, common })
 
   const server = new MockServer({ config, location })
   const blockchain = new Blockchain({
@@ -28,7 +30,14 @@ export async function setup(
   const chain = new MockChain({ config, blockchain, height })
 
   const servers = [server] as any
-  const serviceConfig = new Config({ loglevel, syncmode, servers, lightserv, minPeers: 1 })
+  const serviceConfig = new Config({
+    loglevel,
+    syncmode,
+    servers,
+    lightserv,
+    minPeers: 1,
+    common: common,
+  })
   //@ts-ignore -- attach server eventbus to ethereums service eventbus (to simulate centralized client eventbus))
   server.config.events = serviceConfig.events
   const serviceOpts = {

--- a/packages/client/test/integration/util.ts
+++ b/packages/client/test/integration/util.ts
@@ -17,18 +17,20 @@ export async function setup(
   options: SetupOptions = {}
 ): Promise<[MockServer, FullEthereumService | LightEthereumService]> {
   const { location, height, interval, syncmode, common } = options
-
+  console.log('starting setup for ', location)
   const loglevel = 'error'
   const lightserv = syncmode === 'full'
   const config = new Config({ loglevel, syncmode, lightserv, common })
 
+  console.log('setting up mockserver')
   const server = new MockServer({ config, location })
   const blockchain = await Blockchain.create({
     validateBlocks: false,
     validateConsensus: false,
   })
+  console.log('setting up blockchain')
   const chain = new MockChain({ config, blockchain, height })
-
+  console.log('finished setting up mockchain')
   const servers = [server] as any
   const serviceConfig = new Config({
     loglevel,

--- a/packages/client/test/integration/util.ts
+++ b/packages/client/test/integration/util.ts
@@ -57,11 +57,14 @@ export async function setup(
       lightserv: true,
     })
   }
+  console.log('opening service')
   await service.open()
   if ('execution' in service.synchronizer) {
     service.synchronizer.execution.syncing = false
   }
+  console.log('starting service')
   await service.start()
+  console.log('starting server')
   await server.start()
 
   return [server, service]


### PR DESCRIPTION
This is a proof of concept to create a full integration test of syncing a blockchain with the merge fork set to identify areas of potential change needed to support `the Merge(tm)`. Impacts at this point are primarily limited to the `block` and `blockchain` packages with a focus on the `_putBlockOrHeader` method to account for what logic changes are needed when a PoS block is to be inserted into the chain.