### PR TITLE
client: Make beacon sync more robust

### DIFF
--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -217,6 +217,13 @@ export interface ConfigOptions {
    * to try to refetch and refeed the blocks.
    */
   safeReorgDistance?: number
+
+  /**
+   * If there is a skeleton fillCanonicalChain block lookup errors
+   * because of closing chain conditions, this allows skeleton
+   * to backstep and fill again using reverse block fetcher.
+   */
+  skeletonFillCanonicalBackStep?: number
 }
 
 export class Config {
@@ -239,6 +246,7 @@ export class Config {
   public static readonly DNSADDR_DEFAULT = '8.8.8.8'
   public static readonly DEBUGCODE_DEFAULT = false
   public static readonly SAFE_REORG_DISTANCE = 100
+  public static readonly SKELETON_FILL_CANONICAL_BACKSTEP = 100
 
   public readonly logger: Logger
   public readonly syncmode: SyncMode
@@ -265,6 +273,7 @@ export class Config {
   public readonly accounts: [address: Address, privKey: Buffer][]
   public readonly minerCoinbase?: Address
   public readonly safeReorgDistance: number
+  public readonly skeletonFillCanonicalBackStep: number
   public readonly disableBeaconSync: boolean
 
   public synchronized: boolean
@@ -302,6 +311,8 @@ export class Config {
     this.accounts = options.accounts ?? []
     this.minerCoinbase = options.minerCoinbase
     this.safeReorgDistance = options.safeReorgDistance ?? Config.SAFE_REORG_DISTANCE
+    this.skeletonFillCanonicalBackStep =
+      options.skeletonFillCanonicalBackStep ?? Config.SKELETON_FILL_CANONICAL_BACKSTEP
     this.disableBeaconSync = options.disableBeaconSync ?? false
 
     this.synchronized = false

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -224,6 +224,13 @@ export interface ConfigOptions {
    * to backstep and fill again using reverse block fetcher.
    */
   skeletonFillCanonicalBackStep?: number
+
+  /**
+   * If skeleton subchains can be merged, what is the minimum tail
+   * gain, as subchain merge will lead to the ReverseBlockFetcher
+   * reset
+   */
+  skeletonSubchainMergeMinimum?: number
 }
 
 export class Config {
@@ -247,6 +254,7 @@ export class Config {
   public static readonly DEBUGCODE_DEFAULT = false
   public static readonly SAFE_REORG_DISTANCE = 100
   public static readonly SKELETON_FILL_CANONICAL_BACKSTEP = 100
+  public static readonly SKELETON_SUBCHAIN_MERGE_MINIMUM = 1000
 
   public readonly logger: Logger
   public readonly syncmode: SyncMode
@@ -272,8 +280,10 @@ export class Config {
   public readonly mine: boolean
   public readonly accounts: [address: Address, privKey: Buffer][]
   public readonly minerCoinbase?: Address
+
   public readonly safeReorgDistance: number
   public readonly skeletonFillCanonicalBackStep: number
+  public readonly skeletonSubchainMergeMinimum: number
   public readonly disableBeaconSync: boolean
 
   public synchronized: boolean
@@ -313,6 +323,8 @@ export class Config {
     this.safeReorgDistance = options.safeReorgDistance ?? Config.SAFE_REORG_DISTANCE
     this.skeletonFillCanonicalBackStep =
       options.skeletonFillCanonicalBackStep ?? Config.SKELETON_FILL_CANONICAL_BACKSTEP
+    this.skeletonSubchainMergeMinimum =
+      options.skeletonSubchainMergeMinimum ?? Config.SKELETON_SUBCHAIN_MERGE_MINIMUM
     this.disableBeaconSync = options.disableBeaconSync ?? false
 
     this.synchronized = false

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -221,7 +221,8 @@ export class BeaconSynchronizer extends Synchronizer {
       // to the current canonical, so we can lower the skeleton target by another 1000 blocks
       count = BigInt(this.config.skeletonSubchainMergeMinimum)
     } else {
-      count = tail - this.chain.blocks.height
+      // We sync one less because tail's next should be pointing to the block in chain
+      count = tail - this.chain.blocks.height - BigInt(1)
     }
 
     if (count > BigInt(0) && (!isTruthy(this.fetcher) || isTruthy(this.fetcher.errored))) {

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -200,7 +200,7 @@ export class BeaconSynchronizer extends Synchronizer {
   async syncWithPeer(peer?: Peer): Promise<boolean> {
     if (await this.skeleton.isLinked()) {
       this.clearFetcher()
-      return true
+      return false
     }
 
     const latest = peer ? await this.latest(peer) : undefined

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -198,7 +198,7 @@ export class BeaconSynchronizer extends Synchronizer {
    * @return Resolves when sync completed
    */
   async syncWithPeer(peer?: Peer): Promise<boolean> {
-    if (await this.skeleton.isLinked()) {
+    if (!isTruthy(this.skeleton.bounds()) || (await this.skeleton.isLinked())) {
       this.clearFetcher()
       return false
     }

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -362,7 +362,7 @@ export class Skeleton extends MetaDBManager {
             this.status.progress.subchains[0].next
           )}, block number=${number} hash=${short(block.hash())}`
         )
-        throw Error(`Block don't extend canonical subchain`)
+        throw Error(`Blocks don't extend canonical subchain`)
       }
       merged = await this.trySubChainsMerge()
       // If its merged, we need to break as the new tail could be quite ahead

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -174,10 +174,7 @@ export abstract class Synchronizer {
         this.clearFetcher()
         resolve(true)
         const heightStr = isTruthy(height) ? ` height=${height}` : ''
-        this.config.logger.info(
-          `Finishing up sync with the current fetcher${heightStr}
-          }`
-        )
+        this.config.logger.info(`Finishing up sync with the current fetcher ${heightStr}`)
       }
       this.config.events.once(Event.SYNC_SYNCHRONIZED, resolveSync)
       try {

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -174,7 +174,7 @@ export abstract class Synchronizer {
         this.clearFetcher()
         resolve(true)
         const heightStr = isTruthy(height) ? ` height=${height}` : ''
-        this.config.logger.debug(
+        this.config.logger.info(
           `Finishing up sync with the current fetcher${heightStr}
           }`
         )
@@ -184,9 +184,10 @@ export abstract class Synchronizer {
         if (this.fetcher) {
           await this.fetcher.fetch()
         }
+        this.config.logger.debug(`Fetcher finished fetching...`)
         resolveSync()
       } catch (error: any) {
-        this.config.logger.debug(
+        this.config.logger.error(
           `Received sync error, stopping sync and clearing fetcher: ${error.message ?? error}`
         )
         this.clearFetcher()

--- a/packages/client/test/sync/beaconsync.spec.ts
+++ b/packages/client/test/sync/beaconsync.spec.ts
@@ -105,7 +105,11 @@ tape('[BeaconSynchronizer]', async (t) => {
   })
 
   t.test('should sync to next subchain head or chain height', async (t) => {
-    const config = new Config({ transports: [], safeReorgDistance: 0 })
+    const config = new Config({
+      transports: [],
+      safeReorgDistance: 0,
+      skeletonSubchainMergeMinimum: 0,
+    })
     const pool = new PeerPool() as any
     const chain = new Chain({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -128,13 +132,13 @@ tape('[BeaconSynchronizer]', async (t) => {
     void sync.sync()
     await wait(50)
     t.equal(sync.fetcher!.first, BigInt(5), 'should sync block 5 and 4')
-    t.equal(sync.fetcher!.count, BigInt(2), 'should sync block 5 and 4')
+    t.equal(sync.fetcher!.count, BigInt(5), 'should target syncing all the way to chain')
     await wait(51)
     ;(skeleton as any).status.progress.subchains = [{ head: BigInt(10), tail: BigInt(2) }]
     void sync.sync()
     await wait(50)
     t.equal(sync.fetcher!.first, BigInt(1), 'should sync block 1')
-    t.equal(sync.fetcher!.count, BigInt(1), 'should sync block 1')
+    t.equal(sync.fetcher!.count, BigInt(1), 'should target syncing all the way to chain')
     await wait(51)
     ;(skeleton as any).status.progress.subchains = [{ head: BigInt(10), tail: BigInt(6) }]
     ;(sync as any).chain = { blocks: { height: BigInt(4) } }
@@ -176,7 +180,7 @@ tape('[BeaconSynchronizer]', async (t) => {
     const pool = new PeerPool() as any
     const chain = new Chain({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
-    skeleton.isLinked = () => true // stub
+    skeleton.isLinked = async () => true // stub
     const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
     await sync.open()
     t.ok(await sync.syncWithPeer({} as any))

--- a/packages/client/test/sync/beaconsync.spec.ts
+++ b/packages/client/test/sync/beaconsync.spec.ts
@@ -183,7 +183,11 @@ tape('[BeaconSynchronizer]', async (t) => {
     skeleton.isLinked = async () => true // stub
     const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
     await sync.open()
-    t.ok(await sync.syncWithPeer({} as any))
+    t.equal(
+      await sync.syncWithPeer({} as any),
+      false,
+      `syncWithPeer should return false as nothing to sync`
+    )
     await sync.stop()
     await sync.close()
     t.end()

--- a/packages/client/test/sync/fetcher/reverseblockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/reverseblockfetcher.spec.ts
@@ -209,7 +209,7 @@ tape('[ReverseBlockFetcher]', async (t) => {
 
   t.test('should restart the fetcher when subchains are merged', async (st) => {
     td.reset()
-    const config = new Config({ transports: [] })
+    const config = new Config({ transports: [], skeletonSubchainMergeMinimum: 0 })
     const pool = new PeerPool() as any
     const chain = new Chain({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })

--- a/packages/client/test/sync/skeleton.spec.ts
+++ b/packages/client/test/sync/skeleton.spec.ts
@@ -606,9 +606,9 @@ tape('[Skeleton]', async (t) => {
         'canonical height should stop at block 2 (valid terminal block), since block 3 is invalid (past ttd)'
       )
       st.equal(
-        (skeleton as any).status.progress.subchains.length,
-        0,
-        `Subchains should have been cleared by now because of backstep and will need initSync to start`
+        (skeleton as any).status.progress.subchains[0].tail,
+        BigInt(4),
+        `Subchain should have been backstepped to 4`
       )
     }
   )

--- a/packages/client/test/sync/skeleton.spec.ts
+++ b/packages/client/test/sync/skeleton.spec.ts
@@ -553,7 +553,10 @@ tape('[Skeleton]', async (t) => {
         config: {
           ...genesisJSON.config,
           terminalTotalDifficulty: 200,
+          clique: undefined,
+          ethash: {},
         },
+        extraData: '0x00000000000000000',
         difficulty: '0x1',
       }
       const params = await parseCustomParams(genesis, 'post-merge')

--- a/packages/client/test/sync/skeleton.spec.ts
+++ b/packages/client/test/sync/skeleton.spec.ts
@@ -546,6 +546,71 @@ tape('[Skeleton]', async (t) => {
   )
 
   t.test(
+    'should abort filling the canonical chain and backstep if the terminal block is invalid',
+    async (st) => {
+      const genesis = {
+        ...genesisJSON,
+        config: {
+          ...genesisJSON.config,
+          terminalTotalDifficulty: 200,
+        },
+        difficulty: '0x1',
+      }
+      const params = await parseCustomParams(genesis, 'post-merge')
+      const common = new Common({
+        chain: params.name,
+        customChains: [params],
+      })
+      common.setHardforkByBlockNumber(BigInt(0), BigInt(0))
+      const config = new Config({
+        transports: [],
+        common,
+      })
+      const chain = new Chain({ config })
+      ;(chain.blockchain as any)._validateBlocks = false
+      ;(chain.blockchain as any)._validateConsensus = false
+      await chain.open()
+      const genesisBlock = await chain.getBlock(BigInt(0))
+
+      const block1 = Block.fromBlockData(
+        { header: { number: 1, parentHash: genesisBlock.hash(), difficulty: 100 } },
+        { common }
+      )
+      const block2 = Block.fromBlockData(
+        { header: { number: 2, parentHash: block1.hash(), difficulty: 100 } },
+        { common }
+      )
+      const block3PoW = Block.fromBlockData(
+        { header: { number: 3, parentHash: block2.hash(), difficulty: 100 } },
+        { common }
+      )
+      const block4PoW = Block.fromBlockData(
+        { header: { number: 4, parentHash: block3PoW.hash(), difficulty: 0 } },
+        { common }
+      )
+
+      const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
+      await skeleton.open()
+
+      await skeleton.initSync(block4PoW)
+      await skeleton.putBlocks([block3PoW, block2])
+      st.equal(chain.blocks.height, BigInt(0), 'canonical height should be at genesis')
+      await skeleton.putBlocks([block1])
+      await wait(200)
+      st.equal(
+        chain.blocks.height,
+        BigInt(2),
+        'canonical height should stop at block 2 (valid terminal block), since block 3 is invalid (past ttd)'
+      )
+      st.equal(
+        (skeleton as any).status.progress.subchains.length,
+        0,
+        `Subchains should have been cleared by now because of backstep and will need initSync to start`
+      )
+    }
+  )
+
+  t.test(
     'should abort filling the canonical chain if a PoS block comes too early without hitting ttd',
     async (st) => {
       const genesis = {

--- a/packages/client/test/sync/skeleton.spec.ts
+++ b/packages/client/test/sync/skeleton.spec.ts
@@ -550,7 +550,11 @@ tape('[Skeleton]', async (t) => {
     async (st) => {
       const genesis = {
         ...genesisJSON,
-        config: { ...genesisJSON.config, terminalTotalDifficulty: 200 },
+        config: {
+          ...genesisJSON.config,
+          terminalTotalDifficulty: 200,
+          skeletonFillCanonicalBackStep: 0,
+        },
         difficulty: '0x1',
       }
       const params = await parseCustomParams(genesis, 'post-merge')


### PR DESCRIPTION
Handle few recovery and reorg scenarios to make beacon sync more robust
plus a small refac for better code clarity

@holgerd77 we can target this for `v5 maintenance` if we want, although we can also skip it as beacon sync is relatively new.