### PR TITLE
bug: fix comparison operator bug

### DIFF
--- a/config/cli/ts-build.sh
+++ b/config/cli/ts-build.sh
@@ -72,10 +72,10 @@ build_browser() {
 
 # Begin build process.
 
-if [ "$1" == "node" ];
+if [ "$1" = "node" ];
 then
     build_node
-elif [ "$1" == "browser" ];
+elif [ "$1" = "browser" ];
 then
     build_browser
 else


### PR DESCRIPTION
It wasn't obvious to me if there was any actual issue or not but I've been seeing this sort of error in the build logs for a while:
```sh
> @ethereumjs/vm@5.5.2 build:browser
> ../../config/cli/ts-build.sh browser

../../config/cli/ts-build.sh: 75: [: browser: unexpected operator
../../config/cli/ts-build.sh: 78: [: browser: unexpected operator
[Node build] Using tsconfig.prod.json
> tsc --build ./tsconfig.prod.json
```
The build script was showing errors in the console every time I ran `npm i` and looks like the issue is the `==` operator not being supported by the Bourne shell, per [this article](https://stackoverflow.com/questions/24464690/bash-scripting-unexpected-operator).  Small fix to resolve the error.

