### PR TITLE
client: refac services, syncronizers and fetchers for beacon sync

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -182,6 +182,11 @@ const args = yargs(hideBin(process.argv))
     number: true,
     default: Config.MAXPERREQUEST_DEFAULT,
   })
+  .option('maxFetcherJobs', {
+    describe: 'Max tasks or jobs to be created for a fetcher at a time',
+    number: true,
+    default: Config.MAXFETCHERJOBS_DEFAULT,
+  })
   .option('minPeers', {
     describe: 'Peers needed before syncing',
     number: true,

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -130,9 +130,9 @@ export interface ConfigOptions {
   maxPerRequest?: number
 
   /**
-   * Max jobs to be enqued in a fetcher at any given time
+   * Max jobs to be enqueued in the fetcher at any given time
    *
-   * Default: `100``
+   * Default: `100`
    */
   maxFetcherJobs?: number
 

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -130,6 +130,13 @@ export interface ConfigOptions {
   maxPerRequest?: number
 
   /**
+   * Max jobs to be enqued in a fetcher at any given time
+   *
+   * Default: `100``
+   */
+  maxFetcherJobs?: number
+
+  /**
    * Number of peers needed before syncing
    *
    * Default: `1`
@@ -220,6 +227,7 @@ export class Config {
   public static readonly TRANSPORTS_DEFAULT = ['rlpx', 'libp2p']
   public static readonly PORT_DEFAULT = 30303
   public static readonly MAXPERREQUEST_DEFAULT = 50
+  public static readonly MAXFETCHERJOBS_DEFAULT = 100
   public static readonly MINPEERS_DEFAULT = 1
   public static readonly MAXPEERS_DEFAULT = 25
   public static readonly DNSADDR_DEFAULT = '8.8.8.8'
@@ -240,6 +248,7 @@ export class Config {
   public readonly saveReceipts: boolean
   public readonly txLookupLimit: number
   public readonly maxPerRequest: number
+  public readonly maxFetcherJobs: number
   public readonly minPeers: number
   public readonly maxPeers: number
   public readonly dnsAddr: string
@@ -277,6 +286,7 @@ export class Config {
     this.saveReceipts = options.saveReceipts ?? false
     this.txLookupLimit = options.txLookupLimit ?? 2350000
     this.maxPerRequest = options.maxPerRequest ?? Config.MAXPERREQUEST_DEFAULT
+    this.maxFetcherJobs = options.maxFetcherJobs ?? Config.MAXFETCHERJOBS_DEFAULT
     this.minPeers = options.minPeers ?? Config.MINPEERS_DEFAULT
     this.maxPeers = options.maxPeers ?? Config.MAXPEERS_DEFAULT
     this.dnsAddr = options.dnsAddr ?? Config.DNSADDR_DEFAULT

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -10,8 +10,9 @@ import { Protocol } from '../net/protocol'
 import { Miner } from '../miner'
 import { VMExecution } from '../execution'
 import { Event } from '../types'
+import { short } from '../util'
 
-import type { Block } from '@ethereumjs/block'
+import type { Block, BlockHeader } from '@ethereumjs/block'
 
 interface FullEthereumServiceOptions extends EthereumServiceOptions {
   /** Serve LES requests (default: false) */
@@ -55,13 +56,15 @@ export class FullEthereumService extends EthereumService {
       config: this.config,
       pool: this.pool,
       chain: this.chain,
-      txPool: this.txPool,
       stateDB: options.stateDB,
       metaDB: options.metaDB,
       interval: this.interval,
     })
     this.config.events.on(Event.SYNC_FETCHER_FETCHED, async (...args) => {
-      await this.synchronizer.processBlocks(this.execution, ...args)
+      await this.processBlocks(...args)
+    })
+    this.config.events.on(Event.SYNC_EXECUTION_VM_ERROR, async () => {
+      await this.synchronizer.stop()
     })
 
     if (this.config.mine) {
@@ -178,10 +181,9 @@ export class FullEthereumService extends EthereumService {
       peer.eth!.send('BlockHeaders', { reqId, headers })
     } else if (message.name === 'GetBlockBodies') {
       const { reqId, hashes } = message.data
-      let blocks: Block[] = await Promise.all(
+      const blocks: Block[] = await Promise.all(
         hashes.map((hash: Buffer) => this.chain.getBlock(hash))
       )
-      blocks = blocks.filter((b) => !b._common.gteHardfork(Hardfork.Merge))
       const bodies = blocks.map((block) => block.raw().slice(1))
       peer.eth!.send('BlockBodies', { reqId, bodies })
     } else if (message.name === 'NewBlockHashes') {
@@ -253,10 +255,71 @@ export class FullEthereumService extends EthereumService {
             return
           }
         }
-        let headers = await this.chain.getHeaders(block, max, skip, reverse)
-        headers = headers.filter((h) => !h._common.gteHardfork(Hardfork.Merge))
+        const headers = await this.chain.getHeaders(block, max, skip, reverse)
         peer.les!.send('BlockHeaders', { reqId, bv, headers })
       }
     }
+  }
+
+  async processBlocks(blocks: Block[] | BlockHeader[]) {
+    if (this.config.chainCommon.gteHardfork(Hardfork.Merge)) {
+      if (this.synchronizer.fetcher !== null) {
+        // If we are beyond the merge block we should stop the fetcher
+        this.config.logger.info('Merge hardfork reached, stopping block fetcher')
+        this.synchronizer.clearFetcher()
+      }
+    }
+
+    if (blocks.length === 0) {
+      if (this.synchronizer.fetcher !== null) {
+        this.config.logger.warn('No blocks fetched are applicable for import')
+      }
+      return
+    }
+
+    blocks = blocks as Block[]
+    const first = blocks[0].header.number
+    const last = blocks[blocks.length - 1].header.number
+    const hash = short(blocks[0].hash())
+    const baseFeeAdd = this.config.chainCommon.gteHardfork(Hardfork.London)
+      ? `baseFee=${blocks[0].header.baseFeePerGas} `
+      : ''
+
+    let attentionHF: string | null = null
+    const nextHFBlockNum = this.config.chainCommon.nextHardforkBlockBN()
+    if (nextHFBlockNum !== null) {
+      const remaining = nextHFBlockNum.sub(last)
+      if (remaining.lten(10000)) {
+        const nextHF = this.config.chainCommon.getHardforkByBlockNumber(nextHFBlockNum)
+        attentionHF = `${nextHF} HF in ${remaining} blocks`
+      }
+    } else {
+      if (
+        this.config.chainCommon.hardfork() === Hardfork.MergeForkIdTransition &&
+        !this.config.chainCommon.gteHardfork(Hardfork.Merge)
+      ) {
+        const mergeTD = this.config.chainCommon.hardforkTD(Hardfork.Merge)!
+        const td = this.chain.blocks.td
+        const remaining = mergeTD.sub(td)
+        if (remaining.lte(mergeTD.divn(10))) {
+          attentionHF = `Merge HF in ${remaining} TD`
+        }
+      }
+    }
+
+    this.config.logger.info(
+      `Imported blocks count=${
+        blocks.length
+      } first=${first} last=${last} hash=${hash} ${baseFeeAdd}hardfork=${this.config.chainCommon.hardfork()} peers=${
+        this.pool.size
+      }`,
+      { attentionHF }
+    )
+
+    this.txPool.removeNewBlockTxs(blocks)
+
+    if (!this.running) return
+    await this.execution.run()
+    this.txPool.checkRunState()
   }
 }

--- a/packages/client/lib/sync/fetcher/blockfetcherbase.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcherbase.ts
@@ -40,7 +40,7 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
     this.chain = options.chain
     this.first = options.first
     this.count = options.count
-    this.height = this.first.add(this.count).subn(1)
+    this.height = this.first?.add(this.count).subn(1)
     this.debug(
       `Block fetcher instantiated interval=${this.interval} first=${this.first} count=${this.count} destroyWhenDone=${this.destroyWhenDone}`
     )

--- a/packages/client/lib/sync/fetcher/blockfetcherbase.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcherbase.ts
@@ -12,8 +12,6 @@ export interface BlockFetcherOptions extends FetcherOptions {
   /* How many blocks to fetch */
   count: BN
 
-  height: BN
-
   /* Destroy fetcher once all tasks are done */
   destroyWhenDone?: boolean
 }
@@ -42,7 +40,7 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
     this.chain = options.chain
     this.first = options.first
     this.count = options.count
-    this.height = options.height
+    this.height = this.first.add(this.count).subn(1)
     this.debug(
       `Block fetcher instantiated interval=${this.interval} first=${this.first} count=${this.count} destroyWhenDone=${this.destroyWhenDone}`
     )

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -442,6 +442,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
     }
     this.write()
     this.running = true
