### PR TITLE
client: fix reqId overflow issue in ETH handler

### DIFF
--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -86,7 +86,7 @@ export class EthProtocol extends Protocol {
       name: 'BlockHeaders',
       code: 0x04,
       encode: ({ reqId, headers }: { reqId: BN; headers: BlockHeader[] }) => [
-        reqId.toNumber(),
+        reqId.toArrayLike(Buffer),
         headers.map((h) => h.raw()),
       ],
       decode: ([reqId, headers]: [Buffer, BlockHeaderBuffer[]]) => [
@@ -116,7 +116,7 @@ export class EthProtocol extends Protocol {
       name: 'BlockBodies',
       code: 0x06,
       encode: ({ reqId, bodies }: { reqId: BN; bodies: BlockBodyBuffer[] }) => [
-        reqId.toNumber(),
+        reqId.toArrayLike(Buffer),
         bodies,
       ],
       decode: ([reqId, bodies]: [Buffer, BlockBodyBuffer[]]) => [new BN(reqId), bodies],


### PR DESCRIPTION
Fixes issue where geth sends a `reqId` that is too big for the JS number type and the `ETH` handler in the synchronizer errors out, causing us to lose sync with a peer.

I've run this PR on goerli for 80000 blocks syncing from a fully synced geth clients and experienced no recurrences of it.