### PR TITLE
develop clean-up items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,6 @@
       "workspaces": [
         "packages/*"
       ],
-      "dependencies": {
-        "bigint-crypto-utils": "^3.0.23"
-      },
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^4.27.0",
         "@typescript-eslint/parser": "^4.27.0",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,5 @@
     "e2e:publish": "./scripts/e2e-publish.sh",
     "e2e:resolutions": "node ./scripts/e2e-resolutions.js",
     "e2e:inject": "node ./scripts/e2e-inject-resolutions.js"
-  },
-  "dependencies": {
-    "bigint-crypto-utils": "^3.0.23"
   }
 }

--- a/packages/vm/tests/api/EIPs/eip-3074-authcall.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3074-authcall.spec.ts
@@ -419,7 +419,7 @@ tape('EIP-3074 AUTH', (t) => {
 
 // Setups the environment for the VM, puts `code` at contractAddress and also puts the STORECALLER bytecode at the contractStorageAddress
 async function setupVM(code: Buffer) {
-  const vm = await VM.create({ common })
+  const vm = await VM.create({ common: common.copy() })
   await vm.stateManager.putContractCode(contractAddress, code)
   await vm.stateManager.putContractCode(contractStorageAddress, STORECALLER)
   const account = await vm.stateManager.getAccount(callerAddress)


### PR DESCRIPTION
Clean-up items following on #1943 

 - Removes `bigint-crypto-utils` dep from root `package.json`
 - Fixes memory leak in EIP-3074 tests where [`common` isn't copied](https://github.com/ethereumjs/ethereumjs-monorepo/blob/4481cf2d3f69bc35be343e5ae6709434eb2add9d/packages/vm/tests/api/EIPs/eip-3074-authcall.spec.ts#L228) and the hardfork listener gets duplicated