### PR TITLE
devp2p: add snappy compression to ping/pong

### DIFF
--- a/packages/devp2p/src/rlpx/peer.ts
+++ b/packages/devp2p/src/rlpx/peer.ts
@@ -282,7 +282,7 @@ export class Peer extends EventEmitter {
    */
   _sendPong() {
     debug(`Send PONG to ${this._socket.remoteAddress}:${this._socket.remotePort}`)
-    let data = rlp.encode([])    
+    let data = rlp.encode([])
 
     if (this._hello?.protocolVersion && this._hello.protocolVersion >= 5) {
       data = snappy.compress(data)

--- a/packages/devp2p/src/rlpx/peer.ts
+++ b/packages/devp2p/src/rlpx/peer.ts
@@ -202,6 +202,7 @@ export class Peer extends EventEmitter {
    */
   _sendMessage(code: number, data: Buffer) {
     if (this._closed) return false
+
     const msg = Buffer.concat([rlp.encode(code), data])
     const header = this._eciesSession.createHeader(msg.length)
     if (!header || this._socket.destroyed) return
@@ -263,7 +264,11 @@ export class Peer extends EventEmitter {
    */
   _sendPing() {
     debug(`Send PING to ${this._socket.remoteAddress}:${this._socket.remotePort}`)
-    const data = rlp.encode([])
+    let data = rlp.encode([])
+    if (this._hello?.protocolVersion && this._hello.protocolVersion >= 5) {
+      data = snappy.compress(data)
+    }
+
     if (!this._sendMessage(PREFIXES.PING, data)) return
 
     clearTimeout(this._pingTimeoutId!)
@@ -277,7 +282,11 @@ export class Peer extends EventEmitter {
    */
   _sendPong() {
     debug(`Send PONG to ${this._socket.remoteAddress}:${this._socket.remotePort}`)
-    const data = rlp.encode([])
+    let data = rlp.encode([])    
+
+    if (this._hello?.protocolVersion && this._hello.protocolVersion >= 5) {
+      data = snappy.compress(data)
+    }
     this._sendMessage(PREFIXES.PONG, data)
   }
 


### PR DESCRIPTION
Fixes #1421

When we did the original devp2p v5 in #1399 to add snappy compression to inbound/outbound devp2p messages, we didn't add snappy compression to the `ping`/`pong` messages since I wrongly interpreted them as not having a body so therefore not needing snappy.  This proved incorrect as we are still RLP encoding an empty array for the body and this also needs snappy compression.  Geth will now maintain connection through the `ping`/`pong` process.