### PR TITLE
client: parse gasLimit as number for type safety

### DIFF
--- a/packages/client/lib/util/parse.ts
+++ b/packages/client/lib/util/parse.ts
@@ -166,7 +166,7 @@ async function parseGethParams(json: any) {
     genesis: {
       hash,
       timestamp,
-      gasLimit,
+      gasLimit: parseInt(gasLimit), // Geth stores gasLimit as a hex string while our gasLimit is a `number`
       difficulty,
       nonce,
       extraData,


### PR DESCRIPTION
Geth genesis parameters store the `gasLimit` as a hex string while our `Common` instance calls for a `number`.  It's only currently used in the [header constructor](https://github.com/ethereumjs/ethereumjs-monorepo/blob/3d9774defa21cc9ca3af9c188d4be60d9de8c246/packages/block/src/header.ts#L231-L231) which is incidentally passing the value directly to a `new BN` constructor which currently takes a string as a possible input type so no errors are occuring.  

This small change parses the gasLimit to a `number` to ensure we have type safety for any future use and also keeps Typescript from complaining if you happen to be importing geth genesis parameters that have been converted to our file format as the gas limit will now correctly be converted to an integer first.