### PR TITLE
Common: fixed non-option passing on custom() method

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -247,32 +247,44 @@ export default class Common extends EventEmitter {
       })
     } else {
       if (chainParamsOrName === CustomChain.PolygonMainnet) {
-        return Common.custom({
-          name: CustomChain.PolygonMainnet,
-          chainId: 137,
-          networkId: 137,
-        })
+        return Common.custom(
+          {
+            name: CustomChain.PolygonMainnet,
+            chainId: 137,
+            networkId: 137,
+          },
+          opts
+        )
       }
       if (chainParamsOrName === CustomChain.PolygonMumbai) {
-        return Common.custom({
-          name: CustomChain.PolygonMumbai,
-          chainId: 80001,
-          networkId: 80001,
-        })
+        return Common.custom(
+          {
+            name: CustomChain.PolygonMumbai,
+            chainId: 80001,
+            networkId: 80001,
+          },
+          opts
+        )
       }
       if (chainParamsOrName === CustomChain.ArbitrumRinkebyTestnet) {
-        return Common.custom({
-          name: CustomChain.ArbitrumRinkebyTestnet,
-          chainId: 421611,
-          networkId: 421611,
-        })
+        return Common.custom(
+          {
+            name: CustomChain.ArbitrumRinkebyTestnet,
+            chainId: 421611,
+            networkId: 421611,
+          },
+          opts
+        )
       }
       if (chainParamsOrName === CustomChain.xDaiChain) {
-        return Common.custom({
-          name: CustomChain.xDaiChain,
-          chainId: 100,
-          networkId: 100,
-        })
+        return Common.custom(
+          {
+            name: CustomChain.xDaiChain,
+            chainId: 100,
+            networkId: 100,
+          },
+          opts
+        )
       }
 
       if (chainParamsOrName === CustomChain.OptimisticKovan) {
@@ -283,7 +295,7 @@ export default class Common extends EventEmitter {
             networkId: 69,
           },
           // Optimism has not implemented the London hardfork yet (targeting Q1.22)
-          { hardfork: Hardfork.Berlin }
+          { hardfork: Hardfork.Berlin, ...opts }
         )
       }
 
@@ -295,7 +307,7 @@ export default class Common extends EventEmitter {
             networkId: 10,
           },
           // Optimism has not implemented the London hardfork yet (targeting Q1.22)
-          { hardfork: Hardfork.Berlin }
+          { hardfork: Hardfork.Berlin, ...opts }
         )
       }
       throw new Error(`Custom chain ${chainParamsOrName} not supported`)

--- a/packages/common/tests/customChains.spec.ts
+++ b/packages/common/tests/customChains.spec.ts
@@ -91,11 +91,10 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
     }
 
     common = Common.custom(CustomChain.PolygonMumbai)
-    st.notEqual(common.hardfork(), Hardfork.Byzantium, 'by default PolygonMumbai hardfork is not Byzantium')
     st.equal(
       common.hardfork(),
-      Hardfork.Byzantium,
-      'should correctly set an option (no default options present)'
+      common.DEFAULT_HARDFORK,
+      'uses default hardfork when no options are present'
     )
 
     common = Common.custom(CustomChain.OptimisticEthereum, { hardfork: Hardfork.Byzantium })

--- a/packages/common/tests/customChains.spec.ts
+++ b/packages/common/tests/customChains.spec.ts
@@ -90,6 +90,20 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
       )
     }
 
+    common = Common.custom(CustomChain.PolygonMumbai, { hardfork: Hardfork.Byzantium })
+    st.equal(
+      common.hardfork(),
+      Hardfork.Byzantium,
+      'should correctly set an option (no default options present)'
+    )
+
+    common = Common.custom(CustomChain.OptimisticEthereum, { hardfork: Hardfork.Byzantium })
+    st.equal(
+      common.hardfork(),
+      Hardfork.Byzantium,
+      'should correctly set an option (default options present)'
+    )
+
     try {
       //@ts-ignore TypeScript complains, nevertheless do the test for JS behavior
       Common.custom('this-chain-is-not-supported')

--- a/packages/common/tests/customChains.spec.ts
+++ b/packages/common/tests/customChains.spec.ts
@@ -90,7 +90,8 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
       )
     }
 
-    common = Common.custom(CustomChain.PolygonMumbai, { hardfork: Hardfork.Byzantium })
+    common = Common.custom(CustomChain.PolygonMumbai)
+    st.notEqual(common.hardfork(), Hardfork.Byzantium, 'by default PolygonMumbai hardfork is not Byzantium')
     st.equal(
       common.hardfork(),
       Hardfork.Byzantium,


### PR DESCRIPTION
Fixes a bug discovered in #1838

(open for everyone in the team to review of course)