### PR TITLE
client: Kiln public testnet update

### DIFF
--- a/packages/client/.gitignore
+++ b/packages/client/.gitignore
@@ -1,0 +1,1 @@
+kiln/config

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -100,7 +100,7 @@ const args = yargs(hideBin(process.argv))
   })
   .option('wsPort', {
     describe: 'WS-RPC server listening port',
-    default: 8544,
+    default: 8545,
   })
   .option('wsAddr', {
     describe: 'WS-RPC server listening address',
@@ -113,16 +113,27 @@ const args = yargs(hideBin(process.argv))
   .option('rpcEnginePort', {
     describe: 'HTTP-RPC server listening port for Engine namespace',
     number: true,
-    default: 8550,
+    default: 8551,
   })
   .option('rpcEngineAddr', {
     describe: 'HTTP-RPC server listening interface address for Engine namespace',
     string: true,
     default: 'localhost',
   })
+  .option('wsEnginePort', {
+    describe: 'WS-RPC server listening port for Engine namespace',
+    number: true,
+    default: 8551,
+  })
+  .option('wsEngineAddr', {
+    describe: 'WS-RPC server listening interface address for Engine namespace',
+    string: true,
+    default: 'localhost',
+  })
   .option('rpcEngineAuth', {
     describe: 'Enable jwt authentication for Engine RPC server',
     boolean: true,
+    default: true,
   })
   .option('jwt-secret', {
     describe: 'Provide a file containing a hex encoded jwt secret for Engine RPC server',

--- a/packages/client/bin/startRpc.ts
+++ b/packages/client/bin/startRpc.ts
@@ -57,8 +57,7 @@ function parseJwtSecret(config: Config, jwtFilePath?: string): Buffer {
  * Starts and returns enabled RPCServers
  */
 export function startRPCServers(client: EthereumClient, args: RPCArgs) {
-  const config = client.config
-
+  const { config } = client
   const servers: RPCServer[] = []
   const {
     rpc,
@@ -78,10 +77,10 @@ export function startRPCServers(client: EthereumClient, args: RPCArgs) {
     rpcDebug,
   } = args
   const manager = new RPCManager(client, config)
-  const logger = config.logger
+  const { logger } = config
   const jwtSecret =
     rpcEngine && rpcEngineAuth ? parseJwtSecret(config, jwtSecretPath) : Buffer.from([])
-  let withEngineMethods
+  let withEngineMethods = false
 
   if (rpc || ws) {
     let rpcHttpServer
@@ -110,9 +109,9 @@ export function startRPCServers(client: EthereumClient, args: RPCArgs) {
             : undefined,
       })
       rpcHttpServer.listen(rpcport)
-      config.logger.info(
+      logger.info(
         `Started JSON RPC Server address=http://${rpcaddr}:${rpcport} namespaces=${namespaces}${
-          withEngineMethods ? ', rpcEngineAuth=' + rpcEngineAuth.toString() : ''
+          withEngineMethods ? ' rpcEngineAuth=' + rpcEngineAuth.toString() : ''
         }`
       )
     }
@@ -129,9 +128,9 @@ export function startRPCServers(client: EthereumClient, args: RPCArgs) {
 
       const rpcWsServer = createWsRPCServerListener(opts)
       if (rpcWsServer) rpcWsServer.listen(wsPort)
-      config.logger.info(
+      logger.info(
         `Started JSON RPC Server address=ws://${wsAddr}:${wsPort} namespaces=${namespaces}${
-          withEngineMethods ? ', rpcEngineAuth=' + rpcEngineAuth.toString() : ''
+          withEngineMethods ? ` rpcEngineAuth=${rpcEngineAuth}` : ''
         }`
       )
     }
@@ -153,10 +152,9 @@ export function startRPCServers(client: EthereumClient, args: RPCArgs) {
           }
         : undefined,
     })
-
     rpcHttpServer.listen(rpcEnginePort)
-    config.logger.info(
-      `Started JSON RPC server address=http://${rpcEngineAddr}:${rpcEnginePort} namespaces=engine, rpcEngineAuth=${rpcEngineAuth}`
+    logger.info(
+      `Started JSON RPC server address=http://${rpcEngineAddr}:${rpcEnginePort} namespaces=engine rpcEngineAuth=${rpcEngineAuth}`
     )
 
     if (ws) {
@@ -173,8 +171,8 @@ export function startRPCServers(client: EthereumClient, args: RPCArgs) {
 
       const rpcWsServer = createWsRPCServerListener(opts)
       if (rpcWsServer) rpcWsServer.listen(wsEnginePort)
-      config.logger.info(
-        `Started JSON RPC Server address=ws://${wsEngineAddr}:${wsEnginePort} namespaces=${namespaces}, rpcEngineAuth=${rpcEngineAuth}`
+      logger.info(
+        `Started JSON RPC Server address=ws://${wsEngineAddr}:${wsEnginePort} namespaces=${namespaces} rpcEngineAuth=${rpcEngineAuth}`
       )
     }
   }

--- a/packages/client/bin/startRpc.ts
+++ b/packages/client/bin/startRpc.ts
@@ -123,7 +123,7 @@ export function startRPCServers(client: EthereumClient, args: RPCArgs) {
       }
       if (rpcaddr === wsAddr && rpcport === wsPort) {
         // We want to load the websocket upgrade request to the same server
-        Object.assign(opts, { httpServer: rpcHttpServer })
+        opts.httpServer = rpcHttpServer
       }
 
       const rpcWsServer = createWsRPCServerListener(opts)
@@ -166,7 +166,7 @@ export function startRPCServers(client: EthereumClient, args: RPCArgs) {
 
       if (rpcEngineAddr === wsEngineAddr && rpcEnginePort === wsEnginePort) {
         // We want to load the websocket upgrade request to the same server
-        Object.assign(opts, { httpServer: rpcHttpServer })
+        opts.httpServer = rpcHttpServer
       }
 
       const rpcWsServer = createWsRPCServerListener(opts)

--- a/packages/client/bin/startRpc.ts
+++ b/packages/client/bin/startRpc.ts
@@ -42,13 +42,13 @@ function parseJwtSecret(config: Config, jwtFilePath?: string): Buffer {
     if (!jwtSecretHex || jwtSecretHex.length != 64) {
       throw Error('Need a valid 256 bit hex encoded secret')
     }
-    config.logger.debug(`Read a hex encoded secret, path=${jwtFilePath}`)
+    config.logger.debug(`Read a hex encoded jwt secret from path=${jwtFilePath}`)
     jwtSecret = Buffer.from(jwtSecretHex, 'hex')
   } else {
     jwtFilePath = `${config.datadir}/jwtsecret`
     jwtSecret = Buffer.from(Array.from({ length: 32 }, () => Math.round(Math.random() * 255)))
     writeFileSync(jwtFilePath, jwtSecret.toString('hex'))
-    config.logger.info(`A hex encoded random jwt secret written, path=${jwtFilePath}`)
+    config.logger.info(`Wrote a hex encoded random jwt secret to path=${jwtFilePath}`)
   }
   return jwtSecret
 }

--- a/packages/client/kiln/Dockerfile
+++ b/packages/client/kiln/Dockerfile
@@ -7,7 +7,7 @@ RUN git clone --depth 1 --branch master https://github.com/ethereumjs/ethereumjs
 WORKDIR /usr/app/ethereumjs-monorepo
 RUN npm i
 
-RUN cd packages/client/kiln && git init && git remote add -f origin https://github.com/eth-clients/merge-testnets.git && git config core.sparseCheckout true && echo "kiln/*" >> .git/info/sparse-checkout && git pull --depth=1 origin main
+RUN cd packages/client/kiln && git init && git remote add -f origin https://github.com/eth-clients/merge-testnets.git && git config core.sparseCheckout true && echo "kiln/*" >> .git/info/sparse-checkout && git pull --depth=1 origin main && mv kiln config
 
 FROM node:16-alpine
 WORKDIR /usr/app

--- a/packages/client/kiln/Dockerfile
+++ b/packages/client/kiln/Dockerfile
@@ -2,10 +2,12 @@ FROM node:16-alpine as build
 WORKDIR /usr/app
 RUN apk update && apk add --no-cache bash git && rm -rf /var/cache/apk/*
 
-RUN git clone --depth 1 --branch merge-kiln-v2 https://github.com/ethereumjs/ethereumjs-monorepo.git
+RUN git clone --depth 1 --branch master https://github.com/ethereumjs/ethereumjs-monorepo.git
 
 WORKDIR /usr/app/ethereumjs-monorepo
 RUN npm i
+
+RUN cd packages/client/kiln && git init && git remote add -f origin https://github.com/eth-clients/merge-testnets.git && git config core.sparseCheckout true && echo "kiln/*" >> .git/info/sparse-checkout && git pull --depth=1 origin main
 
 FROM node:16-alpine
 WORKDIR /usr/app

--- a/packages/client/kiln/README.md
+++ b/packages/client/kiln/README.md
@@ -1,8 +1,6 @@
 # Kiln v2 public testnet instructions
 
-Kiln v2 public testnet has been bootstrapped.
-
-The config files can be downloaded from https://github.com/eth-clients/merge-testnets/tree/main/kiln
+Kiln v2 public testnet has been bootstrapped. The config files can be downloaded from https://github.com/eth-clients/merge-testnets/tree/main/kiln
 
 ## Execution - EthereumJS Setup
 
@@ -16,21 +14,22 @@ Please ensure you have Node 12.x+ installed.
 ### Download the config
 
 1. `cd kiln`
-2. `git init && git remote add -f origin https://github.com/eth-clients/merge-testnets.git && git config core.sparseCheckout true && echo "kiln/*" >> .git/info/sparse-checkout && git pull --depth=1 origin main`
+2. `git init && git remote add -f origin https://github.com/eth-clients/merge-testnets.git && git config core.sparseCheckout true && echo "kiln/*" >> .git/info/sparse-checkout && git pull --depth=1 origin main && mv kiln config`
 
-This will download the config files to `kiln/kiln`.
++This will download the config files to `kiln/config`.
 
 ### Run client
 
-1. `npm run client:start -- --datadir kiln/datadir --gethGenesis kiln/kiln/genesis.json --saveReceipts --rpc --rpcport 8545 --ws --rpcEngine --rpcEnginePort=8551 --bootnodes=`
+1. `npm run client:start -- --datadir kiln/datadir --gethGenesis kiln/config/genesis.json --saveReceipts --rpc --rpcport=8545 --ws --rpcEngine --rpcEnginePort=8551 --bootnodes=165.232.180.230:30303`
 
 Starting the client will write a `kiln/datadir/jwtsecret` file with a randomly generated secret to be used in conjunction with a CL client. This secret will be used to authenticate the `engine_*` api requests (hosted at port `8551`) from the CL. In case you want to host `engine_*` without auth, pass `--rpcEngineAuth false` as extra argument in the above run command.
 
 To prevent the secret to be re-generated next time you restart the client, pass the file as an argument to read from via `--jwt-secret=kiln/datadir/jwtsecret`.
 
 ##### Note
+
 1. Other rpc apis, will be hosted openly without auth requirement at 8545.
-2. Websocket endpoints will also be available at `8551` (for `engine_*`) and `8545` for the rest. 
+2. Websocket endpoints will also be available at `8551` (for `engine_*`) and `8545` for the rest.
 
 #### Docker
 
@@ -47,7 +46,7 @@ In `packages/client/kiln` run:
 #### Beacon
 
 1. Use lodestar branch `master` and run `yarn && yarn build`
-2. Export path of the downloaded config dir `export CONFIG_PATH=/path/to/ethereumjs-monorepo/packages/client/kiln/kiln`
+2. Export path of the downloaded config dir `export CONFIG_PATH=/path/to/ethereumjs-monorepo/packages/client/kiln/config`
 3. Export path of the written jwt secret file `export JWT_SECRET_PATH=/path/to/ethereumjs-monorepo/packages/client/kiln/datadir/jwtsecret`
 4. Run cmd: `./lodestar beacon --rootDir kiln/temp --paramsFile $CONFIG_PATH/config.yaml --genesisStateFile $CONFIG_PATH/genesis.ssz --bootnodesFile $CONFIG_PATH/boot_enr.yaml --network.connectToDiscv5Bootnodes --network.discv5.enabled true --eth1.enabled true --eth1.providerUrls=http://localhost:8545 --execution.urls=http://localhost:8551 --eth1.disableEth1DepositDataTracker true --jwt-secret $JWT_SECRET_PATH`
 
@@ -55,7 +54,7 @@ In `packages/client/kiln` run:
 
 1. Run cmd: `./lodestar validator --rootDir=kiln/temp_validatordata --paramsFile=$CONFIG_PATH/config.yaml --keystoresDir=kiln/keystores --secretsDir=kiln/secrets`
 
-Also, one will need to remove `--eth1.disableEth1DepositDataTracker true` and instead provide `--eth1.depositContractDeployBlock <block number>` in the previous beacon start command. The block number can be extracted from `kiln/kiln/deposit_contract_block.txt`
+Also, one will need to remove `--eth1.disableEth1DepositDataTracker true` and instead provide `--eth1.depositContractDeployBlock <block number>` in the previous beacon start command. The block number can be extracted from `kiln/config/deposit_contract_block.txt`
 
 ### Lighthouse
 

--- a/packages/client/kiln/README.md
+++ b/packages/client/kiln/README.md
@@ -1,14 +1,14 @@
-# kiln v2 instructions
+# Kiln v2 public testnet instructions
 
-kiln v2 spec merge-devnet-5 has been bootstrapped.
+Kiln v2 public testnet has been bootstrapped.
 
-The config files can be downloaded from https://github.com/eth-clients/merge-testnets/tree/main/merge-devnet-5
+The config files can be downloaded from https://github.com/eth-clients/merge-testnets/tree/main/kiln
 
 ## Execution - EthereumJS Setup
 
 Please ensure you have Node 12.x+ installed.
 
-1. `git clone --depth 1 --branch merge-kiln-v2 https://github.com/ethereumjs/ethereumjs-monorepo.git`
+1. `git clone --depth 1 --branch master https://github.com/ethereumjs/ethereumjs-monorepo.git`
 1. `cd ethereumjs-monorepo`
 1. `npm i`
 1. `cd packages/client`
@@ -16,15 +16,21 @@ Please ensure you have Node 12.x+ installed.
 ### Download the config
 
 1. `cd kiln`
-2. `git init && git remote add -f origin https://github.com/eth-clients/merge-testnets.git && git config core.sparseCheckout true && echo "merge-devnet-5/*" >> .git/info/sparse-checkout && git pull --depth=1 origin main`
+2. `git init && git remote add -f origin https://github.com/eth-clients/merge-testnets.git && git config core.sparseCheckout true && echo "kiln/*" >> .git/info/sparse-checkout && git pull --depth=1 origin main`
 
-This will download the config files to `kiln/merge-devnet-5`.
+This will download the config files to `kiln/kiln`.
 
 ### Run client
 
-1. `npm run client:start -- --datadir kiln/datadir --gethGenesis kiln/merge-devnet-5/genesis.json --saveReceipts --rpc --ws --rpcEngine --rpcEnginePort=8545 --bootnodes=`
+1. `npm run client:start -- --datadir kiln/datadir --gethGenesis kiln/kiln/genesis.json --saveReceipts --rpc --rpcport 8545 --ws --rpcEngine --rpcEnginePort=8551 --bootnodes=`
 
-Starting the client will write a `kiln/datadir/jwtsecret` file with a randomly generated secret to be used in conjunction with a CL client. To prevent the secret to be re-generated next time you restart the client, pass the file as an argument to read from via `--jwt-secret=kiln/datadir/jwtsecret`.
+Starting the client will write a `kiln/datadir/jwtsecret` file with a randomly generated secret to be used in conjunction with a CL client. This secret will be used to authenticate the `engine_*` api requests (hosted at port `8551`) from the CL. In case you want to host `engine_*` without auth, pass `--rpcEngineAuth false` as extra argument in the above run command.
+
+To prevent the secret to be re-generated next time you restart the client, pass the file as an argument to read from via `--jwt-secret=kiln/datadir/jwtsecret`.
+
+##### Note
+1. Other rpc apis, will be hosted openly without auth requirement at 8545.
+2. Websocket endpoints will also be available at `8551` (for `engine_*`) and `8545` for the rest. 
 
 #### Docker
 
@@ -41,15 +47,15 @@ In `packages/client/kiln` run:
 #### Beacon
 
 1. Use lodestar branch `master` and run `yarn && yarn build`
-2. Export path of the downloaded config dir `export CONFIG_PATH=/path/to/ethereumjs-monorepo/packages/client/kiln/merge-devnet-5`
+2. Export path of the downloaded config dir `export CONFIG_PATH=/path/to/ethereumjs-monorepo/packages/client/kiln/kiln`
 3. Export path of the written jwt secret file `export JWT_SECRET_PATH=/path/to/ethereumjs-monorepo/packages/client/kiln/datadir/jwtsecret`
-4. Run cmd: `./lodestar beacon --rootDir kiln/temp --paramsFile $CONFIG_PATH/config.yaml --genesisStateFile $CONFIG_PATH/genesis.ssz --bootnodesFile $CONFIG_PATH/boot_enr.yaml --network.connectToDiscv5Bootnodes --network.discv5.enabled true --eth1.enabled true --eth1.providerUrls=http://localhost:8545 --execution.urls=http://localhost:8545 --eth1.disableEth1DepositDataTracker true --jwt-secret $JWT_SECRET_PATH`
+4. Run cmd: `./lodestar beacon --rootDir kiln/temp --paramsFile $CONFIG_PATH/config.yaml --genesisStateFile $CONFIG_PATH/genesis.ssz --bootnodesFile $CONFIG_PATH/boot_enr.yaml --network.connectToDiscv5Bootnodes --network.discv5.enabled true --eth1.enabled true --eth1.providerUrls=http://localhost:8545 --execution.urls=http://localhost:8551 --eth1.disableEth1DepositDataTracker true --jwt-secret $JWT_SECRET_PATH`
 
 #### Validator
 
 1. Run cmd: `./lodestar validator --rootDir=kiln/temp_validatordata --paramsFile=$CONFIG_PATH/config.yaml --keystoresDir=kiln/keystores --secretsDir=kiln/secrets`
 
-Also, one will need to remove `--eth1.disableEth1DepositDataTracker true` and instead provide `--eth1.depositContractDeployBlock <block number>` in the previous beacon start command. The block number can be extracted from `kiln/merge-devnet-5/deposit_contract_block.txt`
+Also, one will need to remove `--eth1.disableEth1DepositDataTracker true` and instead provide `--eth1.depositContractDeployBlock <block number>` in the previous beacon start command. The block number can be extracted from `kiln/kiln/deposit_contract_block.txt`
 
 ### Lighthouse
 
@@ -57,4 +63,4 @@ Also, one will need to remove `--eth1.disableEth1DepositDataTracker true` and in
 
 1. Use lighthouse branch `unstable` and run `make`
 1. Make dir `lighthouse/kiln` and copy in from the downloaded config dir: `config.yaml`, `genesis.ssz`, `deploy_block.txt`, `deposit_contract.txt`, `deposit_contract_block.txt`
-1. Run cmd: `lighthouse --debug-level=info --datadir=kiln/datadir --testnet-dir=kiln beacon_node --disable-enr-auto-update --dummy-eth1 --boot-nodes="enr:" --merge --http-allow-sync-stalled --metrics --disable-packet-filter --execution-endpoints=http://127.0.0.1:8545 --terminal-total-difficulty-override=`
+1. Run cmd: `lighthouse --debug-level=info --datadir=kiln/datadir --testnet-dir=kiln beacon_node --disable-enr-auto-update --dummy-eth1 --boot-nodes="enr:" --merge --http-allow-sync-stalled --metrics --disable-packet-filter --execution-endpoints=http://127.0.0.1:8551 --terminal-total-difficulty-override=`

--- a/packages/client/kiln/docker-compose.ethereumjs.yml
+++ b/packages/client/kiln/docker-compose.ethereumjs.yml
@@ -9,6 +9,7 @@ services:
       - ./execution_data:/execution_data
     ports:
       - '8545:8545'
+      - '8551:8551'
     #network_mode: host
     command: >
-      --datadir=/execution_data --gethGenesis=./ethereumjs-monorepo/packages/client/kiln/merge-devnet-5/genesis.json --rpc --rpcEngine --rpcEnginePort=8545 --saveReceipts --bootnodes=
+      --datadir=/execution_data --gethGenesis=./ethereumjs-monorepo/packages/client/kiln/kiln/genesis.json --rpc --rpcport 8545 --ws --rpcEngine --rpcEnginePort=8551 --saveReceipts --bootnodes=

--- a/packages/client/kiln/docker-compose.ethereumjs.yml
+++ b/packages/client/kiln/docker-compose.ethereumjs.yml
@@ -12,4 +12,4 @@ services:
       - '8551:8551'
     #network_mode: host
     command: >
-      --datadir=/execution_data --gethGenesis=./ethereumjs-monorepo/packages/client/kiln/kiln/genesis.json --rpc --rpcport 8545 --ws --rpcEngine --rpcEnginePort=8551 --saveReceipts --bootnodes=
+      --datadir=/execution_data --gethGenesis=./ethereumjs-monorepo/packages/client/kiln/config/genesis.json --rpc --rpcport=8545 --ws --rpcEngine --rpcEnginePort=8551 --saveReceipts --bootnodes=165.232.180.230:30303

--- a/packages/client/lib/client.ts
+++ b/packages/client/lib/client.ts
@@ -120,7 +120,7 @@ export default class EthereumClient {
       )
     })
     this.config.events.on(Event.SYNC_SYNCHRONIZED, (height) => {
-      this.config.logger.info(`Synchronized blockchain at height ${height}`)
+      this.config.logger.info(`Synchronized blockchain at height=${height}`)
     })
 
     await this.execution?.open()

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -377,7 +377,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
     this.debug(`Enqueued num=${tasks.length} tasks`)
     while (this.running) {
       if (!this.next()) {
-        if (this.finished === this.total) {
+        if (this.finished === this.total && this.destroyWhenDone) {
           this.push(null)
         }
         await this.wait()

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -139,11 +139,9 @@ export class FullSynchronizer extends Synchronizer {
       if (!latest) return resolve(false)
 
       const height = latest.number
-      if (!this.syncTargetHeight) {
+      if (!this.syncTargetHeight || this.syncTargetHeight.lt(latest.number)) {
         this.syncTargetHeight = height
-        this.config.logger.info(
-          `New sync target height number=${height} hash=${short(latest.hash())}`
-        )
+        this.config.logger.info(`New sync target height=${height} hash=${short(latest.hash())}`)
       }
 
       const first = this.chain.blocks.height.addn(1)
@@ -298,12 +296,7 @@ export class FullSynchronizer extends Synchronizer {
    * @param data new block hash announcements
    */
   handleNewBlockHashes(data: [Buffer, BN][]) {
-    if (!data.length) {
-      return
-    }
-    if (!this.fetcher) {
-      return
-    }
+    if (!data.length || !this.fetcher) return
     let min = new BN(-1)
     let newSyncHeight
     const blockNumberList: BN[] = []
@@ -320,9 +313,7 @@ export class FullSynchronizer extends Synchronizer {
       }
     })
 
-    if (!newSyncHeight) {
-      return
-    }
+    if (!newSyncHeight) return
     this.syncTargetHeight = newSyncHeight
     const [hash, height] = data[data.length - 1]
     this.config.logger.info(`New sync target height number=${height} hash=${short(hash)}`)

--- a/packages/client/lib/sync/lightsync.ts
+++ b/packages/client/lib/sync/lightsync.ts
@@ -90,11 +90,9 @@ export class LightSynchronizer extends Synchronizer {
       if (!latest) return resolve(false)
 
       const height = peer.les!.status.headNum
-      if (!this.syncTargetHeight) {
+      if (!this.syncTargetHeight || this.syncTargetHeight.lt(height)) {
         this.syncTargetHeight = height
-        this.config.logger.info(
-          `New sync target height number=${height} hash=${short(latest.hash())}`
-        )
+        this.config.logger.info(`New sync target height=${height} hash=${short(latest.hash())}`)
       }
 
       const first = this.chain.headers.height.addn(1)

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -151,7 +151,7 @@ export abstract class Synchronizer {
       if (!this.config.synchronized) {
         const hash = this.chain.headers.latest?.hash()
         this.config.logger.info(
-          `Chain synchronized height=${this.chain.headers.height} number=${short(hash!)}`
+          `Chain synchronized height=${this.chain.headers.height} hash=${short(hash!)}`
         )
       }
       this.config.synchronized = true

--- a/packages/client/lib/sync/txpool.ts
+++ b/packages/client/lib/sync/txpool.ts
@@ -119,7 +119,7 @@ export class TxPool {
   /**
    * Log pool statistics on the given interval
    */
-  private LOG_STATISTICS_INTERVAL = 10000 // ms
+  private LOG_STATISTICS_INTERVAL = 20000 // ms
 
   /**
    * Create new tx pool

--- a/packages/client/lib/util/index.ts
+++ b/packages/client/lib/util/index.ts
@@ -2,7 +2,6 @@
  * @module util
  */
 import { platform } from 'os'
-import { inspect } from 'util'
 import { version as packageVersion } from '../../package.json'
 
 export * from './parse'
@@ -15,21 +14,4 @@ export function short(buffer: Buffer): string {
 export function getClientVersion() {
   const { version } = process
   return `EthereumJS/${packageVersion}/${platform()}/node${version.substring(1)}`
-}
-
-/**
- * Internal util to pretty print params for logging.
- */
-export function inspectParams(params: any, shorten?: number) {
-  let inspected = inspect(params, {
-    colors: true,
-    maxStringLength: 100,
-  } as any)
-  if (shorten) {
-    inspected = inspected.replace(/\n/g, '').replace(/ {2}/g, ' ')
-    if (inspected.length > shorten) {
-      inspected = inspected.slice(0, shorten) + '...'
-    }
-  }
-  return inspected
 }

--- a/packages/client/lib/util/rpc.ts
+++ b/packages/client/lib/util/rpc.ts
@@ -140,10 +140,10 @@ export function createRPCServerListener(opts: CreateRPCServerListenerOpts): Http
 
   if (withEngineMiddleware) {
     const { jwtSecret, unlessFn } = withEngineMiddleware
-    app.use(function (req, res, next) {
+    app.use((req, res, next) => {
       try {
-        if (unlessFn) {
-          if (unlessFn(req)) return next()
+        if (unlessFn && unlessFn(req)) {
+          return next()
         }
         checkHeaderAuth(req, jwtSecret)
         return next()

--- a/packages/client/lib/util/rpc.ts
+++ b/packages/client/lib/util/rpc.ts
@@ -4,6 +4,10 @@ import { json as jsonParser } from 'body-parser'
 import { decode, TAlgorithm } from 'jwt-simple'
 import Connect, { IncomingMessage } from 'connect'
 import cors from 'cors'
+import { inspect } from 'util'
+
+import { RPCManager } from '../rpc'
+import { Logger } from '../logging'
 
 const algorithm: TAlgorithm = 'HS256'
 
@@ -13,6 +17,99 @@ type CreateRPCServerListenerOpts = {
   withEngineMiddleware?: WithEngineMiddleware
 }
 type WithEngineMiddleware = { jwtSecret: Buffer; unlessFn?: (req: IncomingMessage) => boolean }
+
+export enum MethodConfig {
+  WithEngine = 'withengine',
+  WithoutEngine = 'withoutengine',
+  EngineOnly = 'engineonly',
+}
+
+/**
+ * Internal util to pretty print params for logging.
+ */
+export function inspectParams(params: any, shorten?: number) {
+  let inspected = inspect(params, {
+    colors: true,
+    maxStringLength: 100,
+  } as any)
+  if (shorten) {
+    inspected = inspected.replace(/\n/g, '').replace(/ {2}/g, ' ')
+    if (inspected.length > shorten) {
+      inspected = inspected.slice(0, shorten) + '...'
+    }
+  }
+  return inspected
+}
+
+export function createRPCServer(
+  manager: RPCManager,
+  {
+    methodConfig,
+    rpcDebug,
+    logger,
+  }: { methodConfig: MethodConfig; rpcDebug: boolean; logger?: Logger }
+): { server: RPCServer; methods: { [key: string]: Function }; namespaces: string } {
+  const onRequest = (request: any) => {
+    let msg = ''
+    if (rpcDebug) {
+      msg += `${request.method} called with params:\n${inspectParams(request.params)}`
+    } else {
+      msg += `${request.method} called with params: ${inspectParams(request.params, 125)}`
+    }
+    logger?.debug(msg)
+  }
+
+  const handleResponse = (request: any, response: any, batchAddOn = '') => {
+    let msg = ''
+    if (rpcDebug) {
+      msg = `${request.method}${batchAddOn} responded with:\n${inspectParams(response)}`
+    } else {
+      msg = `${request.method}${batchAddOn} responded with: `
+      if (response.result) {
+        msg += inspectParams(response, 125)
+      }
+      if (response.error) {
+        msg += `error: ${response.error.message}`
+      }
+    }
+    logger?.debug(msg)
+  }
+
+  const onBatchResponse = (request: any, response: any) => {
+    // Batch request
+    if (request.length !== undefined) {
+      if (response.length === undefined || response.length !== request.length) {
+        logger?.debug('Invalid batch request received.')
+        return
+      }
+      for (let i = 0; i < request.length; i++) {
+        handleResponse(request[i], response[i], ' (batch request)')
+      }
+    } else {
+      handleResponse(request, response)
+    }
+  }
+
+  let methods
+  switch (methodConfig) {
+    case MethodConfig.WithEngine:
+      methods = { ...manager.getMethods(), ...manager.getMethods(true) }
+      break
+    case MethodConfig.WithoutEngine:
+      methods = { ...manager.getMethods() }
+      break
+    case MethodConfig.EngineOnly:
+      methods = { ...manager.getMethods(true) }
+      break
+  }
+
+  const server = new RPCServer(methods)
+  server.on('request', onRequest)
+  server.on('response', onBatchResponse)
+  const namespaces = [...new Set(Object.keys(methods).map((m) => m.split('_')[0]))].join(',')
+
+  return { server, methods, namespaces }
+}
 
 function checkHeaderAuth(req: any, jwtSecret: Buffer): void {
   const header = (req.headers['Authorization'] ?? req.headers['authorization']) as string

--- a/packages/client/test/cli/cli-rpc.spec.ts
+++ b/packages/client/test/cli/cli-rpc.spec.ts
@@ -31,7 +31,7 @@ tape('[CLI] rpc', (t) => {
 
       if (message.includes('ws://')) {
         // if ws endpoint startup message detected, call ws endpoint with RPC method
-        const client = Client.websocket({ url: 'ws://localhost:8544' })
+        const client = Client.websocket({ url: 'ws://localhost:8545' })
         ;(client as any).ws.on('open', async function () {
           const res = await client.request('web3_clientVersion', [], 2.0)
           st.ok(res.result.includes('EthereumJS'), 'read from WS RPC')

--- a/packages/client/test/sync/fetcher/blockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/blockfetcher.spec.ts
@@ -64,7 +64,19 @@ tape('[BlockFetcher]', async (t) => {
     blockNumberList = [new BN(13), new BN(15)]
     min = new BN(13)
     fetcher.enqueueByNumberList(blockNumberList, min)
-    t.equals((fetcher as any).in.size(), 5, '2 new tasks for two non-subsequent block numbers')
+
+    // Clear fetcher queue for next test of gap when following head
+    fetcher.clear()
+    chain.headers.height = new BN(15)
+    blockNumberList = [new BN(50), new BN(51)]
+    min = new BN(50)
+    fetcher.enqueueByNumberList(blockNumberList, min)
+    t.equals(
+      (fetcher as any).in.size(),
+      2,
+      '1 new task to catch up to head (16-49), 1 new task for subsequent block numbers (50-51)'
+    )
+
     fetcher.destroy()
     t.end()
   })

--- a/packages/client/test/util/rpc.spec.ts
+++ b/packages/client/test/util/rpc.spec.ts
@@ -1,0 +1,46 @@
+import tape from 'tape'
+import { RPCManager } from '../../lib/rpc'
+import {
+  createRPCServer,
+  createRPCServerListener,
+  createWsRPCServerListener,
+  MethodConfig,
+} from '../../lib/util/rpc'
+import Client from '../../lib/client'
+import { Config } from '../../lib/config'
+
+tape('[Util/RPC]', (t) => {
+  t.test('should return enabled RPC servers', (st) => {
+    const config = new Config({ transports: [] })
+    const client = new Client({ config })
+    const manager = new RPCManager(client, config)
+    const { logger } = config
+    for (const methodConfig of Object.values(MethodConfig)) {
+      for (const rpcDebug of [false, true]) {
+        const { server } = createRPCServer(manager, { methodConfig, rpcDebug, logger })
+        const httpServer = createRPCServerListener({
+          server,
+          withEngineMiddleware: { jwtSecret: Buffer.alloc(32) },
+        })
+        const wsServer = createWsRPCServerListener({
+          server,
+          withEngineMiddleware: { jwtSecret: Buffer.alloc(32) },
+        })
+        const req = { id: 1, method: 'eth_getLatestBlock', params: [] }
+        const resp = { id: 1, result: { test: '123' } }
+        const reqBulk = [req, req]
+        const respBulk = [resp, { id: 2, error: { err0: '456' } }]
+        // Valid
+        server.emit('request', req)
+        server.emit('response', req, resp)
+        server.emit('response', reqBulk, respBulk)
+        // Invalid, mismatch
+        server.emit('response', req, respBulk)
+
+        st.ok(httpServer, 'should return http server')
+        st.ok(wsServer, 'should return ws server')
+      }
+    }
+    st.end()
+  })
+})

--- a/packages/client/webpack.config.js
+++ b/packages/client/webpack.config.js
@@ -50,11 +50,13 @@ module.exports = {
       crypto: require.resolve('crypto-browserify'), // used by: rlpxpeer, bin/cli.ts
       dgram: false, // used by: rlpxpeer via @ethereumjs/devp2p
       http: false, // used by: jayson
+      https: false, // used by: jayson
       fs: false, // used by: FullSynchronizer via @ethereumjs/vm
       net: false, // used by: rlpxpeer
       os: require.resolve('os-browserify/browser'), // used by: bin/cli.ts, web3_clientVersion rpc
       path: false, // used by: bin/cli.ts
       stream: require.resolve('stream-browserify'), // used by: fetcher
+      tls: false, // used by: jayson
       zlib: false, // used by: body-parser
     },
   },


### PR DESCRIPTION
This PR 
- updates the Kiln public testnet instructions
- switches on the engine api auth on a separate port 8551 by default (as what how its expected in kiln public testnet). 
- Also allows to  opens a websocket connection (via `-ws` flag) for engine api seperately (on same port 8551 by default for engine, and 8545 by default for non engine)

plus a small refactoring.
