### PR TITLE
common: update status fields for EIPs and hardforks

### DIFF
--- a/packages/common/src/eips/1559.json
+++ b/packages/common/src/eips/1559.json
@@ -1,26 +1,26 @@
 {
-    "name": "EIP-1559",
-    "number": 1559,
-    "comment": "Fee market change for ETH 1.0 chain",
-    "url": "https://eips.ethereum.org/EIPS/eip-1559",
-    "status": "Review",
-    "minimumHardfork": "berlin",
-    "requiredEIPs": [2930],
-    "gasConfig": {
-      "baseFeeMaxChangeDenominator": {
-        "v": 8,
-        "d": "Maximum base fee change denominator"
-      },
-      "elasticityMultiplier": {
-        "v": 2,
-        "d": "Maximum block gas target elasticity"
-      },
-      "initialBaseFee": {
-        "v": 1000000000,
-        "d": "Initial base fee on first EIP1559 block"
-      }
+  "name": "EIP-1559",
+  "number": 1559,
+  "comment": "Fee market change for ETH 1.0 chain",
+  "url": "https://eips.ethereum.org/EIPS/eip-1559",
+  "status": "Final",
+  "minimumHardfork": "berlin",
+  "requiredEIPs": [2930],
+  "gasConfig": {
+    "baseFeeMaxChangeDenominator": {
+      "v": 8,
+      "d": "Maximum base fee change denominator"
     },
-    "gasPrices": {},
-    "vm": {},
-    "pow": {}
-  }
+    "elasticityMultiplier": {
+      "v": 2,
+      "d": "Maximum block gas target elasticity"
+    },
+    "initialBaseFee": {
+      "v": 1000000000,
+      "d": "Initial base fee on first EIP1559 block"
+    }
+  },
+  "gasPrices": {},
+  "vm": {},
+  "pow": {}
+}

--- a/packages/common/src/eips/2315.json
+++ b/packages/common/src/eips/2315.json
@@ -3,7 +3,7 @@
   "number": 2315,
   "comment": "Simple subroutines for the EVM",
   "url": "https://eips.ethereum.org/EIPS/eip-2315",
