### PR TITLE
Set caller to zero address if not provided

### DIFF
--- a/packages/vm/src/runCall.ts
+++ b/packages/vm/src/runCall.ts
@@ -41,7 +41,7 @@ export default function runCall(this: VM, opts: RunCallOpts): Promise<EVMResult>
   )
 
   const message = new Message({
-    caller: opts.caller,
+    caller: opts.caller ?? Address.zero(),
     gasLimit: opts.gasLimit ?? new BN(0xffffff),
     to: opts.to ?? undefined,
     value: opts.value,


### PR DESCRIPTION
The `caller` parameter in `runCallOpts` is optional but causes the EVM to throw if not provided.  The upcoming docs on the `runCallOpts` that are in the `develop` branch indicate the message caller should default to the zero address if not provided in the message so this fix accounts for that design.