### PR TITLE
Util: Upgrade to ethereum-cryptography 1.0

### DIFF
--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -39,8 +39,7 @@
   "dependencies": {
     "@types/bn.js": "^5.1.0",
     "bn.js": "^5.1.2",
-    "create-hash": "^1.1.2",
-    "ethereum-cryptography": "^0.1.3",
+    "ethereum-cryptography": "^1.0.3",
     "rlp": "^2.2.4"
   },
   "devDependencies": {

--- a/packages/util/src/account.ts
+++ b/packages/util/src/account.ts
@@ -1,10 +1,5 @@
 import { BN, rlp } from './externals'
-import {
-  privateKeyVerify,
-  publicKeyCreate,
-  publicKeyVerify,
-  publicKeyConvert,
-} from 'ethereum-cryptography/secp256k1'
+import { Point, utils } from 'ethereum-cryptography/secp256k1'
 import { stripHexPrefix } from './internal'
 import { KECCAK256_RLP, KECCAK256_NULL } from './constants'
 import { zeros, bufferToHex, toBuffer } from './bytes'
@@ -231,7 +226,7 @@ export const generateAddress2 = function (from: Buffer, salt: Buffer, initCode: 
  * Checks if the private key satisfies the rules of the curve secp256k1.
  */
 export const isValidPrivate = function (privateKey: Buffer): boolean {
-  return privateKeyVerify(privateKey)
+  return utils.isValidPrivateKey(privateKey)
 }
 
 /**
@@ -244,14 +239,25 @@ export const isValidPublic = function (publicKey: Buffer, sanitize: boolean = fa
   assertIsBuffer(publicKey)
   if (publicKey.length === 64) {
     // Convert to SEC1 for secp256k1
-    return publicKeyVerify(Buffer.concat([Buffer.from([4]), publicKey]))
+    // Automatically checks whether point is on curve
+    try {
+      Point.fromHex(Buffer.concat([Buffer.from([4]), publicKey]))
+      return true
+    } catch (e) {
+      return false
+    }
   }
 
   if (!sanitize) {
     return false
   }
 
-  return publicKeyVerify(publicKey)
+  try {
+    Point.fromHex(publicKey)
+    return true
+  } catch (e) {
+    return false
+  }
 }
 
 /**
@@ -263,7 +269,7 @@ export const isValidPublic = function (publicKey: Buffer, sanitize: boolean = fa
 export const pubToAddress = function (pubKey: Buffer, sanitize: boolean = false): Buffer {
   assertIsBuffer(pubKey)
   if (sanitize && pubKey.length !== 64) {
-    pubKey = Buffer.from(publicKeyConvert(pubKey, false).slice(1))
+    pubKey = Buffer.from(Point.fromHex(pubKey).toRawBytes(false).slice(1))
   }
   if (pubKey.length !== 64) {
     throw new Error('Expected pubKey to be of length 64')
@@ -280,7 +286,7 @@ export const publicToAddress = pubToAddress
 export const privateToPublic = function (privateKey: Buffer): Buffer {
   assertIsBuffer(privateKey)
   // skip the type flag and use the X, Y points
-  return Buffer.from(publicKeyCreate(privateKey, false)).slice(1)
+  return Buffer.from(Point.fromPrivateKey(privateKey).toRawBytes(false).slice(1))
 }
 
 /**
@@ -297,7 +303,7 @@ export const privateToAddress = function (privateKey: Buffer): Buffer {
 export const importPublic = function (publicKey: Buffer): Buffer {
   assertIsBuffer(publicKey)
   if (publicKey.length !== 64) {
-    publicKey = Buffer.from(publicKeyConvert(publicKey, false).slice(1))
+    publicKey = Buffer.from(Point.fromHex(publicKey).toRawBytes(false).slice(1))
   }
   return publicKey
 }

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -1,4 +1,4 @@
-import { ecdsaSign, ecdsaRecover, publicKeyConvert } from 'ethereum-cryptography/secp256k1'
+import { signSync, recoverPublicKey } from 'ethereum-cryptography/secp256k1'
 import { BN } from './externals'
 import { toBuffer, setLengthLeft, bufferToHex, bufferToInt } from './bytes'
 import { keccak } from './hash'
@@ -23,7 +23,7 @@ export interface ECDSASignatureBuffer {
 export function ecsign(msgHash: Buffer, privateKey: Buffer, chainId?: number): ECDSASignature
 export function ecsign(msgHash: Buffer, privateKey: Buffer, chainId: BNLike): ECDSASignatureBuffer
 export function ecsign(msgHash: Buffer, privateKey: Buffer, chainId: any): any {
-  const { signature, recid: recovery } = ecdsaSign(msgHash, privateKey)
+  const [signature, recovery] = signSync(msgHash, privateKey, { recovered: true, der: false })
 
   const r = Buffer.from(signature.slice(0, 32))
   const s = Buffer.from(signature.slice(32, 64))
@@ -35,6 +35,7 @@ export function ecsign(msgHash: Buffer, privateKey: Buffer, chainId: any): any {
         'The provided number is greater than MAX_SAFE_INTEGER (please use an alternative input type)'
       )
     }
+    // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
     const v = chainId ? recovery + (chainId * 2 + 35) : recovery + 27
     return { r, s, v }
   }
@@ -74,8 +75,9 @@ export const ecrecover = function (
   if (!isValidSigRecovery(recovery)) {
     throw new Error('Invalid signature v value')
   }
-  const senderPubKey = ecdsaRecover(signature, recovery.toNumber(), msgHash)
-  return Buffer.from(publicKeyConvert(senderPubKey, false).slice(1))
+
+  const senderPubKey = recoverPublicKey(msgHash, signature, recovery.toNumber())
+  return Buffer.from(senderPubKey.slice(1))
 }
 
 /**

--- a/packages/util/test/account.spec.ts
+++ b/packages/util/test/account.spec.ts
@@ -183,19 +183,16 @@ tape('Utility Functions', function (t) {
     )
 
     let tmp = '0011223344'
-    st.throws(function () {
-      isValidPrivate(Buffer.from(tmp, 'hex'))
-    }, 'should fail on short input')
+    st.notOk(isValidPrivate(Buffer.from(tmp, 'hex')), 'should fail on short input')
 
     tmp =
       '3a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d'
-    st.throws(function () {
-      isValidPrivate(Buffer.from(tmp, 'hex'))
-    }, 'should fail on too big input')
+    st.notOk(isValidPrivate(Buffer.from(tmp, 'hex')), 'should fail on too big input')
 
-    st.throws(function () {
-      isValidPrivate((<unknown>'WRONG_INPUT_TYPE') as Buffer)
-    }, 'should fail on wrong input type')
+    st.notOk(
+      isValidPrivate((<unknown>'WRONG_INPUT_TYPE') as Buffer),
+      'should fail on wrong input type'
+    )
 
     tmp = '0000000000000000000000000000000000000000000000000000000000000000'
     st.notOk(isValidPrivate(Buffer.from(tmp, 'hex')), 'should fail on invalid curve (zero)')
@@ -241,6 +238,24 @@ tape('Utility Functions', function (t) {
       'hex'
     )
     st.notOk(isValidPublic(pubKey), 'should fail wt.testh an invalid SEC1 public key')
+
+    pubKey = Buffer.from(
+      '03fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f',
+      'hex'
+    )
+    st.notOk(isValidPublic(pubKey), 'should fail an invalid 33-byte public key')
+
+    pubKey = Buffer.from(
+      'fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0000000000000000000000000000000000000000000000000000000000000001',
+      'hex'
+    )
+    st.notOk(isValidPublic(pubKey), 'should fail an invalid 64-byte public key')
+
+    pubKey = Buffer.from(
+      '04fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0000000000000000000000000000000000000000000000000000000000000001',
+      'hex'
+    )
+    st.notOk(isValidPublic(pubKey, true), 'should fail an invalid 65-byte public key')
 
     pubKey = Buffer.from(
       '033a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a',


### PR DESCRIPTION
Two caveats:

1. Added @noble/secp256k1 directly because we forgot to export `recoverPublicKey` to e-c. I suggest to merge like this, and i'll do another PR after we release 1.0.1
2. isValidPrivate tests are failing: noble does not throw on any invalid private, `isValidPrivateKey` is always either true or false. What should I do?

Closes #1668