### PR TITLE
ci: upgrade node to v16

### DIFF
--- a/.github/workflows/block-build.yml
+++ b/.github/workflows/block-build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12]
+        node-version: [16]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -30,9 +30,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
-
       - run: npm i
         working-directory: ${{github.workspace}}
 
@@ -42,6 +39,6 @@ jobs:
         with:
           file: ${{ env.cwd }}/coverage/lcov.info
           flags: block
-        if: ${{ matrix.node-version == 12 }}
+        if: ${{ matrix.node-version == 16 }}
 
       - run: npm run lint

--- a/.github/workflows/blockchain-build.yml
+++ b/.github/workflows/blockchain-build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12]
+        node-version: [16]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -30,9 +30,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
-
       - run: npm i
         working-directory: ${{github.workspace}}
 
@@ -42,6 +39,6 @@ jobs:
         with:
           file: ${{ env.cwd }}/coverage/lcov.info
           flags: blockchain
-        if: ${{ matrix.node-version == 12 }}
+        if: ${{ matrix.node-version == 16 }}
 
       - run: npm run lint

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12]
+        node-version: [16]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -30,9 +30,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
-
       - run: npm i
         working-directory: ${{github.workspace}}
 
@@ -42,7 +39,7 @@ jobs:
         with:
           file: ${{ env.cwd }}/coverage/lcov.info
           flags: client
-        if: ${{ matrix.node-version == 12 }}
+        if: ${{ matrix.node-version == 16 }}
 
       - run: npm run lint
   test-client-cli:
@@ -57,14 +54,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       - run: npm i
         working-directory: ${{github.workspace}}

--- a/.github/workflows/common-build.yml
+++ b/.github/workflows/common-build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12]
+        node-version: [16]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -30,9 +30,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
-
       - run: npm i
         working-directory: ${{github.workspace}}
 
@@ -42,6 +39,6 @@ jobs:
         with:
           file: ${{ env.cwd }}/coverage/lcov.info
           flags: common
-        if: ${{ matrix.node-version == 12 }}
+        if: ${{ matrix.node-version == 16 }}
 
       - run: npm run lint

--- a/.github/workflows/devp2p-build.yml
+++ b/.github/workflows/devp2p-build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12]
+        node-version: [16]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -30,9 +30,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
-
       - run: npm i
         working-directory: ${{github.workspace}}
 
@@ -42,6 +39,6 @@ jobs:
         with:
           file: ${{ env.cwd }}/coverage/lcov.info
           flags: devp2p
-        if: ${{ matrix.node-version == 12 }}
+        if: ${{ matrix.node-version == 16 }}
 
       - run: npm run lint

--- a/.github/workflows/e2e-hardhat.yml
+++ b/.github/workflows/e2e-hardhat.yml
@@ -26,9 +26,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
-
       - run: npm i
         working-directory: ${{github.workspace}}
 

--- a/.github/workflows/ethash-build.yml
+++ b/.github/workflows/ethash-build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12]
+        node-version: [16]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -30,9 +30,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
-
       - run: npm i
         working-directory: ${{github.workspace}}
 
@@ -42,6 +39,6 @@ jobs:
         with:
           file: ${{ env.cwd }}/coverage/lcov.info
           flags: ethash
-        if: ${{ matrix.node-version == 12 }}
+        if: ${{ matrix.node-version == 16 }}
 
       - run: npm run lint

--- a/.github/workflows/node-versions.yml
+++ b/.github/workflows/node-versions.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
 
       - id: set-matrix
         run: echo "::set-output name=matrix::$(npx testable-node-versions)"
@@ -39,9 +39,6 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       - run: npm i
 

--- a/.github/workflows/trie-build.yml
+++ b/.github/workflows/trie-build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12]
+        node-version: [16]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -30,9 +30,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
-
       - run: npm i
         working-directory: ${{github.workspace}}
 
@@ -42,7 +39,7 @@ jobs:
         with:
           file: ${{ env.cwd }}/coverage/lcov.info
           flags: trie
-        if: ${{ matrix.node-version == 12 }}
+        if: ${{ matrix.node-version == 16 }}
 
       - run: npm run lint
 
@@ -53,14 +50,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       - run: npm i
         working-directory: ${{github.workspace}}

