### PR TITLE
Update dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:14-alpine as build
 WORKDIR /usr/app
-RUN apk update && apk add --no-cache g++ make python bash git && rm -rf /var/cache/apk/*
+RUN apk update && apk add --no-cache g++ make py-pip bash git && rm -rf /var/cache/apk/*
 
 ARG VERSION=latest
 ENV VERSION=$VERSION


### PR DESCRIPTION
Docker fails to build image because docker file is installing decommissioned version (2) of python. Updated to install Python 3. Refer to https://stackoverflow.com/questions/62169568/docker-alpine-linux-python-missing.