### PR TITLE
blockchain: Change toBuffer to toArrayLike for BNs

### DIFF
--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Fixed bug in several PoA related methods where BigNumber -> Buffer conversions would break in the browser context for tools like browserify
 ## 5.5.0 - 2021-11-09
 
 ### ArrowGlacier HF Support

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -527,7 +527,7 @@ export default class Blockchain implements BlockchainInterface {
 
     // save to db
     const formatted = this._cliqueLatestSignerStates.map((state) => [
-      state[0].toBuffer(),
+      state[0].toArrayLike(Buffer),
       state[1].map((a) => a.toBuffer()),
     ])
     dbOps.push(DBOp.set(DBTarget.CliqueSignerStates, rlp.encode(formatted)))
@@ -678,7 +678,7 @@ export default class Blockchain implements BlockchainInterface {
     // save votes to db
     const dbOps: DBOp[] = []
     const formatted = this._cliqueLatestVotes.map((v) => [
-      v[0].toBuffer(),
+      v[0].toArrayLike(Buffer),
       [v[1][0].toBuffer(), v[1][1].toBuffer(), v[1][2]],
     ])
     dbOps.push(DBOp.set(DBTarget.CliqueVotes, rlp.encode(formatted)))
@@ -717,7 +717,10 @@ export default class Blockchain implements BlockchainInterface {
     }
 
     // save to db
-    const formatted = this._cliqueLatestBlockSigners.map((b) => [b[0].toBuffer(), b[1].toBuffer()])
+    const formatted = this._cliqueLatestBlockSigners.map((b) => [
+      b[0].toArrayLike(Buffer),
+      b[1].toBuffer(),
+    ])
     dbOps.push(DBOp.set(DBTarget.CliqueBlockSigners, rlp.encode(formatted)))
 
     await this.dbManager.batch(dbOps)


### PR DESCRIPTION
Fixes #1552.  

This addresses an issue where our code currently uses the bn.js `toBuffer()` function in several places in the `Blockchain` library which then breaks in the browser context.  Changes this usage to `toArrayLike()` per the [bn.js docs](https://github.com/indutny/bn.js/#utilities) to fix compatibility issues with browserify and similar bundlers.