### PR TITLE
client: increase json parser size

### DIFF
--- a/packages/client/lib/util/rpc.ts
+++ b/packages/client/lib/util/rpc.ts
@@ -26,7 +26,8 @@ function checkHeaderAuth(req: any, jwtSecret: Buffer): void {
 export function createRPCServerListener(opts: CreateRPCServerListenerOpts): HttpServer {
   const { server, withEngineMiddleware } = opts
   const app = Connect()
-  app.use(jsonParser())
+  // GOSSIP_MAX_SIZE_BELLATRIX is proposed to be 10MiB
+  app.use(jsonParser({ limit: '11mb' }))
 
   if (withEngineMiddleware) {
     const { jwtSecret, unlessFn } = withEngineMiddleware


### PR DESCRIPTION
the kilnv2 payload sizes were throwing error on engine api, updated the size limit in the body-parse as per the bellatrix specs of 10MiB of gossip size.