### PR TITLE
VM: EIP-3450, EIP-3670 Improvements and Test Clean-Ups

### DIFF
--- a/packages/vm/src/evm/opcodes/eof.ts
+++ b/packages/vm/src/evm/opcodes/eof.ts
@@ -1,0 +1,93 @@
+import { handlers } from '.'
+
+export const FORMAT = 0xef
+export const MAGIC = 0x00
+export const VERSION = 0x01
+
+/**
+ *
+ * @param container A `Buffer` containing bytecode to be checked for EOF1 compliance
+ * @returns an object containing the size of the code section and data sections for a valid
+ * EOF1 container or else undefined if `container` is not valid EOF1 bytecode
+ *
+ * Note: See https://eips.ethereum.org/EIPS/eip-3540 for further details
+ */
+export const codeAnalysis = (container: Buffer) => {
+  const secCode = 0x01
+  const secData = 0x02
+  const secTerminator = 0x00
+  let computedContainerSize = 0
+  const sectionSizes = {
+    code: 0,
+    data: 0,
+  }
+  if (container[1] !== MAGIC || container[2] !== VERSION)
+    // Bytecode does not contain EOF1 "magic" or version number in expected positions
+    return
+
+  if (
+    // EOF1 bytecode must be more than 7 bytes long for EOF1 header plus code section (but no data section)
+    container.length > 7 &&
+    // EOF1 code section indicator
+    container[3] === secCode &&
+    // EOF1 header terminator
+    container[6] === secTerminator
+  ) {
+    sectionSizes.code = (container[4] << 8) | container[5]
+    // Calculate expected length of EOF1 container based on code section
+    computedContainerSize = 7 + sectionSizes.code
+    // EOF1 code section must be at least 1 byte long
+    if (sectionSizes.code < 1) return
+  } else if (
+    // EOF1 container must be more than 10 bytes long if data section is included
+    container.length > 10 &&
+    // EOF1 code section indicator
+    container[3] === secCode &&
+    // EOF1 data section indicator
+    container[6] === secData &&
+    // EOF1 header terminator
+    container[9] === secTerminator
+  ) {
+    sectionSizes.code = (container[4] << 8) | container[5]
+    sectionSizes.data = (container[7] << 8) | container[8]
+    // Calculate expected length of EOF1 container based on code and data sections
+    computedContainerSize = 10 + sectionSizes.code + sectionSizes.data
+    // Code & Data sizes cannot be 0
+    if (sectionSizes.code < 1 || sectionSizes.data < 1) return
+  }
+  if (container.length !== computedContainerSize) {
+    // Computed container length based on section details does not match length of actual bytecode
+    return
+  }
+  return sectionSizes
+}
+
+export const validOpcodes = (code: Buffer) => {
+  // EIP-3670 - validate all opcodes
+  const opcodes = new Set(handlers.keys())
+  opcodes.add(0xfe) // Add INVALID opcode to set
+
+  let x = 0
+  while (x < code.length) {
+    const opcode = code[x]
+    x++
+    if (!opcodes.has(opcode)) {
+      // No invalid/undefined opcodes
+      return false
+    }
+    if (opcode >= 0x60 && opcode <= 0x7f) {
+      // Skip data block following push
+      x += opcode - 0x5f
+      if (x > code.length - 1) {
+        // Push blocks must not exceed end of code section
+        return false
+      }
+    }
+  }
+  const terminatingOpcodes = new Set([0x00, 0xf3, 0xfd, 0xfe, 0xff])
+  // Per EIP-3670, the final opcode of a code section must be STOP, RETURN, REVERT, INVALID, or SELFDESTRUCT
+  if (!terminatingOpcodes.has(code[code.length - 1])) {
+    return false
+  }
+  return true
+}

--- a/packages/vm/src/evm/opcodes/util.ts
+++ b/packages/vm/src/evm/opcodes/util.ts
@@ -1,6 +1,5 @@
 import Common from '@ethereumjs/common'
 import { BN, keccak256, setLengthRight, setLengthLeft } from 'ethereumjs-util'
-import { handlers } from '.'
 import { ERROR, VmError } from './../../exceptions'
 import { RunState } from './../interpreter'
 
@@ -261,94 +260,4 @@ export function updateSstoreGas(
     */
     return new BN(common.param('gasPrices', 'sstoreSet'))
   }
