### PR TITLE
vm/tests: add support for test networks with activated EIPs

### DIFF
--- a/packages/vm/tests/tester/config.ts
+++ b/packages/vm/tests/tester/config.ts
@@ -258,7 +258,12 @@ export function getTestDirs(network: string, testType: string) {
  * @param {String} network - the network field of a test
  * @returns {Common} the Common which should be used
  */
-export function getCommon(network: string) {
+export function getCommon(targetNetwork: string) {
+  let network = targetNetwork
+  if (network.includes('+')) {
+    const index = network.indexOf('+')
+    network = network.slice(0, index)
+  }
   const networkLowercase = network.toLowerCase()
   if (normalHardforks.map((str) => str.toLowerCase()).includes(networkLowercase)) {
     // normal hard fork, return the common with this hard fork
@@ -289,13 +294,20 @@ export function getCommon(network: string) {
         })
       }
     }
-    return Common.forCustomChain(
+    console.log(network)
+    console.log(hfName)
+    const common = Common.forCustomChain(
       'mainnet',
       {
         hardforks: testHardforks,
       },
       hfName
     )
+    const eips = targetNetwork.match(/(?<=\+)(.\d+)/g)
+    if (eips) {
+      common.setEIPs(eips.map((e: string) => parseInt(e)))
+    }
+    return common
   } else {
     // this is not a "default fork" network, but it is a "transition" network. we will test the VM if it transitions the right way
     const transitionForks =

--- a/packages/vm/tests/tester/index.ts
+++ b/packages/vm/tests/tester/index.ts
@@ -91,6 +91,27 @@ async function runTests() {
   runnerArgs.value = argv.value // GeneralStateTests
   runnerArgs.debug = argv.debug // BlockchainTests
 
+  /**
+   * Edit the forkConfig string to ensure it works with RegEx (escape + characters)
+   */
+
+  if (testGetterArgs.forkConfig.includes('+')) {
+    let str = testGetterArgs.forkConfig
+    const indicies = []
+    for (let i = 0; i < str.length; i++) {
+      if (str[i] == '+') {
+        indicies.push(i)
+      }
+    }
+    // traverse array in reverse order to ensure indicies match when we replace the '+' with '/+'
+    for (let i = indicies.length - 1; i >= 0; i--) {
+      str = `${str.substr(0, indicies[i])}\\${str.substr(indicies[i])}`
+    }
+    testGetterArgs.forkConfig = str
+  }
+
+  console.log(testGetterArgs.forkConfig)
+
   let expectedTests: number | undefined
   if (argv['verify-test-amount-alltests']) {
     expectedTests = getExpectedTests(FORK_CONFIG_VM, name)


### PR DESCRIPTION
This PR adds support for `ethereum/tests` forks where there are added EIPs; these are usually experimental and it is not clear if they will ever be in an actual fork, but they have tests anyways.

To test;

```cd packages/ethereum-tests
git checkout push0
npm run test:blockchain -- --fork=London+3855
```

Results in 12 passing tests, so looks like we pass the (draft) tests for EIP3855 as well :smile: 