--- a/.github/workflows/tx-build.yml
+++ b/.github/workflows/tx-build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12]
+        node-version: [16]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -30,9 +30,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
-
       - run: npm i
         working-directory: ${{github.workspace}}
 
@@ -42,6 +39,6 @@ jobs:
         with:
           file: ${{ env.cwd }}/coverage/lcov.info
           flags: tx
-        if: ${{ matrix.node-version == 12 }}
+        if: ${{ matrix.node-version == 16 }}
 
       - run: npm run lint

--- a/.github/workflows/util-build.yml
+++ b/.github/workflows/util-build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12]
+        node-version: [16]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -30,9 +30,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
-
       - run: npm i
         working-directory: ${{github.workspace}}
 
@@ -42,6 +39,6 @@ jobs:
         with:
           file: ${{ env.cwd }}/coverage/lcov.info
           flags: util
-        if: ${{ matrix.node-version == 12 }}
+        if: ${{ matrix.node-version == 16 }}
 
       - run: npm run lint

--- a/.github/workflows/vm-build.yml
+++ b/.github/workflows/vm-build.yml
@@ -19,14 +19,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       - run: npm i
         working-directory: ${{github.workspace}}
@@ -47,14 +43,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       - run: npm i
         working-directory: ${{github.workspace}}
@@ -68,14 +60,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       - run: npm i
         working-directory: ${{github.workspace}}
@@ -89,14 +77,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       - run: npm i
         working-directory: ${{github.workspace}}

--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -18,14 +18,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       # The job is meant to run with a fresh lock file
       # to detect any possible issues with new dep versions.
@@ -45,14 +41,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       # The job is meant to run with a fresh lock file
       # to detect any possible issues with new dep versions.
@@ -71,14 +63,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       # The job is meant to run with a fresh lock file
       # to detect any possible issues with new dep versions.
@@ -98,14 +86,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       # The job is meant to run with a fresh lock file
       # to detect any possible issues with new dep versions.

--- a/.github/workflows/vm-pr.yml
+++ b/.github/workflows/vm-pr.yml
@@ -18,14 +18,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       - run: npm i
         working-directory: ${{github.workspace}}
@@ -50,14 +46,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       - run: npm i
         working-directory: ${{github.workspace}}
@@ -89,14 +81,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       - run: npm i
         working-directory: ${{github.workspace}}
@@ -126,14 +114,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       - run: npm i
         working-directory: ${{github.workspace}}
@@ -165,14 +149,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       - run: npm i
         working-directory: ${{github.workspace}}
@@ -186,14 +166,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Use Node.js 12
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 12
+          node-version: 16
           cache: 'npm'
