### PR TITLE
client: add missing tx fields to getBlockByHash

### DIFF
--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -73,7 +73,7 @@ type JsonRpcBlock = {
   gasLimit: string // the maximum gas allowed in this block.
   gasUsed: string // the total used gas by all transactions in this block.
   timestamp: string // the unix timestamp for when the block was collated.
-  transactions: JsonTx[] | string[] // Array of transaction objects, or 32 Bytes transaction hashes depending on the last given parameter.
+  transactions: Array<JsonRpcTx | string> // Array of transaction objects, or 32 Bytes transaction hashes depending on the last given parameter.
   uncles: string[] // Array of uncle hashes
   baseFeePerGas?: string // If EIP-1559 is enabled for this block, returns the base fee per gas
 }
@@ -130,66 +130,6 @@ type JsonRpcLog = {
 }
 
 /**
- * Returns block formatted to the standard JSON-RPC fields
- */
-const jsonRpcBlock = async (
-  block: Block,
-  chain: Chain,
-  includeTransactions: boolean
-): Promise<JsonRpcBlock> => {
-  const json = block.toJSON()
-  const header = json!.header!
-
-  let transactions
-  if (includeTransactions) {
-    transactions = block.transactions.map((tx, idx) => {
-      const transaction = tx.toJSON()
-      const { gasLimit: gas, data: input, ...txData } = transaction
-
-      return {
-        ...txData,
-        // RPC specs specify `input` rather than `data`, and `gas` rather than `gasLimit`
-        input,
-        gas,
-        hash: bufferToHex(tx.hash()),
-        blockHash: bufferToHex(block.header.hash()),
-        blockNumber: bnToHex(block.header.number),
-        transactionIndex: intToHex(idx),
-        from: tx.getSenderAddress().toString(),
-      }
-    })
-  } else {
-    transactions = block.transactions.map((tx) => bufferToHex(tx.hash()))
-  }
-
-  const td = await chain.getTd(block.hash(), block.header.number)
-
-  return {
-    number: header.number!,
-    hash: bufferToHex(block.hash()),
-    parentHash: header.parentHash!,
-    mixHash: header.mixHash,
-    nonce: header.nonce!,
-    sha3Uncles: header.uncleHash!,
-    logsBloom: header.logsBloom!,
-    transactionsRoot: header.transactionsTrie!,
-    stateRoot: header.stateRoot!,
-    receiptsRoot: header.receiptTrie!,
-    miner: header.coinbase!,
-    difficulty: header.difficulty!,
-    totalDifficulty: bnToHex(td),
-    extraData: header.extraData!,
-    size: intToHex(Buffer.byteLength(JSON.stringify(json))),
-    gasLimit: header.gasLimit!,
-    gasUsed: header.gasUsed!,
-    timestamp: header.timestamp!,
-    transactions,
-    uncles: block.uncleHeaders.map((uh) => bufferToHex(uh.hash())),
-    baseFeePerGas: header.baseFeePerGas,
-  }
-}
-
-/**
  * Returns tx formatted to the standard JSON-RPC fields
  */
 const jsonRpcTx = (tx: TypedTransaction, block?: Block, txIndex?: number): JsonRpcTx => {
@@ -214,6 +154,45 @@ const jsonRpcTx = (tx: TypedTransaction, block?: Block, txIndex?: number): JsonR
     v: txJSON.v!,
     r: txJSON.r!,
     s: txJSON.s!,
+  }
+}
+
+/**
+ * Returns block formatted to the standard JSON-RPC fields
+ */
+const jsonRpcBlock = async (
+  block: Block,
+  chain: Chain,
+  includeTransactions: boolean
+): Promise<JsonRpcBlock> => {
+  const json = block.toJSON()
+  const header = json!.header!
+  const transactions = block.transactions.map((tx, txIndex) =>
+    includeTransactions ? jsonRpcTx(tx, block, txIndex) : bufferToHex(tx.hash())
+  )
+  const td = await chain.getTd(block.hash(), block.header.number)
+  return {
+    number: header.number!,
+    hash: bufferToHex(block.hash()),
+    parentHash: header.parentHash!,
+    mixHash: header.mixHash,
+    nonce: header.nonce!,
+    sha3Uncles: header.uncleHash!,
+    logsBloom: header.logsBloom!,
+    transactionsRoot: header.transactionsTrie!,
+    stateRoot: header.stateRoot!,
+    receiptsRoot: header.receiptTrie!,
+    miner: header.coinbase!,
+    difficulty: header.difficulty!,
+    totalDifficulty: bnToHex(td),
+    extraData: header.extraData!,
+    size: intToHex(Buffer.byteLength(JSON.stringify(json))),
+    gasLimit: header.gasLimit!,
+    gasUsed: header.gasUsed!,
+    timestamp: header.timestamp!,
+    transactions,
+    uncles: block.uncleHeaders.map((uh) => bufferToHex(uh.hash())),
+    baseFeePerGas: header.baseFeePerGas,
   }
 }
 

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -153,8 +153,8 @@ const jsonRpcBlock = async (
         gas,
         hash: bufferToHex(tx.hash()),
         blockHash: bufferToHex(block.header.hash()),
-        blockNumber: block.header.number.toString('hex'),
-        transactionIndex: idx,
+        blockNumber: bnToHex(block.header.number),
+        transactionIndex: intToHex(idx),
         from: tx.getSenderAddress().toString(),
       }
     })

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -142,14 +142,20 @@ const jsonRpcBlock = async (
 
   let transactions
   if (includeTransactions) {
-    transactions = block.transactions.map((tx) => {
+    transactions = block.transactions.map((tx, idx) => {
       const transaction = tx.toJSON()
       const { gasLimit: gas, data: input, ...txData } = transaction
+
       return {
         ...txData,
         // RPC specs specify `input` rather than `data`, and `gas` rather than `gasLimit`
         input,
         gas,
+        hash: bufferToHex(tx.hash()),
+        blockHash: bufferToHex(block.header.hash()),
+        blockNumber: block.header.number.toString('hex'),
+        transactionIndex: idx,
+        from: tx.getSenderAddress().toString(),
       }
     })
   } else {

--- a/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
+++ b/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
@@ -1,26 +1,13 @@
 import { Block } from '@ethereumjs/block'
-import { BN, bufferToHex } from 'ethereumjs-util'
+import { Transaction } from '@ethereumjs/tx'
+import { BN } from 'ethereumjs-util'
 import tape from 'tape'
 import { INVALID_PARAMS } from '../../../lib/rpc/error-code'
 import { startRPC, createManager, createClient, params, baseRequest, dummy } from '../helpers'
 import { checkError } from '../util'
 
-const mockedTxData = {
-  nonce: '0x',
-  gasPrice: '0x',
-  gasLimit: '0x',
-  to: '0x',
-  value: '0x',
-  data: '0x',
-  v: '0x',
-  r: '0x',
-  s: '0x',
-  hash: '0xa2285835057e8252ebd4980cf498f7538cedb3600dc183f1c523c6971b6889aa',
-  blockHash: '0xdcf93da321b27bca12087d6526d2c10540a4c8dc29db1b36610c3004e0e5d2d5',
-  blockNumber: '1',
-  transactionIndex: 0,
-  from: '0xcde098d93535445768e8a2345a2f869139f45641',
-}
+const mockedTx1 = Transaction.fromTxData({}).sign(dummy.privKey)
+const mockedTx2 = Transaction.fromTxData({ nonce: 1 }).sign(dummy.privKey)
 
 function createChain() {
   const genesisBlockHash = Buffer.from(
@@ -31,24 +18,15 @@ function createChain() {
     'dcf93da321b27bca12087d6526d2c10540a4c8dc29db1b36610c3004e0e5d2d5',
     'hex'
   )
-  const txHash = Buffer.from(
-    'c6ef2fc5426d6ad6fd9e2a26abeab0aa2411b7ab17f30a99d3cb96aed1d1055b',
-    'hex'
-  )
-  const txHash2 = Buffer.from(
-    'a2285835057e8252ebd4980cf498f7538cedb3600dc183f1c523c6971b6889aa',
-    'hex'
-  )
-
-  const transactions = [{ hash: bufferToHex(txHash) }]
-  const transactions2 = [{ hash: bufferToHex(txHash2) }]
+  const transactions = [mockedTx1]
+  const transactions2 = [mockedTx2]
   const genesisBlock = {
     hash: () => genesisBlockHash,
     header: {
       number: new BN(0),
     },
     toJSON: () => ({ ...Block.fromBlockData({ header: { number: 0 } }).toJSON(), transactions }),
-    transactions: [{ hash: () => txHash }],
+    transactions,
     uncleHeaders: [],
   }
   const block = {
@@ -61,9 +39,7 @@ function createChain() {
       ...Block.fromBlockData({ header: { number: 1 } }).toJSON(),
       transactions: transactions2,
     }),
-    transactions: [
-      { hash: () => txHash2, toJSON: () => mockedTxData, getSenderAddress: () => dummy.addr },
-    ],
+    transactions: transactions2,
     uncleHeaders: [],
   }
   return {
@@ -123,6 +99,7 @@ tape(`${method}: call with latest param`, async (t) => {
   const expectRes = (res: any) => {
     const msg = 'should return a block number'
     t.equal(res.body.result.number, '0x1', msg)
+    t.equal(typeof res.body.result.transactions[0], 'string', 'should only include tx hashes')
   }
   await baseRequest(t, server, req, 200, expectRes)
 })
@@ -184,9 +161,7 @@ tape(`${method}: call with transaction objects`, async (t) => {
   const req = params(method, ['latest', true])
 
   const expectRes = (res: any) => {
-    const [transactionData] = res.body.result.transactions
-    const { gasLimit: gas, data: input, ...txData } = mockedTxData
-    t.deepEqual(transactionData, { ...txData, input, gas })
+    t.equal(typeof res.body.result.transactions[0], 'object', 'should include tx objects')
   }
   await baseRequest(t, server, req, 200, expectRes)
 })

--- a/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
+++ b/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
@@ -2,7 +2,7 @@ import { Block } from '@ethereumjs/block'
 import { BN, bufferToHex } from 'ethereumjs-util'
 import tape from 'tape'
 import { INVALID_PARAMS } from '../../../lib/rpc/error-code'
-import { startRPC, createManager, createClient, params, baseRequest } from '../helpers'
+import { startRPC, createManager, createClient, params, baseRequest, dummy } from '../helpers'
 import { checkError } from '../util'
 
 const mockedTxData = {
@@ -15,6 +15,11 @@ const mockedTxData = {
   v: '0x',
   r: '0x',
   s: '0x',
+  hash: '0xa2285835057e8252ebd4980cf498f7538cedb3600dc183f1c523c6971b6889aa',
+  blockHash: '0xdcf93da321b27bca12087d6526d2c10540a4c8dc29db1b36610c3004e0e5d2d5',
+  blockNumber: '1',
+  transactionIndex: 0,
+  from: '0xcde098d93535445768e8a2345a2f869139f45641',
 }
 
 function createChain() {
@@ -50,12 +55,15 @@ function createChain() {
     hash: () => blockHash,
     header: {
       number: new BN(1),
+      hash: () => blockHash,
     },
     toJSON: () => ({
       ...Block.fromBlockData({ header: { number: 1 } }).toJSON(),
       transactions: transactions2,
     }),
-    transactions: [{ hash: () => txHash2, toJSON: () => mockedTxData }],
+    transactions: [
+      { hash: () => txHash2, toJSON: () => mockedTxData, getSenderAddress: () => dummy.addr },
+    ],
     uncleHeaders: [],
   }
   return {

--- a/packages/client/test/rpc/mockBlockchain.ts
+++ b/packages/client/test/rpc/mockBlockchain.ts
@@ -1,14 +1,13 @@
 import { Block } from '@ethereumjs/block'
-import { BN, bufferToHex, toBuffer } from 'ethereumjs-util'
+import { Transaction } from '@ethereumjs/tx'
+import { BN, toBuffer } from 'ethereumjs-util'
+import { dummy } from './helpers'
 
 export function mockBlockchain(options: any = {}) {
   const number = options.number ?? '0x444444'
   const blockHash =
     options.hash ?? '0x910abca1728c53e8d6df870dd7af5352e974357dc58205dea1676be17ba6becf'
-  const txHash = Buffer.from(
-    '0be3065cf288b071ccff922c1c601e2e5628d488b66e781c260ecee36054a2dc',
-    'hex'
-  )
+  const transactions = options.transactions ?? [Transaction.fromTxData({}).sign(dummy.privKey)]
   const block = {
     hash: () => toBuffer(blockHash),
     header: {
@@ -17,15 +16,9 @@ export function mockBlockchain(options: any = {}) {
     toJSON: () => ({
       ...Block.fromBlockData({ header: { number } }).toJSON(),
       hash: options.hash ?? blockHash,
-      transactions: options.transactions ?? [{ hash: bufferToHex(txHash) }],
+      transactions: transactions.map((t: Transaction) => t.toJSON()),
     }),
-    transactions: options.transactions ?? [
-      {
-        hash: () => {
-          return txHash
-        },
-      },
-    ],
+    transactions,
     uncleHeaders: [],
   }
   return {


### PR DESCRIPTION
Fixes #1880 by adding additional fields to transaction bodies as specified by the [JSON-RPC spec](https://github.com/ethereum/execution-apis/blob/d011196297ef8464deeffaa965fe27f66c9a303e/src/schemas/transaction.json#L275)