### PR TITLE
Finish EIP-2681

### DIFF
--- a/packages/vm/src/evm/eei.ts
+++ b/packages/vm/src/evm/eei.ts
@@ -589,6 +589,7 @@ export default class EEI {
       return new BN(0)
     }
 
+    // EIP-2681 check
     if (this._env.contract.nonce.eq(MAX_UINT64)) {
       return new BN(0)
     }

--- a/packages/vm/src/evm/eei.ts
+++ b/packages/vm/src/evm/eei.ts
@@ -1,5 +1,5 @@
 import { debug as createDebugLogger } from 'debug'
-import { Account, Address, BN } from 'ethereumjs-util'
+import { Account, Address, BN, MAX_UINT64 } from 'ethereumjs-util'
 import { Block } from '@ethereumjs/block'
 import Blockchain from '@ethereumjs/blockchain'
 import Common, { ConsensusAlgorithm } from '@ethereumjs/common'
@@ -589,6 +589,9 @@ export default class EEI {
       return new BN(0)
     }
 
+    if (this._env.contract.nonce.eq(MAX_UINT64)) {
+      return new BN(0)
+    }
     this._env.contract.nonce.iaddn(1)
     await this._state.putAccount(this._env.address, this._env.contract)
 

--- a/packages/vm/src/evm/eei.ts
+++ b/packages/vm/src/evm/eei.ts
@@ -590,7 +590,7 @@ export default class EEI {
     }
 
     // EIP-2681 check
-    if (this._env.contract.nonce.eq(MAX_UINT64)) {
+    if (this._env.contract.nonce.gte(MAX_UINT64)) {
       return new BN(0)
     }
     this._env.contract.nonce.iaddn(1)

--- a/packages/vm/tests/api/runCall.spec.ts
+++ b/packages/vm/tests/api/runCall.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import { Address, BN, keccak256, padToEven } from 'ethereumjs-util'
+import { Address, BN, keccak256, MAX_UINT64, padToEven } from 'ethereumjs-util'
 import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../src'
 
@@ -220,6 +220,59 @@ tape('Ensure that Istanbul sstoreCleanRefundEIP2200 gas is applied correctly', a
   console.log(result.gasUsed, result.execResult.gasRefund)
   t.equal(result.gasUsed.toNumber(), 5812, 'gas used incorrect')
   t.equal(result.execResult.gasRefund!.toNumber(), 4200, 'gas refund incorrect')
+
+  t.end()
+})
+
+tape('Ensure that Istanbul sstoreCleanRefundEIP2200 gas is applied correctly', async (t) => {
+  // setup the accounts for this test
+  const caller = new Address(Buffer.from('00000000000000000000000000000000000000ee', 'hex')) // caller addres
+  const address = new Address(Buffer.from('00000000000000000000000000000000000000ff', 'hex'))
+  const slot = Buffer.from('00'.repeat(32), 'hex')
+  const emptyBuffer = Buffer.from('')
+  // setup the vm
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
+  const vm = new VM({ common: common })
+  const code = '60008080F060005500'
+  /*
+      This simple code tries to create an empty contract and then stores the address of the contract in the zero slot.
+        CODE:
+          PUSH 0 
+          DUP1
+          DUP1
+          CREATE -> Stack is now [0,0,0] ([value, offset, length])
+          PUSH 0
+          SSTORE -> stack is now [0, <Created Address>], so this stores the <Created Address> at slot 0
+          STOP
+    */
+
+  await vm.stateManager.putContractCode(address, Buffer.from(code, 'hex'))
+
+  const account = await vm.stateManager.getAccount(address)
+  account.nonce = MAX_UINT64.subn(1)
+  await vm.stateManager.putAccount(address, account)
+
+  // setup the call arguments
+  const runCallArgs = {
+    caller: caller, // call address
+    to: address,
+    gasLimit: new BN(0xffffffffff), // ensure we pass a lot of gas, so we do not run out of gas
+  }
+
+  await vm.runCall(runCallArgs)
+  let storage = await vm.stateManager.getContractStorage(address, slot)
+
+  // The nonce is MAX_UINT64 - 1, so we are allowed to create a contract (nonce of creating contract is now MAX_UINT64)
+  t.ok(!storage.equals(emptyBuffer), 'succesfully created contract')
+
+  await vm.runCall(runCallArgs)
+
+  // The nonce is MAX_UINT64, so we are NOT allowed to create a contract (nonce of creating contract is now MAX_UINT64)
+  storage = await vm.stateManager.getContractStorage(address, slot)
+  t.ok(
+    storage.equals(emptyBuffer),
+    'failed to create contract; nonce of creating contract is too high (MAX_UINT64)'
+  )
 
   t.end()
 })

