### PR TITLE
Common, VM: Remove unused HF options from Common, move supportedHardforks to VM

### DIFF
--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -48,18 +48,6 @@ c.genesis().hash // 0x41941023680923e0fe4d74a34bdac8141f2540e3ae90623718e47d66d1
 c.bootstrapNodes() // Array with current nodes
 ```
 
-If the initializing library only supports a certain range of `hardforks` you can use the `supportedHardforks` option to restrict hardfork access on the `Common` instance:
-
-```typescript
-const c = new Common({
-  chain: 'ropsten',
-  supportedHardforks: ['byzantium', 'constantinople', 'petersburg'],
-})
-```
-
-This will e.g. throw an error when a param is requested for an unsupported hardfork and
-like this prevents unpredicted behaviour.
-
 For an improved developer experience, there are `Chain` and `Hardfork` enums available:
 
 ```typescript

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -103,10 +103,6 @@ interface BaseOpts {
    */
   hardfork?: string | Hardfork
   /**
-   * Limit parameter returns to the given hardforks
-   */
-  // supportedHardforks?: Array<string | Hardfork>
-  /**
    * Selected EIPs which can be activated, please use an array for instantiation
    * (e.g. `eips: [ 2537, ]`)
    *
@@ -162,13 +158,6 @@ export interface CustomCommonOpts extends BaseOpts {
   baseChain?: string | number | Chain | BN
 }
 
-// interface hardforkOptions {
-//   /** optional, only allow supported HFs (default: false) */
-//   onlySupported?: boolean
-//   /** optional, only active HFs (default: false) */
-//   onlyActive?: boolean
-// }
-
 /**
  * Common class to access chain and hardfork parameters and to provide
  * a unified and shared view on the network and hardfork state.
@@ -182,7 +171,6 @@ export default class Common extends EventEmitter {
 
   private _chainParams: IChain
   private _hardfork: string | Hardfork
-  private _supportedHardforks: Array<string | Hardfork> = []
   private _eips: number[] = []
   private _customChains: IChain[] | [IChain, GenesisState][]
 
@@ -293,13 +281,11 @@ export default class Common extends EventEmitter {
    * chain params on.
    * @param customChainParams The custom parameters of the chain.
    * @param hardfork String identifier ('byzantium') for hardfork (optional)
-   * @param supportedHardforks Limit parameter returns to the given hardforks (optional)
    */
   static forCustomChain(
     baseChain: string | number | Chain,
     customChainParams: Partial<IChain>,
     hardfork?: string | Hardfork
-    // supportedHardforks?: Array<string | Hardfork>
   ): Common {
     const standardChainParams = Common._getChainParams(baseChain)
 
@@ -309,7 +295,6 @@ export default class Common extends EventEmitter {
         ...customChainParams,
       },
       hardfork: hardfork,
-      // supportedHardforks: supportedHardforks,
     })
   }
 
@@ -361,9 +346,6 @@ export default class Common extends EventEmitter {
       }
     }
     this._hardfork = this.DEFAULT_HARDFORK
-    // if (opts.supportedHardforks) {
-    //   this._supportedHardforks = opts.supportedHardforks
-    // }
     if (opts.hardfork) {
       this.setHardfork(opts.hardfork)
     }
