### PR TITLE
Client: more Merge-related logger improvments

### DIFF
--- a/packages/client/lib/blockchain/chain.ts
+++ b/packages/client/lib/blockchain/chain.ts
@@ -196,6 +196,7 @@ export class Chain {
         const num = block.header.number
         const td = await this.blockchain.getTotalDifficulty(block.hash(), num)
         this.config.logger.info(`Merge hardfork reached 🐼 👉 👈 🐼 ! block=${num} td=${td}`)
+        this.config.logger.info(`First block for CL-framed execution: block=${num.addn(1)}`)
       }
     })
   }

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -419,7 +419,7 @@ export class Engine {
         const root = (i > 0 ? blocks[i - 1] : await this.chain.getBlock(block.header.parentHash))
           .header.stateRoot
         const { number } = block.header
-        const td = this.chain.headers.td
+        const td = await this.chain.getTd(block.hash(), number)
         vmCopy._common.setHardforkByBlockNumber(number, td)
         await vmCopy.runBlock({ block, root })
         await vmCopy.blockchain.putBlock(block)

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -320,14 +320,6 @@ export class Engine {
       parentHash,
     } = payloadData
     this.connectionManager.lastPayloadReceived = payloadData
-    if (!this.connectionManager.initialPayloadReceived) {
-      this.connectionManager.initialPayloadReceived = payloadData
-      this.config.logger.info(
-        `Initial consensus payload received block=${Number(payloadData.blockNumber)} parentHash=${
-          payloadData.parentHash
-        }`
-      )
-    }
     const common = this.config.chainCommon
 
     try {
@@ -468,17 +460,8 @@ export class Engine {
   async forkchoiceUpdatedV1(
     params: [forkchoiceState: ForkchoiceStateV1, payloadAttributes: PayloadAttributesV1 | undefined]
   ): Promise<ForkchoiceResponseV1> {
-    this.connectionManager.updateConnectionStatus()
+    this.connectionManager.updateStatus()
     this.connectionManager.lastForkchoiceUpdate = params[0]
-    if (!this.connectionManager.initialForkchoiceUpdate) {
-      this.connectionManager.initialForkchoiceUpdate = params[0]
-      this.config.logger.info(
-        `Initial consensus forkchoice update headBlockHash=${params[0].headBlockHash.substring(
-          0,
-          7
-        )}... finalizedBlockHash=${params[0].finalizedBlockHash}`
-      )
-    }
 
     const { headBlockHash, finalizedBlockHash } = params[0]
     const payloadAttributes = params[1]
@@ -600,7 +583,7 @@ export class Engine {
    * @returns Instance of {@link ExecutionPayloadV1} or an error
    */
   async getPayloadV1(params: [string]) {
-    this.connectionManager.updateConnectionStatus()
+    this.connectionManager.updateStatus()
     const payloadId = toBuffer(params[0])
     try {
       const block = await this.pendingBlock.build(payloadId)
@@ -628,7 +611,7 @@ export class Engine {
   async exchangeTransitionConfigurationV1(
     params: [TransitionConfigurationV1]
   ): Promise<TransitionConfigurationV1> {
-    this.connectionManager.updateConnectionStatus()
+    this.connectionManager.updateStatus()
     const { terminalTotalDifficulty, terminalBlockHash, terminalBlockNumber } = params[0]
     const td = this.chain.config.chainCommon.hardforkTD(Hardfork.Merge)
     if (td === undefined || td === null) {

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -320,6 +320,14 @@ export class Engine {
       parentHash,
     } = payloadData
     this.connectionManager.lastPayloadReceived = payloadData
+    if (!this.connectionManager.initialPayloadReceived) {
+      this.connectionManager.initialPayloadReceived = payloadData
+      this.config.logger.info(
+        `Initial consensus payload received block=${Number(payloadData.blockNumber)} parentHash=${
+          payloadData.parentHash
+        }`
+      )
+    }
     const common = this.config.chainCommon
 
     try {
@@ -459,6 +467,15 @@ export class Engine {
   ): Promise<ForkchoiceResponseV1> {
     this.connectionManager.updateConnectionStatus()
     this.connectionManager.lastForkchoiceUpdate = params[0]
+    if (!this.connectionManager.initialForkchoiceUpdate) {
+      this.connectionManager.initialForkchoiceUpdate = params[0]
+      this.config.logger.info(
+        `Initial consensus forkchoice update headBlockHash=${params[0].headBlockHash.substring(
+          0,
+          7
+        )}... finalizedBlockHash=${params[0].finalizedBlockHash}`
+      )
+    }
 
     const { headBlockHash, finalizedBlockHash } = params[0]
     const payloadAttributes = params[1]

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -426,6 +426,9 @@ export class Engine {
       for (const [i, block] of blocks.entries()) {
         const root = (i > 0 ? blocks[i - 1] : await this.chain.getBlock(block.header.parentHash))
           .header.stateRoot
+        const { number } = block.header
+        const td = this.chain.headers.td
+        vmCopy._common.setHardforkByBlockNumber(number, td)
         await vmCopy.runBlock({ block, root })
         await vmCopy.blockchain.putBlock(block)
       }

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -431,7 +431,7 @@ export class Engine {
       }
     } catch (error) {
       const validationError = `Error verifying block while running: ${error}`
-      this.config.logger.debug(validationError)
+      this.config.logger.error(validationError)
       const latestValidHash = await validHash(block.header.parentHash, this.validBlocks, this.chain)
       return { status: Status.INVALID, latestValidHash, validationError }
     }

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -310,6 +310,9 @@ export class Engine {
    *   3. validationError: String|null - validation error message
    */
   async newPayloadV1(params: [ExecutionPayloadV1]): Promise<PayloadStatusV1> {
+    this.connectionManager.updateStatus()
+    this.connectionManager.lastPayloadReceived = params[0]
+
     const [payloadData] = params
     const {
       blockNumber: number,
@@ -319,8 +322,7 @@ export class Engine {
       transactions,
       parentHash,
     } = payloadData
-    this.connectionManager.lastPayloadReceived = payloadData
-    const common = this.config.chainCommon
+    const { chainCommon: common } = this.config
 
     try {
       const block = await findBlock(toBuffer(parentHash), this.validBlocks, this.chain)

--- a/packages/client/lib/rpc/util/CLConnectionManager.ts
+++ b/packages/client/lib/rpc/util/CLConnectionManager.ts
@@ -33,10 +33,29 @@ export class CLConnectionManager {
   private oneTimeMergeCLConnectionCheck = false
   private lastRequestTimestamp = 0
 
-  public initialPayloadReceived?: ExecutionPayloadV1
-  public initialForkchoiceUpdate?: ForkchoiceStateV1
+  /**
+   * Do not get or set this value directly.
+   * Use the getter and setter without the underscore, i.e.
+   * ```this.connectionManager.lastPayloadReceived = payload```
+   */
+  private _lastPayloadReceived?: ExecutionPayloadV1
 
-  set lastPayloadReceived(payload: ExecutionPayloadV1) {
+  /**
+   * Do not get or set this value directly.
+   * Use the getter and setter without the underscore, i.e.
+   * ```this.connectionManager.lastForkchoiceUpdate = state```
+   */
+  private _lastForkchoiceUpdate?: ForkchoiceStateV1
+
+  private initialPayloadReceived?: ExecutionPayloadV1
+  private initialForkchoiceUpdate?: ForkchoiceStateV1
+
+  get lastPayloadReceived(): ExecutionPayloadV1 | undefined {
+    return this._lastPayloadReceived
+  }
+
+  set lastPayloadReceived(payload: ExecutionPayloadV1 | undefined) {
+    if (!payload) return
     if (!this.initialPayloadReceived) {
       this.initialPayloadReceived = payload
       this.config.logger.info(
@@ -45,10 +64,15 @@ export class CLConnectionManager {
         }`
       )
     }
-    this.lastPayloadReceived = payload
+    this._lastPayloadReceived = payload
   }
 
-  set lastForkchoiceUpdate(state: ForkchoiceStateV1) {
+  get lastForkchoiceUpdate(): ForkchoiceStateV1 | undefined {
+    return this._lastForkchoiceUpdate
+  }
+
+  set lastForkchoiceUpdate(state: ForkchoiceStateV1 | undefined) {
+    if (!state) return
     if (!this.initialForkchoiceUpdate) {
       this.initialForkchoiceUpdate = state
       this.config.logger.info(
@@ -58,7 +82,7 @@ export class CLConnectionManager {
         )}... finalizedBlockHash=${state.finalizedBlockHash}`
       )
     }
-    this.lastForkchoiceUpdate = state
+    this._lastForkchoiceUpdate = state
   }
 
   constructor(opts: CLConnectionManagerOpts) {

--- a/packages/client/lib/rpc/util/CLConnectionManager.ts
+++ b/packages/client/lib/rpc/util/CLConnectionManager.ts
@@ -32,7 +32,9 @@ export class CLConnectionManager {
   private connectionStatus = ConnectionStatus.Disconnected
   private lastRequestTimestamp = 0
 
+  public initialPayloadReceived?: ExecutionPayloadV1
   public lastPayloadReceived?: ExecutionPayloadV1
+  public initialForkchoiceUpdate?: ForkchoiceStateV1
   public lastForkchoiceUpdate?: ForkchoiceStateV1
 
   private oneTimeMergeCLConnectionCheck = false

--- a/packages/client/lib/rpc/util/CLConnectionManager.ts
+++ b/packages/client/lib/rpc/util/CLConnectionManager.ts
@@ -124,6 +124,9 @@ export class CLConnectionManager {
         this.config.logger.warn(
           `Merge HF activated, CL client connection is needed for continued block processing`
         )
+        this.config.logger.warn(
+          '(note that CL client might need to be synced up to beacon chain Merge transition slot until communication starts)'
+        )
       }
       this.oneTimeMergeCLConnectionCheck = true
     }

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -223,7 +223,7 @@ export class FullSynchronizer extends Synchronizer {
         const td = this.chain.blocks.td
         const remaining = mergeTD.sub(td)
         if (remaining.lte(mergeTD.divn(10))) {
-          attentionHF = `Merge HF in ${remaining} TD (diff)`
+          attentionHF = `Merge HF in ${remaining} TD`
         }
       }
     }

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -191,13 +191,17 @@ export class FullSynchronizer extends Synchronizer {
 
   async processBlocks(execution: VMExecution, blocks: Block[] | BlockHeader[]) {
     if (this.config.chainCommon.gteHardfork(Hardfork.Merge)) {
-      // If we are beyond the merge block we should stop the fetcher
-      this.config.logger.info('Merge hardfork reached, stopping block fetcher')
-      this.clearFetcher()
+      if (this.fetcher !== null) {
+        // If we are beyond the merge block we should stop the fetcher
+        this.config.logger.info('Merge hardfork reached, stopping block fetcher')
+        this.clearFetcher()
+      }
     }
 
     if (blocks.length === 0) {
-      this.config.logger.warn('No blocks fetched are applicable for import')
+      if (this.fetcher !== null) {
+        this.config.logger.warn('No blocks fetched are applicable for import')
+      }
       return
     }
 

--- a/packages/client/test/rpc/engine/newPayloadV1.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV1.spec.ts
@@ -145,7 +145,8 @@ tape(`${method}: call with valid data but invalid transactions`, async (t) => {
 })
 
 tape(`${method}: call with valid data & valid transaction but not signed`, async (t) => {
-  const { server, common } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+  const { server, common, chain } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+  chain.config.logger.silent = true
 
   // Let's mock a non-signed transaction so execution fails
   const tx = FeeMarketEIP1559Transaction.fromTxData(


### PR DESCRIPTION
Working on some more logger improvements around the Merge.

- Clean-up on redundant fetcher shutdown and log messages
- Dedicated log note on first CL execution block to clearly differentiate from Merge block
- Continued preMerge and a one-time post Merge warning if no CL connection is available

Here is some screenshot:

<img width="1399" alt="grafik" src="https://user-images.githubusercontent.com/931137/159245236-83bca659-f95a-45c7-a320-d900489bdb76.png">

Will continue still a bit also looking at the "CONNECTED" scenario and see what can happen and should get notifications there.

Work is targeted towards the latest multi-peer-fix branch from @g11tech (works like a charm! 🙏 🙂 🎉) and can be merged in there before or post PR-merge, everything fine for me.