### PR TITLE
Client: Mix hash added to JsonRpcBlock

### DIFF
--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -57,7 +57,7 @@ type JsonRpcBlock = {
   number: string // the block number. null when pending block.
   hash: string // hash of the block. null when pending block.
   parentHash: string // hash of the parent block.
-  mixHash?: string // bit hash which proves combined with the nonce that a sufficient amount of computation has been carried out on this block
+  mixHash?: string // bit hash which proves combined with the nonce that a sufficient amount of computation has been carried out on this block.
   nonce: string // hash of the generated proof-of-work. null when pending block.
   sha3Uncles: string // SHA3 of the uncles data in the block.
   logsBloom: string // the bloom filter for the logs of the block. null when pending block.
@@ -152,6 +152,7 @@ const jsonRpcBlock = async (
     number: header.number!,
     hash: bufferToHex(block.hash()),
     parentHash: header.parentHash!,
+    mixHash: header.mixHash,
     nonce: header.nonce!,
     sha3Uncles: header.uncleHash!,
     logsBloom: header.logsBloom!,
@@ -169,7 +170,6 @@ const jsonRpcBlock = async (
     transactions,
     uncles: block.uncleHeaders.map((uh) => bufferToHex(uh.hash())),
     baseFeePerGas: header.baseFeePerGas,
-    mixHash: header.mixHash,
   }
 }
 

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -74,6 +74,7 @@ type JsonRpcBlock = {
   transactions: string[] // Array of serialized transaction objects, or 32 Bytes transaction hashes depending on the last given parameter.
   uncles: string[] // Array of uncle hashes
   baseFeePerGas?: string // If EIP-1559 is enabled for this block, returns the base fee per gas
+  mixHash?: string // bit hash which proves combined with the nonce that a sufficient amount of computation has been carried out on this block
 }
 type JsonRpcTx = {
   blockHash: string | null // DATA, 32 Bytes - hash of the block where this transaction was in. null when it's pending.
@@ -168,6 +169,7 @@ const jsonRpcBlock = async (
     transactions,
     uncles: block.uncleHeaders.map((uh) => bufferToHex(uh.hash())),
     baseFeePerGas: header.baseFeePerGas,
+    mixHash: header.mixHash,
   }
 }
 

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -57,6 +57,7 @@ type JsonRpcBlock = {
   number: string // the block number. null when pending block.
   hash: string // hash of the block. null when pending block.
   parentHash: string // hash of the parent block.
+  mixHash?: string // bit hash which proves combined with the nonce that a sufficient amount of computation has been carried out on this block
   nonce: string // hash of the generated proof-of-work. null when pending block.
   sha3Uncles: string // SHA3 of the uncles data in the block.
   logsBloom: string // the bloom filter for the logs of the block. null when pending block.
@@ -74,7 +75,6 @@ type JsonRpcBlock = {
   transactions: string[] // Array of serialized transaction objects, or 32 Bytes transaction hashes depending on the last given parameter.
   uncles: string[] // Array of uncle hashes
   baseFeePerGas?: string // If EIP-1559 is enabled for this block, returns the base fee per gas
-  mixHash?: string // bit hash which proves combined with the nonce that a sufficient amount of computation has been carried out on this block
 }
 type JsonRpcTx = {
   blockHash: string | null // DATA, 32 Bytes - hash of the block where this transaction was in. null when it's pending.


### PR DESCRIPTION
This PR aims to add the `mixHash` attribute on the `JsonRpcBlock` type, the reason is that when running the tests against the hive, they query the latest block with `eth_getBlockByNumber` and then they parse that data with Geth lib, which expects mixHash to be in the object, otherwise the hash wont match, making the tests go red