### PR TITLE
feat(vm): use promisify from node.js

### DIFF
--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -59,8 +59,7 @@
     "ethereumjs-util": "^7.1.2",
     "functional-red-black-tree": "^1.0.1",
     "mcl-wasm": "^0.7.1",
-    "rustbn.js": "~0.2.0",
-    "util.promisify": "^1.0.1"
+    "rustbn.js": "~0.2.0"
   },
   "devDependencies": {
     "@types/benchmark": "^1.0.33",

--- a/packages/vm/src/index.ts
+++ b/packages/vm/src/index.ts
@@ -13,7 +13,7 @@ import { OpcodeList, getOpcodesForHF } from './evm/opcodes'
 import { precompiles } from './evm/precompiles'
 import runBlockchain from './runBlockchain'
 const AsyncEventEmitter = require('async-eventemitter')
-const promisify = require('util.promisify')
+import { promisify } from 'util'
 
 // very ugly way to detect if we are running in a browser
 const isBrowser = new Function('try {return this===window;}catch(e){ return false;}')


### PR DESCRIPTION
util.promisify is supported since Node.js 8, there's no point in using a polyfill.

That polyfill also breaks in ESM environments so removing it would be helpful.