### PR TITLE
client: Sync stall investigation improvements

### DIFF
--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -198,6 +198,12 @@ export interface ConfigOptions {
    * If not provided, defaults to the primary account.
    */
   minerCoinbase?: Address
+
+  /**
+   * If there is supposedly a re-org, this is a safe distance from which
+   * to refetch and try feeding the blocks
+   */
+  safeReorgDistance?: number
 }
 
 export class Config {
@@ -218,6 +224,7 @@ export class Config {
   public static readonly MAXPEERS_DEFAULT = 25
   public static readonly DNSADDR_DEFAULT = '8.8.8.8'
   public static readonly DEBUGCODE_DEFAULT = false
+  public static readonly SAFE_REORG_DISTANCE = 100
 
   public readonly logger: Logger
   public readonly syncmode: SyncMode
@@ -242,6 +249,7 @@ export class Config {
   public readonly mine: boolean
   public readonly accounts: [address: Address, privKey: Buffer][]
   public readonly minerCoinbase?: Address
+  public readonly safeReorgDistance: number
 
   public synchronized: boolean
   public lastSyncDate: number
@@ -274,6 +282,7 @@ export class Config {
     this.mine = options.mine ?? false
     this.accounts = options.accounts ?? []
     this.minerCoinbase = options.minerCoinbase
+    this.safeReorgDistance = options.safeReorgDistance ?? Config.SAFE_REORG_DISTANCE
 
     this.synchronized = false
     this.lastSyncDate = 0

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -200,8 +200,8 @@ export interface ConfigOptions {
   minerCoinbase?: Address
 
   /**
-   * If there is supposedly a re-org, this is a safe distance from which
-   * to refetch and try feeding the blocks
+   * If there is a reorg, this is a safe distance from which
+   * to try to refetch and refeed the blocks.
    */
   safeReorgDistance?: number
 }

--- a/packages/client/lib/net/server/server.ts
+++ b/packages/client/lib/net/server/server.ts
@@ -114,4 +114,7 @@ export class Server {
   ban(_peerId: string, _maxAge: number) {
     // don't do anything by default
   }
+
+  connect(_peerId: string) {}
+  disconnect(_peerId: string) {}
 }

--- a/packages/client/lib/net/server/server.ts
+++ b/packages/client/lib/net/server/server.ts
@@ -115,6 +115,6 @@ export class Server {
     // don't do anything by default
   }
 
-  connect(_peerId: string) {}
+  connect(_peerId: string, _steam?: any) {}
   disconnect(_peerId: string) {}
 }

--- a/packages/client/lib/net/server/server.ts
+++ b/packages/client/lib/net/server/server.ts
@@ -115,6 +115,5 @@ export class Server {
     // don't do anything by default
   }
 
-  connect(_peerId: string, _steam?: any) {}
-  disconnect(_peerId: string) {}
+  async connect(_peerId: string, _stream?: any) {}
 }

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -110,16 +110,16 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
     try {
       const num = await this.chain.putBlocks(blocks)
       this.debug(
-        `Fetcher results stored in blockchain (blocks num=${blocks.length}, first=${
+        `Fetcher results stored in blockchain (blocks num=${blocks.length} first=${
           blocks[0]?.header.number
-        }, last=${blocks[blocks.length - 1]?.header.number})`
+        } last=${blocks[blocks.length - 1]?.header.number})`
       )
       this.config.events.emit(Event.SYNC_FETCHER_FETCHED, blocks.slice(0, num))
     } catch (e: any) {
       this.debug(
-        `Error storing fetcher results in blockchain (blocks num=${blocks.length}, first=${
+        `Error storing fetcher results in blockchain (blocks num=${blocks.length} first=${
           blocks[0]?.header.number
-        }, last=${blocks[blocks.length - 1]?.header.number}): ${e}`
+        } last=${blocks[blocks.length - 1]?.header.number}): ${e}`
       )
       throw e
     }

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -109,10 +109,18 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
   async store(blocks: Block[]) {
     try {
       const num = await this.chain.putBlocks(blocks)
-      this.debug(`Fetcher results stored in blockchain (blocks num=${blocks.length})`)
+      this.debug(
+        `Fetcher results stored in blockchain (blocks num=${blocks.length}, first=${
+          blocks[0]?.header.number
+        }, last=${blocks[blocks.length - 1]?.header.number})`
+      )
       this.config.events.emit(Event.SYNC_FETCHER_FETCHED, blocks.slice(0, num))
     } catch (e: any) {
-      this.debug(`Error storing fetcher results in blockchain (blocks num=${blocks.length}): ${e}`)
+      this.debug(
+        `Error storing fetcher results in blockchain (blocks num=${blocks.length}, first=${
+          blocks[0]?.header.number
+        }, last=${blocks[blocks.length - 1]?.header.number}): ${e}`
+      )
       throw e
     }
   }

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -355,8 +355,6 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
       })
       .on('error', (error: Error) => {
         this.error(error)
-        this.running = false
-        writer.destroy()
       })
     this.debug(`Setup writer pipe.`)
   }

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -332,6 +332,12 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
         cb()
       } catch (error: any) {
         this.config.logger.warn(`Error storing received block or header result: ${error}`)
+        /**
+         * TODO: Instead of just erroring on the writer (which stops this writer instance) and
+         * hence fetcher, determine if the fetcher really needs to error or if its recoverable.
+         * For e.g "Error: could not find parent header" is recoverable and all that needs to be done
+         * is to adapt and requeue the job and let it sync again.
+         */
         cb(error)
       }
     }

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -169,7 +169,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
    * @param autoRestart
    */
   enqueueTask(task: JobTask, autoRestart = false) {
-    if (!this.running && !autoRestart) {
+    if (this.errored || (!this.running && !autoRestart)) {
       return
     }
     const job: Job<JobTask, JobResult, StorageItem> = {

--- a/packages/client/lib/sync/fetcher/headerfetcher.ts
+++ b/packages/client/lib/sync/fetcher/headerfetcher.ts
@@ -84,11 +84,17 @@ export class HeaderFetcher extends BlockFetcherBase<BlockHeaderResult, BlockHead
   async store(headers: BlockHeader[]) {
     try {
       const num = await this.chain.putHeaders(headers)
-      this.debug(`Fetcher results stored in blockchain (headers num=${headers.length})`)
+      this.debug(
+        `Fetcher results stored in blockchain (headers num=${headers.length}, first=${
+          headers[0]?.number
+        }, last=${headers[headers.length - 1]?.number})`
+      )
       this.config.events.emit(Event.SYNC_FETCHER_FETCHED, headers.slice(0, num))
     } catch (e: any) {
       this.debug(
-        `Error storing fetcher results in blockchain (headers num=${headers.length}): ${e}`
+        `Error storing fetcher results in blockchain (headers num=${headers.length}, first=${
+          headers[0]?.number
+        }, last=${headers[headers.length - 1]?.number}): ${e}`
       )
       throw e
     }

--- a/packages/client/lib/sync/fetcher/headerfetcher.ts
+++ b/packages/client/lib/sync/fetcher/headerfetcher.ts
@@ -85,16 +85,16 @@ export class HeaderFetcher extends BlockFetcherBase<BlockHeaderResult, BlockHead
     try {
       const num = await this.chain.putHeaders(headers)
       this.debug(
-        `Fetcher results stored in blockchain (headers num=${headers.length}, first=${
+        `Fetcher results stored in blockchain (headers num=${headers.length} first=${
           headers[0]?.number
-        }, last=${headers[headers.length - 1]?.number})`
+        } last=${headers[headers.length - 1]?.number})`
       )
       this.config.events.emit(Event.SYNC_FETCHER_FETCHED, headers.slice(0, num))
     } catch (e: any) {
       this.debug(
-        `Error storing fetcher results in blockchain (headers num=${headers.length}, first=${
+        `Error storing fetcher results in blockchain (headers num=${headers.length} first=${
           headers[0]?.number
-        }, last=${headers[headers.length - 1]?.number}): ${e}`
+        } last=${headers[headers.length - 1]?.number}): ${e}`
       )
       throw e
     }

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -143,7 +143,11 @@ export class FullSynchronizer extends Synchronizer {
         this.config.logger.info(`New sync target height=${height} hash=${short(latest.hash())}`)
       }
 
-      const first = this.chain.blocks.height.addn(1)
+      /**
+       * Start fetcher from a safe distance behind beacause if the previous fetcher exited
+       * beacuse of a reorg, it would make sense to step back and refetch
+       */
+      const first = BN.max(this.chain.blocks.height.subn(this.config.safeReorgDistance), new BN(0))
       const count = height.sub(first).addn(1)
 
       if (count.lten(0)) return resolve(false)

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -167,6 +167,7 @@ export class FullSynchronizer extends Synchronizer {
         if (this.fetcher) {
           await this.fetcher.fetch()
         }
+        resolve(true)
       } catch (error: any) {
         reject(error)
       } finally {

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -178,6 +178,7 @@ export class FullSynchronizer extends Synchronizer {
         //this.pool.ban(peer,6000);
         peer?.server?.disconnect(peer.id)
         peer?.server?.connect(peer.id)
+        this.config.logger.debug(`Fetcher error, disconnect/reconnect with: ${peer.toString(true)}`)
         reject(error)
       } finally {
         this.config.events.removeListener(Event.SYNC_SYNCHRONIZED, resolveSync)

--- a/packages/client/test/integration/peerpool.spec.ts
+++ b/packages/client/test/integration/peerpool.spec.ts
@@ -21,8 +21,8 @@ tape('[Integration:PeerPool]', async (t) => {
   }
 
   async function destroy(server: MockServer, pool: PeerPool) {
+    await pool.stop()
     await server.stop()
-    await pool.close()
   }
 
   t.test('should open', async (t) => {

--- a/packages/client/test/integration/util.ts
+++ b/packages/client/test/integration/util.ts
@@ -24,7 +24,7 @@ export async function setup(
 
   const lightserv = syncmode === 'full'
   const common = options.common
-  const config = new Config({ syncmode, lightserv, minPeers, common })
+  const config = new Config({ syncmode, lightserv, minPeers, common, safeReorgDistance: 0 })
 
   const server = new MockServer({ config, location })
   const blockchain = await Blockchain.create({
@@ -36,7 +36,14 @@ export async function setup(
   const chain = new MockChain({ config, blockchain, height })
 
   const servers = [server] as any
-  const serviceConfig = new Config({ syncmode, servers, lightserv, minPeers, common })
+  const serviceConfig = new Config({
+    syncmode,
+    servers,
+    lightserv,
+    minPeers,
+    common,
+    safeReorgDistance: 0,
+  })
   // attach server to centralized event bus
   ;(server.config as any).events = serviceConfig.events
   const serviceOpts = {

--- a/packages/client/test/sync/fetcher/blockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/blockfetcher.spec.ts
@@ -68,14 +68,13 @@ tape('[BlockFetcher]', async (t) => {
 
     // Clear fetcher queue for next test of gap when following head
     fetcher.clear()
-    chain.headers.height = new BN(15)
     blockNumberList = [new BN(50), new BN(51)]
     min = new BN(50)
     fetcher.enqueueByNumberList(blockNumberList, min)
     t.equals(
       (fetcher as any).in.size(),
-      2,
-      '1 new task to catch up to head (16-49), 1 new task for subsequent block numbers (50-51)'
+      11,
+      '10 new tasks to catch up to head (1-49, 5 per request), 1 new task for subsequent block numbers (50-51)'
     )
 
     fetcher.destroy()

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -17,8 +17,12 @@ tape('[FullSynchronizer]', async (t) => {
   PeerPool.prototype.idle = td.func<any>()
   class BlockFetcher {
     fetch() {}
+    clear() {}
+    destroy() {}
   }
   BlockFetcher.prototype.fetch = td.func<any>()
+  BlockFetcher.prototype.clear = td.func<any>()
+  BlockFetcher.prototype.destroy = td.func<any>()
   td.replace('../../lib/sync/fetcher', { BlockFetcher })
 
   const { FullSynchronizer } = await import('../../lib/sync/fullsync')

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -100,7 +100,7 @@ tape('[FullSynchronizer]', async (t) => {
 
   t.test('should sync', async (t) => {
     t.plan(3)
-    const config = new Config({ transports: [] })
+    const config = new Config({ transports: [], safeReorgDistance: 0 })
     const pool = new PeerPool() as any
     const chain = new Chain({ config })
     const sync = new FullSynchronizer({

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -11,6 +11,7 @@ tape('[FullSynchronizer]', async (t) => {
     open() {}
     close() {}
     idle() {}
+    ban(_peer: any) {}
   }
   PeerPool.prototype.open = td.func<any>()
   PeerPool.prototype.close = td.func<any>()


### PR DESCRIPTION
While running on kiln, some more issues of sync stalling were observed: https://github.com/ethereumjs/ethereumjs-monorepo/issues/1780

The trigger of the sync stall is when the fetcher adds block to blockchain and the blocks fetched are not linearly connected, it leads to issue. 
~~One of the issue was writer was being destroyed.  This PR removes that condition of the writer being destroyed on error  as well as improves the fetcher logging a bit for better debugging.~~
UPDATE: Figured out that the writer's call back `cb(error)` switches off the writer. In case such a thing happened, its better to return an error in `await fetch(..)` and let the sync loop try with a different peer if required.
This also fixes the behavior that other peers were never tried because `fetcher.fetch` was never failing and `syncWithPeer` was never returning/erroring if there was any writer error.
 
- [x] fixes the fetcher getting stalled because if now  `syncWithPeer` errors, and then the new `sync` loop is started with the creating of a new fetcher.
- [x] ~~However there is still an issue that the process dies after too many errors (modified the `store` fn to error every 5 times its called for debugging purposes), so futher resolution will be required, but that would be independent of this `syncWithPeer` fix.~~ RESOLVED the above crash by removing fetcher restart when errored already
- [x] ~~UNRESOLVED: seems like running peer isn't being updated of its best ttd when new sync target is updated in in NewBlockHashes, or NewBlock handling of `async handleEth(message: any, peer: Peer): Promise<void> {`~~ needed this update when the fetcher failed and best peer need to be found again to syncWithPeer with new fetcher (even though current peer was best peer), disconnect/reconnet lead to update of its status (though temporary ban would have been better but it wasn't reconnecting to the peer fast) and restart of the sync
- [x] Handle `could not find parent header` reorg possibility 

Closes #1780