### PR TITLE
Util: More explicit EIP-1191 checksum usage discouraged note / Client: remove Rinkeby from CLI test matrix

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        network: ['rinkeby', 'goerli']
+        network: ['goerli']
         syncmode: ['full', 'light']
       fail-fast: false
     steps:

--- a/packages/util/src/account.ts
+++ b/packages/util/src/account.ts
@@ -139,12 +139,14 @@ export const isValidAddress = function (hexAddress: string): boolean {
 /**
  * Returns a checksummed address.
  *
- * If a eip1191ChainId is provided, the chainId will be included in the checksum calculation. This
+ * If an eip1191ChainId is provided, the chainId will be included in the checksum calculation. This
  * has the effect of checksummed addresses for one chain having invalid checksums for others.
  * For more details see [EIP-1191](https://eips.ethereum.org/EIPS/eip-1191).
  *
- * WARNING: Checksums with and without the chainId will differ. As of 2019-06-26, the most commonly
- * used variation in Ethereum was without the chainId. This may change in the future.
+ * WARNING: Checksums with and without the chainId will differ and the EIP-1191 checksum is not
+ * backwards compatible to the original widely adopted checksum format standard introduced in
+ * [EIP-55](https://eips.ethereum.org/EIPS/eip-55), so this will break in existing applications.
+ * Usage of this EIP is therefore discouraged unless you have a very targeted use case.
  */
 export const toChecksumAddress = function (hexAddress: string, eip1191ChainId?: BNLike): string {
   assertIsHexString(hexAddress)


### PR DESCRIPTION
This PR adds a more explicit note on `toChecksumAddress()` that the usage of EIP-1191 is discouraged due to the lack of backwards compatibility to the existing checksum format.

On a side line it also tests the reactivation of the E2E hardhat tests which I have reactivated in the Actions tab and where a fixing PR has been submitted on the Hardhat side here https://github.com/ethereumjs/ethereumjs-monorepo/pull/1391 by @ryanio which should have solved the test-breaking issue.