-}
-
-/**
- *
- * @param container A `Buffer` containing bytecode to be checked for EOF1 compliance
- * @returns an object containing the size of the code section and data sections for a valid
- * EOF1 container or else undefined if `container` is not valid EOF1 bytecode
- *
- * Note: See https://eips.ethereum.org/EIPS/eip-3540 for further details
- */
-export const eof1CodeAnalysis = (container: Buffer) => {
-  const magic = 0x00
-  const version = 0x01
-  const secCode = 0x01
-  const secData = 0x02
-  const secTerminator = 0x00
-  let computedContainerSize = 0
-  const sectionSizes = {
-    code: 0,
-    data: 0,
-  }
-  if (container[1] !== magic || container[2] !== version)
-    // Bytecode does not contain EOF1 "magic" or version number in expected positions
-    return
-
-  if (
-    // EOF1 bytecode must be more than 7 bytes long for EOF1 header plus code section (but no data section)
-    container.length > 7 &&
-    // EOF1 code section indicator
-    container[3] === secCode &&
-    // EOF1 header terminator
-    container[6] === secTerminator
-  ) {
-    sectionSizes.code = (container[4] << 8) | container[5]
-    // Calculate expected length of EOF1 container based on code section
-    computedContainerSize = 7 + sectionSizes.code
-    // EOF1 code section must be at least 1 byte long
-    if (sectionSizes.code < 1) return
-  } else if (
-    // EOF1 container must be more than 10 bytes long if data section is included
-    container.length > 10 &&
-    // EOF1 code section indicator
-    container[3] === secCode &&
-    // EOF1 data section indicator
-    container[6] === secData &&
-    // EOF1 header terminator
-    container[9] === secTerminator
-  ) {
-    sectionSizes.code = (container[4] << 8) | container[5]
-    sectionSizes.data = (container[7] << 8) | container[8]
-    // Calculate expected length of EOF1 container based on code and data sections
-    computedContainerSize = 10 + sectionSizes.code + sectionSizes.data
-    // Code & Data sizes cannot be 0
-    if (sectionSizes.code < 1 || sectionSizes.data < 1) return
-  }
-  if (container.length !== computedContainerSize) {
-    // Computed container length based on section details does not match length of actual bytecode
-    return
-  }
-  return sectionSizes
-}
-
-export const eof1ValidOpcodes = (code: Buffer) => {
-  // EIP-3670 - validate all opcodes
-  const opcodes = new Set(handlers.keys())
-  opcodes.add(0xfe) // Add INVALID opcode to set
-
-  let x = 0
-  while (x < code.length) {
-    const opcode = code[x]
-    x++
-    if (!opcodes.has(opcode)) {
-      // No invalid/undefined opcodes
-      return false
-    }
-    if (opcode >= 0x60 && opcode <= 0x7f) {
-      // Skip data block following push
-      x += opcode - 0x5f
-      if (x > code.length - 1) {
-        // Push blocks must not exceed end of code section
-        return false
-      }
-    }
-  }
-  const terminatingOpcodes = new Set([0x00, 0xf3, 0xfd, 0xfe, 0xff])
-  // Per EIP-3670, the final opcode of a code section must be STOP, RETURN, REVERT, INVALID, or SELFDESTRUCT
-  if (!terminatingOpcodes.has(code[code.length - 1])) {
-    return false
-  }
-  return true
 }

