### PR TITLE
VM: Make CodeHashes have a DB prefix in StateManager

### DIFF
--- a/packages/vm/src/state/stateManager.ts
+++ b/packages/vm/src/state/stateManager.ts
@@ -20,6 +20,14 @@ import { AccessList, AccessListItem } from '@ethereumjs/tx'
 
 const debug = createDebugLogger('vm:state')
 
+/**
+ * Prefix to distinguish between a contract deployed with code `0x80`
+ * and `RLP([])` (also having the value `0x80`).
+ *
+ * Otherwise the creation of the code hash for the `0x80` contract
+ * will be the same as the hash of the empty trie which leads to
+ * misbehaviour in the underyling trie library.
+ */
 const CODEHASH_PREFIX = Buffer.from('c')
 
 type AddressHex = string

--- a/packages/vm/src/state/stateManager.ts
+++ b/packages/vm/src/state/stateManager.ts
@@ -20,6 +20,8 @@ import { AccessList, AccessListItem } from '@ethereumjs/tx'
 
 const debug = createDebugLogger('vm:state')
 
+const CODEHASH_PREFIX = Buffer.from('c')
+
 type AddressHex = string
 
 /**
@@ -174,7 +176,8 @@ export default class DefaultStateManager implements StateManager {
       return
     }
 
-    await this._trie.db.put(codeHash, value)
+    const key = Buffer.concat([CODEHASH_PREFIX, codeHash])
+    await this._trie.db.put(key, value)
 
     const account = await this.getAccount(address)
     if (this.DEBUG) {
@@ -195,7 +198,8 @@ export default class DefaultStateManager implements StateManager {
     if (!account.isContract()) {
       return Buffer.alloc(0)
     }
-    const code = await this._trie.db.get(account.codeHash)
+    const key = Buffer.concat([CODEHASH_PREFIX, account.codeHash])
+    const code = await this._trie.db.get(key)
     return code ?? Buffer.alloc(0)
   }
 

--- a/packages/vm/tests/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/BlockchainTestsRunner.ts
@@ -79,7 +79,7 @@ export default async function runBlockchainTest(options: any, testData: any, t: 
   await blockchain.initPromise
 
   // set up pre-state
-  await setupPreConditions(vm.stateManager._trie, testData)
+  await setupPreConditions(vm.stateManager, testData)
 
   t.ok(vm.stateManager._trie.root.equals(genesisBlock.header.stateRoot), 'correct pre stateRoot')
 

--- a/packages/vm/tests/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/BlockchainTestsRunner.ts
@@ -179,6 +179,9 @@ export default async function runBlockchainTest(options: any, testData: any, t: 
         return
       }
     } catch (error) {
+      if (options.debug) {
+        await verifyPostConditions(state, testData.postState, t)
+      }
       // caught an error, reduce block number
       currentBlock.isubn(1)
       await handleError(error, expectException)

--- a/packages/vm/tests/GeneralStateTestsRunner.ts
+++ b/packages/vm/tests/GeneralStateTestsRunner.ts
@@ -74,7 +74,7 @@ async function runTestCase(options: any, testData: any, t: tape.Test) {
 
   const vm = new VM({ state, common })
 
-  await setupPreConditions(vm.stateManager._trie, testData)
+  await setupPreConditions(vm.stateManager, testData)
 
   let execInfo = ''
   let tx

--- a/packages/vm/tests/api/runBlock.spec.ts
+++ b/packages/vm/tests/api/runBlock.spec.ts
@@ -29,7 +29,7 @@ tape('runBlock() -> successful API parameter usage', async (t) => {
     const block = Block.fromRLPSerializedBlock(blockRlp)
 
     //@ts-ignore
-    await setupPreConditions(vm.stateManager._trie, testData)
+    await setupPreConditions(vm.stateManager, testData)
 
     t.ok(
       //@ts-ignore
@@ -55,7 +55,7 @@ tape('runBlock() -> successful API parameter usage', async (t) => {
     const testData = require('./testdata/uncleData.json')
 
     //@ts-ignore
-    await setupPreConditions(vm.stateManager._trie, testData)
+    await setupPreConditions(vm.stateManager, testData)
 
     const block1Rlp = testData.blocks[0].rlp
     const block1 = Block.fromRLPSerializedBlock(block1Rlp)
@@ -277,7 +277,7 @@ tape('runBlock() -> runtime behavior', async (t) => {
     block1[0][12] = Buffer.from('dao-hard-fork')
     const block = Block.fromValuesArray(block1)
     // @ts-ignore
-    await setupPreConditions(vm.stateManager._trie, testData)
+    await setupPreConditions(vm.stateManager, testData)
 
     // fill two original DAO child-contracts with funds and the recovery account with funds in order to verify that the balance gets summed correctly
     const fundBalance1 = new BN(Buffer.from('1111', 'hex'))
@@ -422,7 +422,7 @@ async function runWithHf(hardfork: string) {
   const block = Block.fromRLPSerializedBlock(blockRlp)
 
   // @ts-ignore
-  await setupPreConditions(vm.stateManager._trie, testData)
+  await setupPreConditions(vm.stateManager, testData)
 
   const res = await vm.runBlock({
     block,
@@ -469,7 +469,7 @@ tape('runBlock() -> tx types', async (t) => {
     }
 
     //@ts-ignore
-    await setupPreConditions(vm.stateManager._trie, testData)
+    await setupPreConditions(vm.stateManager, testData)
 
     const res = await vm.runBlock({
       block,

--- a/packages/vm/tests/api/runBlockchain.spec.ts
+++ b/packages/vm/tests/api/runBlockchain.spec.ts
@@ -73,7 +73,7 @@ tape('runBlockchain', (t) => {
     const head = await vm.blockchain.getHead()
     st.equal(head.hash().toString('hex'), testData.blocks[0].blockHeader.hash.slice(2))
 
-    await setupPreConditions((vm.stateManager as DefaultStateManager)._trie, testData)
+    await setupPreConditions(vm.stateManager as DefaultStateManager, testData)
 
     vm.runBlock = async () => new Promise((resolve, reject) => reject(new Error('test')))
 
@@ -105,7 +105,7 @@ tape('runBlockchain', (t) => {
     const head = await vm.blockchain.getHead()
     st.equal(head.hash().toString('hex'), testData.blocks[0].blockHeader.hash.slice(2))
 
-    await setupPreConditions((vm.stateManager as DefaultStateManager)._trie, testData)
+    await setupPreConditions(vm.stateManager as DefaultStateManager, testData)
 
     await vm.runBlockchain()
 

--- a/packages/vm/tests/config.ts
+++ b/packages/vm/tests/config.ts
@@ -11,7 +11,6 @@ export const DEFAULT_FORK_CONFIG = 'Istanbul'
 export const SKIP_BROKEN = [
   'ForkStressTest', // Only BlockchainTest, temporary till fixed (2020-05-23)
   'ChainAtoChainB', // Only BlockchainTest, temporary, along expectException fixes (2020-05-23)
-  'undefinedOpcodeFirstByte', // https://github.com/ethereumjs/ethereumjs-monorepo/issues/1271 (2021-05-26)
 
   // In these tests, we have access to two forked chains. Their total difficulty is equal. There are errors in the second chain, but we have no reason to execute this chain if the TD remains equal.
   'blockChainFrontierWithLargerTDvsHomesteadBlockchain2_FrontierToHomesteadAt5',

--- a/packages/vm/tests/util.ts
+++ b/packages/vm/tests/util.ts
@@ -7,6 +7,7 @@ import {
   stripHexPrefix,
   setLengthLeft,
   toBuffer,
+  Address,
 } from 'ethereumjs-util'
 import {
   AccessListEIP2930Transaction,
@@ -16,6 +17,7 @@ import {
 } from '@ethereumjs/tx'
 import { Block, BlockHeader, BlockOptions } from '@ethereumjs/block'
 import Common, { Chain, Hardfork } from '@ethereumjs/common'
+import { DefaultStateManager } from '../src/state'
 
 export function dumpState(state: any, cb: Function) {
   function readAccounts(state: any) {
@@ -311,17 +313,15 @@ export function makeBlockFromEnv(env: any, opts?: BlockOptions): Block {
  * @param state - the state DB/trie
  * @param testData - JSON from tests repo
  */