-  "status": "Draft",
+  "status": "EXPERIMENTAL",
   "minimumHardfork": "istanbul",
   "gasConfig": {},
   "gasPrices": {

--- a/packages/common/src/eips/2315.json
+++ b/packages/common/src/eips/2315.json
@@ -3,7 +3,7 @@
   "number": 2315,
   "comment": "Simple subroutines for the EVM",
   "url": "https://eips.ethereum.org/EIPS/eip-2315",
-  "status": "EXPERIMENTAL",
+  "status": "Draft",
   "minimumHardfork": "istanbul",
   "gasConfig": {},
   "gasPrices": {

--- a/packages/common/src/eips/2565.json
+++ b/packages/common/src/eips/2565.json
@@ -1,17 +1,17 @@
 {
-    "name": "EIP-2565",
-    "number": 2565,
-    "comment": "ModExp gas cost",
-    "url": "https://eips.ethereum.org/EIPS/eip-2565",
-    "status": "Last call",
-    "minimumHardfork": "byzantium",
-    "gasConfig": {},
-    "gasPrices": {
-        "modexpGquaddivisor": {
-            "v": 3,
-            "d": "Gquaddivisor from modexp precompile for gas calculation"
-        }
-    },
-    "vm": {},
-    "pow": {}
+  "name": "EIP-2565",
+  "number": 2565,
+  "comment": "ModExp gas cost",
+  "url": "https://eips.ethereum.org/EIPS/eip-2565",
+  "status": "Final",
+  "minimumHardfork": "byzantium",
+  "gasConfig": {},
+  "gasPrices": {
+    "modexpGquaddivisor": {
+      "v": 3,
+      "d": "Gquaddivisor from modexp precompile for gas calculation"
+    }
+  },
+  "vm": {},
+  "pow": {}
 }

--- a/packages/common/src/eips/2718.json
+++ b/packages/common/src/eips/2718.json
@@ -1,12 +1,11 @@
 {
-    "name": "EIP-2718",
-    "comment": "Typed Transaction Envelope",
-    "url": "https://eips.ethereum.org/EIPS/eip-2718",
-    "status": "Draft",
-    "minimumHardfork": "chainstart",
-    "gasConfig": {},
-    "gasPrices": {},
-    "vm": {},
-    "pow": {}
-  }
-  
+  "name": "EIP-2718",
+  "comment": "Typed Transaction Envelope",
+  "url": "https://eips.ethereum.org/EIPS/eip-2718",
+  "status": "Final",
+  "minimumHardfork": "chainstart",
+  "gasConfig": {},
+  "gasPrices": {},
+  "vm": {},
+  "pow": {}
+}

--- a/packages/common/src/eips/2929.json
+++ b/packages/common/src/eips/2929.json
@@ -2,7 +2,7 @@
   "name": "EIP-2929",
   "comment": "Gas cost increases for state access opcodes",
   "url": "https://eips.ethereum.org/EIPS/eip-2929",
-  "status": "Draft",
+  "status": "Final",
   "minimumHardfork": "chainstart",
   "gasConfig": {},
   "gasPrices": {

--- a/packages/common/src/eips/2930.json
+++ b/packages/common/src/eips/2930.json
@@ -1,22 +1,21 @@
 {
-    "name": "EIP-2930",
-    "comment": "Optional access lists",
-    "url": "https://eips.ethereum.org/EIPS/eip-2930",
-    "status": "Draft",
-    "minimumHardfork": "istanbul",
-    "requiredEIPs": [2718, 2929],
-    "gasConfig": {},
-    "gasPrices": {
-      "accessListStorageKeyCost": {
-        "v": 1900,
-        "d": "Gas cost per storage key in an Access List transaction"
-      },
-      "accessListAddressCost": {
-        "v": 2400,
-        "d": "Gas cost per storage key in an Access List transaction"
-      }
+  "name": "EIP-2930",
+  "comment": "Optional access lists",
+  "url": "https://eips.ethereum.org/EIPS/eip-2930",
+  "status": "Final",
+  "minimumHardfork": "istanbul",
+  "requiredEIPs": [2718, 2929],
+  "gasConfig": {},
+  "gasPrices": {
+    "accessListStorageKeyCost": {
+      "v": 1900,
+      "d": "Gas cost per storage key in an Access List transaction"
     },
-    "vm": {},
-    "pow": {}
-  }
-  
+    "accessListAddressCost": {
+      "v": 2400,
+      "d": "Gas cost per storage key in an Access List transaction"
+    }
+  },
+  "vm": {},
+  "pow": {}
+}

--- a/packages/common/src/eips/3198.json
+++ b/packages/common/src/eips/3198.json
@@ -1,17 +1,17 @@
 {
-    "name": "EIP-3198",
-    "number": 3198,
-    "comment": "BASEFEE opcode",
-    "url": "https://eips.ethereum.org/EIPS/eip-3198",
-    "status": "Review",
-    "minimumHardfork": "london",
-    "gasConfig": {},
-    "gasPrices": {    
-      "basefee": {
-        "v": 2,
-        "d": "Gas cost of the BASEFEE opcode"
-      }
-    },
-    "vm": {},
-    "pow": {}
-  }
+  "name": "EIP-3198",
+  "number": 3198,
+  "comment": "BASEFEE opcode",
+  "url": "https://eips.ethereum.org/EIPS/eip-3198",
+  "status": "Final",
+  "minimumHardfork": "london",
+  "gasConfig": {},
+  "gasPrices": {
+    "basefee": {
+      "v": 2,
+      "d": "Gas cost of the BASEFEE opcode"
+    }
+  },
+  "vm": {},
+  "pow": {}
+}

--- a/packages/common/src/eips/3529.json
+++ b/packages/common/src/eips/3529.json
@@ -1,27 +1,26 @@
 {
-    "name": "EIP-3529",
-    "comment": "Reduction in refunds",
-    "url": "https://eips.ethereum.org/EIPS/eip-3529",
-    "status": "Draft",
-    "minimumHardfork": "berlin",
-    "requiredEIPs": [2929],
-    "gasConfig": {
-      "maxRefundQuotient": {
-        "v": 5,
-        "d": "Maximum refund quotient; max tx refund is min(tx.gasUsed/maxRefundQuotient, tx.gasRefund)"
-      }
+  "name": "EIP-3529",
+  "comment": "Reduction in refunds",
+  "url": "https://eips.ethereum.org/EIPS/eip-3529",
+  "status": "Final",
+  "minimumHardfork": "berlin",
+  "requiredEIPs": [2929],
+  "gasConfig": {
+    "maxRefundQuotient": {
+      "v": 5,
+      "d": "Maximum refund quotient; max tx refund is min(tx.gasUsed/maxRefundQuotient, tx.gasRefund)"
+    }
+  },
+  "gasPrices": {
+    "selfdestructRefund": {
+      "v": 0,
+      "d": "Refunded following a selfdestruct operation"
     },
-    "gasPrices": {
-      "selfdestructRefund": {
-        "v": 0,
-        "d": "Refunded following a selfdestruct operation"
-      },
-      "sstoreClearRefundEIP2200": {
-        "v": 4800,
-        "d": "Once per SSTORE operation for clearing an originally existing storage slot"
-      }
-    },
-    "vm": {},
-    "pow": {}
-  }
-  
+    "sstoreClearRefundEIP2200": {
+      "v": 4800,
+      "d": "Once per SSTORE operation for clearing an originally existing storage slot"
+    }
+  },
+  "vm": {},
+  "pow": {}
+}

--- a/packages/common/src/eips/3541.json
+++ b/packages/common/src/eips/3541.json
@@ -1,13 +1,12 @@
 {
-    "name": "EIP-3541",
-    "comment": "Reject new contracts starting with the 0xEF byte",
-    "url": "https://eips.ethereum.org/EIPS/eip-3541",
-    "status": "Draft",
-    "minimumHardfork": "berlin",
-    "requiredEIPs": [],
-    "gasConfig": {},
-    "gasPrices": {},
-    "vm": {},
-    "pow": {}
-  }
-  
+  "name": "EIP-3541",
+  "comment": "Reject new contracts starting with the 0xEF byte",
+  "url": "https://eips.ethereum.org/EIPS/eip-3541",
+  "status": "Final",
+  "minimumHardfork": "berlin",
+  "requiredEIPs": [],
+  "gasConfig": {},
+  "gasPrices": {},
+  "vm": {},
+  "pow": {}
+}

