### PR TITLE
client: small fixes (txpool result not iterable, rpc validation for exchangeTransitionConfiguration)

### DIFF
--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -256,7 +256,16 @@ export class Engine {
 
     this.exchangeTransitionConfigurationV1 = middleware(
       this.exchangeTransitionConfigurationV1.bind(this),
-      0
+      1,
+      [
+        [
+          validators.object({
+            terminalTotalDifficulty: validators.hex,
+            terminalBlockHash: validators.hex,
+            terminalBlockNumber: validators.hex,
+          }),
+        ],
+      ]
     )
   }
 

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -22,13 +22,15 @@ const level = require('level-mem')
 const config: any = {}
 config.logger = getLogger(config)
 
+type StartRPCOpts = { port?: number; wsServer?: boolean }
 type WithEngineMiddleware = { jwtSecret: Buffer; unlessFn?: (req: IncomingMessage) => boolean }
 
 export function startRPC(
   methods: any,
-  { port, wsServer }: { port?: number; wsServer?: boolean } = { port: 3000 },
+  opts: StartRPCOpts = { port: 3000 },
   withEngineMiddleware?: WithEngineMiddleware
 ) {
+  const { port, wsServer } = opts
   const server = new RPCServer(methods)
   const httpServer = wsServer
     ? createWsRPCServerListener({ server, withEngineMiddleware })


### PR DESCRIPTION
A few small fixes I've gathered:
* add rpc validation for new `engine_exchangeTransitionConfiguration`
* create separate type for test utils type StartRPCOpts
* TxPool: Was getting this error frequently in normal tx pool operation: `Error handling message (eth:NewPooledTransactionHashes): (intermediate value) is not iterable`. After disabling the error catch so I can find the affected lines throwing, this is what resulted:

```
    const [_, txs] = await (peer.eth as EthProtocolMethods).getPooledTransactions({
                     ^
TypeError: (intermediate value) is not iterable
    at TxPool.handleAnnouncedTxHashes (/Users/rg/dev/ethereumjs-monorepo/packages/client/lib/sync/txpool.ts:372:22)
```
I solved the above by first capturing the variable, checking it is defined, then destructuring the array into `const [_, txs]`. The query comes back undefined if it is unsuccessful, which broke during the array destructuring.