### PR TITLE
Monorepo: Remove esModuleInterop and allowSyntheticDefaultImports Options

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -6,7 +6,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "downlevelIteration": true,


### PR DESCRIPTION
TypeScript compiler options:
- `esModuleInterop` 
- `allowSyntheticDefaultImports` 
set to `false` as suggested in #1964

Part of meta issue #1946