--- a/packages/vm/tests/api/runCall.spec.ts
+++ b/packages/vm/tests/api/runCall.spec.ts
@@ -224,7 +224,7 @@ tape('Ensure that Istanbul sstoreCleanRefundEIP2200 gas is applied correctly', a
   t.end()
 })
 
-tape('Ensure that Istanbul sstoreCleanRefundEIP2200 gas is applied correctly', async (t) => {
+tape('Ensure that contracts cannot exceed nonce of MAX_UINT64 when creating new contracts (EIP-2681)', async (t) => {
   // setup the accounts for this test
   const caller = new Address(Buffer.from('00000000000000000000000000000000000000ee', 'hex')) // caller addres
   const address = new Address(Buffer.from('00000000000000000000000000000000000000ff', 'hex'))


### PR DESCRIPTION
This PR closes #1591. 

Note: currently, `ethereum-tests` has not yet released the tests relevant to this, so I ran these locally. 

```
cd ./packages/ethereum-tests/ && git branch && git log -n 4 && cd -
  develop
* refund-tests
commit 658605b000855cec2ea546c4fdf07c442d9ee1d7 (HEAD -> refund-tests, origin/refund-tests)
Author: marioevz <marioevz@gmail.com>
Date:   Fri Dec 10 20:11:32 2021 +0000

    Add Log + Contract Creation OoG

commit 96c5815807804879008b15ccedbf298aa8359f3b
Author: marioevz <marioevz@gmail.com>
Date:   Fri Dec 10 18:38:47 2021 +0000

    Add proper check for self destruct refund on contract creation

commit 18e7f5535246272ee7ed7ff440162acbeeaedc7e
Author: marioevz <marioevz@gmail.com>
Date:   Fri Dec 10 18:25:33 2021 +0000

    Add tests for refund checks on OoG contract creation

commit a47ad2db7bce4abfd95e91516524c607f9854ba2 (origin/develop, origin/HEAD)
Author: marioevz <marioevz@gmail.com>
Date:   Tue Dec 7 21:42:51 2021 +0000

    Create and OOG with max codesize contracts test
```

Run London tests `npm run test:blockchain -- --fork=London` without this PR: (all pass except...)

```
Errors thrown in file: GeneralStateTests/stCreate2/CREATE2_HighNonce.json test: CREATE2_HighNonce_d0g0v0_London:
	Error: invalid receiptTrie (vm hf=london -> block number=1 hash=0xcd8db986b35a4d23e99de3bacf7e6aa979c960366164c949de32a933331e4e12 hf=london baseFeePerGas=10 txs=1 uncles=0)
	correct last header block
Errors thrown in file: GeneralStateTests/stCreate2/CREATE2_HighNonceDelegatecall.json test: CREATE2_HighNonceDelegatecall_d11g0v0_London:
	Error: invalid receiptTrie (vm hf=london -> block number=1 hash=0x06e04a7200fdeda55b440cbfb163ac75d9a95aad4eb6a329da01f702e8fac240 hf=london baseFeePerGas=10 txs=1 uncles=0)
	correct last header block
Errors thrown in file: GeneralStateTests/stCreate2/CREATE2_HighNonceDelegatecall.json test: CREATE2_HighNonceDelegatecall_d17g0v0_London:
	Error: invalid receiptTrie (vm hf=london -> block number=1 hash=0xef1a73782b7d5cfb692d6c207bcfdbdc79e8e2c11a9fe0f1c9e8e6465d4c44bd hf=london baseFeePerGas=10 txs=1 uncles=0)
	correct last header block
Errors thrown in file: GeneralStateTests/stCreate2/CREATE2_HighNonceDelegatecall.json test: CREATE2_HighNonceDelegatecall_d18g0v0_London:
	Error: invalid receiptTrie (vm hf=london -> block number=1 hash=0x0f7448e95a8f38caf4e658472c7af765f882299488b95ac5bdabb2f2561065e2 hf=london baseFeePerGas=10 txs=1 uncles=0)
	correct last header block
Errors thrown in file: GeneralStateTests/stCreate2/CREATE2_HighNonceDelegatecall.json test: CREATE2_HighNonceDelegatecall_d19g0v0_London:
	Error: invalid receiptTrie (vm hf=london -> block number=1 hash=0x9dec2ac6087df295b97f33ab8e852eb46a8fb6d7ee8fe9323b54a3132113f464 hf=london baseFeePerGas=10 txs=1 uncles=0)
	correct last header block
Errors thrown in file: GeneralStateTests/stCreate2/CREATE2_HighNonceDelegatecall.json test: CREATE2_HighNonceDelegatecall_d20g0v0_London:
	Error: invalid receiptTrie (vm hf=london -> block number=1 hash=0xbef39b20b94b3f718fa418255d0ae12814cc0986873564187cab5a9e94331f0a hf=london baseFeePerGas=10 txs=1 uncles=0)
	correct last header block
Errors thrown in file: GeneralStateTests/stCreate2/CREATE2_HighNonceDelegatecall.json test: CREATE2_HighNonceDelegatecall_d21g0v0_London:
	Error: invalid receiptTrie (vm hf=london -> block number=1 hash=0xd8ac7c343e6c75c3373159baa80243120778fd57d7eca6817c54d0a09364d66d hf=london baseFeePerGas=10 txs=1 uncles=0)
	correct last header block
Errors thrown in file: GeneralStateTests/stCreate2/CREATE2_HighNonceDelegatecall.json test: CREATE2_HighNonceDelegatecall_d23g0v0_London:
	Error: invalid receiptTrie (vm hf=london -> block number=1 hash=0x0643248c3d38f6267a2d11772b94b428e6c31289e7a1e4b51648fcf51edeaf7a hf=london baseFeePerGas=10 txs=1 uncles=0)
	correct last header block
Errors thrown in file: GeneralStateTests/stCreate2/CREATE2_HighNonceDelegatecall.json test: CREATE2_HighNonceDelegatecall_d5g0v0_London:
	Error: invalid receiptTrie (vm hf=london -> block number=1 hash=0xa9523df4c863b18cff9c3bf408cec0019c8425e02d8f0f91c1e19353cd7d563e hf=london baseFeePerGas=10 txs=1 uncles=0)
	correct last header block
Errors thrown in file: GeneralStateTests/stCreate2/CREATE2_HighNonceDelegatecall.json test: CREATE2_HighNonceDelegatecall_d6g0v0_London:
	Error: invalid receiptTrie (vm hf=london -> block number=1 hash=0xdae15572e9f0cd6a21d30c05b8f4f8ea38a24db148418778eebecb79b00eba47 hf=london baseFeePerGas=10 txs=1 uncles=0)
	correct last header block
Errors thrown in file: GeneralStateTests/stCreate2/CREATE2_HighNonceDelegatecall.json test: CREATE2_HighNonceDelegatecall_d7g0v0_London:
	Error: invalid receiptTrie (vm hf=london -> block number=1 hash=0x0e345e166d8e52d4d3929b833e2e2f4ec3b093d63c231d265c4a35f8114e1904 hf=london baseFeePerGas=10 txs=1 uncles=0)
	correct last header block
Errors thrown in file: GeneralStateTests/stCreate2/CREATE2_HighNonceDelegatecall.json test: CREATE2_HighNonceDelegatecall_d8g0v0_London:
	Error: invalid receiptTrie (vm hf=london -> block number=1 hash=0x1b6af512e4e0ffabfacf4ee8028f9b5e9d4e64e43f4a93cb9c924f13dc97c54a hf=london baseFeePerGas=10 txs=1 uncles=0)
	correct last header block
Errors thrown in file: GeneralStateTests/stCreate2/CREATE2_HighNonceDelegatecall.json test: CREATE2_HighNonceDelegatecall_d9g0v0_London:
	Error: invalid receiptTrie (vm hf=london -> block number=1 hash=0x319beb7eafd7d0691124620887f67e775f5b776b00ce26c700a9868826f6b11d hf=london baseFeePerGas=10 txs=1 uncles=0)
	correct last header block
Errors thrown in file: GeneralStateTests/stCreateTest/CREATE_HighNonce.json test: CREATE_HighNonce_d0g0v0_London:
	Error: invalid receiptTrie (vm hf=london -> block number=1 hash=0x8bfc20ec0f50588a24f3a016b00418cb387f61211b34a620dde782a1b000d6a9 hf=london baseFeePerGas=10 txs=1 uncles=0)
	correct last header block
```

After this PR re-run the tests but now only the failing directories;

`npm run test:blockchain -- --fork=London --dir=GeneralStateTests/stCreate2`

`npm run test:blockchain -- --fork=London --dir=GeneralStateTests/stCreateTest`

All pass.

CI should pass here as well, please note that thus these `ethereum-tests` are thus not included, to check locally;

```
cd ./packages/ethereum-tests
git fetch
git checkout refund-tests
```

Now run the blockchain test.