### PR TITLE
Common: Rename *BN methods to non-BN names

### DIFF
--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -249,7 +249,7 @@ export class BlockHeader {
 
     if (this._common.isActivatedEIP(1559)) {
       if (baseFeePerGas === undefined) {
-        const londonHfBlock = this._common.hardforkBlockBN(Hardfork.London)
+        const londonHfBlock = this._common.hardforkBlock(Hardfork.London)
         const isInitialEIP1559Block = londonHfBlock && number.eq(londonHfBlock)
         if (isInitialEIP1559Block) {
           baseFeePerGas = new BN(this._common.param('gasConfig', 'initialBaseFee'))
@@ -566,7 +566,7 @@ export class BlockHeader {
     let parentGasLimit = parentBlockHeader.gasLimit
     // EIP-1559: assume double the parent gas limit on fork block
     // to adopt to the new gas target centered logic
-    const londonHardforkBlock = this._common.hardforkBlockBN(Hardfork.London)
+    const londonHardforkBlock = this._common.hardforkBlock(Hardfork.London)
     if (londonHardforkBlock && this.number.eq(londonHardforkBlock)) {
       const elasticity = new BN(this._common.param('gasConfig', 'elasticityMultiplier'))
       parentGasLimit = parentGasLimit.mul(elasticity)
@@ -716,7 +716,7 @@ export class BlockHeader {
         const msg = this._errorMsg('EIP1559 block has no base fee field')
         throw new Error(msg)
       }
-      const londonHfBlock = this._common.hardforkBlockBN(Hardfork.London)
+      const londonHfBlock = this._common.hardforkBlock(Hardfork.London)
       const isInitialEIP1559Block = londonHfBlock && this.number.eq(londonHfBlock)
       if (isInitialEIP1559Block) {
         const initialBaseFee = new BN(this._common.param('gasConfig', 'initialBaseFee'))
@@ -1012,7 +1012,7 @@ export class BlockHeader {
     if (!this._common.hardforkIsActiveOnChain(Hardfork.Dao)) {
       return
     }
-    const DAOActivationBlock = this._common.hardforkBlockBN(Hardfork.Dao)
+    const DAOActivationBlock = this._common.hardforkBlock(Hardfork.Dao)
     if (!DAOActivationBlock || DAOActivationBlock.isZero() || this.number.lt(DAOActivationBlock)) {
       return
     }

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -384,7 +384,7 @@ export class BlockHeader {
 
     if (nonce.length !== 8) {
       // Hack to check for Kovan due to non-standard nonce length (65 bytes)
-      if (this._common.networkIdBN().eqn(42)) {
+      if (this._common.networkId().eqn(42)) {
         if (nonce.length !== 65) {
           const msg = this._errorMsg(
             `nonce must be 65 bytes on kovan, received ${nonce.length} bytes`

--- a/packages/block/test/block.spec.ts
+++ b/packages/block/test/block.spec.ts
@@ -526,7 +526,7 @@ tape('[Block]: block functions', function (t) {
       const common = new Common({ chain: Chain.Mainnet })
       common.setHardfork(Hardfork.Berlin)
 
-      const mainnetForkBlock = common.hardforkBlockBN(Hardfork.London)
+      const mainnetForkBlock = common.hardforkBlock(Hardfork.London)
       const rootBlock = Block.fromBlockData({
         header: {
           number: mainnetForkBlock!.subn(3),

--- a/packages/block/test/eip1559block.spec.ts
+++ b/packages/block/test/eip1559block.spec.ts
@@ -23,7 +23,7 @@ const genesis = Block.fromBlockData({})
 
 // Small hack to hack in the activation block number
 // (Otherwise there would be need for a custom chain only for testing purposes)
-common.hardforkBlockBN = function (hardfork: string | undefined) {
+common.hardforkBlock = function (hardfork: string | undefined) {
   if (hardfork === 'london') {
     return new BN(1)
   } else if (hardfork === 'dao') {

--- a/packages/block/test/util.ts
+++ b/packages/block/test/util.ts
@@ -24,7 +24,7 @@ function createBlock(
   const number = parentBlock.header.number.addn(1)
   const timestamp = parentBlock.header.timestamp.addn(1)
 
-  const londonHfBlock = common.hardforkBlockBN(Hardfork.London)
+  const londonHfBlock = common.hardforkBlock(Hardfork.London)
   const baseFeePerGas =
     londonHfBlock && number.gt(londonHfBlock) ? parentBlock.header.calcNextBaseFee() : undefined
 

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -917,7 +917,7 @@ export default class Blockchain implements BlockchainInterface {
       const currentTd = { header: new BN(0), block: new BN(0) }
       let dbOps: DBOp[] = []
 
-      if (!block._common.chainIdBN().eq(this._common.chainIdBN())) {
+      if (!block._common.chainId().eq(this._common.chainId())) {
         throw new Error('Chain mismatch while trying to put block or header')
       }
 

--- a/packages/blockchain/test/pos.spec.ts
+++ b/packages/blockchain/test/pos.spec.ts
@@ -7,7 +7,7 @@ import testnet from './testdata/testnet.json'
 
 const buildChain = async (blockchain: Blockchain, common: Common, height: number) => {
   const blocks: Block[] = []
-  const londonBlockNumber = common.hardforkBlockBN('london')!.toNumber()
+  const londonBlockNumber = common.hardforkBlock('london')!.toNumber()
   const genesis = Block.genesis({}, { common })
   blocks.push(genesis)
 

--- a/packages/client/lib/blockchain/chain.ts
+++ b/packages/client/lib/blockchain/chain.ts
@@ -142,7 +142,7 @@ export class Chain {
    * Network ID
    */
   get networkId(): BN {
-    return this.config.chainCommon.networkIdBN()
+    return this.config.chainCommon.networkId()
   }
 
   /**

--- a/packages/client/lib/miner/miner.ts
+++ b/packages/client/lib/miner/miner.ts
@@ -216,7 +216,7 @@ export class Miner {
     }
 
     let baseFeePerGas
-    const londonHardforkBlock = this.config.chainCommon.hardforkBlockBN(Hardfork.London)
+    const londonHardforkBlock = this.config.chainCommon.hardforkBlock(Hardfork.London)
     const isInitialEIP1559Block = londonHardforkBlock && number.eq(londonHardforkBlock)
     if (isInitialEIP1559Block) {
       // Get baseFeePerGas from `paramByEIP` since 1559 not currently active on common

--- a/packages/client/lib/net/protocol/lesprotocol.ts
+++ b/packages/client/lib/net/protocol/lesprotocol.ts
@@ -168,7 +168,7 @@ export class LesProtocol extends Protocol {
     }
 
     const forkHash = this.config.chainCommon.forkHash(this.config.chainCommon.hardfork())
-    const nextFork = this.config.chainCommon.nextHardforkBlockBN(this.config.chainCommon.hardfork())
+    const nextFork = this.config.chainCommon.nextHardforkBlock(this.config.chainCommon.hardfork())
     const forkID = [
       Buffer.from(forkHash.slice(2), 'hex'),
       nextFork ? nextFork.toArrayLike(Buffer) : Buffer.from([]),

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -463,7 +463,7 @@ export class Eth {
    * @returns The chain ID.
    */
   async chainId(_params = []) {
-    const chainId = this._chain.config.chainCommon.chainIdBN()
+    const chainId = this._chain.config.chainCommon.chainId()
     return bnToHex(chainId)
   }
 

--- a/packages/client/lib/rpc/modules/net.ts
+++ b/packages/client/lib/rpc/modules/net.ts
@@ -34,7 +34,7 @@ export class Net {
    * @param params An empty array
    */
   version(_params = []) {
-    return this._chain.config.chainCommon.chainIdBN().toString()
+    return this._chain.config.chainCommon.chainId().toString()
   }
 
   /**

--- a/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
+++ b/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
@@ -9,7 +9,7 @@ import { checkError } from '../util'
 const method = 'eth_sendRawTransaction'
 
 tape(`${method}: call with valid arguments`, async (t) => {
-  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlockBN(Hardfork.London)
+  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlock(Hardfork.London)
   const { server } = baseSetup({ syncTargetHeight })
 
   // Mainnet EIP-1559 tx
@@ -44,7 +44,7 @@ tape(`${method}: call with sync target height not set yet`, async (t) => {
 })
 
 tape(`${method}: call with invalid tx (wrong chain ID)`, async (t) => {
-  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlockBN(Hardfork.London)
+  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlock(Hardfork.London)
   const { server } = baseSetup({ syncTargetHeight })
 
   // Baikal EIP-1559 tx
@@ -57,7 +57,7 @@ tape(`${method}: call with invalid tx (wrong chain ID)`, async (t) => {
 })
 
 tape(`${method}: call with unsigned tx`, async (t) => {
-  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlockBN(Hardfork.London)
+  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlock(Hardfork.London)
   const { server } = baseSetup({ syncTargetHeight })
 
   // Mainnet EIP-1559 tx
@@ -79,7 +79,7 @@ tape(`${method}: call with unsigned tx`, async (t) => {
 })
 
 tape(`${method}: call with no peers`, async (t) => {
-  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlockBN(Hardfork.London)
+  const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlock(Hardfork.London)
   const { server } = baseSetup({ syncTargetHeight, noPeers: true })
 
   // Mainnet EIP-1559 tx

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -770,7 +770,7 @@ export default class Common extends EventEmitter {
    * @param hardfork Hardfork name, optional if HF set
    * @returns Block number or null if not available
    */
-  nextHardforkBlockBN(hardfork?: string | Hardfork): BN | null {
+  nextHardforkBlock(hardfork?: string | Hardfork): BN | null {
     hardfork = hardfork ?? this._hardfork
     const hfBlock = this.hardforkBlockBN(hardfork)
     if (hfBlock === null) {
@@ -796,7 +796,7 @@ export default class Common extends EventEmitter {
   isNextHardforkBlock(blockNumber: BNLike, hardfork?: string | Hardfork): boolean {
     blockNumber = toType(blockNumber, TypeOutput.BN)
     hardfork = hardfork ?? this._hardfork
-    const nextHardforkBlock = this.nextHardforkBlockBN(hardfork)
+    const nextHardforkBlock = this.nextHardforkBlock(hardfork)
 
     return nextHardforkBlock === null ? false : nextHardforkBlock.eq(blockNumber)
   }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -962,7 +962,7 @@ export default class Common extends EventEmitter {
    * Returns the Id of current network
    * @returns network Id
    */
-  networkIdBN(): BN {
+  networkId(): BN {
     return new BN(this._chainParams['networkId'])
   }
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -633,7 +633,7 @@ export default class Common extends EventEmitter {
   hardforkIsActiveOnBlock(hardfork: string | Hardfork | null, blockNumber: BNLike): boolean {
     blockNumber = toType(blockNumber, TypeOutput.BN)
     hardfork = hardfork ?? this._hardfork
-    const hfBlock = this.hardforkBlockBN(hardfork)
+    const hfBlock = this.hardforkBlock(hardfork)
     if (hfBlock && blockNumber.gte(hfBlock)) {
       return true
     }
@@ -729,7 +729,7 @@ export default class Common extends EventEmitter {
    * @param hardfork Hardfork name, optional if HF set
    * @returns Block number or null if unscheduled
    */
-  hardforkBlockBN(hardfork?: string | Hardfork): BN | null {
+  hardforkBlock(hardfork?: string | Hardfork): BN | null {
     hardfork = hardfork ?? this._hardfork
     const block = this._getHardfork(hardfork)['block']
     if (block === undefined || block === null) {
@@ -761,7 +761,7 @@ export default class Common extends EventEmitter {
   isHardforkBlock(blockNumber: BNLike, hardfork?: string | Hardfork): boolean {
     blockNumber = toType(blockNumber, TypeOutput.BN)
     hardfork = hardfork ?? this._hardfork
-    const block = this.hardforkBlockBN(hardfork)
+    const block = this.hardforkBlock(hardfork)
     return block ? block.eq(blockNumber) : false
   }
 
@@ -772,7 +772,7 @@ export default class Common extends EventEmitter {
    */
   nextHardforkBlock(hardfork?: string | Hardfork): BN | null {
     hardfork = hardfork ?? this._hardfork
-    const hfBlock = this.hardforkBlockBN(hardfork)
+    const hfBlock = this.hardforkBlock(hardfork)
     if (hfBlock === null) {
       return null
     }

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -946,7 +946,7 @@ export default class Common extends EventEmitter {
    * Returns the Id of current chain
    * @returns chain Id
    */
-  chainIdBN(): BN {
+  chainId(): BN {
     return new BN(this._chainParams['chainId'])
   }
 

--- a/packages/common/tests/chains.spec.ts
+++ b/packages/common/tests/chains.spec.ts
@@ -6,7 +6,7 @@ tape('[Common/Chains]: Initialization / Chain params', function (t: tape.Test) {
   t.test('Should initialize with chain provided', function (st: tape.Test) {
     let c = new Common({ chain: 'mainnet' })
     st.equal(c.chainName(), 'mainnet', 'should initialize with chain name')
-    st.ok(c.chainIdBN().eqn(1), 'should return correct chain Id')
+    st.ok(c.chainId().eqn(1), 'should return correct chain Id')
     st.ok(c.networkIdBN().eqn(1), 'should return correct network Id')
     st.equal(c.hardfork(), 'istanbul', 'should set hardfork to current default hardfork')
     st.equal(
@@ -24,7 +24,7 @@ tape('[Common/Chains]: Initialization / Chain params', function (t: tape.Test) {
   t.test('Should initialize with chain provided by Chain enum', function (st: tape.Test) {
     const c = new Common({ chain: Chain.Mainnet })
     st.equal(c.chainName(), 'mainnet', 'should initialize with chain name')
-    st.ok(c.chainIdBN().eqn(1), 'should return correct chain Id')
+    st.ok(c.chainId().eqn(1), 'should return correct chain Id')
     st.ok(c.networkIdBN().eqn(1), 'should return correct network Id')
     st.equal(c.hardfork(), 'istanbul', 'should set hardfork to current default hardfork')
     st.equal(

--- a/packages/common/tests/chains.spec.ts
+++ b/packages/common/tests/chains.spec.ts
@@ -7,7 +7,7 @@ tape('[Common/Chains]: Initialization / Chain params', function (t: tape.Test) {
     let c = new Common({ chain: 'mainnet' })
     st.equal(c.chainName(), 'mainnet', 'should initialize with chain name')
     st.ok(c.chainId().eqn(1), 'should return correct chain Id')
-    st.ok(c.networkIdBN().eqn(1), 'should return correct network Id')
+    st.ok(c.networkId().eqn(1), 'should return correct network Id')
     st.equal(c.hardfork(), 'istanbul', 'should set hardfork to current default hardfork')
     st.equal(
       c.hardfork(),
@@ -25,7 +25,7 @@ tape('[Common/Chains]: Initialization / Chain params', function (t: tape.Test) {
     const c = new Common({ chain: Chain.Mainnet })
     st.equal(c.chainName(), 'mainnet', 'should initialize with chain name')
     st.ok(c.chainId().eqn(1), 'should return correct chain Id')
-    st.ok(c.networkIdBN().eqn(1), 'should return correct network Id')
+    st.ok(c.networkId().eqn(1), 'should return correct network Id')
     st.equal(c.hardfork(), 'istanbul', 'should set hardfork to current default hardfork')
     st.equal(
       c.hardfork(),

--- a/packages/common/tests/customChains.spec.ts
+++ b/packages/common/tests/customChains.spec.ts
@@ -14,7 +14,7 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
       const c = new Common({ chain: testnet, hardfork: Hardfork.Byzantium })
       st.equal(c.chainName(), 'testnet', 'should initialize with chain name')
       st.ok(c.chainId().eqn(12345), 'should return correct chain Id')
-      st.ok(c.networkIdBN().eqn(12345), 'should return correct network Id')
+      st.ok(c.networkId().eqn(12345), 'should return correct network Id')
       st.equal(
         c.genesis().hash,
         '0xaa00000000000000000000000000000000000000000000000000000000000000',
@@ -53,7 +53,7 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
     // From custom chain params
     st.equal(customChainCommon.chainName(), customChainParams.name)
     st.ok(customChainCommon.chainId().eqn(customChainParams.chainId))
-    st.ok(customChainCommon.networkIdBN().eqn(customChainParams.networkId))
+    st.ok(customChainCommon.networkId().eqn(customChainParams.networkId))
 
     // Fallback params from mainnet
     st.equal(customChainCommon.genesis(), mainnetCommon.genesis())
@@ -68,12 +68,12 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
 
   t.test('custom() -> behavior', function (st: tape.Test) {
     let common = Common.custom({ chainId: 123 })
-    st.deepEqual(common.networkIdBN(), new BN(1), 'should default to mainnet base chain')
+    st.deepEqual(common.networkId(), new BN(1), 'should default to mainnet base chain')
     st.equal(common.chainName(), 'custom-chain', 'should set default custom chain name')
 
     common = Common.custom(CustomChain.PolygonMumbai)
     st.deepEqual(
-      common.networkIdBN(),
+      common.networkId(),
       new BN(80001),
       'supported chain -> should initialize with correct chain ID'
     )

--- a/packages/common/tests/customChains.spec.ts
+++ b/packages/common/tests/customChains.spec.ts
@@ -123,11 +123,11 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
       customChains: [testnet],
     })
     st.equal(c.chainName(), 'mainnet', 'customChains, chain set to supported chain')
-    st.ok(c.hardforkBlockBN()!.eqn(4370000), 'customChains, chain set to supported chain')
+    st.ok(c.hardforkBlock()!.eqn(4370000), 'customChains, chain set to supported chain')
 
     c.setChain('testnet')
     st.equal(c.chainName(), 'testnet', 'customChains, chain switched to custom chain')
-    st.ok(c.hardforkBlockBN()!.eqn(4), 'customChains, chain switched to custom chain')
+    st.ok(c.hardforkBlock()!.eqn(4), 'customChains, chain switched to custom chain')
 
     c = new Common({
       chain: 'testnet',
@@ -135,7 +135,7 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
       customChains: [testnet],
     })
     st.equal(c.chainName(), 'testnet', 'customChains, chain initialized with custom chain')
-    st.ok(c.hardforkBlockBN()!.eqn(4), 'customChains, chain initialized with custom chain')
+    st.ok(c.hardforkBlock()!.eqn(4), 'customChains, chain initialized with custom chain')
     st.deepEqual(
       c.genesisState(),
       {},
@@ -149,7 +149,7 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
       customChains,
     })
     st.equal(c.chainName(), 'testnet2', 'customChains, chain initialized with custom chain')
-    st.ok(c.hardforkBlockBN()!.eqn(10), 'customChains, chain initialized with custom chain')
+    st.ok(c.hardforkBlock()!.eqn(10), 'customChains, chain initialized with custom chain')
 
     c.setChain('testnet')
     st.equal(c.chainName(), 'testnet', 'customChains, should allow to switch custom chain')

--- a/packages/common/tests/customChains.spec.ts
+++ b/packages/common/tests/customChains.spec.ts
@@ -13,7 +13,7 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
     function (st: tape.Test) {
       const c = new Common({ chain: testnet, hardfork: Hardfork.Byzantium })
       st.equal(c.chainName(), 'testnet', 'should initialize with chain name')
-      st.ok(c.chainIdBN().eqn(12345), 'should return correct chain Id')
+      st.ok(c.chainId().eqn(12345), 'should return correct chain Id')
       st.ok(c.networkIdBN().eqn(12345), 'should return correct network Id')
       st.equal(
         c.genesis().hash,
@@ -52,7 +52,7 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
 
     // From custom chain params
     st.equal(customChainCommon.chainName(), customChainParams.name)
-    st.ok(customChainCommon.chainIdBN().eqn(customChainParams.chainId))
+    st.ok(customChainCommon.chainId().eqn(customChainParams.chainId))
     st.ok(customChainCommon.networkIdBN().eqn(customChainParams.networkId))
 
     // Fallback params from mainnet

--- a/packages/common/tests/hardforks.spec.ts
+++ b/packages/common/tests/hardforks.spec.ts
@@ -73,15 +73,15 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
   t.test('hardforkBlock()', function (st: tape.Test) {
     let c = new Common({ chain: Chain.Ropsten })
     let msg = 'should return the correct HF change block for byzantium (provided)'
-    st.ok(c.hardforkBlockBN(Hardfork.Byzantium)!.eqn(1700000), msg)
+    st.ok(c.hardforkBlock(Hardfork.Byzantium)!.eqn(1700000), msg)
 
     c = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Byzantium })
     msg = 'should return the correct HF change block for byzantium (set)'
-    st.ok(c.hardforkBlockBN()!.eqn(1700000), msg)
+    st.ok(c.hardforkBlock()!.eqn(1700000), msg)
 
     c = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Istanbul })
     msg = 'should return the correct HF change block for istanbul (set)'
-    st.ok(c.hardforkBlockBN()!.eqn(6485846), msg)
+    st.ok(c.hardforkBlock()!.eqn(6485846), msg)
 
     st.end()
   })
@@ -221,18 +221,18 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     st.end()
   })
 
-  t.test('hardforkBlockBN()', function (st: tape.Test) {
+  t.test('hardforkBlock()', function (st: tape.Test) {
     const c = new Common({ chain: Chain.Mainnet })
 
     let msg = 'should return correct value'
-    st.ok(c.hardforkBlockBN(Hardfork.Berlin)!.eqn(12244000), msg)
-    st.ok(c.hardforkBlockBN(Hardfork.Berlin)!.eq(new BN(12244000)), msg)
+    st.ok(c.hardforkBlock(Hardfork.Berlin)!.eqn(12244000), msg)
+    st.ok(c.hardforkBlock(Hardfork.Berlin)!.eq(new BN(12244000)), msg)
 
     msg = 'should return null for unscheduled hardfork'
     // developer note: when Shanghai is set,
     // update this test to next unscheduled hardfork.
-    st.equal(c.hardforkBlockBN(Hardfork.Shanghai), null, msg)
-    st.equal(c.hardforkBlockBN(Hardfork.Shanghai), null, msg)
+    st.equal(c.hardforkBlock(Hardfork.Shanghai), null, msg)
+    st.equal(c.hardforkBlock(Hardfork.Shanghai), null, msg)
     st.equal(c.nextHardforkBlock(Hardfork.Shanghai), null, msg)
 
     st.end()

--- a/packages/common/tests/hardforks.spec.ts
+++ b/packages/common/tests/hardforks.spec.ts
@@ -108,22 +108,22 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     let c = new Common({ chain: Chain.Rinkeby, hardfork: Hardfork.Chainstart })
     let msg =
       'should work with HF set / return correct next HF block for chainstart (rinkeby: chainstart -> homestead)'
-    st.ok(c.nextHardforkBlockBN()!.eqn(1), msg)
+    st.ok(c.nextHardforkBlock()!.eqn(1), msg)
 
     msg =
       'should correctly skip a HF where block is set to null (rinkeby: homestead -> (dao) -> tangerineWhistle)'
-    st.ok(c.nextHardforkBlockBN('homestead')!.eqn(2), msg)
+    st.ok(c.nextHardforkBlock('homestead')!.eqn(2), msg)
 
     msg = 'should return correct next HF (rinkeby: byzantium -> constantinople)'
-    st.ok(c.nextHardforkBlockBN(Hardfork.Byzantium)!.eqn(3660663), msg)
+    st.ok(c.nextHardforkBlock(Hardfork.Byzantium)!.eqn(3660663), msg)
 
     msg = 'should return null if next HF is not available (rinkeby: london -> shanghai)'
-    st.equal(c.nextHardforkBlockBN(Hardfork.London), null, msg)
+    st.equal(c.nextHardforkBlock(Hardfork.London), null, msg)
 
     msg =
       'should work correctly along the need to skip several forks (ropsten: chainstart -> (homestead) -> (dao) -> (tangerineWhistle) -> spuriousDragon)'
     c = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Chainstart })
-    st.ok(c.nextHardforkBlockBN()!.eqn(10), msg)
+    st.ok(c.nextHardforkBlock()!.eqn(10), msg)
 
     st.end()
   })
@@ -233,7 +233,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     // update this test to next unscheduled hardfork.
     st.equal(c.hardforkBlockBN(Hardfork.Shanghai), null, msg)
     st.equal(c.hardforkBlockBN(Hardfork.Shanghai), null, msg)
-    st.equal(c.nextHardforkBlockBN(Hardfork.Shanghai), null, msg)
+    st.equal(c.nextHardforkBlock(Hardfork.Shanghai), null, msg)
 
     st.end()
   })

--- a/packages/devp2p/src/eth/index.ts
+++ b/packages/devp2p/src/eth/index.ts
@@ -248,7 +248,7 @@ export class ETH extends EventEmitter {
     if (this._status !== null) return
     this._status = [
       int2buffer(this._version),
-      this._peer._common.chainIdBN().toArrayLike(Buffer),
+      this._peer._common.chainId().toArrayLike(Buffer),
       status.td,
       status.bestHash,
       status.genesisHash,

--- a/packages/devp2p/src/eth/index.ts
+++ b/packages/devp2p/src/eth/index.ts
@@ -61,7 +61,7 @@ export class ETH extends EventEmitter {
       this._latestBlock = c.hardforkBlockBN(this._hardfork) ?? new BN(0)
       this._forkHash = c.forkHash(this._hardfork)
       // Next fork block number or 0 if none available
-      this._nextForkBlock = c.nextHardforkBlockBN(this._hardfork) ?? new BN(0)
+      this._nextForkBlock = c.nextHardforkBlock(this._hardfork) ?? new BN(0)
     }
   }
 
@@ -154,7 +154,7 @@ export class ETH extends EventEmitter {
     }
 
     if (!c.hardforkGteHardfork(peerFork.name, this._hardfork)) {
-      const nextHardforkBlock = c.nextHardforkBlockBN(peerFork.name)
+      const nextHardforkBlock = c.nextHardforkBlock(peerFork.name)
       if (peerNextFork === null || !nextHardforkBlock || !nextHardforkBlock.eq(peerNextFork)) {
         const msg = 'Outdated fork status, remote needs software update'
         this.debug('STATUS', msg)

--- a/packages/devp2p/src/eth/index.ts
+++ b/packages/devp2p/src/eth/index.ts
@@ -58,7 +58,7 @@ export class ETH extends EventEmitter {
       this._hardfork = c.hardfork() ? c.hardfork() : this._hardfork
       // Set latestBlock minimally to start block of fork to have some more
       // accurate basis if no latestBlock is provided along status send
-      this._latestBlock = c.hardforkBlockBN(this._hardfork) ?? new BN(0)
+      this._latestBlock = c.hardforkBlock(this._hardfork) ?? new BN(0)
       this._forkHash = c.forkHash(this._hardfork)
       // Next fork block number or 0 if none available
       this._nextForkBlock = c.nextHardforkBlock(this._hardfork) ?? new BN(0)

--- a/packages/devp2p/src/les/index.ts
+++ b/packages/devp2p/src/les/index.ts
@@ -181,7 +181,7 @@ export class LES extends EventEmitter {
       status['announceType'] = int2buffer(DEFAULT_ANNOUNCE_TYPE)
     }
     status['protocolVersion'] = int2buffer(this._version)
-    status['networkId'] = this._peer._common.chainIdBN().toArrayLike(Buffer)
+    status['networkId'] = this._peer._common.chainId().toArrayLike(Buffer)
 
     this._status = status
 

--- a/packages/tx/examples/custom-chain-tx.ts
+++ b/packages/tx/examples/custom-chain-tx.ts
@@ -48,4 +48,4 @@ if (signedTx.validate() && signedTx.getSenderAddress().equals(address)) {
   console.log('Invalid signature')
 }
 
-console.log("The transaction's chain id is: ", signedTx.common.chainIdBN().toString())
+console.log("The transaction's chain id is: ", signedTx.common.chainId().toString())

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -342,7 +342,7 @@ export abstract class BaseTransaction<TransactionObject> {
     if (chainId) {
       const chainIdBN = new BN(toBuffer(chainId))
       if (common) {
-        if (!common.chainIdBN().eq(chainIdBN)) {
+        if (!common.chainId().eq(chainIdBN)) {
           const msg = this._errorMsg('The chain ID does not match the chain ID of Common')
           throw new Error(msg)
         }

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -187,7 +187,7 @@ export default class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMark
     const { chainId, accessList, maxFeePerGas, maxPriorityFeePerGas } = txData
 
     this.common = this._getCommon(opts.common, chainId)
-    this.chainId = this.common.chainIdBN()
+    this.chainId = this.common.chainId()
 
     if (!this.common.isActivatedEIP(1559)) {
       throw new Error('EIP-1559 not enabled on Common')

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -175,7 +175,7 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
     const { chainId, accessList, gasPrice } = txData
 
     this.common = this._getCommon(opts.common, chainId)
-    this.chainId = this.common.chainIdBN()
+    this.chainId = this.common.chainId()
 
     // EIP-2718 check is done in Common
     if (!this.common.isActivatedEIP(2930)) {

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -126,7 +126,7 @@ export default class Transaction extends BaseTransaction<Transaction> {
         // instead of hashing only the first six elements (i.e. nonce, gasprice, startgas, to, value, data)
         // hash nine elements, with v replaced by CHAIN_ID, r = 0 and s = 0.
         const v = this.v!
-        const chainIdDoubled = this.common.chainIdBN().muln(2)
+        const chainIdDoubled = this.common.chainId().muln(2)
 
         // v and chain ID meet EIP-155 conditions
         if (v.eq(chainIdDoubled.addn(35)) || v.eq(chainIdDoubled.addn(36))) {
@@ -192,7 +192,7 @@ export default class Transaction extends BaseTransaction<Transaction> {
     ]
 
     if (this.supports(Capability.EIP155ReplayProtection)) {
-      values.push(toBuffer(this.common.chainIdBN()))
+      values.push(toBuffer(this.common.chainId()))
       values.push(unpadBuffer(toBuffer(0)))
       values.push(unpadBuffer(toBuffer(0)))
     }
@@ -317,7 +317,7 @@ export default class Transaction extends BaseTransaction<Transaction> {
         v!,
         bnToUnpaddedBuffer(r!),
         bnToUnpaddedBuffer(s!),
-        this.supports(Capability.EIP155ReplayProtection) ? this.common.chainIdBN() : undefined
+        this.supports(Capability.EIP155ReplayProtection) ? this.common.chainId() : undefined
       )
     } catch (e: any) {
       const msg = this._errorMsg('Invalid Signature')
@@ -331,7 +331,7 @@ export default class Transaction extends BaseTransaction<Transaction> {
   protected _processSignature(v: number, r: Buffer, s: Buffer) {
     const vBN = new BN(v)
     if (this.supports(Capability.EIP155ReplayProtection)) {
-      vBN.iadd(this.common.chainIdBN().muln(2).addn(8))
+      vBN.iadd(this.common.chainId().muln(2).addn(8))
     }
 
     const opts = {
@@ -385,12 +385,12 @@ export default class Transaction extends BaseTransaction<Transaction> {
       !v.eqn(28)
     ) {
       if (common) {
-        const chainIdDoubled = common.chainIdBN().muln(2)
+        const chainIdDoubled = common.chainId().muln(2)
         const isValidEIP155V = v.eq(chainIdDoubled.addn(35)) || v.eq(chainIdDoubled.addn(36))
 
         if (!isValidEIP155V) {
           throw new Error(
-            `Incompatible EIP155-based V ${v} and chain id ${common.chainIdBN()}. See the Common parameter of the Transaction constructor to set the chain id.`
+            `Incompatible EIP155-based V ${v} and chain id ${common.chainId()}. See the Common parameter of the Transaction constructor to set the chain id.`
           )
         }
       } else {
@@ -429,7 +429,7 @@ export default class Transaction extends BaseTransaction<Transaction> {
     // If block.number >= 2,675,000 and v = CHAIN_ID * 2 + 35 or v = CHAIN_ID * 2 + 36, then when computing the hash of a transaction for purposes of signing or recovering, instead of hashing only the first six elements (i.e. nonce, gasprice, startgas, to, value, data), hash nine elements, with v replaced by CHAIN_ID, r = 0 and s = 0.
     const v = this.v!
 
-    const chainIdDoubled = this.common.chainIdBN().muln(2)
+    const chainIdDoubled = this.common.chainId().muln(2)
 
     const vAndChainIdMeetEIP155Conditions =
       v.eq(chainIdDoubled.addn(35)) || v.eq(chainIdDoubled.addn(36))

--- a/packages/tx/test/legacy.spec.ts
+++ b/packages/tx/test/legacy.spec.ts
@@ -55,28 +55,28 @@ tape('[Transaction]', function (t) {
     txData[6] = intToBuffer(45) // v with 0-parity and chain ID 5
     let tx = Transaction.fromValuesArray(txData)
     st.ok(
-      tx.common.chainIdBN().eqn(5),
+      tx.common.chainId().eqn(5),
       'should initialize Common with chain ID (supported) derived from v value (v with 0-parity)'
     )
 
     txData[6] = intToBuffer(46) // v with 1-parity and chain ID 5
     tx = Transaction.fromValuesArray(txData)
     st.ok(
-      tx.common.chainIdBN().eqn(5),
+      tx.common.chainId().eqn(5),
       'should initialize Common with chain ID (supported) derived from v value (v with 1-parity)'
     )
 
     txData[6] = intToBuffer(2033) // v with 0-parity and chain ID 999
     tx = Transaction.fromValuesArray(txData)
     st.ok(
-      tx.common.chainIdBN().eqn(999),
+      tx.common.chainId().eqn(999),
       'should initialize Common with chain ID (unsupported) derived from v value (v with 0-parity)'
     )
 
     txData[6] = intToBuffer(2034) // v with 1-parity and chain ID 999
     tx = Transaction.fromValuesArray(txData)
     st.ok(
-      tx.common.chainIdBN().eqn(999),
+      tx.common.chainId().eqn(999),
       'should initialize Common with chain ID (unsupported) derived from v value (v with 1-parity)'
     )
     st.end()
@@ -113,7 +113,7 @@ tape('[Transaction]', function (t) {
     function (st) {
       let common = new Common({ chain: 42, hardfork: Hardfork.Petersburg })
       let tx = Transaction.fromTxData({}, { common })
-      st.ok(tx.common.chainIdBN().eqn(42))
+      st.ok(tx.common.chainId().eqn(42))
       const privKey = Buffer.from(txFixtures[0].privateKey, 'hex')
       tx = tx.sign(privKey)
       const serialized = tx.serialize()
@@ -445,7 +445,7 @@ tape('[Transaction]', function (t) {
   t.test('sign(), verifySignature(): sign tx with chainId specified in params', function (st) {
     const common = new Common({ chain: 42, hardfork: Hardfork.Petersburg })
     let tx = Transaction.fromTxData({}, { common })
-    st.ok(tx.common.chainIdBN().eqn(42))
+    st.ok(tx.common.chainId().eqn(42))
 
     const privKey = Buffer.from(txFixtures[0].privateKey, 'hex')
     tx = tx.sign(privKey)
@@ -454,7 +454,7 @@ tape('[Transaction]', function (t) {
 
     const reTx = Transaction.fromSerializedTx(serialized, { common })
     st.equal(reTx.verifySignature(), true)
-    st.ok(reTx.common.chainIdBN().eqn(42))
+    st.ok(reTx.common.chainId().eqn(42))
 
     st.end()
   })

--- a/packages/tx/test/typedTxsAndEIP2930.spec.ts
+++ b/packages/tx/test/typedTxsAndEIP2930.spec.ts
@@ -57,7 +57,7 @@ tape(
           chainId: 5,
         })
         t.ok(
-          tx.common.chainIdBN().eqn(5),
+          tx.common.chainId().eqn(5),
           'should initialize Common with chain ID provided (supported chain ID)'
         )
 
@@ -65,7 +65,7 @@ tape(
           chainId: 99999,
         })
         t.ok(
-          tx.common.chainIdBN().eqn(99999),
+          tx.common.chainId().eqn(99999),
           'should initialize Common with chain ID provided (unsupported chain ID)'
         )
 

--- a/packages/vm/src/evm/eei.ts
+++ b/packages/vm/src/evm/eei.ts
@@ -327,7 +327,7 @@ export default class EEI {
    * CHAINID opcode proposed in [EIP-1344](https://eips.ethereum.org/EIPS/eip-1344).
    */
   getChainId(): BN {
-    return this._common.chainIdBN()
+    return this._common.chainId()
   }
 
   /**

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -136,7 +136,7 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
   // check for DAO support and if we should apply the DAO fork
   if (
     this._common.hardforkIsActiveOnChain('dao') &&
-    block.header.number.eq(this._common.hardforkBlockBN('dao')!)
+    block.header.number.eq(this._common.hardforkBlock('dao')!)
   ) {
     if (this.DEBUG) {
       debug(`Apply DAO hardfork`)

--- a/packages/vm/tests/api/EIPs/eip-1559-FeeMarket.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-1559-FeeMarket.spec.ts
@@ -20,7 +20,7 @@ const common = new Common({
 
 // Small hack to hack in the activation block number
 // (Otherwise there would be need for a custom chain only for testing purposes)
-common.hardforkBlockBN = function (hardfork: string | undefined) {
+common.hardforkBlock = function (hardfork: string | undefined) {
   if (hardfork === 'london') {
     return new BN(1)
   } else if (hardfork === 'dao') {

--- a/packages/vm/tests/api/EIPs/eip-3198-BaseFee.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3198-BaseFee.spec.ts
@@ -17,7 +17,7 @@ const common = new Common({
 
 // Small hack to hack in the activation block number
 // (Otherwise there would be need for a custom chain only for testing purposes)
-common.hardforkBlockBN = function (hardfork: string | undefined) {
+common.hardforkBlock = function (hardfork: string | undefined) {
   if (hardfork === 'london') {
     return new BN(1)
   } else if (hardfork === 'dao') {

--- a/packages/vm/tests/api/runTx.spec.ts
+++ b/packages/vm/tests/api/runTx.spec.ts
@@ -350,7 +350,7 @@ tape('runTx() -> runtime behavior', async (t) => {
         to: address,
       }
       if (txType.type === 1) {
-        txParams['chainId'] = common.chainIdBN()
+        txParams['chainId'] = common.chainId()
         txParams['accessList'] = []
         txParams['type'] = txType.type
       }

--- a/packages/vm/tests/api/utils.ts
+++ b/packages/vm/tests/api/utils.ts
@@ -66,7 +66,7 @@ export function getTransaction(
   }
 
   if (txType === 1) {
-    txParams['chainId'] = common.chainIdBN()
+    txParams['chainId'] = common.chainId()
     txParams['accessList'] = [
       {
         address: '0x0000000000000000000000000000000000000101',


### PR DESCRIPTION
#1633 

* Common: Rename *BN methods to non-BN names.
1. nextHardforkBlockBN() to nextHardforkBlock()
2. hardforkBlockBN() to hardforkBlock()
3. chainIdBN() to chainId()
4. networkIdBN to networkId()

* Rename method calls in tests and upstream libraries

1. common
1. client
1. devp2p
1. block
1. blockchain
1. vm
1. tx