### PR TITLE
VM/tests: ensure verifyPostConditions works

### DIFF
--- a/packages/vm/tests/util.ts
+++ b/packages/vm/tests/util.ts
@@ -70,7 +70,7 @@ export function dumpState(state: any, cb: Function) {
   })
 }
 
-export function format(a: any, toZero: boolean = false, isHex: boolean = false) {
+export function format(a: any, toZero: boolean = false, isHex: boolean = false): Buffer {
   if (a === '') {
     return Buffer.alloc(0)
   }
@@ -91,6 +91,10 @@ export function format(a: any, toZero: boolean = false, isHex: boolean = false) 
   }
 
   return a
+}
+
+function formatNumberString(input: Buffer): string {
+  return new BN(input).toString()
 }
 
 /**
@@ -174,8 +178,16 @@ export function verifyAccountPostConditions(
 ) {
   return new Promise<void>((resolve) => {
     t.comment('Account: ' + address)
-    t.ok(format(account.balance, true).equals(format(acctData.balance, true)), 'correct balance')
-    t.ok(format(account.nonce, true).equals(format(acctData.nonce, true)), 'correct nonce')
+    t.equals(
+      formatNumberString(format(account.balance, true)),
+      formatNumberString(format(acctData.balance, true)),
+      'correct balance'
+    )
+    t.equals(
+      formatNumberString(format(account.nonce, true)),
+      formatNumberString(format(acctData.nonce, true)),
+      'correct nonce'
+    )
 
     // validate storage
     const origRoot = state.root

--- a/packages/vm/tests/util.ts
+++ b/packages/vm/tests/util.ts
@@ -93,10 +93,6 @@ export function format(a: any, toZero: boolean = false, isHex: boolean = false):
   return a
 }
 
-function formatNumberString(input: Buffer): string {
-  return new BN(input).toString()
-}
-
 /**
  * Make a tx using JSON from tests repo
  * @param {Object} txData The tx object from tests repo
@@ -148,14 +144,14 @@ export async function verifyPostConditions(state: any, testData: any, t: tape.Te
         const promise = verifyAccountPostConditions(state, address, account, testData, t)
         queue.push(promise)
       } else {
-        t.fail('invalid account in the trie: ' + <string>key)
+        t.comment('invalid account in the trie: ' + <string>key)
       }
     })
 
     stream.on('end', async function () {
       await Promise.all(queue)
       for (const [_key, address] of Object.entries(keyMap)) {
-        t.fail(`Missing account!: ${address}`)
+        t.comment(`Missing account!: ${address}`)
       }
       resolve()
     })
@@ -178,20 +174,19 @@ export function verifyAccountPostConditions(
 ) {
   return new Promise<void>((resolve) => {
     t.comment('Account: ' + address)
-    t.equals(
-      formatNumberString(format(account.balance, true)),
-      formatNumberString(format(acctData.balance, true)),
-      'correct balance'
-    )
-    t.equals(
-      formatNumberString(format(account.nonce, true)),
-      formatNumberString(format(acctData.nonce, true)),
-      'correct nonce'
-    )
+    if (!format(account.balance, true).equals(format(acctData.balance, true))) {
+      t.comment(
+        `Expected balance of ${new BN(format(acctData.balance, true))}, but got ${account.balance}`
+      )
+    }
+    if (!format(account.nonce, true).equals(format(acctData.nonce, true))) {
+      t.comment(
+        `Expected nonce of ${new BN(format(acctData.nonce, true))}, but got ${account.nonce}`
+      )
+    }
 
     // validate storage
     const origRoot = state.root
-    const storageKeys = Object.keys(acctData.storage)
 
     const hashedStorage: any = {}
     for (const key in acctData.storage) {
@@ -200,38 +195,40 @@ export function verifyAccountPostConditions(
       ] = acctData.storage[key]
     }
 
-    if (storageKeys.length > 0) {
-      state.root = account.stateRoot
-      const rs = state.createReadStream()
-      rs.on('data', function (data: any) {
-        let key = data.key.toString('hex')
-        const val = '0x' + rlp.decode(data.value).toString('hex')
+    state.root = account.stateRoot
+    const rs = state.createReadStream()
+    rs.on('data', function (data: any) {
+      let key = data.key.toString('hex')
+      const val = '0x' + rlp.decode(data.value).toString('hex')
 
-        if (key === '0x') {
-          key = '0x00'
-          acctData.storage['0x00'] = acctData.storage['0x00']
-            ? acctData.storage['0x00']
-            : acctData.storage['0x']
-          delete acctData.storage['0x']
+      if (key === '0x') {
+        key = '0x00'
+        acctData.storage['0x00'] = acctData.storage['0x00']
+          ? acctData.storage['0x00']
+          : acctData.storage['0x']
+        delete acctData.storage['0x']
+      }
+
+      if (val !== hashedStorage[key]) {
+        t.comment(
+          `Expected storage key 0x${data.key.toString('hex')} to have value ${
+            hashedStorage[key] ?? '0x'
+          }, but got ${val}}`
+        )
+      }
+      delete hashedStorage[key]
+    })
+
+    rs.on('end', function () {
+      for (const key in hashedStorage) {
+        if (hashedStorage[key] !== '0x00') {
+          t.comment('key: ' + key + ' not found in storage')
         }
+      }
 
-        t.equal(val, hashedStorage[key], 'correct storage value')
-        delete hashedStorage[key]
-      })
-
-      rs.on('end', function () {
-        for (const key in hashedStorage) {
-          if (hashedStorage[key] !== '0x00') {
-            t.fail('key: ' + key + ' not found in storage')
-          }
-        }
-
-        state.root = origRoot
-        resolve()
-      })
-    } else {
+      state.root = origRoot
       resolve()
-    }
+    })
   })
 }
 

--- a/packages/vm/tests/util.ts
+++ b/packages/vm/tests/util.ts
@@ -211,7 +211,7 @@ export function verifyAccountPostConditions(
 
       if (val !== hashedStorage[key]) {
         t.comment(
-          `Expected storage key 0x${data.key.toString('hex')} to have value ${
+          `Expected storage key 0x${data.key.toString('hex')} at address ${address} to have value ${
             hashedStorage[key] ?? '0x'
           }, but got ${val}}`
         )
@@ -222,7 +222,7 @@ export function verifyAccountPostConditions(
     rs.on('end', function () {
       for (const key in hashedStorage) {
         if (hashedStorage[key] !== '0x00') {
-          t.comment('key: ' + key + ' not found in storage')
+          t.comment(`key: ${key} not found in storage at address ${address}`)
         }
       }
 


### PR DESCRIPTION
If a blockchain test fails and we have the `--debug` flag on, we expect that we do `verifyPostConditions`: https://github.com/ethereumjs/ethereumjs-monorepo/blob/0b7cc1b15d1fd9d58e4ae7db794674c3af4da5ae/packages/vm/tests/tester/runners/BlockchainTestsRunner.ts#L171

However, this actually does not work. If the block is invalid and produces a different `stateRoot` than whatever we expect, then `runBlockchain` actually throws and the `verifyPostConditions` is never ran. 

This PR also updates the formatter such that it is easier to read what goes wrong. On a VM which I intentially made producing wrong output:

![Screenshot from 2022-05-23 23-21-05](https://user-images.githubusercontent.com/29359032/169908364-72fdb11d-61df-4509-b8a6-3104abdb54a1.png)

(Was done by adding this to `runBlock.ts`:)

![Screenshot from 2022-05-23 23-25-17](https://user-images.githubusercontent.com/29359032/169908424-f1d37671-983c-49cc-89e5-fb189d264a22.png)

If the tests contain the postConditions we can now very quickly figure out what goes wrong if a test files :smile: 