### PR TITLE
vm: Fix contract REVERT bug: upon creation, REVERT return data > maxCodeSize

### DIFF
--- a/packages/vm/src/evm/evm.ts
+++ b/packages/vm/src/evm/evm.ts
@@ -377,6 +377,13 @@ export default class EVM {
     }
     let result = await this.runInterpreter(message)
 
+    if (result.exceptionError) {
+      return {
+        gasUsed: result.gasUsed,
+        execResult: result,
+      }
+    }
+
     // fee for size of the return value
     let totalGas = result.gasUsed
     let returnFee = new BN(0)

--- a/packages/vm/src/evm/evm.ts
+++ b/packages/vm/src/evm/evm.ts
@@ -377,13 +377,6 @@ export default class EVM {
     }
     let result = await this.runInterpreter(message)
 
-    if (result.exceptionError) {
-      return {
-        gasUsed: result.gasUsed,
-        execResult: result,
-      }
-    }
-
     // fee for size of the return value
     let totalGas = result.gasUsed
     let returnFee = new BN(0)
@@ -400,6 +393,7 @@ export default class EVM {
     // Check for SpuriousDragon EIP-170 code size limit
     let allowedCodeSize = true
     if (
+      !result.exceptionError &&
       this._vm._common.gteHardfork('spuriousDragon') &&
       result.returnValue.length > this._vm._common.param('vm', 'maxCodeSize')
     ) {


### PR DESCRIPTION
Bug caused in Kintsugi; https://explorer.kintsugi.themerge.dev/tx/0x1fb8a5ac000196a54dfe63dfda60542340b790a874b1d319b0aa834ef2ea1425/internal-transactions

The problem is this: `REVERT` opcode does not consume all gas and puts a "revert reason message" in the return buffer (accessible with `RETURNDATACOPY`). This return buffer is also used to return whatever code should be deployed when creating a contract. The problem is that we, in general, check that there is no exception error. If there is an exception error, most logic in `executeCreate` of `evm.ts` does not run.

However, this check is not done [here](https://github.com/ethereumjs/ethereumjs-monorepo/blob/68f714921094ee7c6941c9fbbf9aacaf24838706/packages/vm/src/evm/evm.ts#L399), to check if the code size is larger than the max code size. **Hence, if we have a revert reason which is larger than the max code size, we consume all gas** which is not right.

