### PR TITLE
Remove explicit browser builds as monorepo builds already target es2020

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,6 @@ jspm_packages/
 
 # generate output
 dist
-dist.browser
 
 # Gatsby files
 .cache/

--- a/config/README.md
+++ b/config/README.md
@@ -99,8 +99,7 @@ Exposed CLI commands:
 
 ### Usage
 
-The three files below compose the functionality built into `ts-build.sh` and `ts-compile.sh`. Note that the browser build is optional, and in the case it's not present in the package, browser builds will be ignored.
-
+The three files below compose the functionality built into `ts-build.sh` and `ts-compile.sh`. Note that the build is browser compatible with `ES2020` target.
 Add `tsconfig.json`:
 
 ```json
@@ -122,18 +121,6 @@ Add `tsconfig.prod.json`:
 }
 ```
 
-Add `tsconfig.browser.json`:
-
-```json
-{
-  "extends": "../../config/tsconfig.browser.json",
-  "include": ["src/**/*.ts"],
-  "compilerOptions": {
-    "outDir": "./dist.browser"
-  }
-}
-```
-
 Note: the `outDir` property is mandatory to generate assets to a directory.
 
 Use CLI commands above in your `package.json`:
@@ -143,18 +130,6 @@ Use CLI commands above in your `package.json`:
     "tsc":   "../../config/cli/ts-compile.sh",
     "build": "../../config/cli/ts-build.sh"
   }
