### PR TITLE
blockchain: fix iterator return type, reinstate tests

### DIFF
--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -41,7 +41,7 @@ export interface BlockchainInterface {
    * @param onBlock - Function called on each block with params (block: Block,
    * reorg: boolean)
    */
-  iterator(name: string, onBlock: OnBlock): Promise<void | number>
+  iterator(name: string, onBlock: OnBlock): Promise<number>
 }
 
 /**

--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -24,7 +24,7 @@ export class VMExecution extends Execution {
 
   public receiptsManager?: ReceiptsManager
   private pendingReceipts?: Map<string, TxReceipt[]>
-  private vmPromise?: Promise<number | undefined>
+  private vmPromise?: Promise<number>
 
   /** Number of maximum blocks to run per iteration of {@link VMExecution.run} */
   private NUM_BLOCKS_PER_ITERATION = 50
@@ -157,7 +157,6 @@ export class VMExecution extends Execution {
       headBlock = undefined
       parentState = undefined
       errorBlock = undefined
-
       this.vmPromise = blockchain.iterator(
         'vm',
         async (block: Block, reorg: boolean) => {
@@ -247,7 +246,7 @@ export class VMExecution extends Execution {
         },
         this.NUM_BLOCKS_PER_ITERATION
       )
-      numExecuted = (await this.vmPromise) as number
+      numExecuted = await this.vmPromise
 
       if (errorBlock) {
         await this.chain.blockchain.setIteratorHead('vm', (errorBlock as Block).header.parentHash)
@@ -255,7 +254,7 @@ export class VMExecution extends Execution {
       }
 
       const endHeadBlock = await this.vm.blockchain.getIteratorHead('vm')
-      if (numExecuted > 0) {
+      if (numExecuted && numExecuted > 0) {
         const firstNumber = startHeadBlock.header.number
         const firstHash = short(startHeadBlock.hash())
         const lastNumber = endHeadBlock.header.number

--- a/packages/vm/src/runBlockchain.ts
+++ b/packages/vm/src/runBlockchain.ts
@@ -9,7 +9,7 @@ export default async function runBlockchain(
   this: VM,
   blockchain?: Blockchain,
   maxBlocks?: number
-): Promise<void | number> {
+): Promise<number> {
   let headBlock: Block
   let parentState: Buffer
 

--- a/packages/vm/tests/api/runBlockchain.spec.ts
+++ b/packages/vm/tests/api/runBlockchain.spec.ts
@@ -101,7 +101,7 @@ tape('runBlockchain', (t) => {
 
     await vm.runBlockchain()
 
-    const head = await vm.blockchain.getHead()
+    const head = await vm.blockchain.getIteratorHead()
     st.equal(head.hash().toString('hex'), testData.blocks[0].blockHeader.hash.slice(2))
 
     st.end()

--- a/packages/vm/tests/api/runBlockchain.spec.ts
+++ b/packages/vm/tests/api/runBlockchain.spec.ts
@@ -101,6 +101,9 @@ tape('runBlockchain', (t) => {
 
     await vm.runBlockchain()
 
+    const head = await vm.blockchain.getHead()
+    st.equal(head.hash().toString('hex'), testData.blocks[0].blockHeader.hash.slice(2))
+
     st.end()
   })
 
@@ -138,12 +141,16 @@ tape('runBlockchain', (t) => {
     await blockchain.putBlock(b2)
     await blockchain.putBlock(b3)
 
+    let head = await blockchain.getIteratorHead()
+    st.deepEqual(head.hash(), genesisBlock.hash(), 'Iterator head should still be at genesis')
+
     try {
       await vm.runBlockchain()
       st.fail('should have returned error')
     } catch (e: any) {
       st.equal(e.message, 'test')
-
+      head = await blockchain.getIteratorHead()
+      st.deepEqual(head.hash(), b2.hash(), 'should have removed invalid block from head')
       st.end()
     }
   })


### PR DESCRIPTION
Small task to finish #1754.

Removed 'void' as a return type for blockchain.iterator()

Adapted VM and Client methods that use the blockchain iterator

Also reinstate VM tests for blockchain.getIteratorHead()  that were a part of #1822 