### PR TITLE
Pin typescript dependency to 4.4.4 for VM nightly tests

### DIFF
--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -35,6 +35,8 @@ jobs:
       - run: npm i
         working-directory: ${{github.workspace}}
 
+      - run: cat package-lock.json
+
       - run: npm run test:API
       - run: npm run test:API:browser
 

--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -2,6 +2,9 @@ name: VM Nightly
 on:
   schedule:
     - cron: 0 0 * * *
+  push:
+    branches:
+      - vm-nightly-typescript-version
 
 env:
   cwd: ${{github.workspace}}/packages/vm

--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - vm-nightly-typescript-version
-
+      
 env:
   cwd: ${{github.workspace}}/packages/vm
 
@@ -38,8 +38,102 @@ jobs:
       - run: npm i
         working-directory: ${{github.workspace}}
 
+      # The API:browser tests are failing due to this Typescript issue 
+      # https://github.com/monounity/karma-typescript/issues/499
+      # so reverting to Typescript 4.4.4 for browser tests
       - run: npm i typescript@4.4.4
         working-directory: ${{github.workspace}}
-        
+
       - run: npm run test:API
       - run: npm run test:API:browser
+
+  test-vm-state:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: 'npm'
+
+      - name: Use npm v7 for workspaces support
+        run: npm i -g npm@7
+
+      # The job is meant to run with a fresh lock file
+      # to detect any possible issues with new dep versions.
+      - run: rm package-lock.json
+        working-directory: ${{github.workspace}}
+
+      - run: npm i
+        working-directory: ${{github.workspace}}
+
+      # The API:browser tests are failing due to this Typescript issue 
+      # https://github.com/monounity/karma-typescript/issues/499
+      # so reverting to Typescript 4.4.4 for browser tests
+      - run: npm i typescript@4.4.4
+        working-directory: ${{github.workspace}}
+
+      - run: npm run test:state:allForks
+
+  test-vm-blockchain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: 'npm'
+
+      - name: Use npm v7 for workspaces support
+        run: npm i -g npm@7
+
+      # The job is meant to run with a fresh lock file
+      # to detect any possible issues with new dep versions.
+      - run: rm package-lock.json
+        working-directory: ${{github.workspace}}
+
+      - run: npm i
+        working-directory: ${{github.workspace}}
+
+      - run: npm i typescript@4.4.4
+        working-directory: ${{github.workspace}}
+
+      - run: npm run test:blockchain:allForks
+        working-directory: '${{ env.cwd }}'
+
+  test-vm-slow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Use Node.js 12
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12
+          cache: 'npm'
+
+      - name: Use npm v7 for workspaces support
+        run: npm i -g npm@7
+
+      # The job is meant to run with a fresh lock file
+      # to detect any possible issues with new dep versions.
+      - run: rm package-lock.json
+        working-directory: ${{github.workspace}}
+
+      - run: npm i
+        working-directory: ${{github.workspace}}
+
+      - run: npm i typescript@4.4.4
+        working-directory: ${{github.workspace}}
+
+      - run: npm run test:state:slow

--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js 12
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
           cache: 'npm'
 
       - name: Use npm v7 for workspaces support
@@ -53,7 +53,7 @@ jobs:
       - name: Use Node.js 12
         uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 14
           cache: 'npm'
 
       - name: Use npm v7 for workspaces support

--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -38,8 +38,6 @@ jobs:
       - run: npm i
         working-directory: ${{github.workspace}}
 
-      - run: cat package-lock.json
-
       - run: npm run test:API
       - run: npm run test:API:browser
 

--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js 12
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 12
           cache: 'npm'
 
       - name: Use npm v7 for workspaces support
@@ -38,84 +38,8 @@ jobs:
       - run: npm i
         working-directory: ${{github.workspace}}
 
+      - run: npm i typescript@4.4.4
+        working-directory: ${{github.workspace}}
+        
       - run: npm run test:API
       - run: npm run test:API:browser
-
-  test-vm-state:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
-        with:
-          node-version: 14
-          cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
-
-      # The job is meant to run with a fresh lock file
-      # to detect any possible issues with new dep versions.
-      - run: rm package-lock.json
-        working-directory: ${{github.workspace}}
-
-      - run: npm i
-        working-directory: ${{github.workspace}}
-
-      - run: npm run test:state:allForks
-
-  test-vm-blockchain:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12
-          cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
-
-      # The job is meant to run with a fresh lock file
-      # to detect any possible issues with new dep versions.
-      - run: rm package-lock.json
-        working-directory: ${{github.workspace}}
-
-      - run: npm i
-        working-directory: ${{github.workspace}}
-
-      - run: npm run test:blockchain:allForks
-        working-directory: '${{ env.cwd }}'
-
-  test-vm-slow:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
-        with:
-          node-version: 12
-          cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
-
-      # The job is meant to run with a fresh lock file
-      # to detect any possible issues with new dep versions.
-      - run: rm package-lock.json
-        working-directory: ${{github.workspace}}
-
-      - run: npm i
-        working-directory: ${{github.workspace}}
-
-      - run: npm run test:state:slow

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -67,7 +67,7 @@
     "level": "^6.0.0",
     "level-mem": "^5.0.1",
     "libp2p": "^0.30.7",
-    "libp2p-bootstrap": "^0.12.2",
+    "libp2p-bootstrap": "^0.14.0",
     "libp2p-interfaces": "^1.2.0",
     "libp2p-kad-dht": "^0.20.6",
     "libp2p-mplex": "^0.10.2",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -86,7 +86,7 @@
     "tape": "^5.3.1",
     "ts-node": "^10.2.1",
     "typedoc": "^0.22.4",
-    "typescript": "^4.4.2"
+    "typescript": "4.4.4"
   },
   "contributors": [
     "Alex Beregszaszi <alex@rtfs.hu>"


### PR DESCRIPTION
- Bumps `libp2p-bootstrap` to 0.14.0 to resolve missing dependency issue within that dep
- Pins Typescript to v4.4.4 as workaround for [this `karma` issue](https://github.com/monounity/karma-typescript/issues/499) that causes `vm` browser tests on nightly to fail.