### PR TITLE
Client: Geth genesis parser minor fix

### DIFF
--- a/packages/client/lib/util/parse.ts
+++ b/packages/client/lib/util/parse.ts
@@ -166,15 +166,12 @@ async function createGethGenesisBlockHeader(json: any) {
  * @returns genesis parameters in a `CommonOpts` compliant object
  */
 async function parseGethParams(json: any) {
-  const { name, config, difficulty, nonce, mixHash, coinbase } = json
+  const { name, config, difficulty, nonce, mixHash, coinbase, baseFeePerGas } = json
 
-  let { gasLimit, extraData, baseFeePerGas, timestamp } = json
+  let { gasLimit, extraData, timestamp } = json
 
   // geth stores gasLimit as a hex string while our gasLimit is a `number`
   json['gasLimit'] = gasLimit = parseInt(gasLimit)
-  // geth assumes an initial base fee value on londonBlock=0
-  json['baseFeePerGas'] = baseFeePerGas =
-    baseFeePerGas === undefined && config.londonBlock === 0 ? 1000000000 : undefined
   // geth is not strictly putting in empty fields with a 0x prefix
   json['extraData'] = extraData = extraData === '' ? '0x' : extraData
   // geth may use number for timestamp

--- a/packages/client/test/testdata/post-merge.json
+++ b/packages/client/test/testdata/post-merge.json
@@ -1,0 +1,35 @@
+{
+  "config": {
+    "chainId":1,
+    "homesteadBlock":0,
+    "eip150Block":0,
+    "eip155Block":0,
+    "eip158Block":0,
+    "byzantiumBlock":0,
+    "constantinopleBlock":0,
+    "petersburgBlock":0,
+    "istanbulBlock":0,
+    "muirGlacierBlock":0,
+    "berlinBlock":0,
+    "londonBlock":0,
+    "clique": {
+      "period": 5,
+      "epoch": 30000
+    },
+    "terminalTotalDifficulty":0
+  },
+  "nonce":"0x42",
+  "timestamp":"0x0",
+  "extraData":"0x0000000000000000000000000000000000000000000000000000000000000000a94f5374fce5edbc8e2a8697c15331677e6ebf0b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "gasLimit":"0x1C9C380",
+  "difficulty":"0x400000000",
+  "mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000",
+  "coinbase":"0x0000000000000000000000000000000000000000",
+  "alloc":{
+    "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b":{"balance":"0x6d6172697573766477000000"}
+  },
+  "number":"0x0",
+  "gasUsed":"0x0",
+  "parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000",
+  "baseFeePerGas":"0x7"
+}

--- a/packages/client/test/util/parse.spec.ts
+++ b/packages/client/test/util/parse.spec.ts
@@ -102,4 +102,16 @@ tape('[Util/Parse]', (t) => {
       'consensus config matches'
     )
   })
+
+  t.test(
+    'should generate expected hash with london block zero and base fee per gas defined',
+    async (t) => {
+      const json = require('../testdata/post-merge.json')
+      const params = await parseCustomParams(json, 'post-merge')
+      t.equals(
+        params.genesis.hash,
+        '0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a'
+      )
+    }
+  )
 })

--- a/packages/client/test/util/parse.spec.ts
+++ b/packages/client/test/util/parse.spec.ts
@@ -106,12 +106,14 @@ tape('[Util/Parse]', (t) => {
   t.test(
     'should generate expected hash with london block zero and base fee per gas defined',
     async (t) => {
+      t.plan(2)
       const json = require('../testdata/post-merge.json')
       const params = await parseCustomParams(json, 'post-merge')
       t.equals(
         params.genesis.hash,
         '0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a'
       )
+      t.equals(params.genesis.baseFeePerGas, json.baseFeePerGas)
     }
   )
 })


### PR DESCRIPTION
We had a logic where if the london block was zero and the `baseFeePerGas` undefined, we would set the `baseFeePerGas` to `1000000000`, otherwise, it would be undefined, this would not allow us to set the `baseFeePerGas` on the genesis initialization when parsing it with geth format. Now this logic has been moved to the block package (It was done by Ryan a few weeks ago)