@@ -416,9 +398,6 @@ export default class Common extends EventEmitter {
    * @param hardfork String identifier (e.g. 'byzantium') or {@link Hardfork} enum
    */
   setHardfork(hardfork: string | Hardfork): void {
-    // if (!this._isSupportedHardfork(hardfork)) {
-    //   throw new Error(`Hardfork ${hardfork} not set as supported in supportedHardforks`)
-    // }
     let existing = false
     for (const hfChanges of HARDFORK_CHANGES) {
       if (hfChanges[0] === hardfork) {
@@ -520,10 +499,6 @@ export default class Common extends EventEmitter {
    * @returns Hardfork chosen to be used
    */
   _chooseHardfork(hardfork?: string | Hardfork | null): string {
-    // if (!hardfork) {
-    //   hardfork = this._hardfork
-    // }
-    // return hardfork
     return hardfork ?? this._hardfork
   }
 
@@ -539,22 +514,6 @@ export default class Common extends EventEmitter {
     }
     throw new Error(`Hardfork ${hardfork} not defined for chain ${this.chainName()}`)
   }
-
-  /**
-   * Internal helper function to check if a hardfork is set to be supported by the library
-   * @param hardfork Hardfork name
-   * @returns True if hardfork is supported
-   */
-  // _isSupportedHardfork(hardfork: string | Hardfork | null): boolean {
-  //   if (this._supportedHardforks.length > 0) {
-  //     for (const supportedHf of this._supportedHardforks) {
-  //       if (hardfork === supportedHf) return true
-  //     }
-  //   } else {
-  //     return true
-  //   }
-  //   return false
-  // }
 
   /**
    * Sets the active EIPs
@@ -778,7 +737,6 @@ export default class Common extends EventEmitter {
     for (const hf of hfs) {
       if (hf['block'] === null) continue
       if (blockNumber !== undefined && blockNumber !== null && blockNumber < hf['block']) break
-      // if (opts.onlySupported && !this._isSupportedHardfork(hf['name'])) continue
 
       activeHardforks.push(hf)
     }
@@ -816,7 +774,6 @@ export default class Common extends EventEmitter {
    * @returns Block number or null if unscheduled
    */
   hardforkBlockBN(hardfork?: string | Hardfork): BN | null {
-    // hardfork = this._chooseHardfork(hardfork, false)
     hardfork = this._chooseHardfork(hardfork)
     const block = this._getHardfork(hardfork)['block']
     if (block === undefined || block === null) {
@@ -831,7 +788,6 @@ export default class Common extends EventEmitter {
    * @returns Total difficulty or null if no set
    */
   hardforkTD(hardfork?: string | Hardfork): BN | null {
-    // hardfork = this._chooseHardfork(hardfork, false)
     hardfork = this._chooseHardfork(hardfork)
     const td = this._getHardfork(hardfork)['td']
     if (td === undefined || td === null) {
@@ -848,7 +804,6 @@ export default class Common extends EventEmitter {
    */
   isHardforkBlock(blockNumber: BNLike, hardfork?: string | Hardfork): boolean {
     blockNumber = toType(blockNumber, TypeOutput.BN)
-    // hardfork = this._chooseHardfork(hardfork, false)
     hardfork = this._chooseHardfork(hardfork)
     const block = this.hardforkBlockBN(hardfork)
     return block ? block.eq(blockNumber) : false
@@ -871,7 +826,6 @@ export default class Common extends EventEmitter {
    * @returns Block number or null if not available
    */
   nextHardforkBlockBN(hardfork?: string | Hardfork): BN | null {
-    // hardfork = this._chooseHardfork(hardfork, false)
     hardfork = this._chooseHardfork(hardfork)
     const hfBlock = this.hardforkBlockBN(hardfork)
     if (hfBlock === null) {
@@ -896,7 +850,6 @@ export default class Common extends EventEmitter {
    */
   isNextHardforkBlock(blockNumber: BNLike, hardfork?: string | Hardfork): boolean {
     blockNumber = toType(blockNumber, TypeOutput.BN)
-    // hardfork = this._chooseHardfork(hardfork, false)
     hardfork = this._chooseHardfork(hardfork)
     const nextHardforkBlock = this.nextHardforkBlockBN(hardfork)
 
@@ -941,7 +894,6 @@ export default class Common extends EventEmitter {
    * @param hardfork Hardfork name, optional if HF set
    */
   forkHash(hardfork?: string | Hardfork) {
-    // hardfork = this._chooseHardfork(hardfork, false)
     hardfork = this._chooseHardfork(hardfork)
     const data = this._getHardfork(hardfork)
     if (data['block'] === null && data['td'] === undefined) {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -494,15 +494,6 @@ export default class Common extends EventEmitter {
   }
 
   /**
-   * Internal helper function to choose between hardfork set and hardfork provided as param
-   * @param hardfork Hardfork given to function as a parameter
-   * @returns Hardfork chosen to be used
-   */
-  _chooseHardfork(hardfork?: string | Hardfork | null): string {
-    return hardfork ?? this._hardfork
-  }
-
-  /**
    * Internal helper function, returns the params for the given hardfork for the chain set
    * @param hardfork Hardfork name
    * @returns Dictionary with hardfork params
@@ -573,8 +564,6 @@ export default class Common extends EventEmitter {
    * @returns The value requested or `null` if not found
    */
   paramByHardfork(topic: string, name: string, hardfork: string | Hardfork): any {
-    hardfork = this._chooseHardfork(hardfork)
-
     let value = null
     for (const hfChanges of HARDFORK_CHANGES) {
       // EIP-referencing HF file (e.g. berlin.json)
@@ -665,7 +654,7 @@ export default class Common extends EventEmitter {
    */
   hardforkIsActiveOnBlock(hardfork: string | Hardfork | null, blockNumber: BNLike): boolean {
     blockNumber = toType(blockNumber, TypeOutput.BN)
-    hardfork = this._chooseHardfork(hardfork)
+    hardfork = hardfork ?? this._hardfork
     const hfBlock = this.hardforkBlockBN(hardfork)
     if (hfBlock && blockNumber.gte(hfBlock)) {
       return true
@@ -690,7 +679,7 @@ export default class Common extends EventEmitter {
    * @returns True if HF1 gte HF2
    */
   hardforkGteHardfork(hardfork1: string | Hardfork | null, hardfork2: string | Hardfork): boolean {
-    hardfork1 = this._chooseHardfork(hardfork1)
+    hardfork1 = hardfork1 ?? this._hardfork
     const hardforks = this.hardforks()
 
     let posHf1 = -1,
@@ -719,7 +708,7 @@ export default class Common extends EventEmitter {
    * @returns True if hardfork is active on the chain
    */
   hardforkIsActiveOnChain(hardfork?: string | Hardfork | null): boolean {
-    hardfork = this._chooseHardfork(hardfork)
+    hardfork = hardfork ?? this._hardfork
     for (const hf of this.hardforks()) {
       if (hf['name'] === hardfork && hf['block'] !== null) return true
     }
@@ -774,7 +763,7 @@ export default class Common extends EventEmitter {
    * @returns Block number or null if unscheduled
    */
   hardforkBlockBN(hardfork?: string | Hardfork): BN | null {
-    hardfork = this._chooseHardfork(hardfork)
+    hardfork = hardfork ?? this._hardfork
     const block = this._getHardfork(hardfork)['block']
     if (block === undefined || block === null) {
       return null
@@ -788,7 +777,7 @@ export default class Common extends EventEmitter {
    * @returns Total difficulty or null if no set
    */
   hardforkTD(hardfork?: string | Hardfork): BN | null {
-    hardfork = this._chooseHardfork(hardfork)
+    hardfork = hardfork ?? this._hardfork
     const td = this._getHardfork(hardfork)['td']
     if (td === undefined || td === null) {
       return null
@@ -804,7 +793,7 @@ export default class Common extends EventEmitter {
    */
   isHardforkBlock(blockNumber: BNLike, hardfork?: string | Hardfork): boolean {
     blockNumber = toType(blockNumber, TypeOutput.BN)
-    hardfork = this._chooseHardfork(hardfork)
+    hardfork = hardfork ?? this._hardfork
     const block = this.hardforkBlockBN(hardfork)
     return block ? block.eq(blockNumber) : false
   }
@@ -826,7 +815,7 @@ export default class Common extends EventEmitter {
    * @returns Block number or null if not available
    */
   nextHardforkBlockBN(hardfork?: string | Hardfork): BN | null {
-    hardfork = this._chooseHardfork(hardfork)
+    hardfork = hardfork ?? this._hardfork
     const hfBlock = this.hardforkBlockBN(hardfork)
     if (hfBlock === null) {
       return null
@@ -850,7 +839,7 @@ export default class Common extends EventEmitter {
    */
   isNextHardforkBlock(blockNumber: BNLike, hardfork?: string | Hardfork): boolean {
     blockNumber = toType(blockNumber, TypeOutput.BN)
-    hardfork = this._chooseHardfork(hardfork)
+    hardfork = hardfork ?? this._hardfork
     const nextHardforkBlock = this.nextHardforkBlockBN(hardfork)
 
     return nextHardforkBlock === null ? false : nextHardforkBlock.eq(blockNumber)
@@ -894,7 +883,7 @@ export default class Common extends EventEmitter {
    * @param hardfork Hardfork name, optional if HF set
    */
   forkHash(hardfork?: string | Hardfork) {
-    hardfork = this._chooseHardfork(hardfork)
+    hardfork = hardfork ?? this._hardfork
     const data = this._getHardfork(hardfork)
     if (data['block'] === null && data['td'] === undefined) {
       const msg = 'No fork hash calculation possible for future hardfork'

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -105,7 +105,7 @@ interface BaseOpts {
   /**
    * Limit parameter returns to the given hardforks
    */
-  supportedHardforks?: Array<string | Hardfork>
+  // supportedHardforks?: Array<string | Hardfork>
   /**
    * Selected EIPs which can be activated, please use an array for instantiation
    * (e.g. `eips: [ 2537, ]`)
@@ -298,8 +298,8 @@ export default class Common extends EventEmitter {
   static forCustomChain(
     baseChain: string | number | Chain,
     customChainParams: Partial<IChain>,
-    hardfork?: string | Hardfork,
-    supportedHardforks?: Array<string | Hardfork>
+    hardfork?: string | Hardfork
+    // supportedHardforks?: Array<string | Hardfork>
   ): Common {
     const standardChainParams = Common._getChainParams(baseChain)
 
@@ -309,7 +309,7 @@ export default class Common extends EventEmitter {
         ...customChainParams,
       },
       hardfork: hardfork,
-      supportedHardforks: supportedHardforks,
+      // supportedHardforks: supportedHardforks,
     })
   }
 
@@ -361,9 +361,9 @@ export default class Common extends EventEmitter {
       }
     }
     this._hardfork = this.DEFAULT_HARDFORK
-    if (opts.supportedHardforks) {
-      this._supportedHardforks = opts.supportedHardforks
-    }
+    // if (opts.supportedHardforks) {
+    //   this._supportedHardforks = opts.supportedHardforks
+    // }
     if (opts.hardfork) {
       this.setHardfork(opts.hardfork)
     }
@@ -416,9 +416,9 @@ export default class Common extends EventEmitter {
    * @param hardfork String identifier (e.g. 'byzantium') or {@link Hardfork} enum
    */
   setHardfork(hardfork: string | Hardfork): void {
-    if (!this._isSupportedHardfork(hardfork)) {
-      throw new Error(`Hardfork ${hardfork} not set as supported in supportedHardforks`)
-    }
+    // if (!this._isSupportedHardfork(hardfork)) {
+    //   throw new Error(`Hardfork ${hardfork} not set as supported in supportedHardforks`)
+    // }
     let existing = false
     for (const hfChanges of HARDFORK_CHANGES) {
       if (hfChanges[0] === hardfork) {
@@ -519,13 +519,12 @@ export default class Common extends EventEmitter {
    * @param hardfork Hardfork given to function as a parameter
    * @returns Hardfork chosen to be used
    */
-  _chooseHardfork(hardfork?: string | Hardfork | null, onlySupported: boolean = true): string {
-    if (!hardfork) {
-      hardfork = this._hardfork
-    } else if (onlySupported && !this._isSupportedHardfork(hardfork)) {
-      throw new Error(`Hardfork ${hardfork} not set as supported in supportedHardforks`)
-    }
-    return hardfork
+  _chooseHardfork(hardfork?: string | Hardfork | null): string {
+    // if (!hardfork) {
+    //   hardfork = this._hardfork
+    // }
+    // return hardfork
+    return hardfork ?? this._hardfork
   }
 
   /**
@@ -546,16 +545,16 @@ export default class Common extends EventEmitter {
    * @param hardfork Hardfork name
    * @returns True if hardfork is supported
    */
-  _isSupportedHardfork(hardfork: string | Hardfork | null): boolean {
-    if (this._supportedHardforks.length > 0) {
-      for (const supportedHf of this._supportedHardforks) {
-        if (hardfork === supportedHf) return true
-      }
-    } else {
-      return true
-    }
-    return false
-  }
+  // _isSupportedHardfork(hardfork: string | Hardfork | null): boolean {
+  //   if (this._supportedHardforks.length > 0) {
+  //     for (const supportedHf of this._supportedHardforks) {
+  //       if (hardfork === supportedHf) return true
+  //     }
+  //   } else {
+  //     return true
+  //   }
+  //   return false
+  // }
 
   /**
    * Sets the active EIPs
@@ -817,7 +816,8 @@ export default class Common extends EventEmitter {
    * @returns Block number or null if unscheduled
    */
   hardforkBlockBN(hardfork?: string | Hardfork): BN | null {
-    hardfork = this._chooseHardfork(hardfork, false)
+    // hardfork = this._chooseHardfork(hardfork, false)
+    hardfork = this._chooseHardfork(hardfork)
     const block = this._getHardfork(hardfork)['block']
     if (block === undefined || block === null) {
       return null
@@ -831,7 +831,8 @@ export default class Common extends EventEmitter {
    * @returns Total difficulty or null if no set
    */
   hardforkTD(hardfork?: string | Hardfork): BN | null {
-    hardfork = this._chooseHardfork(hardfork, false)
+    // hardfork = this._chooseHardfork(hardfork, false)
+    hardfork = this._chooseHardfork(hardfork)
     const td = this._getHardfork(hardfork)['td']
     if (td === undefined || td === null) {
       return null
@@ -847,7 +848,8 @@ export default class Common extends EventEmitter {
    */
   isHardforkBlock(blockNumber: BNLike, hardfork?: string | Hardfork): boolean {
     blockNumber = toType(blockNumber, TypeOutput.BN)
-    hardfork = this._chooseHardfork(hardfork, false)
+    // hardfork = this._chooseHardfork(hardfork, false)
+    hardfork = this._chooseHardfork(hardfork)
     const block = this.hardforkBlockBN(hardfork)
     return block ? block.eq(blockNumber) : false
   }
@@ -869,7 +871,8 @@ export default class Common extends EventEmitter {
    * @returns Block number or null if not available
    */
   nextHardforkBlockBN(hardfork?: string | Hardfork): BN | null {
-    hardfork = this._chooseHardfork(hardfork, false)
+    // hardfork = this._chooseHardfork(hardfork, false)
+    hardfork = this._chooseHardfork(hardfork)
     const hfBlock = this.hardforkBlockBN(hardfork)
     if (hfBlock === null) {
       return null
@@ -893,7 +896,8 @@ export default class Common extends EventEmitter {
    */
   isNextHardforkBlock(blockNumber: BNLike, hardfork?: string | Hardfork): boolean {
     blockNumber = toType(blockNumber, TypeOutput.BN)
-    hardfork = this._chooseHardfork(hardfork, false)
+    // hardfork = this._chooseHardfork(hardfork, false)
+    hardfork = this._chooseHardfork(hardfork)
     const nextHardforkBlock = this.nextHardforkBlockBN(hardfork)
 
     return nextHardforkBlock === null ? false : nextHardforkBlock.eq(blockNumber)
@@ -937,7 +941,8 @@ export default class Common extends EventEmitter {
    * @param hardfork Hardfork name, optional if HF set
    */
   forkHash(hardfork?: string | Hardfork) {
-    hardfork = this._chooseHardfork(hardfork, false)
+    // hardfork = this._chooseHardfork(hardfork, false)
+    hardfork = this._chooseHardfork(hardfork)
     const data = this._getHardfork(hardfork)
     if (data['block'] === null && data['td'] === undefined) {
       const msg = 'No fork hash calculation possible for future hardfork'

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -162,12 +162,12 @@ export interface CustomCommonOpts extends BaseOpts {
   baseChain?: string | number | Chain | BN
 }
 
-interface hardforkOptions {
-  /** optional, only allow supported HFs (default: false) */
-  onlySupported?: boolean
-  /** optional, only active HFs (default: false) */
-  onlyActive?: boolean
-}
+// interface hardforkOptions {
+//   /** optional, only allow supported HFs (default: false) */
+//   onlySupported?: boolean
+//   /** optional, only active HFs (default: false) */
+//   onlyActive?: boolean
+// }
 
 /**
  * Common class to access chain and hardfork parameters and to provide
@@ -703,17 +703,11 @@ export default class Common extends EventEmitter {
    * Checks if set or provided hardfork is active on block number
    * @param hardfork Hardfork name or null (for HF set)
    * @param blockNumber
-   * @param opts Hardfork options (onlyActive unused)
    * @returns True if HF is active on block number
    */
-  hardforkIsActiveOnBlock(
-    hardfork: string | Hardfork | null,
-    blockNumber: BNLike,
-    opts: hardforkOptions = {}
-  ): boolean {
+  hardforkIsActiveOnBlock(hardfork: string | Hardfork | null, blockNumber: BNLike): boolean {
     blockNumber = toType(blockNumber, TypeOutput.BN)
-    const onlySupported = opts.onlySupported ?? false
-    hardfork = this._chooseHardfork(hardfork, onlySupported)
+    hardfork = this._chooseHardfork(hardfork)
     const hfBlock = this.hardforkBlockBN(hardfork)
     if (hfBlock && blockNumber.gte(hfBlock)) {
       return true
@@ -724,11 +718,10 @@ export default class Common extends EventEmitter {
   /**
    * Alias to hardforkIsActiveOnBlock when hardfork is set
    * @param blockNumber
-   * @param opts Hardfork options (onlyActive unused)
    * @returns True if HF is active on block number
    */
-  activeOnBlock(blockNumber: BNLike, opts?: hardforkOptions): boolean {
-    return this.hardforkIsActiveOnBlock(null, blockNumber, opts)
+  activeOnBlock(blockNumber: BNLike): boolean {
+    return this.hardforkIsActiveOnBlock(null, blockNumber)
   }
 
   /**
@@ -738,20 +731,9 @@ export default class Common extends EventEmitter {
    * @param opts Hardfork options
    * @returns True if HF1 gte HF2
    */
-  hardforkGteHardfork(
-    hardfork1: string | Hardfork | null,
-    hardfork2: string | Hardfork,
-    opts: hardforkOptions = {}
-  ): boolean {
-    const onlyActive = opts.onlyActive === undefined ? false : opts.onlyActive
-    hardfork1 = this._chooseHardfork(hardfork1, opts.onlySupported)
-
-    let hardforks
-    if (onlyActive) {
-      hardforks = this.activeHardforks(null, opts)
-    } else {
-      hardforks = this.hardforks()
-    }
+  hardforkGteHardfork(hardfork1: string | Hardfork | null, hardfork2: string | Hardfork): boolean {
+    hardfork1 = this._chooseHardfork(hardfork1)
+    const hardforks = this.hardforks()
 
     let posHf1 = -1,
       posHf2 = -1
@@ -767,25 +749,19 @@ export default class Common extends EventEmitter {
   /**
    * Alias to hardforkGteHardfork when hardfork is set
    * @param hardfork Hardfork name
-   * @param opts Hardfork options
    * @returns True if hardfork set is greater than hardfork provided
    */
-  gteHardfork(hardfork: string | Hardfork, opts?: hardforkOptions): boolean {
-    return this.hardforkGteHardfork(null, hardfork, opts)
+  gteHardfork(hardfork: string | Hardfork): boolean {
+    return this.hardforkGteHardfork(null, hardfork)
   }
 
   /**
    * Checks if given or set hardfork is active on the chain
    * @param hardfork Hardfork name, optional if HF set
-   * @param opts Hardfork options (onlyActive unused)
    * @returns True if hardfork is active on the chain
    */
-  hardforkIsActiveOnChain(
-    hardfork?: string | Hardfork | null,
-    opts: hardforkOptions = {}
-  ): boolean {
-    const onlySupported = opts.onlySupported ?? false
-    hardfork = this._chooseHardfork(hardfork, onlySupported)
+  hardforkIsActiveOnChain(hardfork?: string | Hardfork | null): boolean {
+    hardfork = this._chooseHardfork(hardfork)
     for (const hf of this.hardforks()) {
       if (hf['name'] === hardfork && hf['block'] !== null) return true
     }
@@ -795,16 +771,15 @@ export default class Common extends EventEmitter {
   /**
    * Returns the active hardfork switches for the current chain
    * @param blockNumber up to block if provided, otherwise for the whole chain
-   * @param opts Hardfork options (onlyActive unused)
    * @return Array with hardfork arrays
    */
-  activeHardforks(blockNumber?: BNLike | null, opts: hardforkOptions = {}): HardforkParams[] {
+  activeHardforks(blockNumber?: BNLike | null): HardforkParams[] {
     const activeHardforks: HardforkParams[] = []
     const hfs = this.hardforks()
     for (const hf of hfs) {
       if (hf['block'] === null) continue
       if (blockNumber !== undefined && blockNumber !== null && blockNumber < hf['block']) break
-      if (opts.onlySupported && !this._isSupportedHardfork(hf['name'])) continue
+      // if (opts.onlySupported && !this._isSupportedHardfork(hf['name'])) continue
 
       activeHardforks.push(hf)
     }
@@ -814,11 +789,10 @@ export default class Common extends EventEmitter {
   /**
    * Returns the latest active hardfork name for chain or block or throws if unavailable
    * @param blockNumber up to block if provided, otherwise for the whole chain
-   * @param opts Hardfork options (onlyActive unused)
    * @return Hardfork name
    */
-  activeHardfork(blockNumber?: BNLike | null, opts: hardforkOptions = {}): string {
-    const activeHardforks = this.activeHardforks(blockNumber, opts)
+  activeHardfork(blockNumber?: BNLike | null): string {
+    const activeHardforks = this.activeHardforks(blockNumber)
     if (activeHardforks.length > 0) {
       return activeHardforks[activeHardforks.length - 1]['name']
     } else {

--- a/packages/common/tests/chains.spec.ts
+++ b/packages/common/tests/chains.spec.ts
@@ -16,7 +16,6 @@ tape('[Common/Chains]: Initialization / Chain params', function (t: tape.Test) {
       c.DEFAULT_HARDFORK,
       'should set hardfork to hardfork set as DEFAULT_HARDFORK'
     )
-    st.equal(c._isSupportedHardfork('constantinople'), true, 'should not restrict supported HFs')
 
     c = new Common({ chain: 1 })
     st.equal(c.chainName(), 'mainnet', 'should initialize with chain Id')
@@ -37,7 +36,6 @@ tape('[Common/Chains]: Initialization / Chain params', function (t: tape.Test) {
       c.DEFAULT_HARDFORK,
       'should set hardfork to hardfork set as DEFAULT_HARDFORK'
     )
-    st.equal(c._isSupportedHardfork('constantinople'), true, 'should not restrict supported HFs')
 
     st.end()
   })
@@ -59,19 +57,6 @@ tape('[Common/Chains]: Initialization / Chain params', function (t: tape.Test) {
     }
   )
 
-  t.test('Should initialize with supportedHardforks provided', function (st: tape.Test) {
-    const c = new Common({
-      chain: 'mainnet',
-      hardfork: 'byzantium',
-      supportedHardforks: ['byzantium', 'constantinople'],
-    })
-    st.equal(c._isSupportedHardfork('byzantium'), true, 'should return true for supported HF')
-    const msg = 'should return false for unsupported HF'
-    st.equal(c._isSupportedHardfork('spuriousDragon'), false, msg)
-
-    st.end()
-  })
-
   t.test('Should handle initialization errors', function (st: tape.Test) {
     let f = function () {
       new Common({ chain: 'chainnotexisting' })
@@ -84,16 +69,6 @@ tape('[Common/Chains]: Initialization / Chain params', function (t: tape.Test) {
     }
     msg = 'should throw an exception on non-existing hardfork'
     st.throws(f, /not supported$/, msg) // eslint-disable-line no-new
-
-    f = function () {
-      new Common({
-        chain: 'mainnet',
-        hardfork: 'spuriousDragon',
-        supportedHardforks: ['byzantium', 'constantinople'],
-      })
-    }
-    msg = 'should throw an exception on conflicting active/supported HF params'
-    st.throws(f, /supportedHardforks$/, msg) // eslint-disable-line no-new
 
     st.end()
   })

--- a/packages/common/tests/hardforks.spec.ts
+++ b/packages/common/tests/hardforks.spec.ts
@@ -164,20 +164,6 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     msg = 'should return 4 active hardforks for Ropsten up to block 10'
     st.equal(c.activeHardforks(10).length, 4, msg)
 
-    c = new Common({
-      chain: Chain.Ropsten,
-      supportedHardforks: [Hardfork.SpuriousDragon, Hardfork.Byzantium, Hardfork.Constantinople],
-    })
-    msg = 'should return 3 active HFs when restricted to supported HFs'
-    st.equal(c.activeHardforks(null, { onlySupported: true }).length, 3, msg)
-
-    c = new Common({
-      chain: Chain.Ropsten,
-      supportedHardforks: [Hardfork.SpuriousDragon, Hardfork.Byzantium, Hardfork.Dao],
-    })
-    msg = 'should return 2 active HFs when restricted to supported HFs'
-    st.equal(c.activeHardforks(null, { onlySupported: true }).length, 2, msg)
-
     c = new Common({ chain: Chain.Mainnet })
     msg = 'should return correct number of active HFs for mainnet'
     st.equal(c.activeHardforks().length, 13, msg)
@@ -200,13 +186,6 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
 
     msg = 'should return spuriousDragon as latest active HF for Ropsten for block 10'
     st.equal(c.activeHardfork(10), Hardfork.SpuriousDragon, msg)
-
-    c = new Common({
-      chain: Chain.Ropsten,
-      supportedHardforks: [Hardfork.TangerineWhistle, Hardfork.SpuriousDragon],
-    })
-    msg = 'should return spuriousDragon as latest active HF for Ropsten with limited supported HFs'
-    st.equal(c.activeHardfork(null, { onlySupported: true }), Hardfork.SpuriousDragon, msg)
 
     c = new Common({ chain: Chain.Rinkeby })
     msg = 'should return correct latest active HF for Rinkeby'
@@ -264,14 +243,8 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     let msg = 'Ropsten, constantinople >= byzantium (provided) -> true'
     st.equal(c.hardforkGteHardfork(Hardfork.Constantinople, Hardfork.Byzantium), true, msg)
 
-    msg = 'Ropsten, dao >= chainstart (provided), onlyActive -> false'
-    st.equal(
-      c.hardforkGteHardfork(Hardfork.Dao, Hardfork.Chainstart, {
-        onlyActive: true,
-      }),
-      false,
-      msg
-    )
+    msg = 'Ropsten, dao >= chainstart (provided) -> false'
+    st.equal(c.hardforkGteHardfork(Hardfork.Dao, Hardfork.Chainstart), false, msg)
 
     msg = 'Ropsten, byzantium >= byzantium (provided) -> true'
     st.equal(c.hardforkGteHardfork(Hardfork.Byzantium, Hardfork.Byzantium), true, msg)
@@ -285,9 +258,6 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
 
     msg = 'Ropsten, byzantium (set) >= spuriousDragon -> true (alias function)'
     st.equal(c.gteHardfork(Hardfork.SpuriousDragon), true, msg)
-
-    msg = 'Ropsten, byzantium (set) >= spuriousDragon, onlyActive -> true'
-    st.equal(c.hardforkGteHardfork(null, Hardfork.SpuriousDragon, { onlyActive: true }), true, msg)
 
     msg = 'Ropsten, byzantium (set) >= byzantium -> true'
     st.equal(c.hardforkGteHardfork(null, Hardfork.Byzantium), true, msg)
@@ -320,25 +290,9 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     msg = 'should return false for a non-existing HF (provided) on Ropsten'
     st.equal(c.hardforkIsActiveOnChain('notexistinghardfork'), false, msg)
 
-    let f = function () {
-      c.hardforkIsActiveOnChain(Hardfork.SpuriousDragon, { onlySupported: true })
-    }
-    msg = 'should not throw with unsupported Hf (provided) and onlySupported set to false'
-    st.doesNotThrow(f, /unsupported hardfork$/, msg)
-
     c = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Byzantium })
     msg = 'should return true for byzantium (set) on Ropsten'
     st.equal(c.hardforkIsActiveOnChain(), true, msg)
-
-    c = new Common({
-      chain: Chain.Ropsten,
-      supportedHardforks: [Hardfork.Byzantium, Hardfork.Constantinople],
-    })
-    f = function () {
-      c.hardforkIsActiveOnChain(Hardfork.SpuriousDragon, { onlySupported: true })
-    }
-    msg = 'should throw with unsupported Hf and onlySupported set to true'
-    st.throws(f, /not set as supported in supportedHardforks$/, msg)
 
     st.end()
   })

--- a/packages/common/tests/params.spec.ts
+++ b/packages/common/tests/params.spec.ts
@@ -32,33 +32,16 @@ tape('[Common]: Parameter access for param(), paramByHardfork()', function (t: t
   })
 
   t.test('Error cases for param(), paramByHardfork()', function (st: tape.Test) {
-    let c = new Common({ chain: Chain.Mainnet })
+    const c = new Common({ chain: Chain.Mainnet })
 
-    let f = function () {
+    const f = function () {
       c.paramByHardfork('gasPrizes', 'ecAdd', 'byzantium')
     }
-    let msg = 'Should throw when called with non-existing topic'
+    const msg = 'Should throw when called with non-existing topic'
     st.throws(f, /Topic gasPrizes not defined$/, msg)
 
     c.setHardfork(Hardfork.Byzantium)
     st.equal(c.param('gasPrices', 'ecAdd'), 500, 'Should return correct value for HF set in class')
-
-    c = new Common({
-      chain: Chain.Mainnet,
-      hardfork: Hardfork.Byzantium,
-      supportedHardforks: [Hardfork.Byzantium, Hardfork.Constantinople],
-    })
-    f = function () {
-      c.paramByHardfork('gasPrices', 'expByte', 'spuriousDragon')
-    }
-    msg = 'Should throw when calling param() with an unsupported hardfork'
-    st.throws(f, /supportedHardforks$/, msg)
-
-    f = function () {
-      c.paramByBlock('gasPrices', 'expByte', 0)
-    }
-    msg = 'Should throw when calling paramByBlock() with an unsupported hardfork'
-    st.throws(f, /supportedHardforks$/, msg)
 
     st.end()
   })

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -140,13 +140,6 @@ const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
 const vm = new VM({ common })
 ```
 
-Please note that the `VM` constructor will throw an error if you pass in a `Common` instance that is set to a hardfork that the `VM` does not currently support. For example, the following would throw because the `VM` does not yet support the Merge hardfork:
-
-```typescript
-const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Merge })
-const vm = new VM({ common })
-```
-
 ## EIP Support
 
 It is possible to individually activate EIP support in the VM by instantiate the `Common` instance passed

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -140,6 +140,18 @@ const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
 const vm = new VM({ common })
 ```
 
+If your use case only supports a certain range of `hardforks`, you can use the `supportedHardforks` option to restrict hardfork access on the `VM` instance:
+
+```typescript
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium })
+const vm = new VM({
+  common,
+  supportedHardforks: [Hardfork.Byzantium, Hardfork.Constantinople],
+})
+```
+
+This will throw an error if the hardfork set in `Common` is not included in the `supportedHardforks` array, which can help prevent unpredicted behaviour.
+
 ## EIP Support
 
 It is possible to individually activate EIP support in the VM by instantiate the `Common` instance passed

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -140,17 +140,12 @@ const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
 const vm = new VM({ common })
 ```
 
-If your use case only supports a certain range of `hardforks`, you can use the `supportedHardforks` option to restrict hardfork access on the `VM` instance:
+Please note that the `VM` constructor will throw an error if you pass in a `Common` instance that is set to a hardfork that the `VM` does not currently support. For example, the following would throw because the `VM` does not yet support the Merge hardfork:
 
 ```typescript
-const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium })
-const vm = new VM({
-  common,
-  supportedHardforks: [Hardfork.Byzantium, Hardfork.Constantinople],
-})
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Merge })
+const vm = new VM({ common })
 ```
-
-This will throw an error if the hardfork set in `Common` is not included in the `supportedHardforks` array, which can help prevent unpredicted behaviour.
 
 ## EIP Support
 

--- a/packages/vm/src/index.ts
+++ b/packages/vm/src/index.ts
@@ -143,7 +143,6 @@ export default class VM extends AsyncEventEmitter {
   protected _opcodes: OpcodeList
   protected readonly _hardforkByBlockNumber: boolean
   protected readonly _hardforkByTD?: BNLike
-  private _supportedHardforks: Array<string | Hardfork> = []
 
   /**
    * Cached emit() function, not for public usage
@@ -213,22 +212,22 @@ export default class VM extends AsyncEventEmitter {
       this._opcodes = getOpcodesForHF(this._common)
     })
 
-    this._supportedHardforks = [
-      'chainstart',
-      'homestead',
-      'dao',
-      'tangerineWhistle',
-      'spuriousDragon',
-      'byzantium',
-      'constantinople',
-      'petersburg',
-      'istanbul',
-      'muirGlacier',
-      'berlin',
-      'london',
-      'arrowGlacier',
+    const supportedHardforks = [
+      Hardfork.Chainstart,
+      Hardfork.Homestead,
+      Hardfork.Dao,
+      Hardfork.TangerineWhistle,
+      Hardfork.SpuriousDragon,
+      Hardfork.Byzantium,
+      Hardfork.Constantinople,
+      Hardfork.Petersburg,
+      Hardfork.Istanbul,
+      Hardfork.MuirGlacier,
+      Hardfork.Berlin,
+      Hardfork.London,
+      Hardfork.ArrowGlacier,
     ]
-    if (!this._supportedHardforks.includes(this._common.hardfork())) {
+    if (!supportedHardforks.includes(this._common.hardfork() as Hardfork)) {
       throw new Error(
         `Hardfork ${this._common.hardfork()} not set as supported in supportedHardforks`
       )

--- a/packages/vm/src/index.ts
+++ b/packages/vm/src/index.ts
@@ -117,10 +117,6 @@ export interface VMOpts {
    * pointing to a Shanghai block: this will lead to set the HF as Shanghai and not the Merge).
    */
   hardforkByTD?: BNLike
-  /**
-   * Limit parameter returns to the given hardforks
-   */
-  supportedHardforks?: Array<string | Hardfork>
 }
 
 /**
@@ -147,7 +143,7 @@ export default class VM extends AsyncEventEmitter {
   protected _opcodes: OpcodeList
   protected readonly _hardforkByBlockNumber: boolean
   protected readonly _hardforkByTD?: BNLike
-  // private _supportedHardforks: Array<string | Hardfork> = []
+  private _supportedHardforks: Array<string | Hardfork> = []
 
   /**
    * Cached emit() function, not for public usage
@@ -210,31 +206,33 @@ export default class VM extends AsyncEventEmitter {
       this._common = opts.common
     } else {
       const DEFAULT_CHAIN = Chain.Mainnet
-      // const supportedHardforks = [
-      //   'chainstart',
-      //   'homestead',
-      //   'dao',
-      //   'tangerineWhistle',
-      //   'spuriousDragon',
-      //   'byzantium',
-      //   'constantinople',
-      //   'petersburg',
-      //   'istanbul',
-      //   'muirGlacier',
-      //   'berlin',
-      //   'arrowGlacier',
-      // ]
 
-      this._common = new Common({
-        chain: DEFAULT_CHAIN,
-        // supportedHardforks,
-      })
-
-      // this._supportedHardforks = supportedHardforks
+      this._common = new Common({ chain: DEFAULT_CHAIN })
     }
     this._common.on('hardforkChanged', () => {
       this._opcodes = getOpcodesForHF(this._common)
     })
+
+    this._supportedHardforks = [
+      'chainstart',
+      'homestead',
+      'dao',
+      'tangerineWhistle',
+      'spuriousDragon',
+      'byzantium',
+      'constantinople',
+      'petersburg',
+      'istanbul',
+      'muirGlacier',
+      'berlin',
+      'london',
+      'arrowGlacier',
+    ]
+    if (!this._supportedHardforks.includes(this._common.hardfork())) {
+      throw new Error(
+        `Hardfork ${this._common.hardfork()} not set as supported in supportedHardforks`
+      )
+    }
 
     // Set list of opcodes based on HF
     // TODO: make this EIP-friendly
@@ -269,14 +267,6 @@ export default class VM extends AsyncEventEmitter {
       } else {
         this._mcl = mcl
       }
-    }
-
-    if (opts.supportedHardforks) {
-      const hardfork = this._common.hardfork()
-      if (!opts.supportedHardforks.includes(hardfork)) {
-        throw new Error(`Hardfork ${hardfork} not set as supported in supportedHardforks`)
-      }
-      // this._supportedHardforks = opts.supportedHardforks
     }
 
     // Safeguard if "process" is not available (browser)

--- a/packages/vm/tests/api/index.spec.ts
+++ b/packages/vm/tests/api/index.spec.ts
@@ -66,14 +66,11 @@ tape('VM -> basic instantiation / boolean switches', (t) => {
   })
 })
 
-tape('VM -> supportedHardforks option', (t) => {
+tape('VM -> supportedHardforks', (t) => {
   t.test('should throw when common is set to an unsupported hardfork', async (st) => {
-    const common = new Common({ chain: Chain.Mainnet })
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Merge })
     try {
-      await VM.create({
-        common,
-        supportedHardforks: [Hardfork.Byzantium, Hardfork.Constantinople],
-      })
+      await VM.create({ common })
       st.fail('should have failed for unsupported hardfork')
     } catch (e: any) {
       st.ok(e.message.includes('supportedHardforks'))
@@ -83,10 +80,7 @@ tape('VM -> supportedHardforks option', (t) => {
 
   t.test('should succeed when common is set to a supported hardfork', async (st) => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium })
-    const vm = await VM.create({
-      common,
-      supportedHardforks: [Hardfork.Byzantium, Hardfork.Constantinople],
-    })
+    const vm = await VM.create({ common })
     st.equal(vm._common.hardfork(), Hardfork.Byzantium)
     st.end()
   })

--- a/packages/vm/tests/api/index.spec.ts
+++ b/packages/vm/tests/api/index.spec.ts
@@ -66,6 +66,32 @@ tape('VM -> basic instantiation / boolean switches', (t) => {
   })
 })
 
+tape('VM -> supportedHardforks option', (t) => {
+  t.test('should throw when common is set to an unsupported hardfork', async (st) => {
+    const common = new Common({ chain: Chain.Mainnet })
+    try {
+      await VM.create({
+        common,
+        supportedHardforks: [Hardfork.Byzantium, Hardfork.Constantinople],
+      })
+      st.fail('should have failed for unsupported hardfork')
+    } catch (e: any) {
+      st.ok(e.message.includes('supportedHardforks'))
+    }
+    st.end()
+  })
+
+  t.test('should succeed when common is set to a supported hardfork', async (st) => {
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium })
+    const vm = await VM.create({
+      common,
+      supportedHardforks: [Hardfork.Byzantium, Hardfork.Constantinople],
+    })
+    st.equal(vm._common.hardfork(), Hardfork.Byzantium)
+    st.end()
+  })
+})
+
 tape('VM -> common (chain, HFs, EIPs)', (t) => {
   t.test('should accept a common object as option', async (st) => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })


### PR DESCRIPTION
Closes #1274

Removing `onlySupported` and `onlyActive` was pretty straightforward, but it took me a bit longer to work out how to move `supportedHardforks` to the `vm` package. When doing so, I realized we might not need to store `opts.supportedHardforks` in the VM instance (e.g. in `this._supportedHardforks`) at all, and instead it just becomes a check at time of instantiation. But I'm not sure if I'm missing something, so I left some potential changes commented out in `packages/vm/src/index.ts`. I can update it either way but wanted to get an initial review to see if I'm on the right track.

I also updated the Common and VM READMEs to reflect the respective changes.