### PR TITLE
client: Add new startBlock parameter to client

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -603,6 +603,9 @@ async function run() {
         const block = await client.chain.getBlock(new BN(args.startBlock + 1))
         await client.chain.blockchain.delBlock(block.header.hash())
         await client.chain.update()
+        client.services.forEach((service) => {
+          if (!service.synchronizer.running) void service.synchronizer.start()
+        })
         logger.info(`Blockchain height reset to ${client.chain.blocks.height.toString(10)}`)
       } catch (err: any) {
         logger.error(err.toString())

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -318,28 +318,29 @@ async function executeBlocks(client: EthereumClient) {
  * Note: this is destructive and removes blocks from the blockchain. Please back up your datadir.
  */
 async function startBlock(client: EthereumClient) {
-  if (args.startBlock) {
-    if (client.chain.blocks.height.ltn(args.startBlock)) {
-      logger.error(
-        `Cannot start chain at height higher than current height ${client.chain.blocks.height}`
-      )
-      process.exit()
-    }
-    try {
-      const headBlock = await client.chain.getBlock(new BN(args.startBlock))
-      const delBlock = await client.chain.getBlock(new BN(args.startBlock).addn(1))
-      await client.chain.blockchain.delBlock(delBlock.header.hash())
-      await client.chain.update()
-      for (const service of client.services) {
-        if (service instanceof FullEthereumService) {
-          void service.execution.vm.stateManager.setStateRoot(headBlock.header.stateRoot)
-        }
+  if (!args.startBlock) return
+  const startBlock = new BN(args.startBlock)
+  if (client.chain.blocks.height.lt(startBlock)) {
+    logger.error(
+      `Cannot start chain at height higher than current height ${client.chain.blocks.height}`
+    )
+    process.exit()
+  }
+  if (client.chain.blocks.height.eq(startBlock)) return
+  try {
+    const headBlock = await client.chain.getBlock(startBlock)
+    const delBlock = await client.chain.getBlock(startBlock.addn(1))
+    await client.chain.blockchain.delBlock(delBlock.header.hash())
+    await client.chain.update()
+    for (const service of client.services) {
+      if (service instanceof FullEthereumService) {
+        void service.execution.vm.stateManager.setStateRoot(headBlock.header.stateRoot)
       }
-      logger.info(`Chain height reset to ${client.chain.blocks.height}`)
-    } catch (err: any) {
-      logger.error(`Error setting back chain in startBlock: ${err}`)
-      process.exit()
     }
+    logger.info(`Chain height reset to ${client.chain.blocks.height}`)
+  } catch (err: any) {
+    logger.error(`Error setting back chain in startBlock: ${err}`)
+    process.exit()
   }
 }
 

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -334,7 +334,7 @@ async function startBlock(client: EthereumClient) {
     await client.chain.update()
     for (const service of client.services) {
       if (service instanceof FullEthereumService) {
-        void service.execution.vm.stateManager.setStateRoot(headBlock.header.stateRoot)
+        await service.execution.vm.stateManager.setStateRoot(headBlock.header.stateRoot)
       }
     }
     logger.info(`Chain height reset to ${client.chain.blocks.height}`)

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -251,7 +251,8 @@ const args = yargs(hideBin(process.argv))
     default: 2350000,
   })
   .option('startBlock', {
-    describe: 'Block number to start syncing from.  Must be less than current local chain tip',
+    describe:
+      'Block number to start syncing from.  Must be less than current local chain tip.  Backup the datadir before doing this as it will delete any blocks after the specified `startBlock` and updates the chain DB',
     number: true,
     optional: true,
   }).argv
@@ -606,7 +607,7 @@ async function run() {
         client.services.forEach((service) => {
           if (!service.synchronizer.running) void service.synchronizer.start()
         })
-        logger.info(`Blockchain height reset to ${client.chain.blocks.height.toString(10)}`)
+        logger.info(`Blockchain height reset to ${client.chain.blocks.height.toString()}`)
       } catch (err: any) {
         logger.error(err.toString())
         process.exit(0)

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -7,7 +7,7 @@ import { randomBytes } from 'crypto'
 import { ensureDirSync, readFileSync, removeSync } from 'fs-extra'
 import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { _getInitializedChains } from '@ethereumjs/common/dist/chains'
-import { Address, toBuffer } from 'ethereumjs-util'
+import { Address, toBuffer, BN } from 'ethereumjs-util'
 import { parseMultiaddrs, parseGenesisState, parseCustomParams } from '../lib/util'
 import EthereumClient from '../lib/client'
 import { Config, DataDirectory } from '../lib/config'
@@ -15,7 +15,6 @@ import { Logger, getLogger } from '../lib/logging'
 import { startRPCServers, helprpc } from './startRpc'
 import type { Chain as IChain, GenesisState } from '@ethereumjs/common/dist/types'
 import { existsSync } from 'fs'
-import { BN } from 'bn.js'
 const level = require('level')
 const yargs = require('yargs/yargs')
 const { hideBin } = require('yargs/helpers')


### PR DESCRIPTION
Adds a new `--startBlock` parameter to the CLI that will rewind the blockchain and set the head to the specified block number and start syncing from that point.