### PR TITLE
Add a method wrapper to directly extract the recovery bit value from ecsign.

### DIFF
--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -40,6 +40,8 @@ export default class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMark
 
   public readonly common: Common
 
+  protected useRawSign: boolean = true
+
   /**
    * The default HF if the tx type is active on that HF
    * or the first greater HF where the tx is active.
@@ -419,7 +421,7 @@ export default class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMark
         value: this.value,
         data: this.data,
         accessList: this.accessList,
-        v: new BN(v - 27), // This looks extremely hacky: ethereumjs-util actually adds 27 to the value, the recovery bit is either 0 or 1.
+        v: new BN(v),
         r: new BN(r),
         s: new BN(s),
       },

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -40,6 +40,8 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
 
   public readonly common: Common
 
+  protected useRawSign: boolean = true
+
   /**
    * The default HF if the tx type is active on that HF
    * or the first greater HF where the tx is active.
@@ -391,7 +393,7 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
         value: this.value,
         data: this.data,
         accessList: this.accessList,
-        v: new BN(v - 27), // This looks extremely hacky: ethereumjs-util actually adds 27 to the value, the recovery bit is either 0 or 1.
+        v: new BN(v),
         r: new BN(r),
         s: new BN(s),
       },

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -24,6 +24,8 @@ export default class Transaction extends BaseTransaction<Transaction> {
 
   public readonly common: Common
 
+  protected useRawSign: boolean = false
+
   /**
    * Instantiate a transaction from a data dictionary.
    *

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -44,6 +44,11 @@ export function ecsign(msgHash: Buffer, privateKey: Buffer, chainId: any): any {
   return { r, s, v }
 }
 
+export function ecsignRaw(msgHash: Buffer, privateKey: Buffer): ECDSASignature {
+  const { r, s, v } = ecsign(msgHash, privateKey)
+  return { r, s, v: v - 27 }
+}
+
 function calculateSigRecovery(v: BNLike, chainId?: BNLike): BN {
   const vBN = toType(v, TypeOutput.BN)
   if (!chainId) {

--- a/packages/util/test/signature.spec.ts
+++ b/packages/util/test/signature.spec.ts
@@ -10,6 +10,7 @@ import {
   toRpcSig,
   toCompactSig,
   intToBuffer,
+  ecsignRaw,
 } from '../src'
 
 const echash = Buffer.from(
@@ -36,6 +37,43 @@ tape('ecsign', function (t) {
       )
     )
     st.equal(sig.v, 27)
+    st.end()
+  })
+
+  t.test('should produce a raw signature - v: 0', function (st) {
+    const sig = ecsignRaw(echash, ecprivkey)
+    st.ok(
+      sig.r.equals(
+        Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex')
+      )
+    )
+    st.ok(
+      sig.s.equals(
+        Buffer.from('129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66', 'hex')
+      )
+    )
+    st.equal(sig.v, 0)
+    st.end()
+  })
+
+  t.test('should produce a raw signature - v: 1', function (st) {
+    // Note: the last hex character has changed from 1 to 4 and this is thus a different key than ecprivkey.
+    const newPrivkey = Buffer.from(
+      '3c9229289a6125f7fdf1885a77bb12c37a8d3b4962d936f7e3084dece32a3ca4',
+      'hex'
+    )
+    const sig = ecsignRaw(echash, newPrivkey)
+    st.ok(
+      sig.r.equals(
+        Buffer.from('c865831b789442c8608da6084d8dd27f1eb1a6e1a6812601485f2ed3798b870d', 'hex')
+      )
+    )
+    st.ok(
+      sig.s.equals(
+        Buffer.from('7467bb32885a9f1ca89fcb95cf7e26fb6aea74da9291034c56e49bfefa0175f9', 'hex')
+      )
+    )
+    st.equal(sig.v, 1)
     st.end()
   })
 


### PR DESCRIPTION
Closes #1597

In `ecsign` we manually add 27 to the recovery bit. `ecsignRaw` returns the recovery bit and not this semi-artificially created "recovery bit" where we add 27 to the bit.

This also neatly cleanups some of the 'hacky' comments in EIP2930/EIP1559 txs and adds a neat flag to base transaction. (Really cool feature these `protected abstract` boolean flags :smile: )