### PR TITLE
docs: add Windows installation note

### DIFF
--- a/config/MONOREPO.md
+++ b/config/MONOREPO.md
@@ -39,6 +39,8 @@ If you ever need to reset this change, you can do so with this command:
 npm config delete script-shell
 ```
 
+---
+
 Going down the road, there are two sets of commands: _project_ and _package-specific_ commands. You can find them at `./package.json` and `./packages/*/package.json`, respectively. Here's a breakdown:
 
 ### Project scripts — run from repository root

--- a/config/MONOREPO.md
+++ b/config/MONOREPO.md
@@ -23,9 +23,11 @@ TLDR: To update dependencies
 npm run build --workspaces
 ```
 
+Above is the quickest way to set you up.
+
 ### ℹ️ Note for Windows users:
 
-Windows users might run into the following error when trying to install the repo: `'.' is not recognized as an internal or external command,`. To remediate for this, you can force Windows to use Git bash to run scripts (you'll need to install [Git for Windows](https://git-scm.com/download/win) for this) with the following command:
+Windows users might run into the following error when trying to install the repo: `'.' is not recognized as an internal or external command`. To remediate for this, you can force Windows to use Git bash to run scripts (you'll need to install [Git for Windows](https://git-scm.com/download/win) for this) with the following command:
 
 ```sh
 npm config set script-shell "C:\\Program Files (x86)\\git\\bin\\bash.exe"
@@ -37,7 +39,7 @@ If you ever need to reset this change, you can do so with this command:
 npm config delete script-shell
 ```
 
-Above is the quickest way to set you up. Going down the road, there are two sets of commands: _project_ and _package-specific_ commands. You can find them at `./package.json` and `./packages/*/package.json`, respectively. Here's a breakdown:
+Going down the road, there are two sets of commands: _project_ and _package-specific_ commands. You can find them at `./package.json` and `./packages/*/package.json`, respectively. Here's a breakdown:
 
 ### Project scripts — run from repository root
 

--- a/config/MONOREPO.md
+++ b/config/MONOREPO.md
@@ -2,7 +2,7 @@
 
 ## Development quick start
 
-First, make sure you have the `ethereum-tests` git submodule, by running: 
+First, make sure you have the `ethereum-tests` git submodule, by running:
 
 ```sh
 git submodule init
@@ -12,16 +12,32 @@ git submodule update
 This monorepo uses [npm workspaces](https://docs.npmjs.com/cli/v7/using-npm/workspaces). It links the local packages together, making development a lot easier.
 
 TLDR: Setup
+
 ```sh
 npm i
 ```
 
 TLDR: To update dependencies
+
 ```sh
 npm run build --workspaces
 ```
 
-Above is the quickest way to set you up. Going down the road, there are two sets of commands: *project* and *package-specific* commands. You can find them at `./package.json` and `./packages/*/package.json`, respectively. Here's a breakdown:
+### ℹ️ Note for Windows users:
+
+Windows users might run into the following error when trying to install the repo: `'.' is not recognized as an internal or external command,`. To remediate for this, you can force Windows to use Git bash to run scripts (you'll need to install [Git for Windows](https://git-scm.com/download/win) for this) with the following command:
+
+```sh
+npm config set script-shell "C:\\Program Files (x86)\\git\\bin\\bash.exe"
+```
+
+If you ever need to reset this change, you can do so with this command:
+
+```sh
+npm config delete script-shell
+```
+
+Above is the quickest way to set you up. Going down the road, there are two sets of commands: _project_ and _package-specific_ commands. You can find them at `./package.json` and `./packages/*/package.json`, respectively. Here's a breakdown:
 
 ### Project scripts — run from repository root
 
@@ -49,8 +65,8 @@ Rebuilds all generated docs.
 
 ### Package scripts — run from `./packages/<name>`
 
- **⚠️ Important: if you run `npm install` from the package directory, it will [ignore the workspace](https://github.com/npm/cli/issues/2546). Run `npm install` from the root only.**
- 
+**⚠️ Important: if you run `npm install` from the package directory, it will [ignore the workspace](https://github.com/npm/cli/issues/2546). Run `npm install` from the root only.**
+
 There's a set of rather standardized commands you will find in each package of this repository.
 
 #### `npm run build`
@@ -75,6 +91,6 @@ Fixes code style according to the rules. Differently from `npm run lint`, this c
 
 #### `npm run test`
 
-Runs the package tests. 
+Runs the package tests.
 
 _Note that the VM has several test scopes - refer to [packages/vm/package.json](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/vm/package.json) for more info._


### PR DESCRIPTION
This PR adds a note for Windows installation to the monorepo docs. See https://github.com/ethereumjs/ethereumjs-monorepo/issues/1460#issuecomment-916480558 for reference.