### PR TITLE
ci: add develop branch

### DIFF
--- a/.github/workflows/block-build.yml
+++ b/.github/workflows/block-build.yml
@@ -1,10 +1,8 @@
 name: Block
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
+    branches: [master, develop]
+    tags: ['*']
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/blockchain-build.yml
+++ b/.github/workflows/blockchain-build.yml
@@ -1,10 +1,8 @@
 name: Blockchain
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
+    branches: [master, develop]
+    tags: ['*']
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -1,10 +1,8 @@
 name: Client
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
+    branches: [master, develop]
+    tags: ['*']
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/common-build.yml
+++ b/.github/workflows/common-build.yml
@@ -1,10 +1,8 @@
 name: Common
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
+    branches: [master, develop]
+    tags: ['*']
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/devp2p-build.yml
+++ b/.github/workflows/devp2p-build.yml
@@ -1,10 +1,8 @@
 name: Devp2p
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
+    branches: [master, develop]
+    tags: ['*']
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/e2e-hardhat.yml
+++ b/.github/workflows/e2e-hardhat.yml
@@ -1,10 +1,8 @@
 name: E2E Hardhat Tests
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
+    branches: [master, develop]
+    tags: ['*']
   pull_request:
     types: [opened, reopened, synchronize]
     

--- a/.github/workflows/ethash-build.yml
+++ b/.github/workflows/ethash-build.yml
@@ -1,10 +1,8 @@
 name: Ethash
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
+    branches: [master, develop]
+    tags: ['*']
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/trie-build.yml
+++ b/.github/workflows/trie-build.yml
@@ -1,10 +1,8 @@
 name: Trie
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
+    branches: [master, develop]
+    tags: ['*']
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/tx-build.yml
+++ b/.github/workflows/tx-build.yml
@@ -1,10 +1,8 @@
 name: Tx
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
+    branches: [master, develop]
+    tags: ['*']
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/util-build.yml
+++ b/.github/workflows/util-build.yml
@@ -1,10 +1,8 @@
 name: Util
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
+    branches: [master, develop]
+    tags: ['*']
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/vm-build.yml
+++ b/.github/workflows/vm-build.yml
@@ -1,10 +1,8 @@
 name: VM
 on:
   push:
-    branches:
-      - master
-    tags:
-      - '*'
+    branches: [master, develop]
+    tags: ['*']
 
 env:
   cwd: ${{github.workspace}}/packages/vm


### PR DESCRIPTION
This PR adds the new `develop` branch to the ci triggers.

The only one left would be the nightly test, do we also want to run this once a day on `develop`? Since `on.schedule` doesn't allow you to specify the branch (https://stackoverflow.com/a/58800550) I am thinking of adding a matrix of `branch: [master, develop]` to the nightly jobs if we do want to add it. Or we could do it less frequently like once every 3 days, or on every push to `develop`, but I think then I'll have to create a new workflow file to customize.

If we merge this commit into master then I think we would also have to do it on `develop` so it has the updated files. I can probably re-open the same PR to merge into `develop` afterwards? Not sure if that would confuse rebasing master onto develop in the future, advice welcome.