### PR TITLE
vscode: add eslint workingDirectories config and enable format-on-save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  },
+  "eslint.format.enable": true,
+  "eslint.workingDirectories": [
+    { "pattern": "./packages/*" }
+  ]
+}


### PR DESCRIPTION
VSCode was always returning this error in our monorepo setup:

> `Parsing error: Cannot read file '/dev/ethereumjs-monorepo/tsconfig.json'.eslint`

This PR adds `.vscode/settings.json` with a `workingDirectories` configuration to fix. See [docs](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint).

I also added format-on-save for developer productivity and time saving. Now when you save your file it should auto format properly with our lint and prettier rules!