### PR TITLE
Devp2p: Per-Message debugging for ETH and other protocols / Improved docs

### DIFF
--- a/packages/devp2p/README.md
+++ b/packages/devp2p/README.md
@@ -439,12 +439,34 @@ DEBUG=devp2p:eth:GET_BLOCK_HEADERS,devp2p:eth:BLOCK_HEADERS -r ts-node/register 
 Exemplary logging output:
 
 ```shell
-  devp2p:eth:GET_BLOCK_HEADERS Received GET_BLOCK_HEADERS message from 207.154.201.177:30303: d188659b37d8e321bc52c782198181c08080 +50ms
-  devp2p:eth:GET_BLOCK_HEADERS Send GET_BLOCK_HEADERS message to 159.65.72.121:30303: c81bc682ded8328080 +431ms
-  devp2p:eth:BLOCK_HEADERS Received BLOCK_HEADERS message from 159.65.72.121:30303: c21bc0 +417ms
-  devp2p:eth:GET_BLOCK_HEADERS Send GET_BLOCK_HEADERS message to 162.55.98.224:30303: c81dc682df0a328080 +339ms
-  devp2p:eth:BLOCK_HEADERS Received BLOCK_HEADERS message from 162.55.98.224:30303: f968dd1df968d9f90217a0af80dab03492dfc689936dc9ff272ed3743da1... +72ms
-  ```
+devp2p:eth:GET_BLOCK_HEADERS Received GET_BLOCK_HEADERS message from 207.154.201.177:30303: d188659b37d8e321bc52c782198181c08080 +50ms
+devp2p:eth:GET_BLOCK_HEADERS Send GET_BLOCK_HEADERS message to 159.65.72.121:30303: c81bc682ded8328080 +431ms
+devp2p:eth:BLOCK_HEADERS Received BLOCK_HEADERS message from 159.65.72.121:30303: c21bc0 +417ms
+devp2p:eth:GET_BLOCK_HEADERS Send GET_BLOCK_HEADERS message to 162.55.98.224:30303: c81dc682df0a328080 +339ms
+devp2p:eth:BLOCK_HEADERS Received BLOCK_HEADERS message from 162.55.98.224:30303: f968dd1df968d9f90217a0af80dab03492dfc689936dc9ff272ed3743da1... +72ms
+```
+
+### Per-Peer Debuggig
+
+There are the following ways to limit debug output to a certain peer:
+
+#### Logging per IP
+
+Log output can be limited to one or several certain IPs. This can be useful to follow on the message exchange with a certain remote peer (e.g. a bootstrap peer):
+
+```shell
+DEBUG=devp2p:3.209.45.79 -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
+```
+
+#### First Connected
+
+Logging can be limited to the peer the first successful subprotocol (e.g. `ETH`) connection could be established:
+
+```shell
+DEBUG=devp2p:FIRST_PEER -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
+```
+
+This logger can be used in various practical scenarios if you want to concentrate on the message exchange with just one peer.
 
 ## Developer
 

--- a/packages/devp2p/README.md
+++ b/packages/devp2p/README.md
@@ -421,9 +421,12 @@ Remove peer: 52.169.42.101:30303 (peer disconnect, reason code: 16) (total: 1)
 
 The following loggers from above support per-message debugging:
 
+| Logger | Usage |
+| - | - |
 | `devp2p:eth` | e.g. `devp2p:eth:GET_BLOCK_HEADERS` |
 | `devp2p:les` | e.g. `devp2p:les:GET_PROOFS` |
-| `devp2p:rlpx:peer` | e.g. `devp2p:rlpx:peer:DISCONNECT` |
+| `devp2p:rlpx:peer` | e.g. `devp2p:rlpx:peer:HELLO` |
+| `devp2p:rlpx:peer:DISCONNECT` | e.g. `devp2p:rlpx:peer:DISCONNECT:TOO_MANY_PEERS` (special logger to filter on `DISCONNECT` reasons) |
 | `devp2p:dpt:server` | e.g. `devp2p:dpt:server:findneighbours` |
 
 Available messages can be added to the logger base name to filter on a per message basis. See the following example to filter

--- a/packages/devp2p/README.md
+++ b/packages/devp2p/README.md
@@ -422,6 +422,7 @@ Remove peer: 52.169.42.101:30303 (peer disconnect, reason code: 16) (total: 1)
 The following loggers from above support per-message debugging:
 
 | `devp2p:eth` | e.g. `devp2p:eth:GET_BLOCK_HEADERS` |
+| `devp2p:les` | e.g. `devp2p:les:GET_PROOFS` |
 
 Available messages can be added to the logger base name to filter on a per message basis. See the following example to filter
 on two message names along `ETH` protocol debugging:

--- a/packages/devp2p/README.md
+++ b/packages/devp2p/README.md
@@ -373,14 +373,33 @@ npm run test
 
 ## Debugging
 
-This library uses [debug](https://github.com/visionmedia/debug) debugging utility package.
+### Introduction
+
+This library uses the [debug](https://github.com/visionmedia/debug) debugging utility package.
 
 For the debugging output to show up, set the `DEBUG` environment variable (e.g. in Linux/Mac OS:
 `export DEBUG=*,-babel`).
 
 Use the `DEBUG` environment variable to active the logger output you are interested in, e.g.:
 
+```shell
 DEBUG=devp2p:dpt:\*,devp2p:eth node -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
