### PR TITLE
vm: delete extra console.log

### DIFF
--- a/packages/vm/tests/api/EIPs/eip-3860.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3860.spec.ts
@@ -22,7 +22,6 @@ tape('EIP 3860 tests', (t) => {
     await vm.stateManager.putAccount(sender, account)
 
     const buffer = Buffer.allocUnsafe(1000000).fill(0x60)
-    console.log(common.isActivatedEIP(3860))
     const tx = FeeMarketEIP1559Transaction.fromTxData({
       data:
         '0x7F6000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060005260206000F3' +


### PR DESCRIPTION
This was showing up when linting https://github.com/ethereumjs/ethereumjs-monorepo/pull/1768, so this PR fixes the linting error