--- a/packages/common/src/eips/3554.json
+++ b/packages/common/src/eips/3554.json
@@ -1,18 +1,17 @@
 {
-    "name": "EIP-3554",
-    "comment": "Reduction in refunds",
-    "url": "Difficulty Bomb Delay to December 1st 2021",
-    "status": "Draft",
-    "minimumHardfork": "muirGlacier",
-    "requiredEIPs": [],
-    "gasConfig": {},
-    "gasPrices": {},
-    "vm": {},
-    "pow": {
-        "difficultyBombDelay": {
-          "v": 9500000,
-          "d": "the amount of blocks to delay the difficulty bomb with"
-        }
-      }
+  "name": "EIP-3554",
+  "comment": "Reduction in refunds",
+  "url": "Difficulty Bomb Delay to December 1st 2021",
+  "status": "Final",
+  "minimumHardfork": "muirGlacier",
+  "requiredEIPs": [],
+  "gasConfig": {},
+  "gasPrices": {},
+  "vm": {},
+  "pow": {
+    "difficultyBombDelay": {
+      "v": 9500000,
+      "d": "the amount of blocks to delay the difficulty bomb with"
+    }
   }
-  
+}

--- a/packages/common/src/eips/3607.json
+++ b/packages/common/src/eips/3607.json
@@ -3,7 +3,7 @@
   "number": 3607,
   "comment": "Reject transactions from senders with deployed code",
   "url": "https://eips.ethereum.org/EIPS/eip-3607",