-export async function setupPreConditions(state: any, testData: any) {
+export async function setupPreConditions(state: DefaultStateManager, testData: any) {
   await state.checkpoint()
-  for (const address of Object.keys(testData.pre)) {
-    const { nonce, balance, code, storage } = testData.pre[address]
+  for (const addressStr of Object.keys(testData.pre)) {
+    const { nonce, balance, code, storage } = testData.pre[addressStr]
 
-    const addressBuf = format(address)
+    const addressBuf = format(addressStr)
+    const address = new Address(addressBuf)
     const codeBuf = format(code)
     const codeHash = keccak256(codeBuf)
-
-    const storageTrie = state.copy(false)
-    storageTrie.root = null
 
     // Set contract storage
     for (const storageKey of Object.keys(storage)) {
@@ -332,21 +332,21 @@ export async function setupPreConditions(state: any, testData: any) {
       const val = rlp.encode(valBN.toArrayLike(Buffer, 'be'))
       const key = setLengthLeft(format(storageKey), 32)
 
-      await storageTrie.put(key, val)
+      await state.putContractStorage(address, key, val)
     }
 
-    const stateRoot = storageTrie.root
+    const stateRoot = (await state.getAccount(address)).stateRoot
 
-    if (testData.exec && testData.exec.address === address) {
-      testData.root = storageTrie.root
+    if (testData.exec && testData.exec.address === addressStr) {
+      testData.root = stateRoot
     }
 
     // Put contract code
-    await state.db.put(codeHash, codeBuf)
+    await state.putContractCode(address, codeBuf)
 
     // Put account data
     const account = Account.fromAccountData({ nonce, balance, codeHash, stateRoot })
-    await state.put(addressBuf, account.serialize())
+    await state.putAccount(address, account)
   }
   await state.commit()
 }

--- a/packages/vm/tests/util.ts
+++ b/packages/vm/tests/util.ts
@@ -320,29 +320,31 @@ export async function setupPreConditions(state: DefaultStateManager, testData: a
 
     const addressBuf = format(addressStr)
     const address = new Address(addressBuf)
+
     const codeBuf = format(code)
     const codeHash = keccak256(codeBuf)
 
     // Set contract storage
     for (const storageKey of Object.keys(storage)) {
+      console.log(storage[storageKey])
       const valBN = new BN(format(storage[storageKey]), 16)
       if (valBN.isZero()) {
         continue
       }
-      const val = rlp.encode(valBN.toArrayLike(Buffer, 'be'))
+      const val = valBN.toArrayLike(Buffer, 'be')
       const key = setLengthLeft(format(storageKey), 32)
 
       await state.putContractStorage(address, key, val)
     }
+
+    // Put contract code
+    await state.putContractCode(address, codeBuf)
 
     const stateRoot = (await state.getAccount(address)).stateRoot
 
     if (testData.exec && testData.exec.address === addressStr) {
       testData.root = stateRoot
     }
-
-    // Put contract code
-    await state.putContractCode(address, codeBuf)
 
     // Put account data
     const account = Account.fromAccountData({ nonce, balance, codeHash, stateRoot })

--- a/packages/vm/tests/util.ts
+++ b/packages/vm/tests/util.ts
@@ -326,7 +326,6 @@ export async function setupPreConditions(state: DefaultStateManager, testData: a
 
     // Set contract storage
     for (const storageKey of Object.keys(storage)) {
-      console.log(storage[storageKey])
       const valBN = new BN(format(storage[storageKey]), 16)
       if (valBN.isZero()) {
         continue
@@ -351,6 +350,9 @@ export async function setupPreConditions(state: DefaultStateManager, testData: a
     await state.putAccount(address, account)
   }
   await state.commit()
+  // Clear the touched stack, otherwise untouched accounts in the block which are empty (>= SpuriousDragon)
+  // will get deleted from the state, resulting in state trie errors
+  ;(<any>state)._touched.clear()
 }
 
 /**


### PR DESCRIPTION
Closes #1271.

In #1271, a contract is deployed with code 0x80, this 0x80 is the same as `RLP([])`, which is the empty trie. Thus, if we hash this (to get the codeHash) then we get the hash of the empty trie. This confuses StateManager, as now suddenly empty state roots point to `0x80`, which is an invalid node which we cannot decode. Therefore, there are two options:

(1) Hardcode that the empty trie hash is indeed an empty trie, if a code is requested then instead return 0x80

(2) prefix codeHashes

(2) is better (after a discussion with Geth). We currently only have one case (the code 0x80) where this runs into problems. However, Geth has reported that they also run into problems when using fast sync. If we at some point start to assume that if a BranchNode/ExtensionNode has an underlying DB value, then we could assume that we have the entire trie below. However, if we thus put the raw code of this BranchNode/ExtensionCode (so not the hash), then we could suddenly assume that we have certain tries, while we only have the raw trie node (or the code), instead of the entire trie. This could lead to problems if we start to use fast sync in a BFS approach (we might think we have certain tries, while we don't have them). We circumvent this problem by prefixing code hash `Buffer.from('c')`. (This is also taken from [Geth](https://github.com/ethereum/go-ethereum/blob/ffae2043f0482e81ac9f5459bf9fceafd74f52e9/core/rawdb/schema.go#L91))

This is a breaking change as it corrupts all existing MPT DBs and therefore points to `develop`.

This PR also ensures that BlockchainTests/StateTests use StateManager methods directly, and don't raw-write to Trie.