### PR TITLE
Common: Support custom hash & state root on genesis

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -537,7 +537,7 @@ async function run() {
     const prefundAddress = accounts[0][0]
     common = await setupDevnet(prefundAddress)
   }
-
+  logger = getLogger(args)
   // Configure common based on args given
   if (
     (args.customChainParams || args.customGenesisState || args.gethGenesis) &&
@@ -569,6 +569,9 @@ async function run() {
     const chainName = path.parse(args.gethGenesis).base.split('.')[0]
     const genesisParams = await parseCustomParams(genesisFile, chainName)
     const genesisState = genesisFile.alloc ? await parseGenesisState(genesisFile) : {}
+    logger.info(
+      `Geth config file loaded chain=${genesisParams.name} id=${genesisParams.chainId} stateRoot=${genesisParams.genesis.stateRoot} hash=${genesisParams.genesis.hash}`
+    )
     common = new Common({
       chain: genesisParams.name,
       customChains: [[genesisParams, genesisState]],
@@ -586,7 +589,6 @@ async function run() {
   const configDirectory = `${datadir}/${common.chainName()}/config`
   ensureDirSync(configDirectory)
   const key = await Config.getClientKey(datadir, common)
-  logger = getLogger(args)
   const bootnodes = args.bootnodes ? parseMultiaddrs(args.bootnodes) : undefined
   const multiaddrs = args.multiaddrs ? parseMultiaddrs(args.multiaddrs) : undefined
   const config = new Config({

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1032,11 +1032,9 @@ export default class Common extends EventEmitter {
    */
   genesisState(): GenesisState {
     // Custom chains with genesis state provided
-    if (this._customChains?.length && Array.isArray(this._customChains[0])) {
-      for (const chainArrayWithGenesis of this._customChains as [IChain, GenesisState][]) {
-        if (chainArrayWithGenesis[0].name === this.chainName()) {
-          return chainArrayWithGenesis[1]
-        }
+    for (const customChain of this._customChains) {
+      if (Array.isArray(customChain) && customChain[0].name === this.chainName()) {
+        return customChain[1] as GenesisState
       }
     }
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -9,6 +9,7 @@ import {
   Chain as IChain,
   GenesisBlock,
   GenesisState,
+  GethGenesisState,
   Hardfork as HardforkParams,
 } from './types'
 
@@ -132,7 +133,7 @@ export interface CommonOpts extends BaseOpts {
    * Initialize (in addition to the supported chains) with the selected
    * custom chains
    *
-   * Usage (directly with the respective chain intialization via the {@link CommonOpts.chain} option):
+   * Usage (directly with the respective chain initialization via the {@link CommonOpts.chain} option):
    *
    * Pattern 1 (without genesis state):
    *
@@ -167,7 +168,7 @@ export interface CommonOpts extends BaseOpts {
    * const common = new Common({ chain: 'myCustomChain1', customChains: [ [ myCustomChain1, complexState ] ]})
    * ```
    */
-  customChains?: IChain[] | [IChain, GenesisState][]
+  customChains?: IChain[] | [IChain, GenesisState | GethGenesisState][]
 }
 
 /**
@@ -203,7 +204,7 @@ export default class Common extends EventEmitter {
   private _hardfork: string | Hardfork
   private _supportedHardforks: Array<string | Hardfork> = []
   private _eips: number[] = []
-  private _customChains: IChain[] | [IChain, GenesisState][]
+  private _customChains: IChain[] | [IChain, GenesisState | GethGenesisState][]
 
   /**
    * Creates a {@link Common} object for a custom chain, based on a standard one.
@@ -401,18 +402,29 @@ export default class Common extends EventEmitter {
     if (typeof chain === 'number' || typeof chain === 'string' || BN.isBN(chain)) {
       // Filter out genesis states if passed in to customChains
       let plainCustomChains: IChain[]
-      if (
-        this._customChains &&
-        this._customChains.length > 0 &&
-        Array.isArray(this._customChains[0])
-      ) {
-        plainCustomChains = (this._customChains as [IChain, GenesisState][]).map((e) => e[0])
+      if (this._customChains?.length && Array.isArray(this._customChains[0])) {
+        plainCustomChains = (this._customChains as [IChain, GenesisState | GethGenesisState][]).map(
+          ([chain, state]) => {
+            if ('hash' && 'stateRoot' in state) {
+              return {
+                ...chain,
+                genesis: {
+                  ...chain.genesis,
+                  hash: state.hash,
+                  stateRoot: state.stateRoot,
+                },
+              } as IChain
+            }
+
+            return chain
+          }
+        )
       } else {
         plainCustomChains = this._customChains as IChain[]
       }
       this._chainParams = Common._getChainParams(chain, plainCustomChains)
     } else if (typeof chain === 'object') {
-      if (this._customChains.length > 0) {
+      if (this._customChains.length) {
         throw new Error(
           'Chain must be a string, number, or BN when initialized with customChains passed in'
         )
@@ -1019,6 +1031,15 @@ export default class Common extends EventEmitter {
    * all values are provided as hex-prefixed strings.
    */
   genesisState(): GenesisState {
+    // Custom chains with genesis state provided
+    if (this._customChains?.length && Array.isArray(this._customChains[0])) {
+      for (const chainArrayWithGenesis of this._customChains as [IChain, GenesisState][]) {
+        if (chainArrayWithGenesis[0].name === this.chainName()) {
+          return chainArrayWithGenesis[1]
+        }
+      }
+    }
+
     // Use require statements here in favor of import statements
     // to load json files on demand
     // (high memory usage by large mainnet.json genesis state file)
@@ -1035,19 +1056,6 @@ export default class Common extends EventEmitter {
         return require('./genesisStates/goerli.json')
       case 'sepolia':
         return require('./genesisStates/sepolia.json')
-    }
-
-    // Custom chains with genesis state provided
-    if (
-      this._customChains &&
-      this._customChains.length > 0 &&
-      Array.isArray(this._customChains[0])
-    ) {
-      for (const chainArrayWithGenesis of this._customChains as [IChain, GenesisState][]) {
-        if (chainArrayWithGenesis[0].name === this.chainName()) {
-          return chainArrayWithGenesis[1]
-        }
-      }
     }
 
     return {}

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -52,6 +52,12 @@ export interface GenesisState {
   [key: PrefixedHexString]: PrefixedHexString | AccountState
 }
 
+export interface GethGenesisState {
+  json?: any
+  hash: string
+  stateRoot: string
+}
+
 export interface eipsType {
   [key: number]: any
 }

--- a/packages/common/tests/customChains.spec.ts
+++ b/packages/common/tests/customChains.spec.ts
@@ -4,8 +4,7 @@ import Common, { Chain, ConsensusType, CustomChain, Hardfork } from '../src/'
 import testnet from './data/testnet.json'
 import testnet2 from './data/testnet2.json'
 import testnet3 from './data/testnet3.json'
-
-import { AccountState, Chain as IChain, GenesisState } from '../src/types'
+import { AccountState, Chain as IChain, GenesisState, GethGenesisState } from '../src/types'
 
 tape('[Common]: Custom chains', function (t: tape.Test) {
   t.test(
@@ -244,6 +243,21 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
       complexGenesisState[contractAccount][2][1][1]
     )
 
+    st.end()
+  })
+
+  t.test('custom hash and state root sent in genesis state', function (st: tape.Test) {
+    const genesisState = {
+      stateRoot: 'cool-state-root',
+      hash: 'cool-hash',
+    }
+    const customChainsWithGenesis: [IChain, GethGenesisState][] = [[testnet, genesisState]]
+    const c = new Common({
+      chain: 'testnet',
+      customChains: customChainsWithGenesis,
+    })
+    st.equal(c.genesis().hash, genesisState.hash)
+    st.equal(c.genesis().stateRoot, genesisState.stateRoot)
     st.end()
   })
 })


### PR DESCRIPTION
This PR aims to support custom hash and state root in `Common` initialization. Currently, we are updating the [`genesis` object](https://github.com/ethereumjs/ethereumjs-monorepo/blob/common/geth-file-support/packages/common/src/index.ts#L411-L415) with the desired hash and state root, but the state given (which is the `json` attribute) is not being used at all, the reason for this is that the geth state parser is in `Client` and not in `Common` package.

I think that we should be able to support also the genesis state object (Since we are passing a state root hash, we need a state that can represent that hash - _If I understand this correctly_). After thinking a bit though this, I think that the easiest way to achieve this is to just make this `json` param to be [`GenesisState` type](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/src/types.ts#L51)

I am seeing this from the point of view of initiating for example the polygon chain, we can set the state with proper hashes, being able to fully execute a block

edit: I marked this as draft because it's not ready yet but would be awesome to get a review just to make sure I am going in the correct path 