### PR TITLE
Client: remove leading zeros on cumulative gas in eth_getTransactionsReceipt method

### DIFF
--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -18,7 +18,7 @@ import {
   rlp,
   toBuffer,
   setLengthLeft,
-  stripZeros,
+  unpadHexString,
 } from 'ethereumjs-util'
 import { middleware, validators } from '../validation'
 import { INTERNAL_ERROR, INVALID_PARAMS, PARSE_ERROR } from '../error-code'
@@ -245,10 +245,7 @@ const jsonRpcReceipt = async (
   logIndex: number,
   contractAddress?: Address
 ): Promise<JsonRpcReceipt> => {
-  let cumulativeGas = receipt.gasUsed
-  if (cumulativeGas.toString('hex').startsWith('0')) {
-    cumulativeGas = Buffer.from(stripZeros(receipt.gasUsed.toString('hex')))
-  }
+  const cumulativeGas = '0x'.concat(receipt.gasUsed.toString('hex'))
   return {
     transactionHash: bufferToHex(tx.hash()),
     transactionIndex: intToHex(txIndex),
@@ -256,7 +253,7 @@ const jsonRpcReceipt = async (
     blockNumber: bnToHex(block.header.number),
     from: tx.getSenderAddress().toString(),
     to: tx.to?.toString() ?? null,
-    cumulativeGasUsed: bufferToHex(cumulativeGas),
+    cumulativeGasUsed: '0x' + unpadHexString(cumulativeGas),
     effectiveGasPrice: bnToHex(effectiveGasPrice),
     gasUsed: bnToHex(gasUsed),
     contractAddress: contractAddress?.toString() ?? null,

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -93,7 +93,7 @@ export const setLengthRight = function (msg: Buffer, length: number) {
  * @param a (Buffer|Array|String)
  * @return (Buffer|Array|String)
  */
-const stripZeros = function (a: any): Buffer | number[] | string {
+export const stripZeros = function (a: any): Buffer | number[] | string {
   let first = a[0]
   while (a.length > 0 && first.toString() === '0') {
     a = a.slice(1)

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -93,7 +93,7 @@ export const setLengthRight = function (msg: Buffer, length: number) {
  * @param a (Buffer|Array|String)
  * @return (Buffer|Array|String)
  */
-export const stripZeros = function (a: any): Buffer | number[] | string {
+const stripZeros = function (a: any): Buffer | number[] | string {
   let first = a[0]
   while (a.length > 0 && first.toString() === '0') {
     a = a.slice(1)


### PR DESCRIPTION
This PR aims to fix the test case [Suggested fee recipient in payload creation](https://hackmd.io/lKw1UArUSWu1_lOdbt3heQ?both#Suggested-Fee-Recipient-in-Payload-creation1). 

We were getting a weird error when the method `eth_getTransactionReceipt` was being called, what was happening is that in one of the transactions, `cumulativeGas` value was being returned as `0x014820` and geth parser was throwing an error of leading zeros in this value.

When trying to debug this, I found out that indeed the leading zeros were not being removed from the `cumulativeGas` attribute; so my question was: How can this happen?

I went ahead and tried to reproduce what the test does, which basically inserts 20 transactions with 21000 gas (eth transfer tx). When it came to the 4th transaction, the `cumulativeGas` is `84000` (represented as BN) - Based on this [line](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/vm/src/runTx.ts#L566), If we try to do:
```typescript
const num = new BN(84000)
const bufferNum = num.toArrayLike(Buffer)
```
`bufferNum` will be equal to `<Buffer 01 48 20>` and then, when trying to fetch all the receipts and return them, the [function `bufferToHex`](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/util/src/bytes.ts#L212-L215) is being called [here](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/client/lib/rpc/modules/eth.ts#L253) - This will do `bufferNum.toString('hex')`; returning `014820`. 

I tried to do `bufferToHex(stripZeros(cumulativeGas))` but it is not working. I went deeper and noticed that, in the [first line](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/util/src/bytes.ts#L97) of `stripZeros` function, we are checking if the first element is zero, but when doing `bufferNum[0]`, one was being received instead of zero; so I came with this solution. Please let me know if you think this is not the correct approach!