### PR TITLE
client: fix error logging

### DIFF
--- a/packages/client/lib/logging.ts
+++ b/packages/client/lib/logging.ts
@@ -105,6 +105,9 @@ export function getLogger(args: { [key: string]: any } = { loglevel: 'info' }) {
   if (args.logFile) {
     transports.push(logFileTransport(args))
   }
-  const logger = createLogger({ transports })
+  const logger = createLogger({
+    transports,
+    format: formatConfig(),
+  })
   return logger
 }


### PR DESCRIPTION
This PR fixes `winston` error logging to properly output error messages along with their stack trace.

While we define the error format for each transport (console: with colors, log file: without colors), winston also needs a top level `format` defined or we get this weird behavior.

---

To test this PR, run `npm run client:start -- --dev` once then comment out ```removeSync(`${args.datadir}/devnet`)``` in `bin/cli.ts:578` and run `npm run client:start -- --dev` again.

Before this PR you should see:

```
INFO [12-06|11:55:48] Initializing Ethereumjs client version=v0.2.0 network=devnet
ERROR [12-06|11:55:48] (empty message)
```

With this PR:

```
INFO [12-06|11:59:22] Initializing Ethereumjs client version=v0.2.0 network=devnet
ERROR [12-06|11:59:22] Error: The genesis block in the DB has a different hash than the provided genesis block.
    at Blockchain._init (/ethereumjs-monorepo/packages/blockchain/src/index.ts:358:13)
    at async Blockchain.initAndLock (/ethereumjs-monorepo/packages/blockchain/src/index.ts:439:5)
    at async Blockchain.getLatestHeader (/ethereumjs-monorepo/packages/blockchain/src/index.ts:804:12)
    at async Chain.update (/ethereumjs-monorepo/packages/client/lib/blockchain/chain.ts:222:22)
...
```