### PR TITLE
client: expand getLogs to accept array of addresses

### DIFF
--- a/packages/client/lib/execution/receipt.ts
+++ b/packages/client/lib/execution/receipt.ts
@@ -159,7 +159,7 @@ export class ReceiptsManager extends MetaDBManager {
   async getLogs(
     from: Block,
     to: Block,
-    address?: Buffer,
+    addresses?: Buffer[],
     topics: (Buffer | Buffer[] | null)[] = []
   ): Promise<GetLogsReturn> {
     const returnedLogs: GetLogsReturn = []
@@ -181,8 +181,8 @@ export class ReceiptsManager extends MetaDBManager {
           }))
         )
       }
-      if (address) {
-        logs = logs.filter((l) => l.log[0].equals(address))
+      if (addresses && addresses.length > 0) {
+        logs = logs.filter((l) => addresses.some((a) => a.equals(l.log[0])))
       }
       if (topics.length > 0) {
         // From https://eth.wiki/json-rpc/API:

--- a/packages/client/lib/execution/receipt.ts
+++ b/packages/client/lib/execution/receipt.ts
@@ -82,7 +82,7 @@ export class ReceiptsManager extends MetaDBManager {
   /**
    * Block range limit for getLogs
    */
-  GET_LOGS_BLOCK_RANGE_LIMIT = 2000
+  GET_LOGS_BLOCK_RANGE_LIMIT = 2500
 
   /**
    * Saves receipts to db. Also saves tx hash indexes if within txLookupLimit,

--- a/packages/client/test/rpc/eth/getLogs.spec.ts
+++ b/packages/client/test/rpc/eth/getLogs.spec.ts
@@ -110,11 +110,30 @@ tape(`${method}: call with valid arguments`, async (t) => {
   }
   await baseRequest(t, server, req, 200, expectRes, false)
 
-  // test filtering by address
+  // test filtering by single address
   req = params(method, [{ address: contractAddr1.toString() }])
   expectRes = (res: any) => {
-    const msg = 'should return the correct logs (filter by address)'
-    if (res.body.result.length === 10 && res.body.result[0].address === contractAddr1.toString()) {
+    const msg = 'should return the correct logs (filter by single address)'
+    if (
+      res.body.result.length === 10 &&
+      res.body.result.every((r: any) => r.address === contractAddr1.toString())
+    ) {
+      t.pass(msg)
+    } else {
+      t.fail(msg)
+    }
+  }
+  await baseRequest(t, server, req, 200, expectRes, false)
+
+  // test filtering by multiple addresses
+  const addresses = [contractAddr1.toString(), contractAddr2.toString()]
+  req = params(method, [{ address: addresses }])
+  expectRes = (res: any) => {
+    const msg = 'should return the correct logs (filter by multiple addresses)'
+    if (
+      res.body.result.length === 20 &&
+      res.body.result.every((r: any) => addresses.includes(r.address))
+    ) {
       t.pass(msg)
     } else {
       t.fail(msg)


### PR DESCRIPTION
Thanks to "Sea Monkey" in our discord, teku was calling eth_getLogs with an array of addresses (rather than a single address) and this is valid according to the spec, so this PR fixes our endpoint.