### PR TITLE
blockchain: v5.5.1 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18568,7 +18568,7 @@
     },
     "packages/blockchain": {
       "name": "@ethereumjs/blockchain",
-      "version": "5.5.0",
+      "version": "5.5.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/block": "^3.6.0",
@@ -18620,7 +18620,7 @@
       "dependencies": {
         "@chainsafe/libp2p-noise": "^4.1.1",
         "@ethereumjs/block": "^3.6.0",
-        "@ethereumjs/blockchain": "^5.5.0",
+        "@ethereumjs/blockchain": "^5.5.1",
         "@ethereumjs/common": "^2.6.0",
         "@ethereumjs/devp2p": "^4.2.0",
         "@ethereumjs/ethash": "^1.1.0",
@@ -19060,7 +19060,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/block": "^3.6.0",
-        "@ethereumjs/blockchain": "^5.5.0",
+        "@ethereumjs/blockchain": "^5.5.1",
         "@ethereumjs/common": "^2.6.0",
         "@ethereumjs/tx": "^3.4.0",
         "async-eventemitter": "^0.2.4",
@@ -19591,7 +19591,7 @@
         "@babel/plugin-transform-spread": "^7.10.1",
         "@chainsafe/libp2p-noise": "^4.1.1",
         "@ethereumjs/block": "^3.6.0",
-        "@ethereumjs/blockchain": "^5.5.0",
+        "@ethereumjs/blockchain": "^5.5.1",
         "@ethereumjs/common": "^2.6.0",
         "@ethereumjs/devp2p": "^4.2.0",
         "@ethereumjs/ethash": "^1.1.0",
@@ -19857,7 +19857,7 @@
       "version": "file:packages/vm",
       "requires": {
         "@ethereumjs/block": "^3.6.0",
-        "@ethereumjs/blockchain": "^5.5.0",
+        "@ethereumjs/blockchain": "^5.5.1",
         "@ethereumjs/common": "^2.6.0",
         "@ethereumjs/tx": "^3.4.0",
         "@types/benchmark": "^1.0.33",

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
-- Fixed bug in several PoA related methods where BigNumber -> Buffer conversions would break in the browser context for tools like browserify
+## 5.5.1 - 2021-11-15
+
+This patch release contains a bug fix for using the blockchain package in a browser context with tools like browserify, see PR [#1566](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1566).
+
 ## 5.5.0 - 2021-11-09
 
 ### ArrowGlacier HF Support

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/blockchain",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "description": "A module to store and interact with blocks",
   "license": "MPL-2.0",
   "keywords": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@chainsafe/libp2p-noise": "^4.1.1",
     "@ethereumjs/block": "^3.6.0",
-    "@ethereumjs/blockchain": "^5.5.0",
+    "@ethereumjs/blockchain": "^5.5.1",
     "@ethereumjs/common": "^2.6.0",
     "@ethereumjs/devp2p": "^4.2.0",
     "@ethereumjs/ethash": "^1.1.0",

--- a/packages/client/test/cli/cli-sync.spec.ts
+++ b/packages/client/test/cli/cli-sync.spec.ts
@@ -7,7 +7,7 @@ const cliArgs = process.argv.filter(
 )
 
 tape('[CLI] sync', (t) => {
-  t.test('should begin downloading blocks', { timeout: 260000 }, (t) => {
+  t.test('should begin downloading blocks', { timeout: 260000 }, (st) => {
     const file = require.resolve('../../dist/bin/cli.js')
     const child = spawn(process.execPath, [file, ...cliArgs])
 
@@ -18,7 +18,7 @@ tape('[CLI] sync', (t) => {
       child.stdout.removeAllListeners()
       child.stderr.removeAllListeners()
       child.kill('SIGINT')
-      t.end()
+      st.end()
     }
 
     child.stdout.on('data', (data) => {
@@ -29,11 +29,11 @@ tape('[CLI] sync', (t) => {
       console.log(message)
 
       if (message.toLowerCase().includes('error')) {
-        t.fail(message)
+        st.fail(message)
         return end()
       }
       if (message.includes('Imported')) {
-        t.pass('successfully imported blocks or headers')
+        st.pass('successfully imported blocks or headers')
         return end()
       }
     })
@@ -44,13 +44,13 @@ tape('[CLI] sync', (t) => {
         // This is okay.
         return
       }
-      t.fail(`stderr: ${message}`)
+      st.fail(`stderr: ${message}`)
       end()
     })
 
     child.on('close', (code) => {
       if (code > 0) {
-        t.fail(`child process exited with code ${code}`)
+        st.fail(`child process exited with code ${code}`)
         end()
       }
     })

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "@ethereumjs/block": "^3.6.0",
-    "@ethereumjs/blockchain": "^5.5.0",
+    "@ethereumjs/blockchain": "^5.5.1",
     "@ethereumjs/common": "^2.6.0",
     "@ethereumjs/tx": "^3.4.0",
     "merkle-patricia-tree": "^4.2.2",


### PR DESCRIPTION
This patch release contains a bug fix for using the blockchain package in a browser context with tools like browserify, see PR [#1566](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1566).