+```
+
+The following loggers are available:
+
+| Logger | Description |
+| - | - |
+| `devp2p:dpt` | General DPT peer discovery logging |
+| `devp2p:dpt:server` | DPT server communication (`ping`, `pong`, `findNeighbour`,... messages) |
+| `devp2p:dpt:ban-list` | DPT ban list |
+| `devp2p:dns:dns` | DNS discovery logging |
+| `devp2p:rlpx` | General RLPx debug logger |
+| `devp2p:rlpx:peer` | RLPx peer message exchange logging (`PING`, `PONG`, `HELLO`, `DISCONNECT`,... messages) |
+| `devp2p:eth` | ETH protocol message logging (`STATUS`, `GET_BLOCK_HEADER`, `TRANSACTIONS`,... messages) |
+| `devp2p:les` | LES protocol message logging (`STATUS`, `GET_BLOCK_HEADER`, `GET_PROOFS`,... messages) |
+
+### Debug Verbosity
 
 For more verbose output on logging (e.g. to output the entire msg payload) use the `verbose` logger
 in addition:
@@ -389,7 +408,7 @@ DEBUG=devp2p:dpt:\*,devp2p:eth,verbose node -r ts-node/register [YOUR_SCRIPT_TO_
 
 Exemplary logging output:
 
-```
+```shell
 Add peer: 52.3.158.184:30303 Geth/v1.7.3-unstable-479aa61f/linux-amd64/go1.9 (eth63) (total: 2)
   devp2p:rlpx:peer Received body 52.169.42.101:30303 01c110 +133ms
   devp2p:rlpx:peer Message code: 1 - 0 = 1 +0ms
@@ -397,6 +416,29 @@ Add peer: 52.3.158.184:30303 Geth/v1.7.3-unstable-479aa61f/linux-amd64/go1.9 (et
   devp2p:rlpx 52.169.42.101:30303 disconnect, reason: 16 +1ms
 Remove peer: 52.169.42.101:30303 (peer disconnect, reason code: 16) (total: 1)
 ```
