### PR TITLE
Common: Add berlin/london hardforks to kovan

### DIFF
--- a/packages/common/src/chains/kovan.json
+++ b/packages/common/src/chains/kovan.json
@@ -62,13 +62,13 @@
     },
     {
       "name": "berlin",
-      "block": null,
-      "forkHash": null
+      "block": 24770900,
+      "forkHash": "0x179f954"
     }, 
     {
       "name": "london",
-      "block": null, 
-      "forkHash": null
+      "block": 26741100,
+      "forkHash": "0x198096c"
     },
     {
       "name": "merge",

--- a/packages/common/src/chains/kovan.json
+++ b/packages/common/src/chains/kovan.json
@@ -63,12 +63,12 @@
     {
       "name": "berlin",
       "block": 24770900,
-      "forkHash": "0x179f954"
+      "forkHash": "0x1a0f10d9"
     }, 
     {
       "name": "london",
       "block": 26741100,
-      "forkHash": "0x198096c"
+      "forkHash": "0x1ed20b71"
     },
     {
       "name": "merge",

--- a/packages/common/tests/hardforks.spec.ts
+++ b/packages/common/tests/hardforks.spec.ts
@@ -380,7 +380,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
 
     c = new Common({ chain: Chain.Kovan })
     const f = () => {
-      c.forkHash(Hardfork.London)
+      c.forkHash(Hardfork.Merge)
     }
     msg = 'should throw when called on non-applied or future HF'
     st.throws(f, /No fork hash calculation possible/, msg)


### PR DESCRIPTION
Adds Berlin and London hardforks to Kovan chain details in Common

Block numbers/fork hashes pulled from:
- Berlin - https://github.com/openethereum/openethereum/commit/392a909cb746b67bb985bb7e6da6e21dfdb4cb16
- London - https://github.com/openethereum/openethereum/pull/502