### PR TITLE
vm: skip `_runStepHook` method if no step event listener

### DIFF
--- a/packages/vm/src/evm/interpreter.ts
+++ b/packages/vm/src/evm/interpreter.ts
@@ -150,7 +150,11 @@ export default class Interpreter {
       await dynamicGasHandler(this._runState, gas, this._vm._common)
     }
 
-    await this._runStepHook(gas, gasLimitClone)
+    if (this._vm.listenerCount('step') > 0) {
+      // Only run this stepHook function if there is an event listener (e.g. test runner)
+      // since its sole purpose is to emit the step event which is not used anywhere else
+      await this._runStepHook(gas, gasLimitClone)
+    }
 
     // Check for invalid opcode
     if (opInfo.name === 'INVALID') {


### PR DESCRIPTION
Adds a check in the `interpreter` to skip the `_runStepHook` function if there are no `step` event listeners since this method's sole purpose is to create and emit the `step` event.  The `step` is only used in tests in our code base so this should produce some (likely minor) overall improvement in VM performance since this function is run on each step in VM execution.