### PR TITLE
vm, client: continuing v6 breaking changes

### DIFF
--- a/packages/client/lib/execution/receipt.ts
+++ b/packages/client/lib/execution/receipt.ts
@@ -2,7 +2,7 @@ import { PreByzantiumTxReceipt, PostByzantiumTxReceipt, TxReceipt } from '@ether
 import { Log } from '@ethereumjs/vm/dist/evm/types'
 import Bloom from '@ethereumjs/vm/dist/bloom'
 import { TypedTransaction } from '@ethereumjs/tx'
-import { rlp, intToBuffer, bufferToInt } from 'ethereumjs-util'
+import { rlp, intToBuffer, bufferToInt, bigIntToBuffer, bufferToBigInt } from 'ethereumjs-util'
 import { MetaDBManager, DBKey } from './metaDBManager'
 import type { Block } from '@ethereumjs/block'
 
@@ -302,7 +302,7 @@ export class ReceiptsManager extends MetaDBManager {
             value.map((r) => [
               (r as PreByzantiumTxReceipt).stateRoot ??
                 intToBuffer((r as PostByzantiumTxReceipt).status),
-              r.gasUsed,
+              bigIntToBuffer(r.gasUsed),
               this.rlp(RlpConvert.Encode, RlpType.Logs, r.logs),
             ])
           )
@@ -315,14 +315,14 @@ export class ReceiptsManager extends MetaDBManager {
               // Pre-Byzantium Receipt
               return {
                 stateRoot: r[0],
-                gasUsed,
+                gasUsed: bufferToBigInt(gasUsed),
                 logs,
               } as PreByzantiumTxReceipt
             } else {
               // Post-Byzantium Receipt
               return {
                 status: bufferToInt(r[0]),
-                gasUsed,
+                gasUsed: bufferToBigInt(gasUsed),
                 logs,
               } as PostByzantiumTxReceipt
             }

