### PR TITLE
Ethtests 10.2 cleanup items

### DIFF
--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -212,7 +212,7 @@ export default class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMark
     })
 
     if (this.gasLimit.mul(this.maxFeePerGas).gt(MAX_INTEGER)) {
-      const msg = this._errorMsg('gasLimit * maxFeePerGas cannot exceed MAX_INTEGER (2^256)')
+      const msg = this._errorMsg('gasLimit * maxFeePerGas cannot exceed MAX_INTEGER (2^256-1)')
       throw new Error(msg)
     }
 

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -111,7 +111,8 @@ export default class Transaction extends BaseTransaction<Transaction> {
     this.gasPrice = new BN(toBuffer(txData.gasPrice === '' ? '0x' : txData.gasPrice))
 
     if (this.gasPrice.mul(this.gasLimit).gt(MAX_INTEGER)) {
-      throw new Error('gas limit * price overflow')
+      const msg = this._errorMsg('gas limit * gasPrice cannot exceed MAX_INTEGER(2^256-1)')
+      throw new Error(msg)
     }
     this._validateCannotExceedMaxInteger({ gasPrice: this.gasPrice })
 

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -111,7 +111,7 @@ export default class Transaction extends BaseTransaction<Transaction> {
     this.gasPrice = new BN(toBuffer(txData.gasPrice === '' ? '0x' : txData.gasPrice))
 
     if (this.gasPrice.mul(this.gasLimit).gt(MAX_INTEGER)) {
-      const msg = this._errorMsg('gas limit * gasPrice cannot exceed MAX_INTEGER(2^256-1)')
+      const msg = this._errorMsg('gas limit * gasPrice cannot exceed MAX_INTEGER (2^256-1)')
       throw new Error(msg)
     }
     this._validateCannotExceedMaxInteger({ gasPrice: this.gasPrice })

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -279,7 +279,16 @@ export const baToJSON = function (ba: any): any {
 
 /**
  * Checks provided Buffers for leading zeroes and throws if found.
+ *
+ * Examples:
+ *
+ * Valid values: 0x1, 0x, 0x01, 0x1234
+ * Invalid values: 0x0, 0x00, 0x001, 0x0001
+ *
+ * Note: This method is useful for validating that RLP encoded integers comply with the rule that all
+ * integer values encoded to RLP must be in the most compact form and contain no leading zeroes
  * @param values An object containing string keys and Buffer values
+ * @throws if any provided value is found to have leading zeroes
  */
 export const validateNoLeadingZeroes = function (values: { [key: string]: Buffer | undefined }) {
   for (const [k, v] of Object.entries(values)) {

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -286,7 +286,7 @@ export const baToJSON = function (ba: any): any {
  * Invalid values: 0x0, 0x00, 0x001, 0x0001
  *
  * Note: This method is useful for validating that RLP encoded integers comply with the rule that all
- * integer values encoded to RLP must be in the most compact form and contain no leading zeroes
+ * integer values encoded to RLP must be in the most compact form and contain no leading zero bytes
  * @param values An object containing string keys and Buffer values
  * @throws if any provided value is found to have leading zero bytes
  */

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -288,7 +288,7 @@ export const baToJSON = function (ba: any): any {
  * Note: This method is useful for validating that RLP encoded integers comply with the rule that all
  * integer values encoded to RLP must be in the most compact form and contain no leading zeroes
  * @param values An object containing string keys and Buffer values
- * @throws if any provided value is found to have leading zeroes
+ * @throws if any provided value is found to have leading zero bytes
  */
 export const validateNoLeadingZeroes = function (values: { [key: string]: Buffer | undefined }) {
   for (const [k, v] of Object.entries(values)) {

--- a/packages/util/test/bytes.spec.ts
+++ b/packages/util/test/bytes.spec.ts
@@ -357,7 +357,10 @@ tape('validateNoLeadingZeroes', function (st) {
   const noLeadingZeroes = {
     a: toBuffer('0x123'),
   }
-  const leadingZeroes = {
+  const noleadingZeroBytes = {
+    a: toBuffer('0x01'),
+  }
+  const leadingZeroBytes = {
     a: toBuffer('0x001'),
   }
   const onlyZeroes = {
@@ -370,6 +373,7 @@ tape('validateNoLeadingZeroes', function (st) {
   const undefinedValue = {
     a: undefined,
   }
+
   st.doesNotThrow(
     () => validateNoLeadingZeroes(noLeadingZeroes),
     'does not throw when no leading zeroes'
@@ -379,19 +383,14 @@ tape('validateNoLeadingZeroes', function (st) {
     () => validateNoLeadingZeroes(undefinedValue),
     'does not throw when undefined passed in'
   )
-  try {
-    validateNoLeadingZeroes(leadingZeroes)
-    st.fail('should throw')
-  } catch (err: any) {
-    st.ok(
-      err.message.includes('a cannot have leading zeroes'),
-      'error message names property with leading zeroes'
-    )
-    st.notOk(
-      err.message.includes('b cannot have leading zeroes'),
-      'error message should not name property without leading zeroes'
-    )
-  }
-  st.throws(() => validateNoLeadingZeroes(onlyZeroes), 'throws when propery has only zeroes')
+  st.doesNotThrow(
+    () => validateNoLeadingZeroes(noleadingZeroBytes),
+    'does not throw when value has leading zero bytes'
+  )
+  st.throws(
+    () => validateNoLeadingZeroes(leadingZeroBytes),
+    'throws when value has leading zero bytes'
+  )
+  st.throws(() => validateNoLeadingZeroes(onlyZeroes), 'throws when value has only zeroes')
   st.end()
 })

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -302,7 +302,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
 
   // EIP-3607: Reject transactions from senders with deployed code
   if (!fromAccount.codeHash.equals(KECCAK256_NULL)) {
-    const msg = _errorMsg('invalid sender address, address is not EOA', this, block, tx)
+    const msg = _errorMsg('invalid sender address, address is not EOA (EIP-3607)', this, block, tx)
     throw new Error(msg)
   }
   if (!opts.skipBalance) {


### PR DESCRIPTION
Clean-up items from #1568 
 - Add explanatory notes to `validateNoLeadingZeroes` method in `util`
 - Clarify error message in VM related to EIP3607
 - Clean up error message in `legacyTransaction` constructor related to integer overflow
 - Add test to demonstrate `0x01` is valid RLP encoding (since leading zeroes only occur if there are leading zero bytes (e.g. `0x001` which translates to `Buffer<00 01>` 