### PR TITLE
Devp2p: RLPx send message code and debug improvements

### DIFF
--- a/packages/devp2p/src/rlpx/peer.ts
+++ b/packages/devp2p/src/rlpx/peer.ts
@@ -52,7 +52,7 @@ export type HelloMsg = {
 }
 
 export interface ProtocolDescriptor {
-  protocol?: any
+  protocol: any
   offset: number
   length?: number
 }
@@ -99,6 +99,11 @@ export class Peer extends EventEmitter {
   _disconnectReason?: DISCONNECT_REASONS
   _disconnectWe: any
   _pingTimeout: number
+
+  /**
+   * Subprotocols (e.g. `ETH`) derived from the exchange on
+   * capabilities
+   */
   _protocols: ProtocolDescriptor[]
 
   constructor(options: any) {
@@ -371,11 +376,17 @@ export class Peer extends EventEmitter {
         const _offset = offset
         offset += obj.length
 
-        const SubProtocol = obj.constructor
-        const protocol = new SubProtocol(obj.version, this, (code: number, data: Buffer) => {
+        // The send method handed over to the subprotocol object (e.g. an `ETH` instance).
+        // The subprotocol is then calling into the lower level method
+        // (e.g. `ETH` calling into `Peer._sendMessage()`).
+        const sendMethod = (code: number, data: Buffer) => {
           if (code > obj.length) throw new Error('Code out of range')
           this._sendMessage(_offset + code, data)
-        })
+        }
+        // Dynamically instantiate the subprotocol object 
+        // from the constructor
+        const SubProtocol = obj.constructor
+        const protocol = new SubProtocol(obj.version, this, sendMethod)
 
         return { protocol, offset: _offset, length: obj.length }
       })
@@ -491,13 +502,22 @@ export class Peer extends EventEmitter {
     if (code !== PREFIXES.HELLO && code !== PREFIXES.DISCONNECT && this._hello === null) {
       return this.disconnect(DISCONNECT_REASONS.PROTOCOL_ERROR)
     }
-    const obj = this._getProtocol(code)
-    if (obj === undefined) return this.disconnect(DISCONNECT_REASONS.PROTOCOL_ERROR)
+    // Protocol object referencing either this Peer object or the
+    // underlying subprotocol (e.g. `ETH`)
+    const protocolObj = this._getProtocol(code)
+    if (protocolObj === undefined) return this.disconnect(DISCONNECT_REASONS.PROTOCOL_ERROR)
 
-    const msgCode = code - obj.offset
-    const prefix = this.getMsgPrefix(msgCode)
+    const msgCode = code - protocolObj.offset
+    const protocolName = protocolObj.protocol.constructor.name
+
+    let prefix = ''
+    if (protocolName === 'Peer') {
+      prefix += `${this.getMsgPrefix(msgCode)}`
+    } else {
+      prefix += `${protocolName} subprotocol`
+    }
     debug(
-      `Received ${prefix} (message code: ${code} - ${obj.offset} = ${msgCode}) ${this._socket.remoteAddress}:${this._socket.remotePort}`
+      `Received ${prefix} message (code: ${code} - ${protocolObj.offset} = ${msgCode}) ${this._socket.remoteAddress}:${this._socket.remotePort}`
     )
 
     try {
@@ -507,8 +527,7 @@ export class Peer extends EventEmitter {
       if (this._hello?.protocolVersion && this._hello?.protocolVersion >= 5) {
         payload = snappy.uncompress(payload)
       }
-
-      obj.protocol._handleMessage(msgCode, payload)
+      protocolObj.protocol._handleMessage(msgCode, payload)
     } catch (err) {
       this.disconnect(DISCONNECT_REASONS.SUBPROTOCOL_ERROR)
       debug(`Error on peer subprotocol message handling: ${err}`)
@@ -559,6 +578,11 @@ export class Peer extends EventEmitter {
     if (this._connected) this.emit('close', this._disconnectReason, this._disconnectWe)
   }
 
+  /**
+   * Returns either a protocol object with a `protocol` parameter
+   * reference to this Peer instance or to a subprotocol instance (e.g. `ETH`)
+   * (depending on the `code` provided)
+   */
   _getProtocol(code: number): ProtocolDescriptor | undefined {
     if (code < BASE_PROTOCOL_LENGTH) return { protocol: this, offset: 0 }
     for (const obj of this._protocols) {

--- a/packages/devp2p/src/rlpx/peer.ts
+++ b/packages/devp2p/src/rlpx/peer.ts
@@ -383,7 +383,7 @@ export class Peer extends EventEmitter {
           if (code > obj.length) throw new Error('Code out of range')
           this._sendMessage(_offset + code, data)
         }
-        // Dynamically instantiate the subprotocol object 
+        // Dynamically instantiate the subprotocol object
         // from the constructor
         const SubProtocol = obj.constructor
         const protocol = new SubProtocol(obj.version, this, sendMethod)


### PR DESCRIPTION
Ok, I hope that this will bring substantially more transparency to this central part of the RLPx code base. This whole "when is it called into which `sendMessage()` function from what context" topic was one of the main sources of confusion before. I actually already figured this out 3-4 times repeatedly and for this PR had to do another 30 minutes of research. 😜

Apart from several documentation additions one core of this PR is the improved "Received ..." debug message. This was before *always* inserting `undefined` for all subprotocol (e.g. `ETH`) messages, where people stumbled upon on debugging several times. What makes it worse is that people *then* interpret respectively associate the message code wrongly. So for `undefined` cases one is intuitively looking at the RLPx message code while the respective code is in this case referring to the subprotocol (e.g. `ETH` message codes) having - partly - the same number but a totally different semantics.

It is now explicitly logged if an RLPx or a subprotocol message is send, RLPx method:

![grafik](https://user-images.githubusercontent.com/931137/130777855-d6bf4184-dd42-467d-bf19-444d1616cd6d.png)

Subprotocol method:

![grafik](https://user-images.githubusercontent.com/931137/130777899-14224bf3-e0f2-4292-a4c4-ba7152049a9b.png)

Hope this substantially reduces confusion on this front in the future. 😄

@acolytec3 maybe you can directly merge this in (if everything is ok) and do a short rebase of your PR on top, should be seamless to integrate.

