### PR TITLE
client: Fix gas calculations on EIP1559 forkblock in miner

### DIFF
--- a/packages/client/lib/miner/miner.ts
+++ b/packages/client/lib/miner/miner.ts
@@ -196,7 +196,6 @@ export class Miner {
       vmCopy.stateManager,
       baseFeePerGas
     )
-    console.log(baseFeePerGas)
     this.config.logger.info(
       `Miner: Assembling block from ${txs.length} eligible txs ${
         baseFeePerGas ? `(baseFee: ${baseFeePerGas.toNumber()})` : ''

--- a/packages/client/lib/miner/miner.ts
+++ b/packages/client/lib/miner/miner.ts
@@ -122,7 +122,7 @@ export class Miner {
 
     const parentBlockHeader = this.latestBlockHeader()
     const number = parentBlockHeader.number.addn(1)
-    const { gasLimit } = parentBlockHeader
+    let { gasLimit } = parentBlockHeader
     const [signerAddress, signerPrivKey] = this.config.accounts[0]
 
     // Abort if we have too recently signed
@@ -168,11 +168,15 @@ export class Miner {
     const londonHardforkBlock = this.config.chainCommon.hardforkBlockBN('london')
     const isInitialEIP1559Block = londonHardforkBlock && number.eq(londonHardforkBlock)
     if (isInitialEIP1559Block) {
-      baseFeePerGas = new BN(this.config.chainCommon.param('gasConfig', 'initialBaseFee'))
+      // Get baseFeePerGas from `paramByEIP` since 1559 not currently active on common
+      baseFeePerGas = new BN(
+        this.config.chainCommon.paramByEIP('gasConfig', 'initialBaseFee', 1559)
+      )
+      // Set initial EIP1559 block gas limit to 2x parent gas limit per logic in `block.validateGasLimit`
+      gasLimit = gasLimit.muln(2)
     } else if (this.config.chainCommon.isActivatedEIP(1559)) {
       baseFeePerGas = parentBlockHeader.calcNextBaseFee()
     }
-
     const parentBlock = (this.synchronizer as any).chain.blocks.latest
     const blockBuilder = await vmCopy.buildBlock({
       parentBlock,
@@ -192,6 +196,7 @@ export class Miner {
       vmCopy.stateManager,
       baseFeePerGas
     )
+    console.log(baseFeePerGas)
     this.config.logger.info(
       `Miner: Assembling block from ${txs.length} eligible txs ${
         baseFeePerGas ? `(baseFee: ${baseFeePerGas.toNumber()})` : ''


### PR DESCRIPTION
When the miner is assembling a new block and the new block happens to be the EIP1559 block, the `assembleBlock` was failing since the `baseFeePerGas` param wasn't active since EIP1559 isn't technically active in the `common` instance of the miner at the point in time where it's assembling the EIP1559 fork block (i.e. `Common` thinks it's EIP1559 fork block - 1).  This looks up the `initialBaseFee` from `common.paramByEIP` instead of `common.param` to retrieve that initial value when executing on the EIP1559 fork block.  It also adjusts the gas limit in line with the logic [validateGasLimit](https://github.com/ethereumjs/ethereumjs-monorepo/blob/90fea3df7a07dd1b1af248a19e76ad56a5432b94/packages/block/src/header.ts#L520-L520).