### PR TITLE
Tx: Execute on deprecation notes

### DIFF
--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -111,15 +111,6 @@ export abstract class BaseTransaction<TransactionObject> {
   }
 
   /**
-   * Alias for {@link BaseTransaction.type}
-   *
-   * @deprecated Use `type` instead
-   */
-  get transactionType(): number {
-    return this.type
-  }
-
-  /**
    * Returns the transaction type.
    *
    * Note: legacy txs will return tx type `0`.

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -49,15 +49,6 @@ export default class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMark
   protected DEFAULT_HARDFORK = 'london'
 
   /**
-   * EIP-2930 alias for `v`
-   *
-   * @deprecated use `v` instead
-   */
-  get yParity() {
-    return this.v
-  }
-
-  /**
    * Instantiate a transaction from a data dictionary.
    *
    * Format: { chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data,

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -87,19 +87,6 @@ export default class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMark
   }
 
   /**
-   * Instantiate a transaction from the serialized tx.
-   * (alias of {@link FeeMarketEIP1559Transaction.fromSerializedTx})
-   *
-   * Note: This means that the Buffer should start with 0x01.
-   *
-   * @deprecated this constructor alias is deprecated and will be removed
-   * in favor of the {@link FeeMarketEIP1559Transaction.fromSerializedTx} constructor
-   */
-  public static fromRlpSerializedTx(serialized: Buffer, opts: TxOptions = {}) {
-    return FeeMarketEIP1559Transaction.fromSerializedTx(serialized, opts)
-  }
-
-  /**
    * Create a transaction from a values array.
    *
    * Format: `[chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data,

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -49,15 +49,6 @@ export default class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMark
   protected DEFAULT_HARDFORK = 'london'
 
   /**
-   * EIP-2930 alias for `r`
-   *
-   * @deprecated use `r` instead
-   */
-  get senderR() {
-    return this.r
-  }
-
-  /**
    * EIP-2930 alias for `s`
    *
    * @deprecated use `s` instead

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -49,15 +49,6 @@ export default class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMark
   protected DEFAULT_HARDFORK = 'london'
 
   /**
-   * EIP-2930 alias for `s`
-   *
-   * @deprecated use `s` instead
-   */
-  get senderS() {
-    return this.s
-  }
-
-  /**
    * EIP-2930 alias for `v`
    *
    * @deprecated use `v` instead

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -49,15 +49,6 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
   protected DEFAULT_HARDFORK = 'berlin'
 
   /**
-   * EIP-2930 alias for `s`
-   *
-   * @deprecated use `s` instead
-   */
-  get senderS() {
-    return this.s
-  }
-
-  /**
    * EIP-2930 alias for `v`
    *
    * @deprecated use `v` instead

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -49,15 +49,6 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
   protected DEFAULT_HARDFORK = 'berlin'
 
   /**
-   * EIP-2930 alias for `r`
-   *
-   * @deprecated use `r` instead
-   */
-  get senderR() {
-    return this.r
-  }
-
-  /**
    * EIP-2930 alias for `s`
    *
    * @deprecated use `s` instead

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -87,19 +87,6 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
   }
 
   /**
-   * Instantiate a transaction from the serialized tx.
-   * (alias of {@link AccessListEIP2930Transaction.fromSerializedTx})
-   *
-   * Note: This means that the Buffer should start with 0x01.
-   *
-   * @deprecated this constructor alias is deprecated and will be removed
-   * in favor of the {@link AccessListEIP2930Transaction.fromSerializedTx} constructor
-   */
-  public static fromRlpSerializedTx(serialized: Buffer, opts: TxOptions = {}) {
-    return AccessListEIP2930Transaction.fromSerializedTx(serialized, opts)
-  }
-
-  /**
    * Create a transaction from a values array.
    *
    * Format: `[chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -49,15 +49,6 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
   protected DEFAULT_HARDFORK = 'berlin'
 
   /**
-   * EIP-2930 alias for `v`
-   *
-   * @deprecated use `v` instead
-   */
-  get yParity() {
-    return this.v
-  }
-
-  /**
    * Instantiate a transaction from a data dictionary.
    *
    * Format: { chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
@@ -344,11 +335,11 @@ export default class AccessListEIP2930Transaction extends BaseTransaction<Access
       throw new Error(msg)
     }
 
-    const { yParity, r, s } = this
+    const { v, r, s } = this
     try {
       return ecrecover(
         msgHash,
-        yParity!.addn(27), // Recover the 27 which was stripped from ecsign
+        v!.addn(27), // Recover the 27 which was stripped from ecsign
         bnToUnpaddedBuffer(r!),
         bnToUnpaddedBuffer(s!)
       )

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -398,28 +398,6 @@ export default class Transaction extends BaseTransaction<Transaction> {
   }
 
   /**
-   * @deprecated if you have called this internal method please use `tx.supports(Capabilities.EIP155ReplayProtection)` instead
-   */
-  private _signedTxImplementsEIP155() {
-    if (!this.isSigned()) {
-      const msg = this._errorMsg('This transaction is not signed')
-      throw new Error(msg)
-    }
-    const onEIP155BlockOrLater = this.common.gteHardfork('spuriousDragon')
-
-    // EIP155 spec:
-    // If block.number >= 2,675,000 and v = CHAIN_ID * 2 + 35 or v = CHAIN_ID * 2 + 36, then when computing the hash of a transaction for purposes of signing or recovering, instead of hashing only the first six elements (i.e. nonce, gasprice, startgas, to, value, data), hash nine elements, with v replaced by CHAIN_ID, r = 0 and s = 0.
-    const v = this.v!
-
-    const chainIdDoubled = this.common.chainId().muln(2)
-
-    const vAndChainIdMeetEIP155Conditions =
-      v.eq(chainIdDoubled.addn(35)) || v.eq(chainIdDoubled.addn(36))
-
-    return vAndChainIdMeetEIP155Conditions && onEIP155BlockOrLater
-  }
-
-  /**
    * Return a compact error string representation of the object
    */
   public errorStr() {

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -52,17 +52,6 @@ export default class Transaction extends BaseTransaction<Transaction> {
   }
 
   /**
-   * Instantiate a transaction from the serialized tx.
-   * (alias of {@link Transaction.fromSerializedTx})
-   *
-   * @deprecated this constructor alias is deprecated and will be removed
-   * in favor of the {@link Transaction.fromSerializedTx} constructor
-   */
-  public static fromRlpSerializedTx(serialized: Buffer, opts: TxOptions = {}) {
-    return Transaction.fromSerializedTx(serialized, opts)
-  }
-
-  /**
    * Create a transaction from a values array.
    *
    * Format: `[nonce, gasPrice, gasLimit, to, value, data, v, r, s]`

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -400,13 +400,6 @@ export default class Transaction extends BaseTransaction<Transaction> {
   /**
    * @deprecated if you have called this internal method please use `tx.supports(Capabilities.EIP155ReplayProtection)` instead
    */
-  private _unsignedTxImplementsEIP155() {
-    return this.common.gteHardfork('spuriousDragon')
-  }
-
-  /**
-   * @deprecated if you have called this internal method please use `tx.supports(Capabilities.EIP155ReplayProtection)` instead
-   */
   private _signedTxImplementsEIP155() {
     if (!this.isSigned()) {
       const msg = this._errorMsg('This transaction is not signed')

--- a/packages/tx/src/transactionFactory.ts
+++ b/packages/tx/src/transactionFactory.ts
@@ -7,7 +7,6 @@ import {
   FeeMarketEIP1559TxData,
 } from './types'
 import { Transaction, AccessListEIP2930Transaction, FeeMarketEIP1559Transaction } from '.'
-import Common from '@ethereumjs/common'
 
 export default class TransactionFactory {
   // It is not possible to instantiate a TransactionFactory object.
@@ -88,30 +87,6 @@ export default class TransactionFactory {
       return Transaction.fromValuesArray(data, txOptions)
     } else {
       throw new Error('Cannot decode transaction: unknown type input')
-    }
-  }
-
-  /**
-   * This helper method allows one to retrieve the class which matches the transactionID
-   * If transactionID is undefined, returns the legacy transaction class.
-   * @deprecated - This method is deprecated and will be removed on the next major release
-   * @param transactionID
-   * @param _common - This option is not used
-   */
-  public static getTransactionClass(transactionID: number = 0, _common?: Common) {
-    const legacyTxn = transactionID == 0 || (transactionID >= 0x80 && transactionID <= 0xff)
-
-    if (legacyTxn) {
-      return Transaction
-    }
-
-    switch (transactionID) {
-      case 1:
-        return AccessListEIP2930Transaction
-      case 2:
-        return FeeMarketEIP1559Transaction
-      default:
-        throw new Error(`TypedTransaction with ID ${transactionID} unknown`)
     }
   }
 }

--- a/packages/tx/test/base.spec.ts
+++ b/packages/tx/test/base.spec.ts
@@ -124,13 +124,6 @@ tape('[BaseTransaction]', function (t) {
 
       st.ok(Object.isFrozen(tx), `${txType.name}: tx should be frozen by default`)
 
-      tx = txType.class.fromRlpSerializedTx(rlpData, { common })
-      st.equal(
-        tx.type,
-        txType.type,
-        `${txType.name}: fromRlpSerializedTx() (deprecated) -> should initialize correctly`
-      )
-
       tx = txType.class.fromSerializedTx(rlpData, { common, freeze: false })
       st.ok(
         !Object.isFrozen(tx),

--- a/packages/tx/test/transactionFactory.spec.ts
+++ b/packages/tx/test/transactionFactory.spec.ts
@@ -147,25 +147,4 @@ tape('[TransactionFactory]: Basic functions', function (t) {
 
     st.end()
   })
-
-  t.test('getTransactionClass() -> success cases', function (st) {
-    const legacyTx = TransactionFactory.getTransactionClass()
-    st.equals(legacyTx!.name, Transaction.name)
-
-    for (const txType of txTypes) {
-      if (!txType.eip2718) {
-        const tx = TransactionFactory.getTransactionClass(txType.type)
-        st.equals(tx.name, txType.class.name)
-      }
-    }
-    st.end()
-  })
-
-  t.test('getTransactionClass() -> error cases', function (st) {
-    st.throws(() => {
-      TransactionFactory.getTransactionClass(3)
-    }, 'should throw when getting an invalid transaction type')
-
-    st.end()
-  })
 })

--- a/packages/tx/test/typedTxsAndEIP2930.spec.ts
+++ b/packages/tx/test/typedTxsAndEIP2930.spec.ts
@@ -262,7 +262,7 @@ tape(
       st.end()
     })
 
-    t.test('sign() / senderS(), senderR(), yParity()', function (t) {
+    t.test('sign() / senderS(), yParity()', function (t) {
       for (const txType of txTypes) {
         let tx = txType.class.fromTxData(
           {
@@ -281,7 +281,6 @@ tape(
         tx = txType.class.fromTxData({}, { common })
         signed = tx.sign(pKey)
 
-        t.deepEqual(signed.senderR, signed.r, `should provide senderR() alias (${txType.name})`)
         t.deepEqual(signed.senderS, signed.s, `should provide senderS() alias (${txType.name})`)
         t.deepEqual(signed.yParity, signed.v, `should provide yParity() alias (${txType.name})`)
 

--- a/packages/tx/test/typedTxsAndEIP2930.spec.ts
+++ b/packages/tx/test/typedTxsAndEIP2930.spec.ts
@@ -262,7 +262,7 @@ tape(
       st.end()
     })
 
-    t.test('sign() / yParity()', function (t) {
+    t.test('sign()', function (t) {
       for (const txType of txTypes) {
         let tx = txType.class.fromTxData(
           {
@@ -280,8 +280,6 @@ tape(
 
         tx = txType.class.fromTxData({}, { common })
         signed = tx.sign(pKey)
-
-        t.deepEqual(signed.yParity, signed.v, `should provide yParity() alias (${txType.name})`)
 
         t.deepEqual(
           tx.accessList,

--- a/packages/tx/test/typedTxsAndEIP2930.spec.ts
+++ b/packages/tx/test/typedTxsAndEIP2930.spec.ts
@@ -262,7 +262,7 @@ tape(
       st.end()
     })
 
-    t.test('sign() / senderS(), yParity()', function (t) {
+    t.test('sign() / yParity()', function (t) {
       for (const txType of txTypes) {
         let tx = txType.class.fromTxData(
           {
@@ -281,7 +281,6 @@ tape(
         tx = txType.class.fromTxData({}, { common })
         signed = tx.sign(pKey)
 
-        t.deepEqual(signed.senderS, signed.s, `should provide senderS() alias (${txType.name})`)
         t.deepEqual(signed.yParity, signed.v, `should provide yParity() alias (${txType.name})`)
 
         t.deepEqual(


### PR DESCRIPTION
Fixes #1739

Remove deprecated method declarations and tests

* get transactionType()
* get senderR()
* get senderS()
* get yParity()
* tx.fromRlpSerializedTx()
* _unsignedTxImplementsEIP155()
* _signedTxImplementsEIP155()
* TransactionFactory.getTransactionClass()