### PR TITLE
util: fix toUtf8 when there is a zero at the end of a line

### DIFF
--- a/packages/util/src/internal.ts
+++ b/packages/util/src/internal.ts
@@ -112,7 +112,8 @@ export function arrayContainsArray(
  * @returns ascii string representation of hex value
  */
 export function toUtf8(hex: string) {
-  const bufferValue = Buffer.from(padToEven(stripHexPrefix(hex).replace(/^0+|0+$/g, '')), 'hex')
+  const zerosRegexp = /^(00)+|(00)+$/g
+  const bufferValue = Buffer.from(padToEven(stripHexPrefix(hex).replace(zerosRegexp, '')), 'hex')
 
   return bufferValue.toString('utf8')
 }

--- a/packages/util/test/internal.spec.ts
+++ b/packages/util/test/internal.spec.ts
@@ -42,6 +42,7 @@ tape('internal', (t) => {
   })
   t.test('toUtf8', (st) => {
     st.equal(toUtf8(buf.toString('hex')), 'hello')
+    st.equal(toUtf8(Buffer.from('bip').toString('hex')), 'bip')
     st.end()
   })
   t.test('toAscii', (st) => {


### PR DESCRIPTION
Problem:

```js
import { toUtf8 } from 'ethereumjs-util';

const hex = Buffer.from('bip').toString('hex'); // '626970'
toUtf8(hex); // '\x06&�'
```

This [line](https://github.com/ethereumjs/ethereumjs-monorepo/blob/986eb64dde1fa3761b19749d3d6aab8b06b6cbc7/packages/util/src/internal.ts#L115) removes zeros at the beginning and end plus add a zero at the beginning in `padToEven` (same problem in `ethjs-util` dependency, which was removed in #1517)

```js
const bufferValue = Buffer.from(padToEven(stripHexPrefix(hex).replace(/^0+|0+$/g, '')), 'hex');

// in padToEven(stripHexPrefix(hex).replace(/^0+|0+$/g, '')
// from '626970' we get '062697'
```

Solution: remove only the grouped zeros at the beginning and end

`/^0+|0+$/g` -> `/^(00)+|(00)+$/g`