--- a/packages/vm/tests/api/EIPs/eip-3540-evm-object-format.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3540-evm-object-format.spec.ts
@@ -12,7 +12,7 @@ tape('EIP 3540 tests', (t) => {
   const common = new Common({
     chain: Chain.Mainnet,
     hardfork: Hardfork.London,
-    eips: [3540, 3541],
+    eips: [3540],
   })
 
   t.test('eof1CodeAnalysis() tests', async (st) => {
@@ -116,7 +116,7 @@ tape('valid contract creation cases', async (st) => {
   const common = new Common({
     chain: Chain.Mainnet,
     hardfork: Hardfork.London,
-    eips: [3540, 3541],
+    eips: [3540],
   })
   const vm = new VM({ common })
   const account = await vm.stateManager.getAccount(sender)
@@ -182,7 +182,7 @@ tape('ensure invalid EOF initcode in EIP-3540 does not consume all gas', (t) => 
     const common = new Common({
       chain: Chain.Mainnet,
       hardfork: Hardfork.London,
-      eips: [3540, 3541],
+      eips: [3540],
     })
     const vm = new VM({ common })
     const account = await vm.stateManager.getAccount(sender)
@@ -212,7 +212,7 @@ tape('ensure invalid EOF initcode in EIP-3540 does not consume all gas', (t) => 
     const common = new Common({
       chain: Chain.Mainnet,
       hardfork: Hardfork.London,
-      eips: [3540, 3541],
+      eips: [3540],
     })
     const vm = new VM({ common })
     const account = await vm.stateManager.getAccount(sender)
@@ -242,7 +242,7 @@ tape('ensure invalid EOF initcode in EIP-3540 does not consume all gas', (t) => 
     const common = new Common({
       chain: Chain.Mainnet,
       hardfork: Hardfork.London,
-      eips: [3540, 3541],
+      eips: [3540],
     })
     const vm = new VM({ common })
     const account = await vm.stateManager.getAccount(sender)

--- a/packages/vm/tests/api/EIPs/eip-3540-evm-object-format.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3540-evm-object-format.spec.ts
@@ -39,6 +39,7 @@ tape('EIP 3540 tests', (t) => {
     )
     st.end()
   })
+
   t.test('invalid object formats', async (st) => {
     const vm = new VM({ common })
     const account = await vm.stateManager.getAccount(sender)
@@ -112,6 +113,7 @@ tape('EIP 3540 tests', (t) => {
     st.ok(code.length === 0, 'code section with trailing bytes')
   })
 })
+
 tape('valid contract creation cases', async (st) => {
   const common = new Common({
     chain: Chain.Mainnet,
@@ -134,6 +136,7 @@ tape('valid contract creation cases', async (st) => {
   let created = result.createdAddress
   let code = await vm.stateManager.getContractCode(created!)
   st.ok(code.length > 0, 'code section with no data section')
+
   tx = FeeMarketEIP1559Transaction.fromTxData({
     data: '0x6BEF00010100010200010000AA600052600C6014F3',
     gasLimit: 100000000,

--- a/packages/vm/tests/api/EIPs/eip-3540-evm-object-format.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3540-evm-object-format.spec.ts
@@ -3,7 +3,7 @@ import VM from '../../../src'
 import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
 import { Address, BN, privateToAddress } from 'ethereumjs-util'
-import { eof1CodeAnalysis } from '../../../src/evm/opcodes'
+import * as eof from '../../../src/evm/opcodes/eof'
 const pkey = Buffer.from('20'.repeat(32), 'hex')
 const GWEI = new BN('1000000000')
 const sender = new Address(privateToAddress(pkey))
@@ -16,14 +16,14 @@ tape('EIP 3540 tests', (t) => {
   })
 
   t.test('eof1CodeAnalysis() tests', async (st) => {
-    const eofHeader = Buffer.from([0xef, 0x00, 0x01])
+    const eofHeader = Buffer.from([eof.FORMAT, eof.MAGIC, eof.VERSION])
     st.ok(
-      eof1CodeAnalysis(Buffer.concat([eofHeader, Uint8Array.from([0x01, 0x00, 0x01, 0x00, 0x00])]))
+      eof.codeAnalysis(Buffer.concat([eofHeader, Uint8Array.from([0x01, 0x00, 0x01, 0x00, 0x00])]))
         ?.code! > 0,
       'valid code section'
     )
     st.ok(
-      eof1CodeAnalysis(
+      eof.codeAnalysis(
         Buffer.concat([
           eofHeader,
           Uint8Array.from([0x01, 0x00, 0x01, 0x02, 0x00, 0x01, 0x00, 0x00, 0xaa]),
@@ -32,7 +32,7 @@ tape('EIP 3540 tests', (t) => {
       'valid data section'
     )
     st.ok(
-      !eof1CodeAnalysis(
+      !eof.codeAnalysis(
         Buffer.concat([eofHeader, Uint8Array.from([0x01, 0x00, 0x01, 0x00, 0x00, 0x00])])
       ),
       'invalid container length'

--- a/packages/vm/tests/api/EIPs/eip-3670-eof-code-validation.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3670-eof-code-validation.spec.ts
@@ -12,7 +12,7 @@ tape('EIP 3670 tests', (t) => {
   const common = new Common({
     chain: Chain.Mainnet,
     hardfork: Hardfork.London,
-    eips: [3540, 3541, 3670],
+    eips: [3540, 3670],
   })
 
   t.test('eof1ValidOpcodes() tests', (st) => {
@@ -36,6 +36,7 @@ tape('EIP 3670 tests', (t) => {
     })
     st.end()
   })
+
   t.test('valid contract code transactions', async (st) => {
     const vm = new VM({ common })
     const account = await vm.stateManager.getAccount(sender)

--- a/packages/vm/tests/api/EIPs/eip-3670-eof-code-validation.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3670-eof-code-validation.spec.ts
@@ -3,7 +3,7 @@ import VM from '../../../src'
 import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
 import { Address, BN, privateToAddress } from 'ethereumjs-util'
-import { eof1ValidOpcodes } from '../../../src/evm/opcodes'
+import * as eof from '../../../src/evm/opcodes/eof'
 const pkey = Buffer.from('20'.repeat(32), 'hex')
 const GWEI = new BN('1000000000')
 const sender = new Address(privateToAddress(pkey))
@@ -16,21 +16,21 @@ tape('EIP 3670 tests', (t) => {
   })
 
   t.test('eof1ValidOpcodes() tests', (st) => {
-    st.ok(eof1ValidOpcodes(Buffer.from([0])), 'valid -- STOP ')
-    st.notOk(eof1ValidOpcodes(Buffer.from([0xaa])), 'invalid -- AA -- undefined opcode')
-    st.ok(eof1ValidOpcodes(Buffer.from([0x60, 0xaa, 0])), 'valid - PUSH1 AA STOP')
+    st.ok(eof.validOpcodes(Buffer.from([0])), 'valid -- STOP ')
+    st.notOk(eof.validOpcodes(Buffer.from([0xaa])), 'invalid -- AA -- undefined opcode')
+    st.ok(eof.validOpcodes(Buffer.from([0x60, 0xaa, 0])), 'valid - PUSH1 AA STOP')
     st.notOk(
-      eof1ValidOpcodes(Buffer.from([0x7f, 0xaa, 0])),
+      eof.validOpcodes(Buffer.from([0x7f, 0xaa, 0])),
       'invalid -- PUSH32 AA STOP -- truncated push'
     )
     st.notOk(
-      eof1ValidOpcodes(Buffer.from([0x61, 0xaa, 0])),
+      eof.validOpcodes(Buffer.from([0x61, 0xaa, 0])),
       'invalid -- PUSH2 AA STOP -- truncated push'
     )
-    st.notOk(eof1ValidOpcodes(Buffer.from([0x30])), 'invalid -- ADDRESS -- invalid terminal opcode')
+    st.notOk(eof.validOpcodes(Buffer.from([0x30])), 'invalid -- ADDRESS -- invalid terminal opcode')
     Array.from([0x00, 0xf3, 0xfd, 0xfe, 0xff]).forEach((opcode) => {
       st.ok(
-        eof1ValidOpcodes(Buffer.from([0x60, 0xaa, opcode])),
+        eof.validOpcodes(Buffer.from([0x60, 0xaa, opcode])),
         `code ends with valid terminating instruction 0x${opcode.toString(16)}`
       )
     })

--- a/packages/vm/tests/api/EIPs/eip-3670-eof-code-validation.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3670-eof-code-validation.spec.ts
@@ -30,8 +30,17 @@ tape('EIP 3670 tests', (t) => {
 
   t.test('EOF > validOpcodes() tests', (st) => {
     st.ok(eof.validOpcodes(Buffer.from([0])), 'valid -- STOP ')
-    st.notOk(eof.validOpcodes(Buffer.from([0xaa])), 'invalid -- AA -- undefined opcode')
+    st.ok(eof.validOpcodes(Buffer.from([0xfe])), 'valid -- INVALID opcode')
     st.ok(eof.validOpcodes(Buffer.from([0x60, 0xaa, 0])), 'valid - PUSH1 AA STOP')
+
+    Array.from([0x00, 0xf3, 0xfd, 0xfe, 0xff]).forEach((opcode) => {
+      st.ok(
+        eof.validOpcodes(Buffer.from([0x60, 0xaa, opcode])),
+        `code ends with valid terminating instruction 0x${opcode.toString(16)}`
+      )
+    })
+
+    st.notOk(eof.validOpcodes(Buffer.from([0xaa])), 'invalid -- AA -- undefined opcode')
     st.notOk(
       eof.validOpcodes(Buffer.from([0x7f, 0xaa, 0])),
       'invalid -- PUSH32 AA STOP -- truncated push'
@@ -40,13 +49,10 @@ tape('EIP 3670 tests', (t) => {
       eof.validOpcodes(Buffer.from([0x61, 0xaa, 0])),
       'invalid -- PUSH2 AA STOP -- truncated push'
     )
-    st.notOk(eof.validOpcodes(Buffer.from([0x30])), 'invalid -- ADDRESS -- invalid terminal opcode')
-    Array.from([0x00, 0xf3, 0xfd, 0xfe, 0xff]).forEach((opcode) => {
-      st.ok(
-        eof.validOpcodes(Buffer.from([0x60, 0xaa, opcode])),
-        `code ends with valid terminating instruction 0x${opcode.toString(16)}`
-      )
-    })
+    st.notOk(
+      eof.validOpcodes(Buffer.from([0x60, 0xaa, 0x30])),
+      'invalid -- PUSH1 AA ADDRESS -- invalid terminal opcode'
+    )
     st.end()
   })
 


### PR DESCRIPTION
This is some follow-up work on #1719 with some improvements and clean-ups on the tests, also meant as some additional implicit review by dealing with the code.

I removed some various redundand code parts in the test files and and did some (very few) test additions and/or modifications. One major change is that I moved the whole EOF logic into its own file, it very much feels to me that this is justified since this is some major new functionality, likely also with additions and evolutions in the future. Let me know if you are ok with how this is integrated.

Otherwise: again, work looks extremely solid, thanks Andrew - also Jochem - for these great PRs! 😄 