### PR TITLE
vm: dedupe ci step

### DIFF
--- a/.github/workflows/vm-build.yml
+++ b/.github/workflows/vm-build.yml
@@ -31,16 +31,14 @@ jobs:
       - run: npm i
         working-directory: ${{github.workspace}}
 
+      - run: npm run lint
       - run: npm run coverage
+      - run: npm run test:API:browser
 
       - uses: codecov/codecov-action@v1
         with:
           file: ${{ env.cwd }}/coverage/lcov.info
           flags: vm
-
-      - run: npm run test:API
-      - run: npm run test:API:browser
-      - run: npm run lint
 
   test-vm-state:
     runs-on: ubuntu-latest

--- a/.github/workflows/vm-pr.yml
+++ b/.github/workflows/vm-pr.yml
@@ -30,16 +30,14 @@ jobs:
       - run: npm i
         working-directory: ${{github.workspace}}
 
+      - run: npm run lint
       - run: npm run coverage
+      - run: npm run test:API:browser
 
       - uses: codecov/codecov-action@v1
         with:
           file: ${{ env.cwd }}/coverage/lcov.info
           flags: vm
-
-      - run: npm run test:API
-      - run: npm run test:API:browser
-      - run: npm run lint
 
   vm-state:
     runs-on: ubuntu-latest

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -26,7 +26,7 @@
     "prepublishOnly": "../../config/cli/prepublish.sh && npm run test:buildIntegrity",
     "clean": "../../config/cli/clean-package.sh",
     "coverage": "nyc npm run coverage:test",
-    "coverage:test": "npm run tape -- './tests/api/**/*.spec.ts' && npm run tester -- --state",
+    "coverage:test": "npm run test:API && npm run tester -- --state",
     "docs:build": "typedoc --options typedoc.js",
     "tape": "tape -r ts-node/register --stack-size=1500",
     "tester": "ts-node ./tests/tester --stack-size=1500",


### PR DESCRIPTION
I noticed we were running `npm run test:API` twice in our ci since it is already run during `coverage:test`, so this PR dedupes it.