-
-      - name: Use npm v7 for workspaces support
-        run: npm i -g npm@7
 
       - run: npm i
         working-directory: ${{github.workspace}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM node:14-alpine as build
+FROM node:16-alpine as build
 WORKDIR /usr/app
-RUN apk update && apk add --no-cache g++ make python bash git && rm -rf /var/cache/apk/*
+RUN apk update && apk add --no-cache bash git && rm -rf /var/cache/apk/*
 
 ARG VERSION=latest
 ENV VERSION=$VERSION

--- a/package-lock.json
+++ b/package-lock.json
@@ -1119,9 +1119,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "11.15.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.54.tgz",
-      "integrity": "sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g=="
+      "version": "16.11.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.19.tgz",
+      "integrity": "sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng=="
     },
     "node_modules/@types/node-dir": {
       "version": "0.0.34",
@@ -13612,11 +13612,6 @@
         "pbts": "bin/pbts"
       }
     },
-    "node_modules/protobufjs/node_modules/@types/node": {
-      "version": "16.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
-      "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w=="
-    },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
@@ -18006,7 +18001,7 @@
       },
       "devDependencies": {
         "@types/lru-cache": "^5.1.0",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
         "eslint": "^6.8.0",
         "karma": "^6.3.2",
@@ -18039,7 +18034,7 @@
       "devDependencies": {
         "@types/async": "^2.4.1",
         "@types/lru-cache": "^5.1.0",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
         "eslint": "^6.8.0",
         "karma": "^6.3.2",
@@ -18113,8 +18108,9 @@
         "@babel/plugin-transform-spread": "^7.10.1",
         "@types/fs-extra": "^8.1.0",
         "@types/levelup": "^4.3.0",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
+        "constants-browserify": "^1.0.0",
         "crypto-browserify": "^3.12.0",
         "eslint": "^6.8.0",
         "file-replace-loader": "^1.2.0",
@@ -18129,6 +18125,7 @@
         "os-browserify": "^0.3.0",
         "pino": "^5.8.0",
         "pino-pretty": "^2.2.2",
+        "process": "^0.11.10",
         "pull-pair": "^1.1.0",
         "stream-browserify": "^3.0.0",
         "supertest": "^6.1.3",
@@ -18167,7 +18164,7 @@
         "ethereumjs-util": "^7.1.3"
       },
       "devDependencies": {
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
         "eslint": "^6.8.0",
         "karma": "^6.3.2",
@@ -18217,7 +18214,7 @@
         "@types/ip": "^1.1.0",
         "@types/keccak": "^3.0.1",
         "@types/ms": "^0.7.30",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/secp256k1": "^4.0.1",
         "@types/tape": "^4.13.2",
         "async": "^2.6.0",
@@ -18356,7 +18353,7 @@
       },
       "devDependencies": {
         "@types/benchmark": "^1.0.33",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
         "0x": "^4.9.1",
         "benchmark": "^2.1.4",
@@ -18397,7 +18394,7 @@
       },
       "devDependencies": {
         "@types/minimist": "^1.2.0",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
         "eslint": "^6.8.0",
         "karma": "^6.3.2",
@@ -18428,7 +18425,7 @@
       },
       "devDependencies": {
         "@types/assert": "^1.5.4",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/secp256k1": "^4.0.1",
         "@types/tape": "^4.13.2",
         "eslint": "^6.8.0",
@@ -18533,7 +18530,7 @@
         "@types/core-js": "^2.5.0",
         "@types/lru-cache": "^5.1.0",
         "@types/minimist": "^1.2.2",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/node-dir": "^0.0.34",
         "@types/tape": "^4.13.2",
         "benchmark": "^2.1.4",
@@ -18978,7 +18975,7 @@
         "@ethereumjs/common": "^2.6.0",
         "@ethereumjs/tx": "^3.4.0",
         "@types/lru-cache": "^5.1.0",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
         "eslint": "^6.8.0",
         "ethereumjs-util": "^7.1.3",
@@ -19004,7 +19001,7 @@
         "@ethereumjs/ethash": "^1.1.0",
         "@types/async": "^2.4.1",
         "@types/lru-cache": "^5.1.0",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
         "debug": "^2.2.0",
         "eslint": "^6.8.0",
@@ -19054,9 +19051,10 @@
         "@ethereumjs/vm": "^5.6.0",
         "@types/fs-extra": "^8.1.0",
         "@types/levelup": "^4.3.0",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
         "chalk": "^4.1.2",
+        "constants-browserify": "^1.0.0",
         "crypto-browserify": "^3.12.0",
         "debug": "^2.2.0",
         "eslint": "^6.8.0",
@@ -19089,6 +19087,7 @@
         "peer-id": "^0.14.3",
         "pino": "^5.8.0",
         "pino-pretty": "^2.2.2",
+        "process": "^0.11.10",
         "pull-pair": "^1.1.0",
         "qheap": "^1.4.0",
         "stream-browserify": "^3.0.0",
@@ -19124,7 +19123,7 @@
     "@ethereumjs/common": {
       "version": "file:packages/common",
       "requires": {
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
         "crc-32": "^1.2.0",
         "eslint": "^6.8.0",
@@ -19157,7 +19156,7 @@
         "@types/keccak": "^3.0.1",
         "@types/lru-cache": "^5.1.0",
         "@types/ms": "^0.7.30",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/secp256k1": "^4.0.1",
         "@types/tape": "^4.13.2",
         "async": "^2.6.0",
@@ -19289,7 +19288,7 @@
       "requires": {
         "@ethereumjs/common": "^2.6.0",
         "@types/minimist": "^1.2.0",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
         "eslint": "^6.8.0",
         "ethereumjs-util": "^7.1.3",
@@ -19319,7 +19318,7 @@
         "@types/core-js": "^2.5.0",
         "@types/lru-cache": "^5.1.0",
         "@types/minimist": "^1.2.2",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/node-dir": "^0.0.34",
         "@types/tape": "^4.13.2",
         "async-eventemitter": "^0.2.4",
@@ -19892,9 +19891,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "11.15.54",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.54.tgz",
-      "integrity": "sha512-1RWYiq+5UfozGsU6MwJyFX6BtktcT10XRjvcAQmskCtMcW3tPske88lM/nHv7BQG1w9KBXI1zPGuu5PnNCX14g=="
+      "version": "16.11.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.19.tgz",
+      "integrity": "sha512-BPAcfDPoHlRQNKktbsbnpACGdypPFBuX4xQlsWDE7B8XXcfII+SpOLay3/qZmCLb39kV5S1RTYwXdkx2lwLYng=="
     },
     "@types/node-dir": {
       "version": "0.0.34",
@@ -23636,7 +23635,7 @@
       "requires": {
         "@types/assert": "^1.5.4",
         "@types/bn.js": "^5.1.0",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/secp256k1": "^4.0.1",
         "@types/tape": "^4.13.2",
         "bn.js": "^5.1.2",
@@ -28191,7 +28190,7 @@
       "requires": {
         "@types/benchmark": "^1.0.33",
         "@types/levelup": "^4.3.0",
-        "@types/node": "^11.13.4",
+        "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
         "0x": "^4.9.1",
         "benchmark": "^2.1.4",
@@ -30094,13 +30093,6 @@
         "@types/long": "^4.0.1",
         "@types/node": ">=13.7.0",
         "long": "^4.0.0"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "16.11.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.6.tgz",
-          "integrity": "sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w=="
-        }
       }
     },
     "protocol-buffers-schema": {

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "@types/lru-cache": "^5.1.0",
-    "@types/node": "^11.13.4",
+    "@types/node": "^16.11.7",
     "@types/tape": "^4.13.2",
     "eslint": "^6.8.0",
     "karma": "^6.3.2",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@types/async": "^2.4.1",
     "@types/lru-cache": "^5.1.0",
-    "@types/node": "^11.13.4",
+    "@types/node": "^16.11.7",
     "@types/tape": "^4.13.2",
     "eslint": "^6.8.0",
     "karma": "^6.3.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -85,7 +85,7 @@
     "@babel/plugin-transform-spread": "^7.10.1",
     "@types/fs-extra": "^8.1.0",
     "@types/levelup": "^4.3.0",
-    "@types/node": "^11.13.4",
+    "@types/node": "^16.11.7",
     "@types/tape": "^4.13.2",
     "constants-browserify": "^1.0.0",
     "crypto-browserify": "^3.12.0",

--- a/packages/client/test/cli/cli-rpc.spec.ts
+++ b/packages/client/test/cli/cli-rpc.spec.ts
@@ -48,7 +48,7 @@ tape('[CLI] rpc', (t) => {
     })
 
     child.on('close', (code) => {
-      if (code > 0) {
+      if (code && code > 0) {
         st.fail(`child process exited with code ${code}`)
         end(child, hasEnded, st)
       }
@@ -82,7 +82,7 @@ tape('[CLI] rpc', (t) => {
     })
 
     child.on('close', (code) => {
-      if (code > 0) {
+      if (code && code > 0) {
         st.fail(`child process exited with code ${code}`)
         end(child, hasEnded, st)
       }

--- a/packages/client/test/cli/cli-sync.spec.ts
+++ b/packages/client/test/cli/cli-sync.spec.ts
@@ -49,7 +49,7 @@ tape('[CLI] sync', (t) => {
     })
 
     child.on('close', (code) => {
-      if (code > 0) {
+      if (code && code > 0) {
         st.fail(`child process exited with code ${code}`)
         end()
       }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -43,7 +43,7 @@
     "ethereumjs-util": "^7.1.3"
   },
   "devDependencies": {
-    "@types/node": "^11.13.4",
+    "@types/node": "^16.11.7",
     "@types/tape": "^4.13.2",
     "eslint": "^6.8.0",
     "karma": "^6.3.2",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -72,7 +72,7 @@
     "@types/ip": "^1.1.0",
     "@types/keccak": "^3.0.1",
     "@types/ms": "^0.7.30",
-    "@types/node": "^11.13.4",
+    "@types/node": "^16.11.7",
     "@types/secp256k1": "^4.0.1",
     "@types/tape": "^4.13.2",
     "async": "^2.6.0",

--- a/packages/devp2p/src/eth/index.ts
+++ b/packages/devp2p/src/eth/index.ts
@@ -190,9 +190,9 @@ export class ETH extends EventEmitter {
 
     const status: any = {
       networkId: this._peerStatus[1],
-      td: Buffer.from(this._peerStatus[2]),
-      bestHash: Buffer.from(this._peerStatus[3]),
-      genesisHash: Buffer.from(this._peerStatus[4]),
+      td: Buffer.from(this._peerStatus[2] as Buffer),
+      bestHash: Buffer.from(this._peerStatus[3] as Buffer),
+      genesisHash: Buffer.from(this._peerStatus[4] as Buffer),
     }
 
     if (this._version >= 64) {

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "0x": "^4.9.1",
     "@types/benchmark": "^1.0.33",
-    "@types/node": "^11.13.4",
+    "@types/node": "^16.11.7",
     "@types/tape": "^4.13.2",
     "benchmark": "^2.1.4",
     "eslint": "^6.8.0",

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@types/minimist": "^1.2.0",
-    "@types/node": "^11.13.4",
+    "@types/node": "^16.11.7",
     "@types/tape": "^4.13.2",
     "eslint": "^6.8.0",
     "karma": "^6.3.2",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@types/assert": "^1.5.4",
-    "@types/node": "^11.13.4",
+    "@types/node": "^16.11.7",
     "@types/secp256k1": "^4.0.1",
     "@types/tape": "^4.13.2",
     "eslint": "^6.8.0",

--- a/packages/util/test/account.spec.ts
+++ b/packages/util/test/account.spec.ts
@@ -554,10 +554,13 @@ tape('Utility Functions', function (t) {
         for (const [chainId, addresses] of Object.entries(eip1191ChecksummAddresses)) {
           for (const addr of addresses) {
             st.equal(toChecksumAddress(addr.toLowerCase(), Number(chainId)), addr)
-            st.equal(toChecksumAddress(addr.toLowerCase(), Buffer.from([chainId])), addr)
+            st.equal(toChecksumAddress(addr.toLowerCase(), Buffer.from([chainId] as any)), addr)
             st.equal(toChecksumAddress(addr.toLowerCase(), new BN(chainId)), addr)
             st.equal(
-              toChecksumAddress(addr.toLowerCase(), '0x' + Buffer.from([chainId]).toString('hex')),
+              toChecksumAddress(
+                addr.toLowerCase(),
+                '0x' + Buffer.from([chainId] as any).toString('hex')
+              ),
               addr
             )
           }
@@ -605,10 +608,10 @@ tape('Utility Functions', function (t) {
         for (const [chainId, addresses] of Object.entries(eip1191ChecksummAddresses)) {
           for (const addr of addresses) {
             st.ok(isValidChecksumAddress(addr, Number(chainId)))
-            st.ok(isValidChecksumAddress(addr, Buffer.from([chainId])))
+            st.ok(isValidChecksumAddress(addr, Buffer.from([chainId] as any)))
             st.ok(isValidChecksumAddress(addr, new BN(chainId)))
             st.equal(
-              isValidChecksumAddress(addr, '0x' + Buffer.from([chainId]).toString('hex')),
+              isValidChecksumAddress(addr, '0x' + Buffer.from([chainId] as any).toString('hex')),
               true
             )
           }

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -66,7 +66,7 @@
     "@types/core-js": "^2.5.0",
     "@types/lru-cache": "^5.1.0",
     "@types/minimist": "^1.2.2",
-    "@types/node": "^11.13.4",
+    "@types/node": "^16.11.7",
     "@types/node-dir": "^0.0.34",
     "@types/tape": "^4.13.2",
     "benchmark": "^2.1.4",

--- a/packages/vm/tests/api/runBlock.spec.ts
+++ b/packages/vm/tests/api/runBlock.spec.ts
@@ -206,7 +206,7 @@ tape('runBlock() -> API parameter usage/data errors', async (t) => {
     const block = Block.fromBlockData({
       header: {
         ...testData.blocks[0].header,
-        gasLimit: Buffer.from('8000000000000000', 16),
+        gasLimit: Buffer.from('8000000000000000', 'hex'),
       },
     })
     await vm


### PR DESCRIPTION
This PR upgrades the ci to run default on Node v16 since v12 will be EOL in April.

Node v16 includes npm v7 by default so we can remove the extra install step.

We still test Node v12 on a nightly basis thanks to @evertonfraga's `node-versions.yml` workflow that pulls and runs all active and LTS versions.