### PR TITLE
client: fix hanging integration test

### DIFF
--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -53,7 +53,6 @@ export abstract class Synchronizer {
   // Time (in ms) after which the synced state is reset
   private SYNCED_STATE_REMOVAL_PERIOD = 60000
   private _syncedStatusCheckInterval: NodeJS.Timeout | undefined /* global NodeJS */
-  private _boundChainUpdatedEvent: () => void
 
   /**
    * Create new node
@@ -78,8 +77,9 @@ export abstract class Synchronizer {
       }
     })
 
-    this._boundChainUpdatedEvent = this.updateSynchronizedState.bind(this)
-    this.config.events.on(Event.CHAIN_UPDATED, this._boundChainUpdatedEvent)
+    this.config.events.on(Event.CHAIN_UPDATED, () => {
+      this.updateSynchronizedState()
+    })
   }
 
   /**
@@ -183,7 +183,6 @@ export abstract class Synchronizer {
       return false
     }
     clearInterval(this._syncedStatusCheckInterval as NodeJS.Timeout)
-    this.config.events.removeListener(Event.CHAIN_UPDATED, this._boundChainUpdatedEvent)
     await new Promise((resolve) => setTimeout(resolve, this.interval))
     this.running = false
     this.config.logger.info('Stopped synchronization.')


### PR DESCRIPTION
This PR fixes the hanging integration test merged onto master by reverting the sync event handler changes, sorry about that!