### PR TITLE
client: Filter out forks with no block set in config

### DIFF
--- a/packages/client/lib/util/parse.ts
+++ b/packages/client/lib/util/parse.ts
@@ -217,10 +217,12 @@ async function parseGethParams(json: any) {
     berlin: 'berlinBlock',
     london: 'londonBlock',
   }
-  params.hardforks = hardforks.map((name) => ({
-    name: name,
-    block: name === 'chainstart' ? 0 : config[forkMap[name]] ?? null,
-  }))
+  params.hardforks = hardforks
+    .map((name) => ({
+      name: name,
+      block: name === 'chainstart' ? 0 : config[forkMap[name]] ?? null,
+    }))
+    .filter((fork) => fork.block !== null)
   return params
 }
 /**


### PR DESCRIPTION
Fixes #1466.  

The source of the issue is that when a geth genesis file is provided to the client, the `parseGethParams` method is inserting hardforks into the chain parameters with null block numbers where the hardfork is not present in the geth file.  When a client tries to connect to another client using the same geth genesis file, if one client isn't fully synced and sends a forkhash that is a subset of the other, the issue causes an error in `_validateForkId` at [this point](https://github.com/ethereumjs/ethereumjs-monorepo/blob/6e6dfb8f4c813c8be4be23b3f5a627e3aa545835/packages/devp2p/src/eth/index.ts#L157-L157) if the hardfork with a null block number is follow a hardfork with a block number since the forkhash is computed for all hardforks that occur on a given block is [the same](https://eips.ethereum.org/EIPS/eip-2124#specification).  If a hardfork exists in the `chainParams` that has a null block value, it is treated as having the same forkhash as the hardfork immediately before it and so `_validateForkId` was finding that the `peerNextFork` was a hardfork with no block number instead of the fork immediately before it in sequence.

This resolves the issue by simply filtering out any hardforks that weren't included in the geth genesis file as these shouldn't exist in the `Common` for that custom network.