### PR TITLE
Rename coinbase to feeRecipient as per v1.0.0-alpha.5 spec

### DIFF
--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -24,7 +24,7 @@ const MESSAGE_ORDER_RESET_ID = new BN(0)
 
 type ExecutionPayloadV1 = {
   parentHash: string // DATA, 32 Bytes
-  coinbase: string // DATA, 20 Bytes
+  feeRecipient: string // DATA, 20 Bytes
   stateRoot: string // DATA, 32 Bytes
   receiptsRoot: string // DATA, 32 bytes
   logsBloom: string // DATA, 256 Bytes
@@ -74,7 +74,7 @@ const blockToExecutionPayload = (block: Block) => {
   const payload: ExecutionPayloadV1 = {
     blockNumber: header.number!,
     parentHash: header.parentHash!,
-    coinbase: header.coinbase!,
+    feeRecipient: header.coinbase!,
     stateRoot: header.stateRoot!,
     receiptsRoot: header.receiptTrie!,
     logsBloom: header.logsBloom!,
@@ -197,9 +197,9 @@ export class Engine {
       [
         validators.object({
           parentHash: validators.blockHash,
-          coinbase: validators.address,
+          feeRecipient: validators.address,
           stateRoot: validators.hex,
-          receiptRoot: validators.hex,
+          receiptsRoot: validators.hex,
           logsBloom: validators.hex,
           random: validators.hex,
           blockNumber: validators.hex,

--- a/packages/client/test/rpc/engine/executePayloadV1.spec.ts
+++ b/packages/client/test/rpc/engine/executePayloadV1.spec.ts
@@ -8,7 +8,7 @@ const method = 'engine_executePayloadV1'
 const validTestVector = {
   blockHash: '0xb084c10440f05f5a23a55d1d7ebcb1b3892935fb56f23cdc9a7f42c348eed174',
   parentHash: '0xa0513a503d5bd6e89a144c3268e5b7e9da9dbf63df125a360e3950a7d0d67131',
-  coinbase: '0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b',
+  feeRecipient: '0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b',
   stateRoot: '0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45',
   receiptsRoot: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
   logsBloom:


### PR DESCRIPTION
Engine Api spec for merge renamed few fields of the execution payload. This PR renames some of the fields which got skipped in the kintsugi branch.


Spec Reference: https://github.com/ethereum/execution-apis/releases/tag/v1.0.0-alpha.5