--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -233,7 +233,7 @@ export class EthProtocol extends Protocol {
           let encodedReceipt = rlp.encode([
             (receipt as PreByzantiumTxReceipt).stateRoot ??
               (receipt as PostByzantiumTxReceipt).status,
-            receipt.gasUsed,
+            bigIntToBuffer(receipt.gasUsed),
             receipt.bitvector,
             receipt.logs,
           ])
@@ -252,7 +252,11 @@ export class EthProtocol extends Protocol {
           // Legacy receipt if r[0] >= 0xc0, otherwise typed receipt with first byte as TransactionType
           const decoded = rlp.decode(r[0] >= 0xc0 ? r : r.slice(1)) as any
           const [stateRootOrStatus, cumulativeGasUsed, logsBloom, logs] = decoded
-          const receipt = { gasUsed: cumulativeGasUsed, bitvector: logsBloom, logs } as TxReceipt
+          const receipt = {
+            gasUsed: bufferToBigInt(cumulativeGasUsed),
+            bitvector: logsBloom,
+            logs,
+          } as TxReceipt
           if (stateRootOrStatus.length === 32) {
             ;(receipt as PreByzantiumTxReceipt).stateRoot = stateRootOrStatus
           } else {

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -249,7 +249,7 @@ const jsonRpcReceipt = async (
   blockNumber: bigIntToHex(block.header.number),
   from: tx.getSenderAddress().toString(),
   to: tx.to?.toString() ?? null,
-  cumulativeGasUsed: bufferToHex(receipt.gasUsed),
+  cumulativeGasUsed: bigIntToHex(receipt.gasUsed),
   effectiveGasPrice: bigIntToHex(effectiveGasPrice),
   gasUsed: bigIntToHex(gasUsed),
   contractAddress: contractAddress?.toString() ?? null,
@@ -535,7 +535,7 @@ export class Eth {
       skipBalance: true,
       skipBlockGasLimitValidation: true,
     })
-    return `0x${gasUsed.toString(16)}`
+    return bigIntToHex(gasUsed)
   }
 
   /**

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -1,4 +1,5 @@
 import { Hardfork } from '@ethereumjs/common'
+import { bigIntToBuffer } from 'ethereumjs-util'
 import { EthereumService, EthereumServiceOptions } from './ethereumservice'
 import { FullSynchronizer } from '../sync/fullsync'
 import { EthProtocol } from '../net/protocol/ethprotocol'
@@ -8,7 +9,6 @@ import { Protocol } from '../net/protocol'
 import { Miner } from '../miner'
 import { VMExecution } from '../execution'
 import { Event } from '../types'
-
 import type { Block } from '@ethereumjs/block'
 
 interface FullEthereumServiceOptions extends EthereumServiceOptions {
@@ -189,6 +189,7 @@ export class FullEthereumService extends EthereumService {
       let receiptsSize = 0
       for (const hash of hashes) {
         const blockReceipts = await receiptsManager.getReceipts(hash, true, true)
+        blockReceipts.forEach((r) => (r.gasUsed = bigIntToBuffer(r.gasUsed) as any))
         if (!blockReceipts) continue
         receipts.push(...blockReceipts)
         receiptsSize += Buffer.byteLength(JSON.stringify(blockReceipts))

--- a/packages/client/lib/util/debug.ts
+++ b/packages/client/lib/util/debug.ts
@@ -43,7 +43,7 @@ const main = async () => {
   const stateManager = new DefaultStateManager({ trie, common })
   // Ensure we run on the right root
   stateManager.setStateRoot(Buffer.from('${(
-    await execution.vm.stateManager.getStateRoot(true)
+    await execution.vm.stateManager.getStateRoot()
   ).toString('hex')}', 'hex'))
 
 

--- a/packages/client/test/net/protocol/ethprotocol.spec.ts
+++ b/packages/client/test/net/protocol/ethprotocol.spec.ts
@@ -5,7 +5,7 @@ import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
 import { Chain } from '../../../lib/blockchain/chain'
 import { Config } from '../../../lib/config'
 import { EthProtocol } from '../../../lib/net/protocol'
-import { bigIntToBuffer, bufferToBigInt, intToBuffer } from 'ethereumjs-util'
+import { bigIntToBuffer, bufferToBigInt } from 'ethereumjs-util'
 
 tape('[EthProtocol]', (t) => {
   t.test('should get properties', (t) => {
@@ -151,14 +151,14 @@ tape('[EthProtocol]', (t) => {
     const receipts = [
       {
         status: 1 as 0 | 1,
-        gasUsed: intToBuffer(100),
+        gasUsed: BigInt(100),
         bitvector: Buffer.alloc(256),
         logs: [[Buffer.alloc(20), [Buffer.alloc(32), Buffer.alloc(32, 1)], Buffer.alloc(10)]],
         txType: 2,
       },
       {
         status: 0 as 0 | 1,
-        gasUsed: intToBuffer(1000),
+        gasUsed: BigInt(1000),
         bitvector: Buffer.alloc(256, 1),
         logs: [[Buffer.alloc(20, 1), [Buffer.alloc(32, 1), Buffer.alloc(32, 1)], Buffer.alloc(10)]],
         txType: 0,

--- a/packages/client/test/service/fullethereumservice.spec.ts
+++ b/packages/client/test/service/fullethereumservice.spec.ts
@@ -1,7 +1,6 @@
 import tape from 'tape'
 import td from 'testdouble'
 import { Log } from '@ethereumjs/vm/dist/evm/types'
-import { intToBuffer } from 'ethereumjs-util'
 import { Config } from '../../lib/config'
 import { Event } from '../../lib/types'
 import { VMExecution } from '../../lib/execution'
@@ -132,7 +131,7 @@ tape('[FullEthereumService]', async (t) => {
     const receipts = [
       {
         status: 1 as 0 | 1,
-        gasUsed: intToBuffer(100),
+        gasUsed: BigInt(100),
         bitvector: Buffer.alloc(256),
         logs: [
           [Buffer.alloc(20), [Buffer.alloc(32), Buffer.alloc(32, 1)], Buffer.alloc(10)],
@@ -141,7 +140,7 @@ tape('[FullEthereumService]', async (t) => {
       },
       {
         status: 0 as 0 | 1,
-        gasUsed: intToBuffer(1000),
+        gasUsed: BigInt(1000),
         bitvector: Buffer.alloc(256, 1),
         logs: [
           [Buffer.alloc(20, 1), [Buffer.alloc(32, 1), Buffer.alloc(32, 1)], Buffer.alloc(10)],

--- a/packages/vm/benchmarks/util.ts
+++ b/packages/vm/benchmarks/util.ts
@@ -68,10 +68,10 @@ export const verifyResult = (block: Block, result: RunBlockResult) => {
     // check if there are receipts
     const { receipts } = result
     if (receipts) {
-      let cumGasUsed = 0
+      let cumGasUsed = BigInt(0)
       for (let index = 0; index < receipts.length; index++) {
-        let gasUsedExpected = parseInt(receipts[index].gasUsed.toString('hex'), 16)
-        let cumGasUsedActual = parseInt(receipts[index].gasUsed.toString('hex'), 16)
+        let gasUsedExpected = receipts[index].gasUsed
+        let cumGasUsedActual = receipts[index].gasUsed
         let gasUsed = cumGasUsedActual - cumGasUsed
         if (gasUsed !== gasUsedExpected) {
           console.log(`[DEBUG]

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -222,7 +222,7 @@ export class BlockBuilder {
       await this.rewardMiner()
     }
 
-    const stateRoot = await this.vm.stateManager.getStateRoot(true)
+    const stateRoot = await this.vm.stateManager.getStateRoot()
     const transactionsTrie = await this.transactionsTrie()
     const receiptTrie = await this.receiptTrie()
     const logsBloom = this.logsBloom()

--- a/packages/vm/src/evm/eei.ts
+++ b/packages/vm/src/evm/eei.ts
@@ -283,13 +283,7 @@ export default class EEI {
   getBlockCoinbase(): bigint {
     let coinbase: Address
     if (this._common.consensusAlgorithm() === ConsensusAlgorithm.Clique) {
-      // Backwards-compatibilty check
-      // TODO: can be removed along VM v5 release
-      if ('cliqueSigner' in this._env.block.header) {
-        coinbase = this._env.block.header.cliqueSigner()
-      } else {
-        coinbase = Address.zero()
-      }
+      coinbase = this._env.block.header.cliqueSigner()
     } else {
       coinbase = this._env.block.header.coinbase
     }
@@ -554,7 +548,7 @@ export default class EEI {
     }
 
     // this should always be safe
-    this.useGas(results.gasUsed, 'CALL, STATICCALL, DELEGATECALL, CALLCODE')
+    this.useGas(results.execResult.gasUsed, 'CALL, STATICCALL, DELEGATECALL, CALLCODE')
 
     // Set return value
     if (
@@ -627,7 +621,7 @@ export default class EEI {
     }
 
     // this should always be safe
-    this.useGas(results.gasUsed, 'CREATE')
+    this.useGas(results.execResult.gasUsed, 'CREATE')
 
     // Set return buffer in case revert happened
     if (

--- a/packages/vm/src/evm/evm.ts
+++ b/packages/vm/src/evm/evm.ts
@@ -305,7 +305,6 @@ export default class EVM {
     if (this._vm._common.isActivatedEIP(3860)) {
       if (message.data.length > this._vm._common.param('vm', 'maxInitCodeSize')) {
         return {
-          gasUsed: message.gasLimit,
           createdAddress: message.to,
           execResult: {
             returnValue: Buffer.alloc(0),

--- a/packages/vm/src/index.ts
+++ b/packages/vm/src/index.ts
@@ -75,11 +75,6 @@ export interface VMOpts {
    */
   stateManager?: StateManager
   /**
-   * A {@link SecureTrie} instance for the state tree (ignored if stateManager is passed)
-   * @deprecated will be removed in next major version release
-   */
-  state?: Trie
-  /**
    * A {@link Blockchain} object for storing/retrieving blocks
    */
   blockchain?: Blockchain
@@ -288,7 +283,7 @@ export default class VM extends AsyncEventEmitter {
     if (opts.stateManager) {
       this.stateManager = opts.stateManager
     } else {
-      const trie = opts.state ?? new Trie()
+      const trie = new Trie()
       this.stateManager = new DefaultStateManager({
         trie,
         common: this._common,

--- a/packages/vm/src/runCode.ts
+++ b/packages/vm/src/runCode.ts
@@ -49,7 +49,7 @@ export interface RunCodeOpts {
   /**
    * Gas limit
    */
-  gasLimit?: bigint
+  gasLimit: bigint
   /**
    * The value in ether that is being sent to `opt.address`. Defaults to `0`
    */

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -1,5 +1,5 @@
 import { debug as createDebugLogger } from 'debug'
-import { Address, bigIntToBuffer, KECCAK256_NULL, toBuffer } from 'ethereumjs-util'
+import { Address, KECCAK256_NULL, toBuffer } from 'ethereumjs-util'
 import { Block } from '@ethereumjs/block'
 import { ConsensusType } from '@ethereumjs/common'
 import {
@@ -93,6 +93,11 @@ export interface RunTxResult extends EVMResult {
    * The tx receipt
    */
   receipt: TxReceipt
+
+  /**
+   * The amount of gas used in this transaction
+   */
+  gasUsed: bigint
 
   /**
    * The amount of gas as that was refunded during the transaction (i.e. `gasUsed = totalGasConsumed - gasRefund`)
@@ -344,8 +349,8 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
     }
   }
 
-  let gasPrice
-  let inclusionFeePerGas
+  let gasPrice: bigint
+  let inclusionFeePerGas: bigint
   // EIP-1559 tx
   if (tx.supports(Capability.EIP1559FeeMarket)) {
     const baseFee = block.header.baseFeePerGas!
@@ -404,12 +409,12 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
 
   const results = (await evm.executeMessage(message)) as RunTxResult
   if (this.DEBUG) {
-    const { gasUsed, exceptionError, returnValue, gasRefund } = results.execResult
+    const { gasUsed, exceptionError, returnValue } = results.execResult
     debug('-'.repeat(100))
     debug(
       `Received tx execResult: [ gasUsed=${gasUsed} exceptionError=${
         exceptionError ? `'${exceptionError.error}'` : 'none'
-      } returnValue=0x${short(returnValue)} gasRefund=${gasRefund ?? 0} ]`
+      } returnValue=0x${short(returnValue)} gasRefund=${results.gasRefund ?? 0} ]`
     )
   }
 
@@ -422,14 +427,14 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
     debug(`Generated tx bloom with logs=${results.execResult.logs?.length}`)
   }
 
-  // Caculate the total gas used
-  results.gasUsed += txBaseFee
+  // Calculate the total gas used
+  results.gasUsed = results.execResult.gasUsed + txBaseFee
   if (this.DEBUG) {
     debugGas(`tx add baseFee ${txBaseFee} to gasUsed (-> ${results.gasUsed})`)
   }
 
   // Process any gas refund
-  let gasRefund = results.execResult.gasRefund ?? BigInt(0)
+  let gasRefund = results.gasRefund ?? BigInt(0)
   const maxRefundQuotient = BigInt(this._common.param('gasConfig', 'maxRefundQuotient'))
   if (gasRefund !== BigInt(0)) {
     const maxRefund = results.gasUsed / maxRefundQuotient
@@ -460,13 +465,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // Update miner's balance
   let miner
   if (this._common.consensusType() === ConsensusType.ProofOfAuthority) {
-    // Backwards-compatibility check
-    // TODO: can be removed along VM v6 release
-    if ('cliqueSigner' in block.header) {
-      miner = block.header.cliqueSigner()
-    } else {
-      miner = Address.zero()
-    }
+    miner = block.header.cliqueSigner()
   } else {
     miner = block.header.coinbase
   }
@@ -474,7 +473,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   const minerAccount = await state.getAccount(miner)
   // add the amount spent on gas to the miner's account
   if (this._common.isActivatedEIP(1559)) {
-    minerAccount.balance += results.gasUsed * <bigint>inclusionFeePerGas
+    minerAccount.balance += results.gasUsed * inclusionFeePerGas!
   } else {
     minerAccount.balance += results.amountSpent
   }
@@ -563,7 +562,7 @@ export async function generateTxReceipt(
   cumulativeGasUsed: bigint
 ): Promise<TxReceipt> {
   const baseReceipt: BaseTxReceipt = {
-    gasUsed: bigIntToBuffer(cumulativeGasUsed),
+    gasUsed: cumulativeGasUsed,
     bitvector: txResult.bloom.bitvector,
     logs: txResult.execResult.logs ?? [],
   }
@@ -589,7 +588,7 @@ export async function generateTxReceipt(
       } as PostByzantiumTxReceipt
     } else {
       // Pre-Byzantium
-      const stateRoot = await this.stateManager.getStateRoot(true)
+      const stateRoot = await this.stateManager.getStateRoot()
       receipt = {
         stateRoot: stateRoot,
         ...baseReceipt,

--- a/packages/vm/src/state/interface.ts
+++ b/packages/vm/src/state/interface.ts
@@ -27,7 +27,7 @@ export interface StateManager {
   checkpoint(): Promise<void>
   commit(): Promise<void>
   revert(): Promise<void>
-  getStateRoot(force?: boolean): Promise<Buffer>
+  getStateRoot(): Promise<Buffer>
   setStateRoot(stateRoot: Buffer): Promise<void>
   dumpStorage(address: Address): Promise<StorageDump>
   hasGenesisState(): Promise<boolean>

--- a/packages/vm/src/types.ts
+++ b/packages/vm/src/types.ts
@@ -1,6 +1,6 @@
 import { Log } from './evm/types'
 
-export type TxReceipt = PreByzantiumTxReceipt | PostByzantiumTxReceipt | EIP2930Receipt
+export type TxReceipt = PreByzantiumTxReceipt | PostByzantiumTxReceipt
 
 /**
  * Abstract interface with common transaction receipt fields
@@ -9,7 +9,7 @@ export interface BaseTxReceipt {
   /**
    * Cumulative gas used in the block including this tx
    */
-  gasUsed: Buffer
+  gasUsed: bigint
   /**
    * Bloom bitvector
    */
@@ -41,17 +41,3 @@ export interface PostByzantiumTxReceipt extends BaseTxReceipt {
    */
   status: 0 | 1
 }
-
-/**
- * EIP2930Receipt, which has the same fields as PostByzantiumTxReceipt
- *
- * @deprecated Please use PostByzantiumTxReceipt instead
- */
-export interface EIP2930Receipt extends PostByzantiumTxReceipt {}
-
-/**
- * EIP1559Receipt, which has the same fields as PostByzantiumTxReceipt
- *
- * @deprecated Please use PostByzantiumTxReceipt instead
- */
-export interface EIP1559Receipt extends PostByzantiumTxReceipt {}

--- a/packages/vm/tests/api/EIPs/eip-1283-net-gas-metering.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-1283-net-gas-metering.spec.ts
@@ -52,9 +52,9 @@ tape('Constantinople: EIP-1283', async (t) => {
 
       try {
         const res = await vm.runCall(runCallArgs)
-        st.assert(res.execResult.exceptionError === undefined)
-        st.assert(BigInt(testCase.used) === res.gasUsed)
-        st.assert(BigInt(testCase.refund) === res.execResult.gasRefund!)
+        st.equal(res.execResult.exceptionError, undefined)
+        st.equal(res.execResult.gasUsed, BigInt(testCase.used))
+        st.equal(res.gasRefund, BigInt(testCase.refund))
       } catch (e: any) {
         st.fail(e.message)
       }

--- a/packages/vm/tests/api/EIPs/eip-2929.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-2929.spec.ts
@@ -99,7 +99,7 @@ tape('EIP 2929: gas cost tests', (t) => {
 
     const result = await vm.runTx({ tx })
 
-    st.ok(result.gasUsed == expectedGasUsed)
+    st.equal(result.gasUsed, expectedGasUsed)
   }
 
   // Checks EXT(codehash,codesize,balance) of precompiles, which should be 100,

--- a/packages/vm/tests/api/EIPs/eip-3529.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3529.spec.ts
@@ -170,9 +170,8 @@ tape('EIP-3529 tests', (t) => {
       tx,
     })
 
-    st.equal(result.execResult.exceptionError, undefined, 'transaction executed succesfully')
-    st.ok(result.execResult.gasRefund !== undefined, 'gas refund is defined')
-    st.equal(result.execResult.gasRefund, BigInt(0), 'gas refund is zero')
+    st.equal(result.execResult.exceptionError, undefined, 'transaction executed successfully')
+    st.equal(result.gasRefund, BigInt(0), 'gas refund is zero')
     st.end()
   })
 
@@ -224,9 +223,8 @@ tape('EIP-3529 tests', (t) => {
     const actualGasUsed = startGas! - finalGas! + BigInt(21000)
     const maxRefund = actualGasUsed / BigInt(5)
     const minGasUsed = actualGasUsed - maxRefund
-    const gasUsed = result.execResult.gasUsed
-    st.ok(result.execResult.gasRefund! > maxRefund, 'refund is larger than the max refund')
-    st.ok(gasUsed >= minGasUsed, 'gas used respects the max refund quotient')
+    st.ok(result.gasRefund! > maxRefund, 'refund is larger than the max refund')
+    st.ok(result.gasUsed >= minGasUsed, 'gas used respects the max refund quotient')
     st.end()
   })
 })

--- a/packages/vm/tests/api/buildBlock.spec.ts
+++ b/packages/vm/tests/api/buildBlock.spec.ts
@@ -94,7 +94,7 @@ tape('BlockBuilder', async (t) => {
 
     await blockBuilder.addTransaction(tx)
 
-    const root1 = await vm.stateManager.getStateRoot(true)
+    const root1 = await vm.stateManager.getStateRoot()
     st.ok(!root0.equals(root1), 'state root should change after adding a tx')
 
     await blockBuilder.revert()

--- a/packages/vm/tests/api/evm/precompiles/hardfork.spec.ts
+++ b/packages/vm/tests/api/evm/precompiles/hardfork.spec.ts
@@ -29,7 +29,7 @@ tape('Precompiles: hardfork availability', (t) => {
       value: BigInt(0),
     })
 
-    st.assert(result.gasUsed === BigInt(100000)) // check that we are using gas (if address would contain no code we use 0 gas)
+    st.equal(result.execResult.gasUsed, BigInt(100000)) // check that we are using gas (if address would contain no code we use 0 gas)
 
     // Check if ECPAIR is available in future hard forks.
     const commonPetersburg = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Petersburg })
@@ -49,7 +49,7 @@ tape('Precompiles: hardfork availability', (t) => {
       value: BigInt(0),
     })
 
-    st.assert(result.gasUsed === BigInt(100000))
+    st.equal(result.execResult.gasUsed, BigInt(100000))
 
     // Check if ECPAIR is not available in Homestead.
     const commonHomestead = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Homestead })
@@ -70,7 +70,7 @@ tape('Precompiles: hardfork availability', (t) => {
       value: BigInt(0),
     })
 
-    st.assert(result.gasUsed === BigInt(0)) // check that we use no gas, because we are calling into an address without code.
+    st.equal(result.execResult.gasUsed, BigInt(0)) // check that we use no gas, because we are calling into an address without code.
 
     st.end()
   })

--- a/packages/vm/tests/api/index.spec.ts
+++ b/packages/vm/tests/api/index.spec.ts
@@ -1,6 +1,5 @@
 import tape from 'tape'
 import { KECCAK256_RLP } from 'ethereumjs-util'
-import { SecureTrie as Trie } from 'merkle-patricia-tree'
 import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { DefaultStateManager } from '../../src/state'
 import VM from '../../src'
@@ -176,17 +175,6 @@ tape('VM -> hardforkByBlockNumber, hardforkByTD, state (deprecated), blockchain'
       )
     }
 
-    st.end()
-  })
-
-  t.test('should work with trie (state) provided', async (st) => {
-    const trie = new Trie()
-    const vm = await VM.create({ state: trie, activatePrecompiles: true })
-    st.notDeepEqual(
-      (vm.stateManager as DefaultStateManager)._trie.root,
-      KECCAK256_RLP,
-      'it has different root'
-    )
     st.end()
   })
 

--- a/packages/vm/tests/api/istanbul/eip-2200.spec.ts
+++ b/packages/vm/tests/api/istanbul/eip-2200.spec.ts
@@ -72,10 +72,10 @@ tape('Istanbul: EIP-2200', async (t) => {
         if (testCase.err) {
           st.equal(res.execResult.exceptionError?.error, testCase.err)
         } else {
-          st.assert(res.execResult.exceptionError === undefined)
+          st.equal(res.execResult.exceptionError, undefined)
         }
-        st.assert(BigInt(testCase.used) === res.gasUsed)
-        st.assert(BigInt(testCase.refund) === res.execResult.gasRefund!)
+        st.equal(res.execResult.gasUsed, BigInt(testCase.used))
+        st.equal(res.gasRefund!, BigInt(testCase.refund))
       } catch (e: any) {
         st.fail(e.message)
       }

--- a/packages/vm/tests/api/runBlock.spec.ts
+++ b/packages/vm/tests/api/runBlock.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import { Address, rlp, KECCAK256_RLP, Account, bufferToBigInt } from 'ethereumjs-util'
+import { Address, rlp, KECCAK256_RLP, Account } from 'ethereumjs-util'
 import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import {
@@ -171,14 +171,14 @@ tape('runBlock() -> successful API parameter usage', async (t) => {
       skipBlockValidation: true,
       generate: true,
     })
-    st.ok(
-      txResultChainstart.results[0].gasUsed ===
-        BigInt(21000) + BigInt(68) * BigInt(3) + BigInt(3) + BigInt(50),
+    st.equal(
+      txResultChainstart.results[0].gasUsed,
+      BigInt(21000) + BigInt(68) * BigInt(3) + BigInt(3) + BigInt(50),
       'tx charged right gas on chainstart hard fork'
     )
-    st.ok(
-      txResultMuirGlacier.results[0].gasUsed ===
-        BigInt(21000) + BigInt(32000) + BigInt(16) * BigInt(3) + BigInt(3) + BigInt(800),
+    st.equal(
+      txResultMuirGlacier.results[0].gasUsed,
+      BigInt(21000) + BigInt(32000) + BigInt(16) * BigInt(3) + BigInt(3) + BigInt(800),
       'tx charged right gas on muir glacier hard fork'
     )
   })
@@ -302,7 +302,7 @@ tape('runBlock() -> runtime behavior', async (t) => {
     // verify that the refund account gets the summed balance of the original refund account + two child DAO accounts
     const msg =
       'should transfer balance from DAO children to the Refund DAO account in the DAO fork'
-    t.ok(DAORefundAccount.balance === BigInt(0x7777), msg)
+    t.equal(DAORefundAccount.balance, BigInt(0x7777), msg)
   })
 
   t.test('should allocate to correct clique beneficiary', async (t) => {
@@ -393,7 +393,7 @@ tape('should correctly reflect generated fields', async (t) => {
 
   t.ok(results.block.header.receiptTrie.equals(KECCAK256_RLP))
   t.ok(results.block.header.transactionsTrie.equals(KECCAK256_RLP))
-  t.equals(results.block.header.gasUsed, BigInt(0))
+  t.equal(results.block.header.gasUsed, BigInt(0))
 })
 
 async function runWithHf(hardfork: string) {
@@ -457,14 +457,11 @@ tape('runBlock() -> tx types', async (t) => {
       generate: true,
     })
 
-    st.ok(
-      res.gasUsed ===
-        res.receipts
-          .map((r) => r.gasUsed)
-          .reduce(
-            (prevValue: bigint, currValue: Buffer) => prevValue + bufferToBigInt(currValue),
-            BigInt(0)
-          ),
+    st.equal(
+      res.gasUsed,
+      res.receipts
+        .map((r) => r.gasUsed)
+        .reduce((prevValue, currValue) => prevValue + currValue, BigInt(0)),
       "gas used should equal transaction's total gasUsed"
     )
   }

--- a/packages/vm/tests/api/runCall.spec.ts
+++ b/packages/vm/tests/api/runCall.spec.ts
@@ -167,7 +167,7 @@ tape('Ensure that precompile activation creates non-empty accounts', async (t) =
   const resultNotActivated = await vmNotActivated.runCall(runCallArgs)
   const resultActivated = await vmActivated.runCall(runCallArgs)
 
-  const diff = resultNotActivated.gasUsed - resultActivated.gasUsed
+  const diff = resultNotActivated.execResult.gasUsed - resultActivated.execResult.gasUsed
   const expected = BigInt(common.param('gasPrices', 'callNewAccount'))
 
   t.equal(diff, expected, 'precompiles are activated')
@@ -220,8 +220,8 @@ tape('Ensure that Istanbul sstoreCleanRefundEIP2200 gas is applied correctly', a
 
   const result = await vm.runCall(runCallArgs)
 
-  t.equal(result.gasUsed, BigInt(5812), 'gas used correct')
-  t.equal(result.execResult.gasRefund!, BigInt(4200), 'gas refund correct')
+  t.equal(result.execResult.gasUsed, BigInt(5812), 'gas used correct')
+  t.equal(result.gasRefund, BigInt(4200), 'gas refund correct')
 
   t.end()
 })
@@ -247,8 +247,8 @@ tape('ensure correct gas for pre-constantinople sstore', async (t) => {
 
   const result = await vm.runCall(runCallArgs)
 
-  t.equal(result.gasUsed, BigInt(20006), 'gas used correct')
-  t.equal(result.execResult.gasRefund!, BigInt(0), 'gas refund correct')
+  t.equal(result.execResult.gasUsed, BigInt(20006), 'gas used correct')
+  t.equal(result.gasRefund, BigInt(0), 'gas refund correct')
 
   t.end()
 })
@@ -276,8 +276,8 @@ tape('ensure correct gas for calling non-existent accounts in homestead', async 
 
   // 7x push + gas + sub + call + callNewAccount
   // 7*3 + 2 + 3 + 40 + 25000 = 25066
-  t.equal(result.gasUsed, BigInt(25066), 'gas used correct')
-  t.equal(result.execResult.gasRefund!, BigInt(0), 'gas refund correct')
+  t.equal(result.execResult.gasUsed, BigInt(25066), 'gas used correct')
+  t.equal(result.gasRefund, BigInt(0), 'gas refund correct')
 
   t.end()
 })
@@ -306,8 +306,8 @@ tape(
 
     const result = await vm.runCall(runCallArgs)
 
-    t.ok(runCallArgs.gasLimit === result.gasUsed, 'gas used correct')
-    t.equal(result.execResult.gasRefund!, BigInt(0), 'gas refund correct')
+    t.equal(runCallArgs.gasLimit, result.execResult.gasUsed, 'gas used correct')
+    t.equal(result.gasRefund, BigInt(0), 'gas refund correct')
     t.ok(result.execResult.exceptionError!.error == ERROR.OUT_OF_GAS, 'call went out of gas')
 
     t.end()
@@ -337,9 +337,9 @@ tape('ensure selfdestruct pays for creating new accounts', async (t) => {
 
   const result = await vm.runCall(runCallArgs)
   // gas: 5000 (selfdestruct) + 25000 (call new account)  + push (1) = 30003
-  t.equal(result.gasUsed, BigInt(30003), 'gas used correct')
+  t.equal(result.execResult.gasUsed, BigInt(30003), 'gas used correct')
   // selfdestruct refund
-  t.equal(result.execResult.gasRefund!, BigInt(24000), 'gas refund correct')
+  t.equal(result.gasRefund, BigInt(24000), 'gas refund correct')
 
   t.end()
 })
@@ -403,8 +403,8 @@ tape('ensure that sstores pay for the right gas costs pre-byzantium', async (t) 
     }
 
     const result = await vm.runCall(runCallArgs)
-    t.equal(result.gasUsed, BigInt(callData.gas), 'gas used correct')
-    t.equal(result.execResult.gasRefund, BigInt(callData.refund), 'gas refund correct')
+    t.equal(result.execResult.gasUsed, BigInt(callData.gas), 'gas used correct')
+    t.equal(result.gasRefund, BigInt(callData.refund), 'gas refund correct')
   }
 
   t.end()

--- a/packages/vm/tests/api/runCode.spec.ts
+++ b/packages/vm/tests/api/runCode.spec.ts
@@ -102,6 +102,7 @@ tape('VM.runCode: RunCodeOptions', (t) => {
 
     const runCodeArgs = {
       value: BigInt(-10),
+      gasLimit: BigInt(1000000),
     }
 
     try {

--- a/packages/vm/tests/api/state/accountExists.spec.ts
+++ b/packages/vm/tests/api/state/accountExists.spec.ts
@@ -42,7 +42,7 @@ tape('correctly apply new account gas fee on pre-Spurious Dragon hardforks', asy
   }
 
   const result = await vm.runCall(runCallArgs)
-  t.ok(result.gasUsed === BigInt(53552), 'vm correctly applies new account gas price')
+  t.equal(result.execResult.gasUsed, BigInt(53552), 'vm correctly applies new account gas price')
   t.end()
 })
 
@@ -87,7 +87,11 @@ tape(
     }
 
     const result = await vm.runCall(runCallArgs)
-    t.ok(result.gasUsed === BigInt(28552), 'new account price not applied as empty account exists')
+    t.equal(
+      result.execResult.gasUsed,
+      BigInt(28552),
+      'new account price not applied as empty account exists'
+    )
     t.end()
   }
 )


### PR DESCRIPTION
This PR accomplishes VM breaking change tasks listed in #1717:

- [x] Remove deprecated `state` (Trie) constructor option
- [x] Remove deprecated `generateTxReceipt` function in `runBlock` (preferring newer version located in `runTx`), remove `Receipt` re-exports
- [x] Remove `StateManager.getStateRoot()` `force=true` parameter (also in interface)
- [x] Removed deprecated `EIP2930Receipt` and `EIP1559Receipt` types
- [x] Do `gasUsed` deduplication https://github.com/ethereumjs/ethereumjs-monorepo/issues/1446#issuecomment-1013359621
  - Moved EVMResult.gasUsed to RunTxResult where it is added to there, and execResult.gasUsed remains the same
- [x] Update BaseTxReceipt gasUsed from Buffer to BigInt (suggestion added by @ryanio)
- [x] `runCode` throws if `gasLimit` is `undefined`: the `gasLimit` parameter is mandatory
- [x] Move `gasRefund` to a tx-level result object instead of `ExecResult` [todo link](https://github.com/ethereumjs/ethereumjs-monorepo/blob/0126581c6e3795d249dfa7522f3cf86e0f0f30b4/packages/vm/src/evm/evm.ts#L191-L193)
  - Moved one level up to EVMResult, since it does not seem appropriate (or used) in execResult