-```
-
-The default production target is ES2017. To support shipping the ES5 target for browsers, add to your `package.json`:
-
-```json
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "browser": "dist.browser/index.js",
-  "files": [
-    "dist",
-    "dist.browser"
-  ]
 ```
 
 ## Documentation

--- a/config/cli/ts-build.sh
+++ b/config/cli/ts-build.sh
@@ -72,13 +72,9 @@ build_browser() {
 
 # Begin build process.
 
-if [ "$1" = "node" ];
-then
-    build_node
-elif [ "$1" = "browser" ];
+if [ "$1" = "browser" ];
 then
     build_browser
 else
     build_node
-    build_browser
 fi

--- a/config/eslint.js
+++ b/config/eslint.js
@@ -8,7 +8,6 @@ module.exports = {
   ignorePatterns: [
     'node_modules/',
     'dist/',
-    'dist.browser/',
     'coverage/',
     'prettier.config.js',
     'typedoc.js',

--- a/config/tsconfig.browser.json
+++ b/config/tsconfig.browser.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "lib": ["dom", "ES2020"]
-  }
-}

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -14,7 +14,6 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist/index.js",
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "prepublishOnly": "../../config/cli/prepublish.sh",

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -10,16 +10,13 @@
   ],
   "files": [
     "dist",
-    "dist.browser",
     "src"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist.browser/index.js",
+  "browser": "dist/index.js",
   "scripts": {
-    "build": "npm run build:node && npm run build:browser",
-    "build:node": "../../config/cli/ts-build.sh node",
-    "build:browser": "../../config/cli/ts-build.sh browser",
+    "build": "../../config/cli/ts-build.sh",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "clean": "../../config/cli/clean-package.sh",
     "coverage": "../../config/cli/coverage.sh",

--- a/packages/block/tsconfig.browser.json
+++ b/packages/block/tsconfig.browser.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../config/tsconfig.browser.json",
-  "include": ["src/**/*.ts"],
-  "compilerOptions": {
-    "outDir": "./dist.browser"
-  }
-}

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -13,7 +13,6 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist/index.js",
   "scripts": {
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "clean": "../../config/cli/clean-package.sh",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -9,18 +9,15 @@
   ],
   "files": [
     "dist",
-    "dist.browser",
     "src"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist.browser/index.js",
+  "browser": "dist/index.js",
   "scripts": {
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "build": "npm run build:node && npm run build:browser",
-    "build:node": "../../config/cli/ts-build.sh node",
-    "build:browser": "../../config/cli/ts-build.sh browser",
+    "build": "../../config/cli/ts-build.sh",
     "coverage": "../../config/cli/coverage.sh",
     "docs:build": "typedoc --options typedoc.js",
     "tsc": "../../config/cli/ts-compile.sh",

--- a/packages/blockchain/tsconfig.browser.json
+++ b/packages/blockchain/tsconfig.browser.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../config/tsconfig.browser.json",
-  "include": ["src/**/*.ts", "src/**/*.json"],
-  "compilerOptions": {
-    "outDir": "./dist.browser",
-    "types": ["node"],
-    "typeRoots": ["node_modules/@types"]
-  }
-}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,8 +27,8 @@
   "scripts": {
     "preinstall": "npm run binWorkaround",
     "binWorkaround": "test -f dist/bin/cli.js || echo 'install fails if bin script does not exist (https://github.com/npm/cli/issues/2632), creating placeholder file at \"dist/bin/cli.js\"' && mkdir -p 'dist/bin' && touch dist/bin/cli.js",
-    "build": "npm run build:node && npm run build:browser",
-    "build:node": "../../config/cli/ts-build.sh node",
+    "build": "npm run build:common && npm run build:browser",
+    "build:common": "../../config/cli/ts-build.sh",
     "build:browser": "../../config/cli/ts-build.sh browser && npm run bundle && rm -rf dist.browser",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "clean": "../../config/cli/clean-package.sh",

--- a/packages/client/tsconfig.browser.json
+++ b/packages/client/tsconfig.browser.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../config/tsconfig.browser.json",
+  "extends": "../../config/tsconfig.json",
   "include": ["browser/index.ts"],
   "exclude": ["lib/index.js"],
   "compilerOptions": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,16 +14,13 @@
   ],
   "files": [
     "dist",
-    "dist.browser",
     "src"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist.browser/index.js",
+  "browser": "dist/index.js",
   "scripts": {
-    "build": "npm run build:node && npm run build:browser",
-    "build:node": "../../config/cli/ts-build.sh node",
-    "build:browser": "../../config/cli/ts-build.sh browser",
+    "build": "../../config/cli/ts-build.sh",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "clean": "../../config/cli/clean-package.sh",
     "coverage": "../../config/cli/coverage.sh",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,7 +18,6 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist/index.js",
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "prepublishOnly": "../../config/cli/prepublish.sh",

--- a/packages/common/tsconfig.browser.json
+++ b/packages/common/tsconfig.browser.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../config/tsconfig.browser.json",
-  "include": ["src/**/*.ts", "src/**/*.json"],
-  "compilerOptions": {
-    "outDir": "./dist.browser"
-  }
-}

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -24,7 +24,6 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist/index.js",
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "prepublishOnly": "../../config/cli/prepublish.sh",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -20,16 +20,13 @@
   },
   "files": [
     "dist",
-    "dist.browser",
     "src"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist.browser/index.js",
+  "browser": "dist/index.js",
   "scripts": {
-    "build": "npm run build:node && npm run build:browser",
-    "build:node": "../../config/cli/ts-build.sh node",
-    "build:browser": "../../config/cli/ts-build.sh browser",
+    "build": "../../config/cli/ts-build.sh",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "clean": "../../config/cli/clean-package.sh",
     "coverage": "../../config/cli/coverage.sh",

--- a/packages/devp2p/tsconfig.browser.json
+++ b/packages/devp2p/tsconfig.browser.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../config/tsconfig.browser.json",
-  "include": ["src/**/*.ts"],
-  "compilerOptions": {
-    "outDir": "./dist.browser",
-    "types": ["node"],
-    "typeRoots": ["node_modules/@types", "src/@types"]
-  }
-}

--- a/packages/ethash/.prettierignore
+++ b/packages/ethash/.prettierignore
@@ -3,6 +3,5 @@
 .vscode
 coverage
 dist
-dist.browser
 docs
 node_modules

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -15,7 +15,6 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist/index.js",
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "tsc": "../../config/cli/ts-compile.sh",

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -11,16 +11,13 @@
   ],
   "files": [
     "dist",
-    "dist.browser",
     "src"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist.browser/index.js",
+  "browser": "dist/index.js",
   "scripts": {
-    "build": "npm run build:node && npm run build:browser",
-    "build:node": "../../config/cli/ts-build.sh node",
-    "build:browser": "../../config/cli/ts-build.sh browser",
+    "build": "../../config/cli/ts-build.sh",
     "tsc": "../../config/cli/ts-compile.sh",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "clean": "../../config/cli/clean-package.sh",

--- a/packages/ethash/tsconfig.browser.json
+++ b/packages/ethash/tsconfig.browser.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../config/tsconfig.browser.json",
-  "include": ["src/**/*.ts"],
-  "compilerOptions": {
-    "outDir": "./dist.browser"
-  }
-}

--- a/packages/evm/.prettierignore
+++ b/packages/evm/.prettierignore
@@ -3,6 +3,5 @@
 .vscode
 coverage
 dist
-dist.browser
 docs
 node_modules

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -10,16 +10,13 @@
   ],
   "files": [
     "dist",
-    "dist.browser",
     "src"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist.browser/index.js",
+  "browser": "dist/index.js",
   "scripts": {
-    "build": "npm run build:node && npm run build:browser",
-    "build:node": "../../config/cli/ts-build.sh node",
-    "build:browser": "../../config/cli/ts-build.sh browser",
+    "build": "../../config/cli/ts-build.sh",
     "profiling": "0x ./benchmarks/run.js profiling",
     "prepublishOnly": "../../config/cli/prepublish.sh && npm run test:buildIntegrity",
     "clean": "../../config/cli/clean-package.sh",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -14,7 +14,6 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist/index.js",
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "profiling": "0x ./benchmarks/run.js profiling",

--- a/packages/evm/tsconfig.browser.json
+++ b/packages/evm/tsconfig.browser.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../config/tsconfig.browser.json",
-  "include": ["src/**/*.ts", "src/**/*.json"],
-  "compilerOptions": {
-    "outDir": "./dist.browser",
-  }
-}

--- a/packages/statemanager/.prettierignore
+++ b/packages/statemanager/.prettierignore
@@ -3,6 +3,5 @@
 .vscode
 coverage
 dist
-dist.browser
 docs
 node_modules

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -14,7 +14,6 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist/index.js",
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "prepublishOnly": "../../config/cli/prepublish.sh && npm run test:node",

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -10,16 +10,13 @@
   ],
   "files": [
     "dist",
-    "dist.browser",
     "src"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist.browser/index.js",
+  "browser": "dist/index.js",
   "scripts": {
-    "build": "npm run build:node && npm run build:browser",
-    "build:node": "../../config/cli/ts-build.sh node",
-    "build:browser": "../../config/cli/ts-build.sh browser",
+    "build": "../../config/cli/ts-build.sh",
     "prepublishOnly": "../../config/cli/prepublish.sh && npm run test:node",
     "clean": "../../config/cli/clean-package.sh",
     "coverage": "../../config/cli/coverage.sh",

--- a/packages/statemanager/tsconfig.browser.json
+++ b/packages/statemanager/tsconfig.browser.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../config/tsconfig.browser.json",
-  "include": ["src/**/*.ts", "src/**/*.json"],
-  "compilerOptions": {
-    "outDir": "./dist.browser",
-  }
-}

--- a/packages/trie/.prettierignore
+++ b/packages/trie/.prettierignore
@@ -1,7 +1,6 @@
 node_modules
 .vscode
 dist
-dist.browser
 .nyc_output
 *.json
 docs

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -16,7 +16,6 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist/index.js",
   "scripts": {
     "benchmarks": "node -r ts-node/register --max-old-space-size=8024 benchmarks",
     "profiling": "tsc --target ES5 benchmarks/random.ts && 0x benchmarks/random.js",

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -12,20 +12,17 @@
   ],
   "files": [
     "dist",
-    "dist.browser",
     "src"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist.browser/index.js",
+  "browser": "dist/index.js",
   "scripts": {
     "benchmarks": "node -r ts-node/register --max-old-space-size=8024 benchmarks",
     "profiling": "tsc --target ES5 benchmarks/random.ts && 0x benchmarks/random.js",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "build": "npm run build:node && npm run build:browser",
-    "build:node": "../../config/cli/ts-build.sh node",
-    "build:browser": "../../config/cli/ts-build.sh browser",
+    "build": "../../config/cli/ts-build.sh",
     "coverage": "../../config/cli/coverage.sh",
     "docs:build": "typedoc --options typedoc.js",
     "lint": "../../config/cli/lint.sh",

--- a/packages/trie/tsconfig.browser.json
+++ b/packages/trie/tsconfig.browser.json
@@ -1,8 +1,0 @@
-{
-    "extends": "../../config/tsconfig.browser.json",
-    "include": ["src/**/*.ts"],
-    "compilerOptions": {
-      "outDir": "./dist.browser",
-    }
-}
-  

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -14,7 +14,6 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist/index.js",
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "prepublishOnly": "../../config/cli/prepublish.sh",

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -10,16 +10,13 @@
   ],
   "files": [
     "dist",
-    "dist.browser",
     "src"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist.browser/index.js",
+  "browser": "dist/index.js",
   "scripts": {
-    "build": "npm run build:node && npm run build:browser",
-    "build:node": "../../config/cli/ts-build.sh node",
-    "build:browser": "../../config/cli/ts-build.sh browser",
+    "build": "../../config/cli/ts-build.sh",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "clean": "../../config/cli/clean-package.sh",
     "coverage": "../../config/cli/coverage.sh",

--- a/packages/tx/tsconfig.browser.json
+++ b/packages/tx/tsconfig.browser.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../config/tsconfig.browser.json",
-  "include": ["src/**/*.ts"],
-  "compilerOptions": {
-    "outDir": "./dist.browser"
-  }
-}

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -14,16 +14,13 @@
   },
   "files": [
     "dist",
-    "dist.browser",
     "src"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist.browser/index.js",
+  "browser": "dist/index.js",
   "scripts": {
-    "build": "npm run build:node && npm run build:browser",
-    "build:node": "../../config/cli/ts-build.sh node",
-    "build:browser": "../../config/cli/ts-build.sh browser",
+    "build": "../../config/cli/ts-build.sh",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "clean": "../../config/cli/clean-package.sh",
     "coverage": "../../config/cli/coverage.sh",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -18,7 +18,6 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist/index.js",
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "prepublishOnly": "../../config/cli/prepublish.sh",

--- a/packages/util/tsconfig.browser.json
+++ b/packages/util/tsconfig.browser.json
@@ -1,8 +1,0 @@
-{
-    "extends": "../../config/tsconfig.browser.json",
-    "include": ["src/**/*.ts"],
-    "compilerOptions": {
-      "outDir": "./dist.browser",
-    }
-}
-  

--- a/packages/vm/.prettierignore
+++ b/packages/vm/.prettierignore
@@ -3,6 +3,5 @@
 .vscode
 coverage
 dist
-dist.browser
 docs
 node_modules

--- a/packages/vm/examples/run-code-browser.js
+++ b/packages/vm/examples/run-code-browser.js
@@ -8,7 +8,7 @@
  * using node-static or `python -mSimpleHTTPServer`).
  */
 const BN = require('bn.js')
-const VM = require('../dist.browser').default
+const VM = require('../dist').default
 
 const run = async () => {
   // Create a new VM instance

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -10,16 +10,13 @@
   ],
   "files": [
     "dist",
-    "dist.browser",
     "src"
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist.browser/index.js",
+  "browser": "dist/index.js",
   "scripts": {
-    "build": "npm run build:node && npm run build:browser",
-    "build:node": "../../config/cli/ts-build.sh node",
-    "build:browser": "../../config/cli/ts-build.sh browser",
+    "build": "../../config/cli/ts-build.sh",
     "build:benchmarks": "npm run build && tsc -p tsconfig.benchmarks.json",
     "benchmarks": "node --max-old-space-size=4096 ./benchmarks/run.js benchmarks mainnetBlocks:10",
     "profiling": "0x ./benchmarks/run.js profiling",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -14,7 +14,6 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "browser": "dist/index.js",
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "build:benchmarks": "npm run build && tsc -p tsconfig.benchmarks.json",

--- a/packages/vm/tsconfig.browser.json
+++ b/packages/vm/tsconfig.browser.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../config/tsconfig.browser.json",
-  "include": ["src/**/*.ts", "src/**/*.json"],
-  "compilerOptions": {
-    "outDir": "./dist.browser",
-  }
-}


### PR DESCRIPTION
Except `client` this PR removes explicit builds for the browser. The client seems to be having some replacements in the webpack config, so separate browser build target retained there for building replacements:
```typescript
replacement(resourcePath) {
            const mapping = {
              [resolve('./dist.browser/lib/logging.js')]: resolve(
                './dist.browser/browser/logging.js'
              ),
              [resolve('./dist.browser/lib/net/peer/libp2pnode.js')]: resolve(
                './dist.browser/browser/libp2pnode.js'
              ),
            }
```