### PR TITLE
Add latest hardforks to tx tests

### DIFF
--- a/packages/tx/test/transactionRunner.ts
+++ b/packages/tx/test/transactionRunner.ts
@@ -10,8 +10,11 @@ const argv = minimist(process.argv.slice(2))
 const file: string | undefined = argv.file
 
 const forkNames: ForkName[] = [
+  'London',
+  'Berlin',
   'Istanbul',
   'Byzantium',
+  'ConstantinopleFix',
   'Constantinople',
   'EIP150',
   'EIP158',
@@ -20,8 +23,11 @@ const forkNames: ForkName[] = [
 ]
 
 const forkNameMap: ForkNamesMap = {
+  London: 'london',
+  Berlin: 'berlin',
   Istanbul: 'istanbul',
   Byzantium: 'byzantium',
+  ConstantinopleFix: 'petersburg',
   Constantinople: 'constantinople',
   EIP150: 'tangerineWhistle',
   EIP158: 'spuriousDragon',
@@ -68,6 +74,7 @@ tape('TransactionTests', async (t) => {
               st.assert(shouldBeInvalid, `Transaction should be invalid on ${forkName}`)
             } else {
               st.fail(`Transaction should be valid on ${forkName}`)
+              st.comment(e)
             }
           }
         }

--- a/packages/tx/test/types.ts
+++ b/packages/tx/test/types.ts
@@ -1,6 +1,9 @@
 export type ForkName =
+  | 'London'
+  | 'Berlin'
   | 'Istanbul'
   | 'Byzantium'
+  | 'ConstantinopleFix'
   | 'Constantinople'
   | 'EIP150'
   | 'EIP158'


### PR DESCRIPTION
I noticed we are not using all hardforks on the tx ethereum/tests tests, so added them here.