### PR TITLE
client: fix eth_call, add remoteBlocks to engine

### DIFF
--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -349,6 +349,13 @@ export class Engine {
     const [payload] = params
     const { parentHash, blockHash } = payload
 
+    const block = await assembleBlock(payload, this.chain)
+    if (!(block instanceof Block)) {
+      // Return error response
+      this.connectionManager.lastNewPayload({ payload, response: block })
+      return block
+    }
+
     const blockExists = await validHash(toBuffer(blockHash), this.chain)
     if (blockExists) {
       const response = {
@@ -358,13 +365,6 @@ export class Engine {
       }
       this.connectionManager.lastNewPayload({ payload: params[0], response })
       return response
-    }
-
-    const block = await assembleBlock(payload, this.chain)
-    if (!(block instanceof Block)) {
-      // Return error response
-      this.connectionManager.lastNewPayload({ payload, response: block })
-      return block
     }
 
     try {

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -167,6 +167,73 @@ const validateTerminalBlock = async (block: Block, chain: Chain): Promise<boolea
 }
 
 /**
+ * Returns a block from a payload.
+ * If errors, returns {@link PayloadStatusV1}
+ */
+const assembleBlock = async (
+  payload: ExecutionPayloadV1,
+  chain: Chain
+): Promise<Block | PayloadStatusV1> => {
+  const {
+    blockNumber: number,
+    receiptsRoot: receiptTrie,
+    prevRandao: mixHash,
+    feeRecipient: coinbase,
+    transactions,
+  } = payload
+  const { config } = chain
+  const { chainCommon: common } = config
+
+  const txs = []
+  for (const [index, serializedTx] of transactions.entries()) {
+    try {
+      const tx = TransactionFactory.fromSerializedData(toBuffer(serializedTx), { common })
+      txs.push(tx)
+    } catch (error) {
+      const validationError = `Invalid tx at index ${index}: ${error}`
+      config.logger.error(validationError)
+      const latestValidHash = await validHash(toBuffer(payload.parentHash), chain)
+      return { status: Status.INVALID, latestValidHash, validationError }
+    }
+  }
+
+  const transactionsTrie = await txsTrieRoot(txs)
+  const header: HeaderData = {
+    ...payload,
+    number,
+    receiptTrie,
+    transactionsTrie,
+    mixHash,
+    coinbase,
+  }
+
+  let block: Block
+  try {
+    block = Block.fromBlockData(
+      { header, transactions: txs },
+      { common, hardforkByTD: chain.headers.td }
+    )
+
+    // Verify blockHash matches payload
+    if (!block.hash().equals(toBuffer(payload.blockHash))) {
+      const validationError = `Invalid blockHash, expected: ${
+        payload.blockHash
+      }, received: ${bufferToHex(block.hash())}`
+      config.logger.debug(validationError)
+      const latestValidHash = await validHash(toBuffer(header.parentHash), chain)
+      return { status: Status.INVALID_BLOCK_HASH, latestValidHash, validationError }
+    }
+  } catch (error) {
+    const validationError = `Error verifying block during init: ${error}`
+    config.logger.debug(validationError)
+    const latestValidHash = await validHash(toBuffer(header.parentHash), chain)
+    return { status: Status.INVALID, latestValidHash, validationError }
+  }
+
+  return block
+}
+
+/**
  * engine_* RPC module
  * @memberof module:rpc/modules
  */
@@ -180,6 +247,7 @@ export class Engine {
   private vm: VM
   private txPool: TxPool
   private pendingBlock: PendingBlock
+  private remoteBlocks: Map<String, Block>
   private connectionManager: CLConnectionManager
 
   /**
@@ -200,6 +268,7 @@ export class Engine {
     this.txPool = (this.service.synchronizer as FullSynchronizer).txPool
     this.connectionManager = new CLConnectionManager({ config: this.chain.config })
     this.pendingBlock = new PendingBlock({ config: this.config, txPool: this.txPool })
+    this.remoteBlocks = new Map()
 
     this.newPayloadV1 = middleware(this.newPayloadV1.bind(this), 1, [
       [
@@ -277,17 +346,8 @@ export class Engine {
    *   3. validationError: String|null - validation error message
    */
   async newPayloadV1(params: [ExecutionPayloadV1]): Promise<PayloadStatusV1> {
-    const [payloadData] = params
-    const {
-      blockNumber: number,
-      receiptsRoot: receiptTrie,
-      prevRandao: mixHash,
-      feeRecipient: coinbase,
-      transactions,
-      parentHash,
-      blockHash,
-    } = payloadData
-    const { chainCommon: common } = this.config
+    const [payload] = params
+    const { parentHash, blockHash } = payload
 
     const blockExists = await validHash(toBuffer(blockHash), this.chain)
     if (blockExists) {
@@ -300,10 +360,17 @@ export class Engine {
       return response
     }
 
+    const block = await assembleBlock(payload, this.chain)
+    if (!(block instanceof Block)) {
+      // Return error response
+      this.connectionManager.lastNewPayload({ payload, response: block })
+      return block
+    }
+
     try {
-      const block = await this.chain.getBlock(toBuffer(parentHash))
-      if (!block._common.gteHardfork(Hardfork.Merge)) {
-        const validTerminalBlock = await validateTerminalBlock(block, this.chain)
+      const parent = await this.chain.getBlock(toBuffer(parentHash))
+      if (!parent._common.gteHardfork(Hardfork.Merge)) {
+        const validTerminalBlock = await validateTerminalBlock(parent, this.chain)
         if (!validTerminalBlock) {
           const response = {
             status: Status.INVALID_TERMINAL_BLOCK,
@@ -315,61 +382,11 @@ export class Engine {
         }
       }
     } catch (error: any) {
+      // Stash the block for a potential forced forkchoice update to it later.
+      this.remoteBlocks.set(block.hash().toString('hex'), block)
       // TODO if we can't find the parent and the block doesn't extend the canonical chain,
       // return ACCEPTED when optimistic sync is supported to store the block for later processing
       const response = { status: Status.SYNCING, validationError: null, latestValidHash: null }
-      this.connectionManager.lastNewPayload({ payload: params[0], response })
-      return response
-    }
-
-    const txs = []
-    for (const [index, serializedTx] of transactions.entries()) {
-      try {
-        const tx = TransactionFactory.fromSerializedData(toBuffer(serializedTx), { common })
-        txs.push(tx)
-      } catch (error) {
-        const validationError = `Invalid tx at index ${index}: ${error}`
-        this.config.logger.error(validationError)
-        const latestValidHash = await validHash(toBuffer(payloadData.parentHash), this.chain)
-        const response = { status: Status.INVALID, latestValidHash, validationError }
-        this.connectionManager.lastNewPayload({ payload: params[0], response })
-        return response
-      }
-    }
-
-    const transactionsTrie = await txsTrieRoot(txs)
-    const header: HeaderData = {
-      ...payloadData,
-      number,
-      receiptTrie,
-      transactionsTrie,
-      mixHash,
-      coinbase,
-    }
-
-    let block: Block
-    try {
-      block = Block.fromBlockData(
-        { header, transactions: txs },
-        { common, hardforkByTD: this.chain.headers.td }
-      )
-
-      // Verify blockHash matches payload
-      if (!block.hash().equals(toBuffer(payloadData.blockHash))) {
-        const validationError = `Invalid blockHash, expected: ${
-          payloadData.blockHash
-        }, received: ${bufferToHex(block.hash())}`
-        this.config.logger.debug(validationError)
-        const latestValidHash = await validHash(toBuffer(header.parentHash), this.chain)
-        const response = { status: Status.INVALID_BLOCK_HASH, latestValidHash, validationError }
-        this.connectionManager.lastNewPayload({ payload: params[0], response })
-        return response
-      }
-    } catch (error) {
-      const validationError = `Error verifying block during init: ${error}`
-      this.config.logger.debug(validationError)
-      const latestValidHash = await validHash(toBuffer(header.parentHash), this.chain)
-      const response = { status: Status.INVALID, latestValidHash, validationError }
       this.connectionManager.lastNewPayload({ payload: params[0], response })
       return response
     }
@@ -441,14 +458,20 @@ export class Engine {
     try {
       headBlock = await this.chain.getBlock(toBuffer(headBlockHash))
     } catch (error) {
-      const latestValidHash = bufferToHex(this.chain.headers.latest!.hash())
-      const payloadStatus = { status: Status.SYNCING, latestValidHash, validationError: null }
-      const response = { payloadStatus, payloadId: null }
-      this.connectionManager.lastForkchoiceUpdate({
-        state: params[0],
-        response,
-      })
-      return response
+      headBlock = this.remoteBlocks.get(headBlockHash.slice(2)) as Block
+      if (!headBlock) {
+        const payloadStatus = {
+          status: Status.SYNCING,
+          latestValidHash: null,
+          validationError: null,
+        }
+        const response = { payloadStatus, payloadId: null }
+        this.connectionManager.lastForkchoiceUpdate({
+          state: params[0],
+          response,
+        })
+        return response
+      }
     }
 
     if (!headBlock._common.gteHardfork(Hardfork.Merge)) {
@@ -498,8 +521,11 @@ export class Engine {
             this.chain
           )
         } catch (error) {
-          const latestValidHash = await validHash(headBlock.header.parentHash, this.chain)
-          const payloadStatus = { status: Status.SYNCING, latestValidHash, validationError: null }
+          const payloadStatus = {
+            status: Status.SYNCING,
+            latestValidHash: null,
+            validationError: null,
+          }
           const response = { payloadStatus, payloadId: null }
           this.connectionManager.lastForkchoiceUpdate({
             state: params[0],
@@ -556,7 +582,7 @@ export class Engine {
         mixHash: prevRandao,
         coinbase: suggestedFeeRecipient,
       })
-      const latestValidHash = await validHash(headBlock.header.parentHash, this.chain)
+      const latestValidHash = await validHash(headBlock.hash(), this.chain)
       const payloadStatus = { status: Status.VALID, latestValidHash, validationError: null }
       const response = { payloadStatus, payloadId: bufferToHex(payloadId) }
       this.connectionManager.lastForkchoiceUpdate({
@@ -567,7 +593,7 @@ export class Engine {
       return response
     }
 
-    const latestValidHash = await validHash(headBlock.header.hash(), this.chain)
+    const latestValidHash = await validHash(headBlock.hash(), this.chain)
     const payloadStatus = { status: Status.VALID, latestValidHash, validationError: null }
     const response = { payloadStatus, payloadId: null }
     this.connectionManager.lastForkchoiceUpdate({

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -545,7 +545,7 @@ export class Engine {
       }
 
       const blocks = [...parentBlocks, headBlock]
-      await this.execution.setHead(headBlock)
+      await this.execution.setHead(blocks)
       this.txPool.removeNewBlockTxs(blocks)
 
       const timeDiff = new Date().getTime() / 1000 - headBlock.header.timestamp.toNumber()

--- a/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
+++ b/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
@@ -64,7 +64,7 @@ tape(`${method}: call with valid data but parent block is not loaded yet`, async
   const req = params(method, [nonExistentHeadBlockHash, validPayloadAttributes])
   const expectRes = (res: any) => {
     t.equal(res.body.result.payloadStatus.status, 'SYNCING')
-    t.equal(res.body.result.payloadStatus.latestValidHash, validForkChoiceState.headBlockHash)
+    t.equal(res.body.result.payloadStatus.latestValidHash, null)
     t.equal(res.body.result.payloadStatus.validationError, null)
     t.equal(res.body.result.payloadId, null)
   }
@@ -77,7 +77,10 @@ tape(`${method}: call with valid data and synced data`, async (t) => {
   const req = params(method, validPayload)
   const expectRes = (res: any) => {
     t.equal(res.body.result.payloadStatus.status, 'VALID')
-    t.equal(res.body.result.payloadStatus.latestValidHash, null)
+    t.equal(
+      res.body.result.payloadStatus.latestValidHash,
+      '0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a'
+    )
     t.equal(res.body.result.payloadStatus.validationError, null)
     t.notEqual(res.body.result.payloadId, null)
   }

--- a/packages/client/test/rpc/engine/newPayloadV1.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV1.spec.ts
@@ -272,3 +272,19 @@ tape(`${method}: re-execute payload and verify that no errors occur`, async (t) 
   }
   await baseRequest(t, server, req, 200, expectRes)
 })
+
+tape(`${method}: parent hash equals to block hash`, async (t) => {
+  const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+  const blockDataHasBlockHashSameAsParentHash = [
+    {
+      ...blockData,
+      blockHash: blockData.parentHash,
+    },
+  ]
+  const req = params(method, blockDataHasBlockHashSameAsParentHash)
+  const expectRes = (res: any) => {
+    t.equal(res.body.result.status, 'INVALID_BLOCK_HASH')
+  }
+
+  await baseRequest(t, server, req, 200, expectRes)
+})

--- a/packages/client/test/rpc/engine/newPayloadV1.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV1.spec.ts
@@ -79,6 +79,7 @@ tape(`${method}: call with non existent parent hash`, async (t) => {
     {
       ...blockData,
       parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
+      blockHash: '0xf31969a769bfcdbcc1c05f2542fdc7aa9336fc1ea9a82c4925320c035095d649',
     },
   ]
   const req = params(method, blockDataNonExistentParentHash)
@@ -88,6 +89,37 @@ tape(`${method}: call with non existent parent hash`, async (t) => {
 
   await baseRequest(t, server, req, 200, expectRes)
 })
+
+tape(
+  `${method}: call with unknown parent hash to store in remoteBlocks, then call valid ancestor in fcU`,
+  async (t) => {
+    const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+
+    let req = params(method, [blocks[1]])
+    let expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'SYNCING')
+    }
+    await baseRequest(t, server, req, 200, expectRes, false)
+
+    req = params(method, [blocks[0]])
+    expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'VALID')
+    }
+    await baseRequest(t, server, req, 200, expectRes, false)
+
+    const state = {
+      headBlockHash: blocks[1].blockHash,
+      safeBlockHash: blocks[1].blockHash,
+      finalizedBlockHash: blocks[0].blockHash,
+    }
+    req = params('engine_forkchoiceUpdatedV1', [state])
+    expectRes = (res: any) => {
+      t.equal(res.body.result.payloadStatus.status, 'VALID')
+    }
+
+    await baseRequest(t, server, req, 200, expectRes)
+  }
+)
 
 tape(`${method}: invalid terminal block`, async (t) => {
   const genesisWithHigherTtd = {


### PR DESCRIPTION
This PR:

1. Fixes `eth_call` error when prysm calls deposit contract with `data: '0x621fd130'` (`get_deposit_count()`). The simulated tx was running into some `gasPrice` issues with `baseFeePerGas`, so I updated the code to use `vm.runCall` which should relax the tx requirements.
2. engine: Adds `remoteBlocks` to handle storing blocks with unknown parent in case `fcU` sets head to it when parent is later given to `newPayload`. Also adds a test for local coverage of this scenario.
3. More strictly follow spec when returning `SYNCING` ensure we return `latestValidHash: null`