-  "status": "Draft",
+  "status": "Final",
   "minimumHardfork": "chainstart",
   "requiredEIPs": [],
   "gasConfig": {},

--- a/packages/common/src/eips/3675.json
+++ b/packages/common/src/eips/3675.json
@@ -3,7 +3,7 @@
   "number": 3675,
   "comment": "Upgrade consensus to Proof-of-Stake",
   "url": "https://eips.ethereum.org/EIPS/eip-3675",
-  "status": "Draft",
+  "status": "Review",
   "minimumHardfork": "london",
   "requiredEIPs": [],
   "gasConfig": {},

--- a/packages/common/src/eips/3855.json
+++ b/packages/common/src/eips/3855.json
@@ -1,18 +1,18 @@
 {
-    "name": "EIP-3855",
-    "number": 3855,
-    "comment": "PUSH0 instruction",
-    "url": "https://eips.ethereum.org/EIPS/eip-3855",
-    "status": "Review",
-    "minimumHardfork": "chainstart",
-    "requiredEIPs": [],
-    "gasConfig": {},
-    "gasPrices": {
-      "push0": {
-        "v": 2,
-        "d": "Base fee of the PUSH0 opcode"
-      }
-    },
-    "vm": {},
-    "pow": {}
-  }
+  "name": "EIP-3855",
+  "number": 3855,
+  "comment": "PUSH0 instruction",
+  "url": "https://eips.ethereum.org/EIPS/eip-3855",
+  "status": "Review",
+  "minimumHardfork": "chainstart",
+  "requiredEIPs": [],
+  "gasConfig": {},
+  "gasPrices": {
+    "push0": {
+      "v": 2,
+      "d": "Base fee of the PUSH0 opcode"
+    }
+  },
+  "vm": {},
+  "pow": {}
+}

--- a/packages/common/src/eips/3860.json
+++ b/packages/common/src/eips/3860.json
@@ -1,23 +1,23 @@
 {
-    "name": "EIP-3860",
-    "number": 3860,
-    "comment": "Limit and meter initcode",
-    "url": "https://eips.ethereum.org/EIPS/eip-3860",
-    "status": "Review",
-    "minimumHardfork": "spuriousDragon",
-    "requiredEIPs": [],
-    "gasConfig": {},
-    "gasPrices": {
-      "initCodeWordCost": {
-        "v": 2,
-        "d": "Gas to pay for each word (32 bytes) of initcode when creating a contract"
-      }
-    },
-    "vm": {
-      "maxInitCodeSize": {
-          "v": 49152,
-          "d": "Maximum length of initialization code when creating a contract"
-      }
-    },
-    "pow": {}
-  }
+  "name": "EIP-3860",
+  "number": 3860,
+  "comment": "Limit and meter initcode",
+  "url": "https://eips.ethereum.org/EIPS/eip-3860",
+  "status": "Review",
+  "minimumHardfork": "spuriousDragon",
+  "requiredEIPs": [],
+  "gasConfig": {},
+  "gasPrices": {
+    "initCodeWordCost": {
+      "v": 2,
+      "d": "Gas to pay for each word (32 bytes) of initcode when creating a contract"
+    }
+  },
+  "vm": {
+    "maxInitCodeSize": {
+      "v": 49152,
+      "d": "Maximum length of initialization code when creating a contract"
+    }
+  },
+  "pow": {}
+}