+
+### Per-Message Debugging
+
+The following loggers from above support per-message debugging:
+
+| `devp2p:eth` | e.g. `devp2p:eth:GET_BLOCK_HEADERS` |
+
+Available messages can be added to the logger base name to filter on a per message basis. See the following example to filter
+on two message names along `ETH` protocol debugging:
+
+```shell
+DEBUG=devp2p:eth:GET_BLOCK_HEADERS,devp2p:eth:BLOCK_HEADERS -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
+```
+
+Exemplary logging output:
+
+```shell
+  devp2p:eth:GET_BLOCK_HEADERS Received GET_BLOCK_HEADERS message from 207.154.201.177:30303: d188659b37d8e321bc52c782198181c08080 +50ms
+  devp2p:eth:GET_BLOCK_HEADERS Send GET_BLOCK_HEADERS message to 159.65.72.121:30303: c81bc682ded8328080 +431ms
+  devp2p:eth:BLOCK_HEADERS Received BLOCK_HEADERS message from 159.65.72.121:30303: c21bc0 +417ms
+  devp2p:eth:GET_BLOCK_HEADERS Send GET_BLOCK_HEADERS message to 162.55.98.224:30303: c81dc682df0a328080 +339ms
+  devp2p:eth:BLOCK_HEADERS Received BLOCK_HEADERS message from 162.55.98.224:30303: f968dd1df968d9f90217a0af80dab03492dfc689936dc9ff272ed3743da1... +72ms
+  ```
 
 ## Developer
 

--- a/packages/devp2p/README.md
+++ b/packages/devp2p/README.md
@@ -423,6 +423,8 @@ The following loggers from above support per-message debugging:
 
 | `devp2p:eth` | e.g. `devp2p:eth:GET_BLOCK_HEADERS` |
 | `devp2p:les` | e.g. `devp2p:les:GET_PROOFS` |
+| `devp2p:rlpx:peer` | e.g. `devp2p:rlpx:peer:DISCONNECT` |
+| `devp2p:dpt:server` | e.g. `devp2p:dpt:server:findneighbours` |
 
 Available messages can be added to the logger base name to filter on a per message basis. See the following example to filter
 on two message names along `ETH` protocol debugging:

--- a/packages/devp2p/src/dpt/server.ts
+++ b/packages/devp2p/src/dpt/server.ts
@@ -8,7 +8,8 @@ import { keccak256, pk2id, createDeferred, formatLogId } from '../util'
 import { DPT, PeerInfo } from './dpt'
 import { Socket as DgramSocket, RemoteInfo } from 'dgram'
 
-const debug = createDebugLogger('devp2p:dpt:server')
+const DEBUG_BASE_NAME = 'devp2p:dpt:server'
+const debug = createDebugLogger(DEBUG_BASE_NAME)
 const verbose = createDebugLogger('verbose').enabled
 
 const VERSION = 0x04
