### PR TITLE
client: pass the maxFetcherJobs arg to the config

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -613,6 +613,7 @@ async function run() {
     logger,
     maxPeers: args.maxPeers,
     maxPerRequest: args.maxPerRequest,
+    maxFetcherJobs: args.maxFetcherJobs,
     mine: args.mine || args.dev,
     minerCoinbase: args.minerCoinbase,
     minPeers: args.minPeers,


### PR DESCRIPTION
In the PR https://github.com/ethereumjs/ethereumjs-monorepo/pull/1858 @holgerd77  noticed that maxFetcherJobs was not being picked up.
this PR fixes the same.

Behavior on passing `--maxFetcherJobs=0`:
![image](https://user-images.githubusercontent.com/76567250/164422298-9d7882de-22fd-488a-ab5f-905910657496.png)
The fetcher keeps on regularly trying to enqueue jobs but to no avail :+1: 