### PR TITLE
client: remove default network param

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -21,7 +21,7 @@ const args = require('yargs')
     network: {
       describe: `Network`,
       choices: networks.map((n) => n[1]),
-      default: 'mainnet',
+      default: undefined,
     },
     'network-id': {
       describe: `Network ID`,
@@ -191,7 +191,7 @@ async function run() {
   let common: Common = {} as Common
   if (
     (args.customChainParams || args.customGenesisState || args.gethGenesis) &&
-    (!(args.network === 'mainnet') || args.networkId)
+    (args.network || args.networkId)
   ) {
     throw new Error('cannot specify both custom chain parameters and preset network ID')
   }


### PR DESCRIPTION
From discussion on #1423, removes the default value of `mainnet` from the `network` parameter to ensure our logic is consistent about throwing an error if values for both a custom chain and a standard network are provided to the client.  

So: `npm run client:start -- --network=mainnet --customChain='my/special/chain/params.json'` should throw an error since these params are inconsistent with each other.