### PR TITLE
blockchain: fix updateCache

### DIFF
--- a/packages/blockchain/src/db/operation.ts
+++ b/packages/blockchain/src/db/operation.ts
@@ -144,9 +144,10 @@ export class DBOp {
   }
 
   public updateCache(cacheMap: CacheMap) {
-    if (this.cacheString && cacheMap[this.cacheString] && Buffer.isBuffer(this.baseDBOp.value)) {
+    if (this.cacheString && cacheMap[this.cacheString]) {
       if (this.baseDBOp.type == 'put') {
-        cacheMap[this.cacheString].set(this.baseDBOp.key, this.baseDBOp.value)
+        Buffer.isBuffer(this.baseDBOp.value) &&
+          cacheMap[this.cacheString].set(this.baseDBOp.key, this.baseDBOp.value)
       } else if (this.baseDBOp.type == 'del') {
         cacheMap[this.cacheString].del(this.baseDBOp.key)
       } else {


### PR DESCRIPTION
When the database operation is `del`, `this.baseDBOp.value` is undefined instead of `Buffer`.
In the old code, when deleting a value, the value is deleted in the database but not in the cache, causing the next read value still exists (because `DBManager` always tries to load data from cache first)

BTW, I tried to add a test case for this fix, but to find out that neither `DBManager` nor `DBOp` has a test case, maybe this should be improved?