### PR TITLE
rlp: add to root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Most packages are [MPL-2.0](<https://tldrlegal.com/license/mozilla-public-licens
 [trie-actions-link]: https://github.com/ethereumjs/ethereumjs-monorepo/actions?query=workflow%3A%22Trie%22
 [trie-coverage-badge]: https://codecov.io/gh/ethereumjs/ethereumjs-monorepo/branch/master/graph/badge.svg?flag=trie
 [trie-coverage-link]: https://codecov.io/gh/ethereumjs/ethereumjs-monorepo/tree/master/packages/trie
-[rlp-package]: ./packages/trie
+[rlp-package]: ./packages/rlp
 [rlp-npm-badge]: https://img.shields.io/npm/v/rlp.svg
 [rlp-npm-link]: https://www.npmjs.com/package/rlp
 [rlp-issues-badge]: https://img.shields.io/github/issues/ethereumjs/ethereumjs-monorepo/package:%20rlp?label=issues

--- a/README.md
+++ b/README.md
@@ -11,17 +11,18 @@ This was originally the EthereumJS VM repository. In Q1 2020 we brought some of 
 
 🚧 Please note that the `master` branch is updated on a daily basis, and to inspect code related to a specific package version, refer to the [tags](https://github.com/ethereumjs/ethereumjs-monorepo/tags).
 
-| package                                     | npm                                                         | issues                                                                  | tests                                                                  | coverage                                                                |
-| ------------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| package                                      | npm                                                         | issues                                                                  | tests                                                                  | coverage                                                                |
+| -------------------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | [@ethereumjs/block][block-package]           | [![NPM Package][block-npm-badge]][block-npm-link]           | [![Block Issues][block-issues-badge]][block-issues-link]                | [![Actions Status][block-actions-badge]][block-actions-link]           | [![Code Coverage][block-coverage-badge]][block-coverage-link]           |
 | [@ethereumjs/blockchain][blockchain-package] | [![NPM Package][blockchain-npm-badge]][blockchain-npm-link] | [![Blockchain Issues][blockchain-issues-badge]][blockchain-issues-link] | [![Actions Status][blockchain-actions-badge]][blockchain-actions-link] | [![Code Coverage][blockchain-coverage-badge]][blockchain-coverage-link] |
-| [@ethereumjs/client][client-package]           | [![NPM Package][client-npm-badge]][client-npm-link]           | [![Client Issues][client-issues-badge]][client-issues-link]                | [![Actions Status][client-actions-badge]][client-actions-link]           | [![Code Coverage][client-coverage-badge]][client-coverage-link]           |
+| [@ethereumjs/client][client-package]         | [![NPM Package][client-npm-badge]][client-npm-link]         | [![Client Issues][client-issues-badge]][client-issues-link]             | [![Actions Status][client-actions-badge]][client-actions-link]         | [![Code Coverage][client-coverage-badge]][client-coverage-link]         |
 | [@ethereumjs/common][common-package]         | [![NPM Package][common-npm-badge]][common-npm-link]         | [![Common Issues][common-issues-badge]][common-issues-link]             | [![Actions Status][common-actions-badge]][common-actions-link]         | [![Code Coverage][common-coverage-badge]][common-coverage-link]         |
-| [@ethereumjs/devp2p][devp2p-package]         | [![NPM Package][devp2p-npm-badge]][devp2p-npm-link]         | [![Devp2p Issues][devp2p-issues-badge]][devp2p-issues-link]             | [![Actions Status][devp2p-actions-badge]][devp2p-actions-link]         | [![Code Coverage][devp2p-coverage-badge]][devp2p-coverage-link] 
+| [@ethereumjs/devp2p][devp2p-package]         | [![NPM Package][devp2p-npm-badge]][devp2p-npm-link]         | [![Devp2p Issues][devp2p-issues-badge]][devp2p-issues-link]             | [![Actions Status][devp2p-actions-badge]][devp2p-actions-link]         | [![Code Coverage][devp2p-coverage-badge]][devp2p-coverage-link]         |
 | [@ethereumjs/ethash][ethash-package]         | [![NPM Package][ethash-npm-badge]][ethash-npm-link]         | [![Ethash Issues][ethash-issues-badge]][ethash-issues-link]             | [![Actions Status][ethash-actions-badge]][ethash-actions-link]         | [![Code Coverage][ethash-coverage-badge]][ethash-coverage-link]         |
-| [merkle-patricia-tree][trie-package]                 | [![NPM Package][trie-npm-badge]][trie-npm-link]                 | [![Trie Issues][trie-issues-badge]][trie-issues-link]                         | [![Actions Status][trie-actions-badge]][trie-actions-link]                 | [![Code Coverage][trie-coverage-badge]][trie-coverage-link] 
+| [merkle-patricia-tree][trie-package]         | [![NPM Package][trie-npm-badge]][trie-npm-link]             | [![Trie Issues][trie-issues-badge]][trie-issues-link]                   | [![Actions Status][trie-actions-badge]][trie-actions-link]             | [![Code Coverage][trie-coverage-badge]][trie-coverage-link]             |
+| [rlp][rlp-package]                           | [![NPM Package][rlp-npm-badge]][rlp-npm-link]               | [![rlp Issues][rlp-issues-badge]][rlp-issues-link]                      | [![Actions Status][rlp-actions-badge]][rlp-actions-link]               | [![Code Coverage][rlp-coverage-badge]][rlp-coverage-link]               |
 | [@ethereumjs/tx][tx-package]                 | [![NPM Package][tx-npm-badge]][tx-npm-link]                 | [![Tx Issues][tx-issues-badge]][tx-issues-link]                         | [![Actions Status][tx-actions-badge]][tx-actions-link]                 | [![Code Coverage][tx-coverage-badge]][tx-coverage-link]                 |
-| [ethereumjs-util][util-package]                 | [![NPM Package][util-npm-badge]][util-npm-link]                 | [![Util Issues][util-issues-badge]][util-issues-link]                         | [![Actions Status][util-actions-badge]][util-actions-link]                 | [![Code Coverage][util-coverage-badge]][util-coverage-link] 
+| [ethereumjs-util][util-package]              | [![NPM Package][util-npm-badge]][util-npm-link]             | [![Util Issues][util-issues-badge]][util-issues-link]                   | [![Actions Status][util-actions-badge]][util-actions-link]             | [![Code Coverage][util-coverage-badge]][util-coverage-link]             |
 | [@ethereumjs/vm][vm-package]                 | [![NPM Package][vm-npm-badge]][vm-npm-link]                 | [![VM Issues][vm-issues-badge]][vm-issues-link]                         | [![Actions Status][vm-actions-badge]][vm-actions-link]                 | [![Code Coverage][vm-coverage-badge]][vm-coverage-link]                 |
 
 ## Coverage report
@@ -131,6 +132,15 @@ Most packages are [MPL-2.0](<https://tldrlegal.com/license/mozilla-public-licens
 [trie-actions-link]: https://github.com/ethereumjs/ethereumjs-monorepo/actions?query=workflow%3A%22Trie%22
 [trie-coverage-badge]: https://codecov.io/gh/ethereumjs/ethereumjs-monorepo/branch/master/graph/badge.svg?flag=trie
 [trie-coverage-link]: https://codecov.io/gh/ethereumjs/ethereumjs-monorepo/tree/master/packages/trie
+[rlp-package]: ./packages/trie
+[rlp-npm-badge]: https://img.shields.io/npm/v/rlp.svg
+[rlp-npm-link]: https://www.npmjs.com/package/rlp
+[rlp-issues-badge]: https://img.shields.io/github/issues/ethereumjs/ethereumjs-monorepo/package:%20rlp?label=issues
+[rlp-issues-link]: https://github.com/ethereumjs/ethereumjs-monorepo/issues?q=is%3Aopen+is%3Aissue+label%3A"package%3A+rlp"
+[rlp-actions-badge]: https://github.com/ethereumjs/ethereumjs-monorepo/workflows/rlp/badge.svg
+[rlp-actions-link]: https://github.com/ethereumjs/ethereumjs-monorepo/actions?query=workflow%3A%22rlp%22
+[rlp-coverage-badge]: https://codecov.io/gh/ethereumjs/ethereumjs-monorepo/branch/master/graph/badge.svg?flag=rlp
+[rlp-coverage-link]: https://codecov.io/gh/ethereumjs/ethereumjs-monorepo/tree/master/packages/rlp
 [util-package]: ./packages/util
 [util-npm-badge]: https://img.shields.io/npm/v/ethereumjs-util.svg
 [util-npm-link]: https://www.npmjs.org/package/ethereumjs-util

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,6 @@ coverage:
         threshold: 5%
 comment:
   layout: 'reach, flags'
+flags:
+  rlp:
+    carryforward: true


### PR DESCRIPTION
This PR adds rlp to the root readme on master.

It also adds the carryforward option for the rlp flag since the coverage is not run on every pr or build (https://docs.codecov.com/docs/flags#carryforward-flags)