### PR TITLE
Block: deprecation tasks

### DIFF
--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -57,15 +57,6 @@ export class BlockHeader {
   }
 
   /**
-   * Backwards compatible alias for {@link BlockHeader.logsBloom}
-   * (planned to be removed in next major release)
-   * @deprecated
-   */
-  get bloom() {
-    return this.logsBloom
-  }
-
-  /**
    * EIP-4399: Post-PoS merge, `mixHash` supplanted as `random`
    */
   get random() {
@@ -85,11 +76,6 @@ export class BlockHeader {
    * @param opts
    */
   public static fromHeaderData(headerData: HeaderData = {}, opts: BlockOptions = {}) {
-    if (headerData.logsBloom === undefined && headerData.bloom !== undefined) {
-      // backwards compatible alias for deprecated `bloom` key renamed to `logsBloom`
-      // (planned to be removed in next major release)
-      headerData.logsBloom = headerData.bloom
-    }
     const {
       parentHash,
       uncleHash,
@@ -987,9 +973,7 @@ export class BlockHeader {
     }
     if (this._common.isActivatedEIP(1559)) {
       jsonDict.baseFeePerGas = '0x' + this.baseFeePerGas!.toString('hex')
-      jsonDict.baseFee = '0x' + this.baseFeePerGas!.toString('hex') // deprecated alias, please use `baseFeePerGas`, will be removed in next major release
     }
-    jsonDict.bloom = jsonDict.logsBloom // deprecated alias, please use `logsBloom`, will be removed in next major release
     return jsonDict
   }
 

--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -99,14 +99,6 @@ export interface HeaderData {
   mixHash?: BufferLike
   nonce?: BufferLike
   baseFeePerGas?: BNLike
-
-  /*
-   * Backwards compatible alias for {@link HeaderData.logsBloom}
-   * Will only be used if {@link HeaderData.logsBloom} is undefined
-   * (planned to be removed in next major release)
-   * @deprecated
-   */
-  bloom?: BufferLike
 }
 
 /**
@@ -162,19 +154,6 @@ export interface JsonHeader {
   mixHash?: string
   nonce?: string
   baseFeePerGas?: string
-
-  /*
-   * Backwards compatible alias for {@link JsonHeader.baseFeePerGas}
-   * (planned to be removed in next major release)
-   * @deprecated
-   */
-  baseFee?: string
-  /*
-   * Backwards compatible alias for {@link JsonHeader.logsBloom}
-   * (planned to be removed in next major release)
-   * @deprecated
-   */
-  bloom?: BufferLike
 }
 
 export interface Blockchain {

--- a/packages/block/test/eip1559block.spec.ts
+++ b/packages/block/test/eip1559block.spec.ts
@@ -491,7 +491,7 @@ tape('EIP1559 tests', function (t) {
         common,
       }
     )
-    st.equal(header.toJSON().baseFee, '0x5')
+    st.equal(header.toJSON().baseFeePerGas, '0x5')
     st.end()
   })
 })


### PR DESCRIPTION
closes #1747 

Removes `bloom` and `baseFee` from `block` package