### PR TITLE
devp2p: remove `async` dependency from integration tests

### DIFF
--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -64,7 +64,6 @@
   "devDependencies": {
     "@ethereumjs/block": "^3.6.2",
     "@ethereumjs/tx": "^3.5.1",
-    "@types/async": "^2.4.1",
     "@types/chalk": "^2.2.0",
     "@types/debug": "^4.1.4",
     "@types/ip": "^1.1.0",
@@ -73,7 +72,6 @@
     "@types/node": "^16.11.7",
     "@types/secp256k1": "^4.0.1",
     "@types/tape": "^4.13.2",
-    "async": "^2.6.0",
     "chalk": "^2.4.2",
     "eslint": "^6.8.0",
     "nyc": "^15.1.0",

--- a/packages/devp2p/test/integration/dpt-simulator.ts
+++ b/packages/devp2p/test/integration/dpt-simulator.ts
@@ -1,17 +1,13 @@
-import async from 'async'
 import test from 'tape'
 import * as util from './util'
 import testdata from '../testdata.json'
 
-async function delay(ms: number) {
-  await new Promise((resolve) => setTimeout(resolve, ms))
-}
-
 test('DPT: new working node', (t) => {
   const dpts = util.initTwoPeerDPTSetup()
 
-  dpts[0].on('peer:new', function (peer: any) {
+  dpts[0].on('peer:new', async (peer: any) => {
     t.equal(peer.address, '127.0.0.1', 'should have added peer on peer:new')
+    await util.delay(500)
     util.destroyDPTs(dpts)
     t.end()
   })
@@ -20,8 +16,9 @@ test('DPT: new working node', (t) => {
 test('DPT: working node added', (t) => {
   const dpts = util.initTwoPeerDPTSetup()
 
-  dpts[0].on('peer:added', function () {
+  dpts[0].on('peer:added', async () => {
     t.equal(dpts[0].getPeers().length, 1, 'should have added peer to k-bucket on peer:added')
+    await util.delay(500)
     util.destroyDPTs(dpts)
     t.end()
   })
@@ -30,102 +27,74 @@ test('DPT: working node added', (t) => {
 test('DPT: remove node', (t) => {
   const dpts = util.initTwoPeerDPTSetup()
 
-  async.series(
-    [
-      function (cb) {
-        dpts[0].on('peer:added', function (peer) {
-          dpts[0].removePeer(peer)
-          cb(null)
-        })
-      },
-      function (cb) {
-        dpts[0].on('peer:removed', function () {
-          t.equal(
-            dpts[0].getPeers().length,
-            0,
-            'should have removed peer from k-bucket on peer:removed'
-          )
-          cb(null)
-        })
-      },
-    ],
-    function (err) {
-      if (err) {
-        t.fail('An unexpected error occured.')
-      }
+  try {
+    dpts[0].on('peer:added', async (peer) => {
+      await util.delay(400)
+      dpts[0].removePeer(peer)
+    })
+    dpts[0].on('peer:removed', async () => {
+      t.equal(
+        dpts[0].getPeers().length,
+        0,
+        'should have removed peer from k-bucket on peer:removed'
+      )
+      await util.delay(500)
       util.destroyDPTs(dpts)
       t.end()
-    }
-  )
+    })
+  } catch (err) {
+    t.fail(`An unexpected error occurred: ${err}`)
+  }
 })
 
 test('DPT: ban node', (t) => {
   const dpts = util.initTwoPeerDPTSetup()
 
-  async.series(
-    [
-      function (cb) {
-        dpts[0].on('peer:added', function (peer) {
-          dpts[0].banPeer(peer)
-          cb(null)
-        })
-      },
-      function (cb) {
-        dpts[0].on('peer:removed', function (peer) {
-          t.equal(dpts[0].banlist.has(peer), true, 'ban-list should contain peer')
-          t.equal(
-            dpts[0].getPeers().length,
-            0,
-            'should have removed peer from k-bucket on peer:removed'
-          )
-          cb(null)
-        })
-      },
-    ],
-    function (err) {
-      if (err) {
-        t.fail('An unexpected error occured.')
-      }
+  try {
+    dpts[0].once('peer:added', async (peer) => {
+      await util.delay(400)
+      dpts[0].banPeer(peer)
+    })
+    dpts[0].once('peer:removed', async (peer) => {
+      t.equal(dpts[0].banlist.has(peer), true, 'ban-list should contain peer')
+      t.equal(
+        dpts[0].getPeers().length,
+        0,
+        'should have removed peer from k-bucket on peer:removed'
+      )
+      await util.delay(500)
       util.destroyDPTs(dpts)
       t.end()
-    }
-  )
+    })
+  } catch (err) {
+    t.fail(`An unexpected error occurred: ${err}`)
+  }
 })
 
 test('DPT: k-bucket ping', (t) => {
   const dpts = util.initTwoPeerDPTSetup()
 
-  async.series(
-    [
-      function (cb) {
-        dpts[0].on('peer:added', function (peer: any) {
-          dpts[0]._onKBucketPing([peer], peer)
-          setTimeout(function () {
-            cb(null)
-          }, 400)
-        })
-      },
-      function (cb) {
-        t.equal(dpts[0].getPeers().length, 1, 'should still have one peer in k-bucket')
-        cb(null)
-      },
-    ],
-    function (err) {
-      if (err) {
-        t.fail('An unexpected error occured.')
-      }
+  try {
+    dpts[0].once('peer:added', async (peer: any) => {
+      dpts[0]._onKBucketPing([peer], peer)
+      await util.delay(400)
+      t.equal(dpts[0].getPeers().length, 1, 'should still have one peer in k-bucket')
+      await util.delay(400)
       util.destroyDPTs(dpts)
       t.end()
-    }
-  )
+    })
+  } catch (err) {
+    t.fail(`An unexpected error occurred: ${err}`)
+  }
 })
 
 test('DPT: add non-available node', async (t) => {
   const dpts = util.getTestDPTs(1)
   const peer = { address: util.localhost, udpPort: util.basePort + 1 }
 
-  await dpts[0].addPeer(peer).catch((e: Error) => {
+  await dpts[0].addPeer(peer).catch(async (e: Error) => {
     t.equal(e.message, 'Timeout error: ping 127.0.0.1:30307', 'should throw Timeout error')
+    await util.delay(400)
     util.destroyDPTs(dpts)
   })
 })
@@ -134,9 +103,9 @@ test('DPT: simulate bootstrap', async (t) => {
   const numDPTs = 6
   const dpts = util.getTestDPTs(numDPTs)
 
-  await delay(250)
+  await util.delay(250)
   await dpts[0].addPeer({ address: util.localhost, udpPort: util.basePort + 1 })
-  await delay(100)
+  await util.delay(100)
 
   for (const dpt of dpts.slice(2)) {
     await dpt.bootstrap({ address: util.localhost, udpPort: util.basePort + 1 })
@@ -146,16 +115,16 @@ test('DPT: simulate bootstrap', async (t) => {
     for (let i = 0; i < 10; i++) {
       dpt.refresh()
     }
-    await delay(400)
+    await util.delay(400)
   }
 
-  await delay(250)
+  await util.delay(250)
 
   // dpts.forEach((dpt, i) => console.log(`${i}:${dpt.getPeers().length}`))
   for (const dpt of dpts) {
     t.equal(dpt.getPeers().length, numDPTs, 'Peers should be distributed to all DPTs')
   }
-  await delay(1000)
+  await util.delay(1000)
 
   util.destroyDPTs(dpts)
 })
@@ -171,7 +140,7 @@ test('DPT: simulate acquiring peers via DNS', async () => {
 
   dpts[0].dns.__setNativeDNSModuleResolve(mockDns)
   dpts[0].refresh()
-  await delay(400)
+  await util.delay(400)
 
   util.destroyDPTs(dpts)
 })

--- a/packages/devp2p/test/integration/rlpx-simulator.ts
+++ b/packages/devp2p/test/integration/rlpx-simulator.ts
@@ -1,4 +1,3 @@
-import async from 'async'
 import test from 'tape'
 import * as util from './util'
 import { DISCONNECT_REASONS } from '../../src/rlpx/peer'
@@ -6,10 +5,11 @@ import { DISCONNECT_REASONS } from '../../src/rlpx/peer'
 test('RLPX: add working node', (t) => {
   const rlpxs = util.initTwoPeerRLPXSetup()
 
-  rlpxs[0].on('peer:added', function (peer: any) {
+  rlpxs[0].on('peer:added', async (peer: any) => {
     t.equal(peer._port, 30306, 'should have added peer on peer:added after successful handshake')
     t.equal(rlpxs[0].getPeers().length, 1, 'peer list length should be 1')
     t.equal(rlpxs[0]._getOpenSlots(), 9, 'should have maxPeers - 1 open slots left')
+    await util.delay(500)
     util.destroyRLPXs(rlpxs)
     t.end()
   })
@@ -17,7 +17,8 @@ test('RLPX: add working node', (t) => {
 
 test('RLPX: ban node with missing tcp port', (t) => {
   const rlpxs = util.initTwoPeerRLPXSetup()
-  rlpxs[0].on('peer:added', function () {
+
+  rlpxs[0].on('peer:added', async () => {
     const peer = {
       id: Buffer.from('abcd', 'hex'),
       address: '127.0.0.1',
@@ -30,6 +31,7 @@ test('RLPX: ban node with missing tcp port', (t) => {
     )
     rlpxs[0]._dpt!.emit('peer:new', peer)
     t.ok(rlpxs[0]._dpt!.banlist.has(peer), 'should be in ban list after bad peer discovered')
+    await util.delay(500)
     util.destroyRLPXs(rlpxs)
     t.end()
   })
@@ -38,34 +40,24 @@ test('RLPX: ban node with missing tcp port', (t) => {
 test('RLPX: remove node', (t) => {
   const rlpxs = util.initTwoPeerRLPXSetup()
 
-  async.series(
-    [
-      function (cb) {
-        rlpxs[0].on('peer:added', function (peer: any) {
-          rlpxs[0].disconnect(peer._remoteId)
-          cb(null)
-        })
-      },
-      function (cb) {
-        rlpxs[0].on('peer:removed', function (peer: any, reason: any) {
-          t.equal(
-            reason,
-            DISCONNECT_REASONS.CLIENT_QUITTING,
-            'should close with CLIENT_QUITTING disconnect reason'
-          )
-          t.equal(rlpxs[0]._getOpenSlots(), 10, 'should have maxPeers open slots left')
-          cb(null)
-        })
-      },
-    ],
-    function (err) {
-      if (err) {
-        t.fail('An unexpected error occured.')
-      }
+  try {
+    rlpxs[0].once('peer:added', (peer: any) => {
+      rlpxs[0].disconnect(peer._remoteId)
+    })
+    rlpxs[0].once('peer:removed', async (peer: any, reason: any) => {
+      t.equal(
+        reason,
+        DISCONNECT_REASONS.CLIENT_QUITTING,
+        'should close with CLIENT_QUITTING disconnect reason'
+      )
+      t.equal(rlpxs[0]._getOpenSlots(), 10, 'should have maxPeers open slots left')
+      await util.delay(500)
       util.destroyRLPXs(rlpxs)
       t.end()
-    }
-  )
+    })
+  } catch (err) {
+    t.fail(`An unexpected error occurred: ${err}`)
+  }
 })
 
 test('RLPX: test peer queue / refill connections', (t) => {
@@ -73,35 +65,26 @@ test('RLPX: test peer queue / refill connections', (t) => {
 
   const peer = { address: util.localhost, udpPort: util.basePort + 1, tcpPort: util.basePort + 1 }
   rlpxs[0]._dpt!.addPeer(peer)
-
-  async.series(
-    [
-      function (cb) {
-        rlpxs[0].once('peer:added', function () {
-          t.equal(rlpxs[0]._peersQueue.length, 0, 'peers queue should contain no peers')
-          const peer2 = {
-            address: util.localhost,
-            udpPort: util.basePort + 2,
-            tcpPort: util.basePort + 2,
-          }
-          rlpxs[0]._dpt!.addPeer(peer2)
-          cb(null)
-        })
-      },
-      function (cb) {
-        rlpxs[0].once('peer:added', function () {
-          // FIXME: values not as expected
-          // t.equal(rlpxs[0]._peersQueue.length, 1, 'peers queue should contain one peer')
-          cb(null)
-        })
-      },
-    ],
-    function (err) {
-      if (err) {
-        t.fail('An unexpected error occured.')
+  try {
+    rlpxs[0].on('peer:added', async (peer) => {
+      if (peer._socket._peername.port === util.basePort + 1) {
+        t.equal(rlpxs[0]._peersQueue.length, 0, 'peers queue should contain no peers')
+        const peer2 = {
+          address: util.localhost,
+          udpPort: util.basePort + 2,
+          tcpPort: util.basePort + 2,
+        }
+        rlpxs[0]._dpt!.addPeer(peer2)
+        await util.delay(500)
+        t.equal(rlpxs[0]._peersQueue.length, 1, 'peers queue should contain one peer')
       }
-      util.destroyRLPXs(rlpxs)
-      t.end()
-    }
-  )
+      if (peer._socket._peername.port === util.basePort + 2) {
+        t.equal(rlpxs[0]._peersQueue.length, 0, 'peers queue should contain no peers')
+        util.destroyRLPXs(rlpxs)
+        t.end()
+      }
+    })
+  } catch (err) {
+    t.fail(`An unexpected error occurred: ${err}`)
+  }
 })

--- a/packages/devp2p/test/integration/util.ts
+++ b/packages/devp2p/test/integration/util.ts
@@ -3,6 +3,10 @@ import { DPT, ETH, RLPx, genPrivateKey } from '../../src'
 import Common, { Chain } from '@ethereumjs/common'
 import testdata from '../testdata.json'
 
+export const delay = async (ms: number) => {
+  await new Promise((resolve) => setTimeout(resolve, ms))
+}
+
 export const localhost = '127.0.0.1'
 export const basePort = 30306
 
@@ -34,8 +38,8 @@ export function getTestDPTsWithDns(numDPTs: number) {
         udpPort: basePort + i,
         tcpPort: basePort + i,
       },
-      timeout: 100,
-      refreshInterval: 10,
+      timeout: 1000,
+      refreshInterval: 400,
       dnsNetworks: [testdata.dns.enrTree],
       shouldFindNeighbours: false,
       shouldGetDnsPeers: true,


### PR DESCRIPTION
This PR removes the `async` dep from the devp2p integration tests.

I was getting some errors from the peer liveness check when the server closed too quickly so I added some 500ms delays before closing, not sure why I had this problem.