### PR TITLE
client: Fetcher reorg handling

### DIFF
--- a/packages/client/lib/net/peerpool.ts
+++ b/packages/client/lib/net/peerpool.ts
@@ -24,8 +24,12 @@ export class PeerPool {
   private opened: boolean
   public running: boolean
 
+  /**
+   * Default status check interval (in ms)
+   */
+  private DEFAULT_STATUS_CHECK_INTERVAL = 20000
+
   private _statusCheckInterval: NodeJS.Timeout | undefined /* global NodeJS */
-  private DEFAULT_STATUS_CHECK_INTERVAL = 20 /* default checks in secs */
   private _reconnectTimeout: NodeJS.Timeout | undefined
 
   /**
@@ -78,7 +82,7 @@ export class PeerPool {
     this._statusCheckInterval = setInterval(
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await this._statusCheck.bind(this),
-      this.DEFAULT_STATUS_CHECK_INTERVAL * 1000
+      this.DEFAULT_STATUS_CHECK_INTERVAL
     )
 
     this.running = true

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -1,7 +1,6 @@
 import { Block, BlockBuffer } from '@ethereumjs/block'
 import { KECCAK256_RLP, KECCAK256_RLP_ARRAY, BN } from 'ethereumjs-util'
 import { Peer } from '../../net/peer'
-import { EthProtocolMethods } from '../../net/protocol'
 import { Job } from './types'
 import { BlockFetcherBase, JobTask, BlockFetcherOptions } from './blockfetcherbase'
 import { Event } from '../../types'
@@ -29,7 +28,7 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
     const blocksRange = `${first}-${first.addn(count)}`
     const peerInfo = `id=${peer?.id.slice(0, 8)} address=${peer?.address}`
 
-    const headersResult = await (peer!.eth as EthProtocolMethods).getBlockHeaders({
+    const headersResult = await peer!.eth!.getBlockHeaders({
       block: first,
       max: count,
     })

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -78,7 +78,8 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
   process(job: Job<JobTask, Block[], Block>, result: Block[]) {
     if (result.length === job.task.count) {
       return result
-    } else if (result.length > 0 && result.length < job.task.count) {
+    }
+    if (result.length > 0 && result.length < job.task.count) {
       // Adopt the start block/header number from the remaining jobs
       // if the number of the results provided is lower than the expected count
       this.debug(

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -373,7 +373,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
             new BN(this.config.safeReorgDistance)
           ).toNumber()
           ;(jobItems[0].task as any).first = (jobItems[0].task as any).first.subn(stepBack)
-          ;(jobItems[0].task as any).count = (jobItems[0].task as any).count + stepBack
+          ;(jobItems[0].task as any).count = ((jobItems[0].task as any).count as number) + stepBack
           this.clear()
           this.failure(job, error, false)
           cb()

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -146,6 +146,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
       // If the job was already dequeued, for example coming from writer pipe, processed
       // needs to be decreased
       if (dequeued) this.processed--
+
       this.in.insert({
         ...job,
         time: Date.now(),
@@ -272,7 +273,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
           (jobItem.task as any)?.count
         }`
         this.debug(
-          `failure-Re-enqueuing job ${jobStr} from peer id=${jobItem.peer?.id?.substr(
+          `Failure - Re-enqueuing job ${jobStr} from peer id=${jobItem.peer?.id?.substr(
             0,
             8
           )} (error: ${error}).`

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -378,18 +378,17 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
       } catch (error: any) {
         this.config.logger.warn(`Error storing received block or header result: ${error}`)
         if (error.message.includes('could not find parent header')) {
-          // non-fatal error: ban peer and re-enqueue job
+          // Non-fatal error: ban peer and re-enqueue job.
           // Modify the first job so that it is enqueued from safeReorgDistance as most likely
-          // this is because of a reorg
+          // this is because of a reorg.
           const stepBack = BN.min(
             (jobItems[0].task as any).first.subn(1),
             new BN(this.config.safeReorgDistance)
           ).toNumber()
-          this.debug(
-            `This could be a possible re-org, stepping back ${stepBack} blocks and requeing the jobs`
-          )
+          this.debug(`Possible re-org, stepping back ${stepBack} blocks and requeuing jobs.`)
           ;(jobItems[0].task as any).first = (jobItems[0].task as any).first.subn(stepBack)
           ;(jobItems[0].task as any).count = ((jobItems[0].task as any).count as number) + stepBack
+          this.debug(`Possible reorg, stepping back ${stepBack} blocks and requeuing jobs.`)
           // This will requeue the jobs as we are marking this failure as non-fatal.
           this.failure(job, error, false, true)
           cb()

--- a/packages/client/lib/sync/fetcher/headerfetcher.ts
+++ b/packages/client/lib/sync/fetcher/headerfetcher.ts
@@ -62,9 +62,11 @@ export class HeaderFetcher extends BlockFetcherBase<BlockHeaderResult, BlockHead
       // if the number of the results provided is lower than the expected count
       const lengthDiff = job.task.count - headers.length
       const adoptedJobs = []
+      let lastTask
       while (this.in.length > 0) {
         const job = this.in.remove()
         if (job) {
+          lastTask = job.task
           job.task.first = job.task.first.subn(lengthDiff)
           adoptedJobs.push(job)
         }
@@ -72,6 +74,13 @@ export class HeaderFetcher extends BlockFetcherBase<BlockHeaderResult, BlockHead
       for (const job of adoptedJobs) {
         this.in.insert(job)
       }
+      if (lastTask) {
+        const tasks = this.tasks(lastTask.first.addn(lastTask.count), new BN(lengthDiff))
+        for (const task of tasks) {
+          this.enqueueTask(task)
+        }
+      }
+
       return headers
     }
     return

--- a/packages/client/lib/sync/fetcher/headerfetcher.ts
+++ b/packages/client/lib/sync/fetcher/headerfetcher.ts
@@ -1,6 +1,6 @@
 import { BlockFetcherBase, BlockFetcherOptions, JobTask } from './blockfetcherbase'
 import { Peer } from '../../net/peer'
-import { FlowControl, LesProtocolMethods } from '../../net/protocol'
+import { FlowControl } from '../../net/protocol'
 import { BlockHeader } from '@ethereumjs/block'
 import { Job } from './types'
 import { BN } from 'ethereumjs-util'
@@ -39,7 +39,7 @@ export class HeaderFetcher extends BlockFetcherBase<BlockHeaderResult, BlockHead
       // we reached our request limit. try with a different peer.
       return
     }
-    const response = await (peer!.les as LesProtocolMethods).getBlockHeaders({
+    const response = await peer!.les!.getBlockHeaders({
       block: task.first,
       max: task.count,
     })

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -203,6 +203,7 @@ export class FullSynchronizer extends Synchronizer {
 
     blocks = blocks as Block[]
     const first = new BN(blocks[0].header.number)
+    const last = new BN(blocks[blocks.length - 1].header.number)
     const hash = short(blocks[0].hash())
     const baseFeeAdd = this.config.chainCommon.gteHardfork(Hardfork.London)
       ? `baseFee=${blocks[0].header.baseFeePerGas} `
@@ -210,7 +211,7 @@ export class FullSynchronizer extends Synchronizer {
     this.config.logger.info(
       `Imported blocks count=${
         blocks.length
-      } number=${first} hash=${hash} ${baseFeeAdd}hardfork=${this.config.chainCommon.hardfork()} peers=${
+      } first=${first} last=${last} hash=${hash} ${baseFeeAdd}hardfork=${this.config.chainCommon.hardfork()} peers=${
         this.pool.size
       }`
     )

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -202,8 +202,8 @@ export class FullSynchronizer extends Synchronizer {
     }
 
     blocks = blocks as Block[]
-    const first = new BN(blocks[0].header.number)
-    const last = new BN(blocks[blocks.length - 1].header.number)
+    const first = blocks[0].header.number
+    const last = blocks[blocks.length - 1].header.number
     const hash = short(blocks[0].hash())
     const baseFeeAdd = this.config.chainCommon.gteHardfork(Hardfork.London)
       ? `baseFee=${blocks[0].header.baseFeePerGas} `

--- a/packages/client/test/sync/fetcher/blockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/blockfetcher.spec.ts
@@ -98,6 +98,26 @@ tape('[BlockFetcher]', async (t) => {
     t.end()
   })
 
+  t.test('should adopt correctly', (t) => {
+    const config = new Config({ transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const fetcher = new BlockFetcher({
+      config,
+      pool,
+      chain,
+      first: new BN(0),
+      count: new BN(0),
+    })
+    const blocks: any = [{ header: { number: 1 } }, { header: { number: 2 } }]
+    const task = { count: 3, first: new BN(1) }
+    ;(fetcher as any).running = true
+    fetcher.enqueueTask(task)
+    fetcher.process({ task } as any, blocks)
+    t.equals((fetcher as any).in.size(), 2, 'Fetcher should have two tasks after adopting')
+    t.end()
+  })
+
   t.test('should find a fetchable peer', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any

--- a/packages/client/test/sync/fetcher/fetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/fetcher.spec.ts
@@ -1,5 +1,6 @@
 import tape from 'tape'
 import td from 'testdouble'
+import { BN } from 'ethereumjs-util'
 import { Config } from '../../../lib/config'
 import { Fetcher } from '../../../lib/sync/fetcher/fetcher'
 import { Job } from '../../../lib/sync/fetcher/types'
@@ -96,6 +97,25 @@ tape('[Fetcher]', (t) => {
     ;(fetcher as any).in.insert(job5)
 
     t.ok(fetcher.next() === false, 'next() fails when heap length exceeds maxQueue')
+  })
+
+  t.test('should re-enqueue on a non-fatal error', (t) => {
+    t.plan(1)
+    const config = new Config({ transports: [] })
+    const fetcher = new FetcherTest({ config, pool: td.object(), timeout: 5000 })
+    const task = { first: new BN(50), count: 10 }
+    const job: any = { peer: {}, task, state: 'active', index: 0 }
+    fetcher.next = td.func<FetcherTest['next']>()
+    fetcher.write()
+    ;(fetcher as any).running = true
+    fetcher.store = td.func<FetcherTest['store']>()
+    td.when(fetcher.store(td.matchers.anything())).thenReject(
+      new Error('could not find parent header')
+    )
+    ;(fetcher as any).success(job, ['something'])
+    setTimeout(() => {
+      t.ok((fetcher as any).in.peek().task.first.eqn(1), 'should step back for safeReorgDistance')
+    }, 20)
   })
 
   t.test('should reset td', (t) => {

--- a/packages/client/test/sync/fetcher/fetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/fetcher.spec.ts
@@ -7,8 +7,8 @@ import { Job } from '../../../lib/sync/fetcher/types'
 import { Event } from '../../../lib/types'
 
 class FetcherTest extends Fetcher<any, any, any> {
-  process(_job: any, _res: any) {
-    return undefined // have to return undefined, otherwise the function return signature is void.
+  process(_job: any, res: any) {
+    return res
   }
   async request(_job: any, _peer: any) {
     return

--- a/packages/client/test/sync/fetcher/headerfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/headerfetcher.spec.ts
@@ -57,8 +57,7 @@ tape('[HeaderFetcher]', async (t) => {
     const pool = new PeerPool()
     const fetcher = new HeaderFetcher({ config, pool })
     td.when((fetcher as any).pool.idle(td.matchers.anything())).thenReturn('peer0')
-    //@ts-ignore
-    t.equals(fetcher.peer(undefined), 'peer0', 'found peer')
+    t.equal(fetcher.peer(), 'peer0', 'found peer')
     t.end()
   })
 

--- a/packages/client/test/sync/fetcher/headerfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/headerfetcher.spec.ts
@@ -34,6 +34,24 @@ tape('[HeaderFetcher]', async (t) => {
     t.end()
   })
 
+  t.test('should adopt correctly', (t) => {
+    const config = new Config({ transports: [] })
+    const pool = new PeerPool() as any
+    const flow = td.object()
+    const fetcher = new HeaderFetcher({
+      config,
+      pool,
+      flow,
+    })
+    const headers = [{ number: 1 }, { number: 2 }]
+    const task = { count: 3, first: new BN(1) }
+    ;(fetcher as any).running = true
+    fetcher.enqueueTask(task)
+    fetcher.process({ task } as any, { headers, bv: new BN(1) } as any)
+    t.equals((fetcher as any).in.size(), 2, 'Fetcher should have two tasks after adopting')
+    t.end()
+  })
+
   t.test('should find a fetchable peer', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool()


### PR DESCRIPTION
This PR is follow up of #1781 and adds the followinf refinements
- [x] fetcher reorg handling
- [x] reverting the processed count on enqueue of a dequeued job which was previously not increasing leading to those many tasks not being pickedup
- [x] ~~:construction:  Still a WIP :construction:~~  , fixed a few corner cases regarding adopting tasks