### PR TITLE
Util: Remove `assert` in favor of simply throwing `Errors` to ensure compatibility with Webpack 5

### DIFF
--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -43,7 +43,6 @@
     "rlp": "^2.2.4"
   },
   "devDependencies": {
-    "@types/assert": "^1.5.4",
     "@types/node": "^16.11.7",
     "@types/secp256k1": "^4.0.1",
     "@types/tape": "^4.13.2",

--- a/packages/util/src/account.ts
+++ b/packages/util/src/account.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { BN, rlp } from './externals'
 import {
   privateKeyVerify,
@@ -214,8 +213,12 @@ export const generateAddress2 = function (from: Buffer, salt: Buffer, initCode: 
   assertIsBuffer(salt)
   assertIsBuffer(initCode)
 
-  assert(from.length === 20)
-  assert(salt.length === 32)
+  if (from.length !== 20) {
+    throw new Error('Expected from to be of length 20')
+  }
+  if (salt.length !== 32) {
+    throw new Error('Expected salt to be of length 32')
+  }
 
   const address = keccak256(
     Buffer.concat([Buffer.from('ff', 'hex'), from, salt, keccak256(initCode)])
@@ -262,7 +265,9 @@ export const pubToAddress = function (pubKey: Buffer, sanitize: boolean = false)
   if (sanitize && pubKey.length !== 64) {
     pubKey = Buffer.from(publicKeyConvert(pubKey, false).slice(1))
   }
-  assert(pubKey.length === 64)
+  if (pubKey.length !== 64) {
+    throw new Error('Expected pubKey to be of length 64')
+  }
   // Only take the lower 160bits of the hash
   return keccak(pubKey).slice(-20)
 }

--- a/packages/util/src/address.ts
+++ b/packages/util/src/address.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { BN } from './externals'
 import { toBuffer, zeros } from './bytes'
 import {
@@ -13,7 +12,9 @@ export class Address {
   public readonly buf: Buffer
 
   constructor(buf: Buffer) {
-    assert(buf.length === 20, 'Invalid address length')
+    if (buf.length !== 20) {
+      throw new Error('Invalid address length')
+    }
     this.buf = buf
   }
 
@@ -29,7 +30,9 @@ export class Address {
    * @param str - Hex-encoded address
    */
   static fromString(str: string): Address {
-    assert(isValidAddress(str), 'Invalid address')
+    if (!isValidAddress(str)) {
+      throw new Error('Invalid address')
+    }
     return new Address(toBuffer(str))
   }
 
@@ -38,7 +41,9 @@ export class Address {
    * @param pubKey The two points of an uncompressed key
    */
   static fromPublicKey(pubKey: Buffer): Address {
-    assert(Buffer.isBuffer(pubKey), 'Public key should be Buffer')
+    if (!Buffer.isBuffer(pubKey)) {
+      throw new Error('Public key should be Buffer')
+    }
     const buf = pubToAddress(pubKey)
     return new Address(buf)
   }
@@ -48,7 +53,9 @@ export class Address {
    * @param privateKey A private key must be 256 bits wide
    */
   static fromPrivateKey(privateKey: Buffer): Address {
-    assert(Buffer.isBuffer(privateKey), 'Private key should be Buffer')
+    if (!Buffer.isBuffer(privateKey)) {
+      throw new Error('Private key should be Buffer')
+    }
     const buf = privateToAddress(privateKey)
     return new Address(buf)
   }
@@ -59,7 +66,9 @@ export class Address {
    * @param nonce The nonce of the from account
    */
   static generate(from: Address, nonce: BN): Address {
-    assert(BN.isBN(nonce))
+    if (!BN.isBN(nonce)) {
+      throw new Error('Expected nonce to be a BigNum')
+    }
     return new Address(generateAddress(from.buf, nonce.toArrayLike(Buffer)))
   }
 
@@ -70,8 +79,12 @@ export class Address {
    * @param initCode The init code of the contract being created
    */
   static generate2(from: Address, salt: Buffer, initCode: Buffer): Address {
-    assert(Buffer.isBuffer(salt))
-    assert(Buffer.isBuffer(initCode))
+    if (!Buffer.isBuffer(salt)) {
+      throw new Error('Expected salt to be a Buffer')
+    }
+    if (!Buffer.isBuffer(initCode)) {
+      throw new Error('Expected initCode to be a Buffer')
+    }
     return new Address(generateAddress2(from.buf, salt, initCode))
   }
 

--- a/packages/util/src/object.ts
+++ b/packages/util/src/object.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { stripHexPrefix } from './internal'
 import { rlp } from './externals'
 import { toBuffer, baToJSON, unpadBuffer } from './bytes'
@@ -49,15 +48,13 @@ export const defineProperties = function (self: any, fields: any, data?: any) {
 
       if (field.allowLess && field.length) {
         v = unpadBuffer(v)
-        assert(
-          field.length >= v.length,
-          `The field ${field.name} must not have more ${field.length} bytes`
-        )
+        if (field.length < v.length) {
+          throw new Error(`The field ${field.name} must not have more ${field.length} bytes`)
+        }
       } else if (!(field.allowZero && v.length === 0) && field.length) {
-        assert(
-          field.length === v.length,
-          `The field ${field.name} must have byte length of ${field.length}`
-        )
+        if (field.length !== v.length) {
+          throw new Error(`The field ${field.name} must have byte length of ${field.length}`)
+        }
       }
 
       self.raw[i] = v


### PR DESCRIPTION
# Motivation

`object.ts` makes use of the `assert` module. This is a Node API that's no longer polyfilled by Webpack 5.

Anyone who depends upon `ethereumjs-util/object` won't be able to upgrade their project to Webpack 5. Webpack will fail to build their project, citing that `assert` is missing. This also implies that anyone trying to use `ethereumjs-util` with Create React App 5 won't be able to either, since CRA5 uses Webpack 5.

Here's an example of folks in the Web3 community having trouble with this: https://github.com/solana-labs/wallet-adapter/issues/241

# Solution

In this PR, rather than to include a full polyfill of `assert` for browsers (eg. https://github.com/ethereumjs/ethereumjs-monorepo/pull/1637) we boil the assertions down to regular `if` statements and thrown `Errors`.

# Test plan

```
cd packages/util
yarn test
```

# Caveat

Eliminating our dependency on the monolithic `assert` polyfill could save ~9KB in the bundle. The only way that this could go wrong is if a consumer of `ethereumjs-util` is doing something like this today:

```
try {
  generateAddress2(/* ... */);
} catch (e) {
  if (e instanceof assert.AssertionError) {
    /* ... */
  }
}
```

Not throwing an instance of `AssertionError` would break this code.