### PR TITLE
client: optimistic (beacon) sync

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -250,6 +250,11 @@ const args = yargs(hideBin(process.argv))
       'Save tx receipts and logs in the meta db (warning: may use a large amount of storage). With `--rpc` allows querying via eth_getLogs (max 10000 logs per request) and eth_getTransactionReceipt (within `--txLookupLimit`)',
     boolean: true,
   })
+  .option('enableBeaconSync', {
+    describe: 'Enables beacon/optimistic sync if the CL gives fcUs which are ahead than the chain',
+    boolean: true,
+    default: true,
+  })
   .option('txLookupLimit', {
     describe:
       'Number of recent blocks to maintain transactions index for (default = about one year, 0 = entire chain)',
@@ -278,7 +283,7 @@ function initDBs(config: Config) {
 
   // Meta DB (receipts, logs, indexes, skeleton chain)
   let metaDB
-  if (args.saveReceipts || args.syncmode === SyncMode.Beacon) {
+  if (args.saveReceipts || args.enableBeaconSync) {
     const metaDataDir = config.getDataDirectory(DataDirectory.Meta)
     ensureDirSync(metaDataDir)
     metaDB = level(metaDataDir)

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -250,10 +250,10 @@ const args = yargs(hideBin(process.argv))
       'Save tx receipts and logs in the meta db (warning: may use a large amount of storage). With `--rpc` allows querying via eth_getLogs (max 10000 logs per request) and eth_getTransactionReceipt (within `--txLookupLimit`)',
     boolean: true,
   })
-  .option('enableBeaconSync', {
-    describe: 'Enables beacon/optimistic sync if the CL gives fcUs which are ahead than the chain',
+  .option('disableBeaconSync', {
+    describe:
+      'Disables beacon (optimistic) sync if the CL provides blocks at the head of the chain',
     boolean: true,
-    default: true,
   })
   .option('txLookupLimit', {
     describe:
@@ -282,12 +282,9 @@ function initDBs(config: Config) {
   const stateDB = level(stateDataDir)
 
   // Meta DB (receipts, logs, indexes, skeleton chain)
-  let metaDB
-  if (args.saveReceipts || args.enableBeaconSync) {
-    const metaDataDir = config.getDataDirectory(DataDirectory.Meta)
-    ensureDirSync(metaDataDir)
-    metaDB = level(metaDataDir)
-  }
+  const metaDataDir = config.getDataDirectory(DataDirectory.Meta)
+  ensureDirSync(metaDataDir)
+  const metaDB = level(metaDataDir)
 
   return { chainDB, stateDB, metaDB }
 }
@@ -626,6 +623,7 @@ async function run() {
     port: args.port,
     saveReceipts: args.saveReceipts,
     syncmode: args.syncmode,
+    disableBeaconSync: args.disableBeaconSync,
     transports: args.transports,
     txLookupLimit: args.txLookupLimit,
   })

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -11,7 +11,7 @@ import { _getInitializedChains } from '@ethereumjs/common/dist/chains'
 import { Address, toBuffer, BN } from 'ethereumjs-util'
 import { parseMultiaddrs, parseGenesisState, parseCustomParams } from '../lib/util'
 import EthereumClient from '../lib/client'
-import { Config, DataDirectory } from '../lib/config'
+import { Config, DataDirectory, SyncMode } from '../lib/config'
 import { Logger, getLogger } from '../lib/logging'
 import { startRPCServers, helprpc } from './startRpc'
 import type { Chain as IChain, GenesisState } from '@ethereumjs/common/dist/types'
@@ -39,7 +39,7 @@ const args = yargs(hideBin(process.argv))
   })
   .option('syncmode', {
     describe: 'Blockchain sync mode (light sync experimental)',
-    choices: ['light', 'full'],
+    choices: Object.values(SyncMode),
     default: Config.SYNCMODE_DEFAULT,
   })
   .option('lightserv', {
@@ -276,9 +276,9 @@ function initDBs(config: Config) {
   ensureDirSync(stateDataDir)
   const stateDB = level(stateDataDir)
 
-  // Meta DB (receipts, logs, indexes)
+  // Meta DB (receipts, logs, indexes, skeleton chain)
   let metaDB
-  if (args.saveReceipts) {
+  if (args.saveReceipts || args.syncmode === SyncMode.Beacon) {
     const metaDataDir = config.getDataDirectory(DataDirectory.Meta)
     ensureDirSync(metaDataDir)
     metaDB = level(metaDataDir)

--- a/packages/client/kiln/README.md
+++ b/packages/client/kiln/README.md
@@ -89,3 +89,12 @@ Also, one will need to remove `--eth1.disableEth1DepositDataTracker true` and in
 1. Download latest Teku binary [here](https://github.com/ConsenSys/teku/releases) and extract from archive
 2. Run cmd (with checkpoint sync): `./teku --data-path "./data" --network kiln --initial-state="https://lodestar-kiln.chainsafe.io/eth/v2/debug/beacon/states/finalized" --ee-endpoint http://localhost:8551 --ee-jwt-secret-file "/path/to/ethjs/packages/client/kiln/datadir/jwtsecret" --logging=DEBUG`
 
+### Nimbus
+
+#### Beacon
+1. Build Nimbus following the [kiln instructions](https://nimbus.guide/kiln.html#3-nimbus)
+2. Get your hands on a SSZ encoded finalized state/block snapshot from a synced client (I used Teku).  Assuming you have a synced Teku (or other CL node running locally that exposes the Beacon REST API), you can use the below `curl` commands to get it.
+`curl -H 'Accept: application/octet-stream' http://127.0.0.1:5051/eth/v2/debug/beacon/states/finalized > state.ssz`
+`curl -H 'Accept: application/octet-stream' http://127.0.0.1:5051/eth/v2/beacon/blocks/[block number corresponding to finalized state above] > block.ssz`
+3. Run cmd (with checkpoint sync and adjust ports/paths accordingly for ): `build/nimbus_beacon_node --network=vendor/merge-testnets/kiln --web3-url=ws://127.0.0.1:8551 --log-level=DEBUG  --jwt-secret="/path/to/ethjs/packages/client/kiln/datadir/jwtsecret" --data-dir=build/kiln --data-dir:trusted --finalized-checkpoint-state=state.ssz --finalized-checkpoint-block=block.ssz`
+

--- a/packages/client/kiln/README.md
+++ b/packages/client/kiln/README.md
@@ -80,8 +80,9 @@ Also, one will need to remove `--eth1.disableEth1DepositDataTracker true` and in
 #### Beacon
 
 1. Use lighthouse branch `unstable` and run `make`
-1. Make dir `lighthouse/kiln` and copy in from the downloaded config dir: `config.yaml`, `genesis.ssz`, `deploy_block.txt`, `deposit_contract.txt`, `deposit_contract_block.txt`
-1. Run cmd: `lighthouse --debug-level=info --datadir=kiln/datadir --testnet-dir=kiln beacon_node --disable-enr-auto-update --dummy-eth1 --boot-nodes="enr:" --merge --http-allow-sync-stalled --metrics --disable-packet-filter --execution-endpoints=http://127.0.0.1:8551 --terminal-total-difficulty-override=`
+2. Make dir `lighthouse/kiln` and copy in from the downloaded config dir: `config.yaml`, `genesis.ssz`, `deploy_block.txt`, `deposit_contract.txt`, `deposit_contract_block.txt`
+3. Run cmd: `lighthouse --debug-level=info --datadir=kiln/datadir --testnet-dir=kiln beacon_node --disable-enr-auto-update --dummy-eth1 --boot-nodes="enr:" --merge --http-allow-sync-stalled --metrics --disable-packet-filter --execution-endpoints=http://127.0.0.1:8551 --terminal-total-difficulty-override=20000000000000`
+4. Run cmd (with checkpoint sync - tested this with a locally running syncd Nimbus client): `lighthouse bn --network kiln --terminal-total-difficulty-override=20000000000000 --merge --http-allow-sync-stalled --checkpoint-sync-url "http://localhost:5052" --logfile logs.txt --logfile-debug-level trace`
 
 ### Teku
 
@@ -96,5 +97,5 @@ Also, one will need to remove `--eth1.disableEth1DepositDataTracker true` and in
 2. Get your hands on a SSZ encoded finalized state/block snapshot from a synced client (I used Teku).  Assuming you have a synced Teku (or other CL node running locally that exposes the Beacon REST API), you can use the below `curl` commands to get it.
 `curl -H 'Accept: application/octet-stream' http://127.0.0.1:5051/eth/v2/debug/beacon/states/finalized > state.ssz`
 `curl -H 'Accept: application/octet-stream' http://127.0.0.1:5051/eth/v2/beacon/blocks/[block number corresponding to finalized state above] > block.ssz`
-3. Run cmd (with checkpoint sync and adjust ports/paths accordingly for ): `build/nimbus_beacon_node --network=vendor/merge-testnets/kiln --web3-url=ws://127.0.0.1:8551 --log-level=DEBUG  --jwt-secret="/path/to/ethjs/packages/client/kiln/datadir/jwtsecret" --data-dir=build/kiln --data-dir:trusted --finalized-checkpoint-state=state.ssz --finalized-checkpoint-block=block.ssz`
+3. Run cmd (with checkpoint sync and adjust ports/paths accordingly for your setup): `build/nimbus_beacon_node --network=vendor/merge-testnets/kiln --web3-url=ws://127.0.0.1:8551 --log-level=DEBUG  --jwt-secret="/path/to/ethjs/packages/client/kiln/datadir/jwtsecret" --data-dir=build/kiln --data-dir:trusted --finalized-checkpoint-state=state.ssz --finalized-checkpoint-block=block.ssz`
 

--- a/packages/client/kiln/README.md
+++ b/packages/client/kiln/README.md
@@ -77,8 +77,15 @@ Also, one will need to remove `--eth1.disableEth1DepositDataTracker true` and in
 
 ### Lighthouse
 
-### Beacon
+#### Beacon
 
 1. Use lighthouse branch `unstable` and run `make`
 1. Make dir `lighthouse/kiln` and copy in from the downloaded config dir: `config.yaml`, `genesis.ssz`, `deploy_block.txt`, `deposit_contract.txt`, `deposit_contract_block.txt`
 1. Run cmd: `lighthouse --debug-level=info --datadir=kiln/datadir --testnet-dir=kiln beacon_node --disable-enr-auto-update --dummy-eth1 --boot-nodes="enr:" --merge --http-allow-sync-stalled --metrics --disable-packet-filter --execution-endpoints=http://127.0.0.1:8551 --terminal-total-difficulty-override=`
+
+### Teku
+
+#### Beacon
+1. Download latest Teku binary [here](https://github.com/ConsenSys/teku/releases) and extract from archive
+2. Run cmd (with checkpoint sync): `./teku --data-path "./data" --network kiln --initial-state="https://lodestar-kiln.chainsafe.io/eth/v2/debug/beacon/states/finalized" --ee-endpoint http://localhost:8551 --ee-jwt-secret-file "/path/to/ethjs/packages/client/kiln/datadir/jwtsecret" --logging=DEBUG`
+

--- a/packages/client/kiln/README.md
+++ b/packages/client/kiln/README.md
@@ -6,10 +6,9 @@ Kiln v2 public testnet has been bootstrapped:
 
 The config files can be downloaded from the [merge-testnets](https://github.com/eth-clients/merge-testnets/tree/main/kiln) config GitHub repository.
 
-
 ## Execution - EthereumJS Setup
 
-Please ensure you have Node 12.x+ installed.
+Please ensure you have Node 16.x installed.
 
 ### Client Installation
 
@@ -28,7 +27,7 @@ The `v0.4.0` client release (respectively follow-up bug fix releases) is ready f
 npm install -g @ethereumjs/client
 ```
 
-Note that you eventually want to adopt the `config` download and accordingly modify the config file access paths as well as start the client just with `ethereumjs` instad of using the `npm run client:start` GitHub start command (also leave the inbetween `--` to forward the client config options).
+Note that you eventually want to adopt the `config` download and accordingly modify the config file access paths as well as start the client just with `ethereumjs` instead of using the `npm run client:start` GitHub start command (also leave the in-between `--` to forward the client config options).
 
 #### Docker
 
@@ -67,7 +66,7 @@ To prevent the secret to be re-generated next time you restart the client, pass 
 1. Use lodestar branch `master` and run `yarn && yarn build`
 2. Export path of the downloaded config dir `export CONFIG_PATH=/path/to/ethereumjs-monorepo/packages/client/kiln/config`
 3. Export path of the written jwt secret file `export JWT_SECRET_PATH=/path/to/ethereumjs-monorepo/packages/client/kiln/datadir/jwtsecret`
-4. Run cmd: `./lodestar beacon --rootDir kiln/temp --paramsFile $CONFIG_PATH/config.yaml --genesisStateFile $CONFIG_PATH/genesis.ssz --bootnodesFile $CONFIG_PATH/boot_enr.yaml --network.connectToDiscv5Bootnodes --network.discv5.enabled true --eth1.enabled true --eth1.providerUrls=http://localhost:8545 --execution.urls=http://localhost:8551 --eth1.disableEth1DepositDataTracker true --jwt-secret $JWT_SECRET_PATH`
+4. Run cmd: `./lodestar beacon --rootDir kiln/temp --paramsFile $CONFIG_PATH/config.yaml --genesisStateFile $CONFIG_PATH/genesis.ssz --bootnodesFile $CONFIG_PATH/boot_enr.yaml --network.connectToDiscv5Bootnodes --network.discv5.enabled true --eth1.enabled true --eth1.providerUrls=http://localhost:8545 --execution.urls=http://localhost:8551 --eth1.disableEth1DepositDataTracker true --jwt-secret $JWT_SECRET_PATH --weakSubjectivityServerUrl https://lodestar-kiln.chainsafe.io --weakSubjectivitySyncLatest`
 
 #### Validator
 
@@ -87,15 +86,16 @@ Also, one will need to remove `--eth1.disableEth1DepositDataTracker true` and in
 ### Teku
 
 #### Beacon
+
 1. Download latest Teku binary [here](https://github.com/ConsenSys/teku/releases) and extract from archive
-2. Run cmd (with checkpoint sync): `./teku --data-path "./data" --network kiln --initial-state="https://lodestar-kiln.chainsafe.io/eth/v2/debug/beacon/states/finalized" --ee-endpoint http://localhost:8551 --ee-jwt-secret-file "/path/to/ethjs/packages/client/kiln/datadir/jwtsecret" --logging=DEBUG`
+2. Run cmd (with checkpoint sync): `./teku --data-path "./data" --network kiln --initial-state="https://lodestar-kiln.chainsafe.io/eth/v2/debug/beacon/states/finalized" --ee-endpoint http://localhost:8551 --ee-jwt-secret-file "/path/to/ethereumjs-monorepo/packages/client/kiln/datadir/jwtsecret" --logging=DEBUG`
 
 ### Nimbus
 
 #### Beacon
-1. Build Nimbus following the [kiln instructions](https://nimbus.guide/kiln.html#3-nimbus)
-2. Get your hands on a SSZ encoded finalized state/block snapshot from a synced client (I used Teku).  Assuming you have a synced Teku (or other CL node running locally that exposes the Beacon REST API), you can use the below `curl` commands to get it.
-`curl -H 'Accept: application/octet-stream' http://127.0.0.1:5051/eth/v2/debug/beacon/states/finalized > state.ssz`
-`curl -H 'Accept: application/octet-stream' http://127.0.0.1:5051/eth/v2/beacon/blocks/[block number corresponding to finalized state above] > block.ssz`
-3. Run cmd (with checkpoint sync and adjust ports/paths accordingly for your setup): `build/nimbus_beacon_node --network=vendor/merge-testnets/kiln --web3-url=ws://127.0.0.1:8551 --log-level=DEBUG  --jwt-secret="/path/to/ethjs/packages/client/kiln/datadir/jwtsecret" --data-dir=build/kiln --data-dir:trusted --finalized-checkpoint-state=state.ssz --finalized-checkpoint-block=block.ssz`
 
+1. Build Nimbus following the [kiln instructions](https://nimbus.guide/kiln.html#3-nimbus)
+2. Get your hands on a SSZ encoded finalized state/block snapshot from a synced client. Assuming you have a synced Teku (or other CL node running locally that exposes the Beacon REST API), you can use the below `curl` commands to get it.
+   `curl -H 'Accept: application/octet-stream' http://127.0.0.1:5051/eth/v2/debug/beacon/states/finalized > state.ssz`
+   `curl -H 'Accept: application/octet-stream' http://127.0.0.1:5051/eth/v2/beacon/blocks/[block number corresponding to finalized state above] > block.ssz`
+3. Run cmd (with checkpoint sync and adjust ports/paths accordingly for your setup): `build/nimbus_beacon_node --network=vendor/merge-testnets/kiln --web3-url=ws://127.0.0.1:8551 --log-level=DEBUG --jwt-secret="/path/to/ethereumjs-monorepo/packages/client/kiln/datadir/jwtsecret" --data-dir=build/kiln --data-dir:trusted --finalized-checkpoint-state=state.ssz --finalized-checkpoint-block=block.ssz`

--- a/packages/client/lib/blockchain/chain.ts
+++ b/packages/client/lib/blockchain/chain.ts
@@ -182,7 +182,7 @@ export class Chain {
     await this.blockchain.db.open()
     await this.blockchain.initPromise
     this.opened = true
-    await this.update()
+    await this.update(false)
 
     this.config.chainCommon.on('hardforkChanged', async (hardfork: string) => {
       if (hardfork !== Hardfork.Merge) {

--- a/packages/client/lib/client.ts
+++ b/packages/client/lib/client.ts
@@ -66,7 +66,7 @@ export default class EthereumClient {
     this.config = options.config
     this.chain = new Chain(options)
 
-    if (this.config.syncmode === SyncMode.Full) {
+    if (this.config.syncmode === SyncMode.Full || this.config.syncmode === SyncMode.Beacon) {
       this.services = [
         new FullEthereumService({
           config: this.config,

--- a/packages/client/lib/client.ts
+++ b/packages/client/lib/client.ts
@@ -31,8 +31,7 @@ export interface EthereumClientOptions {
    * Database to store tx receipts, logs, and indexes.
    * Should be an abstract-leveldown compliant store.
    *
-   * Default: Database created in datadir folder when
-   * `--saveReceipts` is enabled, otherwise undefined
+   * Default: Database created in datadir folder
    */
   metaDB?: LevelUp
 

--- a/packages/client/lib/client.ts
+++ b/packages/client/lib/client.ts
@@ -66,7 +66,7 @@ export default class EthereumClient {
     this.config = options.config
     this.chain = new Chain(options)
 
-    if (this.config.syncmode === SyncMode.Full || this.config.syncmode === SyncMode.Beacon) {
+    if (this.config.syncmode === SyncMode.Full) {
       this.services = [
         new FullEthereumService({
           config: this.config,

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -39,6 +39,14 @@ export interface ConfigOptions {
   syncmode?: SyncMode
 
   /**
+   * Whether to disable beacon (optimistic) sync if CL provides
+   * blocks at the head of chain.
+   *
+   * Default: false
+   */
+  disableBeaconSync?: boolean
+
+  /**
    * Provide a custom VM instance to process blocks
    *
    * Default: VM instance created by client
@@ -259,6 +267,7 @@ export class Config {
   public readonly accounts: [address: Address, privKey: Buffer][]
   public readonly minerCoinbase?: Address
   public readonly safeReorgDistance: number
+  public readonly disableBeaconSync: boolean
 
   public synchronized: boolean
   public lastSyncDate: number
@@ -295,6 +304,7 @@ export class Config {
     this.accounts = options.accounts ?? []
     this.minerCoinbase = options.minerCoinbase
     this.safeReorgDistance = options.safeReorgDistance ?? Config.SAFE_REORG_DISTANCE
+    this.disableBeaconSync = options.disableBeaconSync ?? false
 
     this.synchronized = false
     this.lastSyncDate = 0

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -20,7 +20,6 @@ export enum DataDirectory {
 export enum SyncMode {
   Full = 'full',
   Light = 'light',
-  Beacon = 'beacon',
 }
 
 export interface ConfigOptions {

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -20,6 +20,7 @@ export enum DataDirectory {
 export enum SyncMode {
   Full = 'full',
   Light = 'light',
+  Beacon = 'beacon',
 }
 
 export interface ConfigOptions {

--- a/packages/client/lib/execution/receipt.ts
+++ b/packages/client/lib/execution/receipt.ts
@@ -3,7 +3,7 @@ import { Log } from '@ethereumjs/vm/dist/evm/types'
 import Bloom from '@ethereumjs/vm/dist/bloom'
 import { TypedTransaction } from '@ethereumjs/tx'
 import { rlp, intToBuffer, bufferToInt } from 'ethereumjs-util'
-import { MetaDBManager, DBKey } from './metaDBManager'
+import { MetaDBManager, DBKey } from '../util/metaDBManager'
 import type { Block } from '@ethereumjs/block'
 
 /**

--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -53,7 +53,7 @@ export class VMExecution extends Execution {
       ;(this.vm as any).blockchain = this.chain.blockchain
     }
 
-    if (this.metaDB) {
+    if (this.metaDB && this.config.saveReceipts) {
       this.receiptsManager = new ReceiptsManager({
         chain: this.chain,
         config: this.config,

--- a/packages/client/lib/miner/miner.ts
+++ b/packages/client/lib/miner/miner.ts
@@ -6,6 +6,7 @@ import { Event } from '../types'
 import { Config } from '../config'
 import { FullEthereumService } from '../service'
 import { VMExecution } from '../execution'
+import type { FullSynchronizer } from '../sync'
 
 const level = require('level-mem')
 
@@ -300,7 +301,7 @@ export class Miner {
     this.assembling = false
     if (interrupt) return
     // Put block in blockchain
-    await this.service.synchronizer.handleNewBlock(block)
+    await (this.service.synchronizer as FullSynchronizer).handleNewBlock(block)
     // Remove included txs from TxPool
     this.service.txPool.removeNewBlockTxs([block])
     this.config.events.removeListener(Event.CHAIN_UPDATED, _boundSetInterruptHandler)

--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -66,15 +66,15 @@ export interface EthProtocolMethods {
   getReceipts: (opts: GetReceiptsOpts) => Promise<[BN, TxReceipt[]]>
 }
 
-const id = new BN(0)
-
 /**
  * Implements eth/66 protocol
  * @memberof module:net/protocol
  */
 export class EthProtocol extends Protocol {
   private chain: Chain
+  private nextReqId = new BN(0)
 
+  /* eslint-disable no-invalid-this */
   private protocolMessages: Message[] = [
     {
       name: 'NewBlockHashes',
@@ -108,7 +108,7 @@ export class EthProtocol extends Protocol {
       code: 0x03,
       response: 0x04,
       encode: ({ reqId, block, max, skip = 0, reverse = false }: GetBlockHeadersOpts) => [
-        (reqId === undefined ? id.iaddn(1) : new BN(reqId)).toArrayLike(Buffer),
+        (reqId === undefined ? this.nextReqId.iaddn(1) : new BN(reqId)).toArrayLike(Buffer),
         [BN.isBN(block) ? block.toArrayLike(Buffer) : block, max, skip, !reverse ? 0 : 1],
       ],
       decode: ([reqId, [block, max, skip, reverse]]: any) => ({
@@ -135,7 +135,7 @@ export class EthProtocol extends Protocol {
           // and we look backwards for the correct block)
           BlockHeader.fromValuesArray(h, {
             hardforkByBlockNumber: true,
-            common: this.config.chainCommon, // eslint-disable-line no-invalid-this
+            common: this.config.chainCommon,
           })
         ),
       ],
@@ -145,7 +145,7 @@ export class EthProtocol extends Protocol {
       code: 0x05,
       response: 0x06,
       encode: ({ reqId, hashes }: GetBlockBodiesOpts) => [
-        (reqId === undefined ? id.iaddn(1) : new BN(reqId)).toArrayLike(Buffer),
+        (reqId === undefined ? this.nextReqId.iaddn(1) : new BN(reqId)).toArrayLike(Buffer),
         hashes,
       ],
       decode: ([reqId, hashes]: [Buffer, Buffer[]]) => ({
@@ -168,7 +168,6 @@ export class EthProtocol extends Protocol {
       encode: ([block, td]: [Block, BN]) => [block.raw(), td.toArrayLike(Buffer)],
       decode: ([block, td]: [BlockBuffer, Buffer]) => [
         Block.fromValuesArray(block, {
-          // eslint-disable-next-line no-invalid-this
           common: this.config.chainCommon,
           hardforkByBlockNumber: true,
         }),
@@ -184,7 +183,7 @@ export class EthProtocol extends Protocol {
       code: 0x09,
       response: 0x0a,
       encode: ({ reqId, hashes }: GetPooledTransactionsOpts) => [
-        (reqId === undefined ? id.iaddn(1) : new BN(reqId)).toArrayLike(Buffer),
+        (reqId === undefined ? this.nextReqId.iaddn(1) : new BN(reqId)).toArrayLike(Buffer),
         hashes,
       ],
       decode: ([reqId, hashes]: [Buffer, Buffer[]]) => ({
@@ -219,7 +218,7 @@ export class EthProtocol extends Protocol {
       code: 0x0f,
       response: 0x10,
       encode: ({ reqId, hashes }: { reqId: BN; hashes: Buffer[] }) => [
-        (reqId === undefined ? id.iaddn(1) : new BN(reqId)).toArrayLike(Buffer),
+        (reqId === undefined ? this.nextReqId.iaddn(1) : new BN(reqId)).toArrayLike(Buffer),
         hashes,
       ],
       decode: ([reqId, hashes]: [Buffer, Buffer[]]) => ({
@@ -319,7 +318,6 @@ export class EthProtocol extends Protocol {
         : this.chain.blocks.td.toArrayLike(Buffer),
       bestHash: this.chain.blocks.latest!.hash(),
       genesisHash: this.chain.genesis.hash,
-      latestBlock: this.chain.blocks.latest!.header.number.toArrayLike(Buffer),
     }
   }
 

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -496,16 +496,30 @@ export class Engine {
     }
 
     if (!headBlock._common.gteHardfork(Hardfork.Merge)) {
-      const validTerminalBlock = await validateTerminalBlock(headBlock, this.chain)
-      if (!validTerminalBlock) {
-        const response = {
-          payloadStatus: {
-            status: Status.INVALID_TERMINAL_BLOCK,
-            validationError: null,
-            latestValidHash: null,
-          },
-          payloadId: null,
+      try {
+        const validTerminalBlock = await validateTerminalBlock(headBlock, this.chain)
+        if (!validTerminalBlock) {
+          const response = {
+            payloadStatus: {
+              status: Status.INVALID_TERMINAL_BLOCK,
+              validationError: null,
+              latestValidHash: null,
+            },
+            payloadId: null,
+          }
+          this.connectionManager.lastForkchoiceUpdate({
+            state: params[0],
+            response,
+          })
+          return response
         }
+      } catch (error) {
+        const payloadStatus = {
+          status: Status.SYNCING,
+          latestValidHash: null,
+          validationError: null,
+        }
+        const response = { payloadStatus, payloadId: null }
         this.connectionManager.lastForkchoiceUpdate({
           state: params[0],
           response,

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -8,7 +8,6 @@ import { BeaconSynchronizer } from '../../sync'
 import { middleware, validators } from '../validation'
 import { INTERNAL_ERROR, INVALID_PARAMS } from '../error-code'
 import { short } from '../../util'
-import { SyncMode } from '../../config'
 import { PendingBlock } from '../../miner'
 import { CLConnectionManager } from '../util/CLConnectionManager'
 import type VM from '@ethereumjs/vm'
@@ -267,10 +266,7 @@ export class Engine {
     }
     this.execution = this.service.execution
     this.vm = this.execution.vm
-    this.beaconSync =
-      this.config.syncmode === SyncMode.Beacon
-        ? (this.service.synchronizer as BeaconSynchronizer)
-        : undefined
+    this.beaconSync = this.service.beaconSynchronizer
     this.connectionManager = new CLConnectionManager({ config: this.chain.config })
     this.pendingBlock = new PendingBlock({ config: this.config, txPool: this.service.txPool })
     this.remoteBlocks = new Map()
@@ -393,7 +389,7 @@ export class Engine {
         }
       }
     } catch (error: any) {
-      const status = (await this.beaconSync?.extendChain(block)) ? Status.ACCEPTED : Status.SYNCING
+      const status = (await this.beaconSync?.extendChain(block)) ? Status.SYNCING : Status.ACCEPTED
       if (status !== Status.ACCEPTED) {
         // Stash the block for a potential forced forkchoice update to it later.
         this.remoteBlocks.set(block.hash().toString('hex'), block)

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -382,9 +382,6 @@ export class Engine {
         }
         this.connectionManager.lastNewPayload({ payload: params[0], response })
         return response
-      } else {
-        /** Seems like the block isn't executed yet, force execution */
-        void this.service.beaconSync?.runExecution(true)
       }
     }
 

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -392,7 +392,7 @@ export class Engine {
       const status = (await this.service.beaconSync?.extendChain(block))
         ? Status.SYNCING
         : Status.ACCEPTED
-      if (status !== Status.SYNCING) {
+      if (status === Status.ACCEPTED) {
         // Stash the block for a potential forced forkchoice update to it later.
         this.remoteBlocks.set(block.hash().toString('hex'), block)
       }

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -390,9 +390,9 @@ export class Engine {
         await this.service.switchToBeaconSync()
       }
       const status = (await this.service.beaconSync?.extendChain(block))
-        ? Status.ACCEPTED
-        : Status.SYNCING
-      if (status !== Status.ACCEPTED) {
+        ? Status.SYNCING
+        : Status.ACCEPTED
+      if (status !== Status.SYNCING) {
         // Stash the block for a potential forced forkchoice update to it later.
         this.remoteBlocks.set(block.hash().toString('hex'), block)
       }

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -473,6 +473,17 @@ export class Engine {
         (this.remoteBlocks.get(headBlockHash.slice(2)) as Block)
       if (!headBlock) {
         this.config.logger.debug(`Forkchoice requested unknown head hash=${short(headBlockHash)}`)
+        const payloadStatus = {
+          status: Status.SYNCING,
+          latestValidHash: null,
+          validationError: null,
+        }
+        const response = { payloadStatus, payloadId: null }
+        this.connectionManager.lastForkchoiceUpdate({
+          state: params[0],
+          response,
+        })
+        return response
       } else {
         this.config.logger.debug(
           `Forkchoice requested sync to new head number=${headBlock.header.number} hash=${short(
@@ -482,17 +493,6 @@ export class Engine {
         this.service.beaconSync?.setHead(headBlock)
         this.remoteBlocks.delete(headBlockHash.slice(2))
       }
-      const payloadStatus = {
-        status: Status.SYNCING,
-        latestValidHash: null,
-        validationError: null,
-      }
-      const response = { payloadStatus, payloadId: null }
-      this.connectionManager.lastForkchoiceUpdate({
-        state: params[0],
-        response,
-      })
-      return response
     }
 
     if (!headBlock._common.gteHardfork(Hardfork.Merge)) {

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -496,30 +496,16 @@ export class Engine {
     }
 
     if (!headBlock._common.gteHardfork(Hardfork.Merge)) {
-      try {
-        const validTerminalBlock = await validateTerminalBlock(headBlock, this.chain)
-        if (!validTerminalBlock) {
-          const response = {
-            payloadStatus: {
-              status: Status.INVALID_TERMINAL_BLOCK,
-              validationError: null,
-              latestValidHash: null,
-            },
-            payloadId: null,
-          }
-          this.connectionManager.lastForkchoiceUpdate({
-            state: params[0],
-            response,
-          })
-          return response
+      const validTerminalBlock = await validateTerminalBlock(headBlock, this.chain)
+      if (!validTerminalBlock) {
+        const response = {
+          payloadStatus: {
+            status: Status.INVALID_TERMINAL_BLOCK,
+            validationError: null,
+            latestValidHash: null,
+          },
+          payloadId: null,
         }
-      } catch (error) {
-        const payloadStatus = {
-          status: Status.SYNCING,
-          latestValidHash: null,
-          validationError: null,
-        }
-        const response = { payloadStatus, payloadId: null }
         this.connectionManager.lastForkchoiceUpdate({
           state: params[0],
           response,

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -1001,17 +1001,17 @@ export class Eth {
           message: `no peer available for synchronization`,
         }
       }
-      let highestBlockHeader
-      if ('latest' in synchronizer) {
-        highestBlockHeader = await synchronizer.latest(bestPeer)
+      if (bestPeer.eth?.status.latestBlock.gte(this.client.chain.headers.height)) {
+        highestBlock = bnToHex(bestPeer.eth.status.latestBlock)
+      } else if (bestPeer.les?.status.headNum) {
+        highestBlock = bnToHex(bestPeer.les.status.headNum)
       }
-      if (!highestBlockHeader) {
+      if (!highestBlock) {
         throw {
           code: INTERNAL_ERROR,
-          message: `highest block header unavailable`,
+          message: `highest block unavailable`,
         }
       }
-      highestBlock = bnToHex(highestBlockHeader.number)
     }
 
     return { startingBlock, currentBlock, highestBlock }

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -1001,7 +1001,10 @@ export class Eth {
           message: `no peer available for synchronization`,
         }
       }
-      const highestBlockHeader = await synchronizer.latest(bestPeer)
+      let highestBlockHeader
+      if ('latest' in synchronizer) {
+        highestBlockHeader = await synchronizer.latest(bestPeer)
+      }
       if (!highestBlockHeader) {
         throw {
           code: INTERNAL_ERROR,

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -994,24 +994,21 @@ export class Eth {
     if (syncTargetHeight) {
       highestBlock = bnToHex(syncTargetHeight)
     } else {
-      const bestPeer = synchronizer.best()
+      const bestPeer = await synchronizer.best()
       if (!bestPeer) {
         throw {
           code: INTERNAL_ERROR,
           message: `no peer available for synchronization`,
         }
       }
-      if (bestPeer.eth?.status.latestBlock.gte(this.client.chain.headers.height)) {
-        highestBlock = bnToHex(bestPeer.eth.status.latestBlock)
-      } else if (bestPeer.les?.status.headNum) {
-        highestBlock = bnToHex(bestPeer.les.status.headNum)
-      }
-      if (!highestBlock) {
+      const highestBlockHeader = await synchronizer.latest(bestPeer)
+      if (!highestBlockHeader) {
         throw {
           code: INTERNAL_ERROR,
-          message: `highest block unavailable`,
+          message: `highest block header unavailable`,
         }
       }
+      highestBlock = bnToHex(highestBlockHeader.number)
     }
 
     return { startingBlock, currentBlock, highestBlock }

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -106,7 +106,6 @@ export class FullEthereumService extends EthereumService {
       skeleton,
     })
     await this.synchronizer.open()
-    await this.synchronizer.start()
   }
 
   async open() {

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -51,8 +51,10 @@ export class FullEthereumService extends EthereumService {
       service: this,
     })
 
-    if (this.config.chainCommon.gteHardfork(Hardfork.Merge) && !this.config.disableBeaconSync) {
-      void this.switchToBeaconSync()
+    if (this.config.chainCommon.gteHardfork(Hardfork.Merge)) {
+      if (!this.config.disableBeaconSync) {
+        void this.switchToBeaconSync()
+      }
     } else {
       this.synchronizer = new FullSynchronizer({
         config: this.config,

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -84,6 +84,7 @@ export class FullEthereumService extends EthereumService {
           await this.synchronizer.close()
           this.miner?.stop()
           this.synchronizer = this.beaconSynchronizer
+          this.config.logger.info(`Switching over to beacon sync!`)
         }
       })
     }
@@ -103,6 +104,11 @@ export class FullEthereumService extends EthereumService {
       if (this.beaconSynchronizer.skeleton.bounds()) {
         this.synchronizer = this.beaconSynchronizer
       }
+    }
+    if (this.synchronizer instanceof FullSynchronizer) {
+      this.config.logger.info('Opening FullEthereumService with FullSynchronizer')
+    } else {
+      this.config.logger.info('Opening FullEthereumService with BeaconSynchronizer')
     }
     await super.open()
     await this.execution.open()

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -72,13 +72,8 @@ export class FullEthereumService extends EthereumService {
         pool: this.pool,
         chain: this.chain,
         interval: this.interval,
+        execution: this.execution,
         skeleton,
-      })
-      this.config.events.on(Event.SYNC_FETCHER_FETCHED, async (...args) => {
-        await this.synchronizer.processBlocks(this.execution, ...args)
-      })
-      this.config.events.on(Event.CHAIN_UPDATED, async () => {
-        await this.execution.run()
       })
     }
 

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -97,6 +97,13 @@ export class FullEthereumService extends EthereumService {
   }
 
   async open() {
+    // Check if skelton has sync status, swap syrncroniser with beacon syncronizer
+    if (this.synchronizer instanceof FullSynchronizer) {
+      await this.beaconSynchronizer.skeleton.open()
+      if (this.beaconSynchronizer.skeleton.bounds()) {
+        this.synchronizer = this.beaconSynchronizer
+      }
+    }
     await super.open()
     await this.execution.open()
     this.txPool.open()

--- a/packages/client/lib/service/txpool.ts
+++ b/packages/client/lib/service/txpool.ts
@@ -499,10 +499,7 @@ export class TxPool {
    * @param peerPool Reference to the peer pool
    */
   async handleAnnouncedTxHashes(txHashes: Buffer[], peer: Peer, peerPool: PeerPool) {
-    if (!this.running || txHashes.length === 0) {
-      return
-    }
-    this.config.logger.debug(`TxPool: received new pooled hashes number=${txHashes.length}`)
+    if (!this.running || txHashes.length === 0) return
     this.addToKnownByPeer(txHashes, peer)
     this.cleanup()
 
@@ -515,12 +512,12 @@ export class TxPool {
       reqHashes.push(txHash)
     }
 
-    if (reqHashes.length === 0) {
-      return
-    }
+    if (reqHashes.length === 0) return
+
+    this.config.logger.debug(`TxPool: received new tx hashes number=${reqHashes.length}`)
 
     const reqHashesStr: UnprefixedHash[] = reqHashes.map((hash) => hash.toString('hex'))
-    this.pending.concat(reqHashesStr)
+    this.pending = this.pending.concat(reqHashesStr)
     this.config.logger.debug(
       `TxPool: requesting txs number=${reqHashes.length} pending=${this.pending.length}`
     )

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -243,10 +243,12 @@ export class BeaconSynchronizer extends Synchronizer {
 
   /**
    * Runs vm execution on {@link Event.CHAIN_UPDATED}
+   * @params force for to run execution even if there is a single block
    */
-  async runExecution(): Promise<void> {
+  async runExecution(force?: boolean): Promise<void> {
     // Execute a single block when at head, otherwise run execution in batch of 50 blocks when filling canonical chain.
     if (
+      force ||
       this.skeleton.bounds()?.head.eq(this.chain.blocks.height.addn(1)) ||
       this.chain.blocks.height.modrn(50) === 0
     ) {

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -113,6 +113,9 @@ export class BeaconSynchronizer extends Synchronizer {
       }
       return true
     } catch (error) {
+      if (this.running) {
+        void this.stop()
+      }
       return false
     }
   }

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -145,7 +145,7 @@ export class BeaconSynchronizer extends Synchronizer {
     if (peer && (bounds = this.skeleton.bounds())) {
       const { tail } = bounds
       if (tail.subn(1).isZero()) return null // already linked
-      const first = tail.clone()
+      const first = tail.clone().subn(1)
       // Sync from tail to next subchain
       const count = tail
         .subn(1)

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -102,10 +102,15 @@ export class BeaconSynchronizer extends Synchronizer {
 
   /**
    * Start synchronizer.
+   * If passed a block, will initialize sync starting from the block.
    */
-  async start(): Promise<void> {
+  async start(block?: Block): Promise<void> {
     if (this.running) return
     this.running = true
+
+    if (block) {
+      await this.skeleton.initSync(block)
+    }
 
     const timeout = setTimeout(() => {
       this.forceSync = true
@@ -129,8 +134,7 @@ export class BeaconSynchronizer extends Synchronizer {
     if (!this.opened) return false
     try {
       if (!this.running) {
-        await this.skeleton.initSync(block)
-        void this.start()
+        void this.start(block)
       } else {
         await this.skeleton.setHead(block)
       }
@@ -153,8 +157,7 @@ export class BeaconSynchronizer extends Synchronizer {
     // from the new head.
     try {
       if (!this.running) {
-        await this.skeleton.initSync(block)
-        void this.start()
+        void this.start(block)
       } else {
         await this.skeleton.setHead(block, true)
       }
@@ -171,7 +174,7 @@ export class BeaconSynchronizer extends Synchronizer {
         )
         // Tear down fetcher and start from new head
         await this.stop()
-        void this.start()
+        void this.start(block)
         return true
       } else {
         throw error

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -73,8 +73,20 @@ export class BeaconSynchronizer extends Synchronizer {
    * blockchain. Returns null if no valid peer is found
    */
   best(): Peer | undefined {
+    let best
     const peers = this.pool.peers.filter(this.syncable.bind(this))
-    return peers.length > 0 ? peers[0] : undefined
+    for (const peer of peers) {
+      if (peer.eth?.status) {
+        const { latestBlock } = peer.eth.status
+        if (
+          (!best && latestBlock.gte(this.chain.blocks.height)) ||
+          best?.eth?.status.latestBlock.lt(latestBlock)
+        ) {
+          best = peer
+        }
+      }
+    }
+    return best
   }
 
   /**

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -180,8 +180,10 @@ export class BeaconSynchronizer extends Synchronizer {
     }
 
     blocks = blocks as Block[]
-    const first = blocks[0].header.number
-    const last = blocks[blocks.length - 1].header.number
+    // Blocks are in reverse order, but we keep our first and last terminology same
+    // as thats how its in the job logging
+    const last = blocks[0].header.number
+    const first = blocks[blocks.length - 1].header.number
     const hash = short(blocks[0].hash())
 
     this.config.logger.info(

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -102,8 +102,12 @@ export class BeaconSynchronizer extends Synchronizer {
    */
   async extendChain(block: Block, force = false): Promise<boolean> {
     if (!this.opened) return false
-    await this.skeleton.processNewHead(block, force)
-    return true
+    const canonicalHead = await this.skeleton.getBlock(this.skeleton.bounds().head)
+    if (canonicalHead?.hash().equals(block.header.parentHash)) {
+      await this.skeleton.processNewHead(block, force)
+      return true
+    }
+    return false
   }
 
   /**

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -1,0 +1,247 @@
+import { BN } from 'ethereumjs-util'
+import { short } from '../util'
+import { Event } from '../types'
+import { Synchronizer, SynchronizerOptions } from './sync'
+import { ReverseBlockFetcher } from './fetcher'
+import type { Block, BlockHeader } from '@ethereumjs/block'
+import type { Peer } from '../net/peer/peer'
+import type { Skeleton } from './skeleton'
+import type { VMExecution } from '../execution'
+
+interface BeaconSynchronizerOptions extends SynchronizerOptions {
+  /** Skeleton chain */
+  skeleton: Skeleton
+}
+
+/**
+ * Beacon sync is the post-merge version of the chain synchronization, where the
+ * chain is not downloaded from genesis onward, rather from trusted head backwards.
+ * @memberof module:sync
+ */
+export class BeaconSynchronizer extends Synchronizer {
+  private skeleton: Skeleton
+
+  public running = false
+
+  constructor(options: BeaconSynchronizerOptions) {
+    super(options)
+    this.skeleton = options.skeleton
+  }
+
+  /**
+   * Returns synchronizer type
+   */
+  get type() {
+    return 'beacon'
+  }
+
+  /**
+   * Open synchronizer. Must be called before sync() is called
+   */
+  async open(): Promise<void> {
+    await super.open()
+    await this.chain.open()
+    await this.pool.open()
+    await this.skeleton.open()
+
+    const subchain = this.skeleton.bounds()
+    if (subchain) {
+      const { head, tail, next } = subchain
+      this.config.logger.info(`Resuming beacon sync head=${head} tail=${tail} next=${short(next)}`)
+    }
+  }
+
+  /**
+   * Returns true if peer can be used for syncing
+   */
+  syncable(peer: Peer): boolean {
+    return peer.eth !== undefined
+  }
+
+  /**
+   * Finds the best peer to sync with. We will synchronize to this peer's
+   * blockchain. Returns null if no valid peer is found
+   */
+  best(): Peer | undefined {
+    const peers = this.pool.peers.filter(this.syncable.bind(this))
+    return peers.length > 0 ? peers[0] : undefined
+  }
+
+  /**
+   * Start synchronizer.
+   */
+  async start(): Promise<void> {
+    if (this.running) return
+    this.running = true
+
+    const timeout = setTimeout(() => {
+      this.forceSync = true
+    }, this.interval * 30)
+    while (this.running) {
+      try {
+        await this.sync()
+      } catch (error: any) {
+        this.config.events.emit(Event.SYNC_ERROR, error)
+      }
+      await new Promise((resolve) => setTimeout(resolve, this.interval))
+    }
+    this.running = false
+    clearTimeout(timeout)
+  }
+
+  /**
+   * Returns true if the block successfully extends the chain.
+   */
+  async extendChain(block: Block): Promise<boolean> {
+    await this.skeleton.processNewHead(block)
+    return true
+  }
+
+  /**
+   * Sets the new head of the skeleton chain.
+   */
+  async setHead(block: Block): Promise<boolean> {
+    const reorged = await this.skeleton.processNewHead(block, true)
+    // New head announced, start syncing to it if we are not already.
+    // If this causes a reorg, we will tear down the fetcher and start
+    // from the new head.
+    if (!this.running) {
+      void this.start()
+    } else {
+      if (reorged) {
+        this.config.logger.debug(
+          `Beacon sync reorged, new head number=${block.header.number} hash=${short(
+            block.header.hash()
+          )}`
+        )
+        // Tear down fetcher and start from new head
+        this.clearFetcher()
+        void this.start()
+      } else {
+        this.config.logger.debug(
+          `Beacon sync new head number=${block.header.number} hash=${short(block.header.hash())}`
+        )
+      }
+    }
+    return true
+  }
+
+  /**
+   * Sync blocks from the skeleton chain tail.
+   * @param peer remote peer to sync with
+   * @return Resolves when sync completed
+   */
+  async syncWithPeer(peer?: Peer): Promise<boolean> {
+    // eslint-disable-next-line no-async-promise-executor
+    return await new Promise(async (resolve, reject) => {
+      if (!peer) return resolve(false)
+
+      const bounds = this.skeleton.bounds()
+      if (!bounds) return resolve(false) // have no head yet
+      const { tail } = bounds
+      if (tail.subn(1).isZero()) return resolve(true) // already linked
+      const first = tail.clone()
+      // Sync from tail to next subchain
+      const count = tail
+        .subn(1)
+        .sub((this.skeleton as any).status.progress.subchains[1]?.head ?? new BN(0))
+      const resolveSync = () => {
+        resolve(true)
+      }
+      this.config.events.on(Event.SYNC_SYNCHRONIZED, resolveSync)
+      this.config.logger.debug(`Syncing with peer: ${peer.toString(true)} start=${first}`)
+
+      this.clearFetcher()
+      this.fetcher = new ReverseBlockFetcher({
+        config: this.config,
+        pool: this.pool,
+        chain: this.chain,
+        skeleton: this.skeleton,
+        interval: this.interval,
+        first,
+        count,
+        reverse: true,
+        destroyWhenDone: false,
+      })
+      try {
+        if (this.fetcher) {
+          await this.fetcher.fetch()
+        }
+        resolve(true)
+      } catch (error: any) {
+        // Since the fetcher has errored, likely because of bad data fed by the peer,
+        // the peer should be banned for at least a couple of seconds (default: 60s)
+        // to refresh its status to find the next best peer to start a new fetcher.
+        this.pool.ban(peer)
+        this.config.logger.debug(
+          `Fetcher error, temporarily banning ${peer.toString(true)}: ${error}`
+        )
+        reject(error)
+      } finally {
+        this.config.events.removeListener(Event.SYNC_SYNCHRONIZED, resolveSync)
+        this.clearFetcher()
+      }
+    })
+  }
+
+  async processBlocks(execution: VMExecution, blocks: Block[] | BlockHeader[]) {
+    if (blocks.length === 0) {
+      if (this.fetcher !== null) {
+        this.config.logger.warn('No blocks fetched are applicable for import')
+      }
+      return
+    }
+
+    blocks = blocks as Block[]
+    const first = blocks[0].header.number
+    const last = blocks[blocks.length - 1].header.number
+    const hash = short(blocks[0].hash())
+
+    this.config.logger.info(
+      `Imported blocks count=${blocks.length} first=${first} last=${last} hash=${hash} peers=${this.pool.size}`
+    )
+
+    if (!this.running) return
+
+    // If we have linked the chain, run execution
+    const { tail } = this.skeleton.bounds()
+    if (tail.eqn(0)) {
+      await execution.run()
+    }
+  }
+
+  /**
+   * Clears and destroys the fetcher
+   */
+  private clearFetcher() {
+    if (this.fetcher) {
+      this.fetcher.clear()
+      this.fetcher.destroy()
+      this.fetcher = null
+    }
+    this.running = false
+  }
+
+  /**
+   * Stop synchronization. Returns a promise that resolves once its stopped.
+   */
+  async stop(): Promise<boolean> {
+    if (!this.running) return false
+
+    if (this.fetcher) {
+      this.fetcher.destroy()
+      this.fetcher = null
+    }
+    await super.stop()
+
+    return true
+  }
+
+  /**
+   * Close synchronizer.
+   */
+  async close() {
+    if (!this.opened) return
+    await super.close()
+  }
+}

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -171,7 +171,7 @@ export class BeaconSynchronizer extends Synchronizer {
     const first = tail.subn(1)
     // Sync from tail to next subchain or chain height
     const count = first.sub(
-      (this.skeleton as any).status.progress.subchains[1]?.head ?? this.chain.blocks.height
+      (this.skeleton as any).status.progress.subchains[1]?.head.subn(1) ?? this.chain.blocks.height
     )
     if (count.gtn(0) && (!this.fetcher || this.fetcher.errored)) {
       this.fetcher = new ReverseBlockFetcher({

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -20,7 +20,7 @@ interface BeaconSynchronizerOptions extends SynchronizerOptions {
  * @memberof module:sync
  */
 export class BeaconSynchronizer extends Synchronizer {
-  private skeleton: Skeleton
+  skeleton: Skeleton
   private execution: VMExecution
 
   public running = false
@@ -209,8 +209,8 @@ export class BeaconSynchronizer extends Synchronizer {
     if (!this.running) return
 
     // If we have linked the chain, run execution
-    const { tail } = this.skeleton.bounds()
-    if (tail.eqn(0)) {
+    const bounds = this.skeleton.bounds()
+    if (bounds?.tail.eqn(0)) {
       await this.runExecution()
     }
   }

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -84,12 +84,9 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
     if (result.length === job.task.count) {
       return result
     } else if (result.length > 0 && result.length < job.task.count) {
-      // Adopt the start block/header number from the remaining jobs
-      // if the number of the results provided is lower than the expected count
+      // Save partial result to re-request missing items.
       job.partialResult = result
-      this.debug(
-        `Adopt start block/header number from remaining jobs (provided=${result.length} expected=${job.task.count})`
-      )
+      this.debug(`Partial result received=${result.length} expected=${job.task.count}`)
     }
     return
   }

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -25,10 +25,12 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
     const { task, peer, partialResult } = job
     let { first, count } = task
     if (partialResult) {
-      first = first.addn(partialResult.length)
+      first = !this.reverse ? first.addn(partialResult.length) : first.subn(partialResult.length)
       count -= partialResult.length
     }
-    const blocksRange = `${first}-${first.addn(count)}`
+    const blocksRange = !this.reverse
+      ? `${first}-${first.addn(count)}`
+      : `${first}-${first.subn(count)}`
     const peerInfo = `id=${peer?.id.slice(0, 8)} address=${peer?.address}`
 
     const headersResult = await peer!.eth!.getBlockHeaders({

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -34,6 +34,7 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
     const headersResult = await peer!.eth!.getBlockHeaders({
       block: first,
       max: count,
+      reverse: this.reverse,
     })
     if (!headersResult || headersResult[1].length === 0) {
       // Catch occasional null or empty responses

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -29,8 +29,8 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
       count -= partialResult.length
     }
     const blocksRange = !this.reverse
-      ? `${first}-${first.addn(count)}`
-      : `${first}-${first.subn(count)}`
+      ? `${first}-${first.addn(count - 1)}`
+      : `${first}-${first.subn(count - 1)}`
     const peerInfo = `id=${peer?.id.slice(0, 8)} address=${peer?.address}`
 
     const headersResult = await peer!.eth!.getBlockHeaders({

--- a/packages/client/lib/sync/fetcher/blockfetcherbase.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcherbase.ts
@@ -76,6 +76,8 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
     }
     if (count.gtn(0) && tasks.length < maxTasks) {
       tasks.push({ first: first.clone(), count: count.toNumber() })
+      !this.reverse ? first.iadd(count) : first.isub(count)
+      count.isub(count)
       pushedCount.iadd(count)
     }
     debugStr += ` count=${pushedCount}`

--- a/packages/client/lib/sync/fetcher/blockfetcherbase.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcherbase.ts
@@ -64,7 +64,7 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
   tasks(first = this.first, count = this.count, maxTasks = this.config.maxFetcherJobs): JobTask[] {
     const max = this.config.maxPerRequest
     const tasks: JobTask[] = []
-    let debugStr = `first=${first}`
+    let debugStr = !this.reverse ? `first=${first}` : `last=${first}`
     const pushedCount = new BN(0)
     if (!this.reverse) {
       while (count.gten(max) && tasks.length < maxTasks) {
@@ -83,9 +83,11 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
         tasks.push({ first: first.subn(max).addn(1), count: max })
         first.isubn(max)
         count.isubn(max)
+        pushedCount.iaddn(max)
       }
       if (count.gtn(0) && tasks.length < maxTasks) {
         tasks.push({ first: first.sub(count).addn(1), count: count.toNumber() })
+        pushedCount.iadd(count)
       }
     }
     debugStr += ` count=${pushedCount}`

--- a/packages/client/lib/sync/fetcher/blockfetcherbase.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcherbase.ts
@@ -53,7 +53,9 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
     this.count = options.count
     this.reverse = options.reverse ?? false
     this.debug(
-      `Block fetcher instantiated interval=${this.interval} first=${this.first} count=${this.count} reverse=${this.reverse} destroyWhenDone=${this.destroyWhenDone}`
+      `Block fetcher instantiated interval=${this.interval} ${!this.reverse ? 'first' : 'last'}=${
+        this.first
+      } count=${this.count} reverse=${this.reverse} destroyWhenDone=${this.destroyWhenDone}`
     )
   }
 
@@ -97,7 +99,9 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
 
   nextTasks(): void {
     if (this.in.length === 0 && this.count.gten(0)) {
-      this.debug(`Fetcher pending with first=${this.first} count=${this.count}`)
+      this.debug(
+        `Fetcher pending with ${!this.reverse ? 'first' : 'last'}=${this.first} count=${this.count}`
+      )
       const tasks = this.tasks(this.first, this.count)
       for (const task of tasks) {
         this.enqueueTask(task)

--- a/packages/client/lib/sync/fetcher/blockfetcherbase.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcherbase.ts
@@ -68,29 +68,15 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
     const tasks: JobTask[] = []
     let debugStr = !this.reverse ? `first=${first}` : `last=${first}`
     const pushedCount = new BN(0)
-    if (!this.reverse) {
-      while (count.gten(max) && tasks.length < maxTasks) {
-        tasks.push({ first: first.clone(), count: max })
-        first.iaddn(max)
-        count.isubn(max)
-        pushedCount.iaddn(max)
-      }
-      if (count.gtn(0) && tasks.length < maxTasks) {
-        tasks.push({ first: first.clone(), count: count.toNumber() })
-        pushedCount.iadd(count)
-      }
-    } else {
-      // Sync in reverse order (e.g. for beacon sync)
-      while (count.gten(max) && tasks.length < maxTasks) {
-        tasks.push({ first: first.subn(max).addn(1), count: max })
-        first.isubn(max)
-        count.isubn(max)
-        pushedCount.iaddn(max)
-      }
-      if (count.gtn(0) && tasks.length < maxTasks) {
-        tasks.push({ first: first.sub(count).addn(1), count: count.toNumber() })
-        pushedCount.iadd(count)
-      }
+    while (count.gten(max) && tasks.length < maxTasks) {
+      tasks.push({ first: first.clone(), count: max })
+      !this.reverse ? first.iaddn(max) : first.isubn(max)
+      count.isubn(max)
+      pushedCount.iaddn(max)
+    }
+    if (count.gtn(0) && tasks.length < maxTasks) {
+      tasks.push({ first: first.clone(), count: count.toNumber() })
+      pushedCount.iadd(count)
     }
     debugStr += ` count=${pushedCount}`
     this.debug(`Created new tasks num=${tasks.length} ${debugStr}`)

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -299,9 +299,6 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
     const job = this.in.peek()
     if (!job) {
       this.debug(`No job found on next task, skip next job execution.`)
-      // If there are no jobs despite nextTasks, then we just need to finish up!
-      // especially useful in beacon sync
-      this.running = false
       return false
     }
     if (this._readableState!.length > this.maxQueue) {

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -352,7 +352,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
    * `this.request`
    */
   clear() {
-    this.total = this.total - this.in.length
+    this.total -= this.in.length
     while (this.in.length > 0) {
       this.in.remove()
     }

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -301,12 +301,12 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
       if (this.finished !== this.total) {
         // There are still jobs waiting to be processed out in the writer pipe
         this.debug(
-          `No job found on next task, skip next job execution, finished=${this.finished}, total=${this.total}`
+          `No job found on next task, skip next job execution finished=${this.finished} total=${this.total}`
         )
       } else {
         // There are no more jobs in the fetcher, so its better to resolve
         // the sync and exit
-        this.debug(`Fetcher seems to have processed all jobs, stopping...`)
+        this.debug(`Fetcher seems to have processed all jobs, stopping…`)
         this.running = false
       }
       return false
@@ -357,7 +357,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
       this.in.remove()
     }
     this.debug(
-      `Cleared out fetcher, job stats: total=${this.total}, processed=${this.processed}, finished=${this.finished}`
+      `Cleared out fetcher total=${this.total} processed=${this.processed} finished=${this.finished}`
     )
   }
 

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -299,6 +299,9 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
     const job = this.in.peek()
     if (!job) {
       this.debug(`No job found on next task, skip next job execution.`)
+      // If there are no jobs despite nextTasks, then we just need to finish up!
+      // especially useful in beacon sync
+      this.running = false
       return false
     }
     if (this._readableState!.length > this.maxQueue) {

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -188,7 +188,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
       state: 'idle',
       peer: null,
     }
-    this.debug(`enqueueTask: ${this.jobStr(job)}`)
+    this.debug(`enqueueTask ${this.jobStr(job)}`)
     this.in.insert(job)
     if (!this.running && autoRestart) {
       void this.fetch()
@@ -506,6 +506,9 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
         partialResult = ` partialResults=${job.partialResult.length}`
       }
       str += `first=${first} count=${count}${partialResult}`
+      if ('reverse' in this) {
+        str += ` reverse=${(this as any).reverse}`
+      }
     }
     return str
   }

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -298,7 +298,17 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
     this.nextTasks()
     const job = this.in.peek()
     if (!job) {
-      this.debug(`No job found on next task, skip next job execution.`)
+      if (this.finished !== this.total) {
+        // There are still jobs waiting to be processed out in the writer pipe
+        this.debug(
+          `No job found on next task, skip next job execution, finished=${this.finished}, total=${this.total}`
+        )
+      } else {
+        // There are no more jobs in the fetcher, so its better to resolve
+        // the sync and exit
+        this.debug(`Fetcher seems to have processed all jobs, stopping...`)
+        this.running = false
+      }
       return false
     }
     if (this._readableState!.length > this.maxQueue) {
@@ -338,11 +348,17 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
 
   /**
    * Clears all outstanding tasks from the fetcher
+   * TODO: figure out a way to reject the jobs which are under async processing post
+   * `this.request`
    */
   clear() {
+    this.total = this.total - this.in.length
     while (this.in.length > 0) {
       this.in.remove()
     }
+    this.debug(
+      `Cleared out fetcher, job stats: total=${this.total}, processed=${this.processed}, finished=${this.finished}`
+    )
   }
 
   /**
@@ -376,7 +392,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
         for (const jobItem of jobItems) {
           await this.store(jobItem.result as StorageItem[])
         }
-        this.finished++
+        this.finished += jobItems.length
         cb()
       } catch (error: any) {
         this.config.logger.warn(`Error storing received block or header result: ${error}`)

--- a/packages/client/lib/sync/fetcher/headerfetcher.ts
+++ b/packages/client/lib/sync/fetcher/headerfetcher.ts
@@ -47,6 +47,7 @@ export class HeaderFetcher extends BlockFetcherBase<BlockHeaderResult, BlockHead
     const response = await peer!.les!.getBlockHeaders({
       block: first,
       max: count,
+      reverse: this.reverse,
     })
     return response
   }

--- a/packages/client/lib/sync/fetcher/index.ts
+++ b/packages/client/lib/sync/fetcher/index.ts
@@ -4,3 +4,4 @@
 export * from './fetcher'
 export * from './blockfetcher'
 export * from './headerfetcher'
+export * from './reverseblockfetcher'

--- a/packages/client/lib/sync/fetcher/reverseblockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/reverseblockfetcher.ts
@@ -40,6 +40,7 @@ export class ReverseBlockFetcher extends BlockFetcher {
     } catch (e: any) {
       if (e == errSyncMerged) {
         // Tear down the syncer to restart from new subchain segments
+        this.debug('Skeleton subchains merged, restarting sync')
         this.running = false
         this.clear()
         this.destroy()

--- a/packages/client/lib/sync/fetcher/reverseblockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/reverseblockfetcher.ts
@@ -39,7 +39,7 @@ export class ReverseBlockFetcher extends BlockFetcher {
           blocks[0]?.header.number
         } last=${blocks[blocks.length - 1]?.header.number})`
       )
-      this.config.events.emit(Event.SYNC_FETCHED_SKELETON_BLOCKS, blocks.slice(0, num))
+      this.config.events.emit(Event.SYNC_FETCHED_BLOCKS, blocks.slice(0, num))
     } catch (e: any) {
       this.debug(
         `Error storing fetcher results in skeleton chain (blocks num=${blocks.length} first=${

--- a/packages/client/lib/sync/fetcher/reverseblockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/reverseblockfetcher.ts
@@ -39,7 +39,7 @@ export class ReverseBlockFetcher extends BlockFetcher {
           blocks[0]?.header.number
         } last=${blocks[blocks.length - 1]?.header.number})`
       )
-      this.config.events.emit(Event.SYNC_FETCHER_FETCHED, blocks.slice(0, num))
+      this.config.events.emit(Event.SYNC_FETCHED_SKELETON_BLOCKS, blocks.slice(0, num))
     } catch (e: any) {
       this.debug(
         `Error storing fetcher results in skeleton chain (blocks num=${blocks.length} first=${

--- a/packages/client/lib/sync/fetcher/reverseblockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/reverseblockfetcher.ts
@@ -7,9 +7,6 @@ import type { Skeleton } from '../skeleton'
 interface ReverseBlockFetcherOptions extends BlockFetcherOptions {
   /** Skeleton */
   skeleton: Skeleton
-
-  /** Reverse must be true */
-  reverse: true
 }
 
 /**
@@ -23,7 +20,7 @@ export class ReverseBlockFetcher extends BlockFetcher {
    * Create new block fetcher
    */
   constructor(options: ReverseBlockFetcherOptions) {
-    super(options)
+    super({ ...options, reverse: true })
     this.skeleton = options.skeleton
   }
 
@@ -33,7 +30,7 @@ export class ReverseBlockFetcher extends BlockFetcher {
    */
   async store(blocks: Block[]) {
     try {
-      const num = await this.skeleton.putBlocks(blocks.reverse())
+      const num = await this.skeleton.putBlocks(blocks)
       this.debug(
         `Fetcher results stored in skeleton chain (blocks num=${blocks.length} first=${
           blocks[0]?.header.number

--- a/packages/client/lib/sync/fetcher/reverseblockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/reverseblockfetcher.ts
@@ -1,0 +1,52 @@
+import { BlockFetcherOptions } from './blockfetcherbase'
+import { BlockFetcher } from './blockfetcher'
+import { Event } from '../../types'
+import type { Block } from '@ethereumjs/block'
+import type { Skeleton } from '../skeleton'
+
+interface ReverseBlockFetcherOptions extends BlockFetcherOptions {
+  /** Skeleton */
+  skeleton: Skeleton
+
+  /** Reverse must be true */
+  reverse: true
+}
+
+/**
+ * Implements an eth/66 based reverse block fetcher
+ * @memberof module:sync/fetcher
+ */
+export class ReverseBlockFetcher extends BlockFetcher {
+  private skeleton: Skeleton
+
+  /**
+   * Create new block fetcher
+   */
+  constructor(options: ReverseBlockFetcherOptions) {
+    super(options)
+    this.skeleton = options.skeleton
+  }
+
+  /**
+   * Store fetch result. Resolves once store operation is complete.
+   * @param blocks fetch result
+   */
+  async store(blocks: Block[]) {
+    try {
+      const num = await this.skeleton.putBlocks(blocks.reverse())
+      this.debug(
+        `Fetcher results stored in skeleton chain (blocks num=${blocks.length} first=${
+          blocks[0]?.header.number
+        } last=${blocks[blocks.length - 1]?.header.number})`
+      )
+      this.config.events.emit(Event.SYNC_FETCHER_FETCHED, blocks.slice(0, num))
+    } catch (e: any) {
+      this.debug(
+        `Error storing fetcher results in skeleton chain (blocks num=${blocks.length} first=${
+          blocks[0]?.header.number
+        } last=${blocks[blocks.length - 1]?.header.number}): ${e}`
+      )
+      throw e
+    }
+  }
+}

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -83,17 +83,14 @@ export class FullSynchronizer extends Synchronizer {
    * Finds the best peer to sync with. We will synchronize to this peer's
    * blockchain. Returns null if no valid peer is found
    */
-  best(): Peer | undefined {
+  async best(): Promise<Peer | undefined> {
     let best
     const peers = this.pool.peers.filter(this.syncable.bind(this))
     if (peers.length < this.config.minPeers && !this.forceSync) return
     for (const peer of peers) {
       if (peer.eth?.status) {
         const td = peer.eth.status.td
-        if (
-          (!best && td.gte(this.chain.blocks.td)) ||
-          (best && best.eth && best.eth.status.td.lt(td))
-        ) {
+        if ((!best && td.gte(this.chain.blocks.td)) || best?.eth?.status.td.lt(td)) {
           best = peer
         }
       }

--- a/packages/client/lib/sync/index.ts
+++ b/packages/client/lib/sync/index.ts
@@ -1,6 +1,7 @@
 /**
  * @module sync
  */
+export * from './skeleton'
 export * from './sync'
 export * from './lightsync'
 export * from './fullsync'

--- a/packages/client/lib/sync/index.ts
+++ b/packages/client/lib/sync/index.ts
@@ -4,3 +4,4 @@
 export * from './sync'
 export * from './lightsync'
 export * from './fullsync'
+export * from './beaconsync'

--- a/packages/client/lib/sync/lightsync.ts
+++ b/packages/client/lib/sync/lightsync.ts
@@ -51,17 +51,14 @@ export class LightSynchronizer extends Synchronizer {
    * We will synchronize to this peer's blockchain.
    * @returns undefined if no valid peer is found
    */
-  best(): Peer | undefined {
+  async best(): Promise<Peer | undefined> {
     let best
     const peers = this.pool.peers.filter(this.syncable.bind(this))
     if (peers.length < this.config.minPeers && !this.forceSync) return
     for (const peer of peers) {
       if (peer.les) {
         const td = peer.les.status.headTd
-        if (
-          (!best && td.gte(this.chain.headers.td)) ||
-          (best && best.les && best.les.status.headTd.lt(td))
-        ) {
+        if ((!best && td.gte(this.chain.headers.td)) || best?.les?.status.headTd.lt(td)) {
           best = peer
         }
       }

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -216,9 +216,9 @@ export class Skeleton extends MetaDBManager {
     if (parent && !parent.hash().equals(head.header.parentHash)) {
       if (force) {
         this.config.logger.warn(
-          `Beacon chain forked ancestor=${parent.header.number} hash=${short(parent.hash())} want=${
-            head.header.parentHash
-          }`
+          `Beacon chain forked ancestor=${parent.header.number} hash=${short(
+            parent.hash()
+          )} want=${short(head.header.parentHash)}`
         )
       }
       return true

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -1,0 +1,350 @@
+import { Block } from '@ethereumjs/block'
+import { BN, rlp } from 'ethereumjs-util'
+import { DBKey, MetaDBManager, MetaDBManagerOptions } from '../util/metaDBManager'
+import { short, timeDuration } from '../util'
+
+type SkeletonStatus = {
+  progress: SkeletonProgress
+}
+
+/**
+ * Database entry to allow suspending and resuming a chain
+ * sync. As the skeleton header chain is downloaded backwards, restarts can and
+ * will produce temporarily disjoint subchains. There is no way to restart a
+ * suspended skeleton sync without prior knowledge of all prior suspension points.
+ */
+type SkeletonProgress = {
+  subchains: SkeletonSubchain[]
+}
+
+/**
+ * Contiguous header chain segment that is backed by the database,
+ * but may not be linked to the live chain. The skeleton downloader may produce
+ * a new one of these every time it is restarted until the subchain grows large
+ * enough to connect with a previous subchain.
+ */
+type SkeletonSubchain = {
+  head: BN /** Block number of the newest header in the subchain */
+  tail: BN /** Block number of the oldest header in the subchain */
+  next: Buffer /** Block hash of the next oldest header in the subchain */
+}
+type SkeletonSubchainRLP = [head: Buffer, tail: Buffer, next: Buffer]
+
+/**
+ * The Skeleton chain class helps support beacon sync by accepting head blocks
+ * while backfill syncing the rest of the chain.
+ */
+export class Skeleton extends MetaDBManager {
+  private status: SkeletonStatus
+
+  private started: number /** Timestamp when the skeleton syncer was created */
+  private logged = 0 /** Timestamp when progress was last logged to user */
+  private pulled = new BN(0) /** Number of headers downloaded in this run */
+
+  private STATUS_LOG_INTERVAL = 8000 /** How often to log sync status (in ms) */
+
+  constructor(opts: MetaDBManagerOptions) {
+    super(opts)
+    this.status = { progress: { subchains: [] } }
+    this.started = new Date().getTime()
+  }
+
+  async open() {
+    await this.getSyncStatus()
+  }
+
+  /**
+   * processNewHead does the internal shuffling for a new head marker and either
+   * accepts and integrates it into the skeleton or requests a reorg. Upon reorg,
+   * the syncer will tear itself down and restart with a fresh head. It is simpler
+   * to reconstruct the sync state than to mutate it and hope for the best.
+   *
+   * @returns true if the chain was reorged
+   */
+  async processNewHead(head: Block, force = false): Promise<boolean> {
+    // If the header cannot be inserted without interruption, return an error for
+    // the outer loop to tear down the skeleton sync and restart it
+    const { number } = head.header
+
+    const [lastchain] = this.status.progress.subchains
+    if (lastchain?.tail.gte(number)) {
+      // If the chain is down to a single beacon header, and it is re-announced
+      // once more, ignore it instead of tearing down sync for a noop.
+      if (lastchain.head.eq(lastchain.tail)) {
+        const block = await this.getBlock(number)
+        if (block?.hash().equals(head.hash())) {
+          return false
+        }
+      }
+      // Not a noop / double head announce, abort with a reorg
+      if (force) {
+        this.config.logger.warn(
+          `Beacon chain reorged tail=${lastchain.tail} head=${lastchain.head} newHead=${number}`
+        )
+      }
+      return true
+    }
+    if (lastchain?.head.addn(1).lt(number)) {
+      if (force) {
+        this.config.logger.warn(`Beacon chain gapped head=${lastchain.head} newHead=${number}`)
+      }
+      return true
+    }
+    const parent = await this.getBlock(number.subn(1))
+    if (parent && !parent.hash().equals(head.header.parentHash)) {
+      if (force) {
+        this.config.logger.warn(
+          `Beacon chain forked ancestor=${parent.header.number} hash=${parent.hash()} want=${
+            head.header.parentHash
+          }`
+        )
+      }
+      return true
+    }
+
+    await this.putBlock(head)
+
+    if (lastchain?.head.addn(1).eq(number)) {
+      // Extend subchain
+      lastchain.head.iaddn(1)
+    } else {
+      // Start new subchain
+      const subchain = {
+        head: number.clone(),
+        tail: number.clone(),
+        next: head.header.parentHash,
+      }
+      this.status.progress.subchains.unshift(subchain)
+    }
+
+    await this.writeSyncStatus()
+
+    if (this.chain.blocks.height.addn(1).eq(head.header.number)) {
+      await this.fillCanonicalChain()
+    }
+
+    return false
+  }
+
+  /**
+   * Bounds returns the current head and tail tracked by the skeleton syncer.
+   */
+  bounds(): SkeletonSubchain {
+    return this.status.progress.subchains[0]
+  }
+
+  /**
+   * Writes skeleton blocks to the db by number
+   * @returns number of blocks saved
+   */
+  async putBlocks(blocks: Block[]): Promise<number> {
+    for (const block of blocks) {
+      await this.putBlock(block)
+      this.pulled.iaddn(1)
+      const { number } = block.header
+      // Extend subchain or create new segment if necessary
+      if (this.status.progress.subchains[0].next.equals(block.hash())) {
+        this.status.progress.subchains[0].tail.isubn(1)
+        this.status.progress.subchains[0].next = block.header.parentHash
+      } else {
+        // See if the block can fit in an existing subchain. If not, create a new one.
+        const foundSubchain = this.status.progress.subchains.find((subchain) =>
+          subchain.next.equals(block.hash())
+        )
+        if (foundSubchain) {
+          // Extend
+          foundSubchain.tail.isubn(1)
+          foundSubchain.next = block.header.parentHash
+        } else {
+          // New subchain
+          const subchain = {
+            head: number.clone(),
+            tail: number.clone(),
+            next: block.header.parentHash,
+          }
+          this.status.progress.subchains.push(subchain)
+        }
+      }
+
+      // If the subchain extended into the next subchain, we need to handle
+      // the overlap. Since there could be many overlaps, do this in a loop.
+      while (
+        this.status.progress.subchains.length > 1 &&
+        this.status.progress.subchains[1].head.gte(this.status.progress.subchains[0].tail)
+      ) {
+        // Extract some stats from the second subchain
+        const { head, tail, next } = this.status.progress.subchains[1]
+
+        // Since we just overwrote part of the next subchain, we need to trim
+        // its head independent of matching or mismatching content
+        if (tail.gte(this.status.progress.subchains[0].tail)) {
+          // Fully overwritten, get rid of the subchain as a whole
+          this.config.logger.debug(
+            `Previous subchain fully overwritten head=${head} tail=${tail} next=${short(next)}`
+          )
+          this.status.progress.subchains = this.status.progress.subchains.slice(1)
+        } else {
+          // Partially overwritten, trim the head to the overwritten size
+          this.config.logger.debug(
+            `Previous subchain partially overwritten head=${head} tail=${tail} next=${short(next)}`
+          )
+          this.status.progress.subchains[1].head = this.status.progress.subchains[0].tail.subn(1)
+        }
+
+        // If the old subchain is an extension of the new one, merge the two
+        // and let the skeleton syncer restart (to clean internal state)
+        if (
+          (await this.getBlock(this.status.progress.subchains[1].head))
+            ?.hash()
+            .equals(this.status.progress.subchains[0].next)
+        ) {
+          this.config.logger.debug(
+            `Previous subchain merged head=${head} tail=${tail} next=${short(next)}`
+          )
+          this.status.progress.subchains[0].tail = tail
+          this.status.progress.subchains[0].next = next
+          this.status.progress.subchains = this.status.progress.subchains.slice(1)
+          // If subchains were merged, all further available headers in the scratch
+          // space are invalid since we skipped ahead. Stop processing the scratch
+          // space to avoid dropping peers thinking they delivered invalid data.
+          break
+        }
+      }
+    }
+
+    await this.writeSyncStatus()
+
+    // Print a progress report making the UX a bit nicer
+    if (new Date().getTime() - this.logged > this.STATUS_LOG_INTERVAL) {
+      const left = this.status.progress.subchains[0].tail.subn(1)
+      this.logged = new Date().getTime()
+      if (this.pulled.isZero()) {
+        this.config.logger.info(`Beacon sync starting left=${left}`)
+      } else {
+        const eta = timeDuration(
+          new BN(new Date().getTime() - this.started).div(this.pulled.mul(left)).toNumber()
+        )
+        this.config.logger.info(
+          `Syncing beacon headers downloaded=${this.pulled} left=${left} eta=${eta}`
+        )
+      }
+    }
+
+    // If our tail reaches genesis, start filling.
+    if (this.status.progress.subchains[0].tail.subn(1).isZero()) {
+      void this.fillCanonicalChain()
+    }
+
+    return blocks.length
+  }
+
+  /**
+   * Inserts skeleton blocks into canonical chain and runs execution.
+   * @param block
+   * @returns
+   */
+  private async fillCanonicalChain() {
+    const canonicalHead = this.chain.blocks.height.clone()
+    const next = canonicalHead.addn(1)
+    const { tail } = this.bounds()
+    while (canonicalHead.lt(tail)) {
+      // Get next block
+      const block = await this.getBlock(next)
+      // Insert into chain
+      if (!block) break
+      const num = await this.chain.putBlocks([block])
+      // Delete skeleton block to clean up as we go
+      if (num === 1) await this.deleteBlock(next)
+      canonicalHead.iaddn(1)
+    }
+  }
+
+  /**
+   * Writes a skeleton block to the db by number
+   */
+  private async putBlock(block: Block): Promise<boolean> {
+    await this.delete(DBKey.SkeletonBlock, block.header.number.toArrayLike(Buffer))
+    return true
+  }
+
+  /**
+   * Gets a skeleton block from the db by number
+   */
+  async getBlock(number: BN): Promise<Block | undefined> {
+    try {
+      const rlp = await this.get(DBKey.SkeletonBlock, number.toArrayLike(Buffer))
+      const block = Block.fromRLPSerializedBlock(rlp!, {
+        common: this.config.chainCommon,
+      })
+      return block
+    } catch (error: any) {
+      if (error.type === 'NotFoundError') {
+        return undefined
+      }
+    }
+  }
+
+  /**
+   * Deletes a skeleton block from the db by number
+   */
+  async deleteBlock(number: BN): Promise<boolean> {
+    try {
+      await this.delete(DBKey.SkeletonBlock, number.toArrayLike(Buffer))
+      return true
+    } catch (error: any) {
+      return false
+    }
+  }
+
+  /**
+   * Writes the {@link SkeletonStatus} to db
+   */
+  private async writeSyncStatus(): Promise<boolean> {
+    this.config.logger.debug(
+      `Writing sync status subchains=${this.status.progress.subchains
+        .map((s) => `[head=${s.head} tail=${s.tail} next=${short(s.next)}]`)
+        .join(',')}`
+    )
+    const encodedStatus = this.statusToRLP()
+    await this.put(DBKey.SkeletonStatus, Buffer.alloc(0), encodedStatus)
+    return true
+  }
+
+  /**
+   * Reads the {@link SkeletonStatus} from db
+   */
+  private async getSyncStatus(): Promise<SkeletonStatus | undefined> {
+    const rawStatus = await this.get(DBKey.SkeletonStatus, Buffer.alloc(0))
+    if (!rawStatus) return
+    const status = this.statusRLPtoObject(rawStatus)
+    this.status = status
+    return status
+  }
+
+  /**
+   * Encodes a {@link SkeletonStatus} to RLP for saving to the db
+   */
+  private statusToRLP(): Buffer {
+    const subchains: SkeletonSubchainRLP[] = this.status.progress.subchains.map((subchain) => [
+      subchain.head.toArrayLike(Buffer),
+      subchain.tail.toArrayLike(Buffer),
+      subchain.next,
+    ])
+    return rlp.encode(subchains)
+  }
+
+  /**
+   * Decodes an RLP encoded {@link SkeletonStatus}
+   */
+  private statusRLPtoObject(rawStatus: Buffer): SkeletonStatus {
+    const status: SkeletonStatus = { progress: { subchains: [] } }
+    const rawSubchains = rlp.decode(rawStatus) as unknown as SkeletonSubchainRLP[]
+    const subchains: SkeletonSubchain[] = rawSubchains.map((raw) => ({
+      head: new BN(raw[0]),
+      tail: new BN(raw[1]),
+      next: raw[2],
+    }))
+    status.progress.subchains = subchains
+    return status
+  }
+}

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -2,6 +2,7 @@ import { Block } from '@ethereumjs/block'
 import { BN, rlp } from 'ethereumjs-util'
 import { DBKey, MetaDBManager, MetaDBManagerOptions } from '../util/metaDBManager'
 import { short, timeDuration } from '../util'
+import { Event } from '../types'
 
 // Thanks to go-ethereum for the skeleton design
 
@@ -405,6 +406,7 @@ export class Skeleton extends MetaDBManager {
     this.config.logger.debug(
       `Successfully put blocks start=${start} end=${canonicalHead} from skeleton chain to canonical`
     )
+    this.config.events.emit(Event.SYNC_SYNCHRONIZED, canonicalHead)
   }
 
   /**

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -180,6 +180,11 @@ export class Skeleton extends MetaDBManager {
 
     await this.putBlock(head)
     await this.writeSyncStatus()
+
+    // If the sync is finished, start filling the canonical chain.
+    if (this.isLinked()) {
+      void this.fillCanonicalChain()
+    }
   }
 
   /**

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -412,7 +412,7 @@ export class Skeleton extends MetaDBManager {
     }
     this.filling = false
     this.config.logger.debug(
-      `Successfully put blocks start=${start} end=${canonicalHead} from skeleton chain to canonical`
+      `Successfully put blocks start=${start} end=${canonicalHead} from skeleton chain to canonical, syncTargetHeight=${this.config.syncTargetHeight}`
     )
   }
 

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -350,8 +350,8 @@ export class Skeleton extends MetaDBManager {
         if (this.pulled.isZero()) {
           this.config.logger.info(`Beacon sync starting left=${left}`)
         } else {
-          const sinceStarted = new BN(new Date().getTime() - this.started).divn(1000)
-          const eta = timeDuration(sinceStarted.div(this.pulled).mul(left).toNumber())
+          const sinceStarted = (new Date().getTime() - this.started) / 1000
+          const eta = timeDuration((sinceStarted / this.pulled.toNumber()) * left.toNumber())
           this.config.logger.info(
             `Syncing beacon headers downloaded=${this.pulled} left=${left} eta=${eta}`
           )

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -417,7 +417,7 @@ export class Skeleton extends MetaDBManager {
     }
     this.filling = false
     this.config.logger.debug(
-      `Successfully put blocks start=${start} end=${canonicalHead} from skeleton chain to canonical, syncTargetHeight=${this.config.syncTargetHeight}`
+      `Successfully put blocks start=${start} end=${canonicalHead} from skeleton chain to canonical syncTargetHeight=${this.config.syncTargetHeight}`
     )
   }
 

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -2,7 +2,6 @@ import { Block } from '@ethereumjs/block'
 import { BN, rlp } from 'ethereumjs-util'
 import { DBKey, MetaDBManager, MetaDBManagerOptions } from '../util/metaDBManager'
 import { short, timeDuration } from '../util'
-import { Event } from '../types'
 
 // Thanks to go-ethereum for the skeleton design
 
@@ -406,7 +405,6 @@ export class Skeleton extends MetaDBManager {
     this.config.logger.debug(
       `Successfully put blocks start=${start} end=${canonicalHead} from skeleton chain to canonical`
     )
-    this.config.events.emit(Event.SYNC_SYNCHRONIZED, canonicalHead)
   }
 
   /**

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -348,7 +348,7 @@ export class Skeleton extends MetaDBManager {
 
     // Print a progress report making the UX a bit nicer
     if (new Date().getTime() - this.logged > this.STATUS_LOG_INTERVAL) {
-      let left = this.bounds().tail.subn(1)
+      let left = this.bounds().tail.subn(1).sub(this.chain.blocks.height)
       if (this.isLinked()) left = new BN(0)
       if (left.gtn(0)) {
         this.logged = new Date().getTime()

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -126,7 +126,7 @@ export abstract class Synchronizer {
     clearTimeout(timeout)
   }
 
-  abstract best(): Peer | undefined
+  abstract best(): Promise<Peer | undefined>
 
   abstract syncWithPeer(peer?: Peer): Promise<boolean>
 
@@ -157,12 +157,12 @@ export abstract class Synchronizer {
    * @returns when sync is completed
    */
   async sync(): Promise<boolean> {
-    let peer = this.best()
+    let peer = await this.best()
     let numAttempts = 1
     while (!peer && this.opened) {
       this.config.logger.debug(`Waiting for best peer (attempt #${numAttempts})`)
       await new Promise((resolve) => setTimeout(resolve, 5000))
-      peer = this.best()
+      peer = await this.best()
       numAttempts += 1
     }
 

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -6,8 +6,6 @@ import { FlowControl } from '../net/protocol'
 import { Config } from '../config'
 import { Chain } from '../blockchain'
 import { Event } from '../types'
-// eslint-disable-next-line implicit-dependencies/no-implicit
-import type { LevelUp } from 'levelup'
 import { BlockFetcher, HeaderFetcher } from './fetcher'
 import { short } from '../util'
 
@@ -20,12 +18,6 @@ export interface SynchronizerOptions {
 
   /* Blockchain */
   chain: Chain
-
-  /* State database */
-  stateDB?: LevelUp
-
-  /* Meta database (receipts, logs, indexes) */
-  metaDB?: LevelUp
 
   /* Flow control manager */
   flow?: FlowControl

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -6,7 +6,7 @@ import { FlowControl } from '../net/protocol'
 import { Config } from '../config'
 import { Chain } from '../blockchain'
 import { Event } from '../types'
-import { BlockFetcher, HeaderFetcher } from './fetcher'
+import { BlockFetcher, HeaderFetcher, ReverseBlockFetcher } from './fetcher'
 import { short } from '../util'
 
 export interface SynchronizerOptions {
@@ -129,7 +129,6 @@ export abstract class Synchronizer {
   abstract best(): Peer | undefined
 
   abstract syncWithPeer(peer?: Peer): Promise<boolean>
-
   /**
    * Checks if the synchronized state of the chain has changed
    * @emits {@link Event.SYNC_SYNCHRONIZED}

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -138,7 +138,7 @@ export abstract class Synchronizer {
     if (!this.config.syncTargetHeight) {
       return
     }
-    if (this.chain.headers.height.gte(this.config.syncTargetHeight)) {
+    if (this.chain.headers.height.eq(this.config.syncTargetHeight)) {
       if (!this.config.synchronized) {
         const hash = this.chain.headers.latest?.hash()
         this.config.logger.info(

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -173,9 +173,9 @@ export abstract class Synchronizer {
       const resolveSync = (height?: number) => {
         this.clearFetcher()
         resolve(true)
+        const heightStr = height ? ` height=${height}` : ''
         this.config.logger.debug(
-          `Finishing up sync with the current fetcher height=${
-            height ?? this.chain.headers?.height
+          `Finishing up sync with the current fetcher${heightStr}
           }`
         )
       }

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -170,9 +170,14 @@ export abstract class Synchronizer {
 
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve, reject) => {
-      const resolveSync = () => {
+      const resolveSync = (height?: number) => {
         this.clearFetcher()
         resolve(true)
+        this.config.logger.debug(
+          `Finishing up sync with the current fetcher, height=${
+            height ?? this.chain.headers.height
+          }`
+        )
       }
       this.config.events.once(Event.SYNC_SYNCHRONIZED, resolveSync)
       try {

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -174,7 +174,9 @@ export abstract class Synchronizer {
         this.clearFetcher()
         resolve(true)
         this.config.logger.debug(
-          `Finishing up sync with the current fetcher height=${height ?? this.chain.headers.height}`
+          `Finishing up sync with the current fetcher height=${
+            height ?? this.chain.headers?.height
+          }`
         )
       }
       this.config.events.once(Event.SYNC_SYNCHRONIZED, resolveSync)
@@ -184,6 +186,9 @@ export abstract class Synchronizer {
         }
         resolveSync()
       } catch (error: any) {
+        this.config.logger.debug(
+          `Received sync error, stopping sync and clearing fetcher: ${error.message ?? error}`
+        )
         this.clearFetcher()
         reject(error)
       }

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -174,9 +174,7 @@ export abstract class Synchronizer {
         this.clearFetcher()
         resolve(true)
         this.config.logger.debug(
-          `Finishing up sync with the current fetcher, height=${
-            height ?? this.chain.headers.height
-          }`
+          `Finishing up sync with the current fetcher height=${height ?? this.chain.headers.height}`
         )
       }
       this.config.events.once(Event.SYNC_SYNCHRONIZED, resolveSync)

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -39,7 +39,7 @@ export abstract class Synchronizer {
   protected interval: number
   protected forceSync: boolean
 
-  public fetcher: BlockFetcher | HeaderFetcher | null
+  public fetcher: BlockFetcher | HeaderFetcher | ReverseBlockFetcher | null
   public opened: boolean
   public running: boolean
   public startingBlock: BN

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -129,6 +129,7 @@ export abstract class Synchronizer {
   abstract best(): Peer | undefined
 
   abstract syncWithPeer(peer?: Peer): Promise<boolean>
+
   /**
    * Checks if the synchronized state of the chain has changed
    * @emits {@link Event.SYNC_SYNCHRONIZED}

--- a/packages/client/lib/types.ts
+++ b/packages/client/lib/types.ts
@@ -18,6 +18,7 @@ export enum Event {
   SYNC_FETCHED_BLOCKS = 'sync:fetcher:fetched_blocks',
   SYNC_FETCHED_HEADERS = 'sync:fetcher:fetched_headers',
   SYNC_SYNCHRONIZED = 'sync:synchronized',
+  SYNC_POS_TRANSITION = 'sync:pos:transition',
   SYNC_ERROR = 'sync:error',
   SYNC_FETCHER_ERROR = 'sync:fetcher:error',
   PEER_CONNECTED = 'peer:connected',
@@ -38,6 +39,7 @@ export interface EventParams {
   [Event.SYNC_FETCHED_BLOCKS]: [blocks: Block[]]
   [Event.SYNC_FETCHED_HEADERS]: [headers: BlockHeader[]]
   [Event.SYNC_SYNCHRONIZED]: [chainHeight: BN]
+  [Event.SYNC_POS_TRANSITION]: []
   [Event.SYNC_ERROR]: [syncError: Error]
   [Event.SYNC_FETCHER_ERROR]: [fetchError: Error, task: any, peer: Peer | null | undefined]
   [Event.PEER_CONNECTED]: [connectedPeer: Peer]
@@ -65,6 +67,7 @@ export type EventBusType = EventBus<Event.CHAIN_UPDATED> &
   EventBus<Event.SYNC_FETCHED_BLOCKS> &
   EventBus<Event.SYNC_FETCHED_HEADERS> &
   EventBus<Event.SYNC_SYNCHRONIZED> &
+  EventBus<Event.SYNC_POS_TRANSITION> &
   EventBus<Event.SYNC_FETCHER_ERROR> &
   EventBus<Event.PEER_CONNECTED> &
   EventBus<Event.PEER_DISCONNECTED> &

--- a/packages/client/lib/types.ts
+++ b/packages/client/lib/types.ts
@@ -17,9 +17,7 @@ export enum Event {
   SYNC_EXECUTION_VM_ERROR = 'sync:execution:vm:error',
   SYNC_FETCHED_BLOCKS = 'sync:fetcher:fetched_blocks',
   SYNC_FETCHED_HEADERS = 'sync:fetcher:fetched_headers',
-  SYNC_FETCHED_SKELETON_BLOCKS = 'sync:fetcher:fetched_skeleton_blocks',
   SYNC_SYNCHRONIZED = 'sync:synchronized',
-  SYNC_POS_TRANSITION = 'sync:pos:transition',
   SYNC_ERROR = 'sync:error',
   SYNC_FETCHER_ERROR = 'sync:fetcher:error',
   PEER_CONNECTED = 'peer:connected',
@@ -39,9 +37,7 @@ export interface EventParams {
   [Event.SYNC_EXECUTION_VM_ERROR]: [vmError: Error]
   [Event.SYNC_FETCHED_BLOCKS]: [blocks: Block[]]
   [Event.SYNC_FETCHED_HEADERS]: [headers: BlockHeader[]]
-  [Event.SYNC_FETCHED_SKELETON_BLOCKS]: [blocks: Block[]]
   [Event.SYNC_SYNCHRONIZED]: [chainHeight: BN]
-  [Event.SYNC_POS_TRANSITION]: []
   [Event.SYNC_ERROR]: [syncError: Error]
   [Event.SYNC_FETCHER_ERROR]: [fetchError: Error, task: any, peer: Peer | null | undefined]
   [Event.PEER_CONNECTED]: [connectedPeer: Peer]
@@ -68,9 +64,7 @@ export type EventBusType = EventBus<Event.CHAIN_UPDATED> &
   EventBus<Event.SYNC_EXECUTION_VM_ERROR> &
   EventBus<Event.SYNC_FETCHED_BLOCKS> &
   EventBus<Event.SYNC_FETCHED_HEADERS> &
-  EventBus<Event.SYNC_FETCHED_SKELETON_BLOCKS> &
   EventBus<Event.SYNC_SYNCHRONIZED> &
-  EventBus<Event.SYNC_POS_TRANSITION> &
   EventBus<Event.SYNC_FETCHER_ERROR> &
   EventBus<Event.PEER_CONNECTED> &
   EventBus<Event.PEER_DISCONNECTED> &

--- a/packages/client/lib/types.ts
+++ b/packages/client/lib/types.ts
@@ -17,6 +17,7 @@ export enum Event {
   SYNC_EXECUTION_VM_ERROR = 'sync:execution:vm:error',
   SYNC_FETCHED_BLOCKS = 'sync:fetcher:fetched_blocks',
   SYNC_FETCHED_HEADERS = 'sync:fetcher:fetched_headers',
+  SYNC_FETCHED_SKELETON_BLOCKS = 'sync:fetcher:fetched_skeleton_blocks',
   SYNC_SYNCHRONIZED = 'sync:synchronized',
   SYNC_POS_TRANSITION = 'sync:pos:transition',
   SYNC_ERROR = 'sync:error',
@@ -38,6 +39,7 @@ export interface EventParams {
   [Event.SYNC_EXECUTION_VM_ERROR]: [vmError: Error]
   [Event.SYNC_FETCHED_BLOCKS]: [blocks: Block[]]
   [Event.SYNC_FETCHED_HEADERS]: [headers: BlockHeader[]]
+  [Event.SYNC_FETCHED_SKELETON_BLOCKS]: [blocks: Block[]]
   [Event.SYNC_SYNCHRONIZED]: [chainHeight: BN]
   [Event.SYNC_POS_TRANSITION]: []
   [Event.SYNC_ERROR]: [syncError: Error]
@@ -66,6 +68,7 @@ export type EventBusType = EventBus<Event.CHAIN_UPDATED> &
   EventBus<Event.SYNC_EXECUTION_VM_ERROR> &
   EventBus<Event.SYNC_FETCHED_BLOCKS> &
   EventBus<Event.SYNC_FETCHED_HEADERS> &
+  EventBus<Event.SYNC_FETCHED_SKELETON_BLOCKS> &
   EventBus<Event.SYNC_SYNCHRONIZED> &
   EventBus<Event.SYNC_POS_TRANSITION> &
   EventBus<Event.SYNC_FETCHER_ERROR> &

--- a/packages/client/lib/util/index.ts
+++ b/packages/client/lib/util/index.ts
@@ -8,6 +8,7 @@ export * from './parse'
 export * from './rpc'
 
 export function short(buf: Buffer | string): string {
+  if (!buf) return ''
   const bufStr = Buffer.isBuffer(buf) ? `0x${buf.toString('hex')}` : buf
   let str = bufStr.substring(0, 6) + '…'
   if (bufStr.length === 66) {

--- a/packages/client/lib/util/index.ts
+++ b/packages/client/lib/util/index.ts
@@ -20,3 +20,36 @@ export function getClientVersion() {
   const { version } = process
   return `EthereumJS/${packageVersion}/${platform()}/node${version.substring(1)}`
 }
+
+/**
+ * Returns a friendly time duration.
+ * @param time the number of seconds
+ */
+export function timeDuration(time: number) {
+  const min = 60
+  const hour = min * 60
+  const day = hour * 24
+  let str = ''
+  if (time > day) {
+    str = `${Math.floor(time / day)} day`
+  } else if (time > hour) {
+    str = `${Math.floor(time / hour)} hour`
+  } else if (time > min) {
+    str = `${Math.floor(time / min)} min`
+  } else {
+    str = `${Math.floor(time)} sec`
+  }
+  if (str.substring(0, 2) !== '1 ') {
+    str += 's'
+  }
+  return str
+}
+
+/**
+ * Returns a friendly time diff string.
+ * @param timestamp the timestamp to diff (in seconds) from now
+ */
+export function timeDiff(timestamp: number) {
+  const diff = new Date().getTime() / 1000 - timestamp
+  return timeDuration(diff)
+}

--- a/packages/client/lib/util/metaDBManager.ts
+++ b/packages/client/lib/util/metaDBManager.ts
@@ -16,6 +16,8 @@ const encodingOpts = { keyEncoding: 'binary', valueEncoding: 'binary' }
 export enum DBKey {
   Receipts,
   TxHash,
+  SkeletonBlock,
+  SkeletonStatus,
 }
 
 export interface MetaDBManagerOptions {

--- a/packages/client/lib/util/metaDBManager.ts
+++ b/packages/client/lib/util/metaDBManager.ts
@@ -17,6 +17,7 @@ export enum DBKey {
   Receipts,
   TxHash,
   SkeletonBlock,
+  SkeletonBlockHashToNumber,
   SkeletonStatus,
 }
 

--- a/packages/client/test/execution/vmexecution.spec.ts
+++ b/packages/client/test/execution/vmexecution.spec.ts
@@ -2,12 +2,12 @@ import tape from 'tape'
 import Blockchain from '@ethereumjs/blockchain'
 import Common, { Chain as ChainEnum, Hardfork } from '@ethereumjs/common'
 import VM from '@ethereumjs/vm'
-import { Config } from '../../../lib/config'
-import { Chain } from '../../../lib/blockchain'
-import { VMExecution } from '../../../lib/execution'
-import blocksDataMainnet from './../../testdata/blocks/mainnet.json'
-import blocksDataGoerli from './../../testdata/blocks/goerli.json'
-import testnet from './../../testdata/common/testnet.json'
+import { Config } from '../../lib/config'
+import { Chain } from '../../lib/blockchain'
+import { VMExecution } from '../../lib/execution'
+import blocksDataMainnet from '../testdata/blocks/mainnet.json'
+import blocksDataGoerli from '../testdata/blocks/goerli.json'
+import testnet from '../testdata/common/testnet.json'
 
 tape('[VMExecution]', async (t) => {
   t.test('Initialization', async (t) => {

--- a/packages/client/test/integration/beaconsync.spec.ts
+++ b/packages/client/test/integration/beaconsync.spec.ts
@@ -1,0 +1,89 @@
+import tape from 'tape'
+import Common from '@ethereumjs/common'
+import { BN } from 'ethereumjs-util'
+import { Event } from '../../lib/types'
+import genesisJSON from '../testdata/geth-genesis/post-merge.json'
+import { parseCustomParams } from '../../lib/util'
+import { wait, setup, destroy } from './util'
+
+tape('[Integration:BeaconSync]', async (t) => {
+  const params = await parseCustomParams(genesisJSON, 'post-merge')
+  const common = new Common({
+    chain: params.name,
+    customChains: [params],
+  })
+  common.setHardforkByBlockNumber(new BN(0), new BN(0))
+
+  t.test('should sync blocks', async (t) => {
+    const [remoteServer, remoteService] = await setup({ location: '127.0.0.2', height: 20, common })
+    const [localServer, localService] = await setup({ location: '127.0.0.1', height: 0, common })
+    ;(localService.synchronizer as any).skeleton.status.progress.subchains = [
+      {
+        head: new BN(21),
+        tail: new BN(21),
+        next: (await remoteService.chain.getLatestHeader()).hash(),
+      },
+    ]
+    await localService.synchronizer.stop()
+    await localServer.discover('remotePeer1', '127.0.0.2')
+    localService.config.events.on(Event.SYNC_SYNCHRONIZED, async () => {
+      t.equals(localService.chain.blocks.height.toNumber(), 20, 'synced')
+      await destroy(localServer, localService)
+      await destroy(remoteServer, remoteService)
+    })
+    await localService.synchronizer.start()
+  })
+
+  t.test('should not sync with stale peers', async (t) => {
+    const [remoteServer, remoteService] = await setup({ location: '127.0.0.2', height: 9, common })
+    const [localServer, localService] = await setup({ location: '127.0.0.1', height: 10, common })
+    localService.config.events.on(Event.SYNC_SYNCHRONIZED, async () => {
+      t.fail('synced with a stale peer')
+    })
+    await localServer.discover('remotePeer', '127.0.0.2')
+    await wait(300)
+    await destroy(localServer, localService)
+    await destroy(remoteServer, remoteService)
+    t.pass('did not sync')
+  })
+
+  t.test('should sync with best peer', async (t) => {
+    const [remoteServer1, remoteService1] = await setup({
+      location: '127.0.0.2',
+      height: 7,
+      common,
+    })
+    const [remoteServer2, remoteService2] = await setup({
+      location: '127.0.0.3',
+      height: 10,
+      common,
+    })
+    const [localServer, localService] = await setup({
+      location: '127.0.0.1',
+      height: 0,
+      common,
+      minPeers: 2,
+    })
+    ;(localService.synchronizer as any).skeleton.status.progress.subchains = [
+      {
+        head: new BN(11),
+        tail: new BN(11),
+        next: (await remoteService2.chain.getLatestHeader()).hash(),
+      },
+    ]
+    localService.interval = 1000
+    await localService.synchronizer.stop()
+    await localServer.discover('remotePeer1', '127.0.0.2')
+    await localServer.discover('remotePeer2', '127.0.0.3')
+
+    localService.config.events.on(Event.SYNC_SYNCHRONIZED, async () => {
+      if (localService.chain.blocks.height.toNumber() === 10) {
+        t.pass('synced with best peer')
+        await destroy(localServer, localService)
+        await destroy(remoteServer1, remoteService1)
+        await destroy(remoteServer2, remoteService2)
+      }
+    })
+    await localService.synchronizer.start()
+  })
+})

--- a/packages/client/test/integration/mocks/mockchain.ts
+++ b/packages/client/test/integration/mocks/mockchain.ts
@@ -1,4 +1,5 @@
 import { Block } from '@ethereumjs/block'
+import { Hardfork } from '@ethereumjs/common'
 import { Chain, ChainOptions } from '../../../lib/blockchain'
 
 interface MockChainOptions extends ChainOptions {
@@ -22,17 +23,21 @@ export default class MockChain extends Chain {
   }
 
   async build() {
+    const common = this.config.chainCommon
     const blocks: Block[] = []
     for (let number = 0; number < this.height; number++) {
-      const block = Block.fromBlockData({
-        header: {
-          number: number + 1,
-          difficulty: 1,
-          parentHash: number ? blocks[number - 1].hash() : this.genesis.hash,
+      const block = Block.fromBlockData(
+        {
+          header: {
+            number: number + 1,
+            difficulty: common.gteHardfork(Hardfork.Merge) ? 0 : 1,
+            parentHash: number ? blocks[number - 1].hash() : this.genesis.hash,
+          },
         },
-      })
+        { common }
+      )
       blocks.push(block)
     }
-    await this.putBlocks(blocks)
+    await this.putBlocks(blocks, true)
   }
 }

--- a/packages/client/test/integration/util.ts
+++ b/packages/client/test/integration/util.ts
@@ -1,11 +1,11 @@
+import Blockchain from '@ethereumjs/blockchain'
+import Common from '@ethereumjs/common'
 import { Config, SyncMode } from '../../lib/config'
 import { FullEthereumService, LightEthereumService } from '../../lib/service'
 import { Event } from '../../lib/types'
 import MockServer from './mocks/mockserver'
 import MockChain from './mocks/mockchain'
-
-import Blockchain from '@ethereumjs/blockchain'
-import Common from '@ethereumjs/common'
+const level = require('level-mem')
 
 interface SetupOptions {
   location?: string
@@ -58,6 +58,7 @@ export async function setup(
   } else {
     service = new FullEthereumService({
       ...serviceOpts,
+      metaDB: level(),
       lightserv: true,
     })
   }

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -7,6 +7,7 @@ import { DefaultStateManager, StateManager } from '@ethereumjs/vm/dist/state'
 import { Account, Address, BN } from 'ethereumjs-util'
 import { Config } from '../../lib/config'
 import { FullEthereumService } from '../../lib/service'
+import { FullSynchronizer } from '../../lib/sync'
 import { Chain } from '../../lib/blockchain'
 import { Miner } from '../../lib/miner'
 import { Event } from '../../lib/types'
@@ -247,8 +248,7 @@ tape('[Miner]', async (t) => {
 
     // disable consensus to skip PoA block signer validation
     ;(vm.blockchain as any)._validateConsensus = false
-
-    service.synchronizer.handleNewBlock = async (block: Block) => {
+    ;(service.synchronizer as FullSynchronizer).handleNewBlock = async (block: Block) => {
       t.equal(block.transactions.length, 0, 'should not include tx')
       miner.stop()
       txPool.stop()

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -4,15 +4,14 @@ import Common, { Chain as CommonChain, Hardfork } from '@ethereumjs/common'
 import { FeeMarketEIP1559Transaction, Transaction } from '@ethereumjs/tx'
 import { Block, BlockHeader } from '@ethereumjs/block'
 import { DefaultStateManager, StateManager } from '@ethereumjs/vm/dist/state'
-import { Account, Address, BN } from 'ethereumjs-util'
+import { Account, Address, BN, keccak256 } from 'ethereumjs-util'
 import { Config } from '../../lib/config'
 import { FullEthereumService } from '../../lib/service'
-import { FullSynchronizer } from '../../lib/sync'
 import { Chain } from '../../lib/blockchain'
 import { Miner } from '../../lib/miner'
 import { Event } from '../../lib/types'
 import { wait } from '../integration/util'
-import { keccak256 } from '@ethereumjs/devp2p'
+import type { FullSynchronizer } from '../../lib/sync'
 
 const A = {
   address: new Address(Buffer.from('0b90087d864e82a284dca15923f3776de6bb016f', 'hex')),
@@ -329,25 +328,16 @@ tape('[Miner]', async (t) => {
     txPool.start()
     miner.start()
 
-    let pkey = keccak256(Buffer.from(''))
-
     // add many txs to slow assembling
+    let privateKey = keccak256(Buffer.from(''))
     for (let i = 0; i < 1000; i++) {
       // In order not to pollute TxPool with too many txs from the same address
       // (or txs which are already known), keep generating a new address for each tx
-      const address = Address.fromPrivateKey(pkey)
+      const address = Address.fromPrivateKey(privateKey)
       await setBalance(vm.stateManager, address, new BN('200000000000001'))
-      await txPool.add(
-        createTx(
-          {
-            address,
-            privateKey: pkey,
-          },
-          undefined,
-          i
-        )
-      )
-      pkey = keccak256(pkey)
+      const tx = createTx({ address, privateKey })
+      await txPool.add(tx)
+      privateKey = keccak256(privateKey)
     }
 
     chain.putBlocks = () => {

--- a/packages/client/test/net/protocol/ethprotocol.spec.ts
+++ b/packages/client/test/net/protocol/ethprotocol.spec.ts
@@ -57,7 +57,6 @@ tape('[EthProtocol]', (t) => {
         td: Buffer.from('64', 'hex'),
         bestHash: '0xaa',
         genesisHash: '0xbb',
-        latestBlock: Buffer.from('0A', 'hex'),
       },
       'encode status'
     )

--- a/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
+++ b/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
@@ -1,5 +1,7 @@
 import tape from 'tape'
 import { Block } from '@ethereumjs/block'
+import { BN } from 'ethereumjs-util'
+
 import { INVALID_PARAMS } from '../../../lib/rpc/error-code'
 import { params, baseRequest, baseSetup, setupChain } from '../helpers'
 import { checkError } from '../util'
@@ -137,11 +139,15 @@ tape(`${method}: invalid terminal block with 1+ blocks`, async (t) => {
       header: {
         number: blocks[0].blockNumber,
         parentHash: blocks[0].parentHash,
+        difficulty: new BN(1),
       },
     },
     { common }
   )
-
+  // A zero difficulty block shouldn't be put in the chain without chain transition to PoS
+  // May be a check in putBlocks?
+  // Also if the block is not in chain or skeleton chain, then should the forkChoice respond
+  // with INVALID instead of currently syncing?
   await chain.putBlocks([newBlock])
   const req = params(method, [
     { ...validForkChoiceState, headBlockHash: '0x' + newBlock.hash().toString('hex') },

--- a/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
+++ b/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
@@ -1,7 +1,5 @@
 import tape from 'tape'
 import { Block } from '@ethereumjs/block'
-import { BN } from 'ethereumjs-util'
-
 import { INVALID_PARAMS } from '../../../lib/rpc/error-code'
 import { params, baseRequest, baseSetup, setupChain } from '../helpers'
 import { checkError } from '../util'
@@ -139,15 +137,12 @@ tape(`${method}: invalid terminal block with 1+ blocks`, async (t) => {
       header: {
         number: blocks[0].blockNumber,
         parentHash: blocks[0].parentHash,
-        difficulty: new BN(1),
+        difficulty: 1,
       },
     },
     { common }
   )
-  // A zero difficulty block shouldn't be put in the chain without chain transition to PoS
-  // May be a check in putBlocks?
-  // Also if the block is not in chain or skeleton chain, then should the forkChoice respond
-  // with INVALID instead of currently syncing?
+
   await chain.putBlocks([newBlock])
   const req = params(method, [
     { ...validForkChoiceState, headBlockHash: '0x' + newBlock.hash().toString('hex') },

--- a/packages/client/test/rpc/engine/newPayloadV1.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV1.spec.ts
@@ -71,7 +71,6 @@ tape(`${method}: call with non existent block hash`, async (t) => {
   await baseRequest(t, server, req, 200, expectRes)
 })
 
-// TODO(cbrzn): Change this to expect ACCEPTED when optimistic sync is supported
 tape(`${method}: call with non existent parent hash`, async (t) => {
   const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
 
@@ -84,7 +83,7 @@ tape(`${method}: call with non existent parent hash`, async (t) => {
   ]
   const req = params(method, blockDataNonExistentParentHash)
   const expectRes = (res: any) => {
-    t.equal(res.body.result.status, 'SYNCING')
+    t.equal(res.body.result.status, 'ACCEPTED')
   }
 
   await baseRequest(t, server, req, 200, expectRes)
@@ -97,7 +96,7 @@ tape(
 
     let req = params(method, [blocks[1]])
     let expectRes = (res: any) => {
-      t.equal(res.body.result.status, 'SYNCING')
+      t.equal(res.body.result.status, 'ACCEPTED')
     }
     await baseRequest(t, server, req, 200, expectRes, false)
 

--- a/packages/client/test/rpc/eth/syncing.spec.ts
+++ b/packages/client/test/rpc/eth/syncing.spec.ts
@@ -54,7 +54,7 @@ tape(`${method}: should return highest block header unavailable error`, async (t
 
   const req = params(method, [])
 
-  const expectRes = checkError(t, INTERNAL_ERROR, 'highest block header unavailable')
+  const expectRes = checkError(t, INTERNAL_ERROR, 'highest block unavailable')
   await baseRequest(t, rpcServer, req, 200, expectRes)
 })
 
@@ -66,8 +66,7 @@ tape(`${method}: should return syncing status object when unsynced`, async (t) =
   const synchronizer = client.services[0].synchronizer as FullSynchronizer
   synchronizer.best = td.func<typeof synchronizer['best']>()
   synchronizer.latest = td.func<typeof synchronizer['latest']>()
-  td.when(synchronizer.best()).thenReturn('peer')
-  td.when(synchronizer.latest('peer' as any)).thenResolve({ number: new BN(2) })
+  td.when(synchronizer.best()).thenReturn({ eth: { status: { latestBlock: new BN(2) } } } as any)
 
   client.config.synchronized = false
   t.equals(client.config.synchronized, false, 'not synchronized yet')

--- a/packages/client/test/rpc/eth/syncing.spec.ts
+++ b/packages/client/test/rpc/eth/syncing.spec.ts
@@ -47,14 +47,14 @@ tape(`${method}: should return highest block header unavailable error`, async (t
 
   const synchronizer = client.services[0].synchronizer
   synchronizer.best = td.func<typeof synchronizer['best']>()
-  td.when(synchronizer.best()).thenReturn('peer')
+  td.when(synchronizer.best()).thenResolve('peer')
 
   client.config.synchronized = false
   t.equals(client.config.synchronized, false, 'not synchronized yet')
 
   const req = params(method, [])
 
-  const expectRes = checkError(t, INTERNAL_ERROR, 'highest block unavailable')
+  const expectRes = checkError(t, INTERNAL_ERROR, 'highest block header unavailable')
   await baseRequest(t, rpcServer, req, 200, expectRes)
 })
 
@@ -66,7 +66,8 @@ tape(`${method}: should return syncing status object when unsynced`, async (t) =
   const synchronizer = client.services[0].synchronizer as FullSynchronizer
   synchronizer.best = td.func<typeof synchronizer['best']>()
   synchronizer.latest = td.func<typeof synchronizer['latest']>()
-  td.when(synchronizer.best()).thenReturn({ eth: { status: { latestBlock: new BN(2) } } } as any)
+  td.when(synchronizer.best()).thenResolve('peer')
+  td.when(synchronizer.latest('peer' as any)).thenResolve({ number: new BN(2) })
 
   client.config.synchronized = false
   t.equals(client.config.synchronized, false, 'not synchronized yet')

--- a/packages/client/test/rpc/eth/syncing.spec.ts
+++ b/packages/client/test/rpc/eth/syncing.spec.ts
@@ -4,6 +4,7 @@ import { BN } from 'ethereumjs-util'
 import { INTERNAL_ERROR } from '../../../lib/rpc/error-code'
 import { baseRequest, createManager, createClient, params, startRPC } from '../helpers'
 import { checkError } from '../util'
+import { FullSynchronizer } from '../../../lib/sync'
 
 const method = 'eth_syncing'
 
@@ -62,7 +63,7 @@ tape(`${method}: should return syncing status object when unsynced`, async (t) =
   const manager = createManager(client)
   const rpcServer = startRPC(manager.getMethods())
 
-  const synchronizer = client.services[0].synchronizer
+  const synchronizer = client.services[0].synchronizer as FullSynchronizer
   synchronizer.best = td.func<typeof synchronizer['best']>()
   synchronizer.latest = td.func<typeof synchronizer['latest']>()
   td.when(synchronizer.best()).thenReturn('peer')

--- a/packages/client/test/rpc/eth/syncing.spec.ts
+++ b/packages/client/test/rpc/eth/syncing.spec.ts
@@ -4,7 +4,7 @@ import { BN } from 'ethereumjs-util'
 import { INTERNAL_ERROR } from '../../../lib/rpc/error-code'
 import { baseRequest, createManager, createClient, params, startRPC } from '../helpers'
 import { checkError } from '../util'
-import { FullSynchronizer } from '../../../lib/sync'
+import type { FullSynchronizer } from '../../../lib/sync'
 
 const method = 'eth_syncing'
 

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -121,6 +121,9 @@ export function createClient(clientOpts: any = {}) {
         ],
         synchronizer,
         execution,
+        switchToBeaconSync: () => {
+          return undefined
+        },
       },
     ],
     servers,

--- a/packages/client/test/service/fullethereumservice.spec.ts
+++ b/packages/client/test/service/fullethereumservice.spec.ts
@@ -111,7 +111,7 @@ tape('[FullEthereumService]', async (t) => {
     const chain = new Chain({ config })
     const service = new FullEthereumService({ config, chain })
     await service.handle({ name: 'NewBlock', data: [{}, new BN(1)] }, 'eth', undefined as any)
-    td.verify(service.synchronizer.handleNewBlock({} as any, undefined))
+    td.verify((service.synchronizer as any).handleNewBlock({} as any, undefined))
     t.end()
   })
 

--- a/packages/client/test/service/fullethereumservice.spec.ts
+++ b/packages/client/test/service/fullethereumservice.spec.ts
@@ -37,7 +37,7 @@ tape('[FullEthereumService]', async (t) => {
   FullSynchronizer.prototype.open = td.func<any>()
   FullSynchronizer.prototype.close = td.func<any>()
   FullSynchronizer.prototype.handleNewBlock = td.func<any>()
-  td.replace('../../lib/sync/fullsync', { FullSynchronizer })
+  td.replace('../../lib/sync', { FullSynchronizer })
 
   class Block {
     static fromValuesArray() {
@@ -111,7 +111,7 @@ tape('[FullEthereumService]', async (t) => {
     const chain = new Chain({ config })
     const service = new FullEthereumService({ config, chain })
     await service.handle({ name: 'NewBlock', data: [{}, new BN(1)] }, 'eth', undefined as any)
-    td.verify((service.synchronizer as any).handleNewBlock({} as any, undefined))
+    td.verify((service.synchronizer as any).handleNewBlock({}, undefined))
     t.end()
   })
 

--- a/packages/client/test/sync/beaconsync.spec.ts
+++ b/packages/client/test/sync/beaconsync.spec.ts
@@ -102,8 +102,8 @@ tape('[BeaconSynchronizer]', async (t) => {
     }
     void sync.sync()
     await wait(50)
-    t.equal(sync.fetcher!.first.toNumber(), 5, 'should sync block 5')
-    t.equal(sync.fetcher!.count.toNumber(), 1, 'should sync block 5')
+    t.equal(sync.fetcher!.first.toNumber(), 5, 'should sync block 5 and 4')
+    t.equal(sync.fetcher!.count.toNumber(), 2, 'should sync block 5 and 4')
     await wait(51)
     ;(skeleton as any).status.progress.subchains = [{ head: new BN(10), tail: new BN(2) }]
     void sync.sync()

--- a/packages/client/test/sync/beaconsync.spec.ts
+++ b/packages/client/test/sync/beaconsync.spec.ts
@@ -1,5 +1,6 @@
 import tape from 'tape'
 import td from 'testdouble'
+import { Block } from '@ethereumjs/block'
 import { BN } from 'ethereumjs-util'
 import { Config } from '../../lib/config'
 import { Chain } from '../../lib/blockchain'
@@ -43,7 +44,7 @@ tape('[BeaconSynchronizer]', async (t) => {
     const metaDB = level()
     const skeleton = new Skeleton({ chain, config, metaDB })
     const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
-    t.equals(sync.type, 'beacon', 'beacon type')
+    t.equal(sync.type, 'beacon', 'beacon type')
     t.end()
   })
 
@@ -63,6 +64,23 @@ tape('[BeaconSynchronizer]', async (t) => {
     t.end()
   })
 
+  t.test('should get height', async (t) => {
+    const config = new Config({ transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const metaDB = level()
+    const skeleton = new Skeleton({ chain, config, metaDB })
+    const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
+    const peer = { eth: { getBlockHeaders: td.func(), status: { bestHash: 'hash' } } }
+    const headers = [{ number: new BN(5) }]
+    td.when(peer.eth.getBlockHeaders({ block: 'hash', max: 1 })).thenResolve([new BN(1), headers])
+    const latest = await sync.latest(peer as any)
+    t.ok(latest!.number.eqn(5), 'got height')
+    await sync.stop()
+    await sync.close()
+    t.end()
+  })
+
   t.test('should find best', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
@@ -72,12 +90,20 @@ tape('[BeaconSynchronizer]', async (t) => {
     const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
     ;(sync as any).running = true
     const peers = [
-      { eth: { status: { latestBlock: new BN(1) } }, inbound: false },
-      { eth: { status: { latestBlock: new BN(3) } }, inbound: false },
+      { eth: { getBlockHeaders: td.func(), status: { bestHash: 'hash1' }, inbound: false } },
+      { eth: { getBlockHeaders: td.func(), status: { bestHash: 'hash2' }, inbound: false } },
     ]
+    td.when(peers[0].eth.getBlockHeaders({ block: 'hash1', max: 1 })).thenResolve([
+      new BN(1),
+      [{ number: new BN(5) }],
+    ])
+    td.when(peers[1].eth.getBlockHeaders({ block: 'hash2', max: 1 })).thenResolve([
+      new BN(1),
+      [{ number: new BN(10) }],
+    ])
     ;(sync as any).pool = { peers }
     ;(sync as any).forceSync = true
-    t.equals(sync.best(), peers[1], 'found best')
+    t.equal(await sync.best(), peers[1], 'found best')
     await sync.stop()
     await sync.close()
     t.end()
@@ -91,7 +117,12 @@ tape('[BeaconSynchronizer]', async (t) => {
     const skeleton = new Skeleton({ chain, config, metaDB })
     const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
     sync.best = td.func<typeof sync['best']>()
-    td.when(sync.best()).thenReturn('peer')
+    sync.latest = td.func<typeof sync['latest']>()
+    td.when(sync.best()).thenResolve('peer')
+    td.when(sync.latest('peer' as any)).thenResolve({
+      number: new BN(2),
+      hash: () => Buffer.from([]),
+    })
     td.when(ReverseBlockFetcher.prototype.fetch(), { delay: 100, times: 3 }).thenResolve(undefined)
     ;(skeleton as any).status.progress.subchains = [
       { head: new BN(10), tail: new BN(6) },
@@ -119,10 +150,33 @@ tape('[BeaconSynchronizer]', async (t) => {
     t.equal(sync.fetcher!.count.toNumber(), 1, 'should sync block 5')
   })
 
-  t.test('should put received blocks in the skeleton chain', async (_t) => {})
-  t.test('should fill the canonical chain when linked and run execution', async (_t) => {})
-  t.test('should extend with a new valid head', async (_t) => {})
-  t.test('should not extend with an invalid head', async (_t) => {})
+  t.test('should extend and set with a valid head', async (t) => {
+    const config = new Config({ transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const metaDB = level()
+    const skeleton = new Skeleton({ chain, config, metaDB })
+    const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
+    ;(skeleton as any).status.progress.subchains = [
+      {
+        head: new BN(15),
+        tail: new BN(11),
+      },
+    ]
+    await sync.open()
+    const block = Block.fromBlockData({ header: { number: new BN(16) } })
+    t.ok(await sync.extendChain(block), 'should extend chain successfully')
+    t.ok(await sync.setHead(block), 'should set head successfully')
+    t.equal(skeleton.bounds().head.toNumber(), 16, 'head should be updated')
+
+    const gapBlock = Block.fromBlockData({ header: { number: new BN(18) } })
+    t.notOk(await sync.extendChain(gapBlock), 'should not extend chain with gapped block')
+    t.ok(await sync.setHead(gapBlock), 'should not set head with gapped block')
+    t.equal(skeleton.bounds().head.toNumber(), 16, 'head should not update with gapped block')
+    await sync.stop()
+    await sync.close()
+    t.end()
+  })
 
   t.test('should reset td', (t) => {
     td.reset()

--- a/packages/client/test/sync/beaconsync.spec.ts
+++ b/packages/client/test/sync/beaconsync.spec.ts
@@ -72,12 +72,12 @@ tape('[BeaconSynchronizer]', async (t) => {
     const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
     ;(sync as any).running = true
     const peers = [
-      { eth: { status: {} }, inbound: false },
-      { eth: { status: {} }, inbound: false },
+      { eth: { status: { latestBlock: new BN(1) } }, inbound: false },
+      { eth: { status: { latestBlock: new BN(3) } }, inbound: false },
     ]
     ;(sync as any).pool = { peers }
     ;(sync as any).forceSync = true
-    t.equals(sync.best(), peers[0], 'found best')
+    t.equals(sync.best(), peers[1], 'found best')
     await sync.stop()
     await sync.close()
     t.end()

--- a/packages/client/test/sync/beaconsync.spec.ts
+++ b/packages/client/test/sync/beaconsync.spec.ts
@@ -178,6 +178,21 @@ tape('[BeaconSynchronizer]', async (t) => {
     t.end()
   })
 
+  t.test('syncWithPeer should return early if skeleton is already linked', async (t) => {
+    const config = new Config({ transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const metaDB = level()
+    const skeleton = new Skeleton({ chain, config, metaDB })
+    skeleton.isLinked = () => true // stub
+    const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
+    await sync.open()
+    t.ok(await sync.syncWithPeer({} as any))
+    await sync.stop()
+    await sync.close()
+    t.end()
+  })
+
   t.test('should reset td', (t) => {
     td.reset()
     t.end()

--- a/packages/client/test/sync/beaconsync.spec.ts
+++ b/packages/client/test/sync/beaconsync.spec.ts
@@ -171,8 +171,8 @@ tape('[BeaconSynchronizer]', async (t) => {
 
     const gapBlock = Block.fromBlockData({ header: { number: new BN(18) } })
     t.notOk(await sync.extendChain(gapBlock), 'should not extend chain with gapped block')
-    t.ok(await sync.setHead(gapBlock), 'should not set head with gapped block')
-    t.equal(skeleton.bounds().head.toNumber(), 16, 'head should not update with gapped block')
+    t.ok(await sync.setHead(gapBlock), 'should be able to set and update head with gapped block')
+    t.equal(skeleton.bounds().head.toNumber(), 18, 'head should update with gapped block')
     await sync.stop()
     await sync.close()
     t.end()

--- a/packages/client/test/sync/beaconsync.spec.ts
+++ b/packages/client/test/sync/beaconsync.spec.ts
@@ -1,0 +1,131 @@
+import tape from 'tape'
+import td from 'testdouble'
+import { BN } from 'ethereumjs-util'
+import { Config } from '../../lib/config'
+import { Chain } from '../../lib/blockchain'
+import { Skeleton } from '../../lib/sync'
+import { wait } from '../integration/util'
+const level = require('level-mem')
+
+tape('[BeaconSynchronizer]', async (t) => {
+  const execution: any = { run: () => {} }
+  class PeerPool {
+    open() {}
+    close() {}
+    idle() {}
+    ban(_peer: any) {}
+  }
+  PeerPool.prototype.open = td.func<any>()
+  PeerPool.prototype.close = td.func<any>()
+  PeerPool.prototype.idle = td.func<any>()
+  class ReverseBlockFetcher {
+    first: BN
+    count: BN
+    constructor(opts: any) {
+      this.first = opts.first
+      this.count = opts.count
+    }
+    fetch() {}
+    clear() {}
+    destroy() {}
+  }
+  ReverseBlockFetcher.prototype.fetch = td.func<any>()
+  ReverseBlockFetcher.prototype.clear = td.func<any>()
+  ReverseBlockFetcher.prototype.destroy = td.func<any>()
+  td.replace('../../lib/sync/fetcher', { ReverseBlockFetcher })
+
+  const { BeaconSynchronizer } = await import('../../lib/sync/beaconsync')
+
+  t.test('should initialize correctly', async (t) => {
+    const config = new Config({ transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const metaDB = level()
+    const skeleton = new Skeleton({ chain, config, metaDB })
+    const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
+    t.equals(sync.type, 'beacon', 'beacon type')
+    t.end()
+  })
+
+  t.test('should open', async (t) => {
+    const config = new Config({ transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const metaDB = level()
+    const skeleton = new Skeleton({ chain, config, metaDB })
+    const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
+    ;(sync as any).pool.open = td.func<PeerPool['open']>()
+    ;(sync as any).pool.peers = []
+    td.when((sync as any).pool.open()).thenResolve(null)
+    await sync.open()
+    t.pass('opened')
+    await sync.close()
+    t.end()
+  })
+
+  t.test('should find best', async (t) => {
+    const config = new Config({ transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const metaDB = level()
+    const skeleton = new Skeleton({ chain, config, metaDB })
+    const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
+    ;(sync as any).running = true
+    const peers = [
+      { eth: { status: {} }, inbound: false },
+      { eth: { status: {} }, inbound: false },
+    ]
+    ;(sync as any).pool = { peers }
+    ;(sync as any).forceSync = true
+    t.equals(sync.best(), peers[0], 'found best')
+    await sync.stop()
+    await sync.close()
+    t.end()
+  })
+
+  t.test('should sync to next subchain head or chain height', async (t) => {
+    const config = new Config({ transports: [], safeReorgDistance: 0 })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const metaDB = level()
+    const skeleton = new Skeleton({ chain, config, metaDB })
+    const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
+    sync.best = td.func<typeof sync['best']>()
+    td.when(sync.best()).thenReturn('peer')
+    td.when(ReverseBlockFetcher.prototype.fetch(), { delay: 100, times: 3 }).thenResolve(undefined)
+    ;(skeleton as any).status.progress.subchains = [
+      { head: new BN(10), tail: new BN(6) },
+      { head: new BN(4), tail: new BN(2) },
+    ]
+    ;(sync as any).chain = {
+      blocks: { height: new BN(0) },
+    }
+    void sync.sync()
+    await wait(50)
+    t.equal(sync.fetcher!.first.toNumber(), 5, 'should sync block 5')
+    t.equal(sync.fetcher!.count.toNumber(), 1, 'should sync block 5')
+    await wait(51)
+    ;(skeleton as any).status.progress.subchains = [{ head: new BN(10), tail: new BN(2) }]
+    void sync.sync()
+    await wait(50)
+    t.equal(sync.fetcher!.first.toNumber(), 1, 'should sync block 1')
+    t.equal(sync.fetcher!.count.toNumber(), 1, 'should sync block 1')
+    await wait(51)
+    ;(skeleton as any).status.progress.subchains = [{ head: new BN(10), tail: new BN(6) }]
+    ;(sync as any).chain = { blocks: { height: new BN(4) } }
+    void sync.sync()
+    await wait(50)
+    t.equal(sync.fetcher!.first.toNumber(), 5, 'should sync block 5')
+    t.equal(sync.fetcher!.count.toNumber(), 1, 'should sync block 5')
+  })
+
+  t.test('should put received blocks in the skeleton chain', async (_t) => {})
+  t.test('should fill the canonical chain when linked and run execution', async (_t) => {})
+  t.test('should extend with a new valid head', async (_t) => {})
+  t.test('should not extend with an invalid head', async (_t) => {})
+
+  t.test('should reset td', (t) => {
+    td.reset()
+    t.end()
+  })
+})

--- a/packages/client/test/sync/fetcher/blockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/blockfetcher.spec.ts
@@ -171,6 +171,7 @@ tape('[BlockFetcher]', async (t) => {
       job.peer.eth.getBlockHeaders({
         block: job.task.first.addn(partialResult.length),
         max: job.task.count - partialResult.length,
+        reverse: false,
       })
     )
     t.end()

--- a/packages/client/test/sync/fetcher/headerfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/headerfetcher.spec.ts
@@ -92,6 +92,7 @@ tape('[HeaderFetcher]', async (t) => {
       job.peer.les.getBlockHeaders({
         block: job.task.first.addn(partialResult.length),
         max: job.task.count - partialResult.length,
+        reverse: false,
       })
     )
     t.end()

--- a/packages/client/test/sync/fetcher/reverseblockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/reverseblockfetcher.spec.ts
@@ -126,12 +126,12 @@ tape('[ReverseBlockFetcher]', async (t) => {
       pool,
       chain,
       skeleton,
-      first: new BN(0),
-      count: new BN(0),
+      first: new BN(10),
+      count: new BN(5),
     })
-    const partialResult: any = [{ header: { number: 1 } }, { header: { number: 2 } }]
+    const partialResult: any = [{ header: { number: 10 } }, { header: { number: 9 } }]
 
-    const task = { count: 3, first: new BN(1) }
+    const task = { first: new BN(10), count: 5 }
     const peer = {
       eth: { getBlockBodies: td.func<any>(), getBlockHeaders: td.func<any>() },
       id: 'random',
@@ -141,7 +141,7 @@ tape('[ReverseBlockFetcher]', async (t) => {
     await fetcher.request(job as any)
     td.verify(
       job.peer.eth.getBlockHeaders({
-        block: job.task.first.addn(partialResult.length),
+        block: job.task.first.subn(partialResult.length),
         max: job.task.count - partialResult.length,
         reverse: true,
       })

--- a/packages/client/test/sync/fetcher/reverseblockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/reverseblockfetcher.spec.ts
@@ -1,0 +1,189 @@
+import tape from 'tape'
+import td from 'testdouble'
+import { BN } from 'ethereumjs-util'
+import { Config } from '../../../lib/config'
+import { Chain } from '../../../lib/blockchain/chain'
+import { Skeleton } from '../../../lib/sync'
+import { wait } from '../../integration/util'
+import { Event } from '../../../lib/types'
+const level = require('level-mem')
+
+tape('[ReverseBlockFetcher]', async (t) => {
+  class PeerPool {
+    idle() {}
+    ban() {}
+  }
+  PeerPool.prototype.idle = td.func<any>()
+  PeerPool.prototype.ban = td.func<any>()
+
+  const { ReverseBlockFetcher } = await import('../../../lib/sync/fetcher/reverseblockfetcher')
+
+  t.test('should start/stop', async (t) => {
+    const config = new Config({ maxPerRequest: 5, transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const metaDB = level()
+    const skeleton = new Skeleton({ chain, config, metaDB })
+    const fetcher = new ReverseBlockFetcher({
+      config,
+      pool,
+      chain,
+      skeleton,
+      first: new BN(1),
+      count: new BN(10),
+      timeout: 5,
+    })
+    fetcher.next = () => false
+    t.notOk((fetcher as any).running, 'not started')
+    void fetcher.fetch()
+    t.equals((fetcher as any).in.size(), 2, 'added 2 tasks')
+    await wait(100)
+    t.ok((fetcher as any).running, 'started')
+    fetcher.destroy()
+    await wait(100)
+    t.notOk((fetcher as any).running, 'stopped')
+    t.end()
+  })
+
+  t.test('should process', (t) => {
+    const config = new Config({ transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const metaDB = level()
+    const skeleton = new Skeleton({ chain, config, metaDB })
+    const fetcher = new ReverseBlockFetcher({
+      config,
+      pool,
+      chain,
+      skeleton,
+      first: new BN(0),
+      count: new BN(0),
+    })
+    const blocks: any = [{ header: { number: 1 } }, { header: { number: 2 } }]
+    t.deepEquals(fetcher.process({ task: { count: 2 } } as any, blocks), blocks, 'got results')
+    t.notOk(fetcher.process({ task: { count: 2 } } as any, { blocks: [] } as any), 'bad results')
+    t.end()
+  })
+
+  t.test('should adopt correctly', (t) => {
+    const config = new Config({ transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const metaDB = level()
+    const skeleton = new Skeleton({ chain, config, metaDB })
+    const fetcher = new ReverseBlockFetcher({
+      config,
+      pool,
+      chain,
+      skeleton,
+      first: new BN(0),
+      count: new BN(0),
+    })
+    const blocks: any = [{ header: { number: 1 } }, { header: { number: 2 } }]
+    const task = { count: 3, first: new BN(1) }
+    ;(fetcher as any).running = true
+    fetcher.enqueueTask(task)
+    const job = (fetcher as any).in.peek()
+    let results = fetcher.process(job as any, blocks)
+    t.equal((fetcher as any).in.size(), 1, 'Fetcher should still have same job')
+    t.equal(job?.partialResult?.length, 2, 'Should have two partial results')
+    t.equal(results, undefined, 'Process should not return full results yet')
+
+    const remainingBlocks: any = [{ header: { number: 3 } }]
+    results = fetcher.process(job as any, remainingBlocks)
+    t.equal(results?.length, 3, 'Should return full results')
+
+    t.end()
+  })
+
+  t.test('should find a fetchable peer', async (t) => {
+    const config = new Config({ transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const metaDB = level()
+    const skeleton = new Skeleton({ chain, config, metaDB })
+    const fetcher = new ReverseBlockFetcher({
+      config,
+      pool,
+      chain,
+      skeleton,
+      first: new BN(0),
+      count: new BN(0),
+    })
+    td.when((fetcher as any).pool.idle(td.matchers.anything())).thenReturn('peer0')
+    t.equals(fetcher.peer(), 'peer0', 'found peer')
+    t.end()
+  })
+
+  t.test('should request correctly', async (t) => {
+    const config = new Config({ transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const metaDB = level()
+    const skeleton = new Skeleton({ chain, config, metaDB })
+    const fetcher = new ReverseBlockFetcher({
+      config,
+      pool,
+      chain,
+      skeleton,
+      first: new BN(0),
+      count: new BN(0),
+    })
+    const partialResult: any = [{ header: { number: 1 } }, { header: { number: 2 } }]
+
+    const task = { count: 3, first: new BN(1) }
+    const peer = {
+      eth: { getBlockBodies: td.func<any>(), getBlockHeaders: td.func<any>() },
+      id: 'random',
+      address: 'random',
+    }
+    const job = { peer, partialResult, task }
+    await fetcher.request(job as any)
+    td.verify(
+      job.peer.eth.getBlockHeaders({
+        block: job.task.first.addn(partialResult.length),
+        max: job.task.count - partialResult.length,
+        reverse: true,
+      })
+    )
+    t.end()
+  })
+
+  t.test('store()', async (st) => {
+    td.reset()
+    st.plan(2)
+
+    const config = new Config({ maxPerRequest: 5, transports: [] })
+    const pool = new PeerPool() as any
+    const chain = new Chain({ config })
+    const metaDB = level()
+    const skeleton = new Skeleton({ chain, config, metaDB })
+    skeleton.putBlocks = td.func<any>()
+    const fetcher = new ReverseBlockFetcher({
+      config,
+      pool,
+      chain,
+      skeleton,
+      first: new BN(1),
+      count: new BN(10),
+      timeout: 5,
+    })
+    td.when(skeleton.putBlocks(td.matchers.anything())).thenReject(new Error('err0'))
+    try {
+      await fetcher.store([])
+    } catch (err: any) {
+      st.ok(err.message === 'err0', 'store() threw on invalid block')
+    }
+    td.reset()
+    skeleton.putBlocks = td.func<any>()
+    td.when(skeleton.putBlocks(td.matchers.anything())).thenResolve(1)
+    config.events.on(Event.SYNC_FETCHED_BLOCKS, () =>
+      st.pass('store() emitted SYNC_FETCHED_BLOCKS event on putting blocks')
+    )
+    await fetcher.store([])
+  })
+  t.test('should reset td', (t) => {
+    td.reset()
+    t.end()
+  })
+})

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -101,7 +101,7 @@ tape('[FullSynchronizer]', async (t) => {
     td.when((sync as any).height(peers[1])).thenDo((peer: any) =>
       Promise.resolve(peer.eth.status.td)
     )
-    t.equals(sync.best(), peers[1], 'found best')
+    t.equal(await sync.best(), peers[1], 'found best')
     await sync.stop()
     await sync.close()
     t.end()
@@ -122,7 +122,7 @@ tape('[FullSynchronizer]', async (t) => {
     })
     sync.best = td.func<typeof sync['best']>()
     sync.latest = td.func<typeof sync['latest']>()
-    td.when(sync.best()).thenReturn('peer')
+    td.when(sync.best()).thenResolve('peer')
     td.when(sync.latest('peer' as any)).thenResolve({
       number: new BN(2),
       hash: () => Buffer.from([]),

--- a/packages/client/test/sync/lightsync.spec.ts
+++ b/packages/client/test/sync/lightsync.spec.ts
@@ -56,7 +56,7 @@ tape('[LightSynchronizer]', async (t) => {
     ]
     ;(sync as any).pool = { peers }
     ;(sync as any).forceSync = true
-    t.equals(sync.best(), peers[1], 'found best')
+    t.equal(await sync.best(), peers[1], 'found best')
     t.end()
   })
 
@@ -73,7 +73,7 @@ tape('[LightSynchronizer]', async (t) => {
     })
     sync.best = td.func<typeof sync['best']>()
     sync.latest = td.func<typeof sync['latest']>()
-    td.when(sync.best()).thenReturn({ les: { status: { headNum: new BN(2) } } } as any)
+    td.when(sync.best()).thenResolve({ les: { status: { headNum: new BN(2) } } } as any)
     td.when(sync.latest(td.matchers.anything())).thenResolve({
       number: new BN(2),
       hash: () => Buffer.from([]),
@@ -110,7 +110,7 @@ tape('[LightSynchronizer]', async (t) => {
     })
     sync.best = td.func<typeof sync['best']>()
     sync.latest = td.func<typeof sync['latest']>()
-    td.when(sync.best()).thenReturn({ les: { status: { headNum: new BN(2) } } } as any)
+    td.when(sync.best()).thenResolve({ les: { status: { headNum: new BN(2) } } } as any)
     td.when(sync.latest(td.matchers.anything())).thenResolve({
       number: new BN(2),
       hash: () => Buffer.from([]),
@@ -144,7 +144,7 @@ tape('[LightSynchronizer]', async (t) => {
     })
     sync.best = td.func<typeof sync['best']>()
     sync.latest = td.func<typeof sync['latest']>()
-    td.when(sync.best()).thenReturn({ les: { status: { headNum: new BN(2) } } } as any)
+    td.when(sync.best()).thenResolve({ les: { status: { headNum: new BN(2) } } } as any)
     td.when(sync.latest(td.matchers.anything())).thenResolve({
       number: new BN(2),
       hash: () => Buffer.from([]),

--- a/packages/client/test/sync/skeleton.spec.ts
+++ b/packages/client/test/sync/skeleton.spec.ts
@@ -352,7 +352,7 @@ tape('[Skeleton]', async (t) => {
     )
     for (const block of [block1, block2, block3, block4, block5]) {
       st.equal(
-        await skeleton.getBlock(block.header.number),
+        await skeleton.getBlock(block.header.number, true),
         undefined,
         `skeleton block ${block.header.number} should be cleaned up after filling canonical chain`
       )
@@ -401,7 +401,7 @@ tape('[Skeleton]', async (t) => {
       )
       for (const block of [block3, block4, block5]) {
         st.equal(
-          await skeleton.getBlock(block.header.number),
+          await skeleton.getBlock(block.header.number, true),
           undefined,
           `skeleton block ${block.header.number} should be cleaned up after filling canonical chain`
         )

--- a/packages/client/test/sync/skeleton.spec.ts
+++ b/packages/client/test/sync/skeleton.spec.ts
@@ -1,0 +1,310 @@
+import tape from 'tape'
+import td from 'testdouble'
+import { Block } from '@ethereumjs/block'
+import Common from '@ethereumjs/common'
+import { BN } from 'ethereumjs-util'
+import { Config } from '../../lib/config'
+import { Chain } from '../../lib/blockchain'
+import { Skeleton } from '../../lib/sync'
+const level = require('level-mem')
+
+const common = new Common({ chain: 1 })
+
+// Create a few key headers
+const block49 = Block.fromBlockData({ header: { number: 49 } }, { common })
+const block49B = Block.fromBlockData(
+  { header: { number: 49, extraData: Buffer.from('B') } },
+  { common }
+)
+const block50 = Block.fromBlockData(
+  { header: { number: 50, parentHash: block49.hash() } },
+  { common }
+)
+const block51 = Block.fromBlockData(
+  { header: { number: 51, parentHash: block50.hash() } },
+  { common }
+)
+
+type Subchain = {
+  head: BN
+  tail: BN
+}
+
+tape('[Skeleton]', async (t) => {
+  // Tests various sync initializations based on previous leftovers in the database
+  // and announced heads.
+  t.test('should pass sync init test cases', async (st) => {
+    interface TestCase {
+      blocks?: Block[] /** Database content (besides the genesis) */
+      oldState?: Subchain[] /** Old sync state with various interrupted subchains */
+      head: Block /** New head header to announce to reorg to */
+      newState: Subchain[] /** Expected sync state after the reorg */
+    }
+    const testCases: TestCase[] = [
+      // Completely empty database with only the genesis set. The sync is expected
+      // to create a single subchain with the requested head.
+      {
+        head: block50,
+        newState: [{ head: new BN(50), tail: new BN(50) }],
+      },
+      // Empty database with only the genesis set with a leftover empty sync
+      // progress. This is a synthetic case, just for the sake of covering things.
+      { oldState: [], head: block50, newState: [{ head: new BN(50), tail: new BN(50) }] },
+      // A single leftover subchain is present, older than the new head. The
+      // old subchain should be left as is and a new one appended to the sync
+      // status.
+      {
+        oldState: [{ head: new BN(10), tail: new BN(5) }],
+        head: block50,
+        newState: [
+          { head: new BN(50), tail: new BN(50) },
+          { head: new BN(10), tail: new BN(5) },
+        ],
+      },
+      // Multiple leftover subchains are present, older than the new head. The
+      // old subchains should be left as is and a new one appended to the sync
+      // status.
+      {
+        oldState: [
+          { head: new BN(20), tail: new BN(15) },
+          { head: new BN(10), tail: new BN(5) },
+        ],
+        head: block50,
+        newState: [
+          { head: new BN(50), tail: new BN(50) },
+          { head: new BN(20), tail: new BN(15) },
+          { head: new BN(10), tail: new BN(5) },
+        ],
+      },
+      // A single leftover subchain is present, newer than the new head. The
+      // newer subchain should be deleted and a fresh one created for the head.
+      {
+        oldState: [{ head: new BN(65), tail: new BN(60) }],
+        head: block50,
+        newState: [{ head: new BN(50), tail: new BN(50) }],
+      },
+      // Multiple leftover subchain is present, newer than the new head. The
+      // newer subchains should be deleted and a fresh one created for the head.
+      {
+        oldState: [
+          { head: new BN(75), tail: new BN(70) },
+          { head: new BN(65), tail: new BN(60) },
+        ],
+        head: block50,
+        newState: [{ head: new BN(50), tail: new BN(50) }],
+      },
+      // Two leftover subchains are present, one fully older and one fully
+      // newer than the announced head. The head should delete the newer one,
+      // keeping the older one.
+      {
+        oldState: [
+          { head: new BN(65), tail: new BN(60) },
+          { head: new BN(10), tail: new BN(5) },
+        ],
+        head: block50,
+        newState: [
+          { head: new BN(50), tail: new BN(50) },
+          { head: new BN(10), tail: new BN(5) },
+        ],
+      },
+      // Multiple leftover subchains are present, some fully older and some
+      // fully newer than the announced head. The head should delete the newer
+      // ones, keeping the older ones.
+      {
+        oldState: [
+          { head: new BN(75), tail: new BN(70) },
+          { head: new BN(65), tail: new BN(60) },
+          { head: new BN(20), tail: new BN(15) },
+          { head: new BN(10), tail: new BN(5) },
+        ],
+        head: block50,
+        newState: [
+          { head: new BN(50), tail: new BN(50) },
+          { head: new BN(20), tail: new BN(15) },
+          { head: new BN(10), tail: new BN(5) },
+        ],
+      },
+      // A single leftover subchain is present and the new head is extending
+      // it with one more header. We expect the subchain head to be pushed
+      // forward.
+      {
+        blocks: [block49],
+        oldState: [{ head: new BN(49), tail: new BN(5) }],
+        head: block50,
+        newState: [{ head: new BN(50), tail: new BN(5) }],
+      },
+      // A single leftover subchain is present. A new head is announced that
+      // links into the middle of it, correctly anchoring into an existing
+      // header. We expect the old subchain to be truncated and extended with
+      // the new head.
+      {
+        blocks: [block49],
+        oldState: [{ head: new BN(100), tail: new BN(5) }],
+        head: block50,
+        newState: [{ head: new BN(50), tail: new BN(5) }],
+      },
+      // A single leftover subchain is present. A new head is announced that
+      // links into the middle of it, but does not anchor into an existing
+      // header. We expect the old subchain to be truncated and a new chain
+      // be created for the dangling head.
+      {
+        blocks: [block49B],
+        oldState: [{ head: new BN(100), tail: new BN(5) }],
+        head: block50,
+        newState: [
+          { head: new BN(50), tail: new BN(50) },
+          { head: new BN(49), tail: new BN(5) },
+        ],
+      },
+    ]
+    for (const [testCaseIndex, testCase] of testCases.entries()) {
+      const config = new Config({ transports: [] })
+      const chain = new Chain({ config })
+      const metaDB = level()
+      const skeleton = new Skeleton({ chain, config, metaDB })
+      await skeleton.open()
+
+      for (const block of testCase.blocks ?? []) {
+        await (skeleton as any).putBlock(block)
+      }
+
+      if (testCase.oldState) {
+        ;(skeleton as any).status.progress.subchains = testCase.oldState
+      }
+
+      await skeleton.processNewHead(testCase.head, true)
+
+      const { progress } = (skeleton as any).status
+      if (progress.subchains.length !== testCase.newState.length) {
+        st.fail(
+          `test ${testCaseIndex}: subchain count mismatch: have ${progress.subchains.length}, want ${testCase.newState.length}`
+        )
+        console.log(progress.subchains, testCase.newState)
+      }
+      for (const [i, subchain] of progress.subchains.entries()) {
+        if (!subchain.head.eq(testCase.newState[i].head)) {
+          st.fail(
+            `test ${testCaseIndex}: subchain head mismatch: have ${subchain.head}, want ${testCase.newState[i].head}`
+          )
+        } else if (!subchain.tail.eq(testCase.newState[i].tail)) {
+          st.fail(
+            `test ${testCaseIndex}: subchain tail mismatch: have ${subchain.tail}, want ${testCase.newState[i].tail}`
+          )
+        } else {
+          st.pass(`test ${testCaseIndex}: subchain[${i}] matched`)
+        }
+      }
+    }
+  })
+
+  // Tests that a running skeleton sync can be extended with properly linked up
+  // headers but not with side chains.
+  t.test('should pass sync extend test cases', async (st) => {
+    interface TestCase {
+      head: Block /** New head header to announce to reorg to */
+      extend: Block /** New head header to announce to extend with */
+      newState: Subchain[] /** Expected sync state after the reorg */
+      err?: string /** Whether extension succeeds or not */
+    }
+    const errReorgDenied = 'reorg denied'
+    const testCases: TestCase[] = [
+      // Initialize a sync and try to extend it with a subsequent block.
+      {
+        head: block49,
+        extend: block50,
+        newState: [{ head: new BN(50), tail: new BN(49) }],
+      },
+      // Initialize a sync and try to extend it with the existing head block.
+      {
+        head: block49,
+        extend: block49,
+        newState: [{ head: new BN(49), tail: new BN(49) }],
+      },
+      // Initialize a sync and try to extend it with a sibling block.
+      {
+        head: block49,
+        extend: block49B,
+        newState: [{ head: new BN(49), tail: new BN(49) }],
+        err: errReorgDenied,
+      },
+      // Initialize a sync and try to extend it with a number-wise sequential
+      // header, but a hash wise non-linking one.
+      {
+        head: block49B,
+        extend: block50,
+        newState: [{ head: new BN(49), tail: new BN(49) }],
+        err: errReorgDenied,
+      },
+      // Initialize a sync and try to extend it with a non-linking future block.
+      {
+        head: block49,
+        extend: block51,
+        newState: [{ head: new BN(49), tail: new BN(49) }],
+        err: errReorgDenied,
+      },
+      // Initialize a sync and try to extend it with a past canonical block.
+      {
+        head: block50,
+        extend: block49,
+        newState: [{ head: new BN(50), tail: new BN(50) }],
+        err: errReorgDenied,
+      },
+      // Initialize a sync and try to extend it with a past sidechain block.
+      {
+        head: block50,
+        extend: block49B,
+        newState: [{ head: new BN(50), tail: new BN(50) }],
+        err: errReorgDenied,
+      },
+    ]
+    for (const [testCaseIndex, testCase] of testCases.entries()) {
+      const config = new Config({ transports: [] })
+      const chain = new Chain({ config })
+      const metaDB = level()
+      const skeleton = new Skeleton({ chain, config, metaDB })
+      await skeleton.open()
+
+      await skeleton.processNewHead(testCase.head, true)
+
+      try {
+        await skeleton.processNewHead(testCase.extend)
+        if (testCase.err) {
+          t.fail('should have failed')
+        } else {
+          t.pass('successfully passed')
+        }
+      } catch (error: any) {
+        if (error.message.includes(testCase.err)) {
+          t.pass('passed with correct error')
+        } else {
+          t.pass('received wrong error')
+        }
+      }
+
+      const { progress } = (skeleton as any).status
+      if (progress.subchains.length !== testCase.newState.length) {
+        st.fail(
+          `test ${testCaseIndex}: subchain count mismatch: have ${progress.subchains.length}, want ${testCase.newState.length}`
+        )
+      }
+      for (const [i, subchain] of progress.subchains.entries()) {
+        if (!subchain.head.eq(testCase.newState[i].head)) {
+          st.fail(
+            `test ${testCaseIndex}: subchain head mismatch: have ${subchain.head}, want ${testCase.newState[i].head}`
+          )
+        } else if (!subchain.tail.eq(testCase.newState[i].tail)) {
+          st.fail(
+            `test ${testCaseIndex}: subchain tail mismatch: have ${subchain.tail}, want ${testCase.newState[i].tail}`
+          )
+        } else {
+          st.pass(`test ${testCaseIndex}: subchain[${i}] matched`)
+        }
+      }
+    }
+  })
+
+  t.test('should reset td', (t) => {
+    td.reset()
+    t.end()
+  })
+})

--- a/packages/client/test/sync/sync.spec.ts
+++ b/packages/client/test/sync/sync.spec.ts
@@ -13,7 +13,7 @@ class SynchronizerTest extends Synchronizer {
   async sync() {
     return false
   }
-  best() {
+  async best() {
     return undefined
   }
 }

--- a/packages/devp2p/src/rlpx/peer.ts
+++ b/packages/devp2p/src/rlpx/peer.ts
@@ -423,7 +423,10 @@ export class Peer extends EventEmitter {
    */
   _handleDisconnect(payload: any) {
     this._closed = true
-    this._disconnectReason = payload[0].length === 0 ? 0 : payload[0][0]
+    // When `payload` is from rlpx it is `Buffer` and when from subprotocol it is `[Buffer]`
+    this._disconnectReason = Buffer.isBuffer(payload)
+      ? buffer2int(payload)
+      : buffer2int(payload[0] ?? Buffer.from([0]))
     const reason = DISCONNECT_REASONS[this._disconnectReason as number]
     const debugMsg = `DISCONNECT reason: ${reason} ${this._socket.remoteAddress}:${this._socket.remotePort}`
     this.debug('DISCONNECT', debugMsg, reason)

--- a/packages/vm/src/state/baseStateManager.ts
+++ b/packages/vm/src/state/baseStateManager.ts
@@ -282,6 +282,7 @@ export abstract class BaseStateManager {
   }
 
   abstract hasGenesisState(): Promise<boolean>
+  abstract hasStateRoot(root: Buffer): Promise<boolean>
 
   /**
    * Generates a canonical genesis state on the instance based on the

--- a/packages/vm/src/state/baseStateManager.ts
+++ b/packages/vm/src/state/baseStateManager.ts
@@ -282,7 +282,7 @@ export abstract class BaseStateManager {
   }
 
   abstract hasGenesisState(): Promise<boolean>
-  abstract hasStateRoot(root: Buffer): Promise<boolean>
+  abstract hasStateRoot?(root: Buffer): Promise<boolean>
 
   /**
    * Generates a canonical genesis state on the instance based on the

--- a/packages/vm/src/state/interface.ts
+++ b/packages/vm/src/state/interface.ts
@@ -28,6 +28,7 @@ export interface StateManager {
   setStateRoot(stateRoot: Buffer): Promise<void>
   dumpStorage(address: Address): Promise<StorageDump>
   hasGenesisState(): Promise<boolean>
+  hasStateRoot(root: Buffer): Promise<boolean>
   generateCanonicalGenesis(): Promise<void>
   generateGenesis(initState: any): Promise<void>
   accountIsEmpty(address: Address): Promise<boolean>

--- a/packages/vm/src/state/interface.ts
+++ b/packages/vm/src/state/interface.ts
@@ -28,7 +28,7 @@ export interface StateManager {
   setStateRoot(stateRoot: Buffer): Promise<void>
   dumpStorage(address: Address): Promise<StorageDump>
   hasGenesisState(): Promise<boolean>
-  hasStateRoot(root: Buffer): Promise<boolean>
+  hasStateRoot?(root: Buffer): Promise<boolean>
   generateCanonicalGenesis(): Promise<void>
   generateGenesis(initState: any): Promise<void>
   accountIsEmpty(address: Address): Promise<boolean>

--- a/packages/vm/src/state/stateManager.ts
+++ b/packages/vm/src/state/stateManager.ts
@@ -487,6 +487,14 @@ export default class DefaultStateManager extends BaseStateManager implements Sta
   }
 
   /**
+   * Checks whether there is a state corresponding to a stateRoot
+   */
+
+  async hasStateRoot(root: Buffer): Promise<boolean> {
+    return await this._trie.checkRoot(root)
+  }
+
+  /**
    * Checks if the `account` corresponding to `address`
    * exists
    * @param address - Address of the `account` to check

--- a/packages/vm/src/state/stateManager.ts
+++ b/packages/vm/src/state/stateManager.ts
@@ -489,7 +489,6 @@ export default class DefaultStateManager extends BaseStateManager implements Sta
   /**
    * Checks whether there is a state corresponding to a stateRoot
    */
-
   async hasStateRoot(root: Buffer): Promise<boolean> {
     return await this._trie.checkRoot(root)
   }


### PR DESCRIPTION
This PR adds [optimistic](https://github.com/ethereum/consensus-specs/blob/dev/sync/optimistic.md) (beacon) sync to the client, where blocks are downloaded in reverse from the announced trusted head.

Thanks to go-ethereum for the skeleton design and test cases.

You can test with the instructions in `packages/client/kiln/README.md` with these new params for lodestar: `--weakSubjectivityServerUrl https://lodestar-kiln.chainsafe.io --weakSubjectivitySyncLatest`

Thanks to @g11tech for following this work and providing help and commits along the way!
