### PR TITLE
client: Add client protocol and synchronizer for snap sync

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -263,6 +263,10 @@ const args = yargs(hideBin(process.argv))
       'Disables beacon (optimistic) sync if the CL provides blocks at the head of the chain',
     boolean: true,
   })
+  .option('forceSnapSync', {
+    describe: 'Force a snap sync run (for testing and development purposes)',
+    boolean: true,
+  })
   .option('txLookupLimit', {
     describe:
       'Number of recent blocks to maintain transactions index for (default = about one year, 0 = entire chain)',

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -286,6 +286,8 @@ export class Config {
   public readonly skeletonFillCanonicalBackStep: number
   public readonly skeletonSubchainMergeMinimum: number
   public readonly disableBeaconSync: boolean
+  // Just a development only flag, will/should be removed
+  public readonly disableSnapSync: boolean = false
 
   public synchronized: boolean
   public lastSyncDate: number

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -46,6 +46,16 @@ export interface ConfigOptions {
   disableBeaconSync?: boolean
 
   /**
+   * Whether to test and run snapSync. When fully ready, this needs to
+   * be replaced by a more sophisticated condition based on how far back we are
+   * from the head, and how to run it in conjuction with the beacon sync
+   * blocks at the head of chain.
+   *
+   * Default: false
+   */
+  forceSnapSync?: boolean
+
+  /**
    * Provide a custom VM instance to process blocks
    *
    * Default: VM instance created by client
@@ -286,6 +296,7 @@ export class Config {
   public readonly skeletonFillCanonicalBackStep: number
   public readonly skeletonSubchainMergeMinimum: number
   public readonly disableBeaconSync: boolean
+  public readonly forceSnapSync: boolean
   // Just a development only flag, will/should be removed
   public readonly disableSnapSync: boolean = false
 
@@ -329,6 +340,7 @@ export class Config {
     this.skeletonSubchainMergeMinimum =
       options.skeletonSubchainMergeMinimum ?? Config.SKELETON_SUBCHAIN_MERGE_MINIMUM
     this.disableBeaconSync = options.disableBeaconSync ?? false
+    this.forceSnapSync = options.forceSnapSync ?? false
 
     this.synchronized = false
     this.lastSyncDate = 0

--- a/packages/client/lib/net/peer/peer.ts
+++ b/packages/client/lib/net/peer/peer.ts
@@ -4,6 +4,7 @@ import { Config } from '../../config'
 import {
   BoundProtocol,
   EthProtocolMethods,
+  SnapProtocolMethods,
   LesProtocolMethods,
   Protocol,
   Sender,
@@ -58,6 +59,7 @@ export class Peer extends events.EventEmitter {
 
   // Dynamically bound protocol properties
   public eth: (BoundProtocol & EthProtocolMethods) | undefined
+  public snap: (BoundProtocol & SnapProtocolMethods) | undefined
   public les: (BoundProtocol & LesProtocolMethods) | undefined
 
   /**

--- a/packages/client/lib/net/peer/rlpxpeer.ts
+++ b/packages/client/lib/net/peer/rlpxpeer.ts
@@ -166,9 +166,6 @@ export class RlpxPeer extends Peer {
         if (protocol && name != 'snap') {
           const sender = new RlpxSender(rlpxProtocol)
           return this.bindProtocol(protocol, sender).then(() => {
-            // use the same sender to bind snap as snap doesn't need any of its own
-            // handshake. May be this conditional could be handled better or
-            // somewhere else
             if (name === 'eth') {
               const snapRlpxProtocol = rlpxPeer
                 .getProtocols()

--- a/packages/client/lib/net/peer/rlpxpeer.ts
+++ b/packages/client/lib/net/peer/rlpxpeer.ts
@@ -171,10 +171,10 @@ export class RlpxPeer extends Peer {
                 .getProtocols()
                 .filter((p) => p.constructor.name.toLowerCase() === 'snap')[0]
               const snapProtocol =
-              (snapRlpxProtocol !== undefined) &&
+              (snapRlpxProtocol !== undefined)?
                 this.protocols.find(
                   (p) => p.name === snapRlpxProtocol?.constructor.name.toLowerCase()
-                )
+                ):undefined
               if (snapProtocol !== undefined) {
                 const snapSender = new RlpxSender(snapRlpxProtocol)
                 return this.bindProtocol(snapProtocol, snapSender)

--- a/packages/client/lib/net/peer/rlpxpeer.ts
+++ b/packages/client/lib/net/peer/rlpxpeer.ts
@@ -174,7 +174,7 @@ export class RlpxPeer extends Peer {
                 .getProtocols()
                 .filter((p) => p.constructor.name.toLowerCase() === 'snap')[0]
               const snapProtocol =
-                isTruthy(snapRlpxProtocol) &&
+              (snapRlpxProtocol !== undefined) &&
                 this.protocols.find(
                   (p) => p.name === snapRlpxProtocol?.constructor.name.toLowerCase()
                 )

--- a/packages/client/lib/net/peer/rlpxpeer.ts
+++ b/packages/client/lib/net/peer/rlpxpeer.ts
@@ -175,7 +175,7 @@ export class RlpxPeer extends Peer {
                 this.protocols.find(
                   (p) => p.name === snapRlpxProtocol?.constructor.name.toLowerCase()
                 )
-              if (isTruthy(snapProtocol)) {
+              if (snapProtocol !== undefined) {
                 const snapSender = new RlpxSender(snapRlpxProtocol)
                 return this.bindProtocol(snapProtocol, snapSender)
               }

--- a/packages/client/lib/net/peer/rlpxpeer.ts
+++ b/packages/client/lib/net/peer/rlpxpeer.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'crypto'
 import {
   Capabilities as Devp2pCapabilities,
   ETH as Devp2pETH,
+  SNAP as Devp2pSNAP,
   LES as Devp2pLES,
   Peer as Devp2pRlpxPeer,
   RLPx as Devp2pRLPx,
@@ -13,6 +14,7 @@ import { Protocol, RlpxSender } from '../protocol'
 import { RlpxServer } from '../server'
 import { Peer, PeerOptions } from './peer'
 const devp2pCapabilities: any = {
+  snap1: Devp2pSNAP.snap,
   eth66: Devp2pETH.eth66,
   les2: Devp2pLES.les2,
   les3: Devp2pLES.les3,
@@ -159,8 +161,28 @@ export class RlpxPeer extends Peer {
       rlpxPeer.getProtocols().map((rlpxProtocol) => {
         const name = rlpxProtocol.constructor.name.toLowerCase()
         const protocol = this.protocols.find((p) => p.name === name)
-        if (protocol) {
-          return this.bindProtocol(protocol, new RlpxSender(rlpxProtocol))
+        // Since snap is running atop/besides eth, it doesn't need a separate sender
+        // handshake, and can just use the eth handshake
+        if (protocol && name != 'snap') {
+          const sender = new RlpxSender(rlpxProtocol)
+          return this.bindProtocol(protocol, sender).then(() => {
+            // use the same sender to bind snap as snap doesn't need any of its own
+            // handshake. May be this conditional could be handled better or
+            // somewhere else
+            if (name === 'eth') {
+              const snapProtocolSender = rlpxPeer
+                .getProtocols()
+                .filter((p) => p.constructor.name.toLowerCase() === 'snap')[0]
+              const snapProtocol =
+                snapProtocolSender &&
+                this.protocols.find(
+                  (p) => p.name === snapProtocolSender?.constructor.name.toLowerCase()
+                )
+              if (snapProtocol) {
+                return this.bindProtocol(snapProtocol, sender)
+              }
+            }
+          })
         }
       })
     )

--- a/packages/client/lib/net/peer/rlpxpeer.ts
+++ b/packages/client/lib/net/peer/rlpxpeer.ts
@@ -174,11 +174,11 @@ export class RlpxPeer extends Peer {
                 .getProtocols()
                 .filter((p) => p.constructor.name.toLowerCase() === 'snap')[0]
               const snapProtocol =
-                snapRlpxProtocol &&
+                isTruthy(snapRlpxProtocol) &&
                 this.protocols.find(
                   (p) => p.name === snapRlpxProtocol?.constructor.name.toLowerCase()
                 )
-              if (snapProtocol) {
+              if (isTruthy(snapProtocol)) {
                 const snapSender = new RlpxSender(snapRlpxProtocol)
                 return this.bindProtocol(snapProtocol, snapSender)
               }

--- a/packages/client/lib/net/peer/rlpxpeer.ts
+++ b/packages/client/lib/net/peer/rlpxpeer.ts
@@ -170,16 +170,17 @@ export class RlpxPeer extends Peer {
             // handshake. May be this conditional could be handled better or
             // somewhere else
             if (name === 'eth') {
-              const snapProtocolSender = rlpxPeer
+              const snapRlpxProtocol = rlpxPeer
                 .getProtocols()
                 .filter((p) => p.constructor.name.toLowerCase() === 'snap')[0]
               const snapProtocol =
-                snapProtocolSender &&
+                snapRlpxProtocol &&
                 this.protocols.find(
-                  (p) => p.name === snapProtocolSender?.constructor.name.toLowerCase()
+                  (p) => p.name === snapRlpxProtocol?.constructor.name.toLowerCase()
                 )
               if (snapProtocol) {
-                return this.bindProtocol(snapProtocol, sender)
+                const snapSender = new RlpxSender(snapRlpxProtocol)
+                return this.bindProtocol(snapProtocol, snapSender)
               }
             }
           })

--- a/packages/client/lib/net/protocol/index.ts
+++ b/packages/client/lib/net/protocol/index.ts
@@ -3,7 +3,6 @@
  */
 
 export * from './boundprotocol'
-export * from './snapprotocol'
 export * from './ethprotocol'
 export * from './flowcontrol'
 export * from './lesprotocol'
@@ -11,3 +10,4 @@ export * from './libp2psender'
 export * from './protocol'
 export * from './rlpxsender'
 export * from './sender'
+export * from './snapprotocol'

--- a/packages/client/lib/net/protocol/index.ts
+++ b/packages/client/lib/net/protocol/index.ts
@@ -3,6 +3,7 @@
  */
 
 export * from './boundprotocol'
+export * from './snapprotocol'
 export * from './ethprotocol'
 export * from './flowcontrol'
 export * from './lesprotocol'

--- a/packages/client/lib/net/protocol/protocol.ts
+++ b/packages/client/lib/net/protocol/protocol.ts
@@ -161,7 +161,12 @@ export class Protocol {
       peer: peer,
       sender: sender,
     })
-    await bound.handshake(sender)
+    // Handshake only when snap, else
+    if (this.name !== 'snap') {
+      await bound.handshake(sender)
+    } else {
+      if (sender.status === undefined) throw Error('Snap can only be bound on handshaked peer')
+    }
     //@ts-ignore TODO: evaluate this line
     peer[this.name] = bound
     return bound

--- a/packages/client/lib/net/protocol/rlpxsender.ts
+++ b/packages/client/lib/net/protocol/rlpxsender.ts
@@ -1,4 +1,4 @@
-import { ETH as Devp2pETH, LES as Devp2pLES } from '@ethereumjs/devp2p'
+import { ETH as Devp2pETH, SNAP as Devp2pSNAP, LES as Devp2pLES } from '@ethereumjs/devp2p'
 
 import { Sender } from './sender'
 
@@ -9,13 +9,13 @@ import { Sender } from './sender'
  * @memberof module:net/protocol
  */
 export class RlpxSender extends Sender {
-  private sender: Devp2pETH | Devp2pLES
+  private sender: Devp2pETH | Devp2pLES | Devp2pSNAP
 
   /**
    * Creates a new DevP2P/Rlpx protocol sender
    * @param rlpxProtocol protocol object from @ethereumjs/devp2p
    */
-  constructor(rlpxProtocol: Devp2pETH | Devp2pLES) {
+  constructor(rlpxProtocol: Devp2pETH | Devp2pLES | Devp2pSNAP) {
     super()
 
     this.sender = rlpxProtocol

--- a/packages/client/lib/net/protocol/snapprotocol.ts
+++ b/packages/client/lib/net/protocol/snapprotocol.ts
@@ -21,6 +21,32 @@ type GetAccountRangeOpts = {
   bytes: BN
 }
 
+type GetStorageRangesOpts = {
+  reqId?: BN
+  root: Buffer
+  accounts: Buffer[]
+  origin: Buffer
+  limit: Buffer
+  bytes: BN
+}
+
+type StorageData = {
+  hash: Buffer
+  body: Buffer
+}
+
+type GetByteCodesOpts = {
+  reqId?: BN
+  hashes: Buffer[]
+  bytes: BN
+}
+
+type GetTrieNodesOpts = {
+  reqId?: BN
+  root: Buffer
+  paths: Buffer[][]
+  bytes: BN
+}
 /*
  * Messages with responses that are added as
  * methods in camelCase to BoundProtocol.
@@ -87,6 +113,111 @@ export class SnapProtocol extends Protocol {
           reqId: new BN(reqId),
           accounts: accounts.map(([hash, body]: any) => ({ hash, body } as AccountData)),
           proof,
+        }
+      },
+    },
+    {
+      name: 'GetStorageRanges',
+      code: 0x02,
+      response: 0x03,
+      encode: ({ reqId, root, accounts, origin, limit, bytes }: GetStorageRangesOpts) => {
+        return [
+          (reqId === undefined ? id.iaddn(1) : new BN(reqId)).toArrayLike(Buffer),
+          root,
+          accounts,
+          origin,
+          limit,
+          bytes,
+        ]
+      },
+      decode: ([reqId, root, accounts, origin, limit, bytes]: any) => {
+        return {
+          reqId: new BN(reqId),
+          root,
+          accounts,
+          origin,
+          limit,
+          bytes: new BN(bytes),
+        }
+      },
+    },
+    {
+      name: 'StorageRanges',
+      code: 0x03,
+      encode: ({ reqId, slots, proof }: { reqId: BN; slots: StorageData[]; proof: Buffer[] }) => {
+        return [reqId.toArrayLike(Buffer), slots.map((slot) => [slot.hash, slot.body]), proof]
+      },
+      decode: ([reqId, slots, proof]: any) => {
+        return {
+          reqId: new BN(reqId),
+          slots: slots.map(([hash, body]: any) => ({ hash, body } as StorageData)),
+          proof,
+        }
+      },
+    },
+    {
+      name: 'GetByteCodes',
+      code: 0x04,
+      response: 0x05,
+      encode: ({ reqId, hashes, bytes }: GetByteCodesOpts) => {
+        return [
+          (reqId === undefined ? id.iaddn(1) : new BN(reqId)).toArrayLike(Buffer),
+          hashes,
+          bytes,
+        ]
+      },
+      decode: ([reqId, hashes, bytes]: any) => {
+        return {
+          reqId: new BN(reqId),
+          hashes,
+          bytes: new BN(bytes),
+        }
+      },
+    },
+    {
+      name: 'ByteCodes',
+      code: 0x05,
+      encode: ({ reqId, codes }: { reqId: BN; codes: Buffer[] }) => {
+        return [reqId.toArrayLike(Buffer), codes]
+      },
+      decode: ([reqId, codes]: any) => {
+        return {
+          reqId: new BN(reqId),
+          codes,
+        }
+      },
+    },
+    {
+      name: 'GetTrieNodes',
+      code: 0x06,
+      response: 0x07,
+      encode: ({ reqId, root, paths, bytes }: GetTrieNodesOpts) => {
+        return [
+          (reqId === undefined ? id.iaddn(1) : new BN(reqId)).toArrayLike(Buffer),
+          root,
+          paths,
+          bytes,
+        ]
+      },
+      decode: ([reqId, root, paths, bytes]: any) => {
+        return {
+          reqId: new BN(reqId),
+          root,
+          paths,
+          bytes: new BN(bytes),
+        }
+      },
+    },
+    {
+      name: 'TrieNodes',
+      code: 0x07,
+      encode: ({ reqId, nodes }: { reqId: BN; nodes: Buffer[] }) => {
+        return [reqId.toArrayLike(Buffer), nodes]
+      },
+      decode: ([reqId, nodes]: any) => {
+        return {
+          reqId: new BN(reqId),
+          nodes,
         }
       },
     },

--- a/packages/client/lib/net/protocol/snapprotocol.ts
+++ b/packages/client/lib/net/protocol/snapprotocol.ts
@@ -46,10 +46,13 @@ export class SnapProtocol extends Protocol {
       encode: ({ reqId, root, origin, limit, bytes }: GetAccountRangeOpts) => {
         return [
           (reqId === undefined ? id.iaddn(1) : new BN(reqId)).toArrayLike(Buffer),
-          [root, origin, limit, bytes],
+          root,
+          origin,
+          limit,
+          bytes,
         ]
       },
-      decode: ([reqId, [root, origin, limit, bytes]]: any) => ({
+      decode: ([reqId, root, origin, limit, bytes]: any) => ({
         reqId: new BN(reqId),
         root,
         origin,

--- a/packages/client/lib/net/protocol/snapprotocol.ts
+++ b/packages/client/lib/net/protocol/snapprotocol.ts
@@ -43,10 +43,12 @@ export class SnapProtocol extends Protocol {
       name: 'GetAccountRange',
       code: 0x00,
       response: 0x04,
-      encode: ({ reqId, root, origin, limit, bytes }: GetAccountRangeOpts) => [
-        (reqId === undefined ? id.iaddn(1) : new BN(reqId)).toArrayLike(Buffer),
-        [root, origin, limit, bytes],
-      ],
+      encode: ({ reqId, root, origin, limit, bytes }: GetAccountRangeOpts) => {
+        return [
+          (reqId === undefined ? id.iaddn(1) : new BN(reqId)).toArrayLike(Buffer),
+          [root, origin, limit, bytes],
+        ]
+      },
       decode: ([reqId, [root, origin, limit, bytes]]: any) => ({
         reqId: new BN(reqId),
         root,

--- a/packages/client/lib/net/protocol/snapprotocol.ts
+++ b/packages/client/lib/net/protocol/snapprotocol.ts
@@ -1,5 +1,5 @@
 import { AccountData as AccountDataBody, bigIntToBuffer, bufferToBigInt } from '@ethereumjs/util'
-import { Chain } from './../../blockchain'
+import { Chain } from '../../blockchain'
 import { Message, Protocol, ProtocolOptions } from './protocol'
 
 interface SnapProtocolOptions extends ProtocolOptions {

--- a/packages/client/lib/net/protocol/snapprotocol.ts
+++ b/packages/client/lib/net/protocol/snapprotocol.ts
@@ -1,0 +1,100 @@
+import { BN } from 'ethereumjs-util'
+import { Chain } from './../../blockchain'
+import { Message, Protocol, ProtocolOptions } from './protocol'
+
+interface SnapProtocolOptions extends ProtocolOptions {
+  /* Blockchain */
+  chain: Chain
+}
+
+type AccountData = {
+  hash: Buffer
+  body: Buffer
+}
+
+type GetAccountRangeOpts = {
+  /* Request id (default: next internal id) */
+  reqId?: BN
+  root: Buffer
+  origin: Buffer
+  limit: Buffer
+  bytes: BN
+}
+
+/*
+ * Messages with responses that are added as
+ * methods in camelCase to BoundProtocol.
+ */
+export interface SnapProtocolMethods {
+  getAccountRange: (opts: GetAccountRangeOpts) => Promise<[BN, AccountData[], Buffer[][]]>
+}
+
+const id = new BN(0)
+
+/**
+ * Implements snap/1 protocol
+ * @memberof module:net/protocol
+ */
+export class SnapProtocol extends Protocol {
+  private chain: Chain
+
+  private protocolMessages: Message[] = [
+    {
+      name: 'GetAccountRange',
+      code: 0x00,
+      response: 0x04,
+      encode: ({ reqId, root, origin, limit, bytes }: GetAccountRangeOpts) => [
+        (reqId === undefined ? id.iaddn(1) : new BN(reqId)).toArrayLike(Buffer),
+        [root, origin, limit, bytes],
+      ],
+      decode: ([reqId, [root, origin, limit, bytes]]: any) => ({
+        reqId: new BN(reqId),
+        root,
+        origin,
+        limit,
+        bytes: new BN(bytes),
+      }),
+    },
+  ]
+
+  /**
+   * Create snap protocol
+   */
+  constructor(options: SnapProtocolOptions) {
+    super(options)
+
+    this.chain = options.chain
+  }
+
+  /**
+   * Name of protocol
+   */
+  get name() {
+    return 'snap'
+  }
+
+  /**
+   * Protocol versions supported
+   */
+  get versions() {
+    return [1]
+  }
+
+  /**
+   * Messages defined by this protocol
+   */
+  get messages() {
+    return this.protocolMessages
+  }
+
+  /**
+   * Opens protocol and any associated dependencies
+   */
+  async open(): Promise<boolean | void> {
+    if (this.opened) {
+      return false
+    }
+    await this.chain.open()
+    this.opened = true
+  }
+}

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -9,7 +9,7 @@ import { Protocol } from '../net/protocol'
 import { SnapProtocol } from '../net/protocol/snapprotocol'
 import { EthProtocol } from '../net/protocol/ethprotocol'
 import { LesProtocol } from '../net/protocol/lesprotocol'
-import { BeaconSynchronizer, FullSynchronizer } from '../sync'
+import { BeaconSynchronizer, FullSynchronizer, SnapSynchronizer } from '../sync'
 import { Skeleton } from '../sync/skeleton'
 import { EthereumService, EthereumServiceOptions } from './ethereumservice'
 import { TxPool } from './txpool'
@@ -24,7 +24,7 @@ interface FullEthereumServiceOptions extends EthereumServiceOptions {
  * @memberof module:service
  */
 export class FullEthereumService extends EthereumService {
-  public synchronizer!: BeaconSynchronizer | FullSynchronizer
+  public synchronizer!: BeaconSynchronizer | FullSynchronizer | SnapSynchronizer
   public lightserv: boolean
   public miner: Miner | undefined
   public execution: VMExecution
@@ -57,12 +57,13 @@ export class FullEthereumService extends EthereumService {
         void this.switchToBeaconSync()
       }
     } else {
-      this.synchronizer = new FullSynchronizer({
+      // This is just for testing a proper syncronizer change condition
+      // should comeup, irrespective of pre-merge/post merge ideally
+      // depending on how far we are from the last executed block
+      this.synchronizer = new SnapSynchronizer({
         config: this.config,
         pool: this.pool,
         chain: this.chain,
-        txPool: this.txPool,
-        execution: this.execution,
         interval: this.interval,
       })
     }

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -52,20 +52,31 @@ export class FullEthereumService extends EthereumService {
       service: this,
     })
 
-    if (this.config.chainCommon.gteHardfork(Hardfork.Merge) === true) {
-      if (!this.config.disableBeaconSync) {
-        void this.switchToBeaconSync()
-      }
-    } else {
-      // This is just for testing a proper syncronizer change condition
-      // should comeup, irrespective of pre-merge/post merge ideally
-      // depending on how far we are from the last executed block
+    // This flag is just to run and test snap sync, when fully ready, this needs to
+    // be replaced by a more sophisticated condition based on how far back we are
+    // from the head, and how to run it in conjuction with the beacon sync
+    if (this.config.forceSnapSync) {
       this.synchronizer = new SnapSynchronizer({
         config: this.config,
         pool: this.pool,
         chain: this.chain,
         interval: this.interval,
       })
+    } else {
+      if (this.config.chainCommon.gteHardfork(Hardfork.Merge) === true) {
+        if (!this.config.disableBeaconSync) {
+          void this.switchToBeaconSync()
+        }
+      } else {
+        this.synchronizer = new FullSynchronizer({
+          config: this.config,
+          pool: this.pool,
+          chain: this.chain,
+          txPool: this.txPool,
+          execution: this.execution,
+          interval: this.interval,
+        })
+      }
     }
 
     if (this.config.mine) {

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -2,11 +2,11 @@ import type { Block } from '@ethereumjs/block'
 import { Hardfork } from '@ethereumjs/common'
 import { isFalsy, isTruthy } from '@ethereumjs/util'
 import { encodeReceipt } from '@ethereumjs/vm/dist/runBlock'
-
 import { VMExecution } from '../execution'
 import { Miner } from '../miner'
 import { Peer } from '../net/peer/peer'
 import { Protocol } from '../net/protocol'
+import { SnapProtocol } from '../net/protocol/snapprotocol'
 import { EthProtocol } from '../net/protocol/ethprotocol'
 import { LesProtocol } from '../net/protocol/lesprotocol'
 import { BeaconSynchronizer, FullSynchronizer } from '../sync'
@@ -168,6 +168,11 @@ export class FullEthereumService extends EthereumService {
   get protocols(): Protocol[] {
     const protocols: Protocol[] = [
       new EthProtocol({
+        config: this.config,
+        chain: this.chain,
+        timeout: this.timeout,
+      }),
+      new SnapProtocol({
         config: this.config,
         chain: this.chain,
         timeout: this.timeout,

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -219,7 +219,11 @@ export class FullEthereumService extends EthereumService {
           (isTruthy(reverse) && block > this.chain.headers.height) ||
           (isFalsy(reverse) && block + BigInt(max * skip) > this.chain.headers.height)
         ) {
-          // Don't respond to requests greater than the current height
+          // Respond with an empty list in case the header is higher than the current height
+          // This is to ensure Geth does not disconnect with "useless peer"
+          // TODO: in batch queries filter out the headers we do not have and do not send
+          // the empty list in case one or more headers are not available
+          peer.eth!.send('BlockHeaders', { reqId, headers: [] })
           return
         }
       }

--- a/packages/client/lib/sync/index.ts
+++ b/packages/client/lib/sync/index.ts
@@ -2,8 +2,8 @@
  * @module sync
  */
 export * from './beaconsync'
-export * from './snapsync'
 export * from './fullsync'
 export * from './lightsync'
 export * from './skeleton'
+export * from './snapsync'
 export * from './sync'

--- a/packages/client/lib/sync/index.ts
+++ b/packages/client/lib/sync/index.ts
@@ -2,6 +2,7 @@
  * @module sync
  */
 export * from './beaconsync'
+export * from './snapsync'
 export * from './fullsync'
 export * from './lightsync'
 export * from './skeleton'

--- a/packages/client/lib/sync/snapsync.ts
+++ b/packages/client/lib/sync/snapsync.ts
@@ -73,18 +73,20 @@ export class SnapSynchronizer extends Synchronizer {
     if (!latest) return false
 
     const stateRoot = latest.stateRoot
-
     const rangeResult = await peer!.snap!.getAccountRange({
       root: stateRoot,
       origin: Buffer.from(
         '0000000000000000000000000000000000000000000000000000000000000000',
         'hex'
       ),
-      limit: Buffer.from('0000000000000000000000000000000000000000000000000000000000000010', 'hex'),
-      bytes: new BN(100000),
+      limit: Buffer.from('0000000000000000000000000f00000000000000000000000000000000000010', 'hex'),
+      bytes: new BN(5000000),
     })
 
-    console.log({ rangeResult })
+    console.log({ rangeResult: rangeResult?.accounts[0] })
+    // if (rangeResult) {
+    //   process.exit()
+    // }
 
     const height = latest.number
     if (!this.config.syncTargetHeight || this.config.syncTargetHeight.lt(latest.number)) {

--- a/packages/client/lib/sync/snapsync.ts
+++ b/packages/client/lib/sync/snapsync.ts
@@ -70,7 +70,7 @@ export class SnapSynchronizer extends Synchronizer {
     const latest = peer ? await this.latest(peer) : undefined
     if (!latest) return false
 
-    // Just a small snipped to test out the methods manually
+    // Just a small snippet to test out the methods manually
     // From/for g11tech:
     //  Clean it up, once we have a full fetcher implemented, else let them
     //  stay commented for easy reference and manual testing

--- a/packages/client/lib/sync/snapsync.ts
+++ b/packages/client/lib/sync/snapsync.ts
@@ -1,0 +1,98 @@
+import { short } from '../util'
+import { Synchronizer, SynchronizerOptions } from './sync'
+import type { Peer } from '../net/peer/peer'
+import { BN } from 'ethereumjs-util'
+
+interface SnapSynchronizerOptions extends SynchronizerOptions {}
+
+export class SnapSynchronizer extends Synchronizer {
+  public running = false
+  constructor(options: SnapSynchronizerOptions) {
+    super(options)
+  }
+
+  /**
+   * Returns synchronizer type
+   */
+  get type() {
+    return 'snap'
+  }
+
+  /**
+   * Open synchronizer. Must be called before sync() is called
+   */
+  async open(): Promise<void> {}
+
+  /**
+   * Returns true if peer can be used for syncing
+   */
+  syncable(peer: Peer): boolean {
+    // Need eth as well to get the latest of the peer
+    // TODO: review
+    return peer.snap !== undefined && peer.eth !== undefined
+  }
+
+  /**
+   * Finds the best peer to sync with. We will synchronize to this peer's
+   * blockchain. Returns null if no valid peer is found
+   */
+  async best(): Promise<Peer | undefined> {
+    let best: [Peer, BN] | undefined
+    const peers = this.pool.peers.filter(this.syncable.bind(this))
+    if (peers.length < this.config.minPeers && !this.forceSync) return
+    for (const peer of peers) {
+      const latest = await this.latest(peer)
+      if (latest) {
+        const { number } = latest
+        if ((!best && number.gte(this.chain.blocks.height)) || (best && best[1].lt(number))) {
+          best = [peer, number]
+        }
+      }
+    }
+    return best ? best[0] : undefined
+  }
+
+  /**
+   * Get latest header of peer
+   */
+  async latest(peer: Peer) {
+    const result = await peer.eth?.getBlockHeaders({
+      block: peer.eth!.status.bestHash,
+      max: 1,
+    })
+    return result ? result[1][0] : undefined
+  }
+
+  /**
+   * Called from `sync()` to sync blocks and state from peer starting from current height.
+   * @param peer remote peer to sync with
+   * @returns a boolean if the setup was successful
+   */
+  async syncWithPeer(peer?: Peer): Promise<boolean> {
+    const latest = peer ? await this.latest(peer) : undefined
+    if (!latest) return false
+
+    const height = latest.number
+    if (!this.config.syncTargetHeight || this.config.syncTargetHeight.lt(latest.number)) {
+      this.config.syncTargetHeight = height
+      this.config.logger.info(`New sync target height=${height} hash=${short(latest.hash())}`)
+    }
+
+    return false
+  }
+
+  /**
+   * Stop synchronization. Returns a promise that resolves once its stopped.
+   */
+  async stop(): Promise<boolean> {
+    return super.stop()
+  }
+
+  /**
+   * Close synchronizer.
+   */
+  async close() {
+    if (!this.opened) return
+    await super.close()
+  }
+}

--- a/packages/client/lib/sync/snapsync.ts
+++ b/packages/client/lib/sync/snapsync.ts
@@ -1,5 +1,5 @@
-import { Synchronizer, SynchronizerOptions } from './sync'
 import type { Peer } from '../net/peer/peer'
+import { Synchronizer, SynchronizerOptions } from './sync'
 
 interface SnapSynchronizerOptions extends SynchronizerOptions {}
 

--- a/packages/client/lib/sync/snapsync.ts
+++ b/packages/client/lib/sync/snapsync.ts
@@ -72,6 +72,20 @@ export class SnapSynchronizer extends Synchronizer {
     const latest = peer ? await this.latest(peer) : undefined
     if (!latest) return false
 
+    const stateRoot = latest.stateRoot
+
+    const rangeResult = await peer!.snap!.getAccountRange({
+      root: stateRoot,
+      origin: Buffer.from(
+        '0000000000000000000000000000000000000000000000000000000000000000',
+        'hex'
+      ),
+      limit: Buffer.from('0000000000000000000000000000000000000000000000000000000000000010', 'hex'),
+      bytes: new BN(100000),
+    })
+
+    console.log({ rangeResult })
+
     const height = latest.number
     if (!this.config.syncTargetHeight || this.config.syncTargetHeight.lt(latest.number)) {
       this.config.syncTargetHeight = height

--- a/packages/client/test/service/fullethereumservice.spec.ts
+++ b/packages/client/test/service/fullethereumservice.spec.ts
@@ -1,5 +1,7 @@
 import { Common } from '@ethereumjs/common'
 import { Log } from '@ethereumjs/evm/dist/types'
+import { isTruthy } from '@ethereumjs/util'
+
 import * as tape from 'tape'
 import * as td from 'testdouble'
 
@@ -75,12 +77,18 @@ tape('[FullEthereumService]', async (t) => {
     let config = new Config({ transports: [] })
     const chain = new Chain({ config })
     let service = new FullEthereumService({ config, chain })
-    t.ok(service.protocols[0] instanceof EthProtocol, 'full protocol')
-    t.notOk(service.protocols[1], 'no light protocol')
+    t.ok(isTruthy(service.protocols.filter((p) => p instanceof EthProtocol)[0]), 'full protocol')
+    t.notOk(
+      isTruthy(service.protocols.filter((p) => p instanceof LesProtocol)[0]),
+      'no light protocol'
+    )
     config = new Config({ transports: [], lightserv: true })
     service = new FullEthereumService({ config, chain })
-    t.ok(service.protocols[0] instanceof EthProtocol, 'full protocol')
-    t.ok(service.protocols[1] instanceof LesProtocol, 'lightserv protocols')
+    t.ok(isTruthy(service.protocols.filter((p) => p instanceof EthProtocol)[0]), 'full protocol')
+    t.ok(
+      isTruthy(service.protocols.filter((p) => p instanceof LesProtocol)[0]),
+      'lightserv protocols'
+    )
     t.end()
   })
 

--- a/packages/client/test/service/fullethereumservice.spec.ts
+++ b/packages/client/test/service/fullethereumservice.spec.ts
@@ -1,6 +1,5 @@
 import { Common } from '@ethereumjs/common'
 import { Log } from '@ethereumjs/evm/dist/types'
-import { isTruthy } from '@ethereumjs/util'
 
 import * as tape from 'tape'
 import * as td from 'testdouble'
@@ -77,16 +76,16 @@ tape('[FullEthereumService]', async (t) => {
     let config = new Config({ transports: [] })
     const chain = new Chain({ config })
     let service = new FullEthereumService({ config, chain })
-    t.ok(isTruthy(service.protocols.filter((p) => p instanceof EthProtocol)[0]), 'full protocol')
+    t.ok(service.protocols.filter((p) => p instanceof EthProtocol).length>0, 'full protocol')
     t.notOk(
-      isTruthy(service.protocols.filter((p) => p instanceof LesProtocol)[0]),
+      service.protocols.filter((p) => p instanceof LesProtocol).length>0,
       'no light protocol'
     )
     config = new Config({ transports: [], lightserv: true })
     service = new FullEthereumService({ config, chain })
-    t.ok(isTruthy(service.protocols.filter((p) => p instanceof EthProtocol)[0]), 'full protocol')
+    t.ok(service.protocols.filter((p) => p instanceof EthProtocol).length>0, 'full protocol')
     t.ok(
-      isTruthy(service.protocols.filter((p) => p instanceof LesProtocol)[0]),
+      service.protocols.filter((p) => p instanceof LesProtocol).length >0,
       'lightserv protocols'
     )
     t.end()

--- a/packages/devp2p/src/protocol/eth.ts
+++ b/packages/devp2p/src/protocol/eth.ts
@@ -41,8 +41,8 @@ export class ETH extends Protocol {
 
   static eth62 = { name: 'eth', version: 62, length: 8, constructor: ETH }
   static eth63 = { name: 'eth', version: 63, length: 17, constructor: ETH }
-  static eth64 = { name: 'eth', version: 64, length: 29, constructor: ETH }
-  static eth65 = { name: 'eth', version: 65, length: 29, constructor: ETH }
+  static eth64 = { name: 'eth', version: 64, length: 17, constructor: ETH }
+  static eth65 = { name: 'eth', version: 65, length: 17, constructor: ETH }
   static eth66 = { name: 'eth', version: 66, length: 17, constructor: ETH }
 
   _handleMessage(code: ETH.MESSAGE_CODES, data: any) {

--- a/packages/devp2p/src/protocol/eth.ts
+++ b/packages/devp2p/src/protocol/eth.ts
@@ -43,7 +43,7 @@ export class ETH extends Protocol {
   static eth63 = { name: 'eth', version: 63, length: 17, constructor: ETH }
   static eth64 = { name: 'eth', version: 64, length: 29, constructor: ETH }
   static eth65 = { name: 'eth', version: 65, length: 29, constructor: ETH }
-  static eth66 = { name: 'eth', version: 66, length: 29, constructor: ETH }
+  static eth66 = { name: 'eth', version: 66, length: 17, constructor: ETH }
 
   _handleMessage(code: ETH.MESSAGE_CODES, data: any) {
     const payload = arrToBufArr(RLP.decode(bufArrToArr(data)))

--- a/packages/devp2p/src/protocol/snap.ts
+++ b/packages/devp2p/src/protocol/snap.ts
@@ -39,6 +39,10 @@ export class SNAP extends Protocol {
     this.emit('message', code, payload)
   }
 
+  sendStatus() {
+    throw Error('SNAP prococol doesnot support status handshake')
+  }
+
   /**
    *
    * @param code Message code

--- a/packages/devp2p/src/rlpx/peer.ts
+++ b/packages/devp2p/src/rlpx/peer.ts
@@ -227,7 +227,12 @@ export class Peer extends EventEmitter {
   _sendHello() {
     const debugMsg = `Send HELLO to ${this._socket.remoteAddress}:${
       this._socket.remotePort
-    } capabilities=${(this._capabilities ?? []).map((c) => `${c.name}${c.version}`).join(' ')}`
+    } capabilities=${(this._capabilities ?? [])
+      // Filter out snap because we can't yet provide snap endpoints to the peers
+      // TODO: Remove when we can also serve snap requests from other peers
+      .filter((c) => c.name !== 'snap')
+      .map((c) => `${c.name}${c.version}`)
+      .join(',')}`
     this.debug('HELLO', debugMsg)
     const payload: HelloMsg = [
       int2buffer(BASE_PROTOCOL_VERSION),

--- a/packages/devp2p/src/rlpx/peer.ts
+++ b/packages/devp2p/src/rlpx/peer.ts
@@ -227,12 +227,7 @@ export class Peer extends EventEmitter {
   _sendHello() {
     const debugMsg = `Send HELLO to ${this._socket.remoteAddress}:${
       this._socket.remotePort
-    } capabilities=${(this._capabilities ?? [])
-      // Filter out snap because we can't yet provide snap endpoints to the peers
-      // TODO: Remove when we can also serve snap requests from other peers
-      .filter((c) => c.name !== 'snap')
-      .map((c) => `${c.name}${c.version}`)
-      .join(',')}`
+    } capabilities=${(this._capabilities ?? []).map((c) => `${c.name}${c.version}`).join(' ')}`
     this.debug('HELLO', debugMsg)
     const payload: HelloMsg = [
       int2buffer(BASE_PROTOCOL_VERSION),


### PR DESCRIPTION
This PR will enable fetching snap data for accounts,storage,codeby using the devp2p interface exposed in the PR: https://github.com/ethereumjs/ethereumjs-monorepo/pull/1883.  

Currently this PR is pointing to #1883, but when that gets merged, this PR will be updated to pointing master. This is so we can leverage the devp2p work being done in 1883 while independently developing some client capabilities with regard to consuming and fetching snap data (and get some early feedback)

### Curent status
`snap` protocol availability in the peer:
```typescript
[05-18|16:28:57] DEBUG Peer connected: id=e9631196 address=10.244.0.112:30303 transport=rlpx protocols=eth,snap inbound=false 
[05-18|16:28:57] DEBUG Found full peer: id=e9631196 address=10.244.0.112:30303 transport=rlpx protocols=eth,snap inbound=false 
[05-18|16:28:57] DEBUG Peer added: id=e9631196 address=10.244.0.112:30303 transport=rlpx protocols=eth,snap inbound=false 
```
Next Steps (all with a static peer):
- [x] Call getAccountRange on snap capable peer
- [x] Add remaining methods
 
Tests and coverage will follow via 
- https://github.com/ethereumjs/ethereumjs-monorepo/pull/1933