### PR TITLE
Client: Improve stalled Kiln startup

### DIFF
--- a/packages/client/lib/net/peerpool.ts
+++ b/packages/client/lib/net/peerpool.ts
@@ -25,6 +25,7 @@ export class PeerPool {
   public running: boolean
 
   private _statusCheckInterval: NodeJS.Timeout | undefined /* global NodeJS */
+  private DEFAULT_STATUS_CHECK_INTERVAL = 10 /* default checks in secs */
   private _reconnectTimeout: NodeJS.Timeout | undefined
 
   /**
@@ -74,8 +75,11 @@ export class PeerPool {
     if (this.running) {
       return false
     }
-    // eslint-disable-next-line @typescript-eslint/await-thenable
-    this._statusCheckInterval = setInterval(await this._statusCheck.bind(this), 20000)
+    this._statusCheckInterval = setInterval(
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await this._statusCheck.bind(this),
+      this.DEFAULT_STATUS_CHECK_INTERVAL * 1000
+    )
 
     this.running = true
     return true

--- a/packages/client/lib/net/peerpool.ts
+++ b/packages/client/lib/net/peerpool.ts
@@ -25,7 +25,7 @@ export class PeerPool {
   public running: boolean
 
   private _statusCheckInterval: NodeJS.Timeout | undefined /* global NodeJS */
-  private DEFAULT_STATUS_CHECK_INTERVAL = 10 /* default checks in secs */
+  private DEFAULT_STATUS_CHECK_INTERVAL = 20 /* default checks in secs */
   private _reconnectTimeout: NodeJS.Timeout | undefined
 
   /**

--- a/packages/client/lib/net/peerpool.ts
+++ b/packages/client/lib/net/peerpool.ts
@@ -223,15 +223,17 @@ export class PeerPool {
     if (this.size === 0) {
       this.noPeerPeriods += 1
       if (this.noPeerPeriods >= 3) {
+        this.noPeerPeriods = 0
         const promises = this.config.servers.map(async (server) => {
-          if (server instanceof RlpxServer && server.discovery) {
-            this.config.logger.info('Restarting RLPx server: bootstrap')
+          if (server instanceof RlpxServer) {
+            this.config.logger.info('Restarting RLPx server')
             await server.stop()
             await server.start()
+            this.config.logger.info('Reinitiating server bootstrap')
+            await server.bootstrap()
           }
         })
         await Promise.all(promises)
-        this.noPeerPeriods = 0
       } else {
         let tablesize: number | undefined = 0
         this.config.servers.forEach((server) => {


### PR DESCRIPTION
This will redo a new bootstrap in the client along status checks to allow for connection re-pickup if the initial connection fails. Behavior is now also activated in non-discovery scenarios (as in Kiln where a single bootnode is used for connection).

This was requested in the chat since otherwise auto-starting a client is very much unreliable.