### PR TITLE
eslint: disable no-extra-semi, remove overrides

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -41,6 +41,7 @@ module.exports = {
     ],
     '@typescript-eslint/no-unnecessary-condition': 'off',
     'no-dupe-class-members': 'off',
+    'no-extra-semi': 'off',
     'prettier/prettier': 'error',
     'no-redeclare': 'off',
     '@typescript-eslint/no-redeclare': ['error'],

--- a/packages/block/test/eip1559block.spec.ts
+++ b/packages/block/test/eip1559block.spec.ts
@@ -89,7 +89,6 @@ tape('EIP1559 tests', function (t) {
     }
 
     try {
-      // eslint-disable-next-line no-extra-semi
       ;(header as any).baseFeePerGas = undefined
       await header.validate(blockchain1)
     } catch (e: any) {
@@ -100,7 +99,6 @@ tape('EIP1559 tests', function (t) {
       )
     }
 
-    // eslint-disable-next-line no-extra-semi
     ;(header as any).baseFeePerGas = new BN(7) // reset for next test
     const block = Block.fromBlockData({ header }, { common })
     try {

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -479,7 +479,6 @@ async function inputAccounts() {
     readline.clearLine((rl as any).output, 1)
     // replace the original input with asterisks:
     for (let i = 0; i < len; i++) {
-      // eslint-disable-next-line no-extra-semi
       ;(rl as any).output.write('*')
     }
   })

--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -257,10 +257,8 @@ export class EthProtocol extends Protocol {
           const [stateRootOrStatus, cumulativeGasUsed, logsBloom, logs] = decoded
           const receipt = { gasUsed: cumulativeGasUsed, bitvector: logsBloom, logs } as TxReceipt
           if (stateRootOrStatus.length === 32) {
-            // eslint-disable-next-line no-extra-semi
             ;(receipt as PreByzantiumTxReceipt).stateRoot = stateRootOrStatus
           } else {
-            // eslint-disable-next-line no-extra-semi
             ;(receipt as PostByzantiumTxReceipt).status = bufferToInt(stateRootOrStatus) as 0 | 1
           }
           return receipt

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -572,7 +572,6 @@ export default class Common extends EventEmitter {
         )
       }
       if (EIPs[eip].requiredEIPs) {
-        // eslint-disable-next-line no-extra-semi
         ;(EIPs[eip].requiredEIPs as number[]).forEach((elem) => {
           if (!(eips.includes(elem) || this.isActivatedEIP(elem))) {
             throw new Error(`${eip} requires EIP ${elem}, but is not included in the EIP list`)

--- a/packages/tx/test/base.spec.ts
+++ b/packages/tx/test/base.spec.ts
@@ -387,7 +387,6 @@ tape('[BaseTransaction]', function (t) {
   t.test('_validateCannotExceedMaxInteger()', function (st) {
     const tx = FeeMarketEIP1559Transaction.fromTxData(eip1559Txs[0])
     try {
-      // eslint-disable-next-line no-extra-semi
       ;(tx as any)._validateCannotExceedMaxInteger({ a: MAX_INTEGER }, 256, true)
     } catch (err: any) {
       st.ok(
@@ -396,13 +395,11 @@ tape('[BaseTransaction]', function (t) {
       )
     }
     try {
-      // eslint-disable-next-line no-extra-semi
       ;(tx as any)._validateCannotExceedMaxInteger({ a: MAX_INTEGER.addn(1) }, 256, false)
     } catch (err: any) {
       st.ok(err.message.includes('exceed MAX_INTEGER'), 'throws when value exceeds MAX_INTEGER')
     }
     try {
-      // eslint-disable-next-line no-extra-semi
       ;(tx as any)._validateCannotExceedMaxInteger({ a: new BN(0) }, 100, false)
     } catch (err: any) {
       st.ok(
@@ -411,13 +408,11 @@ tape('[BaseTransaction]', function (t) {
       )
     }
     try {
-      // eslint-disable-next-line no-extra-semi
       ;(tx as any)._validateCannotExceedMaxInteger({ a: MAX_UINT64.addn(1) }, 64, false)
     } catch (err: any) {
       st.ok(err.message.includes('2^64'), 'throws when 64 bit integer exceeds MAX_UINT64')
     }
     try {
-      // eslint-disable-next-line no-extra-semi
       ;(tx as any)._validateCannotExceedMaxInteger({ a: MAX_UINT64 }, 64, true)
     } catch (err: any) {
       st.ok(err.message.includes('2^64'), 'throws when 64 bit integer equals or exceeds MAX_UINT64')


### PR DESCRIPTION
This PR disables eslint's `no-extra-semi` rule since it gets in the way when a semicolon is needed, like when the line starts with an opening parenthesis. I found that prettier rules already exhaustively cover semi formatting.