### PR TITLE
Common: Fixed Event Listener Take-Over on Common.copy()

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1218,6 +1218,8 @@ export default class Common extends EventEmitter {
    * Returns a deep copy of this {@link Common} instance.
    */
   copy(): Common {
-    return Object.assign(Object.create(Object.getPrototypeOf(this)), this)
+    const copy = Object.assign(Object.create(Object.getPrototypeOf(this)), this)
+    copy.removeAllListeners()
+    return copy
   }
 }

--- a/packages/common/tests/chains.spec.ts
+++ b/packages/common/tests/chains.spec.ts
@@ -231,3 +231,18 @@ tape('[Common]: isSupportedChainId static method', function (t: tape.Test) {
     st.end()
   })
 })
+
+tape('[Common]: copy() listener tests', (t) => {
+  const common = new Common({ chain: 'mainnet' })
+  common.on('hardforkChanged', () => {
+    'its a new hardfork!'
+  })
+  common.on('hardforkChanged', () => {
+    'goodbye old hardfork'
+  })
+  const listeners = common.listenerCount('hardforkChanged')
+  const fakeCommon = common.copy()
+  const fakeCommonListeners = fakeCommon.listenerCount('hardforkChanged')
+  t.ok(listeners > fakeCommonListeners, 'copied common instance should have less listeners')
+  t.end()
+})

--- a/packages/common/tests/chains.spec.ts
+++ b/packages/common/tests/chains.spec.ts
@@ -234,15 +234,19 @@ tape('[Common]: isSupportedChainId static method', function (t: tape.Test) {
 
 tape('[Common]: copy() listener tests', (t) => {
   const common = new Common({ chain: 'mainnet' })
-  common.on('hardforkChanged', () => {
-    'its a new hardfork!'
-  })
-  common.on('hardforkChanged', () => {
-    'goodbye old hardfork'
-  })
-  const listeners = common.listenerCount('hardforkChanged')
-  const fakeCommon = common.copy()
-  const fakeCommonListeners = fakeCommon.listenerCount('hardforkChanged')
-  t.ok(listeners > fakeCommonListeners, 'copied common instance should have less listeners')
+  // Add two listeners
+  common.on('hardforkChanged', () => {})
+  common.on('hardforkChanged', () => {})
+  const commonCopy = common.copy()
+  t.equal(
+    common.listenerCount('hardforkChanged'),
+    2,
+    'original common instance should have two listeners'
+  )
+  t.equal(
+    commonCopy.listenerCount('hardforkChanged'),
+    0,
+    'copied common instance should have zero listeners'
+  )
   t.end()
 })


### PR DESCRIPTION
On the Common `copy()` method the event listeners from the original object persist also on the copied object. This has  unwanted side effects. I discovered this in the client where the Block instantiation with the chain common [here](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/client/lib/net/protocol/ethprotocol.ts#L138) causes the `hardforkUpdated` event to still get consumed by the original listeners added to `chainCommon` when fired on the copied Common in the new Block object when the [hardfork is set](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/block/src/header.ts#L260) in the constructor.