### PR TITLE
Client: even more Merge logging improvements

### DIFF
--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -17,7 +17,7 @@ import type { EthereumService } from '../../service'
 import type { FullSynchronizer } from '../../sync'
 import type { TxPool } from '../../sync/txpool'
 
-enum Status {
+export enum Status {
   ACCEPTED = 'ACCEPTED',
   INVALID = 'INVALID',
   INVALID_BLOCK_HASH = 'INVALID_BLOCK_HASH',
@@ -338,7 +338,9 @@ export class Engine {
     } catch (error: any) {
       // TODO if we can't find the parent and the block doesn't extend the canonical chain,
       // return ACCEPTED when optimistic sync is supported to store the block for later processing
-      return { status: Status.SYNCING, validationError: null, latestValidHash: null }
+      const response = { status: Status.SYNCING, validationError: null, latestValidHash: null }
+      this.connectionManager.lastNewPayload({ payload: params[0], response })
+      return response
     }
 
     const txs = []

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -558,9 +558,11 @@ export class Engine {
         this.validBlocks.delete(block.hash().toString('hex'))
       }
 
+      const timeDiff = new Date().getTime() / 1000 - headBlock.header.timestamp.toNumber()
       if (
-        !this.synchronizer.syncTargetHeight ||
-        this.synchronizer.syncTargetHeight.lt(headBlock.header.number)
+        (!this.synchronizer.syncTargetHeight ||
+          this.synchronizer.syncTargetHeight.lt(headBlock.header.number)) &&
+        timeDiff < 30
       ) {
         this.config.synchronized = true
         this.config.lastSyncDate = Date.now()

--- a/packages/client/lib/rpc/util/CLConnectionManager.ts
+++ b/packages/client/lib/rpc/util/CLConnectionManager.ts
@@ -2,11 +2,12 @@ import { Block } from '@ethereumjs/block'
 import { Hardfork } from '@ethereumjs/common'
 import { Event } from '../../types'
 import type { Config } from '../../config'
-import type {
+import {
   ExecutionPayloadV1,
   ForkchoiceResponseV1,
   ForkchoiceStateV1,
   PayloadStatusV1,
+  Status,
 } from '../modules/engine'
 
 export enum ConnectionStatus {
@@ -59,6 +60,7 @@ export class CLConnectionManager {
 
   private _lastPayload?: NewPayload
   private _lastForkchoiceUpdate?: ForkchoiceUpdate
+  private oneTimeSyncingResponseCheck = false
 
   private _initialPayload?: NewPayload
   private _initialForkchoiceUpdate?: ForkchoiceUpdate
@@ -171,6 +173,17 @@ export class CLConnectionManager {
       this.config.logger.info(
         `Initial consensus payload received ${this._getPayloadLogMsg(payload)}`
       )
+    }
+    if (!this.oneTimeSyncingResponseCheck) {
+      if (payload.response?.status === Status.SYNCING) {
+        this.config.logger.warn(
+          `CL client is requesting payload verification on future blocks which requires optimistic sync (unimplemented)`
+        )
+        this.config.logger.warn(
+          `Please restart your CL client sync from a present EL execution block`
+        )
+        this.oneTimeSyncingResponseCheck = true
+      }
     }
     this._lastPayload = payload
   }

--- a/packages/client/lib/rpc/util/CLConnectionManager.ts
+++ b/packages/client/lib/rpc/util/CLConnectionManager.ts
@@ -17,10 +17,10 @@ export class CLConnectionManager {
   private config: Config
 
   /** Threshold for a disconnected status decision */
-  private DISCONNECTED_THRESHOLD = 10000
+  private DISCONNECTED_THRESHOLD = 15000
 
   /** Threshold for a uncertain status decision */
-  private UNCERTAIN_THRESHOLD = 4000
+  private UNCERTAIN_THRESHOLD = 7000
 
   /** Default connection check interval (in ms) */
   private DEFAULT_CONNECTION_CHECK_INTERVAL = 10000
@@ -164,7 +164,7 @@ export class CLConnectionManager {
         }
       } else {
         this.connectionStatus = ConnectionStatus.Disconnected
-        this.config.logger.warn('Consensus disconnected', { attentionCL: null })
+        this.config.logger.warn('Consensus client disconnected', { attentionCL: null })
       }
     }
 

--- a/packages/client/lib/rpc/util/CLConnectionManager.ts
+++ b/packages/client/lib/rpc/util/CLConnectionManager.ts
@@ -35,10 +35,10 @@ export class CLConnectionManager {
   private config: Config
 
   /** Threshold for a disconnected status decision */
-  private DISCONNECTED_THRESHOLD = 20000
+  private DISCONNECTED_THRESHOLD = 30000
 
   /** Threshold for an uncertain status decision */
-  private UNCERTAIN_THRESHOLD = 10000
+  private UNCERTAIN_THRESHOLD = 15000
 
   /** Default connection check interval (in ms) */
   private DEFAULT_CONNECTION_CHECK_INTERVAL = 10000

--- a/packages/client/lib/rpc/util/CLConnectionManager.ts
+++ b/packages/client/lib/rpc/util/CLConnectionManager.ts
@@ -94,19 +94,23 @@ export class CLConnectionManager {
   constructor(opts: CLConnectionManagerOpts) {
     this.config = opts.config
     this.config.events.on(Event.CHAIN_UPDATED, () => {
-      if (
-        this.config.chainCommon.gteHardfork(Hardfork.PreMerge) &&
-        !this._connectionCheckInterval
-      ) {
+      if (this.config.chainCommon.gteHardfork(Hardfork.PreMerge)) {
         this.start()
       }
     })
+    if (this.config.chainCommon.gteHardfork(Hardfork.PreMerge)) {
+      this.start()
+    }
     this.config.events.once(Event.CLIENT_SHUTDOWN, () => {
       this.stop()
     })
   }
 
   start() {
+    // Connection Manager already started
+    if (this._connectionCheckInterval) {
+      return
+    }
     this._connectionCheckInterval = setInterval(
       this.connectionCheck.bind(this), // eslint-disable @typescript-eslint/await-thenable
       this.DEFAULT_CONNECTION_CHECK_INTERVAL

--- a/packages/client/lib/rpc/util/CLConnectionManager.ts
+++ b/packages/client/lib/rpc/util/CLConnectionManager.ts
@@ -20,7 +20,7 @@ export class CLConnectionManager {
   private DISCONNECTED_THRESHOLD = 10000
 
   /** Threshold for a uncertain status decision */
-  private UNCERTAIN_THRESHOLD = 2000
+  private UNCERTAIN_THRESHOLD = 4000
 
   /** Default connection check interval (in ms) */
   private DEFAULT_CONNECTION_CHECK_INTERVAL = 10000

--- a/packages/client/lib/rpc/util/CLConnectionManager.ts
+++ b/packages/client/lib/rpc/util/CLConnectionManager.ts
@@ -209,7 +209,10 @@ export class CLConnectionManager {
 
     if (this.config.chainCommon.hardfork() == Hardfork.PreMerge) {
       if (this.connectionStatus === ConnectionStatus.Disconnected) {
-        this.config.logger.warn('No CL client connection available, Merge HF happening soon')
+        this.config.logger.warn('CL client connection is needed, Merge HF happening soon')
+        this.config.logger.warn(
+          '(no CL <-> EL communication yet, connection might be in a workable state though)'
+        )
       }
     }
 

--- a/packages/client/lib/rpc/util/CLConnectionManager.ts
+++ b/packages/client/lib/rpc/util/CLConnectionManager.ts
@@ -25,10 +25,10 @@ export class CLConnectionManager {
   private config: Config
 
   /** Threshold for a disconnected status decision */
-  private DISCONNECTED_THRESHOLD = 15000
+  private DISCONNECTED_THRESHOLD = 20000
 
   /** Threshold for a uncertain status decision */
-  private UNCERTAIN_THRESHOLD = 7000
+  private UNCERTAIN_THRESHOLD = 10000
 
   /** Default connection check interval (in ms) */
   private DEFAULT_CONNECTION_CHECK_INTERVAL = 10000
@@ -124,7 +124,22 @@ export class CLConnectionManager {
   private _getForkchoiceUpdateLogMsg(update: ForkchoiceUpdate) {
     let msg = `head block hash=${update.state.headBlockHash.substring(0, 7)}...`
     if (update.headBlock) {
-      msg += ` number=${update.headBlock.header.number}`
+      const timeDiff = new Date().getTime() / 1000 - update.headBlock.header.timestamp.toNumber()
+      const min = 60
+      const hour = min * 60
+      const day = hour * 24
+      let timeDiffStr = ''
+      if (timeDiff > day) {
+        timeDiffStr = `${Math.floor(timeDiff / day)} days`
+      } else if (timeDiff > hour) {
+        timeDiffStr = `${Math.floor(timeDiff / hour)} hours`
+      } else if (timeDiff > min) {
+        timeDiffStr = `${Math.floor(timeDiff / min)} mins`
+      } else {
+        timeDiffStr = `${Math.floor(timeDiff)} secs`
+      }
+
+      msg += ` number=${update.headBlock.header.number} tsDiff=${timeDiffStr}`
     }
     msg += ` finalized block hash=${update.state.finalizedBlockHash} response=${
       update.response ? update.response.payloadStatus.status : '-'


### PR DESCRIPTION
This is adding more Merge logging improvements like adjusting connection loss status values, fixing CL connection status display on client startup and refactor especially the forkchoice update log to be able to also log along RPC responses and various head block properties (block number / timestamp right now).

PR also updates the synchronized-status-check to only trigger a an update on recent blocks with a close-to-present timestamp, so that this is both not permanently logged and (likely more important) also not triggering synchronized-status based client logic.

A bit in a rush right now, should be ready for review I guess.