+    this.nextTasks()
 
     while (this.running) {
       if (!this.next()) {

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -188,6 +188,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
       state: 'idle',
       peer: null,
     }
+    this.debug(`enqueueTask ${this.jobStr(job)}`)
     this.in.insert(job)
     if (!this.running && autoRestart) {
       void this.fetch()

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -1,9 +1,20 @@
+import { Hardfork } from '@ethereumjs/common'
 import { BN } from 'ethereumjs-util'
 import { Peer } from '../net/peer/peer'
 import { short } from '../util'
+import { Event } from '../types'
 import { Synchronizer, SynchronizerOptions } from './sync'
 import { BlockFetcher } from './fetcher'
-import type { Block } from '@ethereumjs/block'
+import { VMExecution } from '../execution'
+import type { Block, BlockHeader } from '@ethereumjs/block'
+import type { TxPool } from '../service/txpool'
+
+interface FullSynchronizerOptions extends SynchronizerOptions {
+  /** Tx Pool */
+  txPool: TxPool
+  execution: VMExecution
+}
+
 interface HandledObject {
   hash: Buffer
   added: number
@@ -15,11 +26,19 @@ type PeerId = string
  * @memberof module:sync
  */
 export class FullSynchronizer extends Synchronizer {
+  private txPool: TxPool
+  private execution: VMExecution
   private newBlocksKnownByPeer: Map<PeerId, HandledObject[]>
 
-  constructor(options: SynchronizerOptions) {
+  constructor(options: FullSynchronizerOptions) {
     super(options)
+    this.txPool = options.txPool
+    this.execution = options.execution
     this.newBlocksKnownByPeer = new Map()
+
+    this.config.events.on(Event.SYNC_FETCHER_FETCHED, this.processBlocks)
+    this.config.events.on(Event.SYNC_EXECUTION_VM_ERROR, this.stop)
+
     void this.chain.update()
   }
 
@@ -42,6 +61,7 @@ export class FullSynchronizer extends Synchronizer {
     const hash = this.chain.blocks.latest!.hash()
     this.startingBlock = number
     this.config.chainCommon.setHardforkByBlockNumber(number, td)
+
     this.config.logger.info(
       `Latest local block number=${Number(number)} td=${td} hash=${short(
         hash
@@ -247,11 +267,80 @@ export class FullSynchronizer extends Synchronizer {
     }
   }
 
+  async stop(): Promise<boolean> {
+    this.config.events.on(Event.SYNC_FETCHER_FETCHED, this.processBlocks)
+    this.config.events.on(Event.SYNC_EXECUTION_VM_ERROR, this.stop)
+
+    return await super.stop()
+  }
+
   /**
    * Close synchronizer.
    */
   async close() {
     if (!this.opened) return
     await super.close()
+  }
+
+  async processBlocks(blocks: Block[] | BlockHeader[]) {
+    if (this.config.chainCommon.gteHardfork(Hardfork.Merge)) {
+      if (this.fetcher !== null) {
+        // If we are beyond the merge block we should stop the fetcher
+        this.config.logger.info('Merge hardfork reached, stopping block fetcher')
+        this.clearFetcher()
+      }
+    }
+
+    if (blocks.length === 0) {
+      if (this.fetcher !== null) {
+        this.config.logger.warn('No blocks fetched are applicable for import')
+      }
+      return
+    }
+
+    blocks = blocks as Block[]
+    const first = blocks[0].header.number
+    const last = blocks[blocks.length - 1].header.number
+    const hash = short(blocks[0].hash())
+    const baseFeeAdd = this.config.chainCommon.gteHardfork(Hardfork.London)
+      ? `baseFee=${blocks[0].header.baseFeePerGas} `
+      : ''
+
+    let attentionHF: string | null = null
+    const nextHFBlockNum = this.config.chainCommon.nextHardforkBlockBN()
+    if (nextHFBlockNum !== null) {
+      const remaining = nextHFBlockNum.sub(last)
+      if (remaining.lten(10000)) {
+        const nextHF = this.config.chainCommon.getHardforkByBlockNumber(nextHFBlockNum)
+        attentionHF = `${nextHF} HF in ${remaining} blocks`
+      }
+    } else {
+      if (
+        this.config.chainCommon.hardfork() === Hardfork.MergeForkIdTransition &&
+        !this.config.chainCommon.gteHardfork(Hardfork.Merge)
+      ) {
+        const mergeTD = this.config.chainCommon.hardforkTD(Hardfork.Merge)!
+        const td = this.chain.blocks.td
+        const remaining = mergeTD.sub(td)
+        if (remaining.lte(mergeTD.divn(10))) {
+          attentionHF = `Merge HF in ${remaining} TD`
+        }
+      }
+    }
+
+    this.config.logger.info(
+      `Imported blocks count=${
+        blocks.length
+      } first=${first} last=${last} hash=${hash} ${baseFeeAdd}hardfork=${this.config.chainCommon.hardfork()} peers=${
+        this.pool.size
+      }`,
+      { attentionHF }
+    )
+
+    this.txPool.removeNewBlockTxs(blocks)
+
+    if (!this.running) return
+    await this.execution.run()
+    this.txPool.checkRunState()
   }
 }

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -151,6 +151,68 @@ export class FullSynchronizer extends Synchronizer {
     return null
   }
 
+  async processBlocks(blocks: Block[] | BlockHeader[]) {
+    if (this.config.chainCommon.gteHardfork(Hardfork.Merge)) {
+      if (this.fetcher !== null) {
+        // If we are beyond the merge block we should stop the fetcher
+        this.config.logger.info('Merge hardfork reached, stopping block fetcher')
+        this.clearFetcher()
+      }
+    }
+
+    if (blocks.length === 0) {
+      if (this.fetcher !== null) {
+        this.config.logger.warn('No blocks fetched are applicable for import')
+      }
+      return
+    }
+
+    blocks = blocks as Block[]
+    const first = blocks[0].header.number
+    const last = blocks[blocks.length - 1].header.number
+    const hash = short(blocks[0].hash())
+    const baseFeeAdd = this.config.chainCommon.gteHardfork(Hardfork.London)
+      ? `baseFee=${blocks[0].header.baseFeePerGas} `
+      : ''
+
+    let attentionHF: string | null = null
+    const nextHFBlockNum = this.config.chainCommon.nextHardforkBlockBN()
+    if (nextHFBlockNum !== null) {
+      const remaining = nextHFBlockNum.sub(last)
+      if (remaining.lten(10000)) {
+        const nextHF = this.config.chainCommon.getHardforkByBlockNumber(nextHFBlockNum)
+        attentionHF = `${nextHF} HF in ${remaining} blocks`
+      }
+    } else {
+      if (
+        this.config.chainCommon.hardfork() === Hardfork.MergeForkIdTransition &&
+        !this.config.chainCommon.gteHardfork(Hardfork.Merge)
+      ) {
+        const mergeTD = this.config.chainCommon.hardforkTD(Hardfork.Merge)!
+        const td = this.chain.blocks.td
+        const remaining = mergeTD.sub(td)
+        if (remaining.lte(mergeTD.divn(10))) {
+          attentionHF = `Merge HF in ${remaining} TD`
+        }
+      }
+    }
+
+    this.config.logger.info(
+      `Imported blocks count=${
+        blocks.length
+      } first=${first} last=${last} hash=${hash} ${baseFeeAdd}hardfork=${this.config.chainCommon.hardfork()} peers=${
+        this.pool.size
+      }`,
+      { attentionHF }
+    )
+
+    this.txPool.removeNewBlockTxs(blocks)
+
+    if (!this.running) return
+    await this.execution.run()
+    this.txPool.checkRunState()
+  }
+
   /**
    * Add newly broadcasted blocks to peer record
    * @param blockHash hash of block received in NEW_BLOCK message
@@ -280,67 +342,5 @@ export class FullSynchronizer extends Synchronizer {
   async close() {
     if (!this.opened) return
     await super.close()
-  }
-
-  async processBlocks(blocks: Block[] | BlockHeader[]) {
-    if (this.config.chainCommon.gteHardfork(Hardfork.Merge)) {
-      if (this.fetcher !== null) {
-        // If we are beyond the merge block we should stop the fetcher
-        this.config.logger.info('Merge hardfork reached, stopping block fetcher')
-        this.clearFetcher()
-      }
-    }
-
-    if (blocks.length === 0) {
-      if (this.fetcher !== null) {
-        this.config.logger.warn('No blocks fetched are applicable for import')
-      }
-      return
-    }
-
-    blocks = blocks as Block[]
-    const first = blocks[0].header.number
-    const last = blocks[blocks.length - 1].header.number
-    const hash = short(blocks[0].hash())
-    const baseFeeAdd = this.config.chainCommon.gteHardfork(Hardfork.London)
-      ? `baseFee=${blocks[0].header.baseFeePerGas} `
-      : ''
-
-    let attentionHF: string | null = null
-    const nextHFBlockNum = this.config.chainCommon.nextHardforkBlockBN()
-    if (nextHFBlockNum !== null) {
-      const remaining = nextHFBlockNum.sub(last)
-      if (remaining.lten(10000)) {
-        const nextHF = this.config.chainCommon.getHardforkByBlockNumber(nextHFBlockNum)
-        attentionHF = `${nextHF} HF in ${remaining} blocks`
-      }
-    } else {
-      if (
-        this.config.chainCommon.hardfork() === Hardfork.MergeForkIdTransition &&
-        !this.config.chainCommon.gteHardfork(Hardfork.Merge)
-      ) {
-        const mergeTD = this.config.chainCommon.hardforkTD(Hardfork.Merge)!
-        const td = this.chain.blocks.td
-        const remaining = mergeTD.sub(td)
-        if (remaining.lte(mergeTD.divn(10))) {
-          attentionHF = `Merge HF in ${remaining} TD`
-        }
-      }
-    }
-
-    this.config.logger.info(
-      `Imported blocks count=${
-        blocks.length
-      } first=${first} last=${last} hash=${hash} ${baseFeeAdd}hardfork=${this.config.chainCommon.hardfork()} peers=${
-        this.pool.size
-      }`,
-      { attentionHF }
-    )
-
-    this.txPool.removeNewBlockTxs(blocks)
-
-    if (!this.running) return
-    await this.execution.run()
-    this.txPool.checkRunState()
   }
 }

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -36,6 +36,9 @@ export class FullSynchronizer extends Synchronizer {
     this.execution = options.execution
     this.newBlocksKnownByPeer = new Map()
 
+    this.processBlocks = this.processBlocks.bind(this)
+    this.stop = this.stop.bind(this)
+
     this.config.events.on(Event.SYNC_FETCHER_FETCHED, this.processBlocks)
     this.config.events.on(Event.SYNC_EXECUTION_VM_ERROR, this.stop)
 
@@ -330,8 +333,8 @@ export class FullSynchronizer extends Synchronizer {
   }
 
   async stop(): Promise<boolean> {
-    this.config.events.on(Event.SYNC_FETCHER_FETCHED, this.processBlocks)
-    this.config.events.on(Event.SYNC_EXECUTION_VM_ERROR, this.stop)
+    this.config.events.removeListener(Event.SYNC_FETCHER_FETCHED, this.processBlocks)
+    this.config.events.removeListener(Event.SYNC_EXECUTION_VM_ERROR, this.stop)
 
     return await super.stop()
   }

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -119,7 +119,6 @@ export class FullSynchronizer extends Synchronizer {
             interval: this.interval,
             first,
             count,
-            height,
             destroyWhenDone: false,
           })
         } else {

--- a/packages/client/lib/sync/lightsync.ts
+++ b/packages/client/lib/sync/lightsync.ts
@@ -127,7 +127,9 @@ export class LightSynchronizer extends Synchronizer {
             destroyWhenDone: false,
           })
         } else {
-          if (height.gt(this.fetcher.height)) this.fetcher.height = height
+          const fetcherHeight = this.fetcher.first.add(this.fetcher.count).subn(1)
+          if (height.gt(fetcherHeight)) this.fetcher.count.iadd(height.sub(fetcherHeight))
+          this.config.logger.info(`peer=${peer} updated fetcher target to height=${height}`)
         }
       }
     }

--- a/packages/client/lib/sync/lightsync.ts
+++ b/packages/client/lib/sync/lightsync.ts
@@ -1,10 +1,8 @@
-import { Hardfork } from '@ethereumjs/common'
+import { BN } from 'ethereumjs-util'
 import { Peer } from '../net/peer/peer'
 import { short } from '../util'
-import { Event } from '../types'
 import { Synchronizer, SynchronizerOptions } from './sync'
 import { HeaderFetcher } from './fetcher'
-import type { BlockHeader } from '@ethereumjs/block'
 
 /**
  * Implements an ethereum light sync synchronizer
@@ -81,78 +79,39 @@ export class LightSynchronizer extends Synchronizer {
    * @param peer remote peer to sync with
    * @return Resolves when sync completed
    */
-  async syncWithPeer(peer?: Peer): Promise<boolean> {
-    // eslint-disable-next-line no-async-promise-executor
-    return await new Promise(async (resolve, reject) => {
-      if (!peer) return resolve(false)
-
-      const latest = await this.latest(peer)
-      if (!latest) return resolve(false)
-
+  async syncWithPeer(peer?: Peer): Promise<HeaderFetcher | null> {
+    let latest
+    if (peer && (latest = await this.latest(peer))) {
       const height = peer.les!.status.headNum
       if (!this.config.syncTargetHeight || this.config.syncTargetHeight.lt(height)) {
         this.config.syncTargetHeight = height
         this.config.logger.info(`New sync target height=${height} hash=${short(latest.hash())}`)
       }
 
-      const first = this.chain.headers.height.addn(1)
+      // Start fetcher from a safe distance behind because if the previous fetcher exited
+      // due to a reorg, it would make sense to step back and refetch.
+      const first = BN.max(
+        this.chain.headers.height.addn(1).subn(this.config.safeReorgDistance),
+        new BN(1)
+      )
       const count = height.sub(first).addn(1)
-      if (count.lten(0)) return resolve(false)
-
-      this.config.logger.debug(`Syncing with peer: ${peer.toString(true)} height=${height}`)
-
-      this.fetcher = new HeaderFetcher({
-        config: this.config,
-        pool: this.pool,
-        chain: this.chain,
-        flow: this.flow,
-        interval: this.interval,
-        first,
-        count,
-        destroyWhenDone: false,
-      })
-
-      this.config.events.on(Event.SYNC_FETCHER_FETCHED, (headers) => {
-        headers = headers as BlockHeader[]
-        if (headers.length === 0) {
-          this.config.logger.warn('No headers fetched are applicable for import')
-          return
+      if (count.gtn(0)) {
+        if (!this.fetcher || this.fetcher.errored) {
+          return new HeaderFetcher({
+            config: this.config,
+            pool: this.pool,
+            chain: this.chain,
+            flow: this.flow,
+            interval: this.interval,
+            first,
+            count,
+            destroyWhenDone: false,
+          })
+        } else {
+          if (height.gt(this.fetcher.height)) this.fetcher.height = height
         }
-        const first = headers[0].number
-        const hash = short(headers[0].hash())
-        const baseFeeAdd = this.config.chainCommon.gteHardfork(Hardfork.London)
-          ? `baseFee=${headers[0].baseFeePerGas} `
-          : ''
-        this.config.logger.info(
-          `Imported headers count=${headers.length} number=${first} hash=${hash} ${baseFeeAdd}peers=${this.pool.size}`
-        )
-      })
-
-      this.config.events.on(Event.SYNC_SYNCHRONIZED, () => {
-        resolve(true)
-      })
-
-      try {
-        await this.fetcher.fetch()
-      } catch (error: any) {
-        reject(error)
       }
-    })
-  }
-
-  /**
-   * Stop synchronization.
-   * Returns a promise that resolves once its stopped.
-   */
-  async stop(): Promise<boolean> {
-    if (!this.running) {
-      return false
     }
-    if (this.fetcher) {
-      this.fetcher.destroy()
-      this.fetcher = null
-    }
-    await super.stop()
-    return true
+    return null
   }
 }

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -189,12 +189,11 @@ export abstract class Synchronizer {
           if (this.fetcher) {
             await this.fetcher.fetch()
           }
-          resolve(true)
+          resolveSync(true)
         } catch (error: any) {
-          reject(error)
-        } finally {
-          this.config.events.removeListener(Event.SYNC_SYNCHRONIZED, resolveSync)
           this.clearFetcher()
+          this.config.events.removeListener(Event.SYNC_SYNCHRONIZED, resolveSync)
+          reject(error)
         }
       })
     }

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -189,7 +189,7 @@ export abstract class Synchronizer {
           if (this.fetcher) {
             await this.fetcher.fetch()
           }
-          resolveSync(true)
+          resolveSync()
         } catch (error: any) {
           this.clearFetcher()
           this.config.events.removeListener(Event.SYNC_SYNCHRONIZED, resolveSync)

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -43,7 +43,7 @@ export abstract class Synchronizer {
 
   protected pool: PeerPool
   protected chain: Chain
-  protected fetcher: BlockFetcher | HeaderFetcher | null
+  fetcher: BlockFetcher | HeaderFetcher | null
   protected flow: FlowControl
   protected interval: number
   public opened: boolean
@@ -135,7 +135,7 @@ export abstract class Synchronizer {
 
   abstract best(): Peer | undefined
 
-  abstract syncWithPeer(peer?: Peer): Promise<boolean>
+  abstract syncWithPeer(peer?: Peer): Promise<BlockFetcher | HeaderFetcher | null>
 
   /**
    * Checks if the synchronized state of the chain has changed
@@ -172,13 +172,48 @@ export abstract class Synchronizer {
       peer = this.best()
       numAttempts += 1
     }
-    return this.syncWithPeer(peer)
+    const fetcher = await this.syncWithPeer(peer)
+    if (fetcher) {
+      this.clearFetcher()
+      this.fetcher = fetcher
+
+      // eslint-disable-next-line no-async-promise-executor
+      return new Promise(async (resolve, reject) => {
+        const resolveSync = () => {
+          this.clearFetcher()
+          this.config.events.removeListener(Event.SYNC_SYNCHRONIZED, resolveSync)
+          resolve(true)
+        }
+        this.config.events.on(Event.SYNC_SYNCHRONIZED, resolveSync)
+        try {
+          if (this.fetcher) {
+            await this.fetcher.fetch()
+          }
+          resolve(true)
+        } catch (error: any) {
+          reject(error)
+        } finally {
+          this.config.events.removeListener(Event.SYNC_SYNCHRONIZED, resolveSync)
+          this.clearFetcher()
+        }
+      })
+    }
+    return false
+  }
+
+  clearFetcher() {
+    if (this.fetcher) {
+      this.fetcher.clear()
+      this.fetcher.destroy()
+      this.fetcher = null
+    }
   }
 
   async stop(): Promise<boolean> {
     if (!this.running) {
       return false
     }
+    this.clearFetcher()
     clearInterval(this._syncedStatusCheckInterval as NodeJS.Timeout)
     await new Promise((resolve) => setTimeout(resolve, this.interval))
     this.running = false

--- a/packages/client/test/sync/fetcher/blockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/blockfetcher.spec.ts
@@ -58,19 +58,23 @@ tape('[BlockFetcher]', async (t) => {
 
     let blockNumberList = [new BN(11), new BN(12)]
     let min = new BN(11)
-    fetcher.enqueueByNumberList(blockNumberList, min)
+    let max = new BN(12)
+    fetcher.enqueueByNumberList(blockNumberList, min, max)
     t.equals((fetcher as any).in.size(), 3, '1 new task for two subsequent block numbers')
 
     blockNumberList = [new BN(13), new BN(15)]
     min = new BN(13)
-    fetcher.enqueueByNumberList(blockNumberList, min)
-    t.equals((fetcher as any).in.size(), 5, '2 new tasks for two non-subsequent block numbers')
+    max = new BN(15)
+    fetcher.enqueueByNumberList(blockNumberList, min, max)
+    t.equals((fetcher as any).in.size(), 3, 'no new task added only the height changed')
+    t.equals(fetcher.first.add(fetcher.count).subn(1).eqn(15), true, 'height should now be 15')
 
     // Clear fetcher queue for next test of gap when following head
     fetcher.clear()
     blockNumberList = [new BN(50), new BN(51)]
     min = new BN(50)
-    fetcher.enqueueByNumberList(blockNumberList, min)
+    max = new BN(51)
+    fetcher.enqueueByNumberList(blockNumberList, min, max)
     t.equals(
       (fetcher as any).in.size(),
       11,

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -7,6 +7,8 @@ import { Event } from '../../lib/types'
 import { Block } from '@ethereumjs/block'
 
 tape('[FullSynchronizer]', async (t) => {
+  const txPool: any = { removeNewBlockTxs: () => {}, checkRunState: () => {} }
+  const execution: any = { run: () => {} }
   class PeerPool {
     open() {}
     close() {}
@@ -32,7 +34,7 @@ tape('[FullSynchronizer]', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
     const chain = new Chain({ config })
-    const sync = new FullSynchronizer({ config, pool, chain })
+    const sync = new FullSynchronizer({ config, pool, chain, txPool, execution })
     t.equals(sync.type, 'full', 'full type')
     t.end()
   })
@@ -45,6 +47,8 @@ tape('[FullSynchronizer]', async (t) => {
       config,
       pool,
       chain,
+      txPool,
+      execution,
     })
     ;(sync as any).pool.open = td.func<PeerPool['open']>()
     ;(sync as any).pool.peers = []
@@ -59,7 +63,7 @@ tape('[FullSynchronizer]', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
     const chain = new Chain({ config })
-    const sync = new FullSynchronizer({ config, pool, chain })
+    const sync = new FullSynchronizer({ config, pool, chain, txPool, execution })
     const peer = { eth: { getBlockHeaders: td.func(), status: { bestHash: 'hash' } } }
     const headers = [{ number: new BN(5) }]
     td.when(peer.eth.getBlockHeaders({ block: 'hash', max: 1 })).thenResolve([new BN(1), headers])
@@ -79,6 +83,8 @@ tape('[FullSynchronizer]', async (t) => {
       interval: 1,
       pool,
       chain,
+      txPool,
+      execution,
     })
     ;(sync as any).running = true
     ;(sync as any).height = td.func()
@@ -111,6 +117,8 @@ tape('[FullSynchronizer]', async (t) => {
       interval: 1,
       pool,
       chain,
+      txPool,
+      execution,
     })
     sync.best = td.func<typeof sync['best']>()
     sync.latest = td.func<typeof sync['latest']>()
@@ -149,6 +157,8 @@ tape('[FullSynchronizer]', async (t) => {
       interval: 1,
       pool,
       chain,
+      txPool,
+      execution,
     })
     ;(sync as any).fetcher = {
       enqueueByNumberList: (blockNumberList: BN[], min: BN) => {

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -7,7 +7,6 @@ import { Event } from '../../lib/types'
 import { Block } from '@ethereumjs/block'
 
 tape('[FullSynchronizer]', async (t) => {
-  const txPool: any = { removeNewBlockTxs: () => {}, checkRunState: () => {} }
   class PeerPool {
     open() {}
     close() {}
@@ -33,7 +32,7 @@ tape('[FullSynchronizer]', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
     const chain = new Chain({ config })
-    const sync = new FullSynchronizer({ config, pool, chain, txPool })
+    const sync = new FullSynchronizer({ config, pool, chain })
     t.equals(sync.type, 'full', 'full type')
     t.end()
   })
@@ -46,7 +45,6 @@ tape('[FullSynchronizer]', async (t) => {
       config,
       pool,
       chain,
-      txPool,
     })
     ;(sync as any).pool.open = td.func<PeerPool['open']>()
     ;(sync as any).pool.peers = []
@@ -61,7 +59,7 @@ tape('[FullSynchronizer]', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
     const chain = new Chain({ config })
-    const sync = new FullSynchronizer({ config, pool, chain, txPool: txPool })
+    const sync = new FullSynchronizer({ config, pool, chain })
     const peer = { eth: { getBlockHeaders: td.func(), status: { bestHash: 'hash' } } }
     const headers = [{ number: new BN(5) }]
     td.when(peer.eth.getBlockHeaders({ block: 'hash', max: 1 })).thenResolve([new BN(1), headers])
@@ -81,7 +79,6 @@ tape('[FullSynchronizer]', async (t) => {
       interval: 1,
       pool,
       chain,
-      txPool,
     })
     ;(sync as any).running = true
     ;(sync as any).height = td.func()
@@ -114,7 +111,6 @@ tape('[FullSynchronizer]', async (t) => {
       interval: 1,
       pool,
       chain,
-      txPool,
     })
     sync.best = td.func<typeof sync['best']>()
     sync.latest = td.func<typeof sync['latest']>()
@@ -153,7 +149,6 @@ tape('[FullSynchronizer]', async (t) => {
       interval: 1,
       pool,
       chain,
-      txPool,
     })
     ;(sync as any).fetcher = {
       enqueueByNumberList: (blockNumberList: BN[], min: BN) => {

--- a/packages/client/test/sync/sync.spec.ts
+++ b/packages/client/test/sync/sync.spec.ts
@@ -8,7 +8,7 @@ import { Event } from '../../lib/types'
 
 class SynchronizerTest extends Synchronizer {
   async syncWithPeer() {
-    return true
+    return null
   }
   async sync() {
     return false


### PR DESCRIPTION
This PR refactors services, syncronizers and fetchers to make things cleaner for beacon sync
- [x] ~~Move txPool and `processBlocks` references out of `syncronizer` to the `fullethereumservice` so that txPool's processing will also be available in beacon sync processing of canonical chain~~ 
  As discussed with @ryanio this is per syncronizer processing, so moved back to the fullsync as beacon sync will have its own. however also moved the event association with it as its better that syncronizer wires up/cleans its own events
- [x] Fetcher now doesn't create tasks all the way to chainHeight, rather it creates tasks now in batch of 100 (configurable) and then creates more when the previous one are done
- [x] Earlier if better peer was available (With better height) the previous fetcher was torn apart and new one was created. With the new approach of creating more tasks when previous ones are done with, and updating height if better height is available with, this is no longer required. This could lead to more leaner processing of the fetching jobs.
- [x] Abstracted the fetch loop logic out of the derived syncronizers to the base syncronizer class which also looks extendable to the potential beacon sync syncronizer (with first cut look at @ryanio 's optimistic sync). Hopefull this leads to cleaner code and more usable/tested components across the syncronizers.
- [x] Some code cleanup like move `clearFetcher`,`stop` to the base syncronizer,
- [x] Update Height on the new hashes annoucement (`enqueueByNumberList`)
- [x] Removed the filtering (out) of postmerge blocks on GetBlocks/GetHeaders request responses as this is how some other node using beacon sync might get data from us.  

Testing
- [x] Test sync with single peer pre-merge
- [x] Test sync with multi peer pre-merge
- [x] Test sync post merge