### PR TITLE
Add fallback for node constants

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -87,6 +87,7 @@
     "@types/levelup": "^4.3.0",
     "@types/node": "^11.13.4",
     "@types/tape": "^4.13.2",
+    "constants-browserify": "^1.0.0",
     "crypto-browserify": "^3.12.0",
     "eslint": "^6.8.0",
     "file-replace-loader": "^1.2.0",

--- a/packages/client/webpack.config.js
+++ b/packages/client/webpack.config.js
@@ -46,6 +46,7 @@ module.exports = {
   resolve: {
     fallback: {
       buffer: require.resolve('buffer'),
+      constants: require.resolve("constants-browserify"),
       crypto: require.resolve('crypto-browserify'), // used by: rlpxpeer, bin/cli.ts
       dgram: false, // used by: rlpxpeer via @ethereumjs/devp2p
       fs: false, // used by: FullSynchronizer via @ethereumjs/vm


### PR DESCRIPTION
Fix broken dependency in webpack where node's `constants` package isn't being polyfilled by webpack 5.