### PR TITLE
Blockchain, VM, Client: New Bugfix Releases

### DIFF
--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.5.3 - 2022-06-03
+
+- Fixed a bug in `cliqueCheckRecentlySigned()` throwing a false-positive "recently signed" error when a PoS Clique block is added within a reorg scenario, PR [#1930](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1930)
+
 ## 5.5.2 - 2022-03-15
 
 - Fixed a bug where a delete-operation would be performed on DB but not in the cache leading to inconsistent behavior, PR [#1786](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1786)

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/blockchain",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "description": "A module to store and interact with blocks",
   "license": "MPL-2.0",
   "keywords": [

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.5.1 - 2022-06-03
+
+- Updated to a new `@ethereumjs/blockchain` library version containing a Clique-related bugfix on signer-validation, PR [#1930](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1930)
+
 ## 0.5.0 - 2022-06-02
 
 ### Merge: Kiln v2.1 Support

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/client",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "EthereumJS client implementation",
   "license": "MPL-2.0",
   "author": "Vinay Pulim (v@pulim.com)",
@@ -51,12 +51,12 @@
   "dependencies": {
     "@chainsafe/libp2p-noise": "^4.1.1",
     "@ethereumjs/block": "^3.6.2",
-    "@ethereumjs/blockchain": "^5.5.2",
+    "@ethereumjs/blockchain": "^5.5.3",
     "@ethereumjs/common": "^2.6.4",
     "@ethereumjs/devp2p": "^4.2.2",
     "@ethereumjs/ethash": "^1.1.0",
     "@ethereumjs/tx": "^3.5.2",
-    "@ethereumjs/vm": "^5.9.1",
+    "@ethereumjs/vm": "^5.9.2",
     "body-parser": "^1.19.2",
     "chalk": "^4.1.2",
     "connect": "^3.7.0",

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.9.2 - 2022-06-03
+
+- Updated to a new `@ethereumjs/blockchain` library version containing a Clique-related bugfix on signer-validation, PR [#1930](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1930)
+
 ## 5.9.1 - 2022-06-02
 
 ### Additions / Features

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/vm",
-  "version": "5.9.1",
+  "version": "5.9.2",
   "description": "An Ethereum VM implementation",
   "license": "MPL-2.0",
   "author": "mjbecze <mjbecze@gmail.com>",
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@ethereumjs/block": "^3.6.2",
-    "@ethereumjs/blockchain": "^5.5.2",
+    "@ethereumjs/blockchain": "^5.5.3",
     "@ethereumjs/common": "^2.6.4",
     "@ethereumjs/tx": "^3.5.2",
     "merkle-patricia-tree": "^4.2.4",


### PR DESCRIPTION
@ryanio made me aware that I had forgotten a release for the Blockchain library containing the last-minute fix from #1931.

This PR catches up on this, it also includes new releases for VM and Client so that the changes are surely applied.

PR is targeted towards `v5-maintenance` so that it doesn't interrupt the current (rebase and the like) processes.