### PR TITLE
VM: Cache Improvements

### DIFF
--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -64,6 +64,7 @@
   "devDependencies": {
     "@types/benchmark": "^1.0.33",
     "@types/core-js": "^2.5.0",
+    "@types/functional-red-black-tree": "^1.0.1",
     "@types/lru-cache": "^5.1.0",
     "@types/minimist": "^1.2.2",
     "@types/node": "^11.13.4",

--- a/packages/vm/src/state/cache.ts
+++ b/packages/vm/src/state/cache.ts
@@ -1,5 +1,5 @@
 import { Account, Address } from 'ethereumjs-util'
-const Tree = require('functional-red-black-tree')
+import createTree from 'functional-red-black-tree'
 
 export type getCb = (address: Address) => Promise<Account | undefined>
 export type putCb = (keyBuf: Buffer, accountRlp: Buffer) => Promise<void>
@@ -15,7 +15,7 @@ export interface CacheOpts {
  * @ignore
  */
 export default class Cache {
-  _cache: any
+  _cache: createTree.Tree<string, any>
   _checkpoints: any[]
 
   _getCb: getCb
@@ -23,7 +23,7 @@ export default class Cache {
   _deleteCb: deleteCb
 
   constructor(opts: CacheOpts) {
-    this._cache = Tree()
+    this._cache = createTree<string, any>()
     this._getCb = opts.getCb
     this._putCb = opts.putCb
     this._deleteCb = opts.deleteCb
@@ -111,7 +111,7 @@ export default class Cache {
       if (it.value && it.value.modified && !it.value.deleted) {
         it.value.modified = false
         const accountRlp = it.value.val
-        const keyBuf = Buffer.from(it.key, 'hex')
+        const keyBuf = Buffer.from(it.key as string, 'hex')
         await this._putCb(keyBuf, accountRlp)
         next = it.hasNext
         it.next()
@@ -120,7 +120,7 @@ export default class Cache {
         it.value.deleted = true
         it.value.virtual = true
         it.value.val = new Account().serialize()
-        const keyBuf = Buffer.from(it.key, 'hex')
+        const keyBuf = Buffer.from(it.key as string, 'hex')
         await this._deleteCb(keyBuf)
         next = it.hasNext
         it.next()
@@ -157,7 +157,7 @@ export default class Cache {
    * Clears cache.
    */
   clear(): void {
-    this._cache = Tree()
+    this._cache = createTree<string, any>()
   }
 
   /**

--- a/packages/vm/src/state/stateManager.ts
+++ b/packages/vm/src/state/stateManager.ts
@@ -301,22 +301,24 @@ export default class DefaultStateManager extends BaseStateManager implements Sta
    * @param stateRoot - The state-root to reset the instance to
    */
   async setStateRoot(stateRoot: Buffer): Promise<void> {
-    if (this._checkpointCount !== 0) {
-      throw new Error('Cannot set state root with uncommitted checkpoints')
-    }
+    const oldRoot = await this.getStateRoot()
 
-    await this._cache.flush()
-
-    if (!stateRoot.equals(this._trie.EMPTY_TRIE_ROOT)) {
-      const hasRoot = await this._trie.checkRoot(stateRoot)
-      if (!hasRoot) {
-        throw new Error('State trie does not contain state root')
+    if (!stateRoot.equals(oldRoot)) {
+      if (this._checkpointCount !== 0) {
+        throw new Error('Cannot set state root with uncommitted checkpoints')
       }
-    }
 
-    this._trie.root = stateRoot
-    this._cache.clear()
-    this._storageTries = {}
+      if (!stateRoot.equals(this._trie.EMPTY_TRIE_ROOT)) {
+        const hasRoot = await this._trie.checkRoot(stateRoot)
+        if (!hasRoot) {
+          throw new Error('State trie does not contain state root')
+        }
+      }
+
+      this._trie.root = stateRoot
+      this._cache.clear()
+      this._storageTries = {}
+    }
   }
 
   /**


### PR DESCRIPTION
This PR does some improvements on the VM StateManager cache.

On this first iteration it only clears the caches and updates the state root in `StateManager.setStateRoot()` if the new state root actually differs from the old one.

This targets the situation where we are calling the `setStateRoot()` function from within the client before running a new block when - in the normal occurence of things - the state root should already have been updated in the trie by the state updates which happened during tx execution and the resulting state root should therefore match the block state root anyhow (the alternative would have been to remove the `setStateRoot()` call in the client but I guess this is the more robust version where more use cases can benefit).

I tested this in the client with the following command `cd ../vm && npm run build:node && cd ../client/ && npm run client:start --executeBlocks=205049-205449` and with counting the cache + the trie reads.

Before: Trie: 1840 Cache: 6475
After: Trie: 817 Cache: 7455

So this *does* save a signifcant amount of Trie reads. Execution time did not change along this test (on my (old) laptop always at 9 seconds for the block range from above). I guess there might be a more signifcant effect later on when having a larger trie, couldn't test this since my local mainnet sync is not that much further advanced in the chain.

With this change we would need to care a bit more about cache size (this might be a good idea in general), will give this some thought here along.
