### PR TITLE
Monorepo: Lodestar-inspired Error Management PoC

### DIFF
--- a/packages/block/src/errors.ts
+++ b/packages/block/src/errors.ts
@@ -1,0 +1,12 @@
+import { EthereumJSError } from 'ethereumjs-util'
+
+export enum HeaderValidationErrorCode {
+  WRONG_TX_TRIE_LENGTH = 'WRONG_TX_TRIE_LENGTH',
+}
+
+export type HeaderValidationErrorType = {
+  block: string
+  received: string
+}
+
+export class HeaderValidationError extends EthereumJSError<HeaderValidationErrorType> {}

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -26,6 +26,7 @@ import {
   CLIQUE_DIFF_INTURN,
   CLIQUE_DIFF_NOTURN,
 } from './clique'
+import { HeaderValidationError, HeaderValidationErrorCode } from './errors'
 
 interface HeaderCache {
   hash: Buffer | undefined
@@ -355,10 +356,15 @@ export class BlockHeader {
       throw new Error(msg)
     }
     if (transactionsTrie.length !== 32) {
-      const msg = this._errorMsg(
-        `transactionsTrie must be 32 bytes, received ${transactionsTrie.length} bytes`
+      const e = new HeaderValidationError(
+        'transactionsTrie must be 32 bytes',
+        HeaderValidationErrorCode.WRONG_TX_TRIE_LENGTH,
+        {
+          block: this.errorStr(),
+          received: `${transactionsTrie.toString('hex')} (${transactionsTrie.length} bytes)`,
+        }
       )
-      throw new Error(msg)
+      throw e
     }
     if (receiptTrie.length !== 32) {
       const msg = this._errorMsg(

--- a/packages/util/src/errors.ts
+++ b/packages/util/src/errors.ts
@@ -1,0 +1,30 @@
+/**
+ * Generic EthereumJS error with metadata attached
+ *
+ * Kudos to https://github.com/ChainSafe/lodestar monorepo
+ * for the inspiration :-)
+ */
+export class EthereumJSError<T extends {}> extends Error {
+  code: string
+  errorContext: T
+
+  constructor(msg: string, code: string, errorContext: T) {
+    super(msg)
+    this.code = code
+    this.errorContext = errorContext
+  }
+
+  getErrorContext(): Record<string, string | number | null> {
+    return { code: this.code, ...this.errorContext }
+  }
+
+  /**
+   * Get the metadata and the stacktrace for the error.
+   */
+  toObject(): Record<string, string | number | null> {
+    return {
+      ...this.getErrorContext(),
+      stack: this.stack ?? '',
+    }
+  }
+}

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -14,6 +14,11 @@ export * from './account'
 export * from './address'
 
 /**
+ * EthereumJS Extended Errors
+ */
+export * from './errors'
+
+/**
  * ECDSA signature
  */
 export * from './signature'


### PR DESCRIPTION
Continues/replaces #1469 

This is a first PoC of a Lodestar-inspired monorepo error management based on the discussion [here](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1469#discussion_r866940713).

The basic Lodestar error class is defined [here](https://github.com/ChainSafe/lodestar/blob/master/packages/utils/src/errors.ts), I used the `Eth1Error` from [here](https://github.com/ChainSafe/lodestar/blob/dd0e4dd7318648ea83137c18abea483a52e6add3/packages/lodestar/src/eth1/errors.ts) and applied e.g. [here](https://github.com/ChainSafe/lodestar/blob/dd0e4dd7318648ea83137c18abea483a52e6add3/packages/lodestar/src/eth1/utils/deposits.ts#L33) as some orientation on how things could be done.

I adopted and simplified various things and I am relatively pleased with the result since I have the impression that this should sufficiently satisfy our needs. 🙂 

I adopted the following things:

- `code` is not part of the - on the Lodestar side - called `metadata` any more but a separate constructor argument, this simplified some typings and the UI (from my PoV) gets a bit nicer
- `message` is also a dedicated separate constructor argument being mandatory. I didn't want the `code` be used for the original error object `message` property but rather have this separated
- I've renamed `metadata` to `errorContext` which I find a bit less "technocratic" 😋 and fitting

This is how an error is thrown:

```typescript
const e = new HeaderValidationError(
  'transactionsTrie must be 32 bytes',
  HeaderValidationErrorCode.WRONG_TX_TRIE_LENGTH,
  {
    block: this.errorStr(),
    received: `${transactionsTrie.toString('hex')} (${transactionsTrie.length} bytes)`,
  }
)
throw e
```

(can of course also be thrown directly)

An error thrown with this now looks like this:

```
Uncaught Error: transactionsTrie must be 32 bytes
    at BlockHeader._validateHeaderFields (/ethereumjs-monorepo-develop/packages/block/src/header.ts:359:13)
    at new BlockHeader (/ethereumjs-monorepo-develop/packages/block/src/header.ts:303:10)
    at/ethereumjs-monorepo-develop/packages/block/<repl>.ts:2:9
    at Script.runInThisContext (node:vm:129:12)
    at runInContext (/node_modules/ts-node/src/repl.ts:603:19)
    at Object.execCommand (/node_modules/ts-node/src/repl.ts:569:28)
    at /node_modules/ts-node/src/repl.ts:591:47
    at Array.reduce (<anonymous>)
    at appendCompileAndEvalInput (/node_modules/ts-node/src/repl.ts:591:23)
    at evalCodeInternal (/node_modules/ts-node/src/repl.ts:212:12) {
  code: 'WRONG_TX_TRIE_LENGTH',
  errorContext: {
    block: 'block header number=0 hash=0x7939e4f199f7ec79ce8cff286a0b4b0af01bbd782ff0e10305915d0d2e099de0 hf=london baseFeePerGas=7',
    lengthReceived: 32
  }
```

All this leads to the following properties (which we didn't have before):

- The more generic Error (here `HeaderValidationError`) can be checked with `e instanceof HeaderValidationError` (tested)
- The specific error can be checked with `e.code === HeaderValidationErrorCode.WRONG_TX_TRIE_LENGTH` (tested) independently from an eventually changing error message
- An arbitrary and typed error context can be provided via the `errorContext` property

At the same time I have the impression that this remains sufficiently simple.

Let me know what you think!

@gabrocheleau: it would be good if you can have some deepened look here if this respects and covers all eventual particularities which you might have already covered in some adopted form in #1469. 