### PR TITLE
ci: fix client integration failure

### DIFF
--- a/.github/workflows/node-versions.yml
+++ b/.github/workflows/node-versions.yml
@@ -5,6 +5,8 @@ name: Node versions
 on:
   schedule:
     - cron: 0 0 * * *
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   get-node-versions:

--- a/.github/workflows/node-versions.yml
+++ b/.github/workflows/node-versions.yml
@@ -5,8 +5,6 @@ name: Node versions
 on:
   schedule:
     - cron: 0 0 * * *
-  pull_request:
-    types: [opened, reopened, synchronize]
 
 jobs:
   get-node-versions:

--- a/packages/client/test/integration/fullsync.spec.ts
+++ b/packages/client/test/integration/fullsync.spec.ts
@@ -44,9 +44,9 @@ tape('[Integration:FullSync]', async (t) => {
     localService.config.events.on(Event.SYNC_SYNCHRONIZED, async () => {
       if (localService.chain.blocks.height.toNumber() === 10) {
         t.pass('synced with best peer')
+        await destroy(localServer, localService)
         await destroy(remoteServer1, remoteService1)
         await destroy(remoteServer2, remoteService2)
-        await destroy(localServer, localService)
       }
     })
     await localService.synchronizer.start()

--- a/packages/client/test/integration/mocks/mockserver.ts
+++ b/packages/client/test/integration/mocks/mockserver.ts
@@ -42,12 +42,8 @@ export default class MockServer extends Server {
   }
 
   async stop(): Promise<boolean> {
-    await new Promise((resolve) => {
-      setTimeout(() => {
-        destroyServer(this.location)
-        resolve(undefined)
-      }, 20)
-    })
+    await this.wait(20)
+    destroyServer(this.location)
     await super.stop()
     return this.started
   }


### PR DESCRIPTION
Closes #1736 

This was a weird race condition that sometimes passed and sometimes didn't on my local without any code changes.

By moving the localServer up in the destroy sequence it should execute it more reliably before the next test starts. I also replaced the setTimeout in `await new Promise` with `this.wait`