### PR TITLE
Common: add custom params for Optimism L2

### DIFF
--- a/packages/common/docs/classes/default.md
+++ b/packages/common/docs/classes/default.md
@@ -1579,6 +1579,8 @@ Note that these supported custom chains only provide some base parameters (usual
 network ID and a name) and can only be used for selected use cases (e.g. sending a tx with
 the `@ethereumjs/tx` library to a Layer-2 chain).
 
+Note: For Optimistic Kovan and Optimistic Ethereum, the London hardfork has not been implemented yet so attempts to send EIP1559 transactions will fail.
+
 #### Parameters
 
 | Name | Type | Description |

--- a/packages/common/docs/classes/default.md
+++ b/packages/common/docs/classes/default.md
@@ -1579,8 +1579,6 @@ Note that these supported custom chains only provide some base parameters (usual
 network ID and a name) and can only be used for selected use cases (e.g. sending a tx with
 the `@ethereumjs/tx` library to a Layer-2 chain).
 
-Note: For Optimistic Kovan and Optimistic Ethereum, the London hardfork has not been implemented yet so attempts to send EIP1559 transactions will fail.
-
 #### Parameters
 
 | Name | Type | Description |

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -40,6 +40,21 @@ export enum CustomChain {
    * - [Documentation](https://www.xdaichain.com/)
    */
   xDaiChain = 'x-dai-chain',
+
+  /**
+   * Optimistic Kovan - testnet for Optimism roll-up
+   *
+   * - [Documentation](https://community.optimism.io/docs/developers/tutorials.html)
+   */
+
+  OptimisticKovan = 'optimistic-kovan',
+
+  /**
+   * Optimistic Ethereum - mainnet for Optimism roll-up
+   *
+   * - [Documentation](https://community.optimism.io/docs/developers/tutorials.html)
+   */
+  OptimisticEthereum = 'optimistic-ethereum',
 }
 
 export enum Chain {
@@ -240,6 +255,29 @@ export default class Common extends EventEmitter {
         })
       }
 
+      if (chainParamsOrName === CustomChain.OptimisticKovan) {
+        return Common.custom(
+          {
+            name: CustomChain.OptimisticKovan,
+            chainId: 69,
+            networkId: 69,
+          },
+          // Optimism has not implemented the London hardfork yet (targeting Q1.22)
+          { hardfork: Hardfork.Berlin }
+        )
+      }
+
+      if (chainParamsOrName === CustomChain.OptimisticEthereum) {
+        return Common.custom(
+          {
+            name: CustomChain.OptimisticEthereum,
+            chainId: 10,
+            networkId: 10,
+          },
+          // Optimism has not implemented the London hardfork yet (targeting Q1.22)
+          { hardfork: Hardfork.Berlin }
+        )
+      }
       throw new Error(`Custom chain ${chainParamsOrName} not supported`)
     }
   }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -46,7 +46,6 @@ export enum CustomChain {
    *
    * - [Documentation](https://community.optimism.io/docs/developers/tutorials.html)
    */
-
   OptimisticKovan = 'optimistic-kovan',
 
   /**

--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -237,6 +237,7 @@ The following L2 networks have been tested to work with `@ethereumjs/tx`, see us
 | Optimistic Ethereum | `Common.OptimisticEthereum` | [#1554](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1554)
 
 Note: For Optimistic Kovan and Optimistic Ethereum, the London hardfork has not been implemented so transactions submitted with a `baseFee` will revert.
+The London hardfork is targeted to implement on Optimism in Q1.22.
 
 For a non-predefined custom chain it is also possible to just provide a chain ID as well as other parameters to `Common`:
 

--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -233,8 +233,10 @@ The following L2 networks have been tested to work with `@ethereumjs/tx`, see us
 | Polygon Mainnet | `CustomChain.PolygonMainnet` | [#1289](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1289) |
 | Polygon Mumbai Testnet | `CustomChain.PolygonMumbai` | [#1289](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1289) |
 | xDai Chain | `Common.xDaiChain` | [#1323](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1323) |
+| Optimistic Kovan | `Common.OptimisticKovan` | [#1554](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1554)
+| Optimistic Ethereum | `Common.OptimisticEthereum` | [#1554](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1554)
 
-
+Note: For Optimistic Kovan and Optimistic Ethereum, the London hardfork has not been implemented so transactions submitted with a `baseFee` will revert.
 
 For a non-predefined custom chain it is also possible to just provide a chain ID as well as other parameters to `Common`:
 


### PR DESCRIPTION
Adds new custom parameters for Optimism L2 to the `CustomChains` `enum` in Common.