### PR TITLE
Client: Validate finalized block hash on ForkchoiceUpdated 

### DIFF
--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -548,11 +548,19 @@ export class Engine {
 
     /*
      * Process finalized block
+     * All zeros means no finalized block yet which is okay
      */
-    if (finalizedBlockHash === '0'.repeat(64)) {
-      // All zeros means no finalized block yet which is okay
-    } else {
-      this.chain.lastFinalizedBlockHash = toBuffer(finalizedBlockHash)
+    if (!(finalizedBlockHash === '0'.repeat(64))) {
+      try {
+        this.chain.lastFinalizedBlockHash = (
+          await this.chain.getBlock(toBuffer(finalizedBlockHash))
+        ).hash()
+      } catch (error) {
+        throw {
+          message: 'finalized block hash not available',
+          code: INVALID_PARAMS,
+        }
+      }
     }
 
     /*

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -1,6 +1,6 @@
 import { Block, HeaderData } from '@ethereumjs/block'
 import { TransactionFactory, TypedTransaction } from '@ethereumjs/tx'
-import { toBuffer, bufferToHex, rlp, BN } from 'ethereumjs-util'
+import { toBuffer, bufferToHex, rlp, BN, zeros } from 'ethereumjs-util'
 import { BaseTrie as Trie } from 'merkle-patricia-tree'
 import { Hardfork } from '@ethereumjs/common'
 
@@ -550,7 +550,9 @@ export class Engine {
      * Process finalized block
      * All zeros means no finalized block yet which is okay
      */
-    if (!(finalizedBlockHash === '0'.repeat(64))) {
+    const zeroHash = zeros(32)
+    const finalizedHash = toBuffer(finalizedBlockHash)
+    if (!finalizedHash.equals(zeroHash)) {
       try {
         this.chain.lastFinalizedBlockHash = (
           await this.chain.getBlock(toBuffer(finalizedBlockHash))

--- a/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
+++ b/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
@@ -257,7 +257,19 @@ tape(`${method}: call with deep parent lookup and with stored safe block hash`, 
   await baseRequest(t, server, req, 200, expectRes)
 })
 
-tape.only(`${method}: invalid safe block hash`, async (t) => {
+tape(`${method}: unknown finalized block hash`, async (t) => {
+  const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+  const req = params(method, [
+    {
+      ...validForkChoiceState,
+      finalizedBlockHash: '0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4b',
+    },
+  ])
+  const expectRes = checkError(t, INVALID_PARAMS, 'finalized block hash not available')
+  await baseRequest(t, server, req, 200, expectRes)
+})
+
+tape(`${method}: invalid safe block hash`, async (t) => {
   const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
   const req = params(method, [
     {
@@ -266,5 +278,6 @@ tape.only(`${method}: invalid safe block hash`, async (t) => {
     },
   ])
   const expectRes = checkError(t, INVALID_PARAMS, 'safe block hash not available')
+
   await baseRequest(t, server, req, 200, expectRes)
 })


### PR DESCRIPTION
This PR aims to validate that the finalized block exists in the chain. Fixing the test case from the Hive: [Unknown SafeBlockHash](https://hackmd.io/lKw1UArUSWu1_lOdbt3heQ#Full-Description-of-Test-Cases)

Implementation inspired from geth: https://github.com/ethereum/go-ethereum/blob/master/eth/catalyst/api.go#L154-L167

Also, this is bullet number 6 from [fork choice update specs](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#specification-1) 