### PR TITLE
Include polyfill for Node `assert` API to ensure compatibility with Webpack 5

### DIFF
--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -36,6 +36,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
+    "assert": "^2.0.0",
     "@types/bn.js": "^5.1.0",
     "bn.js": "^5.1.2",
     "create-hash": "^1.1.2",


### PR DESCRIPTION
`object.ts` makes use of the `assert` module. This is a Node API that's no longer polyfilled by Webpack 5.

Anyone who depends upon `ethereumjs-util/object` won't be able to upgrade their project to Webpack 5. Webpack will fail to build their project, citing that `assert` is missing. This also implies that anyone trying to use `ethereumjs-util` with Create React App 5 won't be able to either, since CRA5 uses Webpack 5.

Here's an example of folks in the Web3 community having trouble with this: https://github.com/solana-labs/wallet-adapter/issues/241