### PR TITLE
Common: method deprecations

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,22 @@
+name: Packages examples
+on:
+  push:
+    branches: [master, develop]
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  test-examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: 'npm'
+
+      - run: npm i
+      - run: npm run examples

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "preinstall": "npm run checkNpmVersion",
     "postinstall": "npm run build --workspaces",
     "checkNpmVersion": "./scripts/check-npm-version.sh",
+    "examples": "npm run examples --workspaces --if-present",
     "clean": "./config/cli/clean-root.sh",
     "e2e:publish": "./scripts/e2e-publish.sh",
     "e2e:resolutions": "node ./scripts/e2e-resolutions.js",

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -249,7 +249,7 @@ export class BlockHeader {
 
     if (this._common.isActivatedEIP(1559)) {
       if (baseFeePerGas === undefined) {
-        const londonHfBlock = this._common.hardforkBlockBN(Hardfork.London)
+        const londonHfBlock = this._common.hardforkBlock(Hardfork.London)
         const isInitialEIP1559Block = londonHfBlock && number.eq(londonHfBlock)
         if (isInitialEIP1559Block) {
           baseFeePerGas = new BN(this._common.param('gasConfig', 'initialBaseFee'))
@@ -566,7 +566,7 @@ export class BlockHeader {
     let parentGasLimit = parentBlockHeader.gasLimit
     // EIP-1559: assume double the parent gas limit on fork block
     // to adopt to the new gas target centered logic
-    const londonHardforkBlock = this._common.hardforkBlockBN(Hardfork.London)
+    const londonHardforkBlock = this._common.hardforkBlock(Hardfork.London)
     if (londonHardforkBlock && this.number.eq(londonHardforkBlock)) {
       const elasticity = new BN(this._common.param('gasConfig', 'elasticityMultiplier'))
       parentGasLimit = parentGasLimit.mul(elasticity)
@@ -716,7 +716,7 @@ export class BlockHeader {
         const msg = this._errorMsg('EIP1559 block has no base fee field')
         throw new Error(msg)
       }
-      const londonHfBlock = this._common.hardforkBlockBN(Hardfork.London)
+      const londonHfBlock = this._common.hardforkBlock(Hardfork.London)
       const isInitialEIP1559Block = londonHfBlock && this.number.eq(londonHfBlock)
       if (isInitialEIP1559Block) {
         const initialBaseFee = new BN(this._common.param('gasConfig', 'initialBaseFee'))
@@ -1012,7 +1012,7 @@ export class BlockHeader {
     if (!this._common.hardforkIsActiveOnChain(Hardfork.Dao)) {
       return
     }
-    const DAOActivationBlock = this._common.hardforkBlockBN(Hardfork.Dao)
+    const DAOActivationBlock = this._common.hardforkBlock(Hardfork.Dao)
     if (!DAOActivationBlock || DAOActivationBlock.isZero() || this.number.lt(DAOActivationBlock)) {
       return
     }

--- a/packages/block/test/block.spec.ts
+++ b/packages/block/test/block.spec.ts
@@ -526,7 +526,7 @@ tape('[Block]: block functions', function (t) {
       const common = new Common({ chain: Chain.Mainnet })
       common.setHardfork(Hardfork.Berlin)
 
-      const mainnetForkBlock = common.hardforkBlockBN(Hardfork.London)
+      const mainnetForkBlock = common.hardforkBlock(Hardfork.London)
       const rootBlock = Block.fromBlockData({
         header: {
           number: mainnetForkBlock!.subn(3),

--- a/packages/block/test/eip1559block.spec.ts
+++ b/packages/block/test/eip1559block.spec.ts
@@ -23,7 +23,7 @@ const genesis = Block.fromBlockData({})
 
 // Small hack to hack in the activation block number
 // (Otherwise there would be need for a custom chain only for testing purposes)
-common.hardforkBlockBN = function (hardfork: string | undefined) {
+common.hardforkBlock = function (hardfork: string | undefined) {
   if (hardfork === 'london') {
     return new BN(1)
   } else if (hardfork === 'dao') {

--- a/packages/block/test/util.ts
+++ b/packages/block/test/util.ts
@@ -24,7 +24,7 @@ function createBlock(
   const number = parentBlock.header.number.addn(1)
   const timestamp = parentBlock.header.timestamp.addn(1)
 
-  const londonHfBlock = common.hardforkBlockBN(Hardfork.London)
+  const londonHfBlock = common.hardforkBlock(Hardfork.London)
   const baseFeePerGas =
     londonHfBlock && number.gt(londonHfBlock) ? parentBlock.header.calcNextBaseFee() : undefined
 

--- a/packages/blockchain/test/pos.spec.ts
+++ b/packages/blockchain/test/pos.spec.ts
@@ -7,7 +7,7 @@ import testnet from './testdata/testnet.json'
 
 const buildChain = async (blockchain: Blockchain, common: Common, height: number) => {
   const blocks: Block[] = []
-  const londonBlockNumber = common.hardforkBlockBN('london')!.toNumber()
+  const londonBlockNumber = common.hardforkBlock('london')!.toNumber()
   const genesis = Block.genesis({}, { common })
   blocks.push(genesis)
 

--- a/packages/client/lib/miner/miner.ts
+++ b/packages/client/lib/miner/miner.ts
@@ -216,7 +216,7 @@ export class Miner {
     }
 
     let baseFeePerGas
-    const londonHardforkBlock = this.config.chainCommon.hardforkBlockBN(Hardfork.London)
+    const londonHardforkBlock = this.config.chainCommon.hardforkBlock(Hardfork.London)
     const isInitialEIP1559Block = londonHardforkBlock && number.eq(londonHardforkBlock)
     if (isInitialEIP1559Block) {
       // Get baseFeePerGas from `paramByEIP` since 1559 not currently active on common

--- a/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
+++ b/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
@@ -9,7 +9,7 @@ import { checkError } from '../util'
 const method = 'eth_sendRawTransaction'
 
 tape(`${method}: call with valid arguments`, async (t) => {
-  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlockBN(Hardfork.London)
+  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlock(Hardfork.London)
   const { server } = baseSetup({ syncTargetHeight })
 
   // Mainnet EIP-1559 tx
@@ -44,7 +44,7 @@ tape(`${method}: call with sync target height not set yet`, async (t) => {
 })
 
 tape(`${method}: call with invalid tx (wrong chain ID)`, async (t) => {
-  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlockBN(Hardfork.London)
+  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlock(Hardfork.London)
   const { server } = baseSetup({ syncTargetHeight })
 
   // Baikal EIP-1559 tx
@@ -57,7 +57,7 @@ tape(`${method}: call with invalid tx (wrong chain ID)`, async (t) => {
 })
 
 tape(`${method}: call with unsigned tx`, async (t) => {
-  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlockBN(Hardfork.London)
+  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlock(Hardfork.London)
   const { server } = baseSetup({ syncTargetHeight })
 
   // Mainnet EIP-1559 tx
@@ -79,7 +79,7 @@ tape(`${method}: call with unsigned tx`, async (t) => {
 })
 
 tape(`${method}: call with no peers`, async (t) => {
-  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlockBN(Hardfork.London)
+  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlock(Hardfork.London)
   const { server } = baseSetup({ syncTargetHeight, noPeers: true })
 
   // Mainnet EIP-1559 tx

--- a/packages/common/docs/classes/default.md
+++ b/packages/common/docs/classes/default.md
@@ -24,7 +24,10 @@ can be created via the main constructor and the [CommonOpts.customChains](../int
 ### Properties
 
 - [DEFAULT\_HARDFORK](default.md#default_hardfork)
+- [captureRejectionSymbol](default.md#capturerejectionsymbol)
+- [captureRejections](default.md#capturerejections)
 - [defaultMaxListeners](default.md#defaultmaxlisteners)
+- [errorMonitor](default.md#errormonitor)
 
 ### Methods
 
@@ -56,7 +59,6 @@ can be created via the main constructor and the [CommonOpts.customChains](../int
 - [gteHardfork](default.md#gtehardfork)
 - [hardfork](default.md#hardfork)
 - [hardforkBlock](default.md#hardforkblock)
-- [hardforkBlockBN](default.md#hardforkblockbn)
 - [hardforkForForkHash](default.md#hardforkforforkhash)
 - [hardforkGteHardfork](default.md#hardforkgtehardfork)
 - [hardforkIsActiveOnBlock](default.md#hardforkisactiveonblock)
@@ -91,8 +93,10 @@ can be created via the main constructor and the [CommonOpts.customChains](../int
 - [setMaxListeners](default.md#setmaxlisteners)
 - [custom](default.md#custom)
 - [forCustomChain](default.md#forcustomchain)
+- [getEventListeners](default.md#geteventlisteners)
 - [isSupportedChainId](default.md#issupportedchainid)
 - [listenerCount](default.md#listenercount)
+- [on](default.md#on)
 - [once](default.md#once)
 
 ## Constructors
@@ -113,7 +117,7 @@ EventEmitter.constructor
 
 #### Defined in
 
-[packages/common/src/index.ts:351](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L351)
+[packages/common/src/index.ts:353](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L353)
 
 ## Properties
 
@@ -123,7 +127,37 @@ EventEmitter.constructor
 
 #### Defined in
 
-[packages/common/src/index.ts:179](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L179)
+[packages/common/src/index.ts:181](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L181)
+
+___
+
+### captureRejectionSymbol
+
+▪ `Static` `Readonly` **captureRejectionSymbol**: typeof [`captureRejectionSymbol`](default.md#capturerejectionsymbol)
+
+#### Inherited from
+
+EventEmitter.captureRejectionSymbol
+
+#### Defined in
+
+node_modules/@types/node/events.d.ts:273
+
+___
+
+### captureRejections
+
+▪ `Static` **captureRejections**: `boolean`
+
+Sets or gets the default captureRejection value for all emitters.
+
+#### Inherited from
+
+EventEmitter.captureRejections
+
+#### Defined in
+
+node_modules/@types/node/events.d.ts:278
 
 ___
 
@@ -137,7 +171,29 @@ EventEmitter.defaultMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:20
+node_modules/@types/node/events.d.ts:279
+
+___
+
+### errorMonitor
+
+▪ `Static` `Readonly` **errorMonitor**: typeof [`errorMonitor`](default.md#errormonitor)
+
+This symbol shall be used to install a listener for only monitoring `'error'`
+events. Listeners installed using this symbol are called before the regular
+`'error'` listeners are called.
+
+Installing a listener using this symbol does not change the behavior once an
+`'error'` event is emitted, therefore the process will still crash if no
+regular `'error'` listener is installed.
+
+#### Inherited from
+
+EventEmitter.errorMonitor
+
+#### Defined in
+
+node_modules/@types/node/events.d.ts:272
 
 ## Methods
 
@@ -161,7 +217,7 @@ Fork hash as hex string
 
 #### Defined in
 
-[packages/common/src/index.ts:932](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L932)
+[packages/common/src/index.ts:922](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L922)
 
 ___
 
@@ -186,7 +242,7 @@ Hardfork chosen to be used
 
 #### Defined in
 
-[packages/common/src/index.ts:520](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L520)
+[packages/common/src/index.ts:522](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L522)
 
 ___
 
@@ -210,7 +266,7 @@ Dictionary with hardfork params
 
 #### Defined in
 
-[packages/common/src/index.ts:534](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L534)
+[packages/common/src/index.ts:536](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L536)
 
 ___
 
@@ -234,7 +290,7 @@ True if hardfork is supported
 
 #### Defined in
 
-[packages/common/src/index.ts:547](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L547)
+[packages/common/src/index.ts:549](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L549)
 
 ___
 
@@ -259,7 +315,7 @@ Hardfork name
 
 #### Defined in
 
-[packages/common/src/index.ts:819](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L819)
+[packages/common/src/index.ts:820](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L820)
 
 ___
 
@@ -284,7 +340,7 @@ Array with hardfork arrays
 
 #### Defined in
 
-[packages/common/src/index.ts:800](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L800)
+[packages/common/src/index.ts:801](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L801)
 
 ___
 
@@ -309,19 +365,23 @@ True if HF is active on block number
 
 #### Defined in
 
-[packages/common/src/index.ts:729](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L729)
+[packages/common/src/index.ts:730](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L730)
 
 ___
 
 ### addListener
 
-▸ **addListener**(`event`, `listener`): [`default`](default.md)
+▸ **addListener**(`eventName`, `listener`): [`default`](default.md)
+
+Alias for `emitter.on(eventName, listener)`.
+
+**`since`** v0.1.26
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `event` | `string` \| `symbol` |
+| `eventName` | `string` \| `symbol` |
 | `listener` | (...`args`: `any`[]) => `void` |
 
 #### Returns
@@ -334,7 +394,7 @@ EventEmitter.addListener
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:595
+node_modules/@types/node/events.d.ts:299
 
 ___
 
@@ -352,7 +412,7 @@ Dict with bootstrap nodes
 
 #### Defined in
 
-[packages/common/src/index.ts:1046](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1046)
+[packages/common/src/index.ts:1038](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1038)
 
 ___
 
@@ -372,7 +432,7 @@ chain Id
 
 #### Defined in
 
-[packages/common/src/index.ts:1071](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1071)
+[packages/common/src/index.ts:1063](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1063)
 
 ___
 
@@ -390,7 +450,7 @@ chain Id
 
 #### Defined in
 
-[packages/common/src/index.ts:1079](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1079)
+[packages/common/src/index.ts:1071](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1071)
 
 ___
 
@@ -408,7 +468,7 @@ chain name (lower case)
 
 #### Defined in
 
-[packages/common/src/index.ts:1087](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1087)
+[packages/common/src/index.ts:1079](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1079)
 
 ___
 
@@ -430,7 +490,7 @@ Note: This value can update along a hardfork.
 
 #### Defined in
 
-[packages/common/src/index.ts:1147](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1147)
+[packages/common/src/index.ts:1139](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1139)
 
 ___
 
@@ -457,7 +517,7 @@ Note: This value can update along a hardfork.
 
 #### Defined in
 
-[packages/common/src/index.ts:1177](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1177)
+[packages/common/src/index.ts:1169](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1169)
 
 ___
 
@@ -476,7 +536,7 @@ Note: This value can update along a hardfork.
 
 #### Defined in
 
-[packages/common/src/index.ts:1122](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1122)
+[packages/common/src/index.ts:1114](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1114)
 
 ___
 
@@ -492,7 +552,7 @@ Returns a deep copy of this {@link Common} instance.
 
 #### Defined in
 
-[packages/common/src/index.ts:1198](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1198)
+[packages/common/src/index.ts:1190](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1190)
 
 ___
 
@@ -510,7 +570,7 @@ Array of DNS ENR urls
 
 #### Defined in
 
-[packages/common/src/index.ts:1054](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1054)
+[packages/common/src/index.ts:1046](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1046)
 
 ___
 
@@ -528,19 +588,59 @@ List of EIPs
 
 #### Defined in
 
-[packages/common/src/index.ts:1112](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1112)
+[packages/common/src/index.ts:1104](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1104)
 
 ___
 
 ### emit
 
-▸ **emit**(`event`, ...`args`): `boolean`
+▸ **emit**(`eventName`, ...`args`): `boolean`
+
+Synchronously calls each of the listeners registered for the event named`eventName`, in the order they were registered, passing the supplied arguments
+to each.
+
+Returns `true` if the event had listeners, `false` otherwise.
+
+```js
+const EventEmitter = require('events');
+const myEmitter = new EventEmitter();
+
+// First listener
+myEmitter.on('event', function firstListener() {
+  console.log('Helloooo! first listener');
+});
+// Second listener
+myEmitter.on('event', function secondListener(arg1, arg2) {
+  console.log(`event with parameters ${arg1}, ${arg2} in second listener`);
+});
+// Third listener
+myEmitter.on('event', function thirdListener(...args) {
+  const parameters = args.join(', ');
+  console.log(`event with parameters ${parameters} in third listener`);
+});
+
+console.log(myEmitter.listeners('event'));
+
+myEmitter.emit('event', 1, 2, 3, 4, 5);
+
+// Prints:
+// [
+//   [Function: firstListener],
+//   [Function: secondListener],
+//   [Function: thirdListener]
+// ]
+// Helloooo! first listener
+// event with parameters 1, 2 in second listener
+// event with parameters 1, 2, 3, 4, 5 in third listener
+```
+
+**`since`** v0.1.26
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `event` | `string` \| `symbol` |
+| `eventName` | `string` \| `symbol` |
 | `...args` | `any`[] |
 
 #### Returns
@@ -553,13 +653,31 @@ EventEmitter.emit
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:605
+node_modules/@types/node/events.d.ts:555
 
 ___
 
 ### eventNames
 
 ▸ **eventNames**(): (`string` \| `symbol`)[]
+
+Returns an array listing the events for which the emitter has registered
+listeners. The values in the array are strings or `Symbol`s.
+
+```js
+const EventEmitter = require('events');
+const myEE = new EventEmitter();
+myEE.on('foo', () => {});
+myEE.on('bar', () => {});
+
+const sym = Symbol('symbol');
+myEE.on(sym, () => {});
+
+console.log(myEE.eventNames());
+// Prints: [ 'foo', 'bar', Symbol(symbol) ]
+```
+
+**`since`** v6.0.0
 
 #### Returns
 
@@ -571,7 +689,7 @@ EventEmitter.eventNames
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:610
+node_modules/@types/node/events.d.ts:614
 
 ___
 
@@ -593,7 +711,7 @@ Returns an eth/64 compliant fork hash (EIP-2124)
 
 #### Defined in
 
-[packages/common/src/index.ts:964](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L964)
+[packages/common/src/index.ts:954](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L954)
 
 ___
 
@@ -611,7 +729,7 @@ Genesis dictionary
 
 #### Defined in
 
-[packages/common/src/index.ts:993](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L993)
+[packages/common/src/index.ts:983](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L983)
 
 ___
 
@@ -628,7 +746,7 @@ all values are provided as hex-prefixed strings.
 
 #### Defined in
 
-[packages/common/src/index.ts:1001](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1001)
+[packages/common/src/index.ts:991](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L991)
 
 ___
 
@@ -658,13 +776,18 @@ The name of the HF
 
 #### Defined in
 
-[packages/common/src/index.ts:447](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L447)
+[packages/common/src/index.ts:449](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L449)
 
 ___
 
 ### getMaxListeners
 
 ▸ **getMaxListeners**(): `number`
+
+Returns the current max listener value for the `EventEmitter` which is either
+set by `emitter.setMaxListeners(n)` or defaults to [defaultMaxListeners](default.md#defaultmaxlisteners).
+
+**`since`** v1.0.0
 
 #### Returns
 
@@ -676,7 +799,7 @@ EventEmitter.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:602
+node_modules/@types/node/events.d.ts:471
 
 ___
 
@@ -701,7 +824,7 @@ True if hardfork set is greater than hardfork provided
 
 #### Defined in
 
-[packages/common/src/index.ts:772](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L772)
+[packages/common/src/index.ts:773](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L773)
 
 ___
 
@@ -719,39 +842,13 @@ Hardfork name
 
 #### Defined in
 
-[packages/common/src/index.ts:1062](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1062)
+[packages/common/src/index.ts:1054](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1054)
 
 ___
 
 ### hardforkBlock
 
-▸ **hardforkBlock**(`hardfork?`): ``null`` \| `number`
-
-Returns the hardfork change block for hardfork provided or set
-
-**`deprecated`** Please use {@link Common.hardforkBlockBN} for large number support
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `hardfork?` | `string` | Hardfork name, optional if HF set |
-
-#### Returns
-
-``null`` \| `number`
-
-Block number or null if unscheduled
-
-#### Defined in
-
-[packages/common/src/index.ts:834](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L834)
-
-___
-
-### hardforkBlockBN
-
-▸ **hardforkBlockBN**(`hardfork?`): ``null`` \| `BN`
+▸ **hardforkBlock**(`hardfork?`): ``null`` \| `BN`
 
 Returns the hardfork change block for hardfork provided or set
 
@@ -769,7 +866,7 @@ Block number or null if unscheduled
 
 #### Defined in
 
-[packages/common/src/index.ts:844](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L844)
+[packages/common/src/index.ts:834](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L834)
 
 ___
 
@@ -791,7 +888,7 @@ Array with hardfork data (name, block, forkHash)
 
 #### Defined in
 
-[packages/common/src/index.ts:982](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L982)
+[packages/common/src/index.ts:972](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L972)
 
 ___
 
@@ -817,7 +914,7 @@ True if HF1 gte HF2
 
 #### Defined in
 
-[packages/common/src/index.ts:740](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L740)
+[packages/common/src/index.ts:741](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L741)
 
 ___
 
@@ -843,7 +940,7 @@ True if HF is active on block number
 
 #### Defined in
 
-[packages/common/src/index.ts:708](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L708)
+[packages/common/src/index.ts:709](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L709)
 
 ___
 
@@ -868,7 +965,7 @@ True if hardfork is active on the chain
 
 #### Defined in
 
-[packages/common/src/index.ts:782](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L782)
+[packages/common/src/index.ts:783](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L783)
 
 ___
 
@@ -892,7 +989,7 @@ Total difficulty or null if no set
 
 #### Defined in
 
-[packages/common/src/index.ts:858](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L858)
+[packages/common/src/index.ts:848](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L848)
 
 ___
 
@@ -910,7 +1007,7 @@ Array with arrays of hardforks
 
 #### Defined in
 
-[packages/common/src/index.ts:1038](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1038)
+[packages/common/src/index.ts:1030](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1030)
 
 ___
 
@@ -937,7 +1034,7 @@ by the [CommonOpts.eips](../interfaces/CommonOpts.md#eips) constructor option
 
 #### Defined in
 
-[packages/common/src/index.ts:686](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L686)
+[packages/common/src/index.ts:687](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L687)
 
 ___
 
@@ -962,7 +1059,7 @@ True if blockNumber is HF block
 
 #### Defined in
 
-[packages/common/src/index.ts:873](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L873)
+[packages/common/src/index.ts:863](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L863)
 
 ___
 
@@ -987,19 +1084,23 @@ True if blockNumber is HF block
 
 #### Defined in
 
-[packages/common/src/index.ts:919](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L919)
+[packages/common/src/index.ts:909](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L909)
 
 ___
 
 ### listenerCount
 
-▸ **listenerCount**(`type`): `number`
+▸ **listenerCount**(`eventName`): `number`
+
+Returns the number of listeners listening to the event named `eventName`.
+
+**`since`** v3.2.0
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `type` | `string` \| `symbol` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `eventName` | `string` \| `symbol` | The name of the event being listened for |
 
 #### Returns
 
@@ -1011,19 +1112,31 @@ EventEmitter.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:606
+node_modules/@types/node/events.d.ts:561
 
 ___
 
 ### listeners
 
-▸ **listeners**(`event`): `Function`[]
+▸ **listeners**(`eventName`): `Function`[]
+
+Returns a copy of the array of listeners for the event named `eventName`.
+
+```js
+server.on('connection', (stream) => {
+  console.log('someone connected!');
+});
+console.log(util.inspect(server.listeners('connection')));
+// Prints: [ [Function] ]
+```
+
+**`since`** v0.1.26
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `event` | `string` \| `symbol` |
+| `eventName` | `string` \| `symbol` |
 
 #### Returns
 
@@ -1035,7 +1148,7 @@ EventEmitter.listeners
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:603
+node_modules/@types/node/events.d.ts:484
 
 ___
 
@@ -1055,7 +1168,7 @@ network Id
 
 #### Defined in
 
-[packages/common/src/index.ts:1096](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1096)
+[packages/common/src/index.ts:1088](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1088)
 
 ___
 
@@ -1073,7 +1186,7 @@ network Id
 
 #### Defined in
 
-[packages/common/src/index.ts:1104](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1104)
+[packages/common/src/index.ts:1096](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L1096)
 
 ___
 
@@ -1099,7 +1212,7 @@ Block number or null if not available
 
 #### Defined in
 
-[packages/common/src/index.ts:886](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L886)
+[packages/common/src/index.ts:876](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L876)
 
 ___
 
@@ -1123,19 +1236,23 @@ Block number or null if not available
 
 #### Defined in
 
-[packages/common/src/index.ts:896](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L896)
+[packages/common/src/index.ts:886](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L886)
 
 ___
 
 ### off
 
-▸ **off**(`event`, `listener`): [`default`](default.md)
+▸ **off**(`eventName`, `listener`): [`default`](default.md)
+
+Alias for `emitter.removeListener()`.
+
+**`since`** v10.0.0
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `event` | `string` \| `symbol` |
+| `eventName` | `string` \| `symbol` |
 | `listener` | (...`args`: `any`[]) => `void` |
 
 #### Returns
@@ -1148,20 +1265,48 @@ EventEmitter.off
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:599
+node_modules/@types/node/events.d.ts:444
 
 ___
 
 ### on
 
-▸ **on**(`event`, `listener`): [`default`](default.md)
+▸ **on**(`eventName`, `listener`): [`default`](default.md)
+
+Adds the `listener` function to the end of the listeners array for the
+event named `eventName`. No checks are made to see if the `listener` has
+already been added. Multiple calls passing the same combination of `eventName`and `listener` will result in the `listener` being added, and called, multiple
+times.
+
+```js
+server.on('connection', (stream) => {
+  console.log('someone connected!');
+});
+```
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+By default, event listeners are invoked in the order they are added. The`emitter.prependListener()` method can be used as an alternative to add the
+event listener to the beginning of the listeners array.
+
+```js
+const myEE = new EventEmitter();
+myEE.on('foo', () => console.log('a'));
+myEE.prependListener('foo', () => console.log('b'));
+myEE.emit('foo');
+// Prints:
+//   b
+//   a
+```
+
+**`since`** v0.1.101
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `event` | `string` \| `symbol` |
-| `listener` | (...`args`: `any`[]) => `void` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `eventName` | `string` \| `symbol` | The name of the event. |
+| `listener` | (...`args`: `any`[]) => `void` | The callback function |
 
 #### Returns
 
@@ -1173,20 +1318,46 @@ EventEmitter.on
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:596
+node_modules/@types/node/events.d.ts:330
 
 ___
 
 ### once
 
-▸ **once**(`event`, `listener`): [`default`](default.md)
+▸ **once**(`eventName`, `listener`): [`default`](default.md)
+
+Adds a **one-time**`listener` function for the event named `eventName`. The
+next time `eventName` is triggered, this listener is removed and then invoked.
+
+```js
+server.once('connection', (stream) => {
+  console.log('Ah, we have our first user!');
+});
+```
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+By default, event listeners are invoked in the order they are added. The`emitter.prependOnceListener()` method can be used as an alternative to add the
+event listener to the beginning of the listeners array.
+
+```js
+const myEE = new EventEmitter();
+myEE.once('foo', () => console.log('a'));
+myEE.prependOnceListener('foo', () => console.log('b'));
+myEE.emit('foo');
+// Prints:
+//   b
+//   a
+```
+
+**`since`** v0.3.0
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `event` | `string` \| `symbol` |
-| `listener` | (...`args`: `any`[]) => `void` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `eventName` | `string` \| `symbol` | The name of the event. |
+| `listener` | (...`args`: `any`[]) => `void` | The callback function |
 
 #### Returns
 
@@ -1198,7 +1369,7 @@ EventEmitter.once
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:597
+node_modules/@types/node/events.d.ts:359
 
 ___
 
@@ -1227,7 +1398,7 @@ The value requested or `null` if not found
 
 #### Defined in
 
-[packages/common/src/index.ts:596](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L596)
+[packages/common/src/index.ts:597](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L597)
 
 ___
 
@@ -1251,7 +1422,7 @@ Returns a parameter for the hardfork active on block number
 
 #### Defined in
 
-[packages/common/src/index.ts:671](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L671)
+[packages/common/src/index.ts:672](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L672)
 
 ___
 
@@ -1277,7 +1448,7 @@ The value requested or `null` if not found
 
 #### Defined in
 
-[packages/common/src/index.ts:649](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L649)
+[packages/common/src/index.ts:650](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L650)
 
 ___
 
@@ -1303,20 +1474,35 @@ The value requested or `null` if not found
 
 #### Defined in
 
-[packages/common/src/index.ts:616](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L616)
+[packages/common/src/index.ts:617](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L617)
 
 ___
 
 ### prependListener
 
-▸ **prependListener**(`event`, `listener`): [`default`](default.md)
+▸ **prependListener**(`eventName`, `listener`): [`default`](default.md)
+
+Adds the `listener` function to the _beginning_ of the listeners array for the
+event named `eventName`. No checks are made to see if the `listener` has
+already been added. Multiple calls passing the same combination of `eventName`and `listener` will result in the `listener` being added, and called, multiple
+times.
+
+```js
+server.prependListener('connection', (stream) => {
+  console.log('someone connected!');
+});
+```
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`since`** v6.0.0
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `event` | `string` \| `symbol` |
-| `listener` | (...`args`: `any`[]) => `void` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `eventName` | `string` \| `symbol` | The name of the event. |
+| `listener` | (...`args`: `any`[]) => `void` | The callback function |
 
 #### Returns
 
@@ -1328,20 +1514,33 @@ EventEmitter.prependListener
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:608
+node_modules/@types/node/events.d.ts:579
 
 ___
 
 ### prependOnceListener
 
-▸ **prependOnceListener**(`event`, `listener`): [`default`](default.md)
+▸ **prependOnceListener**(`eventName`, `listener`): [`default`](default.md)
+
+Adds a **one-time**`listener` function for the event named `eventName` to the_beginning_ of the listeners array. The next time `eventName` is triggered, this
+listener is removed, and then invoked.
+
+```js
+server.prependOnceListener('connection', (stream) => {
+  console.log('Ah, we have our first user!');
+});
+```
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`since`** v6.0.0
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `event` | `string` \| `symbol` |
-| `listener` | (...`args`: `any`[]) => `void` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `eventName` | `string` \| `symbol` | The name of the event. |
+| `listener` | (...`args`: `any`[]) => `void` | The callback function |
 
 #### Returns
 
@@ -1353,19 +1552,48 @@ EventEmitter.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:609
+node_modules/@types/node/events.d.ts:595
 
 ___
 
 ### rawListeners
 
-▸ **rawListeners**(`event`): `Function`[]
+▸ **rawListeners**(`eventName`): `Function`[]
+
+Returns a copy of the array of listeners for the event named `eventName`,
+including any wrappers (such as those created by `.once()`).
+
+```js
+const emitter = new EventEmitter();
+emitter.once('log', () => console.log('log once'));
+
+// Returns a new Array with a function `onceWrapper` which has a property
+// `listener` which contains the original listener bound above
+const listeners = emitter.rawListeners('log');
+const logFnWrapper = listeners[0];
+
+// Logs "log once" to the console and does not unbind the `once` event
+logFnWrapper.listener();
+
+// Logs "log once" to the console and removes the listener
+logFnWrapper();
+
+emitter.on('log', () => console.log('log persistently'));
+// Will return a new Array with a single function bound by `.on()` above
+const newListeners = emitter.rawListeners('log');
+
+// Logs "log persistently" twice
+newListeners[0]();
+emitter.emit('log');
+```
+
+**`since`** v9.4.0
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `event` | `string` \| `symbol` |
+| `eventName` | `string` \| `symbol` |
 
 #### Returns
 
@@ -1377,13 +1605,23 @@ EventEmitter.rawListeners
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:604
+node_modules/@types/node/events.d.ts:514
 
 ___
 
 ### removeAllListeners
 
 ▸ **removeAllListeners**(`event?`): [`default`](default.md)
+
+Removes all listeners, or those of the specified `eventName`.
+
+It is bad practice to remove listeners added elsewhere in the code,
+particularly when the `EventEmitter` instance was created by some other
+component or module (e.g. sockets or file streams).
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`since`** v0.1.26
 
 #### Parameters
 
@@ -1401,19 +1639,98 @@ EventEmitter.removeAllListeners
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:600
+node_modules/@types/node/events.d.ts:455
 
 ___
 
 ### removeListener
 
-▸ **removeListener**(`event`, `listener`): [`default`](default.md)
+▸ **removeListener**(`eventName`, `listener`): [`default`](default.md)
+
+Removes the specified `listener` from the listener array for the event named`eventName`.
+
+```js
+const callback = (stream) => {
+  console.log('someone connected!');
+};
+server.on('connection', callback);
+// ...
+server.removeListener('connection', callback);
+```
+
+`removeListener()` will remove, at most, one instance of a listener from the
+listener array. If any single listener has been added multiple times to the
+listener array for the specified `eventName`, then `removeListener()` must be
+called multiple times to remove each instance.
+
+Once an event is emitted, all listeners attached to it at the
+time of emitting are called in order. This implies that any`removeListener()` or `removeAllListeners()` calls _after_ emitting and_before_ the last listener finishes execution will
+not remove them from`emit()` in progress. Subsequent events behave as expected.
+
+```js
+const myEmitter = new MyEmitter();
+
+const callbackA = () => {
+  console.log('A');
+  myEmitter.removeListener('event', callbackB);
+};
+
+const callbackB = () => {
+  console.log('B');
+};
+
+myEmitter.on('event', callbackA);
+
+myEmitter.on('event', callbackB);
+
+// callbackA removes listener callbackB but it will still be called.
+// Internal listener array at time of emit [callbackA, callbackB]
+myEmitter.emit('event');
+// Prints:
+//   A
+//   B
+
+// callbackB is now removed.
+// Internal listener array [callbackA]
+myEmitter.emit('event');
+// Prints:
+//   A
+```
+
+Because listeners are managed using an internal array, calling this will
+change the position indices of any listener registered _after_ the listener
+being removed. This will not impact the order in which listeners are called,
+but it means that any copies of the listener array as returned by
+the `emitter.listeners()` method will need to be recreated.
+
+When a single function has been added as a handler multiple times for a single
+event (as in the example below), `removeListener()` will remove the most
+recently added instance. In the example the `once('ping')`listener is removed:
+
+```js
+const ee = new EventEmitter();
+
+function pong() {
+  console.log('pong');
+}
+
+ee.on('ping', pong);
+ee.once('ping', pong);
+ee.removeListener('ping', pong);
+
+ee.emit('ping');
+ee.emit('ping');
+```
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`since`** v0.1.26
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `event` | `string` \| `symbol` |
+| `eventName` | `string` \| `symbol` |
 | `listener` | (...`args`: `any`[]) => `void` |
 
 #### Returns
@@ -1426,7 +1743,7 @@ EventEmitter.removeListener
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:598
+node_modules/@types/node/events.d.ts:439
 
 ___
 
@@ -1450,7 +1767,7 @@ The dictionary with parameters set as chain
 
 #### Defined in
 
-[packages/common/src/index.ts:379](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L379)
+[packages/common/src/index.ts:381](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L381)
 
 ___
 
@@ -1472,7 +1789,7 @@ Sets the active EIPs
 
 #### Defined in
 
-[packages/common/src/index.ts:562](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L562)
+[packages/common/src/index.ts:564](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L564)
 
 ___
 
@@ -1494,7 +1811,7 @@ Sets the hardfork to get params for
 
 #### Defined in
 
-[packages/common/src/index.ts:416](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L416)
+[packages/common/src/index.ts:418](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L418)
 
 ___
 
@@ -1524,13 +1841,22 @@ The name of the HF set
 
 #### Defined in
 
-[packages/common/src/index.ts:509](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L509)
+[packages/common/src/index.ts:511](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L511)
 
 ___
 
 ### setMaxListeners
 
 ▸ **setMaxListeners**(`n`): [`default`](default.md)
+
+By default `EventEmitter`s will print a warning if more than `10` listeners are
+added for a particular event. This is a useful default that helps finding
+memory leaks. The `emitter.setMaxListeners()` method allows the limit to be
+modified for this specific `EventEmitter` instance. The value can be set to`Infinity` (or `0`) to indicate an unlimited number of listeners.
+
+Returns a reference to the `EventEmitter`, so that calls can be chained.
+
+**`since`** v0.3.5
 
 #### Parameters
 
@@ -1548,7 +1874,7 @@ EventEmitter.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:601
+node_modules/@types/node/events.d.ts:465
 
 ___
 
@@ -1589,7 +1915,7 @@ the `@ethereumjs/tx` library to a Layer-2 chain).
 
 #### Defined in
 
-[packages/common/src/index.ts:211](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L211)
+[packages/common/src/index.ts:213](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L213)
 
 ___
 
@@ -1617,7 +1943,59 @@ params from [baseChain](../interfaces/CustomCommonOpts.md#basechain) except the 
 
 #### Defined in
 
-[packages/common/src/index.ts:296](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L296)
+[packages/common/src/index.ts:298](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L298)
+
+___
+
+### getEventListeners
+
+▸ `Static` **getEventListeners**(`emitter`, `name`): `Function`[]
+
+Returns a copy of the array of listeners for the event named `eventName`.
+
+For `EventEmitter`s this behaves exactly the same as calling `.listeners` on
+the emitter.
+
+For `EventTarget`s this is the only way to get the event listeners for the
+event target. This is useful for debugging and diagnostic purposes.
+
+```js
+const { getEventListeners, EventEmitter } = require('events');
+
+{
+  const ee = new EventEmitter();
+  const listener = () => console.log('Events are fun');
+  ee.on('foo', listener);
+  getEventListeners(ee, 'foo'); // [listener]
+}
+{
+  const et = new EventTarget();
+  const listener = () => console.log('Events are fun');
+  et.addEventListener('foo', listener);
+  getEventListeners(et, 'foo'); // [listener]
+}
+```
+
+**`since`** v15.2.0
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `emitter` | `DOMEventTarget` \| `EventEmitter` |
+| `name` | `string` \| `symbol` |
+
+#### Returns
+
+`Function`[]
+
+#### Inherited from
+
+EventEmitter.getEventListeners
+
+#### Defined in
+
+node_modules/@types/node/events.d.ts:262
 
 ___
 
@@ -1625,7 +2003,7 @@ ___
 
 ▸ `Static` **isSupportedChainId**(`chainId`): `boolean`
 
-Static method to determine if a {@link chainId} is supported as a standard chain
+Static method to determine if a [chainId](default.md#chainid) is supported as a standard chain
 
 #### Parameters
 
@@ -1641,22 +2019,35 @@ boolean
 
 #### Defined in
 
-[packages/common/src/index.ts:319](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L319)
+[packages/common/src/index.ts:321](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L321)
 
 ___
 
 ### listenerCount
 
-▸ `Static` **listenerCount**(`emitter`, `event`): `number`
+▸ `Static` **listenerCount**(`emitter`, `eventName`): `number`
 
-**`deprecated`** since v4.0.0
+A class method that returns the number of listeners for the given `eventName`registered on the given `emitter`.
+
+```js
+const { EventEmitter, listenerCount } = require('events');
+const myEmitter = new EventEmitter();
+myEmitter.on('event', () => {});
+myEmitter.on('event', () => {});
+console.log(listenerCount(myEmitter, 'event'));
+// Prints: 2
+```
+
+**`since`** v0.9.12
+
+**`deprecated`** Since v3.2.0 - Use `listenerCount` instead.
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `emitter` | `EventEmitter` |
-| `event` | `string` \| `symbol` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `emitter` | `EventEmitter` | The emitter to query |
+| `eventName` | `string` \| `symbol` | The event name |
 
 #### Returns
 
@@ -1668,20 +2059,187 @@ EventEmitter.listenerCount
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:17
+node_modules/@types/node/events.d.ts:234
+
+___
+
+### on
+
+▸ `Static` **on**(`emitter`, `eventName`, `options?`): `AsyncIterableIterator`<`any`\>
+
+```js
+const { on, EventEmitter } = require('events');
+
+(async () => {
+  const ee = new EventEmitter();
+
+  // Emit later on
+  process.nextTick(() => {
+    ee.emit('foo', 'bar');
+    ee.emit('foo', 42);
+  });
+
+  for await (const event of on(ee, 'foo')) {
+    // The execution of this inner block is synchronous and it
+    // processes one event at a time (even with await). Do not use
+    // if concurrent execution is required.
+    console.log(event); // prints ['bar'] [42]
+  }
+  // Unreachable here
+})();
+```
+
+Returns an `AsyncIterator` that iterates `eventName` events. It will throw
+if the `EventEmitter` emits `'error'`. It removes all listeners when
+exiting the loop. The `value` returned by each iteration is an array
+composed of the emitted event arguments.
+
+An `AbortSignal` can be used to cancel waiting on events:
+
+```js
+const { on, EventEmitter } = require('events');
+const ac = new AbortController();
+
+(async () => {
+  const ee = new EventEmitter();
+
+  // Emit later on
+  process.nextTick(() => {
+    ee.emit('foo', 'bar');
+    ee.emit('foo', 42);
+  });
+
+  for await (const event of on(ee, 'foo', { signal: ac.signal })) {
+    // The execution of this inner block is synchronous and it
+    // processes one event at a time (even with await). Do not use
+    // if concurrent execution is required.
+    console.log(event); // prints ['bar'] [42]
+  }
+  // Unreachable here
+})();
+
+process.nextTick(() => ac.abort());
+```
+
+**`since`** v13.6.0, v12.16.0
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `emitter` | `EventEmitter` | - |
+| `eventName` | `string` | The name of the event being listened for |
+| `options?` | `StaticEventEmitterOptions` | - |
+
+#### Returns
+
+`AsyncIterableIterator`<`any`\>
+
+that iterates `eventName` events emitted by the `emitter`
+
+#### Inherited from
+
+EventEmitter.on
+
+#### Defined in
+
+node_modules/@types/node/events.d.ts:217
 
 ___
 
 ### once
 
-▸ `Static` **once**(`emitter`, `event`): `Promise`<`any`[]\>
+▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
+
+Creates a `Promise` that is fulfilled when the `EventEmitter` emits the given
+event or that is rejected if the `EventEmitter` emits `'error'` while waiting.
+The `Promise` will resolve with an array of all the arguments emitted to the
+given event.
+
+This method is intentionally generic and works with the web platform [EventTarget](https://dom.spec.whatwg.org/#interface-eventtarget) interface, which has no special`'error'` event
+semantics and does not listen to the `'error'` event.
+
+```js
+const { once, EventEmitter } = require('events');
+
+async function run() {
+  const ee = new EventEmitter();
+
+  process.nextTick(() => {
+    ee.emit('myevent', 42);
+  });
+
+  const [value] = await once(ee, 'myevent');
+  console.log(value);
+
+  const err = new Error('kaboom');
+  process.nextTick(() => {
+    ee.emit('error', err);
+  });
+
+  try {
+    await once(ee, 'myevent');
+  } catch (err) {
+    console.log('error happened', err);
+  }
+}
+
+run();
+```
+
+The special handling of the `'error'` event is only used when `events.once()`is used to wait for another event. If `events.once()` is used to wait for the
+'`error'` event itself, then it is treated as any other kind of event without
+special handling:
+
+```js
+const { EventEmitter, once } = require('events');
+
+const ee = new EventEmitter();
+
+once(ee, 'error')
+  .then(([err]) => console.log('ok', err.message))
+  .catch((err) => console.log('error', err.message));
+
+ee.emit('error', new Error('boom'));
+
+// Prints: ok boom
+```
+
+An `AbortSignal` can be used to cancel waiting for the event:
+
+```js
+const { EventEmitter, once } = require('events');
+
+const ee = new EventEmitter();
+const ac = new AbortController();
+
+async function foo(emitter, event, signal) {
+  try {
+    await once(emitter, event, { signal });
+    console.log('event emitted!');
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      console.error('Waiting for the event was canceled!');
+    } else {
+      console.error('There was an error', error.message);
+    }
+  }
+}
+
+foo(ee, 'foo', ac.signal);
+ac.abort(); // Abort waiting for the event
+ee.emit('foo'); // Prints: Waiting for the event was canceled!
+```
+
+**`since`** v11.13.0, v10.16.0
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `emitter` | `NodeEventTarget` |
-| `event` | `string` \| `symbol` |
+| `eventName` | `string` \| `symbol` |
+| `options?` | `StaticEventEmitterOptions` |
 
 #### Returns
 
@@ -1693,16 +2251,17 @@ EventEmitter.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:13
+node_modules/@types/node/events.d.ts:157
 
-▸ `Static` **once**(`emitter`, `event`): `Promise`<`any`[]\>
+▸ `Static` **once**(`emitter`, `eventName`, `options?`): `Promise`<`any`[]\>
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `emitter` | `DOMEventTarget` |
-| `event` | `string` |
+| `eventName` | `string` |
+| `options?` | `StaticEventEmitterOptions` |
 
 #### Returns
 
@@ -1714,4 +2273,4 @@ EventEmitter.once
 
 #### Defined in
 
-node_modules/@types/node/events.d.ts:14
+node_modules/@types/node/events.d.ts:158

--- a/packages/common/docs/enums/Chain.md
+++ b/packages/common/docs/enums/Chain.md
@@ -11,6 +11,7 @@
 - [Mainnet](Chain.md#mainnet)
 - [Rinkeby](Chain.md#rinkeby)
 - [Ropsten](Chain.md#ropsten)
+- [Sepolia](Chain.md#sepolia)
 
 ## Enumeration members
 
@@ -61,3 +62,13 @@ ___
 #### Defined in
 
 [packages/common/src/index.ts:61](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L61)
+
+___
+
+### Sepolia
+
+• **Sepolia** = `11155111`
+
+#### Defined in
+
+[packages/common/src/index.ts:65](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L65)

--- a/packages/common/docs/enums/ConsensusAlgorithm.md
+++ b/packages/common/docs/enums/ConsensusAlgorithm.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[packages/common/src/index.ts:93](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L93)
+[packages/common/src/index.ts:95](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L95)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:92](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L92)
+[packages/common/src/index.ts:94](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L94)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:91](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L91)
+[packages/common/src/index.ts:93](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L93)

--- a/packages/common/docs/enums/ConsensusType.md
+++ b/packages/common/docs/enums/ConsensusType.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[packages/common/src/index.ts:87](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L87)
+[packages/common/src/index.ts:89](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L89)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:85](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L85)
+[packages/common/src/index.ts:87](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L87)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:86](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L86)
+[packages/common/src/index.ts:88](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L88)

--- a/packages/common/docs/enums/Hardfork.md
+++ b/packages/common/docs/enums/Hardfork.md
@@ -6,6 +6,7 @@
 
 ### Enumeration members
 
+- [ArrowGlacier](Hardfork.md#arrowglacier)
 - [Berlin](Hardfork.md#berlin)
 - [Byzantium](Hardfork.md#byzantium)
 - [Chainstart](Hardfork.md#chainstart)
@@ -23,13 +24,23 @@
 
 ## Enumeration members
 
+### ArrowGlacier
+
+• **ArrowGlacier** = `"arrowGlacier"`
+
+#### Defined in
+
+[packages/common/src/index.ts:81](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L81)
+
+___
+
 ### Berlin
 
 • **Berlin** = `"berlin"`
 
 #### Defined in
 
-[packages/common/src/index.ts:78](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L78)
+[packages/common/src/index.ts:79](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L79)
 
 ___
 
@@ -39,7 +50,7 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:73](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L73)
+[packages/common/src/index.ts:74](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L74)
 
 ___
 
@@ -49,7 +60,7 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:68](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L68)
+[packages/common/src/index.ts:69](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L69)
 
 ___
 
@@ -59,7 +70,7 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:74](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L74)
+[packages/common/src/index.ts:75](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L75)
 
 ___
 
@@ -69,7 +80,7 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:70](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L70)
+[packages/common/src/index.ts:71](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L71)
 
 ___
 
@@ -79,7 +90,7 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:69](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L69)
+[packages/common/src/index.ts:70](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L70)
 
 ___
 
@@ -89,7 +100,7 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:76](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L76)
+[packages/common/src/index.ts:77](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L77)
 
 ___
 
@@ -99,7 +110,7 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:79](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L79)
+[packages/common/src/index.ts:80](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L80)
 
 ___
 
@@ -109,7 +120,7 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:81](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L81)
+[packages/common/src/index.ts:83](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L83)
 
 ___
 
@@ -119,7 +130,7 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:77](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L77)
+[packages/common/src/index.ts:78](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L78)
 
 ___
 
@@ -129,7 +140,7 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:75](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L75)
+[packages/common/src/index.ts:76](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L76)
 
 ___
 
@@ -139,7 +150,7 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:80](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L80)
+[packages/common/src/index.ts:82](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L82)
 
 ___
 
@@ -149,7 +160,7 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:72](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L72)
+[packages/common/src/index.ts:73](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L73)
 
 ___
 
@@ -159,4 +170,4 @@ ___
 
 #### Defined in
 
-[packages/common/src/index.ts:71](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L71)
+[packages/common/src/index.ts:72](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L72)

--- a/packages/common/docs/interfaces/CommonOpts.md
+++ b/packages/common/docs/interfaces/CommonOpts.md
@@ -32,7 +32,7 @@ passed in via [CommonOpts.customChains](CommonOpts.md#customchains).
 
 #### Defined in
 
-[packages/common/src/index.ts:127](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L127)
+[packages/common/src/index.ts:129](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L129)
 
 ___
 
@@ -62,7 +62,7 @@ const common = new Common({ chain: 'myCustomChain1', customChains: [ [ myCustomC
 
 #### Defined in
 
-[packages/common/src/index.ts:149](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L149)
+[packages/common/src/index.ts:151](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L151)
 
 ___
 
@@ -83,7 +83,7 @@ BaseOpts.eips
 
 #### Defined in
 
-[packages/common/src/index.ts:115](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L115)
+[packages/common/src/index.ts:117](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L117)
 
 ___
 
@@ -101,7 +101,7 @@ BaseOpts.hardfork
 
 #### Defined in
 
-[packages/common/src/index.ts:102](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L102)
+[packages/common/src/index.ts:104](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L104)
 
 ___
 
@@ -117,4 +117,4 @@ BaseOpts.supportedHardforks
 
 #### Defined in
 
-[packages/common/src/index.ts:106](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L106)
+[packages/common/src/index.ts:108](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L108)

--- a/packages/common/docs/interfaces/CustomCommonOpts.md
+++ b/packages/common/docs/interfaces/CustomCommonOpts.md
@@ -30,7 +30,7 @@ a standard chain used to base the custom chain params on.
 
 #### Defined in
 
-[packages/common/src/index.ts:160](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L160)
+[packages/common/src/index.ts:162](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L162)
 
 ___
 
@@ -51,7 +51,7 @@ BaseOpts.eips
 
 #### Defined in
 
-[packages/common/src/index.ts:115](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L115)
+[packages/common/src/index.ts:117](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L117)
 
 ___
 
@@ -69,7 +69,7 @@ BaseOpts.hardfork
 
 #### Defined in
 
-[packages/common/src/index.ts:102](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L102)
+[packages/common/src/index.ts:104](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L104)
 
 ___
 
@@ -85,4 +85,4 @@ BaseOpts.supportedHardforks
 
 #### Defined in
 
-[packages/common/src/index.ts:106](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L106)
+[packages/common/src/index.ts:108](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/index.ts#L108)

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -830,19 +830,8 @@ export default class Common extends EventEmitter {
    * Returns the hardfork change block for hardfork provided or set
    * @param hardfork Hardfork name, optional if HF set
    * @returns Block number or null if unscheduled
-   * @deprecated Please use {@link Common.hardforkBlockBN} for large number support
    */
-  hardforkBlock(hardfork?: string | Hardfork): number | null {
-    const block = this.hardforkBlockBN(hardfork)
-    return toType(block, TypeOutput.Number)
-  }
-
-  /**
-   * Returns the hardfork change block for hardfork provided or set
-   * @param hardfork Hardfork name, optional if HF set
-   * @returns Block number or null if unscheduled
-   */
-  hardforkBlockBN(hardfork?: string | Hardfork): BN | null {
+  hardforkBlock(hardfork?: string | Hardfork): BN | null {
     hardfork = this._chooseHardfork(hardfork, false)
     const block = this._getHardfork(hardfork)['block']
     if (block === undefined || block === null) {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -714,7 +714,7 @@ export default class Common extends EventEmitter {
     blockNumber = toType(blockNumber, TypeOutput.BN)
     const onlySupported = opts.onlySupported ?? false
     hardfork = this._chooseHardfork(hardfork, onlySupported)
-    const hfBlock = this.hardforkBlockBN(hardfork)
+    const hfBlock = this.hardforkBlock(hardfork)
     if (hfBlock && blockNumber.gte(hfBlock)) {
       return true
     }
@@ -874,7 +874,7 @@ export default class Common extends EventEmitter {
   isHardforkBlock(blockNumber: BNLike, hardfork?: string | Hardfork): boolean {
     blockNumber = toType(blockNumber, TypeOutput.BN)
     hardfork = this._chooseHardfork(hardfork, false)
-    const block = this.hardforkBlockBN(hardfork)
+    const block = this.hardforkBlock(hardfork)
     return block ? block.eq(blockNumber) : false
   }
 
@@ -896,7 +896,7 @@ export default class Common extends EventEmitter {
    */
   nextHardforkBlockBN(hardfork?: string | Hardfork): BN | null {
     hardfork = this._chooseHardfork(hardfork, false)
-    const hfBlock = this.hardforkBlockBN(hardfork)
+    const hfBlock = this.hardforkBlock(hardfork)
     if (hfBlock === null) {
       return null
     }

--- a/packages/common/tests/customChains.spec.ts
+++ b/packages/common/tests/customChains.spec.ts
@@ -155,11 +155,11 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
       customChains: [testnet],
     })
     st.equal(c.chainName(), 'mainnet', 'customChains, chain set to supported chain')
-    st.equal(c.hardforkBlock(), 4370000, 'customChains, chain set to supported chain')
+    st.ok(c.hardforkBlock()!.eqn(4370000), 'customChains, chain set to supported chain')
 
     c.setChain('testnet')
     st.equal(c.chainName(), 'testnet', 'customChains, chain switched to custom chain')
-    st.equal(c.hardforkBlock(), 4, 'customChains, chain switched to custom chain')
+    st.ok(c.hardforkBlock()!.eqn(4), 'customChains, chain switched to custom chain')
 
     c = new Common({
       chain: 'testnet',
@@ -167,7 +167,7 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
       customChains: [testnet],
     })
     st.equal(c.chainName(), 'testnet', 'customChains, chain initialized with custom chain')
-    st.equal(c.hardforkBlock(), 4, 'customChains, chain initialized with custom chain')
+    st.ok(c.hardforkBlock()!.eqn(4), 'customChains, chain initialized with custom chain')
     st.deepEqual(
       c.genesisState(),
       {},
@@ -181,7 +181,7 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
       customChains,
     })
     st.equal(c.chainName(), 'testnet2', 'customChains, chain initialized with custom chain')
-    st.equal(c.hardforkBlock(), 10, 'customChains, chain initialized with custom chain')
+    st.ok(c.hardforkBlock()!.eqn(10), 'customChains, chain initialized with custom chain')
 
     c.setChain('testnet')
     st.equal(c.chainName(), 'testnet', 'customChains, should allow to switch custom chain')

--- a/packages/common/tests/hardforks.spec.ts
+++ b/packages/common/tests/hardforks.spec.ts
@@ -1,5 +1,4 @@
 import tape from 'tape'
-import { BN } from 'ethereumjs-util'
 import Common, { Chain, ConsensusAlgorithm, ConsensusType, Hardfork } from '../src'
 
 tape('[Common]: Hardfork logic', function (t: tape.Test) {
@@ -73,15 +72,15 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
   t.test('hardforkBlock()', function (st: tape.Test) {
     let c = new Common({ chain: Chain.Ropsten })
     let msg = 'should return the correct HF change block for byzantium (provided)'
-    st.equal(c.hardforkBlock(Hardfork.Byzantium), 1700000, msg)
+    st.ok(c.hardforkBlock(Hardfork.Byzantium)!.eqn(1700000), msg)
 
     c = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Byzantium })
     msg = 'should return the correct HF change block for byzantium (set)'
-    st.equal(c.hardforkBlock(), 1700000, msg)
+    st.ok(c.hardforkBlock()!.eqn(1700000), msg)
 
     c = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Istanbul })
     msg = 'should return the correct HF change block for istanbul (set)'
-    st.equal(c.hardforkBlock(), 6485846, msg)
+    st.ok(c.hardforkBlock()!.eqn(6485846), msg)
 
     st.end()
   })
@@ -246,14 +245,13 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     const c = new Common({ chain: Chain.Mainnet })
 
     let msg = 'should return correct value'
-    st.equal(c.hardforkBlock(Hardfork.Berlin), 12244000, msg)
-    st.ok(c.hardforkBlockBN(Hardfork.Berlin)!.eq(new BN(12244000)), msg)
+    st.ok(c.hardforkBlock(Hardfork.Berlin)!.eqn(12244000), msg)
 
     msg = 'should return null for unscheduled hardfork'
     // developer note: when Shanghai is set,
     // update this test to next unscheduled hardfork.
     st.equal(c.hardforkBlock(Hardfork.Shanghai), null, msg)
-    st.equal(c.hardforkBlockBN(Hardfork.Shanghai), null, msg)
+    st.equal(c.hardforkBlock(Hardfork.Shanghai), null, msg)
     st.equal(c.nextHardforkBlockBN(Hardfork.Shanghai), null, msg)
 
     st.end()

--- a/packages/devp2p/src/eth/index.ts
+++ b/packages/devp2p/src/eth/index.ts
@@ -58,7 +58,7 @@ export class ETH extends EventEmitter {
       this._hardfork = c.hardfork() ? c.hardfork() : this._hardfork
       // Set latestBlock minimally to start block of fork to have some more
       // accurate basis if no latestBlock is provided along status send
-      this._latestBlock = c.hardforkBlockBN(this._hardfork) ?? new BN(0)
+      this._latestBlock = c.hardforkBlock(this._hardfork) ?? new BN(0)
       this._forkHash = c.forkHash(this._hardfork)
       // Next fork block number or 0 if none available
       this._nextForkBlock = c.nextHardforkBlockBN(this._hardfork) ?? new BN(0)

--- a/packages/tx/examples/transactions.ts
+++ b/packages/tx/examples/transactions.ts
@@ -43,18 +43,18 @@ console.log('--------------------')
 // You can decode it with the rlp module.
 // After that you should have something like:
 const rawTx = [
-  '0x00',
+  '0x',
   '0x09184e72a000',
   '0x2710',
   '0x0000000000000000000000000000000000000000',
-  '0x00',
+  '0x',
   '0x7f7465737432000000000000000000000000000000000000000000000000000000600057',
   '0x1c',
   '0x5e1d3a76fbf824220eafc8c79ad578ad2b67d01b0c2425eb1f1347e8f50882ab',
   '0x5bd428537f05f9830e93792f90ea6a3e2d1ee84952dd96edbae9f658f831ab13',
 ]
 
-const tx2 = Transaction.fromValuesArray(rawTx.map(toBuffer)) // This is also a maninnet transaction
+const tx2 = Transaction.fromValuesArray(rawTx.map(toBuffer)) // This is also a mainnet transaction
 
 // Note rlp.decode will produce an array of buffers.
 // So assuming that you were able to parse the transaction, we will now get the sender's address.

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -30,7 +30,8 @@
     "tape": "tape -r ts-node/register",
     "test": "npm run test:node && npm run test:browser",
     "test:node": "tape -r ts-node/register ./test/index.ts",
-    "test:browser": "karma start karma.conf.js"
+    "test:browser": "karma start karma.conf.js",
+    "examples": "ts-node ../../scripts/examples-runner.ts -- tx"
   },
   "dependencies": {
     "@ethereumjs/common": "^2.6.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -44,7 +44,6 @@
     "rlp": "^2.2.4"
   },
   "devDependencies": {
-    "@types/assert": "^1.5.4",
     "@types/node": "^16.11.7",
     "@types/secp256k1": "^4.0.1",
     "@types/tape": "^4.13.2",

--- a/packages/util/src/account.ts
+++ b/packages/util/src/account.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { BN, rlp } from './externals'
 import {
   privateKeyVerify,
@@ -214,8 +213,12 @@ export const generateAddress2 = function (from: Buffer, salt: Buffer, initCode: 
   assertIsBuffer(salt)
   assertIsBuffer(initCode)
 
-  assert(from.length === 20)
-  assert(salt.length === 32)
+  if (from.length !== 20) {
+    throw new Error('Expected from to be of length 20')
+  }
+  if (salt.length !== 32) {
+    throw new Error('Expected salt to be of length 32')
+  }
 
   const address = keccak256(
     Buffer.concat([Buffer.from('ff', 'hex'), from, salt, keccak256(initCode)])
@@ -262,7 +265,9 @@ export const pubToAddress = function (pubKey: Buffer, sanitize: boolean = false)
   if (sanitize && pubKey.length !== 64) {
     pubKey = Buffer.from(publicKeyConvert(pubKey, false).slice(1))
   }
-  assert(pubKey.length === 64)
+  if (pubKey.length !== 64) {
+    throw new Error('Expected pubKey to be of length 64')
+  }
   // Only take the lower 160bits of the hash
   return keccak(pubKey).slice(-20)
 }

--- a/packages/util/src/address.ts
+++ b/packages/util/src/address.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { BN } from './externals'
 import { toBuffer, zeros } from './bytes'
 import {
@@ -13,7 +12,9 @@ export class Address {
   public readonly buf: Buffer
 
   constructor(buf: Buffer) {
-    assert(buf.length === 20, 'Invalid address length')
+    if (buf.length !== 20) {
+      throw new Error('Invalid address length')
+    }
     this.buf = buf
   }
 
@@ -29,7 +30,9 @@ export class Address {
    * @param str - Hex-encoded address
    */
   static fromString(str: string): Address {
-    assert(isValidAddress(str), 'Invalid address')
+    if (!isValidAddress(str)) {
+      throw new Error('Invalid address')
+    }
     return new Address(toBuffer(str))
   }
 
@@ -38,7 +41,9 @@ export class Address {
    * @param pubKey The two points of an uncompressed key
    */
   static fromPublicKey(pubKey: Buffer): Address {
-    assert(Buffer.isBuffer(pubKey), 'Public key should be Buffer')
+    if (!Buffer.isBuffer(pubKey)) {
+      throw new Error('Public key should be Buffer')
+    }
     const buf = pubToAddress(pubKey)
     return new Address(buf)
   }
@@ -48,7 +53,9 @@ export class Address {
    * @param privateKey A private key must be 256 bits wide
    */
   static fromPrivateKey(privateKey: Buffer): Address {
-    assert(Buffer.isBuffer(privateKey), 'Private key should be Buffer')
+    if (!Buffer.isBuffer(privateKey)) {
+      throw new Error('Private key should be Buffer')
+    }
     const buf = privateToAddress(privateKey)
     return new Address(buf)
   }
@@ -59,7 +66,9 @@ export class Address {
    * @param nonce The nonce of the from account
    */
   static generate(from: Address, nonce: BN): Address {
-    assert(BN.isBN(nonce))
+    if (!BN.isBN(nonce)) {
+      throw new Error('Expected nonce to be a BigNum')
+    }
     return new Address(generateAddress(from.buf, nonce.toArrayLike(Buffer)))
   }
 
@@ -70,8 +79,12 @@ export class Address {
    * @param initCode The init code of the contract being created
    */
   static generate2(from: Address, salt: Buffer, initCode: Buffer): Address {
-    assert(Buffer.isBuffer(salt))
-    assert(Buffer.isBuffer(initCode))
+    if (!Buffer.isBuffer(salt)) {
+      throw new Error('Expected salt to be a Buffer')
+    }
+    if (!Buffer.isBuffer(initCode)) {
+      throw new Error('Expected initCode to be a Buffer')
+    }
     return new Address(generateAddress2(from.buf, salt, initCode))
   }
 

--- a/packages/util/src/object.ts
+++ b/packages/util/src/object.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { stripHexPrefix } from './internal'
 import { rlp } from './externals'
 import { toBuffer, baToJSON, unpadBuffer } from './bytes'
@@ -49,15 +48,13 @@ export const defineProperties = function (self: any, fields: any, data?: any) {
 
       if (field.allowLess && field.length) {
         v = unpadBuffer(v)
-        assert(
-          field.length >= v.length,
-          `The field ${field.name} must not have more ${field.length} bytes`
-        )
+        if (field.length < v.length) {
+          throw new Error(`The field ${field.name} must not have more ${field.length} bytes`)
+        }
       } else if (!(field.allowZero && v.length === 0) && field.length) {
-        assert(
-          field.length === v.length,
-          `The field ${field.name} must have byte length of ${field.length}`
-        )
+        if (field.length !== v.length) {
+          throw new Error(`The field ${field.name} must have byte length of ${field.length}`)
+        }
       }
 
       self.raw[i] = v

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -136,7 +136,7 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
   // check for DAO support and if we should apply the DAO fork
   if (
     this._common.hardforkIsActiveOnChain('dao') &&
-    block.header.number.eq(this._common.hardforkBlockBN('dao')!)
+    block.header.number.eq(this._common.hardforkBlock('dao')!)
   ) {
     if (this.DEBUG) {
       debug(`Apply DAO hardfork`)

--- a/packages/vm/tests/api/EIPs/eip-1559-FeeMarket.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-1559-FeeMarket.spec.ts
@@ -20,7 +20,7 @@ const common = new Common({
 
 // Small hack to hack in the activation block number
 // (Otherwise there would be need for a custom chain only for testing purposes)
-common.hardforkBlockBN = function (hardfork: string | undefined) {
+common.hardforkBlock = function (hardfork: string | undefined) {
   if (hardfork === 'london') {
     return new BN(1)
   } else if (hardfork === 'dao') {

--- a/packages/vm/tests/api/EIPs/eip-3198-BaseFee.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3198-BaseFee.spec.ts
@@ -17,7 +17,7 @@ const common = new Common({
 
 // Small hack to hack in the activation block number
 // (Otherwise there would be need for a custom chain only for testing purposes)
-common.hardforkBlockBN = function (hardfork: string | undefined) {
+common.hardforkBlock = function (hardfork: string | undefined) {
   if (hardfork === 'london') {
     return new BN(1)
   } else if (hardfork === 'dao') {

--- a/packages/vm/tests/api/runBlock.spec.ts
+++ b/packages/vm/tests/api/runBlock.spec.ts
@@ -29,7 +29,7 @@ tape('runBlock() -> successful API parameter usage', async (t) => {
     const block = Block.fromRLPSerializedBlock(blockRlp)
 
     //@ts-ignore
-    await setupPreConditions(vm.stateManager._trie, testData)
+    await setupPreConditions(vm.stateManager, testData)
 
     st.ok(
       //@ts-ignore
@@ -55,7 +55,7 @@ tape('runBlock() -> successful API parameter usage', async (t) => {
     const testData = require('./testdata/uncleData.json')
 
     //@ts-ignore
-    await setupPreConditions(vm.stateManager._trie, testData)
+    await setupPreConditions(vm.stateManager, testData)
 
     const block1Rlp = testData.blocks[0].rlp
     const block1 = Block.fromRLPSerializedBlock(block1Rlp)
@@ -264,7 +264,7 @@ tape('runBlock() -> runtime behavior', async (t) => {
     block1[0][12] = Buffer.from('dao-hard-fork')
     const block = Block.fromValuesArray(block1)
     // @ts-ignore
-    await setupPreConditions(vm.stateManager._trie, testData)
+    await setupPreConditions(vm.stateManager, testData)
 
     // fill two original DAO child-contracts with funds and the recovery account with funds in order to verify that the balance gets summed correctly
     const fundBalance1 = new BN(Buffer.from('1111', 'hex'))
@@ -404,7 +404,7 @@ async function runWithHf(hardfork: string) {
   const block = Block.fromRLPSerializedBlock(blockRlp)
 
   // @ts-ignore
-  await setupPreConditions(vm.stateManager._trie, testData)
+  await setupPreConditions(vm.stateManager, testData)
 
   const res = await vm.runBlock({
     block,
@@ -449,7 +449,7 @@ tape('runBlock() -> tx types', async (t) => {
     }
 
     //@ts-ignore
-    await setupPreConditions(vm.stateManager._trie, testData)
+    await setupPreConditions(vm.stateManager, testData)
 
     const res = await vm.runBlock({
       block,

--- a/packages/vm/tests/api/runBlockchain.spec.ts
+++ b/packages/vm/tests/api/runBlockchain.spec.ts
@@ -71,7 +71,7 @@ tape('runBlockchain', (t) => {
     const head = await vm.blockchain.getHead()
     st.equal(head.hash().toString('hex'), testData.blocks[0].blockHeader.hash.slice(2))
 
-    await setupPreConditions((vm.stateManager as DefaultStateManager)._trie, testData)
+    await setupPreConditions(vm.stateManager as DefaultStateManager, testData)
 
     vm.runBlock = async () => new Promise((resolve, reject) => reject(new Error('test')))
 
@@ -103,7 +103,7 @@ tape('runBlockchain', (t) => {
     const head = await vm.blockchain.getHead()
     st.equal(head.hash().toString('hex'), testData.blocks[0].blockHeader.hash.slice(2))
 
-    await setupPreConditions((vm.stateManager as DefaultStateManager)._trie, testData)
+    await setupPreConditions(vm.stateManager as DefaultStateManager, testData)
 
     await vm.runBlockchain()
 

--- a/packages/vm/tests/tester/config.ts
+++ b/packages/vm/tests/tester/config.ts
@@ -17,7 +17,6 @@ export const DEFAULT_FORK_CONFIG = 'Istanbul'
 export const SKIP_BROKEN = [
   'ForkStressTest', // Only BlockchainTest, temporary till fixed (2020-05-23)
   'ChainAtoChainB', // Only BlockchainTest, temporary, along expectException fixes (2020-05-23)
-  'undefinedOpcodeFirstByte', // https://github.com/ethereumjs/ethereumjs-monorepo/issues/1271 (2021-05-26)
 
   // In these tests, we have access to two forked chains. Their total difficulty is equal. There are errors in the second chain, but we have no reason to execute this chain if the TD remains equal.
   'blockChainFrontierWithLargerTDvsHomesteadBlockchain2_FrontierToHomesteadAt5',

--- a/packages/vm/tests/tester/runners/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/tester/runners/BlockchainTestsRunner.ts
@@ -81,7 +81,7 @@ export default async function runBlockchainTest(options: any, testData: any, t: 
   await blockchain.initPromise
 
   // set up pre-state
-  await setupPreConditions(vm.stateManager._trie, testData)
+  await setupPreConditions(vm.stateManager, testData)
 
   t.ok(vm.stateManager._trie.root.equals(genesisBlock.header.stateRoot), 'correct pre stateRoot')
 
@@ -180,6 +180,9 @@ export default async function runBlockchainTest(options: any, testData: any, t: 
         return
       }
     } catch (error: any) {
+      if (options.debug) {
+        await verifyPostConditions(state, testData.postState, t)
+      }
       // caught an error, reduce block number
       currentBlock.isubn(1)
       await handleError(error, expectException)

--- a/packages/vm/tests/tester/runners/GeneralStateTestsRunner.ts
+++ b/packages/vm/tests/tester/runners/GeneralStateTestsRunner.ts
@@ -76,7 +76,8 @@ async function runTestCase(options: any, testData: any, t: tape.Test) {
 
   const vm = new VM({ state, common })
 
-  await setupPreConditions(vm.stateManager._trie, testData)
+  await setupPreConditions(vm.stateManager, testData)
+
   let execInfo = ''
   let tx
 

--- a/packages/vm/tests/util.ts
+++ b/packages/vm/tests/util.ts
@@ -15,7 +15,9 @@ import {
   stripHexPrefix,
   setLengthLeft,
   toBuffer,
+  Address,
 } from 'ethereumjs-util'
+import { DefaultStateManager } from '../src/state'
 
 export function dumpState(state: any, cb: Function) {
   function readAccounts(state: any) {
@@ -307,17 +309,16 @@ export function makeBlockFromEnv(env: any, opts?: BlockOptions): Block {
  * @param state - the state DB/trie
  * @param testData - JSON from tests repo
  */
-export async function setupPreConditions(state: any, testData: any) {
+export async function setupPreConditions(state: DefaultStateManager, testData: any) {
   await state.checkpoint()
-  for (const address of Object.keys(testData.pre)) {
-    const { nonce, balance, code, storage } = testData.pre[address]
+  for (const addressStr of Object.keys(testData.pre)) {
+    const { nonce, balance, code, storage } = testData.pre[addressStr]
 
-    const addressBuf = format(address)
+    const addressBuf = format(addressStr)
+    const address = new Address(addressBuf)
+
     const codeBuf = format(code)
     const codeHash = keccak256(codeBuf)
-
-    const storageTrie = state.copy(false)
-    storageTrie.root = null
 
     // Set contract storage
     for (const storageKey of Object.keys(storage)) {
@@ -325,26 +326,29 @@ export async function setupPreConditions(state: any, testData: any) {
       if (valBN.isZero()) {
         continue
       }
-      const val = rlp.encode(valBN.toArrayLike(Buffer, 'be'))
+      const val = valBN.toArrayLike(Buffer, 'be')
       const key = setLengthLeft(format(storageKey), 32)
 
-      await storageTrie.put(key, val)
-    }
-
-    const stateRoot = storageTrie.root
-
-    if (testData.exec && testData.exec.address === address) {
-      testData.root = storageTrie.root
+      await state.putContractStorage(address, key, val)
     }
 
     // Put contract code
-    await state.db.put(codeHash, codeBuf)
+    await state.putContractCode(address, codeBuf)
+
+    const stateRoot = (await state.getAccount(address)).stateRoot
+
+    if (testData.exec && testData.exec.address === addressStr) {
+      testData.root = stateRoot
+    }
 
     // Put account data
     const account = Account.fromAccountData({ nonce, balance, codeHash, stateRoot })
-    await state.put(addressBuf, account.serialize())
+    await state.putAccount(address, account)
   }
   await state.commit()
+  // Clear the touched stack, otherwise untouched accounts in the block which are empty (>= SpuriousDragon)
+  // will get deleted from the state, resulting in state trie errors
+  ;(<any>state)._touched.clear()
 }
 
 /**

--- a/scripts/examples-runner.ts
+++ b/scripts/examples-runner.ts
@@ -1,0 +1,26 @@
+import { extname, join } from 'path'
+import { readdir } from 'fs'
+
+const pkg = process.argv[3]
+if (!pkg) {
+  throw new Error('Package argument must be passed')
+}
+
+const examplesPath = `../packages/${pkg}/examples/`
+const path = join(__dirname, examplesPath)
+
+readdir(path, async (err, files) => {
+  if (err) {
+    throw new Error('Error loading examples directory: ' + err.message)
+  }
+
+  const getTsFiles = (fileName: string): Promise<NodeModule> | undefined => {
+    if (extname(fileName) === '.ts') {
+      return import(examplesPath + fileName)
+    }
+  }
+
+  const importedFiles = files.map(getTsFiles).filter((file) => file)
+
+  await Promise.all(importedFiles)
+})


### PR DESCRIPTION
1. VM / Client / Devp2p / Block / Common: Rename hardforkBlockBN() to hardforkBlock()
2. Common: Remove deprecated hardforkBlock()
3. Common: Update build:docs
4. Rename hardforkBlock in tests 
5. Fix tests by using .eqn to test BN's against numbers.