### PR TITLE
Refactor EVM internals

### DIFF
--- a/packages/vm/src/evm/message.ts
+++ b/packages/vm/src/evm/message.ts
@@ -68,7 +68,7 @@ export default class Message {
     this.isCompiled = opts.isCompiled ?? defaults.isCompiled
     this.salt = opts.salt
     this.selfdestruct = opts.selfdestruct
-    this.delegatecall = opts.delegatecall ?? defaults.delegatecall
+    this.delegatecall = opts.delegatecall ?? defaults.delegatecall // This is used to preserve CALLVALUE and to ensure we pass balance checks (do not actually send ETH)
     this.authcallOrigin = opts.authcallOrigin
 
     if (this.value < 0) {

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -20,6 +20,7 @@ import type {
   PreByzantiumTxReceipt,
   PostByzantiumTxReceipt,
 } from './types'
+import { EVMEnvironment } from './evm/types'
 
 const debug = createDebugLogger('vm:tx')
 const debugGas = createDebugLogger('vm:tx:gas')
@@ -407,15 +408,22 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
     )
   }
 
-  const results = (await this.evm.runCall({
-    block,
-    gasPrice,
-    caller,
-    gasLimit,
-    to,
-    value,
-    data,
-  })) as RunTxResult
+  const env: EVMEnvironment = {
+    frameEnvironment: {
+      caller,
+      gasLimit,
+      value,
+      data,
+      to
+    },
+    globalEnvironment: {
+      block,
+      gasPrice,
+      origin: caller
+    }
+  }
+
+  const results = (await this.evm.runCall(env)) as RunTxResult
 
   if (this.DEBUG) {
     const { gasUsed, exceptionError, returnValue } = results.execResult


### PR DESCRIPTION
Part of #1912 (added by @holgerd77)

Extra PR because I am not entirely sure this is the way to go (but getting more convinced that this has extremely nice properties). Also writing this down for myself so I ensure I don't lose track.

The idea is that the bare interface of an `EVM` implementation should be only a single method:

`runCall(env: EVMEnvironment): Promise<EVMResult>`

Here `EVMEnvironment` (see `src/evm/types.ts`) is supposed to cover the bare minimum which we want the VM to receive. This is equal to the input to `runCall` from `src/runTx.ts`. Since we also provide the bare minimum of the output (`EVMResult`) this ensures that our VM can work with the output whatever the EVM gives.

However, in our internal implementation these types will be much larger. In particular, `EVMEnvironment` also holds the state of the Interpreter once we invoke it. Second of all, any local variables written (such as decreasing gas limit, setting auth variables, etc.) is not done on class-level but is done within the environment. 

This has the very nice property that you can take a "snapshot" of the current environment (so we capture current address, code, the current PC, gasLeft, etc.) and you can dump this into `runCall` to re-execute everything from that point. Note that the external environment might have a different state at this point though, but that can be edited via the public `eei` of EVM.

Internally (this is also currently done like this, but we expand here) anything which has to do with calls/creates eventually calls back into EVM's `runCall`. Since Interpreter and EVM do not have any variables which change (all changes are written to current environment which is in a function closure, not dangling in the object somewhere), we can create a singleton instance of Interpreter inside EVM (just like what we do with EEI, this was also instantiated each call/create but not anymore).

This has the extremely nice property that we can now do calls like `evm.interpreter.delegatecall(args)` - i.e. we can directly execute a delegatecall without creating a tx first. I am sure that some test tools have integrated this themselves, but it would be very nice to support. It is also more clean to me to not use class-wide semi-public variables to track state, but instead keep track of it during the chained function calls, which mirrors how the EVM works too.

Steps:

- [ ] Extract minimum types for the `EVMEnvironment` 
- [ ] Expand `EVMEnvironment` with extra variables which we need inside EVM and Interpreter (these are taken from Env, RunState, and the properties of the classes which change during executiong (`_lastReturned`, `_gasLeft`). This deletes the classes/types `Env`, `RunState`, `Message`
- [ ] Ensure that this is an argument passed into `runCall` and ensure that all (?) of these properties are allowed to be undefined, the internal value should have all values defined (if a value has to be undefined such as `auth`, use explit `null`)
- [ ] Ensure that `EVMEnvironment` object gets passed around (somewhat like how we pass `_runState` around)
- [ ] Ensure that any call/create method inside Interpreter creates the correct new environment and calls back into EVM
- [ ] Add warm addresses + touched accounts to MachineState and remove it from EEI 