### PR TITLE
develop: small fixes

### DIFF
--- a/packages/block/test/testdata/testnetMerge.json
+++ b/packages/block/test/testdata/testnetMerge.json
@@ -14,7 +14,6 @@
   "comment": "Private test network",
   "url": "[TESTNET_URL]",
   "genesis": {
-    "timestamp": null,
     "gasLimit": 1000000,
     "difficulty": 1,
     "nonce": "0xbb00000000000000",

--- a/packages/blockchain/src/consensus/clique.ts
+++ b/packages/blockchain/src/consensus/clique.ts
@@ -136,12 +136,8 @@ export class CliqueConsensus implements Consensus {
     const { header } = block
     const commonAncestorNumber = commonAncestor?.number
     if (commonAncestorNumber !== undefined) {
-      await this._cliqueDeleteSnapshots(commonAncestorNumber! + BigInt(1))
-      for (
-        let number = commonAncestorNumber! + BigInt(1);
-        number <= header.number;
-        number += BigInt(1)
-      ) {
+      await this._cliqueDeleteSnapshots(commonAncestorNumber + BigInt(1))
+      for (let number = commonAncestorNumber + BigInt(1); number <= header.number; number++) {
         const canonicalHeader = await this.blockchain.getCanonicalHeader(number)
         await this._cliqueBuildSnapshots(canonicalHeader)
       }

--- a/packages/blockchain/src/db/manager.ts
+++ b/packages/blockchain/src/db/manager.ts
@@ -47,9 +47,9 @@ export class DBManager {
    */
   async getHeads(): Promise<{ [key: string]: Buffer }> {
     const heads = await this.get(DBTarget.Heads)
-    Object.keys(heads).forEach((key) => {
+    for (const key of Object.keys(heads)) {
       heads[key] = Buffer.from(heads[key])
-    })
+    }
     return heads
   }
 

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -214,12 +214,6 @@ export default class Blockchain implements BlockchainInterface {
    * {@link BlockchainOptions}.
    */
   protected constructor(opts: BlockchainOptions = {}) {
-    // Throw on chain or hardfork options removed in latest major release to
-    // prevent implicit chain setup on a wrong chain
-    if ('chain' in opts || 'hardfork' in opts) {
-      throw new Error('Chain/hardfork options are not allowed any more on initialization')
-    }
-
     if (opts.common) {
       this._common = opts.common
     } else {

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -327,7 +327,7 @@ export default class Blockchain implements BlockchainInterface {
       } else {
         stateRoot = await genesisStateRoot(this.genesisState())
       }
-      genesisBlock = this.genesisBlock(stateRoot)
+      genesisBlock = this.createGenesisBlock(stateRoot)
     }
 
     // If the DB has a genesis block, then verify that the genesis block in the
@@ -1167,18 +1167,18 @@ export default class Blockchain implements BlockchainInterface {
   }
 
   /**
-   * Returns the genesis {@link Block} for the blockchain.
-   * @param stateRoot When initializing the block, pass the genesis stateRoot.
-   *                  After the blockchain is initialized, this parameter is not used
-   *                  as the cached genesis block is returned.
+   * The genesis {@link Block} for the blockchain.
    */
-  genesisBlock(stateRoot?: Buffer): Block {
-    if (this._genesisBlock) {
-      return this._genesisBlock
-    }
+  get genesisBlock(): Block {
+    if (!this._genesisBlock) throw new Error('genesis block not set (init may not be finished)')
+    return this._genesisBlock
+  }
 
-    if (!stateRoot) throw new Error('stateRoot required for genesis block creation')
-
+  /**
+   * Creates a genesis {@link Block} for the blockchain with params from {@link Common.genesis}
+   * @param stateRoot The genesis stateRoot
+   */
+  createGenesisBlock(stateRoot: Buffer): Block {
     const common = this._common.copy()
     common.setHardforkByBlockNumber(0)
 

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -1,7 +1,6 @@
 import Semaphore from 'semaphore-async-await'
 import { Block, BlockData, BlockHeader } from '@ethereumjs/block'
 import Common, { Chain, ConsensusAlgorithm, ConsensusType, Hardfork } from '@ethereumjs/common'
-import { toBuffer } from 'ethereumjs-util'
 import { DBManager } from './db/manager'
 import { DBOp, DBSetBlockOrHeader, DBSetTD, DBSetHashToNumber, DBSaveLookups } from './db/helpers'
 import { DBTarget } from './db/operation'
@@ -1183,20 +1182,10 @@ export default class Blockchain implements BlockchainInterface {
     const common = this._common.copy()
     common.setHardforkByBlockNumber(0)
 
-    const { gasLimit, timestamp, difficulty, extraData, nonce, baseFeePerGas } = common.genesis()
-
     const header: BlockData['header'] = {
+      ...common.genesis(),
       number: 0,
-      gasLimit: BigInt(gasLimit),
-      timestamp: BigInt(timestamp ?? 0),
-      difficulty: BigInt(difficulty),
-      extraData: toBuffer(extraData),
-      nonce: toBuffer(nonce),
       stateRoot,
-    }
-
-    if (baseFeePerGas !== undefined && common.gteHardfork(Hardfork.London)) {
-      header.baseFeePerGas = BigInt(baseFeePerGas)
     }
 
     return Block.fromBlockData({ header }, { common })

--- a/packages/blockchain/test/clique.spec.ts
+++ b/packages/blockchain/test/clique.spec.ts
@@ -17,7 +17,7 @@ tape('Clique: Initialization', (t) => {
     const blockchain = await Blockchain.create({ common })
 
     const head = await blockchain.getIteratorHead()
-    st.ok(head.hash().equals(blockchain.genesisBlock().hash()), 'correct genesis hash')
+    st.ok(head.hash().equals(blockchain.genesisBlock.hash()), 'correct genesis hash')
 
     st.deepEquals(
       (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(),

--- a/packages/blockchain/test/index.spec.ts
+++ b/packages/blockchain/test/index.spec.ts
@@ -25,7 +25,7 @@ tape('blockchain test', (t) => {
     const iteratorHead = await blockchain.getIteratorHead()
 
     st.ok(
-      iteratorHead.hash().equals(blockchain.genesisBlock().hash()),
+      iteratorHead.hash().equals(blockchain.genesisBlock.hash()),
       'correct genesis hash (getIteratorHead())'
     )
 
@@ -843,7 +843,7 @@ tape('initialization tests', (t) => {
       hardfork: Hardfork.Chainstart,
     })
     const blockchain = await Blockchain.create({ common })
-    const genesisHash = blockchain.genesisBlock().hash()
+    const genesisHash = blockchain.genesisBlock.hash()
 
     st.ok(
       (await blockchain.getIteratorHead()).hash().equals(genesisHash),
@@ -946,8 +946,8 @@ tape('initialization tests', (t) => {
       '217b0bbcfb72e2d57e28f33cb361b9983513177755dc3f33ce3e7022ed62b77b',
       'hex'
     )
-    st.ok(blockchain.genesisBlock().hash().equals(ropstenGenesisBlockHash))
-    st.ok(blockchain.genesisBlock().header.stateRoot.equals(ropstenGenesisStateRoot))
+    st.ok(blockchain.genesisBlock.hash().equals(ropstenGenesisBlockHash))
+    st.ok(blockchain.genesisBlock.header.stateRoot.equals(ropstenGenesisStateRoot))
     st.end()
   })
 })

--- a/packages/blockchain/test/pos.spec.ts
+++ b/packages/blockchain/test/pos.spec.ts
@@ -7,7 +7,7 @@ import testnet from './testdata/testnet.json'
 const buildChain = async (blockchain: Blockchain, common: Common, height: number) => {
   const blocks: Block[] = []
   const londonBlockNumber = Number(common.hardforkBlock('london')!)
-  const genesis = blockchain.genesisBlock()
+  const genesis = blockchain.genesisBlock
   blocks.push(genesis)
 
   for (let number = 1; number <= height; number++) {

--- a/packages/blockchain/test/testdata/testnet.json
+++ b/packages/blockchain/test/testdata/testnet.json
@@ -10,7 +10,6 @@
   "comment": "Private test network",
   "url": "[TESTNET_URL]",
   "genesis": {
-    "timestamp": null,
     "gasLimit": 5000,
     "difficulty": 1,
     "nonce": "0xbb00000000000000",

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -371,7 +371,7 @@ async function startClient(config: Config, customGenesisState?: GenesisState) {
       validateBlocks: true,
       validateConsensus,
     })
-    setCommonForkHashes(config.chainCommon, blockchain.genesisBlock().hash())
+    setCommonForkHashes(config.chainCommon, blockchain.genesisBlock.hash())
   }
 
   const client = new EthereumClient({

--- a/packages/client/lib/blockchain/chain.ts
+++ b/packages/client/lib/blockchain/chain.ts
@@ -143,7 +143,7 @@ export class Chain {
    * Genesis block for the chain
    */
   get genesis() {
-    return this.blockchain.genesisBlock()
+    return this.blockchain.genesisBlock
   }
 
   /**

--- a/packages/client/lib/rpc/modules/admin.ts
+++ b/packages/client/lib/rpc/modules/admin.ts
@@ -2,7 +2,6 @@ import { bufferToHex } from 'ethereumjs-util'
 import { getClientVersion } from '../../util'
 import { middleware } from '../validation'
 import type { Chain } from '../../blockchain'
-import type { EthProtocol } from '../../net/protocol'
 import type { RlpxServer } from '../../net/server'
 import type EthereumClient from '../../client'
 import type { EthereumService } from '../../service'
@@ -14,7 +13,6 @@ import type { EthereumService } from '../../service'
 export class Admin {
   readonly _chain: Chain
   readonly _client: EthereumClient
-  readonly _ethProtocol: EthProtocol
 
   /**
    * Create admin_* RPC module
@@ -24,7 +22,6 @@ export class Admin {
     const service = client.services.find((s) => s.name === 'eth') as EthereumService
     this._chain = service.chain
     this._client = client
-    this._ethProtocol = service.protocols.find((p) => p.name === 'eth') as EthProtocol
 
     this.nodeInfo = middleware(this.nodeInfo.bind(this), 0, [])
   }
@@ -40,8 +37,6 @@ export class Admin {
     const { discovery, listener } = ports
     const clientName = getClientVersion()
 
-    // TODO version not present in reference..
-    // const ethVersion = Math.max.apply(Math, this._ethProtocol.versions)
     const latestHeader = this._chain.headers.latest!
     const difficulty = latestHeader.difficulty.toString()
     const genesis = bufferToHex(this._chain.genesis.hash())

--- a/packages/client/test/integration/merge.spec.ts
+++ b/packages/client/test/integration/merge.spec.ts
@@ -40,7 +40,6 @@ tape('[Integration:Merge]', async (t) => {
   const commonPoW = Common.custom(
     {
       genesis: {
-        timestamp: null,
         gasLimit: 16777216,
         difficulty: 1,
         nonce: '0x0000000000000042',

--- a/packages/client/test/rpc/mockBlockchain.ts
+++ b/packages/client/test/rpc/mockBlockchain.ts
@@ -39,6 +39,6 @@ export function mockBlockchain(options: any = {}) {
     getCanonicalHeadHeader: () => {
       return Block.fromBlockData().header
     },
-    genesisBlock: () => block,
+    genesisBlock: block,
   }
 }

--- a/packages/client/test/testdata/common/testnet.json
+++ b/packages/client/test/testdata/common/testnet.json
@@ -10,7 +10,6 @@
   "comment": "Private test network",
   "url": "[TESTNET_URL]",
   "genesis": {
-    "timestamp": null,
     "gasLimit": 1000000,
     "difficulty": 1,
     "nonce": "0xbb00000000000000",

--- a/packages/common/src/chains/kovan.json
+++ b/packages/common/src/chains/kovan.json
@@ -14,7 +14,6 @@
   "comment": "Parity PoA test network",
   "url": "https://kovan-testnet.github.io/website/",
   "genesis": {
-    "timestamp": null,
     "gasLimit": 6000000,
     "difficulty": 131072,
     "nonce": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",

--- a/packages/common/src/chains/mainnet.json
+++ b/packages/common/src/chains/mainnet.json
@@ -11,7 +11,6 @@
   "comment": "The Ethereum main chain",
   "url": "https://ethstats.net/",
   "genesis": {
-    "timestamp": null,
     "gasLimit": 5000,
     "difficulty": 17179869184,
     "nonce": "0x0000000000000042",

--- a/packages/common/src/chains/ropsten.json
+++ b/packages/common/src/chains/ropsten.json
@@ -11,7 +11,6 @@
   "comment": "PoW test network",
   "url": "https://github.com/ethereum/ropsten",
   "genesis": {
-    "timestamp": null,
     "gasLimit": 16777216,
     "difficulty": 1048576,
     "nonce": "0x0000000000000042",

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -36,7 +36,7 @@ export interface ChainConfig {
 }
 
 export interface GenesisBlockConfig {
-  timestamp: string | null
+  timestamp?: string
   gasLimit: number
   difficulty: number
   nonce: string

--- a/packages/common/tests/data/merge/testnetMerge.json
+++ b/packages/common/tests/data/merge/testnetMerge.json
@@ -14,7 +14,6 @@
   "comment": "Private test network",
   "url": "[TESTNET_URL]",
   "genesis": {
-    "timestamp": null,
     "gasLimit": 1000000,
     "difficulty": 1,
     "nonce": "0xbb00000000000000",

--- a/packages/common/tests/data/merge/testnetPOS.json
+++ b/packages/common/tests/data/merge/testnetPOS.json
@@ -11,7 +11,6 @@
   "comment": "Private test network (TODO: genesis block not constructed according to POS block rules yet)",
   "url": "[TESTNET_URL]",
   "genesis": {
-    "timestamp": null,
     "gasLimit": 1000000,
     "difficulty": 1,
     "nonce": "0xbb00000000000000",

--- a/packages/common/tests/data/testnet.json
+++ b/packages/common/tests/data/testnet.json
@@ -10,7 +10,6 @@
   "comment": "Private test network",
   "url": "[TESTNET_URL]",
   "genesis": {
-    "timestamp": null,
     "gasLimit": 1000000,
     "difficulty": 1,
     "nonce": "0xbb00000000000000",

--- a/packages/common/tests/data/testnet2.json
+++ b/packages/common/tests/data/testnet2.json
@@ -14,7 +14,6 @@
   "comment": "Private test network",
   "url": "[TESTNET_URL]",
   "genesis": {
-    "timestamp": null,
     "gasLimit": 1000000,
     "difficulty": 1,
     "nonce": "0xbb00000000000000",

--- a/packages/common/tests/data/testnet3.json
+++ b/packages/common/tests/data/testnet3.json
@@ -14,7 +14,6 @@
   "comment": "Private test network",
   "url": "[TESTNET_URL]",
   "genesis": {
-    "timestamp": null,
     "gasLimit": 1000000,
     "difficulty": 1,
     "nonce": "0xbb00000000000000",

--- a/packages/devp2p/examples/peer-communication-les.ts
+++ b/packages/devp2p/examples/peer-communication-les.ts
@@ -5,7 +5,6 @@ import { TypedTransaction } from '@ethereumjs/tx'
 import { Block, BlockHeader } from '@ethereumjs/block'
 import ms from 'ms'
 import chalk from 'chalk'
-import assert from 'assert'
 import { randomBytes } from 'crypto'
 
 const PRIVATE_KEY = randomBytes(32)
@@ -161,7 +160,7 @@ rlpx.on('peer:removed', (peer, reasonCode, disconnectWe) => {
 rlpx.on('peer:error', (peer, err) => {
   if (err.code === 'ECONNRESET') return
 
-  if (err instanceof assert.AssertionError) {
+  if (err instanceof Error) {
     const peerId = peer.getId()
     if (peerId !== null) dpt.banPeer(peerId, ms('5m'))
 

--- a/packages/devp2p/examples/peer-communication.ts
+++ b/packages/devp2p/examples/peer-communication.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { randomBytes } from 'crypto'
 import LRUCache from 'lru-cache'
 import ms from 'ms'
@@ -301,7 +300,7 @@ rlpx.on('peer:removed', (peer, reasonCode, disconnectWe) => {
 rlpx.on('peer:error', (peer, err) => {
   if (err.code === 'ECONNRESET') return
 
-  if (err instanceof assert.AssertionError) {
+  if (err instanceof Error) {
     const peerId = peer.getId()
     if (peerId !== null) dpt.banPeer(peerId, ms('5m'))
 

--- a/packages/devp2p/src/dns/dns.ts
+++ b/packages/devp2p/src/dns/dns.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { PeerInfo } from '../dpt'
 import { ENR } from './enr'
 import { debug as createDebugLogger } from 'debug'
@@ -174,9 +173,8 @@ export class DNS {
 
     const response = await dns.promises.resolve(location, 'TXT')
 
-    assert(response.length, 'Received empty result array while fetching TXT record')
-    assert(response[0].length, 'Received empty TXT record')
-
+    if (!response.length) throw new Error('Received empty result array while fetching TXT record')
+    if (!response[0].length) throw new Error('Received empty TXT record')
     // Branch entries can be an array of strings of comma delimited subdomains, with
     // some subdomain strings split across the array elements
     // (e.g btw end of arr[0] and beginning of arr[1])

--- a/packages/devp2p/src/dns/enr.ts
+++ b/packages/devp2p/src/dns/enr.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import * as base32 from 'hi-base32'
 import { sscanf } from 'scanf'
 import { ecdsaVerify } from 'secp256k1'
@@ -49,10 +48,8 @@ export class ENR {
    * @return {PeerInfo}
    */
   static parseAndVerifyRecord(enr: string): PeerInfo {
-    assert(
-      enr.startsWith(this.RECORD_PREFIX),
-      `String encoded ENR must start with '${this.RECORD_PREFIX}'`
-    )
+    if (!enr.startsWith(this.RECORD_PREFIX))
+      throw new Error(`String encoded ENR must start with '${this.RECORD_PREFIX}'`)
 
     // ENRs are RLP encoded and written to DNS TXT entries as base64 url-safe strings
     const base64BufferEnr = base64url.toBuffer(enr.slice(this.RECORD_PREFIX.length))
@@ -73,7 +70,7 @@ export class ENR {
       obj.secp256k1
     )
 
-    assert(isVerified, 'Unable to verify ENR signature')
+    if (!isVerified) throw new Error('Unable to verify ENR signature')
 
     const { ipCode, tcpCode, udpCode } = this._getIpProtocolConversionCodes(obj.id)
 
@@ -95,10 +92,8 @@ export class ENR {
    * @return {string} subdomain subdomain to retrieve branch records from.
    */
   static parseAndVerifyRoot(root: string, publicKey: string): string {
-    assert(
-      root.startsWith(this.ROOT_PREFIX),
-      `ENR root entry must start with '${this.ROOT_PREFIX}'`
-    )
+    if (!root.startsWith(this.ROOT_PREFIX))
+      throw new Error(`ENR root entry must start with '${this.ROOT_PREFIX}'`)
 
     const rootVals = sscanf(
       root,
@@ -109,10 +104,10 @@ export class ENR {
       'signature'
     ) as ENRRootValues
 
-    assert.ok(rootVals.eRoot, "Could not parse 'e' value from ENR root entry")
-    assert.ok(rootVals.lRoot, "Could not parse 'l' value from ENR root entry")
-    assert.ok(rootVals.seq, "Could not parse 'seq' value from ENR root entry")
-    assert.ok(rootVals.signature, "Could not parse 'sig' value from ENR root entry")
+    if (!rootVals.eRoot) throw new Error("Could not parse 'e' value from ENR root entry")
+    if (!rootVals.lRoot) throw new Error("Could not parse 'l' value from ENR root entry")
+    if (!rootVals.seq) throw new Error("Could not parse 'seq' value from ENR root entry")
+    if (!rootVals.signature) throw new Error("Could not parse 'sig' value from ENR root entry")
 
     const decodedPublicKey = base32.decode.asBytes(publicKey)
 
@@ -126,7 +121,7 @@ export class ENR {
 
     const isVerified = ecdsaVerify(signatureBuffer, keccak256(signedComponentBuffer), keyBuffer)
 
-    assert(isVerified, 'Unable to verify ENR root signature')
+    if (!isVerified) throw new Error('Unable to verify ENR root signature')
 
     return rootVals.eRoot
   }
@@ -140,10 +135,8 @@ export class ENR {
    * @return {ENRTreeValues}
    */
   static parseTree(tree: string): ENRTreeValues {
-    assert(
-      tree.startsWith(this.TREE_PREFIX),
-      `ENR tree entry must start with '${this.TREE_PREFIX}'`
-    )
+    if (!tree.startsWith(this.TREE_PREFIX))
+      throw new Error(`ENR tree entry must start with '${this.TREE_PREFIX}'`)
 
     const treeVals = sscanf(
       tree,
@@ -152,8 +145,8 @@ export class ENR {
       'domain'
     ) as ENRTreeValues
 
-    assert.ok(treeVals.publicKey, 'Could not parse public key from ENR tree entry')
-    assert.ok(treeVals.domain, 'Could not parse domain from ENR tree entry')
+    if (!treeVals.publicKey) throw new Error('Could not parse public key from ENR tree entry')
+    if (!treeVals.domain) throw new Error('Could not parse domain from ENR tree entry')
 
     return treeVals
   }
@@ -165,10 +158,8 @@ export class ENR {
    * @return {string[]}
    */
   static parseBranch(branch: string): string[] {
-    assert(
-      branch.startsWith(this.BRANCH_PREFIX),
-      `ENR branch entry must start with '${this.BRANCH_PREFIX}'`
-    )
+    if (!branch.startsWith(this.BRANCH_PREFIX))
+      throw new Error(`ENR branch entry must start with '${this.BRANCH_PREFIX}'`)
 
     return branch.split(this.BRANCH_PREFIX)[1].split(',')
   }

--- a/packages/devp2p/src/protocol/eth.ts
+++ b/packages/devp2p/src/protocol/eth.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import snappy from 'snappyjs'
 import {
   arrToBufArr,
@@ -115,7 +114,7 @@ export class ETH extends Protocol {
         if (this._latestBlock >= peerNextFork) {
           const msg = 'Remote is advertising a future fork that passed locally'
           this.debug('STATUS', msg)
-          throw new assert.AssertionError({ message: msg })
+          throw new Error(msg)
         }
       }
     }
@@ -123,7 +122,7 @@ export class ETH extends Protocol {
     if (peerFork === null) {
       const msg = 'Unknown fork hash'
       this.debug('STATUS', msg)
-      throw new assert.AssertionError({ message: msg })
+      throw new Error(msg)
     }
 
     if (!c.hardforkGteHardfork(peerFork.name, this._hardfork)) {
@@ -131,7 +130,7 @@ export class ETH extends Protocol {
       if (peerNextFork === null || !nextHardforkBlock || nextHardforkBlock !== peerNextFork) {
         const msg = 'Outdated fork status, remote needs software update'
         this.debug('STATUS', msg)
-        throw new assert.AssertionError({ message: msg })
+        throw new Error(msg)
       }
     }
   }

--- a/packages/devp2p/src/util.ts
+++ b/packages/devp2p/src/util.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { randomBytes } from 'crypto'
 import { privateKeyVerify, publicKeyConvert } from 'secp256k1'
 import createKeccakHash from 'keccak'
@@ -81,9 +80,7 @@ export function assertEq(
     } else {
       debug(debugMsg)
     }
-    throw new assert.AssertionError({
-      message: fullMsg,
-    })
+    throw new Error(fullMsg)
   }
 
   if (expected === actual) return
@@ -93,9 +90,7 @@ export function assertEq(
   } else {
     debug(fullMsg)
   }
-  throw new assert.AssertionError({
-    message: fullMsg,
-  })
+  throw new Error(fullMsg)
 }
 
 export function formatLogId(id: string, verbose: boolean): string {

--- a/packages/vm/examples/run-solidity-contract.ts
+++ b/packages/vm/examples/run-solidity-contract.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { join } from 'path'
 import { readFileSync } from 'fs'
 import { defaultAbiCoder as AbiCoder, Interface } from '@ethersproject/abi'
@@ -184,7 +183,10 @@ async function main() {
 
   console.log('Greeting:', greeting)
 
-  assert.equal(greeting, INITIAL_GREETING)
+  if (greeting !== INITIAL_GREETING)
+    throw new Error(
+      `initial greeting not equal, received ${greeting}, expected ${INITIAL_GREETING}`
+    )
 
   console.log('Changing greeting...')
 
@@ -194,7 +196,8 @@ async function main() {
 
   console.log('Greeting:', greeting2)
 
-  assert.equal(greeting2, SECOND_GREETING)
+  if (greeting2 !== SECOND_GREETING)
+    throw new Error(`second greeting not equal, received ${greeting2}, expected ${SECOND_GREETING}`)
 
   // Now let's look at what we created. The transaction
   // should have created a new account for the contract

--- a/packages/vm/src/bloom/index.ts
+++ b/packages/vm/src/bloom/index.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { keccak256 } from 'ethereum-cryptography/keccak'
 import { zeros } from 'ethereumjs-util'
 
@@ -14,7 +13,7 @@ export default class Bloom {
     if (!bitvector) {
       this.bitvector = zeros(BYTE_SIZE)
     } else {
-      assert(bitvector.length === BYTE_SIZE, 'bitvectors must be 2048 bits long')
+      if (bitvector.length !== BYTE_SIZE) throw new Error('bitvectors must be 2048 bits long')
       this.bitvector = bitvector
     }
   }
@@ -24,7 +23,6 @@ export default class Bloom {
    * @param e - The element to add
    */
   add(e: Buffer) {
-    assert(Buffer.isBuffer(e), 'Element should be buffer')
     e = Buffer.from(keccak256(e))
     const mask = 2047 // binary 11111111111
 
@@ -42,7 +40,6 @@ export default class Bloom {
    * @param e - The element to check
    */
   check(e: Buffer): boolean {
-    assert(Buffer.isBuffer(e), 'Element should be Buffer')
     e = Buffer.from(keccak256(e))
     const mask = 2047 // binary 11111111111
     let match = true

--- a/packages/vm/src/evm/eof.ts
+++ b/packages/vm/src/evm/eof.ts
@@ -1,8 +1,8 @@
 import { handlers } from './opcodes'
 
-const FORMAT = 0xef
-const MAGIC = 0x00
-const VERSION = 0x01
+export const FORMAT = 0xef
+export const MAGIC = 0x00
+export const VERSION = 0x01
 
 /**
  *
@@ -12,7 +12,7 @@ const VERSION = 0x01
  *
  * Note: See https://eips.ethereum.org/EIPS/eip-3540 for further details
  */
-const codeAnalysis = (container: Buffer) => {
+export const codeAnalysis = (container: Buffer) => {
   const secCode = 0x01
   const secData = 0x02
   const secTerminator = 0x00
@@ -62,7 +62,7 @@ const codeAnalysis = (container: Buffer) => {
   return sectionSizes
 }
 
-const validOpcodes = (code: Buffer) => {
+export const validOpcodes = (code: Buffer) => {
   // EIP-3670 - validate all opcodes
   const opcodes = new Set(handlers.keys())
   opcodes.add(0xfe) // Add INVALID opcode to set

--- a/packages/vm/src/evm/eof.ts
+++ b/packages/vm/src/evm/eof.ts
@@ -1,8 +1,8 @@
-import { handlers } from '.'
+import { handlers } from './opcodes'
 
-export const FORMAT = 0xef
-export const MAGIC = 0x00
-export const VERSION = 0x01
+const FORMAT = 0xef
+const MAGIC = 0x00
+const VERSION = 0x01
 
 /**
  *
@@ -12,7 +12,7 @@ export const VERSION = 0x01
  *
  * Note: See https://eips.ethereum.org/EIPS/eip-3540 for further details
  */
-export const codeAnalysis = (container: Buffer) => {
+const codeAnalysis = (container: Buffer) => {
   const secCode = 0x01
   const secData = 0x02
   const secTerminator = 0x00
@@ -62,7 +62,7 @@ export const codeAnalysis = (container: Buffer) => {
   return sectionSizes
 }
 
-export const validOpcodes = (code: Buffer) => {
+const validOpcodes = (code: Buffer) => {
   // EIP-3670 - validate all opcodes
   const opcodes = new Set(handlers.keys())
   opcodes.add(0xfe) // Add INVALID opcode to set
@@ -91,3 +91,6 @@ export const validOpcodes = (code: Buffer) => {
   }
   return true
 }
+
+const EOF = { FORMAT, MAGIC, VERSION, codeAnalysis, validOpcodes }
+export default EOF

--- a/packages/vm/src/evm/evm.ts
+++ b/packages/vm/src/evm/evm.ts
@@ -22,7 +22,7 @@ import EEI from './eei'
 import { ERROR, VmError } from '../exceptions'
 import { default as Interpreter, InterpreterOpts, RunState } from './interpreter'
 import Message, { MessageWithTo } from './message'
-import * as eof from './opcodes/eof'
+import EOF from './eof'
 import { getOpcodesForHF, OpcodeList, OpHandler } from './opcodes'
 import { AsyncDynamicGasHandler, SyncDynamicGasHandler } from './opcodes/gas'
 import { CustomPrecompile, getActivePrecompiles, PrecompileFunc } from './precompiles'
@@ -581,13 +581,13 @@ export default class EVM extends AsyncEventEmitter {
     // If enough gas and allowed code size
     let CodestoreOOG = false
     if (totalGas <= message.gasLimit && (this._allowUnlimitedContractSize || allowedCodeSize)) {
-      if (this._common.isActivatedEIP(3541) && result.returnValue[0] === eof.FORMAT) {
+      if (this._common.isActivatedEIP(3541) && result.returnValue[0] === EOF.FORMAT) {
         if (!this._common.isActivatedEIP(3540)) {
           result = { ...result, ...INVALID_BYTECODE_RESULT(message.gasLimit) }
         }
         // Begin EOF1 contract code checks
         // EIP-3540 EOF1 header check
-        const eof1CodeAnalysisResults = eof.codeAnalysis(result.returnValue)
+        const eof1CodeAnalysisResults = EOF.codeAnalysis(result.returnValue)
         if (!eof1CodeAnalysisResults?.code) {
           result = {
             ...result,
@@ -600,7 +600,7 @@ export default class EVM extends AsyncEventEmitter {
           // index 7 (if no data section is present) or index 10 (if a data section is present)
           // in the bytecode of the contract
           if (
-            !eof.validOpcodes(
+            !EOF.validOpcodes(
               result.returnValue.slice(codeStart, codeStart + eof1CodeAnalysisResults.code)
             )
           ) {

--- a/packages/vm/src/evm/interpreter.ts
+++ b/packages/vm/src/evm/interpreter.ts
@@ -7,7 +7,7 @@ import Memory from './memory'
 import Stack from './stack'
 import EEI from './eei'
 import { Opcode, OpHandler, AsyncOpHandler } from './opcodes'
-import * as eof from './opcodes/eof'
+import EOF from './eof'
 import Common from '@ethereumjs/common'
 import EVM from './evm'
 
@@ -93,18 +93,18 @@ export default class Interpreter {
   }
 
   async run(code: Buffer, opts: InterpreterOpts = {}): Promise<InterpreterResult> {
-    if (!this._common.isActivatedEIP(3540) || code[0] !== eof.FORMAT) {
+    if (!this._common.isActivatedEIP(3540) || code[0] !== EOF.FORMAT) {
       // EIP-3540 isn't active and first byte is not 0xEF - treat as legacy bytecode
       this._runState.code = code
     } else if (this._common.isActivatedEIP(3540)) {
-      if (code[1] !== eof.MAGIC) {
+      if (code[1] !== EOF.MAGIC) {
         // Bytecode contains invalid EOF magic byte
         return {
           runState: this._runState,
           exceptionError: new VmError(ERROR.INVALID_BYTECODE_RESULT),
         }
       }
-      if (code[2] !== eof.VERSION) {
+      if (code[2] !== EOF.VERSION) {
         // Bytecode contains invalid EOF version number
         return {
           runState: this._runState,
@@ -112,7 +112,7 @@ export default class Interpreter {
         }
       }
       // Code is EOF1 format
-      const codeSections = eof.codeAnalysis(code)
+      const codeSections = EOF.codeAnalysis(code)
       if (!codeSections) {
         // Code is invalid EOF1 format if `codeSections` is falsy
         return {

--- a/packages/vm/src/evm/memory.ts
+++ b/packages/vm/src/evm/memory.ts
@@ -1,5 +1,3 @@
-import assert from 'assert'
-
 const ceil = (value: number, ceiling: number): number => {
   const r = value % ceiling
   if (r === 0) {
@@ -47,9 +45,8 @@ export default class Memory {
       return
     }
 
-    assert(value.length === size, 'Invalid value size')
-    assert(offset + size <= this._store.length, 'Value exceeds memory capacity')
-    assert(Buffer.isBuffer(value), 'Invalid value type')
+    if (value.length !== size) throw new Error('Invalid value size')
+    if (offset + size > this._store.length) throw new Error('Value exceeds memory capacity')
 
     for (let i = 0; i < size; i++) {
       this._store[offset + i] = value[i]

--- a/packages/vm/src/evm/precompiles/01-ecrecover.ts
+++ b/packages/vm/src/evm/precompiles/01-ecrecover.ts
@@ -7,10 +7,9 @@ import {
 } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
-const assert = require('assert')
 
 export default function (opts: PrecompileInput): ExecResult {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const gasUsed = opts._common.param('gasPrices', 'ecRecover')
 

--- a/packages/vm/src/evm/precompiles/02-sha256.ts
+++ b/packages/vm/src/evm/precompiles/02-sha256.ts
@@ -2,10 +2,9 @@ import { sha256 } from 'ethereum-cryptography/sha256'
 import { toBuffer } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
-const assert = require('assert')
 
 export default function (opts: PrecompileInput): ExecResult {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const data = opts.data
 

--- a/packages/vm/src/evm/precompiles/03-ripemd160.ts
+++ b/packages/vm/src/evm/precompiles/03-ripemd160.ts
@@ -2,10 +2,9 @@ import { ripemd160 } from 'ethereum-cryptography/ripemd160'
 import { setLengthLeft, toBuffer } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
-const assert = require('assert')
 
 export default function (opts: PrecompileInput): ExecResult {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const data = opts.data
 

--- a/packages/vm/src/evm/precompiles/04-identity.ts
+++ b/packages/vm/src/evm/precompiles/04-identity.ts
@@ -1,9 +1,8 @@
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
-const assert = require('assert')
 
 export default function (opts: PrecompileInput): ExecResult {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const data = opts.data
 

--- a/packages/vm/src/evm/precompiles/05-modexp.ts
+++ b/packages/vm/src/evm/precompiles/05-modexp.ts
@@ -1,7 +1,6 @@
 import { setLengthRight, setLengthLeft, bufferToBigInt, bigIntToBuffer } from 'ethereumjs-util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
-const assert = require('assert')
 
 function multComplexity(x: bigint): bigint {
   let fac1
@@ -75,7 +74,7 @@ export function expmod(a: bigint, power: bigint, modulo: bigint) {
 }
 
 export default function (opts: PrecompileInput): ExecResult {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const data = opts.data
 

--- a/packages/vm/src/evm/precompiles/06-ecadd.ts
+++ b/packages/vm/src/evm/precompiles/06-ecadd.ts
@@ -1,10 +1,9 @@
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
-const assert = require('assert')
 const bn128 = require('rustbn.js')
 
 export default function (opts: PrecompileInput): ExecResult {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const inputData = opts.data
 

--- a/packages/vm/src/evm/precompiles/07-ecmul.ts
+++ b/packages/vm/src/evm/precompiles/07-ecmul.ts
@@ -1,10 +1,9 @@
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
-const assert = require('assert')
 const bn128 = require('rustbn.js')
 
 export default function (opts: PrecompileInput): ExecResult {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const inputData = opts.data
   const gasUsed = opts._common.param('gasPrices', 'ecMul')

--- a/packages/vm/src/evm/precompiles/08-ecpairing.ts
+++ b/packages/vm/src/evm/precompiles/08-ecpairing.ts
@@ -1,10 +1,9 @@
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
-const assert = require('assert')
 const bn128 = require('rustbn.js')
 
 export default function (opts: PrecompileInput): ExecResult {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const inputData = opts.data
   // no need to care about non-divisible-by-192, because bn128.pairing will properly fail in that case

--- a/packages/vm/src/evm/precompiles/09-blake2f.ts
+++ b/packages/vm/src/evm/precompiles/09-blake2f.ts
@@ -1,7 +1,6 @@
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
 import { VmError, ERROR } from '../../exceptions'
-const assert = require('assert')
 
 // The following blake2 code has been taken from (license: Creative Commons CC0):
 // https://github.com/dcposch/blakejs/blob/410c640d0f08d3b26904c6d1ab3d81df3619d282/blake2b.js
@@ -155,7 +154,7 @@ export function F(h: Uint32Array, m: Uint32Array, t: Uint32Array, f: boolean, ro
 }
 
 export default function (opts: PrecompileInput): ExecResult {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const data = opts.data
   if (data.length !== 213) {

--- a/packages/vm/src/evm/precompiles/0a-bls12-g1add.ts
+++ b/packages/vm/src/evm/precompiles/0a-bls12-g1add.ts
@@ -1,11 +1,10 @@
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'
-const assert = require('assert')
 const { BLS12_381_ToG1Point, BLS12_381_FromG1Point } = require('./util/bls12_381')
 
 export default async function (opts: PrecompileInput): Promise<ExecResult> {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const mcl = opts._EVM._mcl
 

--- a/packages/vm/src/evm/precompiles/0b-bls12-g1mul.ts
+++ b/packages/vm/src/evm/precompiles/0b-bls12-g1mul.ts
@@ -1,7 +1,6 @@
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'
-const assert = require('assert')
 const {
   BLS12_381_ToG1Point,
   BLS12_381_FromG1Point,
@@ -9,7 +8,7 @@ const {
 } = require('./util/bls12_381')
 
 export default async function (opts: PrecompileInput): Promise<ExecResult> {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const mcl = opts._EVM._mcl
 

--- a/packages/vm/src/evm/precompiles/0c-bls12-g1multiexp.ts
+++ b/packages/vm/src/evm/precompiles/0c-bls12-g1multiexp.ts
@@ -1,7 +1,6 @@
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'
-const assert = require('assert')
 const {
   BLS12_381_ToG1Point,
   BLS12_381_ToFrPoint,
@@ -9,7 +8,7 @@ const {
 } = require('./util/bls12_381')
 
 export default async function (opts: PrecompileInput): Promise<ExecResult> {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const mcl = opts._EVM._mcl
 

--- a/packages/vm/src/evm/precompiles/0d-bls12-g2add.ts
+++ b/packages/vm/src/evm/precompiles/0d-bls12-g2add.ts
@@ -1,11 +1,10 @@
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'
-const assert = require('assert')
 const { BLS12_381_ToG2Point, BLS12_381_FromG2Point } = require('./util/bls12_381')
 
 export default async function (opts: PrecompileInput): Promise<ExecResult> {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const mcl = opts._EVM._mcl
 

--- a/packages/vm/src/evm/precompiles/0e-bls12-g2mul.ts
+++ b/packages/vm/src/evm/precompiles/0e-bls12-g2mul.ts
@@ -1,7 +1,6 @@
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'
-const assert = require('assert')
 const {
   BLS12_381_ToG2Point,
   BLS12_381_FromG2Point,
@@ -9,7 +8,7 @@ const {
 } = require('./util/bls12_381')
 
 export default async function (opts: PrecompileInput): Promise<ExecResult> {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const mcl = opts._EVM._mcl
 

--- a/packages/vm/src/evm/precompiles/0f-bls12-g2multiexp.ts
+++ b/packages/vm/src/evm/precompiles/0f-bls12-g2multiexp.ts
@@ -2,7 +2,6 @@ import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'
 import { gasDiscountPairs } from './util/bls12_381'
-const assert = require('assert')
 const {
   BLS12_381_ToG2Point,
   BLS12_381_ToFrPoint,
@@ -10,7 +9,7 @@ const {
 } = require('./util/bls12_381')
 
 export default async function (opts: PrecompileInput): Promise<ExecResult> {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const mcl = opts._EVM._mcl
 

--- a/packages/vm/src/evm/precompiles/10-bls12-pairing.ts
+++ b/packages/vm/src/evm/precompiles/10-bls12-pairing.ts
@@ -1,14 +1,14 @@
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'
-const assert = require('assert')
+
 const { BLS12_381_ToG1Point, BLS12_381_ToG2Point } = require('./util/bls12_381')
 
 const zeroBuffer = Buffer.alloc(32, 0)
 const oneBuffer = Buffer.concat([Buffer.alloc(31, 0), Buffer.from('01', 'hex')])
 
 export default async function (opts: PrecompileInput): Promise<ExecResult> {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const mcl = opts._EVM._mcl
 

--- a/packages/vm/src/evm/precompiles/11-bls12-map-fp-to-g1.ts
+++ b/packages/vm/src/evm/precompiles/11-bls12-map-fp-to-g1.ts
@@ -1,11 +1,10 @@
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'
-const assert = require('assert')
 const { BLS12_381_ToFpPoint, BLS12_381_FromG1Point } = require('./util/bls12_381')
 
 export default async function (opts: PrecompileInput): Promise<ExecResult> {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const mcl = opts._EVM._mcl
 

--- a/packages/vm/src/evm/precompiles/12-bls12-map-fp2-to-g2.ts
+++ b/packages/vm/src/evm/precompiles/12-bls12-map-fp2-to-g2.ts
@@ -1,11 +1,10 @@
 import { PrecompileInput } from './types'
 import { VmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, VmError } from '../../exceptions'
-const assert = require('assert')
 const { BLS12_381_ToFp2Point, BLS12_381_FromG2Point } = require('./util/bls12_381')
 
 export default async function (opts: PrecompileInput): Promise<ExecResult> {
-  assert(opts.data)
+  if (!opts.data) throw new Error('opts.data missing but required')
 
   const mcl = opts._EVM._mcl
 

--- a/packages/vm/src/index.ts
+++ b/packages/vm/src/index.ts
@@ -179,12 +179,6 @@ export default class VM extends AsyncEventEmitter {
 
     this._opts = opts
 
-    // Throw on chain or hardfork options removed in latest major release
-    // to prevent implicit chain setup on a wrong chain
-    if ('chain' in opts || 'hardfork' in opts) {
-      throw new Error('Chain/hardfork options are not allowed any more on initialization')
-    }
-
     if (opts.common) {
       // Supported EIPs
       const supportedEIPs = [

--- a/packages/vm/tests/api/EIPs/eip-3540-evm-object-format.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3540-evm-object-format.spec.ts
@@ -3,7 +3,7 @@ import VM from '../../../src'
 import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
 import { Address, privateToAddress } from 'ethereumjs-util'
-import * as eof from '../../../src/evm/opcodes/eof'
+import EOF from '../../../src/evm/eof'
 
 const pkey = Buffer.from('20'.repeat(32), 'hex')
 const GWEI = BigInt('1000000000')
@@ -30,14 +30,14 @@ tape('EIP 3540 tests', (t) => {
   })
 
   t.test('EOF > codeAnalysis() tests', async (st) => {
-    const eofHeader = Buffer.from([eof.FORMAT, eof.MAGIC, eof.VERSION])
+    const eofHeader = Buffer.from([EOF.FORMAT, EOF.MAGIC, EOF.VERSION])
     st.ok(
-      eof.codeAnalysis(Buffer.concat([eofHeader, Uint8Array.from([0x01, 0x00, 0x01, 0x00, 0x00])]))
+      EOF.codeAnalysis(Buffer.concat([eofHeader, Uint8Array.from([0x01, 0x00, 0x01, 0x00, 0x00])]))
         ?.code! > 0,
       'valid code section'
     )
     st.ok(
-      eof.codeAnalysis(
+      EOF.codeAnalysis(
         Buffer.concat([
           eofHeader,
           Uint8Array.from([0x01, 0x00, 0x01, 0x02, 0x00, 0x01, 0x00, 0x00, 0xaa]),
@@ -46,13 +46,13 @@ tape('EIP 3540 tests', (t) => {
       'valid data section'
     )
     st.ok(
-      !eof.codeAnalysis(
+      !EOF.codeAnalysis(
         Buffer.concat([eofHeader, Uint8Array.from([0x01, 0x00, 0x01, 0x00, 0x00, 0x00])])
       ),
       'invalid container length (too long)'
     )
     st.ok(
-      !eof.codeAnalysis(Buffer.concat([eofHeader, Uint8Array.from([0x01, 0x00, 0x01, 0x00])])),
+      !EOF.codeAnalysis(Buffer.concat([eofHeader, Uint8Array.from([0x01, 0x00, 0x01, 0x00])])),
       'invalid container length (too short)'
     )
     st.end()

--- a/packages/vm/tests/api/EIPs/eip-3670-eof-code-validation.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3670-eof-code-validation.spec.ts
@@ -3,7 +3,7 @@ import VM from '../../../src'
 import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
 import { Address, privateToAddress } from 'ethereumjs-util'
-import * as eof from '../../../src/evm/opcodes/eof'
+import EOF from '../../../src/evm/eof'
 const pkey = Buffer.from('20'.repeat(32), 'hex')
 const GWEI = BigInt('1000000000')
 const sender = new Address(privateToAddress(pkey))
@@ -29,28 +29,28 @@ tape('EIP 3670 tests', (t) => {
   })
 
   t.test('EOF > validOpcodes() tests', (st) => {
-    st.ok(eof.validOpcodes(Buffer.from([0])), 'valid -- STOP ')
-    st.ok(eof.validOpcodes(Buffer.from([0xfe])), 'valid -- INVALID opcode')
-    st.ok(eof.validOpcodes(Buffer.from([0x60, 0xaa, 0])), 'valid - PUSH1 AA STOP')
+    st.ok(EOF.validOpcodes(Buffer.from([0])), 'valid -- STOP ')
+    st.ok(EOF.validOpcodes(Buffer.from([0xfe])), 'valid -- INVALID opcode')
+    st.ok(EOF.validOpcodes(Buffer.from([0x60, 0xaa, 0])), 'valid - PUSH1 AA STOP')
 
     Array.from([0x00, 0xf3, 0xfd, 0xfe, 0xff]).forEach((opcode) => {
       st.ok(
-        eof.validOpcodes(Buffer.from([0x60, 0xaa, opcode])),
+        EOF.validOpcodes(Buffer.from([0x60, 0xaa, opcode])),
         `code ends with valid terminating instruction 0x${opcode.toString(16)}`
       )
     })
 
-    st.notOk(eof.validOpcodes(Buffer.from([0xaa])), 'invalid -- AA -- undefined opcode')
+    st.notOk(EOF.validOpcodes(Buffer.from([0xaa])), 'invalid -- AA -- undefined opcode')
     st.notOk(
-      eof.validOpcodes(Buffer.from([0x7f, 0xaa, 0])),
+      EOF.validOpcodes(Buffer.from([0x7f, 0xaa, 0])),
       'invalid -- PUSH32 AA STOP -- truncated push'
     )
     st.notOk(
-      eof.validOpcodes(Buffer.from([0x61, 0xaa, 0])),
+      EOF.validOpcodes(Buffer.from([0x61, 0xaa, 0])),
       'invalid -- PUSH2 AA STOP -- truncated push'
     )
     st.notOk(
-      eof.validOpcodes(Buffer.from([0x60, 0xaa, 0x30])),
+      EOF.validOpcodes(Buffer.from([0x60, 0xaa, 0x30])),
       'invalid -- PUSH1 AA ADDRESS -- invalid terminal opcode'
     )
     st.end()

--- a/packages/vm/tests/api/bloom.spec.ts
+++ b/packages/vm/tests/api/bloom.spec.ts
@@ -15,7 +15,7 @@ tape('bloom', (t: tape.Test) => {
   t.test('shouldnt initialize with invalid bitvector', (st) => {
     st.throws(
       () => new Bloom(utils.zeros(byteSize / 2)),
-      /AssertionError/,
+      /bitvectors must be 2048 bits long/,
       'should fail for invalid length'
     )
     st.end()

--- a/packages/vm/tests/api/testdata/testnet.json
+++ b/packages/vm/tests/api/testdata/testnet.json
@@ -10,7 +10,6 @@
   "comment": "Private test network",
   "url": "[TESTNET_URL]",
   "genesis": {
-    "timestamp": null,
     "gasLimit": 1000000,
     "difficulty": 1,
     "nonce": "0xbb00000000000000",

--- a/packages/vm/tests/api/testdata/testnet2.json
+++ b/packages/vm/tests/api/testdata/testnet2.json
@@ -14,7 +14,6 @@
   "comment": "Private test network",
   "url": "[TESTNET_URL]",
   "genesis": {
-    "timestamp": null,
     "gasLimit": 1000000,
     "difficulty": 1,
     "nonce": "0xbb00000000000000",

--- a/packages/vm/tests/api/testdata/testnetMerge.json
+++ b/packages/vm/tests/api/testdata/testnetMerge.json
@@ -14,7 +14,6 @@
   "comment": "Private test network",
   "url": "[TESTNET_URL]",
   "genesis": {
-    "timestamp": null,
     "gasLimit": 1000000,
     "difficulty": 1,
     "nonce": "0xbb00000000000000",


### PR DESCRIPTION
This PR:
* Simplifies setting blockchain genesis parameters from common for future extensibility of additional fields
    * (feedback from https://github.com/ethereumjs/ethereumjs-monorepo/pull/1916#discussion_r885457874)
    * also makes genesis `timestamp` optional instead of `| null` to satisfy BlockHeader type constraints.
* Moves vm's `EOF` file one folder up (couldn't find a reason it needed to be in `vm/opcodes`), export default rather than wildcard import
* Removes last `assert` usages from evm/precompiles, devp2p
    * (no `assert` usage left across the monorepo, woo!)