@@ -46,6 +47,9 @@ export class Server extends EventEmitter {
   _requestsCache: LRUCache<string, Promise<any>>
   _socket: DgramSocket | null
 
+  // Message debuggers (e.g. { 'findneighbours': [debug Object], ...})
+  private msgDebuggers: { [key: string]: (debug: string) => void } = {}
+
   constructor(dpt: DPT, privateKey: Buffer, options: DPTServerOptions) {
     super()
 
@@ -57,6 +61,8 @@ export class Server extends EventEmitter {
     this._requests = new Map()
     this._parityRequestMap = new Map()
     this._requestsCache = new LRUCache({ max: 1000, maxAge: ms('1s'), stale: false })
+
+    this.initMsgDebuggers()
 
     const createSocket = options.createSocket ?? dgram.createSocket.bind(null, { type: 'udp4' })
     this._socket = createSocket()
@@ -137,11 +143,10 @@ export class Server extends EventEmitter {
   }
 
   _send(peer: PeerInfo, typename: string, data: any) {
-    debug(
-      `send ${typename} to ${peer.address}:${peer.udpPort} (peerId: ${
-        peer.id ? formatLogId(peer.id.toString('hex'), verbose) : '-'
-      })`
-    )
+    const debugMsg = `send ${typename} to ${peer.address}:${peer.udpPort} (peerId: ${
+      peer.id ? formatLogId(peer.id.toString('hex'), verbose) : '-'
+    })`
+    this.debug(typename, debugMsg)
 
     const msg = encode(typename, data, this._privateKey)
     // Parity hack
@@ -166,12 +171,11 @@ export class Server extends EventEmitter {
   _handler(msg: Buffer, rinfo: RemoteInfo) {
     const info = decode(msg)
     const peerId = pk2id(info.publicKey)
-    debug(
-      `received ${info.typename} from ${rinfo.address}:${rinfo.port} (peerId: ${formatLogId(
-        peerId.toString('hex'),
-        verbose
-      )})`
-    )
+    const debugMsg = `received ${info.typename} from ${rinfo.address}:${rinfo.port} (peerId: ${formatLogId(
+      peerId.toString('hex'),
+      verbose
+    )})`
+    this.debug(info.typename.toString(), debugMsg)
 
     // add peer if not in our table
     const peer = this._dpt.getPeer(peerId)
@@ -235,6 +239,26 @@ export class Server extends EventEmitter {
         )
         break
       }
+    }
+  }
+
+  private initMsgDebuggers() {
+    const MESSAGE_NAMES = ['ping', 'pong', 'findneighbours', 'neighbours']
+    for (const name of MESSAGE_NAMES) {
+      this.msgDebuggers[name] = createDebugLogger(`${DEBUG_BASE_NAME}:${name}`)
+    }
+  }
+
+  /**
+   * Debug message both on the generic as well as the
+   * per-message debug logger
+   * @param messageName Lower capital message name (e.g. `findneighbours`)
+   * @param msg Message text to debug
+   */
+  private debug(messageName: string, msg: string) {
+    debug(msg)
+    if (this.msgDebuggers[messageName]) {
+      this.msgDebuggers[messageName](msg)
     }
   }
 }

--- a/packages/devp2p/src/dpt/server.ts
+++ b/packages/devp2p/src/dpt/server.ts
@@ -171,10 +171,9 @@ export class Server extends EventEmitter {
   _handler(msg: Buffer, rinfo: RemoteInfo) {
     const info = decode(msg)
     const peerId = pk2id(info.publicKey)
-    const debugMsg = `received ${info.typename} from ${rinfo.address}:${rinfo.port} (peerId: ${formatLogId(
-      peerId.toString('hex'),
-      verbose
-    )})`
+    const debugMsg = `received ${info.typename} from ${rinfo.address}:${
+      rinfo.port
+    } (peerId: ${formatLogId(peerId.toString('hex'), verbose)})`
     this.debug(info.typename.toString(), debugMsg)
 
     // add peer if not in our table

--- a/packages/devp2p/src/eth/index.ts
+++ b/packages/devp2p/src/eth/index.ts
@@ -44,6 +44,8 @@ export class ETH extends EventEmitter {
       this._peer.disconnect(DISCONNECT_REASONS.TIMEOUT)
     }, ms('5s'))
 
+    this.initMsgDebuggers()
+
     // Set forkHash and nextForkBlock
     if (this._version >= 64) {
       const c = this._peer._common
@@ -55,8 +57,6 @@ export class ETH extends EventEmitter {
       // Next fork block number or 0 if none available
       this._nextForkBlock = c.nextHardforkBlockBN(this._hardfork) ?? new BN(0)
     }
-
-    this.initMsgDebuggers()
   }
 
   static eth62 = { name: 'eth', version: 62, length: 8, constructor: ETH }

--- a/packages/devp2p/src/les/index.ts
+++ b/packages/devp2p/src/les/index.ts
@@ -6,19 +6,26 @@ import { debug as createDebugLogger } from 'debug'
 import { int2buffer, buffer2int, assertEq, formatLogData } from '../util'
 import { Peer, DISCONNECT_REASONS } from '../rlpx/peer'
 
-const debug = createDebugLogger('devp2p:les')
+const DEBUG_BASE_NAME = 'devp2p:les'
+const debug = createDebugLogger(DEBUG_BASE_NAME)
 const verbose = createDebugLogger('verbose').enabled
 
 export const DEFAULT_ANNOUNCE_TYPE = 1
 
+type SendMethod = (code: LES.MESSAGE_CODES, data: Buffer) => any
+
 export class LES extends EventEmitter {
-  _version: any
+  _version: number
   _peer: Peer
-  _send: any
+  _send: SendMethod
   _status: LES.Status | null
   _peerStatus: LES.Status | null
   _statusTimeoutId: NodeJS.Timeout
-  constructor(version: number, peer: Peer, send: any) {
+
+  // Message debuggers (e.g. { 'GET_BLOCK_HEADERS': [debug Object], ...})
+  private msgDebuggers: { [key: string]: (debug: string) => void } = {}
+
+  constructor(version: number, peer: Peer, send: SendMethod) {
     super()
 
     this._version = version
@@ -30,6 +37,8 @@ export class LES extends EventEmitter {
     this._statusTimeoutId = setTimeout(() => {
       this._peer.disconnect(DISCONNECT_REASONS.TIMEOUT)
     }, ms('5s'))
+
+    this.initMsgDebuggers()
   }
 
   static les2 = { name: 'les', version: 2, length: 21, constructor: LES }
@@ -38,26 +47,29 @@ export class LES extends EventEmitter {
 
   _handleMessage(code: LES.MESSAGE_CODES, data: any) {
     const payload = rlp.decode(data)
+    const messageName = this.getMsgPrefix(code)
+    const debugMsg = `Received ${messageName} message from ${this._peer._socket.remoteAddress}:${this._peer._socket.remotePort}`
+
     if (code !== LES.MESSAGE_CODES.STATUS) {
-      const debugMsg = `Received ${this.getMsgPrefix(code)} message from ${
-        this._peer._socket.remoteAddress
-      }:${this._peer._socket.remotePort}`
       const logData = formatLogData(data.toString('hex'), verbose)
-      debug(`${debugMsg}: ${logData}`)
+      this.debug(messageName, `${debugMsg}: ${logData}`)
     }
     switch (code) {
       case LES.MESSAGE_CODES.STATUS: {
-        assertEq(this._peerStatus, null, 'Uncontrolled status message', debug)
+        assertEq(
+          this._peerStatus,
+          null,
+          'Uncontrolled status message',
+          this.debug.bind(this),
+          'STATUS'
+        )
         const statusArray: any = {}
         payload.forEach(function (value: any) {
           statusArray[value[0].toString()] = value[1]
         })
         this._peerStatus = statusArray
-        debug(
-          `Received ${this.getMsgPrefix(code)} message from ${this._peer._socket.remoteAddress}:${
-            this._peer._socket.remotePort
-          }: : ${this._peerStatus ? this._getStatusString(this._peerStatus) : ''}`
-        )
+        const peerStatusMsg = `${this._peerStatus ? this._getStatusString(this._peerStatus) : ''}`
+        this.debug(messageName, `${debugMsg}: ${peerStatusMsg}`)
         this._handleStatus()
         break
       }
@@ -105,14 +117,22 @@ export class LES extends EventEmitter {
       this._status['protocolVersion'],
       this._peerStatus['protocolVersion'],
       'Protocol version mismatch',
-      debug
+      this.debug.bind(this),
+      'STATUS'
     )
-    assertEq(this._status['networkId'], this._peerStatus['networkId'], 'NetworkId mismatch', debug)
+    assertEq(
+      this._status['networkId'],
+      this._peerStatus['networkId'],
+      'NetworkId mismatch',
+      this.debug.bind(this),
+      'STATUS'
+    )
     assertEq(
       this._status['genesisHash'],
       this._peerStatus['genesisHash'],
       'Genesis block mismatch',
-      debug
+      this.debug.bind(this),
+      'STATUS'
     )
 
     this.emit('status', this._peerStatus)
@@ -162,7 +182,8 @@ export class LES extends EventEmitter {
       statusList.push([key, status[key]])
     })
 
-    debug(
+    this.debug(
+      'STATUS',
       `Send STATUS message to ${this._peer._socket.remoteAddress}:${
         this._peer._socket.remotePort
       } (les${this._version}): ${this._getStatusString(this._status)}`
@@ -185,11 +206,11 @@ export class LES extends EventEmitter {
    * @param payload Payload (including reqId, e.g. `[1, [437000, 1, 0, 0]]`)
    */
   sendMessage(code: LES.MESSAGE_CODES, payload: any) {
-    const debugMsg = `Send ${this.getMsgPrefix(code)} message to ${
-      this._peer._socket.remoteAddress
-    }:${this._peer._socket.remotePort}`
+    const messageName = this.getMsgPrefix(code)
     const logData = formatLogData(rlp.encode(payload).toString('hex'), verbose)
-    debug(`${debugMsg}: ${logData}`)
+    const debugMsg = `Send ${messageName} message to ${this._peer._socket.remoteAddress}:${this._peer._socket.remotePort}: ${logData}`
+
+    this.debug(messageName, debugMsg)
 
     switch (code) {
       case LES.MESSAGE_CODES.STATUS:
@@ -240,6 +261,28 @@ export class LES extends EventEmitter {
 
   getMsgPrefix(msgCode: LES.MESSAGE_CODES) {
     return LES.MESSAGE_CODES[msgCode]
+  }
+
+  private initMsgDebuggers() {
+    const MESSAGE_NAMES = Object.values(LES.MESSAGE_CODES).filter(
+      (value) => typeof value === 'string'
+    ) as string[]
+    for (const name of MESSAGE_NAMES) {
+      this.msgDebuggers[name] = createDebugLogger(`${DEBUG_BASE_NAME}:${name}`)
+    }
+  }
+
+  /**
+   * Debug message both on the generic as well as the
+   * per-message debug logger
+   * @param messageName Capitalized message name (e.g. `GET_BLOCK_HEADERS`)
+   * @param msg Message text to debug
+   */
+  private debug(messageName: string, msg: string) {
+    debug(msg)
+    if (this.msgDebuggers[messageName]) {
+      this.msgDebuggers[messageName](msg)
+    }
   }
 }
 

--- a/packages/devp2p/src/rlpx/peer.ts
+++ b/packages/devp2p/src/rlpx/peer.ts
@@ -635,12 +635,31 @@ export class Peer extends EventEmitter {
       this.msgDebuggers[name] = createDebugLogger(`${DEBUG_BASE_NAME}:${name}`)
     }
 
+    // Remote Peer IP logger
+    const ip = this._socket.remoteAddress
+    if (ip) {
+      this.msgDebuggers[ip] = createDebugLogger(`devp2p:${ip}`)
+    }
+
     // Special DISCONNECT per-reason logger
     const DISCONNECT_NAMES = Object.values(DISCONNECT_REASONS).filter(
       (value) => typeof value === 'string'
     ) as string[]
     for (const name of DISCONNECT_NAMES) {
       this.msgDebuggers[name] = createDebugLogger(`${DEBUG_BASE_NAME}:DISCONNECT:${name}`)
+    }
+  }
+
+  /**
+   * Called once from the subprotocol (e.g. `ETH`) on the peer
+   * where a first successful `STATUS` msg exchange could be achieved.
+   *
+   * Can be used together with the `devp2p:FIRST_PEER` debugger.
+   */
+  _addFirstPeerDebugger() {
+    const ip = this._socket.remoteAddress
+    if (ip) {
+      this.msgDebuggers[ip] = createDebugLogger(`devp2p:FIRST_PEER`)
     }
   }
 
@@ -654,6 +673,10 @@ export class Peer extends EventEmitter {
     debug(msg)
     if (this.msgDebuggers[messageName]) {
       this.msgDebuggers[messageName](msg)
+    }
+    const ip = this._socket.remoteAddress
+    if (ip && this.msgDebuggers[ip]) {
+      this.msgDebuggers[ip](msg)
     }
     if (disconnectReason && messageName === 'DISCONNECT') {
       if (this.msgDebuggers[disconnectReason]) {

--- a/packages/devp2p/src/rlpx/peer.ts
+++ b/packages/devp2p/src/rlpx/peer.ts
@@ -11,7 +11,8 @@ import { ECIES } from './ecies'
 import { ETH, LES } from '../'
 import { int2buffer, buffer2int, formatLogData } from '../util'
 
-const debug = createDebugLogger('devp2p:rlpx:peer')
+const DEBUG_BASE_NAME = 'devp2p:rlpx:peer'
+const debug = createDebugLogger(DEBUG_BASE_NAME)
 const verbose = createDebugLogger('verbose').enabled
 
 export const BASE_PROTOCOL_VERSION = 5
@@ -100,6 +101,9 @@ export class Peer extends EventEmitter {
   _disconnectWe: any
   _pingTimeout: number
 
+  // Message debuggers (e.g. { 'HELLO': [debug Object], ...})
+  private msgDebuggers: { [key: string]: (debug: string) => void } = {}
+
   /**
    * Subprotocols (e.g. `ETH`) derived from the exchange on
    * capabilities
@@ -144,6 +148,8 @@ export class Peer extends EventEmitter {
 
     // sub-protocols
     this._protocols = []
+
+    this.initMsgDebuggers()
 
     // send AUTH if outgoing connection
     if (this._remoteId !== null) {
@@ -221,7 +227,8 @@ export class Peer extends EventEmitter {
    * Send HELLO message
    */
   _sendHello() {
-    debug(`Send HELLO to ${this._socket.remoteAddress}:${this._socket.remotePort}`)
+    const debugMsg = `Send HELLO to ${this._socket.remoteAddress}:${this._socket.remotePort}`
+    this.debug('HELLO', debugMsg)
     const payload: HelloMsg = [
       int2buffer(BASE_PROTOCOL_VERSION),
       this._clientId,
@@ -245,11 +252,10 @@ export class Peer extends EventEmitter {
    * @param reason
    */
   _sendDisconnect(reason: DISCONNECT_REASONS) {
-    debug(
-      `Send DISCONNECT to ${this._socket.remoteAddress}:${
-        this._socket.remotePort
-      } (reason: ${this.getDisconnectPrefix(reason)})`
-    )
+    const debugMsg = `Send DISCONNECT to ${this._socket.remoteAddress}:${
+      this._socket.remotePort
+    } (reason: ${this.getDisconnectPrefix(reason)})`
+    this.debug('DISCONNECT', debugMsg)
     const data = rlp.encode(reason)
     if (!this._sendMessage(PREFIXES.DISCONNECT, data)) return
 
@@ -263,7 +269,8 @@ export class Peer extends EventEmitter {
    * Send PING message
    */
   _sendPing() {
-    debug(`Send PING to ${this._socket.remoteAddress}:${this._socket.remotePort}`)
+    const debugMsg = `Send PING to ${this._socket.remoteAddress}:${this._socket.remotePort}`
+    this.debug('PING', debugMsg)
     let data = rlp.encode([])
     if (this._hello?.protocolVersion && this._hello.protocolVersion >= 5) {
       data = snappy.compress(data)
@@ -281,7 +288,8 @@ export class Peer extends EventEmitter {
    * Send PONG message
    */
   _sendPong() {
-    debug(`Send PONG to ${this._socket.remoteAddress}:${this._socket.remotePort}`)
+    const debugMsg = `Send PONG to ${this._socket.remoteAddress}:${this._socket.remotePort}`
+    this.debug('PONG', debugMsg)
     let data = rlp.encode([])
 
     if (this._hello?.protocolVersion && this._hello.protocolVersion >= 5) {
@@ -418,11 +426,10 @@ export class Peer extends EventEmitter {
   _handleDisconnect(payload: any) {
     this._closed = true
     this._disconnectReason = payload[0].length === 0 ? 0 : payload[0][0]
-    debug(
-      `DISCONNECT reason: ${DISCONNECT_REASONS[this._disconnectReason as number]} ${
-        this._socket.remoteAddress
-      }:${this._socket.remotePort}`
-    )
+    const debugMsg = `DISCONNECT reason: ${DISCONNECT_REASONS[this._disconnectReason as number]} ${
+      this._socket.remoteAddress
+    }:${this._socket.remotePort}`
+    this.debug('DISCONNECT', debugMsg)
     this._disconnectWe = false
     this._socket.end()
   }
@@ -519,15 +526,15 @@ export class Peer extends EventEmitter {
     const msgCode = code - protocolObj.offset
     const protocolName = protocolObj.protocol.constructor.name
 
-    let prefix = ''
+    const postAdd = `(code: ${code} - ${protocolObj.offset} = ${msgCode}) ${this._socket.remoteAddress}:${this._socket.remotePort}`
     if (protocolName === 'Peer') {
-      prefix += `${this.getMsgPrefix(msgCode)}`
+      const messageName = this.getMsgPrefix(msgCode)
+      this.debug(messageName, `Received ${messageName} message ${postAdd}`)
     } else {
-      prefix += `${protocolName} subprotocol`
+      debug(
+        `Received ${protocolName} subprotocol message ${postAdd}`
+      )
     }
-    debug(
-      `Received ${prefix} message (code: ${code} - ${protocolObj.offset} = ${msgCode}) ${this._socket.remoteAddress}:${this._socket.remotePort}`
-    )
 
     try {
       let payload = body.slice(1)
@@ -622,5 +629,27 @@ export class Peer extends EventEmitter {
 
   disconnect(reason: DISCONNECT_REASONS = DISCONNECT_REASONS.DISCONNECT_REQUESTED) {
     this._sendDisconnect(reason)
+  }
+
+  private initMsgDebuggers() {
+    const MESSAGE_NAMES = Object.values(PREFIXES).filter(
+      (value) => typeof value === 'string'
+    ) as string[]
+    for (const name of MESSAGE_NAMES) {
+      this.msgDebuggers[name] = createDebugLogger(`${DEBUG_BASE_NAME}:${name}`)
+    }
+  }
+
+  /**
+   * Debug message both on the generic as well as the
+   * per-message debug logger
+   * @param messageName Capitalized message name (e.g. `HELLO`)
+   * @param msg Message text to debug
+   */
+  private debug(messageName: string, msg: string) {
+    debug(msg)
+    if (this.msgDebuggers[messageName]) {
+      this.msgDebuggers[messageName](msg)
+    }
   }
 }

--- a/packages/devp2p/src/util.ts
+++ b/packages/devp2p/src/util.ts
@@ -64,23 +64,33 @@ export function assertEq(
   expected: assertInput,
   actual: assertInput,
   msg: string,
-  debug: Function
+  debug: Function,
+  messageName?: string
 ): void {
-  let message
+  let fullMsg
   if (Buffer.isBuffer(expected) && Buffer.isBuffer(actual)) {
     if (expected.equals(actual)) return
-    message = `${msg}: ${expected.toString('hex')} / ${actual.toString('hex')}`
-    debug(`[ERROR] ${message}`)
+    fullMsg = `${msg}: ${expected.toString('hex')} / ${actual.toString('hex')}`
+    const debugMsg = `[ERROR] ${fullMsg}`
+    if (messageName) {
+      debug(messageName, debugMsg)
+    } else {
+      debug(debugMsg)
+    }
     throw new assert.AssertionError({
-      message: message,
+      message: fullMsg,
     })
   }
 
   if (expected === actual) return
-  message = `${msg}: ${expected} / ${actual}`
-  debug(message)
+  fullMsg = `${msg}: ${expected} / ${actual}`
+  if (messageName) {
+    debug(messageName, fullMsg)
+  } else {
+    debug(fullMsg)
+  }
   throw new assert.AssertionError({
-    message: message,
+    message: fullMsg,
   })
 }
 


### PR DESCRIPTION
This PR adds per-message debugging on the devp2p library for the ETH protocol as well as other protocols. This should hopefully significantly help us on a more targeted debugging along client development.

Per-Message debugging can be used as follows, see also the additions to the docs for more information:

```shell
DEBUG=devp2p:eth:BLOCK_HEADERS,devp2p:eth:GET_BLOCK_HEADERS npm run client:start
```

Example output:

![grafik](https://user-images.githubusercontent.com/931137/131972634-5ec96261-d412-4a50-89f3-f7cfd91cc75f.png)
