### PR TITLE
vm: Improve `skipBalance` logic

### DIFF
--- a/packages/vm/src/evm/evm.ts
+++ b/packages/vm/src/evm/evm.ts
@@ -638,7 +638,7 @@ export default class EVM {
   async _reduceSenderBalance(account: Account, message: Message): Promise<void> {
     account.balance -= message.value
     if (account.balance < BigInt(0)) {
-      throw new Error('sender account has insufficient funds to execute message')
+      throw new VmError(ERROR.INSUFFICIENT_BALANCE)
     }
     const result = this._state.putAccount(message.authcallOrigin ?? message.caller, account)
     if (this._vm.DEBUG) {

--- a/packages/vm/src/exceptions.ts
+++ b/packages/vm/src/exceptions.ts
@@ -13,6 +13,7 @@ export enum ERROR {
   STOP = 'stop',
   REFUND_EXHAUSTED = 'refund exhausted',
   VALUE_OVERFLOW = 'value overflow',
+  INSUFFICIENT_BALANCE = 'insufficient balance',
   INVALID_BEGINSUB = 'invalid BEGINSUB',
   INVALID_RETURNSUB = 'invalid RETURNSUB',
   INVALID_JUMPSUB = 'invalid JUMPSUB',

--- a/packages/vm/src/runCall.ts
+++ b/packages/vm/src/runCall.ts
@@ -66,7 +66,7 @@ export interface RunCallOpts {
    */
   selfdestruct?: { [k: string]: boolean }
   /**
-   * Skip balance checks if true.
+   * Skip balance checks if true and adds transaction value to balance to ensure message execution doesn't fail on balance checks
    */
   skipBalance?: boolean
   /**

--- a/packages/vm/src/runCall.ts
+++ b/packages/vm/src/runCall.ts
@@ -99,7 +99,7 @@ export default async function runCall(this: VM, opts: RunCallOpts): Promise<EVMR
     caller,
     gasLimit: opts.gasLimit ?? BigInt(0xffffff),
     to: opts.to ?? undefined,
-    value: opts.value,
+    value,
     data: opts.data,
     code: opts.code,
     depth: opts.depth ?? 0,

--- a/packages/vm/src/runCall.ts
+++ b/packages/vm/src/runCall.ts
@@ -93,7 +93,7 @@ export default async function runCall(this: VM, opts: RunCallOpts): Promise<EVMR
     const balance = callerAccount.balance
 
     if (opts.value && balance < opts.value) {
-      callerAccount.balance += opts.value - balance
+      callerAccount.balance += opts.value
       await this.stateManager.putAccount(caller, callerAccount)
     }
   }

--- a/packages/vm/src/runCall.ts
+++ b/packages/vm/src/runCall.ts
@@ -88,8 +88,9 @@ export default async function runCall(this: VM, opts: RunCallOpts): Promise<EVMR
 
   const caller = opts.caller ?? Address.zero()
   const value = opts.value ?? BigInt(0)
+
   if (opts.skipBalance) {
-    // if skipBalance, ensure the caller has enough balance for `value` transfer
+    // if skipBalance, add `value` to caller balance to ensure sufficient funds
     const callerAccount = await this.stateManager.getAccount(caller)
     callerAccount.balance += value
     await this.stateManager.putAccount(caller, callerAccount)

--- a/packages/vm/src/runCall.ts
+++ b/packages/vm/src/runCall.ts
@@ -86,8 +86,9 @@ export default async function runCall(this: VM, opts: RunCallOpts): Promise<EVMR
     opts.origin ?? opts.caller ?? Address.zero()
   )
 
+  const caller = opts.caller ?? Address.zero()
   if (opts.skipBalance) {
-    const caller = opts.caller ?? Address.zero()
+    // if skipBalance, ensure the caller has enough balance for `value` transfer
     const callerAccount = await this.stateManager.getAccount(caller)
     const balance = callerAccount.balance
     if (opts.value && balance < opts.value) {
@@ -95,8 +96,9 @@ export default async function runCall(this: VM, opts: RunCallOpts): Promise<EVMR
       await this.stateManager.putAccount(caller, callerAccount)
     }
   }
+
   const message = new Message({
-    caller: opts.caller ?? Address.zero(),
+    caller,
     gasLimit: opts.gasLimit ?? BigInt(0xffffff),
     to: opts.to ?? undefined,
     value: opts.value,

--- a/packages/vm/src/runCall.ts
+++ b/packages/vm/src/runCall.ts
@@ -87,15 +87,12 @@ export default async function runCall(this: VM, opts: RunCallOpts): Promise<EVMR
   )
 
   const caller = opts.caller ?? Address.zero()
+  const value = opts.value ?? BigInt(0)
   if (opts.skipBalance) {
     // if skipBalance, ensure the caller has enough balance for `value` transfer
     const callerAccount = await this.stateManager.getAccount(caller)
-    const balance = callerAccount.balance
-
-    if (opts.value && balance < opts.value) {
-      callerAccount.balance += opts.value
-      await this.stateManager.putAccount(caller, callerAccount)
-    }
+    callerAccount.balance += value
+    await this.stateManager.putAccount(caller, callerAccount)
   }
 
   const message = new Message({

--- a/packages/vm/src/runCall.ts
+++ b/packages/vm/src/runCall.ts
@@ -66,7 +66,7 @@ export interface RunCallOpts {
    */
   selfdestruct?: { [k: string]: boolean }
   /**
-   * Skip balance checks if true and adds transaction value to balance to ensure message execution doesn't fail on balance checks
+   * Skip balance checks if true. Adds transaction value to balance to ensure execution doesn't fail.
    */
   skipBalance?: boolean
   /**

--- a/packages/vm/src/runCall.ts
+++ b/packages/vm/src/runCall.ts
@@ -91,6 +91,7 @@ export default async function runCall(this: VM, opts: RunCallOpts): Promise<EVMR
     // if skipBalance, ensure the caller has enough balance for `value` transfer
     const callerAccount = await this.stateManager.getAccount(caller)
     const balance = callerAccount.balance
+
     if (opts.value && balance < opts.value) {
       callerAccount.balance += opts.value - balance
       await this.stateManager.putAccount(caller, callerAccount)

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -312,7 +312,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   const cost = tx.getUpfrontCost(block.header.baseFeePerGas)
   if (opts.skipBalance) {
     // when skipBalance, ensure the caller has enough balance for the total tx cost
-    fromAccount.balance += cost - balance
+    fromAccount.balance += cost
     await this.stateManager.putAccount(caller, fromAccount)
   } else {
     if (balance < cost) {

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -311,7 +311,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
 
   const cost = tx.getUpfrontCost(block.header.baseFeePerGas)
   if (opts.skipBalance) {
-    // when skipBalance, ensure the caller has enough balance for the total tx cost
+    // if skipBalance, add tx cost to sender balance to ensure sufficient funds
     fromAccount.balance += cost
     await this.stateManager.putAccount(caller, fromAccount)
   } else {

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -45,7 +45,7 @@ export interface RunTxOpts {
    */
   skipNonce?: boolean
   /**
-   * Skip balance checks if true and adds transaction value to balance to ensure transaction execution doesn't fail on balance checks
+   * Skip balance checks if true. Adds transaction value to balance to ensure execution doesn't fail.
    */
   skipBalance?: boolean
 

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -45,7 +45,7 @@ export interface RunTxOpts {
    */
   skipNonce?: boolean
   /**
-   * If true, skips the balance check
+   * Skip balance checks if true and adds transaction value to balance to ensure transaction execution doesn't fail on balance checks
    */
   skipBalance?: boolean
 

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -45,7 +45,7 @@ export interface RunTxOpts {
    */
   skipNonce?: boolean
   /**
-   * Skip balance checks if true. Adds transaction value to balance to ensure execution doesn't fail.
+   * Skip balance checks if true. Adds transaction cost to balance to ensure execution doesn't fail.
    */
   skipBalance?: boolean
 

--- a/packages/vm/tests/api/runCall.spec.ts
+++ b/packages/vm/tests/api/runCall.spec.ts
@@ -1,6 +1,13 @@
 import tape from 'tape'
 import { keccak256 } from 'ethereum-cryptography/keccak'
-import { Account, Address, toBuffer, MAX_UINT64, padToEven } from 'ethereumjs-util'
+import {
+  Account,
+  Address,
+  toBuffer,
+  MAX_UINT64,
+  padToEven,
+  privateToAddress,
+} from 'ethereumjs-util'
 import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import VM from '../../src'
 import { ERROR } from '../../src/exceptions'
@@ -524,4 +531,39 @@ tape('Throws on negative call value', async (t) => {
   }
 
   t.end()
+})
+
+tape('Skip balance checks', async (t) => {
+  t.plan(3)
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
+  const vm = await VM.create({ common })
+  const code = '600260015260015160005260206000F3'
+  const returndata = Buffer.alloc(32)
+  returndata[31] = 0x02
+
+  const senderKey = Buffer.from(
+    'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
+    'hex'
+  )
+  const caller = new Address(privateToAddress(senderKey))
+  const address = new Address(Buffer.from('000000000000000000000000636F6E7472616374', 'hex'))
+
+  await vm.stateManager.putContractCode(address, Buffer.from(code, 'hex'))
+  const runCallArgs = {
+    gasLimit: BigInt(21000 + 9000),
+    to: address,
+    value: BigInt(1),
+    from: caller,
+    skipBalance: true,
+  }
+
+  const res = await vm.runCall(runCallArgs)
+  t.pass('runCall should not throw with no balance and skipBalance = true')
+  const callerBalance = (await vm.stateManager.getAccount(caller)).balance
+  t.equal(
+    callerBalance,
+    BigInt(0),
+    'caller balance should be 0 if skipBalance = true and caller balance less than tx cost'
+  )
+  t.equal(res.execResult.exceptionError, undefined, 'no exceptionError when skipBalance = true')
 })

--- a/packages/vm/tests/api/runCall.spec.ts
+++ b/packages/vm/tests/api/runCall.spec.ts
@@ -533,7 +533,7 @@ tape('Throws on negative call value', async (t) => {
   t.end()
 })
 
-tape.only('Skip balance checks', async (t) => {
+tape('Skip balance checks', async (t) => {
   t.plan(4)
   const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
   const vm = await VM.create({ common })
@@ -560,10 +560,9 @@ tape.only('Skip balance checks', async (t) => {
   const res = await vm.runCall(runCallArgs)
   t.pass('runCall should not throw with no balance and skipBalance = true')
   const callerBalance = (await vm.stateManager.getAccount(caller)).balance
-  t.equal(
-    callerBalance,
-    BigInt(0),
-    'caller balance should be 0 if skipBalance = true and caller balance less than tx cost'
+  t.ok(
+    callerBalance >= BigInt(0),
+    'caller balance should be >= 0 if skipBalance = true and caller balance less than tx cost'
   )
   t.equal(res.execResult.exceptionError, undefined, 'no exceptionError when skipBalance = true')
 

--- a/packages/vm/tests/api/runCall.spec.ts
+++ b/packages/vm/tests/api/runCall.spec.ts
@@ -533,8 +533,8 @@ tape('Throws on negative call value', async (t) => {
   t.end()
 })
 
-tape('Skip balance checks', async (t) => {
-  t.plan(3)
+tape.only('Skip balance checks', async (t) => {
+  t.plan(4)
   const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
   const vm = await VM.create({ common })
   const code = '600260015260015160005260206000F3'
@@ -545,7 +545,7 @@ tape('Skip balance checks', async (t) => {
     'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
     'hex'
   )
-  const caller = new Address(privateToAddress(senderKey))
+  const caller = Address.fromPrivateKey(senderKey)
   const address = new Address(Buffer.from('000000000000000000000000636F6E7472616374', 'hex'))
 
   await vm.stateManager.putContractCode(address, Buffer.from(code, 'hex'))
@@ -566,4 +566,11 @@ tape('Skip balance checks', async (t) => {
     'caller balance should be 0 if skipBalance = true and caller balance less than tx cost'
   )
   t.equal(res.execResult.exceptionError, undefined, 'no exceptionError when skipBalance = true')
+
+  const res2 = await vm.runCall({ ...runCallArgs, ...{ skipBalance: false } })
+  t.equal(
+    res2.execResult.exceptionError?.error,
+    'insufficient balance',
+    'runCall reverts when insufficient caller balance and skipBalance = false'
+  )
 })

--- a/packages/vm/tests/api/runCall.spec.ts
+++ b/packages/vm/tests/api/runCall.spec.ts
@@ -551,7 +551,7 @@ tape('Skip balance checks', async (t) => {
       skipBalance: true,
     }
 
-    await vm.stateManager.modifyAccountFields(caller, { balance: balance })
+    await vm.stateManager.modifyAccountFields(caller, { nonce: BigInt(0), balance: balance })
     const res = await vm.runCall(runCallArgs)
     t.pass('runCall should not throw with no balance and skipBalance = true')
     const callerBalance = (await vm.stateManager.getAccount(caller)).balance

--- a/packages/vm/tests/api/runCall.spec.ts
+++ b/packages/vm/tests/api/runCall.spec.ts
@@ -567,7 +567,7 @@ tape.only('Skip balance checks', async (t) => {
   )
   t.equal(res.execResult.exceptionError, undefined, 'no exceptionError when skipBalance = true')
 
-  const res2 = await vm.runCall({ ...runCallArgs, ...{ skipBalance: false } })
+  const res2 = await vm.runCall({ ...runCallArgs, skipBalance: false })
   t.equal(
     res2.execResult.exceptionError?.error,
     'insufficient balance',

--- a/packages/vm/tests/api/runCall.spec.ts
+++ b/packages/vm/tests/api/runCall.spec.ts
@@ -551,7 +551,7 @@ tape('Skip balance checks', async (t) => {
       skipBalance: true,
     }
 
-    await vm.stateManager.putAccount(caller, new Account(BigInt(0), balance))
+    await vm.stateManager.modifyAccountFields(caller, { balance: balance })
     const res = await vm.runCall(runCallArgs)
     t.pass('runCall should not throw with no balance and skipBalance = true')
     const callerBalance = (await vm.stateManager.getAccount(caller)).balance

--- a/packages/vm/tests/api/runTx.spec.ts
+++ b/packages/vm/tests/api/runTx.spec.ts
@@ -1,5 +1,5 @@
 import tape from 'tape'
-import { Account, Address, MAX_INTEGER, privateToAddress } from 'ethereumjs-util'
+import { Account, Address, MAX_INTEGER } from 'ethereumjs-util'
 import { Block } from '@ethereumjs/block'
 import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import {
@@ -642,7 +642,7 @@ tape('runTx() -> RunTxOptions', (t) => {
 })
 
 tape('skipBalance checks', async (t) => {
-  t.plan(3)
+  t.plan(6)
   const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
   const vm = await VM.create({ common })
   const code = '600260015260015160005260206000F3'
@@ -656,20 +656,30 @@ tape('skipBalance checks', async (t) => {
   const address = new Address(Buffer.from('000000000000000000000000636F6E7472616374', 'hex'))
 
   await vm.stateManager.putContractCode(address, Buffer.from(code, 'hex'))
-  const tx = Transaction.fromTxData({
-    gasLimit: BigInt(21000 + 9000),
-    to: address,
-    value: BigInt(1),
-  }).sign(senderKey)
+  for (const balance of [undefined, BigInt(5)]) {
+    if (balance) {
+      await vm.stateManager.putAccount(
+        Address.fromPrivateKey(senderKey),
+        new Account(BigInt(0), balance)
+      )
+    }
 
-  const res = await vm.runTx({ tx, skipBalance: true })
-  t.pass('runTx should not throw with no balance and skipBalance = true')
+    const tx = Transaction.fromTxData({
+      gasLimit: BigInt(21000 + 9000),
+      to: address,
+      value: BigInt(1),
+    }).sign(senderKey)
 
-  const callerBalance = (await vm.stateManager.getAccount(Address.fromPrivateKey(senderKey)))
-    .balance
-  t.ok(
-    callerBalance >= BigInt(0),
-    'caller balance should be >= 0 if skipBalance = true and caller balance less than tx cost'
-  )
-  t.equal(res.execResult.exceptionError, undefined, 'no exceptionError when skipBalance = true')
+    const res = await vm.runTx({ tx, skipBalance: true })
+    t.pass('runTx should not throw with no balance and skipBalance = true')
+    const afterTxCallerBalance = (
+      await vm.stateManager.getAccount(Address.fromPrivateKey(senderKey))
+    ).balance
+    t.equal(
+      afterTxCallerBalance,
+      balance ?? BigInt(0),
+      `caller balance before and after transaction should be equal if skipBalance = true and caller balance less than tx cost`
+    )
+    t.equal(res.execResult.exceptionError, undefined, 'no exceptionError when skipBalance = true')
+  }
 })

--- a/packages/vm/tests/api/runTx.spec.ts
+++ b/packages/vm/tests/api/runTx.spec.ts
@@ -653,15 +653,13 @@ tape('skipBalance checks', async (t) => {
     'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
     'hex'
   )
+  const caller = Address.fromPrivateKey(senderKey)
   const address = new Address(Buffer.from('000000000000000000000000636F6E7472616374', 'hex'))
 
   await vm.stateManager.putContractCode(address, Buffer.from(code, 'hex'))
   for (const balance of [undefined, BigInt(5)]) {
     if (balance) {
-      await vm.stateManager.putAccount(
-        Address.fromPrivateKey(senderKey),
-        new Account(BigInt(0), balance)
-      )
+      await vm.stateManager.modifyAccountFields(caller, { balance: balance })
     }
 
     const tx = Transaction.fromTxData({

--- a/packages/vm/tests/api/runTx.spec.ts
+++ b/packages/vm/tests/api/runTx.spec.ts
@@ -667,10 +667,9 @@ tape('skipBalance checks', async (t) => {
 
   const callerBalance = (await vm.stateManager.getAccount(Address.fromPrivateKey(senderKey)))
     .balance
-  t.equal(
-    callerBalance,
-    BigInt(0),
-    'caller balance should be 0 if skipBalance = true and caller balance less than tx cost'
+  t.ok(
+    callerBalance >= BigInt(0),
+    'caller balance should be >= 0 if skipBalance = true and caller balance less than tx cost'
   )
   t.equal(res.execResult.exceptionError, undefined, 'no exceptionError when skipBalance = true')
 })

--- a/packages/vm/tests/api/runTx.spec.ts
+++ b/packages/vm/tests/api/runTx.spec.ts
@@ -665,7 +665,7 @@ tape('skipBalance checks', async (t) => {
   const res = await vm.runTx({ tx, skipBalance: true })
   t.pass('runTx should not throw with no balance and skipBalance = true')
 
-  const callerBalance = (await vm.stateManager.getAccount(new Address(privateToAddress(senderKey))))
+  const callerBalance = (await vm.stateManager.getAccount(Address.fromPrivateKey(senderKey)))
     .balance
   t.equal(
     callerBalance,

--- a/packages/vm/tests/api/runTx.spec.ts
+++ b/packages/vm/tests/api/runTx.spec.ts
@@ -659,7 +659,7 @@ tape('skipBalance checks', async (t) => {
   await vm.stateManager.putContractCode(address, Buffer.from(code, 'hex'))
   for (const balance of [undefined, BigInt(5)]) {
     if (balance) {
-      await vm.stateManager.modifyAccountFields(caller, { balance: balance })
+      await vm.stateManager.modifyAccountFields(caller, { nonce: BigInt(0), balance: balance })
     }
 
     const tx = Transaction.fromTxData({

--- a/packages/vm/tests/api/runTx.spec.ts
+++ b/packages/vm/tests/api/runTx.spec.ts
@@ -641,7 +641,7 @@ tape('runTx() -> RunTxOptions', (t) => {
   })
 })
 
-tape.only('runTx() -> skipBalance behavior', async (t) => {
+tape('runTx() -> skipBalance behavior', async (t) => {
   t.plan(6)
   const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
   const vm = await VM.create({ common })


### PR DESCRIPTION
Fixes #1839 

This addresses the fact that `skipBalance` in `runTx` doesn't handle skipping balance checks correctly after the initial transaction options are parsed.  Now, if `skipBalance` is set to true and the calling account balance is less than the transaction cost (i.e. intrinsic gas + value), it sets the balance equal to the transaction cost so the transaction will not fail due to an account having an insufficient balance.

It adds similar logic in `runCall` that checks to verify that the account has sufficient balance for any value transferred in the call.