### PR TITLE
Client: add JSON-RPC help (`--helprpc`)

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -14,6 +14,7 @@ import EthereumClient from '../lib/client'
 import { Config } from '../lib/config'
 import { Logger } from '../lib/logging'
 import { RPCManager } from '../lib/rpc'
+import * as modules from '../lib/rpc/modules'
 import { Event } from '../lib/types'
 import type { Chain as IChain, GenesisState } from '@ethereumjs/common/dist/types'
 const level = require('level')
@@ -88,6 +89,10 @@ const args = require('yargs')
     rpcaddr: {
       describe: 'HTTP-RPC server listening interface',
       default: Config.RPCADDR_DEFAULT,
+    },
+    helprpc: {
+      describe: 'Display the JSON RPC help with a list of all RPC methods implemented (and exit)',
+      boolean: true,
     },
     loglevel: {
       describe: 'Logging verbosity',
@@ -207,6 +212,23 @@ function runRpcServer(client: EthereumClient, config: Config) {
  * Main entry point to start a client
  */
 async function run() {
+  if (args.helprpc) {
+    // Display RPC help and exit
+    console.log('-'.repeat(27))
+    console.log('JSON-RPC: Supported Methods')
+    console.log('-'.repeat(27))
+    console.log()
+    modules.list.forEach((modName: string) => {
+      console.log(`${modName}:`)
+      RPCManager.getMethodNames((modules as any)[modName]).forEach((methodName: string) => {
+        console.log(`-> ${modName.toLowerCase()}_${methodName}`)
+      })
+      console.log()
+    })
+    console.log()
+    process.exit()
+  }
+
   // give network id precedence over network name
   const chain = args.networkId ?? args.network ?? Chain.Mainnet
 

--- a/packages/client/lib/rpc/index.ts
+++ b/packages/client/lib/rpc/index.ts
@@ -7,16 +7,6 @@ import * as modules from './modules'
  */
 
 /**
- * get all methods. e.g., getBlockByNumber in eth module
- * @private
- * @param Object mod
- * @returns string[]
- */
-function getMethodNames(mod: any): string[] {
-  return Object.getOwnPropertyNames(mod.prototype)
-}
-
-/**
  * RPC server manager
  * @memberof module:rpc
  */
@@ -41,7 +31,7 @@ export class RPCManager {
       this._config.logger.debug(`Initialize ${modName} module`)
       const mod = new (modules as any)[modName](this._client)
 
-      getMethodNames((modules as any)[modName])
+      RPCManager.getMethodNames((modules as any)[modName])
         .filter((methodName: string) => methodName !== 'constructor')
         .forEach((methodName: string) => {
           const concatedMethodName = `${modName.toLowerCase()}_${methodName}`
@@ -52,5 +42,17 @@ export class RPCManager {
     })
 
     return methods
+  }
+
+  /**
+   * get all methods. e.g., getBlockByNumber in eth module
+   * @param Object mod
+   * @returns string[]
+   */
+  static getMethodNames(mod: any): string[] {
+    const methodNames = Object.getOwnPropertyNames(mod.prototype).filter(
+      (methodName: string) => methodName !== 'constructor'
+    )
+    return methodNames
   }
 }


### PR DESCRIPTION
This PR adds a JSON-RPC help for CLI which lists all currently implemented RPC methods and can be used with a new `--helprpc` CLI option.

This should be useful for users to get an overview on the currently implemented RPC methods, making it unnecessary to refer to the - often outdated - respective tracking issue currently still linked in the RPC docs).

Output looks like the following:

![grafik](https://user-images.githubusercontent.com/931137/135618847-327f7f48-cacc-49aa-b32b-531ea9974be9.png)
