### PR TITLE
Common: Genesis state logic improved

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -507,6 +507,8 @@ async function run() {
     const chainName = path.parse(args.gethGenesis).base.split('.')[0]
     const genesisParams = await parseCustomParams(genesisFile, chainName)
     const genesisState = genesisFile.alloc ? await parseGenesisState(genesisFile) : {}
+    console.log('Genesis block hash: ', genesisParams.genesis.hash)
+    console.log('Genesis state root: ', genesisParams.genesis.stateRoot)
     common = new Common({
       chain: genesisParams.name,
       customChains: [[genesisParams, genesisState]],

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -32,6 +32,7 @@
     "lint:fix": "../../config/cli/lint-fix.sh",
     "tape": "tape -r ts-node/register",
     "test": "npm run test:node && npm run test:browser",
+    "test:temp": "npm run tape -- ./tests/customChains.spec.ts",
     "test:node": "npm run tape -- ./tests/*.spec.ts",
     "test:browser": "karma start karma.conf.js",
     "docs:build": "typedoc --options typedoc.js"

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -40,9 +40,20 @@ export interface Chain {
   }
 }
 
-export interface GenesisState {
-  [key: string]: string | [string, [[string, string]]] // balance | [balance, code, [[storageKey, storageValue]]]
+export interface GethGenesisState {
+  json?: any
+  hash: string
+  stateRoot: string
 }
+
+export interface AccountState {
+  balance: string
+  nonce: string
+  code?: string
+  storage?: Record<string, string>
+}
+
+export type GenesisState = Record<string, string | AccountState>
 
 export interface eipsType {
   [key: number]: any

--- a/packages/common/tests/customChains.spec.ts
+++ b/packages/common/tests/customChains.spec.ts
@@ -4,10 +4,9 @@ import Common, { Chain, ConsensusType, CustomChain, Hardfork } from '../src/'
 import testnet from './data/testnet.json'
 import testnet2 from './data/testnet2.json'
 import testnet3 from './data/testnet3.json'
+import { AccountState, Chain as IChain, GenesisState, GethGenesisState } from '../src/types'
 
-import { Chain as IChain, GenesisState } from '../src/types'
-
-tape('[Common]: Custom chains', function (t: tape.Test) {
+tape.only('[Common]: Custom chains', function (t: tape.Test) {
   t.test(
     'chain -> object: should provide correct access to private network chain parameters',
     function (st: tape.Test) {
@@ -208,6 +207,46 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
 
     st.equal(c.hardforks()[3].forkHash, '0x215201ca', 'forkhash should be calculated correctly')
 
+    st.end()
+  })
+
+  t.test('custom genesis state', function (st: tape.Test) {
+    const mockedCode = '0xcde'
+    const firstAddress = '0x0000000000000000000000000000000000000001'
+    const genesisState = {
+      '0x0000000000000000000000000000000000000000': '0x1',
+      [firstAddress]: {
+        balance: '0x1',
+        nonce: '0x',
+        storage: {},
+        code: mockedCode,
+      },
+    }
+    const customChainsWithGenesis: [IChain, GenesisState][] = [[testnet, genesisState]]
+    const c = new Common({
+      chain: 'testnet',
+      customChains: customChainsWithGenesis,
+    })
+
+    const expectedGenesisState = c.genesisState()[firstAddress] as AccountState
+
+    st.equal(c.genesisState(), genesisState)
+    st.equal(expectedGenesisState.code, genesisState[firstAddress].code)
+    st.end()
+  })
+
+  t.test('custom hash and state root sent in genesis state', function (st: tape.Test) {
+    const genesisState = {
+      stateRoot: 'cool-state-root',
+      hash: 'cool-hash',
+    }
+    const customChainsWithGenesis: [IChain, GethGenesisState][] = [[testnet, genesisState]]
+    const c = new Common({
+      chain: 'testnet',
+      customChains: customChainsWithGenesis,
+    })
+    st.equal(c.genesis().hash, genesisState.hash)
+    st.equal(c.genesis().stateRoot, genesisState.stateRoot)
     st.end()
   })
 })


### PR DESCRIPTION
This is a very WIP PR that aims to improve the genesis state management in the common library. Open to any feedback just wanted to see what you think 

- State root and hash of genesis block can be passed as GenesisState in attribute customChains
- Now we show genesis block hash and state root in client process logs
- Genesis state is now storing storage, nonce, code and balance attributes to work with complex genesis files

Ideas on TODO:
- Handle geth genesis file format in common
- Add some examples
- Study if we can remove the static files in genesisState() method and try to retrieve it from configuration given, this way we can remove a lot of code from Common package
