### PR TITLE
VM, Client: Remove ProofStateManager interface

### DIFF
--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -31,7 +31,7 @@ import type {
   TxReceipt,
 } from '@ethereumjs/vm/dist/types'
 import type { Log } from '@ethereumjs/vm/dist/evm/types'
-import type { Proof, ProofStateManager } from '@ethereumjs/vm/dist/state'
+import type { Proof } from '@ethereumjs/vm/dist/state'
 import type { EthereumClient } from '../..'
 import type { Chain } from '../../blockchain'
 import type { EthProtocol } from '../../net/protocol'
@@ -928,11 +928,15 @@ export class Eth {
     }
 
     const vm = this._vm.copy()
+
+    if (!('getProof' in vm.stateManager)) {
+      throw new Error('getProof RPC method not supported with the StateManager provided')
+    }
     await vm.stateManager.setStateRoot(block.header.stateRoot)
 
     const address = Address.fromString(addressHex)
     const slots = slotsHex.map((slotHex) => setLengthLeft(toBuffer(slotHex), 32))
-    const proof = await (vm.stateManager as ProofStateManager).getProof(address, slots)
+    const proof = await vm.stateManager.getProof!(address, slots)
     return proof
   }
 

--- a/packages/vm/src/state/index.ts
+++ b/packages/vm/src/state/index.ts
@@ -1,3 +1,3 @@
-export { StateManager, EIP2929StateManager, ProofStateManager } from './interface'
+export { StateManager, EIP2929StateManager } from './interface'
 export { BaseStateManager } from './baseStateManager'
 export { default as DefaultStateManager, Proof } from './stateManager'

--- a/packages/vm/src/state/interface.ts
+++ b/packages/vm/src/state/interface.ts
@@ -34,6 +34,8 @@ export interface StateManager {
   accountExists(address: Address): Promise<boolean>
   cleanupTouchedAccounts(): Promise<void>
   clearOriginalStorageCache(): void
+  getProof?(address: Address, storageSlots: Buffer[]): Promise<Proof>
+  verifyProof?(proof: Proof): Promise<boolean>
 }
 
 export interface EIP2929StateManager extends StateManager {
@@ -43,14 +45,4 @@ export interface EIP2929StateManager extends StateManager {
   isWarmedStorage(address: Buffer, slot: Buffer): boolean
   clearWarmedAccounts(): void
   generateAccessList?(addressesRemoved: Address[], addressesOnlyStorage: Address[]): AccessList
-}
-
-/**
- * Note: if a StateManager supports both EIP2929StateManager and
- * the ProofStateManager interface, it can be cast as:
- * <EIP2929StateManager & ProofStateManager>(StateManager)
- */
-export interface ProofStateManager extends StateManager {
-  getProof(address: Address, storageSlots: Buffer[]): Promise<Proof>
-  verifyProof(proof: Proof): Promise<boolean>
 }


### PR DESCRIPTION
Part of #1533
(to be done towards `master` since generic and relevant for minor releases)

I had some doubts on the ProofStateManager for some time since this would add some additional complexity on the StateManager interface collection. Now I directly stumbled upon this on the start of trying to add a VerkleTrie StateManager.

So I wouldn't want (couldn't) implement this functionality in such a state manager. But then in these RPC code parts of the client I would need some somewhat ugly `any` casts (and then do this functionality check anyhow) to get this working.

So I think this is a somewhat more flexible and practical solution - to add these as optional methods to the generic interface. Then TypeScript knows that this functionality might be there (people who use this would as well) and one is generally incentiviced to put some guard around that.

An alternative would be to generally keep this a bit more under radar and not expose at all atm (since this is very much an "extra" functionality) and for now in our single place own internal usage for now go with the `any` cast + method check solution.

Then this would cause no friction/confusion for anyone at all. I am somewhat more inclined to this solution here, but not a totally strong opinion.