--- a/packages/common/src/eips/4345.json
+++ b/packages/common/src/eips/4345.json
@@ -1,17 +1,17 @@
 {
-    "name": "EIP-4345",
-    "number": 4345,
-    "comment": "Difficulty Bomb Delay to June 2022",
-    "url": "https://eips.ethereum.org/EIPS/eip-4345",
-    "status": "Review",
-    "minimumHardfork": "london",
-    "gasConfig": {},
-    "gasPrices": {},
-    "vm": {},
-    "pow": {
-        "difficultyBombDelay": {
-            "v": 10700000,
-            "d": "the amount of blocks to delay the difficulty bomb with"
-        }
+  "name": "EIP-4345",
+  "number": 4345,
+  "comment": "Difficulty Bomb Delay to June 2022",
+  "url": "https://eips.ethereum.org/EIPS/eip-4345",
+  "status": "Final",
+  "minimumHardfork": "london",
+  "gasConfig": {},
+  "gasPrices": {},
+  "vm": {},
+  "pow": {
+    "difficultyBombDelay": {
+      "v": 10700000,
+      "d": "the amount of blocks to delay the difficulty bomb with"
     }
+  }
 }

--- a/packages/common/src/eips/4399.json
+++ b/packages/common/src/eips/4399.json
@@ -3,7 +3,7 @@
   "number": 4399,
   "comment": "Supplant DIFFICULTY opcode with PREVRANDAO",
   "url": "https://eips.ethereum.org/EIPS/eip-4399",
-  "status": "Draft",
+  "status": "Review",
   "minimumHardfork": "london",
   "requiredEIPs": [],
   "gasConfig": {},

--- a/packages/common/src/hardforks/berlin.json
+++ b/packages/common/src/hardforks/berlin.json
@@ -2,6 +2,6 @@
   "name": "berlin",
   "comment": "HF targeted for July 2020 following the Muir Glacier HF",
   "url": "https://eips.ethereum.org/EIPS/eip-2070",
-  "status": "Draft",
-  "eips": [ 2565, 2929, 2718, 2930 ]
+  "status": "Final",
+  "eips": [2565, 2929, 2718, 2930]
 }

--- a/packages/common/src/hardforks/istanbul.json
+++ b/packages/common/src/hardforks/istanbul.json
@@ -2,7 +2,7 @@
   "name": "istanbul",
   "comment": "HF targeted for December 2019 following the Constantinople/Petersburg HF",
   "url": "https://eips.ethereum.org/EIPS/eip-1679",
-  "status": "Draft",
+  "status": "Final",
   "gasConfig": {},
   "gasPrices": {
     "blake2Round": {

--- a/packages/common/src/hardforks/london.json
+++ b/packages/common/src/hardforks/london.json
@@ -2,6 +2,6 @@
   "name": "london",
   "comment": "HF targeted for July 2021 following the Berlin fork",
   "url": "https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/london.md",
-  "status": "Draft",
-  "eips": [ 1559, 3198, 3529, 3541 ]
+  "status": "Final",
+  "eips": [1559, 3198, 3529, 3541]
 }

--- a/packages/common/src/hardforks/petersburg.json
+++ b/packages/common/src/hardforks/petersburg.json
@@ -2,7 +2,7 @@
   "name": "petersburg",
   "comment": "Aka constantinopleFix, removes EIP-1283, activate together with or after constantinople",
   "url": "https://eips.ethereum.org/EIPS/eip-1716",
-  "status": "Draft",
+  "status": "Final",
   "gasConfig": {},
   "gasPrices": {
     "netSstoreNoopGas": {


### PR DESCRIPTION
Closes #1773

Have only updated the "status" fields, the rest are prettier formats.

(I wonder if we should open a separate PR to format all of our JSON and markdown files in the monorepo at once, the command from root would be: `npx prettier "**/*.{json,md}" --write`)