### PR TITLE
client: Handle partial results in multi-peer safe manner

### DIFF
--- a/packages/client/lib/blockchain/chain.ts
+++ b/packages/client/lib/blockchain/chain.ts
@@ -196,6 +196,7 @@ export class Chain {
         const num = block.header.number
         const td = await this.blockchain.getTotalDifficulty(block.hash(), num)
         this.config.logger.info(`Merge hardfork reached 🐼 👉 👈 🐼 ! block=${num} td=${td}`)
+        this.config.logger.info(`First block for CL-framed execution: block=${num.addn(1)}`)
       }
     })
   }

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -420,10 +420,7 @@ export class Engine {
       for (const [i, block] of blocks.entries()) {
         const root = (i > 0 ? blocks[i - 1] : await this.chain.getBlock(block.header.parentHash))
           .header.stateRoot
-        const { number } = block.header
-        const td = await this.chain.getTd(block.hash(), number)
-        vmCopy._common.setHardforkByBlockNumber(number, td)
-        await vmCopy.runBlock({ block, root })
+        await vmCopy.runBlock({ block, root, hardforkByTD: this.chain.headers.td })
         await vmCopy.blockchain.putBlock(block)
       }
     } catch (error) {

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -310,6 +310,9 @@ export class Engine {
    *   3. validationError: String|null - validation error message
    */
   async newPayloadV1(params: [ExecutionPayloadV1]): Promise<PayloadStatusV1> {
+    this.connectionManager.updateStatus()
+    this.connectionManager.lastPayloadReceived = params[0]
+
     const [payloadData] = params
     const {
       blockNumber: number,
@@ -319,8 +322,7 @@ export class Engine {
       transactions,
       parentHash,
     } = payloadData
-    this.connectionManager.lastPayloadReceived = payloadData
-    const common = this.config.chainCommon
+    const { chainCommon: common } = this.config
 
     try {
       const block = await findBlock(toBuffer(parentHash), this.validBlocks, this.chain)
@@ -418,12 +420,15 @@ export class Engine {
       for (const [i, block] of blocks.entries()) {
         const root = (i > 0 ? blocks[i - 1] : await this.chain.getBlock(block.header.parentHash))
           .header.stateRoot
+        const { number } = block.header
+        const td = await this.chain.getTd(block.hash(), number)
+        vmCopy._common.setHardforkByBlockNumber(number, td)
         await vmCopy.runBlock({ block, root })
         await vmCopy.blockchain.putBlock(block)
       }
     } catch (error) {
       const validationError = `Error verifying block while running: ${error}`
-      this.config.logger.debug(validationError)
+      this.config.logger.error(validationError)
       const latestValidHash = await validHash(block.header.parentHash, this.validBlocks, this.chain)
       return { status: Status.INVALID, latestValidHash, validationError }
     }
@@ -457,7 +462,7 @@ export class Engine {
   async forkchoiceUpdatedV1(
     params: [forkchoiceState: ForkchoiceStateV1, payloadAttributes: PayloadAttributesV1 | undefined]
   ): Promise<ForkchoiceResponseV1> {
-    this.connectionManager.updateConnectionStatus()
+    this.connectionManager.updateStatus()
     this.connectionManager.lastForkchoiceUpdate = params[0]
 
     const { headBlockHash, finalizedBlockHash } = params[0]
@@ -580,7 +585,7 @@ export class Engine {
    * @returns Instance of {@link ExecutionPayloadV1} or an error
    */
   async getPayloadV1(params: [string]) {
-    this.connectionManager.updateConnectionStatus()
+    this.connectionManager.updateStatus()
     const payloadId = toBuffer(params[0])
     try {
       const block = await this.pendingBlock.build(payloadId)
@@ -608,7 +613,7 @@ export class Engine {
   async exchangeTransitionConfigurationV1(
     params: [TransitionConfigurationV1]
   ): Promise<TransitionConfigurationV1> {
-    this.connectionManager.updateConnectionStatus()
+    this.connectionManager.updateStatus()
     const { terminalTotalDifficulty, terminalBlockHash, terminalBlockNumber } = params[0]
     const td = this.chain.config.chainCommon.hardforkTD(Hardfork.Merge)
     if (td === undefined || td === null) {

--- a/packages/client/lib/rpc/util/CLConnectionManager.ts
+++ b/packages/client/lib/rpc/util/CLConnectionManager.ts
@@ -30,10 +30,60 @@ export class CLConnectionManager {
   private _forkchoiceLogInterval?: NodeJS.Timeout
 
   private connectionStatus = ConnectionStatus.Disconnected
+  private oneTimeMergeCLConnectionCheck = false
   private lastRequestTimestamp = 0
 
-  public lastPayloadReceived?: ExecutionPayloadV1
-  public lastForkchoiceUpdate?: ForkchoiceStateV1
+  /**
+   * Do not get or set this value directly.
+   * Use the getter and setter without the underscore, i.e.
+   * ```this.connectionManager.lastPayloadReceived = payload```
+   */
+  private _lastPayloadReceived?: ExecutionPayloadV1
+
+  /**
+   * Do not get or set this value directly.
+   * Use the getter and setter without the underscore, i.e.
+   * ```this.connectionManager.lastForkchoiceUpdate = state```
+   */
+  private _lastForkchoiceUpdate?: ForkchoiceStateV1
+
+  private initialPayloadReceived?: ExecutionPayloadV1
+  private initialForkchoiceUpdate?: ForkchoiceStateV1
+
+  get lastPayloadReceived(): ExecutionPayloadV1 | undefined {
+    return this._lastPayloadReceived
+  }
+
+  set lastPayloadReceived(payload: ExecutionPayloadV1 | undefined) {
+    if (!payload) return
+    if (!this.initialPayloadReceived) {
+      this.initialPayloadReceived = payload
+      this.config.logger.info(
+        `Initial consensus payload received block=${Number(payload.blockNumber)} parentHash=${
+          payload.parentHash
+        }`
+      )
+    }
+    this._lastPayloadReceived = payload
+  }
+
+  get lastForkchoiceUpdate(): ForkchoiceStateV1 | undefined {
+    return this._lastForkchoiceUpdate
+  }
+
+  set lastForkchoiceUpdate(state: ForkchoiceStateV1 | undefined) {
+    if (!state) return
+    if (!this.initialForkchoiceUpdate) {
+      this.initialForkchoiceUpdate = state
+      this.config.logger.info(
+        `Initial consensus forkchoice update headBlockHash=${state.headBlockHash.substring(
+          0,
+          7
+        )}... finalizedBlockHash=${state.finalizedBlockHash}`
+      )
+    }
+    this._lastForkchoiceUpdate = state
+  }
 
   constructor(opts: CLConnectionManagerOpts) {
     this.config = opts.config
@@ -79,7 +129,7 @@ export class CLConnectionManager {
   /**
    * Updates the Consensus Client connection status on new RPC requests
    */
-  updateConnectionStatus() {
+  updateStatus() {
     if ([ConnectionStatus.Disconnected, ConnectionStatus.Lost].includes(this.connectionStatus)) {
       this.config.logger.info('Consensus client connection established', { attentionCL: 'CL' })
     }
@@ -104,6 +154,27 @@ export class CLConnectionManager {
         this.connectionStatus = ConnectionStatus.Disconnected
         this.config.logger.warn('Consensus disconnected', { attentionCL: null })
       }
+    }
+
+    if (this.config.chainCommon.hardfork() == Hardfork.PreMerge) {
+      if (this.connectionStatus === ConnectionStatus.Disconnected) {
+        this.config.logger.warn(`No CL client connection available, Merge HF happening soon`)
+      }
+    }
+
+    if (
+      !this.oneTimeMergeCLConnectionCheck &&
+      this.config.chainCommon.hardfork() == Hardfork.Merge
+    ) {
+      if (this.connectionStatus === ConnectionStatus.Disconnected) {
+        this.config.logger.warn(
+          `Merge HF activated, CL client connection is needed for continued block processing`
+        )
+        this.config.logger.warn(
+          '(note that CL client might need to be synced up to beacon chain Merge transition slot until communication starts)'
+        )
+      }
+      this.oneTimeMergeCLConnectionCheck = true
     }
   }
 

--- a/packages/client/lib/rpc/util/CLConnectionManager.ts
+++ b/packages/client/lib/rpc/util/CLConnectionManager.ts
@@ -17,7 +17,7 @@ export class CLConnectionManager {
   private config: Config
 
   /** Default connection check interval (in ms) */
-  private DEFAULT_CONNECTION_CHECK_INTERVAL = 5000
+  private DEFAULT_CONNECTION_CHECK_INTERVAL = 10000
 
   /** Default payload log interval (in ms) */
   private DEFAULT_PAYLOAD_LOG_INTERVAL = 10000

--- a/packages/client/lib/rpc/util/CLConnectionManager.ts
+++ b/packages/client/lib/rpc/util/CLConnectionManager.ts
@@ -158,7 +158,7 @@ export class CLConnectionManager {
 
     if (this.config.chainCommon.hardfork() == Hardfork.PreMerge) {
       if (this.connectionStatus === ConnectionStatus.Disconnected) {
-        this.config.logger.warn(`No CL client connection available, Merge HF happening soon`)
+        this.config.logger.warn('No CL client connection available, Merge HF happening soon')
       }
     }
 
@@ -168,7 +168,7 @@ export class CLConnectionManager {
     ) {
       if (this.connectionStatus === ConnectionStatus.Disconnected) {
         this.config.logger.warn(
-          `Merge HF activated, CL client connection is needed for continued block processing`
+          'Merge HF activated, CL client connection is needed for continued block processing'
         )
         this.config.logger.warn(
           '(note that CL client might need to be synced up to beacon chain Merge transition slot until communication starts)'

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -26,7 +26,7 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
     let { first, count } = task
     if (partialResult) {
       first = first.addn(partialResult.length)
-      count = count - partialResult.length
+      count -= partialResult.length
     }
     const blocksRange = `${first}-${first.addn(count)}`
     const peerInfo = `id=${peer?.id.slice(0, 8)} address=${peer?.address}`

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -1,5 +1,5 @@
 import { Block, BlockBuffer } from '@ethereumjs/block'
-import { KECCAK256_RLP, KECCAK256_RLP_ARRAY, BN } from 'ethereumjs-util'
+import { KECCAK256_RLP, KECCAK256_RLP_ARRAY } from 'ethereumjs-util'
 import { Peer } from '../../net/peer'
 import { Job } from './types'
 import { BlockFetcherBase, JobTask, BlockFetcherOptions } from './blockfetcherbase'
@@ -22,9 +22,12 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
    * @param job
    */
   async request(job: Job<JobTask, Block[], Block>): Promise<Block[]> {
-    const { task, peer } = job
-    const { first, count } = task
-
+    const { task, peer, partialResult } = job
+    let { first, count } = task
+    if (partialResult) {
+      first = first.addn(partialResult.length)
+      count = count - partialResult.length
+    }
     const blocksRange = `${first}-${first.addn(count)}`
     const peerInfo = `id=${peer?.id.slice(0, 8)} address=${peer?.address}`
 
@@ -76,37 +79,17 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
    * @returns results of processing job or undefined if job not finished
    */
   process(job: Job<JobTask, Block[], Block>, result: Block[]) {
+    result = (job.partialResult ?? []).concat(result)
+    job.partialResult = undefined
     if (result.length === job.task.count) {
       return result
-    }
-    if (result.length > 0 && result.length < job.task.count) {
+    } else if (result.length > 0 && result.length < job.task.count) {
       // Adopt the start block/header number from the remaining jobs
       // if the number of the results provided is lower than the expected count
+      job.partialResult = result
       this.debug(
         `Adopt start block/header number from remaining jobs (provided=${result.length} expected=${job.task.count})`
       )
-      const lengthDiff = job.task.count - result.length
-      const adoptedJobs = []
-      let lastTask
-      while (this.in.length > 0) {
-        const job = this.in.remove()
-        if (job) {
-          lastTask = job.task
-          job.task.first = job.task.first.subn(lengthDiff)
-          adoptedJobs.push(job)
-        }
-      }
-      for (const job of adoptedJobs) {
-        this.in.insert(job)
-      }
-      if (lastTask) {
-        const tasks = this.tasks(lastTask.first.addn(lastTask.count), new BN(lengthDiff))
-        for (const task of tasks) {
-          this.enqueueTask(task)
-        }
-      }
-
-      return result
     }
     return
   }

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -206,7 +206,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
    */
   private success(job: Job<JobTask, JobResult, StorageItem>, result?: JobResult) {
     if (job.state !== 'active') return
-    const jobStr = this.jobStr(job, true)
+    let jobStr = this.jobStr(job, true)
     let reenqueue = false
     let resultSet = ''
     if (result === undefined) {
@@ -231,6 +231,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
     } else {
       job.peer!.idle = true
       job.result = this.process(job, result)
+      jobStr = this.jobStr(job, true)
       if (job.result) {
         this.out.insert(job)
         this.dequeue()
@@ -496,8 +497,16 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
       str += `index=${job.index} `
     }
     if (this.isBlockFetcherJobTask(job.task)) {
-      str += `first=${job.task.first} count=${job.task.count}`
+      let { first, count } = job.task
+      if (job.partialResult) {
+        first = first.addn((job.partialResult as any).length)
+        count = count - (job.partialResult as any).length
+      }
+      str += `first=${first} count=${count} ${
+        job.partialResult ? `partialResults=${(job.partialResult as any)?.length}` : ''
+      }`
     }
+
     return str
   }
 

--- a/packages/client/lib/sync/fetcher/headerfetcher.ts
+++ b/packages/client/lib/sync/fetcher/headerfetcher.ts
@@ -42,7 +42,7 @@ export class HeaderFetcher extends BlockFetcherBase<BlockHeaderResult, BlockHead
     let { first, count } = task
     if (partialResult) {
       first = first.addn(partialResult.length)
-      count = count - partialResult.length
+      count -= partialResult.length
     }
     const response = await peer!.les!.getBlockHeaders({
       block: first,

--- a/packages/client/lib/sync/fetcher/headerfetcher.ts
+++ b/packages/client/lib/sync/fetcher/headerfetcher.ts
@@ -34,14 +34,19 @@ export class HeaderFetcher extends BlockFetcherBase<BlockHeaderResult, BlockHead
    * @param job
    */
   async request(job: Job<JobTask, BlockHeaderResult, BlockHeader>) {
-    const { task, peer } = job
+    const { task, peer, partialResult } = job
     if (this.flow.maxRequestCount(peer!, 'GetBlockHeaders') < this.config.maxPerRequest) {
       // we reached our request limit. try with a different peer.
       return
     }
+    let { first, count } = task
+    if (partialResult) {
+      first = first.addn(partialResult.length)
+      count = count - partialResult.length
+    }
     const response = await peer!.les!.getBlockHeaders({
-      block: task.first,
-      max: task.count,
+      block: first,
+      max: count,
     })
     return response
   }

--- a/packages/client/lib/sync/fetcher/types.ts
+++ b/packages/client/lib/sync/fetcher/types.ts
@@ -5,6 +5,7 @@ export type Job<JobTask, JobResult, StorageItem> = {
   time: number
   index: number
   result?: JobResult | StorageItem[]
+  partialResult?: StorageItem[]
   state: 'idle' | 'expired' | 'active'
   peer: Peer | null
 }

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -191,13 +191,17 @@ export class FullSynchronizer extends Synchronizer {
 
   async processBlocks(execution: VMExecution, blocks: Block[] | BlockHeader[]) {
     if (this.config.chainCommon.gteHardfork(Hardfork.Merge)) {
-      // If we are beyond the merge block we should stop the fetcher
-      this.config.logger.info('Merge hardfork reached, stopping block fetcher')
-      this.clearFetcher()
+      if (this.fetcher !== null) {
+        // If we are beyond the merge block we should stop the fetcher
+        this.config.logger.info('Merge hardfork reached, stopping block fetcher')
+        this.clearFetcher()
+      }
     }
 
     if (blocks.length === 0) {
-      this.config.logger.warn('No blocks fetched are applicable for import')
+      if (this.fetcher !== null) {
+        this.config.logger.warn('No blocks fetched are applicable for import')
+      }
       return
     }
 
@@ -223,7 +227,7 @@ export class FullSynchronizer extends Synchronizer {
         const td = this.chain.blocks.td
         const remaining = mergeTD.sub(td)
         if (remaining.lte(mergeTD.divn(10))) {
-          attentionHF = `Merge HF in ${remaining} TD (diff)`
+          attentionHF = `Merge HF in ${remaining} TD`
         }
       }
     }

--- a/packages/client/test/rpc/engine/newPayloadV1.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV1.spec.ts
@@ -145,7 +145,8 @@ tape(`${method}: call with valid data but invalid transactions`, async (t) => {
 })
 
 tape(`${method}: call with valid data & valid transaction but not signed`, async (t) => {
-  const { server, common } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+  const { server, common, chain } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+  chain.config.logger.silent = true
 
   // Let's mock a non-signed transaction so execution fails
   const tx = FeeMarketEIP1559Transaction.fromTxData(

--- a/packages/client/test/sync/fetcher/blockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/blockfetcher.spec.ts
@@ -113,8 +113,16 @@ tape('[BlockFetcher]', async (t) => {
     const task = { count: 3, first: new BN(1) }
     ;(fetcher as any).running = true
     fetcher.enqueueTask(task)
-    fetcher.process({ task } as any, blocks)
-    t.equals((fetcher as any).in.size(), 2, 'Fetcher should have two tasks after adopting')
+    const job = (fetcher as any).in.peek()
+    let results = fetcher.process(job as any, blocks)
+    t.equals((fetcher as any).in.size(), 1, 'Fetcher should still have same job')
+    t.equals(job?.partialResult?.length, 2, 'Should have two partial results')
+    t.equals(results, undefined, 'Process should not return full results yet')
+
+    const remainingBlocks: any = [{ header: { number: 3 } }]
+    results = fetcher.process(job as any, remainingBlocks)
+    t.equals(results?.length, 3, 'Should return full results')
+
     t.end()
   })
 

--- a/packages/client/test/sync/fetcher/headerfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/headerfetcher.spec.ts
@@ -70,6 +70,33 @@ tape('[HeaderFetcher]', async (t) => {
     t.end()
   })
 
+  t.test('should request correctly', async (t) => {
+    const config = new Config({ transports: [] })
+    const pool = new PeerPool() as any
+    const flow = td.object()
+    const fetcher = new HeaderFetcher({
+      config,
+      pool,
+      flow,
+    })
+    const partialResult = [{ number: 1 }, { number: 2 }]
+    const task = { count: 3, first: new BN(1) }
+    const peer = {
+      les: { getBlockHeaders: td.func<any>() },
+      id: 'random',
+      address: 'random',
+    }
+    const job = { peer, partialResult, task }
+    await fetcher.request(job as any)
+    td.verify(
+      job.peer.les.getBlockHeaders({
+        block: job.task.first.addn(partialResult.length),
+        max: job.task.count - partialResult.length,
+      })
+    )
+    t.end()
+  })
+
   t.test('store()', async (st) => {
     st.plan(2)
 

--- a/packages/client/test/sync/fetcher/headerfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/headerfetcher.spec.ts
@@ -47,8 +47,17 @@ tape('[HeaderFetcher]', async (t) => {
     const task = { count: 3, first: new BN(1) }
     ;(fetcher as any).running = true
     fetcher.enqueueTask(task)
-    fetcher.process({ task } as any, { headers, bv: new BN(1) } as any)
-    t.equals((fetcher as any).in.size(), 2, 'Fetcher should have two tasks after adopting')
+    const job = (fetcher as any).in.peek()
+
+    let results = fetcher.process(job as any, { headers, bv: new BN(1) } as any)
+    t.equals((fetcher as any).in.size(), 1, 'Fetcher should still have same job')
+    t.equals(job?.partialResult?.length, 2, 'Should have two partial results')
+    t.equals(results, undefined, 'Process should not return full results yet')
+
+    const remainingHeaders: any = [{ number: 3 }]
+    results = fetcher.process(job as any, { headers: remainingHeaders, bv: new BN(1) } as any)
+    t.equals(results?.length, 3, 'Should return full results')
+
     t.end()
   })
 

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -39,7 +39,7 @@ export interface RunBlockOpts {
   root?: Buffer
   /**
    * Whether to generate the stateRoot and other related fields.
-   * If `true`, `runBlock` will set the fields `stateRoot`, `receiptsTrie`, `gasUsed`, and `bloom` (logs bloom) after running the block.
+   * If `true`, `runBlock` will set the fields `stateRoot`, `receiptTrie`, `gasUsed`, and `bloom` (logs bloom) after running the block.
    * If `false`, `runBlock` throws if any fields do not match.
    * Defaults to `false`.
    */
@@ -58,6 +58,10 @@ export interface RunBlockOpts {
    * If true, skips the balance check
    */
   skipBalance?: boolean
+  /**
+   * For merge transition support, pass the chain TD up to the block being run
+   */
+  hardforkByTD?: BN
 }
 
 /**
@@ -113,9 +117,13 @@ export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<Ru
    */
   await this._emit('beforeBlock', block)
 
-  if (this._hardforkByBlockNumber || this._hardforkByTD) {
-    this._common.setHardforkByBlockNumber(block.header.number.toNumber(), this._hardforkByTD)
+  if (this._hardforkByBlockNumber || this._hardforkByTD || opts.hardforkByTD) {
+    this._common.setHardforkByBlockNumber(
+      block.header.number,
+      opts.hardforkByTD ?? this._hardforkByTD
+    )
   }
+
   if (this.DEBUG) {
     debug('-'.repeat(100))
     debug(


### PR DESCRIPTION
The way we were adopting/handling jobs wasn't multi-peer safe when the results were provided less than asked for, as any shifting of jobs were not being reflected in the next job being fetched  by some other peer for e.g.
This PR fixes that, and enqueues the job again (instead of shifting/adopting all other jobs) to fetch the remaining data:
Example log:
```
client:fetcher Job index greater than processed + max queue size, skip next job execution. +0ms
  client:fetcher Requested blocks=24034-24051 from id=e9631196 address=10.244.0.164:30303 (received: 17 headers / 7 bodies) +23ms
  client:fetcher Adopt start block/header number from remaining jobs (provided=40 expected=50) +6ms
  client:fetcher Re-enqueuing job index=480 first=24041 count=10 partialResults=40 from peer id=e9631196 (reply contains unexpected data). +0ms
```
