### PR TITLE
Client: Validate block safe hash on ForkchoiceUpdated

### DIFF
--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -499,12 +499,10 @@ export class Engine {
       try {
         await this.chain.getBlock(toBuffer(safeBlockHash))
       } catch (error) {
-        const payloadStatus = {
-          status: Status.INVALID,
-          latestValidHash: null,
-          validationError: 'Safe head not available',
+        throw {
+          code: INVALID_PARAMS,
+          message: 'safe block hash not available',
         }
-        return { payloadStatus, payloadId: null }
       }
     }
 

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -462,7 +462,7 @@ export class Engine {
     this.connectionManager.updateStatus()
     this.connectionManager.lastForkchoiceUpdate = params[0]
 
-    const { headBlockHash, finalizedBlockHash } = params[0]
+    const { headBlockHash, finalizedBlockHash, safeBlockHash } = params[0]
     const payloadAttributes = params[1]
 
     /*
@@ -492,6 +492,19 @@ export class Engine {
           },
           payloadId: null,
         }
+      }
+    }
+
+    if (safeBlockHash !== headBlockHash) {
+      try {
+        await this.chain.getBlock(toBuffer(safeBlockHash))
+      } catch (error) {
+        const payloadStatus = {
+          status: Status.INVALID,
+          latestValidHash: null,
+          validationError: 'Safe head not available',
+        }
+        return { payloadStatus, payloadId: null }
       }
     }
 

--- a/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
+++ b/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
@@ -226,3 +226,17 @@ tape(`${method}: call with deep parent lookup`, async (t) => {
   }
   await baseRequest(t, server, req, 200, expectRes)
 })
+
+tape(`${method}: invalid safe block hash`, async (t) => {
+  const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+  const req = params(method, [
+    {
+      ...validForkChoiceState,
+      safeBlockHash: '0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4b',
+    },
+  ])
+  const expectRes = (res: any) => {
+    t.equal(res.body.result.payloadStatus.status, 'INVALID')
+  }
+  await baseRequest(t, server, req, 200, expectRes, false)
+})

--- a/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
+++ b/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
@@ -227,7 +227,37 @@ tape(`${method}: call with deep parent lookup`, async (t) => {
   await baseRequest(t, server, req, 200, expectRes)
 })
 
-tape(`${method}: invalid safe block hash`, async (t) => {
+tape(`${method}: call with deep parent lookup and with stored safe block hash`, async (t) => {
+  const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+
+  let req = params(method, [validForkChoiceState])
+  let expectRes = (res: any) => {
+    t.equal(res.body.result.payloadStatus.status, 'VALID')
+  }
+  await baseRequest(t, server, req, 200, expectRes, false)
+
+  for (let i = 0; i < 3; i++) {
+    const req = params('engine_newPayloadV1', [blocks[i]])
+    const expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'VALID')
+    }
+    await baseRequest(t, server, req, 200, expectRes, false)
+  }
+
+  req = params(method, [
+    {
+      ...validForkChoiceState,
+      headBlockHash: blocks[2].blockHash,
+      safeBlockHash: blocks[0].blockHash,
+    },
+  ])
+  expectRes = (res: any) => {
+    t.equal(res.body.result.payloadStatus.status, 'VALID')
+  }
+  await baseRequest(t, server, req, 200, expectRes)
+})
+
+tape.only(`${method}: invalid safe block hash`, async (t) => {
   const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
   const req = params(method, [
     {
@@ -235,8 +265,6 @@ tape(`${method}: invalid safe block hash`, async (t) => {
       safeBlockHash: '0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4b',
     },
   ])
-  const expectRes = (res: any) => {
-    t.equal(res.body.result.payloadStatus.status, 'INVALID')
-  }
-  await baseRequest(t, server, req, 200, expectRes, false)
+  const expectRes = checkError(t, INVALID_PARAMS, 'safe block hash not available')
+  await baseRequest(t, server, req, 200, expectRes)
 })


### PR DESCRIPTION
This PR aims to validate that the safe head block exists in the chain. Fixing the test case from the Hive: [Unknown SafeBlockHash](https://hackmd.io/lKw1UArUSWu1_lOdbt3heQ#Full-Description-of-Test-Cases)

Implementation inspired from geth: https://github.com/ethereum/go-ethereum/blob/master/eth/catalyst/api.go#L168-L179

Also, this is the validation mentioned on [Forkchoice state specs](https://github.com/ethereum/execution-apis/blob/main/src/engine/specification.md#forkchoicestatev1)

edit: this PR will have conflicts with #1803 - I will take care of that once one of these two PRs got merged