### PR TITLE
Client: Bootnodes fix

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -68,7 +68,7 @@ const args = yargs(hideBin(process.argv))
     array: true,
   })
   .option('bootnodes', {
-    describe: 'Network bootnodes',
+    describe: 'Comma-separated list of network bootnodes',
     array: true,
   })
   .option('port', {

--- a/packages/client/kiln/README.md
+++ b/packages/client/kiln/README.md
@@ -20,7 +20,7 @@ Please ensure you have Node 12.x+ installed.
 
 ### Run client
 
-1. `npm run client:start -- --datadir kiln/datadir --gethGenesis kiln/config/genesis.json --saveReceipts --rpc --rpcport=8545 --ws --rpcEngine --rpcEnginePort=8551 --bootnodes=165.232.180.230:30303`
+1. `npm run client:start -- --datadir kiln/datadir --gethGenesis kiln/config/genesis.json --saveReceipts --rpc --rpcport=8545 --ws --rpcEngine --rpcEnginePort=8551 --bootnodes=164.92.130.5:30303,138.68.66.103:30303,165.232.180.230:30303,164.92.140.200:30303`
 
 Starting the client will write a `kiln/datadir/jwtsecret` file with a randomly generated secret to be used in conjunction with a CL client. This secret will be used to authenticate the `engine_*` api requests (hosted at port `8551`) from the CL. In case you want to host `engine_*` without auth, pass `--rpcEngineAuth false` as extra argument in the above run command.
 

--- a/packages/client/lib/util/parse.ts
+++ b/packages/client/lib/util/parse.ts
@@ -31,7 +31,12 @@ export function parseMultiaddrs(input: MultiaddrLike): Multiaddr[] {
   if (!Array.isArray(input) && typeof input === 'object') {
     return [input] as Multiaddr[]
   }
-  if (!Array.isArray(input)) {
+  if (Array.isArray(input)) {
+    // Comma-separated bootnodes
+    if (input.length === 1 && typeof input[0] === 'string' && input[0].includes(',')) {
+      input = input[0].split(',')
+    }
+  } else {
     input = input.split(',')
   }
   try {


### PR DESCRIPTION
This PR is adding additional Kiln bootnodes from [here](https://config.kiln.themerge.dev/el/bootnodes). It also fixes a bug where comma-separated bootnodes passed on CLI have not been parsed correctly.

The whole input situation - so, what get's into this `parseMultiaddrs()` in what format from where - is generally a bit chaotic (and might benefit from some small refactoring at some point), so I stayed conservative and rather a bit over-cautious and very much limited the added condition on this very specific case, since I couldn't completely oversee eventual side effects.
