### PR TITLE
client: move missing headers/bodies message to correct log level

### DIFF
--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -30,7 +30,7 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
     })
     if (!headersResult) {
       // Catch occasional null responses from peers who do not return block headers from peer.eth request
-      this.config.logger.warn(
+      this.config.logger.debug(
         `peer ${peer?.id} returned no headers for blocks ${first}-${first.addn(count)} from ${
           peer?.address
         }`
@@ -41,7 +41,7 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
     const bodiesResult = await peer!.eth!.getBlockBodies({ hashes: headers.map((h) => h.hash()) })
     if (!bodiesResult) {
       // Catch occasional null responses from peers who do not return block bodies from peer.eth request
-      this.config.logger.warn(
+      this.config.logger.debug(
         `peer ${peer?.id} returned no bodies for blocks ${first}-${first.addn(count)} from ${
           peer?.address
         }`


### PR DESCRIPTION
As mentioned [here](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1176#issuecomment-900218077), the log messages regarding peers sending useless responses to `eth` protocol messages are moved from `warn` to `debug` to reflect that these are not items that our client is responsible for.