### PR TITLE
ci: add concurrency

### DIFF
--- a/.github/workflows/block-build.yml
+++ b/.github/workflows/block-build.yml
@@ -13,6 +13,10 @@ defaults:
   run:
     working-directory: packages/block
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-block:
     runs-on: ubuntu-latest

--- a/.github/workflows/blockchain-build.yml
+++ b/.github/workflows/blockchain-build.yml
@@ -13,6 +13,10 @@ defaults:
   run:
     working-directory: packages/blockchain
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-blockchain:
     runs-on: ubuntu-latest

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -13,6 +13,10 @@ defaults:
   run:
     working-directory: packages/client
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-client:
     runs-on: ubuntu-latest

--- a/.github/workflows/common-build.yml
+++ b/.github/workflows/common-build.yml
@@ -13,6 +13,10 @@ defaults:
   run:
     working-directory: packages/common
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-common:
     runs-on: ubuntu-latest

--- a/.github/workflows/devp2p-build.yml
+++ b/.github/workflows/devp2p-build.yml
@@ -13,6 +13,10 @@ defaults:
   run:
     working-directory: packages/devp2p
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-devp2p:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-hardhat.yml
+++ b/.github/workflows/e2e-hardhat.yml
@@ -9,6 +9,10 @@ on:
 env:
   cwd: ${{github.workspace}}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   e2e-hardhat:
     runs-on: ubuntu-latest

--- a/.github/workflows/ethash-build.yml
+++ b/.github/workflows/ethash-build.yml
@@ -13,6 +13,10 @@ defaults:
   run:
     working-directory: packages/ethash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-ethash:
     runs-on: ubuntu-latest

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -2,8 +2,13 @@ name: Packages examples
 on:
   push:
     branches: [master, develop]
+    tags: ['*']
   pull_request:
     types: [opened, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   test-examples:

--- a/.github/workflows/node-versions.yml
+++ b/.github/workflows/node-versions.yml
@@ -1,9 +1,6 @@
-#
 # This special file aims to run node tests for each relevant node version.
 # A relevant node version can be: active, current, maintenance or EOL with some months of tolerance
 # For more details, please check ./scripts/node-versions.js
-#
-
 name: Node versions
 on:
   schedule:

--- a/.github/workflows/rlp-build.yml
+++ b/.github/workflows/rlp-build.yml
@@ -15,6 +15,10 @@ defaults:
   run:
     working-directory: packages/rlp
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-rlp:
     runs-on: ubuntu-latest

--- a/.github/workflows/trie-build.yml
+++ b/.github/workflows/trie-build.yml
@@ -13,6 +13,10 @@ defaults:
   run:
     working-directory: packages/trie
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-trie:
     runs-on: ubuntu-latest

--- a/.github/workflows/tx-build.yml
+++ b/.github/workflows/tx-build.yml
@@ -13,6 +13,10 @@ defaults:
   run:
     working-directory: packages/tx
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-tx:
     runs-on: ubuntu-latest

--- a/.github/workflows/util-build.yml
+++ b/.github/workflows/util-build.yml
@@ -13,6 +13,10 @@ defaults:
   run:
     working-directory: packages/util
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-util:
     runs-on: ubuntu-latest

--- a/.github/workflows/vm-build.yml
+++ b/.github/workflows/vm-build.yml
@@ -11,6 +11,10 @@ defaults:
   run:
     working-directory: packages/vm
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test-vm-api:
     runs-on: ubuntu-latest

--- a/.github/workflows/vm-pr.yml
+++ b/.github/workflows/vm-pr.yml
@@ -10,6 +10,10 @@ defaults:
   run:
     working-directory: packages/vm
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   vm-api:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a new feature recently added to GitHub Action workflows, concurrency: https://docs.github.com/en/actions/using-jobs/using-concurrency

This allows us to automatically cancel previous runs for the same PR, rather than manually doing it or waiting for the outdated runs to finish.

To test, I will push a commit right after this to ensure that the behavior works as expected.