### PR TITLE
Fix broken Readme link to run the VM in a browser

### DIFF
--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -70,7 +70,7 @@ Note: along the `EIP-2929` (Gas cost increases for state access opcodes) impleme
 
 # BROWSER
 
-To build the VM for standalone use in the browser, see: [Running the VM in a browser](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/vm/examples/run-code-browser).
+To build the VM for standalone use in the browser, see: [Running the VM in a browser](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/vm/examples/run-code-browser.js).
 
 # SETUP
 


### PR DESCRIPTION
Clicking on the "Running the VM in a browser" link was resulting in a 404 error.
This change adds the `.js` extension to the URL, fixing the issue.