### PR TITLE
vm: fix keyMap iterator in blockchain test runner

### DIFF
--- a/packages/vm/tests/util.ts
+++ b/packages/vm/tests/util.ts
@@ -150,9 +150,9 @@ export async function verifyPostConditions(state: any, testData: any, t: tape.Te
 
     stream.on('end', async function () {
       await Promise.all(queue)
-      Object.entries(keyMap).forEach((entry: any) => {
-        t.fail('Missing account!: ' + <string>entry[1])
-      })
+      for (const entry of Object.entries(keyMap)) {
+        t.fail(`Missing account!: ${entry[1]}`)
+      }
 
       resolve()
     })

--- a/packages/vm/tests/util.ts
+++ b/packages/vm/tests/util.ts
@@ -150,10 +150,9 @@ export async function verifyPostConditions(state: any, testData: any, t: tape.Te
 
     stream.on('end', async function () {
       await Promise.all(queue)
-
-      for (const hash of keyMap) {
-        t.fail('Missing account!: ' + <string>keyMap[hash])
-      }
+      Object.entries(keyMap).forEach((entry: any) => {
+        t.fail('Missing account!: ' + <string>entry[1])
+      })
 
       resolve()
     })

--- a/packages/vm/tests/util.ts
+++ b/packages/vm/tests/util.ts
@@ -150,8 +150,8 @@ export async function verifyPostConditions(state: any, testData: any, t: tape.Te
 
     stream.on('end', async function () {
       await Promise.all(queue)
-      for (const entry of Object.entries(keyMap)) {
-        t.fail(`Missing account!: ${entry[1]}`)
+      for (const [_key, address] of Object.entries(keyMap)) {
+        t.fail(`Missing account!: ${address}`)
       }
 
       resolve()

--- a/packages/vm/tests/util.ts
+++ b/packages/vm/tests/util.ts
@@ -153,7 +153,6 @@ export async function verifyPostConditions(state: any, testData: any, t: tape.Te
       for (const [_key, address] of Object.entries(keyMap)) {
         t.fail(`Missing account!: ${address}`)
       }
-
       resolve()
     })
   })


### PR DESCRIPTION
The `blockchain` test runner currently errors out at the end of the test run when you set the `--debug` if there are no failing tests.  This can be seen by running the below command on the current master branc.
` npm run tester -- --blockchain --file="dayLimitConstruction.json" --debug` and noting the output
```
ok 12 correct storage value
/home/jim/development/ethereumjs-monorepo/packages/vm/tests/util.ts:154
      for (const hash of keyMap) {
                         ^
TypeError: keyMap is not iterable
    at TrieReadStream.<anonymous> (/home/jim/development/ethereumjs-monorepo/packages/vm/tests/util.ts:154:26)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

This PR resolves the issue by converting the `for property...of..keyMap` to a proper iterator using `Object.entries` to ensure that the test runner doesn't crash when the `keyMap` is an empty object.