### PR TITLE
devp2p: fix per-message debug logging

### DIFF
--- a/packages/devp2p/src/protocol/eth.ts
+++ b/packages/devp2p/src/protocol/eth.ts
@@ -1,8 +1,7 @@
 import assert from 'assert'
 import snappy from 'snappyjs'
-import { devp2pDebug } from '../util'
 import { BN, rlp } from 'ethereumjs-util'
-import { int2buffer, buffer2int, assertEq, formatLogId, formatLogData } from '../util'
+import { int2buffer, buffer2int, assertEq, formatLogId, formatLogData, devp2pDebug } from '../util'
 import { Peer } from '../rlpx/peer'
 import { Protocol } from './protocol'
 

--- a/packages/devp2p/src/protocol/eth.ts
+++ b/packages/devp2p/src/protocol/eth.ts
@@ -6,20 +6,17 @@ import { Peer } from '../rlpx/peer'
 import { EthProtocol, Protocol, SendMethod } from './protocol'
 
 export class ETH extends Protocol {
-  _status: ETH.StatusMsg | null
-  _peerStatus: ETH.StatusMsg | null
+  _status: ETH.StatusMsg | null = null
+  _peerStatus: ETH.StatusMsg | null = null
 
   // Eth64
-  _hardfork: string = 'chainstart'
+  _hardfork = 'chainstart'
   _latestBlock = new BN(0)
-  _forkHash: string = ''
+  _forkHash = ''
   _nextForkBlock = new BN(0)
 
   constructor(version: number, peer: Peer, send: SendMethod) {
     super(peer, send, EthProtocol.ETH, version, ETH.MESSAGE_CODES)
-
-    this._status = null
-    this._peerStatus = null
 
     // Set forkHash and nextForkBlock
     if (this._version >= 64) {

--- a/packages/devp2p/src/protocol/eth.ts
+++ b/packages/devp2p/src/protocol/eth.ts
@@ -1,16 +1,13 @@
 import assert from 'assert'
 import snappy from 'snappyjs'
 import { BN, rlp } from 'ethereumjs-util'
-import { int2buffer, buffer2int, assertEq, formatLogId, formatLogData, devp2pDebug } from '../util'
+import { int2buffer, buffer2int, assertEq, formatLogId, formatLogData } from '../util'
 import { Peer } from '../rlpx/peer'
-import { Protocol } from './protocol'
-
-const DEBUG_BASE_NAME = 'eth'
+import { EthProtocol, Protocol } from './protocol'
 
 type SendMethod = (code: ETH.MESSAGE_CODES, data: Buffer) => any
 
 export class ETH extends Protocol {
-  _version: number
   _status: ETH.StatusMsg | null
   _peerStatus: ETH.StatusMsg | null
   _send: SendMethod
@@ -22,12 +19,9 @@ export class ETH extends Protocol {
   _nextForkBlock = new BN(0)
 
   constructor(version: number, peer: Peer, send: SendMethod) {
-    super(peer, ETH.MESSAGE_CODES, DEBUG_BASE_NAME)
+    super(peer, EthProtocol.ETH, version, ETH.MESSAGE_CODES)
 
-    this._version = version
-    this._peer = peer
     this._send = send
-    this._debug = devp2pDebug.extend(DEBUG_BASE_NAME)
     this._status = null
     this._peerStatus = null
 

--- a/packages/devp2p/src/protocol/eth.ts
+++ b/packages/devp2p/src/protocol/eth.ts
@@ -3,14 +3,11 @@ import snappy from 'snappyjs'
 import { BN, rlp } from 'ethereumjs-util'
 import { int2buffer, buffer2int, assertEq, formatLogId, formatLogData } from '../util'
 import { Peer } from '../rlpx/peer'
-import { EthProtocol, Protocol } from './protocol'
-
-type SendMethod = (code: ETH.MESSAGE_CODES, data: Buffer) => any
+import { EthProtocol, Protocol, SendMethod } from './protocol'
 
 export class ETH extends Protocol {
   _status: ETH.StatusMsg | null
   _peerStatus: ETH.StatusMsg | null
-  _send: SendMethod
 
   // Eth64
   _hardfork: string = 'chainstart'
@@ -19,9 +16,8 @@ export class ETH extends Protocol {
   _nextForkBlock = new BN(0)
 
   constructor(version: number, peer: Peer, send: SendMethod) {
-    super(peer, EthProtocol.ETH, version, ETH.MESSAGE_CODES)
+    super(peer, send, EthProtocol.ETH, version, ETH.MESSAGE_CODES)
 
-    this._send = send
     this._status = null
     this._peerStatus = null
 

--- a/packages/devp2p/src/protocol/les.ts
+++ b/packages/devp2p/src/protocol/les.ts
@@ -3,21 +3,17 @@ import { rlp } from 'ethereumjs-util'
 import snappy from 'snappyjs'
 import { int2buffer, buffer2int, assertEq, formatLogData } from '../util'
 import { Peer, DISCONNECT_REASONS } from '../rlpx/peer'
-import { EthProtocol, Protocol } from './protocol'
+import { EthProtocol, Protocol, SendMethod } from './protocol'
 
 export const DEFAULT_ANNOUNCE_TYPE = 1
 
-type SendMethod = (code: LES.MESSAGE_CODES, data: Buffer) => any
-
 export class LES extends Protocol {
-  _send: SendMethod
   _status: LES.Status | null
   _peerStatus: LES.Status | null
 
   constructor(version: number, peer: Peer, send: SendMethod) {
-    super(peer, EthProtocol.LES, version, LES.MESSAGE_CODES)
+    super(peer, send, EthProtocol.LES, version, LES.MESSAGE_CODES)
 
-    this._send = send
     this._status = null
     this._peerStatus = null
     this._statusTimeoutId = setTimeout(() => {

--- a/packages/devp2p/src/protocol/les.ts
+++ b/packages/devp2p/src/protocol/les.ts
@@ -24,7 +24,7 @@ export class LES extends Protocol {
     this._version = version
     this._peer = peer
     this._send = send
-    this._debug = devp2pDebug
+    this._debug = devp2pDebug.extend(DEBUG_BASE_NAME)
     this._status = null
     this._peerStatus = null
     this._statusTimeoutId = setTimeout(() => {

--- a/packages/devp2p/src/protocol/les.ts
+++ b/packages/devp2p/src/protocol/les.ts
@@ -1,30 +1,23 @@
 import ms from 'ms'
 import { rlp } from 'ethereumjs-util'
 import snappy from 'snappyjs'
-import { devp2pDebug } from '../util'
 import { int2buffer, buffer2int, assertEq, formatLogData } from '../util'
 import { Peer, DISCONNECT_REASONS } from '../rlpx/peer'
-import { Protocol } from './protocol'
-
-const DEBUG_BASE_NAME = 'les'
+import { EthProtocol, Protocol } from './protocol'
 
 export const DEFAULT_ANNOUNCE_TYPE = 1
 
 type SendMethod = (code: LES.MESSAGE_CODES, data: Buffer) => any
 
 export class LES extends Protocol {
-  _version: number
   _send: SendMethod
   _status: LES.Status | null
   _peerStatus: LES.Status | null
 
   constructor(version: number, peer: Peer, send: SendMethod) {
-    super(peer, LES.MESSAGE_CODES, DEBUG_BASE_NAME)
+    super(peer, EthProtocol.LES, version, LES.MESSAGE_CODES)
 
-    this._version = version
-    this._peer = peer
     this._send = send
-    this._debug = devp2pDebug.extend(DEBUG_BASE_NAME)
     this._status = null
     this._peerStatus = null
     this._statusTimeoutId = setTimeout(() => {

--- a/packages/devp2p/src/protocol/les.ts
+++ b/packages/devp2p/src/protocol/les.ts
@@ -8,14 +8,12 @@ import { EthProtocol, Protocol, SendMethod } from './protocol'
 export const DEFAULT_ANNOUNCE_TYPE = 1
 
 export class LES extends Protocol {
-  _status: LES.Status | null
-  _peerStatus: LES.Status | null
+  _status: LES.Status | null = null
+  _peerStatus: LES.Status | null = null
 
   constructor(version: number, peer: Peer, send: SendMethod) {
     super(peer, send, EthProtocol.LES, version, LES.MESSAGE_CODES)
 
-    this._status = null
-    this._peerStatus = null
     this._statusTimeoutId = setTimeout(() => {
       this._peer.disconnect(DISCONNECT_REASONS.TIMEOUT)
     }, ms('5s'))

--- a/packages/devp2p/src/protocol/protocol.ts
+++ b/packages/devp2p/src/protocol/protocol.ts
@@ -9,10 +9,12 @@ export enum EthProtocol {
   LES = 'les',
 }
 type MessageCodes = { [key: number | string]: number | string }
+export type SendMethod = (code: number, data: Buffer) => any
 
 export class Protocol extends EventEmitter {
   _version: number
   _peer: Peer
+  _send: SendMethod
   _statusTimeoutId: NodeJS.Timeout
   _messageCodes: MessageCodes
   _debug: Debugger
@@ -22,16 +24,22 @@ export class Protocol extends EventEmitter {
    * Will be set to the first successfully connected peer to allow for
    * debugging with the `devp2p:FIRST_PEER` debugger
    */
-  _firstPeer: string
+  _firstPeer = ''
 
   // Message debuggers (e.g. { 'GET_BLOCK_HEADERS': [debug Object], ...})
   protected msgDebuggers: { [key: string]: (debug: string) => void } = {}
 
-  constructor(peer: Peer, protocol: EthProtocol, version: number, messageCodes: MessageCodes) {
+  constructor(
+    peer: Peer,
+    send: SendMethod,
+    protocol: EthProtocol,
+    version: number,
+    messageCodes: MessageCodes
+  ) {
     super()
 
-    this._firstPeer = ''
     this._peer = peer
+    this._send = send
     this._version = version
     this._messageCodes = messageCodes
     this._statusTimeoutId = setTimeout(() => {

--- a/packages/devp2p/src/protocol/protocol.ts
+++ b/packages/devp2p/src/protocol/protocol.ts
@@ -1,6 +1,7 @@
 import ms from 'ms'
 import { debug as createDebugLogger, Debugger } from 'debug'
 import { EventEmitter } from 'events'
+import { devp2pDebug } from '../util'
 import { Peer, DISCONNECT_REASONS } from '../rlpx/peer'
 
 type MessageCodes = { [key: number | string]: number | string }
@@ -31,7 +32,7 @@ export class Protocol extends EventEmitter {
       this._peer.disconnect(DISCONNECT_REASONS.TIMEOUT)
     }, ms('5s'))
 
-    this._debug = createDebugLogger(debugBaseName)
+    this._debug = devp2pDebug.extend(debugBaseName)
     this._verbose = createDebugLogger('verbose').enabled
     this.initMsgDebuggers(debugBaseName)
   }
@@ -41,13 +42,13 @@ export class Protocol extends EventEmitter {
       (value) => typeof value === 'string'
     ) as string[]
     for (const name of MESSAGE_NAMES) {
-      this.msgDebuggers[name] = createDebugLogger(`${debugBaseName}:${name}`)
+      this.msgDebuggers[name] = devp2pDebug.extend(debugBaseName).extend(name)
     }
 
     // Remote Peer IP logger
     const ip = this._peer._socket.remoteAddress
     if (ip) {
-      this.msgDebuggers[ip] = createDebugLogger(`devp2p:${ip}`)
+      this.msgDebuggers[ip] = devp2pDebug.extend(ip)
     }
   }
 
@@ -60,7 +61,7 @@ export class Protocol extends EventEmitter {
   _addFirstPeerDebugger() {
     const ip = this._peer._socket.remoteAddress
     if (ip) {
-      this.msgDebuggers[ip] = createDebugLogger(`devp2p:FIRST_PEER`)
+      this.msgDebuggers[ip] = devp2pDebug.extend('FIRST_PEER')
       this._peer._addFirstPeerDebugger()
       this._firstPeer = ip
     }

--- a/packages/devp2p/src/protocol/protocol.ts
+++ b/packages/devp2p/src/protocol/protocol.ts
@@ -8,7 +8,9 @@ export enum EthProtocol {
   ETH = 'eth',
   LES = 'les',
 }
+
 type MessageCodes = { [key: number | string]: number | string }
+
 export type SendMethod = (code: number, data: Buffer) => any
 
 export class Protocol extends EventEmitter {


### PR DESCRIPTION
Quick fix following up on https://github.com/ethereumjs/ethereumjs-monorepo/pull/1600#pullrequestreview-905465290, the main issue here was that the per-message debug logs were not prefixed with `devp2p` (so they were being output e.g. `eth:STATUS` rather than `devp2p:eth:STATUS`)

edit: I have also further consolidated the classes, moving _version and _send to the parent class