### PR TITLE
client: Subsume engine's INVALID_TERMINAL_BLOCK into INVALID response

### DIFF
--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -16,7 +16,6 @@ import type { VMExecution } from '../../execution'
 import type { Config } from '../../config'
 import type { FullEthereumService } from '../../service'
 
-export const ZERO_VALID_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000'
 export enum Status {
   ACCEPTED = 'ACCEPTED',
   INVALID = 'INVALID',
@@ -397,7 +396,7 @@ export class Engine {
           const response = {
             status: Status.INVALID,
             validationError: null,
-            latestValidHash: ZERO_VALID_HASH,
+            latestValidHash: bufferToHex(zeros(32)),
           }
           this.connectionManager.lastNewPayload({ payload: params[0], response })
           return response
@@ -522,7 +521,7 @@ export class Engine {
           payloadStatus: {
             status: Status.INVALID,
             validationError: null,
-            latestValidHash: ZERO_VALID_HASH,
+            latestValidHash: bufferToHex(zeros(32)),
           },
           payloadId: null,
         }

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -16,11 +16,11 @@ import type { VMExecution } from '../../execution'
 import type { Config } from '../../config'
 import type { FullEthereumService } from '../../service'
 
+export const ZERO_VALID_HASH = '0x0000000000000000000000000000000000000000000000000000000000000000'
 export enum Status {
   ACCEPTED = 'ACCEPTED',
   INVALID = 'INVALID',
   INVALID_BLOCK_HASH = 'INVALID_BLOCK_HASH',
-  INVALID_TERMINAL_BLOCK = 'INVALID_TERMINAL_BLOCK',
   SYNCING = 'SYNCING',
   VALID = 'VALID',
 }
@@ -349,7 +349,6 @@ export class Engine {
    *        SYNCING - sync process is in progress
    *        ACCEPTED - blockHash is valid, doesn't extend the canonical chain, hasn't been fully validated
    *        INVALID_BLOCK_HASH - blockHash validation failed
-   *        INVALID_TERMINAL_BLOCK - block fails transition block validity
    *   2. latestValidHash: DATA|null - the hash of the most recent
    *      valid block in the branch defined by payload and its ancestors
    *   3. validationError: String|null - validation error message
@@ -396,9 +395,9 @@ export class Engine {
         const validTerminalBlock = await validateTerminalBlock(parent, this.chain)
         if (!validTerminalBlock) {
           const response = {
-            status: Status.INVALID_TERMINAL_BLOCK,
+            status: Status.INVALID,
             validationError: null,
-            latestValidHash: null,
+            latestValidHash: ZERO_VALID_HASH,
           }
           this.connectionManager.lastNewPayload({ payload: params[0], response })
           return response
@@ -471,7 +470,6 @@ export class Engine {
    *        VALID
    *        INVALID
    *        SYNCING
-   *        INVALID_TERMINAL_BLOCK
    *   2. payloadId: DATA|null - 8 Bytes - identifier of the payload build process or `null`
    */
   async forkchoiceUpdatedV1(
@@ -522,9 +520,9 @@ export class Engine {
       if (!validTerminalBlock) {
         const response = {
           payloadStatus: {
-            status: Status.INVALID_TERMINAL_BLOCK,
+            status: Status.INVALID,
             validationError: null,
-            latestValidHash: null,
+            latestValidHash: ZERO_VALID_HASH,
           },
           payloadId: null,
         }

--- a/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
+++ b/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
@@ -6,6 +6,7 @@ import { checkError } from '../util'
 import genesisJSON from '../../testdata/geth-genesis/post-merge.json'
 import blocks from '../../testdata/blocks/beacon.json'
 import { batchBlocks } from './newPayloadV1.spec'
+import { ZERO_VALID_HASH } from '../../../lib/rpc/modules/engine'
 
 const method = 'engine_forkchoiceUpdatedV1'
 
@@ -114,7 +115,8 @@ tape(`${method}: invalid terminal block with only genesis block`, async (t) => {
 
   const req = params(method, [validForkChoiceState, null])
   const expectRes = (res: any) => {
-    t.equal(res.body.result.payloadStatus.status, 'INVALID_TERMINAL_BLOCK')
+    t.equal(res.body.result.payloadStatus.status, 'INVALID')
+    t.equal(res.body.result.payloadStatus.latestValidHash, ZERO_VALID_HASH)
   }
   await baseRequest(t, server, req, 200, expectRes)
 })
@@ -149,7 +151,8 @@ tape(`${method}: invalid terminal block with 1+ blocks`, async (t) => {
     null,
   ])
   const expectRes = (res: any) => {
-    t.equal(res.body.result.payloadStatus.status, 'INVALID_TERMINAL_BLOCK')
+    t.equal(res.body.result.payloadStatus.status, 'INVALID')
+    t.equal(res.body.result.payloadStatus.latestValidHash, ZERO_VALID_HASH)
   }
   await baseRequest(t, server, req, 200, expectRes)
 })

--- a/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
+++ b/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
@@ -6,7 +6,7 @@ import { checkError } from '../util'
 import genesisJSON from '../../testdata/geth-genesis/post-merge.json'
 import blocks from '../../testdata/blocks/beacon.json'
 import { batchBlocks } from './newPayloadV1.spec'
-import { ZERO_VALID_HASH } from '../../../lib/rpc/modules/engine'
+import { bufferToHex, zeros } from 'ethereumjs-util'
 
 const method = 'engine_forkchoiceUpdatedV1'
 
@@ -116,7 +116,7 @@ tape(`${method}: invalid terminal block with only genesis block`, async (t) => {
   const req = params(method, [validForkChoiceState, null])
   const expectRes = (res: any) => {
     t.equal(res.body.result.payloadStatus.status, 'INVALID')
-    t.equal(res.body.result.payloadStatus.latestValidHash, ZERO_VALID_HASH)
+    t.equal(res.body.result.payloadStatus.latestValidHash, bufferToHex(zeros(32)))
   }
   await baseRequest(t, server, req, 200, expectRes)
 })
@@ -152,7 +152,7 @@ tape(`${method}: invalid terminal block with 1+ blocks`, async (t) => {
   ])
   const expectRes = (res: any) => {
     t.equal(res.body.result.payloadStatus.status, 'INVALID')
-    t.equal(res.body.result.payloadStatus.latestValidHash, ZERO_VALID_HASH)
+    t.equal(res.body.result.payloadStatus.latestValidHash, bufferToHex(zeros(32)))
   }
   await baseRequest(t, server, req, 200, expectRes)
 })

--- a/packages/client/test/rpc/engine/newPayloadV1.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV1.spec.ts
@@ -7,6 +7,7 @@ import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
 import { Address } from 'ethereumjs-util'
 import blocks from '../../testdata/blocks/beacon.json'
 import { HttpServer } from 'jayson'
+import { ZERO_VALID_HASH } from '../../../lib/rpc/modules/engine'
 
 const method = 'engine_newPayloadV1'
 
@@ -135,7 +136,8 @@ tape(`${method}: invalid terminal block`, async (t) => {
 
   const req = params(method, [blockData, null])
   const expectRes = (res: any) => {
-    t.equal(res.body.result.status, 'INVALID_TERMINAL_BLOCK')
+    t.equal(res.body.result.status, 'INVALID')
+    t.equal(res.body.result.latestValidHash, ZERO_VALID_HASH)
   }
   await baseRequest(t, server, req, 200, expectRes)
 })

--- a/packages/client/test/rpc/engine/newPayloadV1.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV1.spec.ts
@@ -7,7 +7,7 @@ import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
 import { Address } from 'ethereumjs-util'
 import blocks from '../../testdata/blocks/beacon.json'
 import { HttpServer } from 'jayson'
-import { ZERO_VALID_HASH } from '../../../lib/rpc/modules/engine'
+import { bufferToHex, zeros } from 'ethereumjs-util'
 
 const method = 'engine_newPayloadV1'
 
@@ -137,7 +137,7 @@ tape(`${method}: invalid terminal block`, async (t) => {
   const req = params(method, [blockData, null])
   const expectRes = (res: any) => {
     t.equal(res.body.result.status, 'INVALID')
-    t.equal(res.body.result.latestValidHash, ZERO_VALID_HASH)
+    t.equal(res.body.result.latestValidHash, bufferToHex(zeros(32)))
   }
   await baseRequest(t, server, req, 200, expectRes)
 })


### PR DESCRIPTION
The https://github.com/ethereum/execution-apis/pull/217 part of the v1.0.0-alpha.9 subsumes the INVALID_TERMINAL_BLOCK into INVALID response via  {status: INVALID, latestValidHash: 0x0000000000000000000000000000000000000000000000000000000000000000}

This PR implements the same.