### PR TITLE
util: move misplaced functions

### DIFF
--- a/packages/util/src/account.ts
+++ b/packages/util/src/account.ts
@@ -7,7 +7,7 @@ import { keccak, keccak256, keccakFromString, rlphash } from './hash'
 import { assertIsString, assertIsHexString, assertIsBuffer } from './helpers'
 import { BigIntLike, BufferLike } from './types'
 
-const _0tttttttttttttn = BigInt(0)
+const _0n = BigInt(0)
 
 export interface AccountData {
   nonce?: BigIntLike

--- a/packages/util/src/account.ts
+++ b/packages/util/src/account.ts
@@ -2,12 +2,12 @@ import { rlp } from './externals'
 import { Point, utils } from 'ethereum-cryptography/secp256k1'
 import { stripHexPrefix } from './internal'
 import { KECCAK256_RLP, KECCAK256_NULL } from './constants'
-import { zeros, bufferToHex, toBuffer, bufferToBigInt } from './bytes'
+import { zeros, bufferToHex, toBuffer, bufferToBigInt, bigIntToUnpaddedBuffer } from './bytes'
 import { keccak, keccak256, keccakFromString, rlphash } from './hash'
 import { assertIsString, assertIsHexString, assertIsBuffer } from './helpers'
-import { BigIntLike, BufferLike, bigIntToUnpaddedBuffer } from './types'
+import { BigIntLike, BufferLike } from './types'
 
-const _0n = BigInt(0)
+const _0tttttttttttttn = BigInt(0)
 
 export interface AccountData {
   nonce?: BigIntLike

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -129,7 +129,7 @@ export const unpadArray = function (a: number[]): number[] {
 export const unpadHexString = function (a: string): string {
   assertIsHexString(a)
   a = stripHexPrefix(a)
-  return stripZeros(a) as string
+  return ('0x' + stripZeros(a)) as string
 }
 
 export type ToBufferInputTypes =

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -102,16 +102,6 @@ const stripZeros = function (a: any): Buffer | number[] | string {
 }
 
 /**
- * Trims leading zeros from a `Buffer`.
- * @param a (Buffer)
- * @return (Buffer)
- */
-export const unpadBuffer = function (a: Buffer): Buffer {
-  assertIsBuffer(a)
-  return stripZeros(a) as Buffer
-}
-
-/**
  * Trims leading zeros from an `Array` (of numbers).
  * @param a (number[])
  * @return (number[])
@@ -352,4 +342,20 @@ export function bufArrToArr(arr: Buffer | NestedBufferArray): Uint8Array | Neste
     return Uint8Array.from(arr ?? [])
   }
   return arr.map((a) => bufArrToArr(a))
+}
+
+/**
+ * Converts a {@link bigint} to a `0x` prefixed hex string
+ */
+export const bigIntToHex = (num: bigint) => {
+  return '0x' + num.toString(16)
+}
+
+/**
+ * Convert value from bigint to an unpadded Buffer
+ * (useful for RLP transport)
+ * @param value value to convert
+ */
+export function bigIntToUnpaddedBuffer(value: bigint): Buffer {
+  return unpadBuffer(bigIntToBuffer(value))
 }

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -102,6 +102,16 @@ const stripZeros = function (a: any): Buffer | number[] | string {
 }
 
 /**
+ * Trims leading zeros from a `Buffer`.
+ * @param a (Buffer)
+ * @return (Buffer)
+ */
+export const unpadBuffer = function (a: Buffer): Buffer {
+  assertIsBuffer(a)
+  return stripZeros(a) as Buffer
+}
+
+/**
  * Trims leading zeros from an `Array` (of numbers).
  * @param a (number[])
  * @return (number[])

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -1,13 +1,6 @@
 import { isHexString } from './internal'
 import { Address } from './address'
-import {
-  unpadBuffer,
-  toBuffer,
-  ToBufferInputTypes,
-  bigIntToBuffer,
-  bufferToBigInt,
-  bufferToHex,
-} from './bytes'
+import { toBuffer, ToBufferInputTypes, bufferToBigInt, bufferToHex } from './bytes'
 
 /*
  * A type that represents an input that can be converted to a BigInt.
@@ -54,15 +47,6 @@ export interface TransformableToBuffer {
 
 export type NestedUint8Array = Array<Uint8Array | NestedUint8Array>
 export type NestedBufferArray = Array<Buffer | NestedBufferArray>
-
-/**
- * Convert value from bigint to an unpadded Buffer
- * (useful for RLP transport)
- * @param value value to convert
- */
-export function bigIntToUnpaddedBuffer(value: bigint): Buffer {
-  return unpadBuffer(bigIntToBuffer(value))
-}
 
 /**
  * Type output options
@@ -133,8 +117,4 @@ export function toType<T extends TypeOutput>(
     default:
       throw new Error('unknown outputType')
   }
-}
-
-export const bigIntToHex = (num: bigint) => {
-  return '0x' + num.toString(16)
 }

--- a/packages/util/test/bytes.spec.ts
+++ b/packages/util/test/bytes.spec.ts
@@ -96,7 +96,7 @@ tape('unpadHexString', function (t) {
   t.test('should unpad a hex prefixed string', function (st) {
     const str = '0x0000000006600'
     const r = unpadHexString(str)
-    st.equal(r, '6600')
+    st.equal(r, '0x6600')
     st.end()
   })
   t.test('should throw if input is not hex-prefixed', function (st) {

--- a/packages/util/test/bytes.spec.ts
+++ b/packages/util/test/bytes.spec.ts
@@ -24,6 +24,8 @@ import {
   validateNoLeadingZeroes,
   bufferToBigInt,
   bigIntToBuffer,
+  bigIntToUnpaddedBuffer,
+  bigIntToHex,
 } from '../src'
 
 tape('zeros function', function (t) {
@@ -454,5 +456,18 @@ tape('bufferToBigInt', (st) => {
 tape('bigIntToBuffer', (st) => {
   const num = BigInt(0x123)
   st.deepEqual(toBuffer('0x123'), bigIntToBuffer(num))
+  st.end()
+})
+
+tape('bigIntToUnpaddedBuffer', function (t) {
+  t.test('should equal unpadded buffer value', function (st) {
+    st.ok(bigIntToUnpaddedBuffer(BigInt(0)).equals(Buffer.from([])))
+    st.ok(bigIntToUnpaddedBuffer(BigInt(100)).equals(Buffer.from('64', 'hex')))
+    st.end()
+  })
+})
+
+tape('bigIntToHex', (st) => {
+  st.equal(bigIntToHex(BigInt(1)), '0x1')
   st.end()
 })

--- a/packages/util/test/types.spec.ts
+++ b/packages/util/test/types.spec.ts
@@ -5,7 +5,6 @@ import {
   intToBuffer,
   bufferToHex,
   intToHex,
-  bigIntToUnpaddedBuffer,
   toBuffer,
   bigIntToHex,
   bigIntToBuffer,
@@ -134,17 +133,4 @@ tape('toType', function (t) {
       st.end()
     })
   })
-})
-
-tape('bigIntToUnpaddedBuffer', function (t) {
-  t.test('should equal unpadded buffer value', function (st) {
-    st.ok(bigIntToUnpaddedBuffer(BigInt(0)).equals(Buffer.from([])))
-    st.ok(bigIntToUnpaddedBuffer(BigInt(100)).equals(Buffer.from('64', 'hex')))
-    st.end()
-  })
-})
-
-tape('bigIntToHex', (st) => {
-  st.equal(bigIntToHex(BigInt(1)), '0x1')
-  st.end()
 })


### PR DESCRIPTION
Addresses the below item from #1717

- [x] Move misplaced bigIntToHex() and bigIntToUnpaddedBuffer() methods (and tests) from types to the bytes module
- [ ] Unify const stripZeros = function (a: any): Buffer | number[] | string and bigIntToUnpaddedBuffer() to const stripZeros = function (a: any): BufferLike (which also encompassed BN)? (from @holgerd77, thought about this while reading over https://github.com/ethereumjs/ethereumjs-util/issues/141 ) (Update @holgerd77: removed from TODO list)

On the second item, in looking at the code, I'm not really sure it makes sense to merge `stripZeroes` and `bigIntToUnpaddedBuffer` as they do different things.  To my way of thinking, it makes much more sense to merge:
- `stripZeros`
- `unpadBuffer`
- `unpadArray`
- `unpadHexString`

@holgerd77 Any thoughts here since it looks like the second item was your recommendation?