### PR TITLE
Fix client integration tests

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -45,6 +45,8 @@ jobs:
           flags: client
         if: ${{ matrix.node-version == 16 }}
 
+      - run: npm run test:integration
+      
       - run: npm run lint
   test-client-cli:
     runs-on: ubuntu-latest

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -249,7 +249,8 @@ export class BeaconSynchronizer extends Synchronizer {
     // Execute single block when within 50 blocks of head,
     // otherwise run execution in batch of 50 blocks when filling canonical chain.
     if (
-      this.chain.blocks.height > this.skeleton.bounds().head - BigInt(50) ||
+      (this.skeleton.bounds() &&
+        this.chain.blocks.height > this.skeleton.bounds().head - BigInt(50)) ||
       this.chain.blocks.height % BigInt(50) === BigInt(0)
     ) {
       void this.execution.run(false)

--- a/packages/client/test/integration/mocks/mockchain.ts
+++ b/packages/client/test/integration/mocks/mockchain.ts
@@ -29,7 +29,6 @@ export default class MockChain extends Chain {
         {
           header: {
             number: number + 1,
-            difficulty: 1,
             parentHash: number ? blocks[number - 1].hash() : this.genesis.hash(),
           },
         },


### PR DESCRIPTION
This PR re-enables the Client integration tests that were accidentally removed in #1556 and also fixes some broken integration tests related to beacon sync.