### PR TITLE
Blockchain--Add-consensus-Option (master)

### DIFF
--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -29,6 +29,7 @@ export class Blockchain implements BlockchainInterface {
 
   private _genesisBlock?: Block /** The genesis block of this blockchain */
   private _customGenesisState?: GenesisState /** Custom genesis state */
+  private _consensus?: string /** consensus algorithm */
 
   /**
    * The following two heads and the heads stored within the `_heads` always point
@@ -114,11 +115,10 @@ export class Blockchain implements BlockchainInterface {
     this._validateConsensus = opts.validateConsensus ?? true
     this._validateBlocks = opts.validateBlocks ?? true
     this._customGenesisState = opts.genesisState
-
+    this._consensus = opts.consensus ?? this._common.consensusAlgorithm()
     this.db = opts.db ? opts.db : new MemoryLevel()
     this.dbManager = new DBManager(this.db, this._common)
-
-    switch (this._common.consensusAlgorithm()) {
+    switch (this._consensus) {
       case ConsensusAlgorithm.Casper:
         this.consensus = new CasperConsensus({ blockchain: this })
         break

--- a/packages/blockchain/src/types.ts
+++ b/packages/blockchain/src/types.ts
@@ -1,6 +1,8 @@
 import { Block } from '@ethereumjs/block'
 import Common from '@ethereumjs/common'
 import { AbstractLevel } from 'abstract-level'
+import { Consensus } from '.'
+import { Blockchain } from './blockchain'
 import { GenesisState } from './genesisStates'
 
 export type OnBlock = (block: Block, reorg: boolean) => Promise<void> | void
@@ -81,6 +83,14 @@ export interface BlockchainOptions {
    * Default: `true`.
    */
   validateConsensus?: boolean
+
+  /**
+   * Options to pass in string to define consensus
+   * Or to pass in custom consensusAlgorithm that correctly implements `Consensus`
+   */
+
+  consensus?: 'casper' | 'clique' | 'ethash'
+  consensusAlgorithm?: (blockchain: { blockchain: Blockchain }) => Consensus
 
   /**
    * This flag indicates if protocol-given consistency checks on

--- a/packages/blockchain/test/index.spec.ts
+++ b/packages/blockchain/test/index.spec.ts
@@ -1,7 +1,7 @@
 import Common, { Chain, Hardfork } from '@ethereumjs/common'
 import { Block, BlockHeader, BlockOptions } from '@ethereumjs/block'
 import * as tape from 'tape'
-import Blockchain from '../src'
+import Blockchain, { CasperConsensus, Consensus, EthashConsensus } from '../src'
 import { generateBlockchain, generateBlocks, isConsecutive, createTestDB } from './util'
 import * as testDataPreLondon from './testdata/testdata_pre-london.json'
 import * as blocksData from './testdata/blocks_mainnet.json'
@@ -35,6 +35,64 @@ tape('blockchain test', (t) => {
       'tangerineWhistle',
       'correct HF setting with hardforkByHeadBlockNumber option'
     )
+    st.end()
+  })
+
+  t.test('should initialize correctly with consensus option passed in', async (st) => {
+    const common = new Common({ chain: Chain.Goerli, hardfork: Hardfork.Chainstart })
+    let blockchain = await Blockchain.create({ common: common, consensus: 'casper' })
+    let iteratorHead = await blockchain.getIteratorHead()
+    st.ok(
+      iteratorHead.hash().equals(blockchain.genesisBlock.hash()),
+      'correct genesis hash (getIteratorHead()) - casper'
+    )
+    blockchain = await Blockchain.create({ common: common, consensus: 'ethash' })
+    iteratorHead = await blockchain.getIteratorHead()
+    st.ok(
+      iteratorHead.hash().equals(blockchain.genesisBlock.hash()),
+      'correct genesis hash (getIteratorHead()) - ethash'
+    )
+    blockchain = await Blockchain.create({ common: common, consensus: 'clique' })
+    iteratorHead = await blockchain.getIteratorHead()
+    st.ok(
+      iteratorHead.hash().equals(blockchain.genesisBlock.hash()),
+      'correct genesis hash (getIteratorHead()) -  clique'
+    )
+    st.end()
+  })
+  t.test('should initialize correctly with consensusAlgorithm option passed in', async (st) => {
+    const common = new Common({ chain: Chain.Goerli, hardfork: Hardfork.Chainstart })
+    let blockchain = await Blockchain.create({
+      common: common,
+      consensusAlgorithm: (_blockchain: { blockchain: Blockchain }) =>
+        new CasperConsensus(_blockchain) as Consensus,
+    })
+    let iteratorHead = await blockchain.getIteratorHead()
+    st.ok(
+      iteratorHead.hash().equals(blockchain.genesisBlock.hash()),
+      'correct genesis hash (getIteratorHead()) - casper'
+    )
+    blockchain = await Blockchain.create({
+      common: common,
+      consensusAlgorithm: (_blockchain: { blockchain: Blockchain }) =>
+        new EthashConsensus(_blockchain) as Consensus,
+    })
+    iteratorHead = await blockchain.getIteratorHead()
+    st.ok(
+      iteratorHead.hash().equals(blockchain.genesisBlock.hash()),
+      'correct genesis hash (getIteratorHead()) - ethash'
+    )
+    blockchain = await Blockchain.create({
+      common: common,
+      consensusAlgorithm: (_blockchain: { blockchain: Blockchain }) =>
+        new CasperConsensus(_blockchain) as Consensus,
+    })
+    iteratorHead = await blockchain.getIteratorHead()
+    st.ok(
+      iteratorHead.hash().equals(blockchain.genesisBlock.hash()),
+      'correct genesis hash (getIteratorHead()) - clique'
+    )
+
     st.end()
   })
 


### PR DESCRIPTION
re: #1993

Add consensus as an option for Blockchain.create()

Implemented two ways:

`consensus` is an optional string input that functions much like common.consensusAlgorithm().   You can pass in `casper`, `clique`, or `ethash`, and the blockchain constructor will create a `CasperConsensus`, `CliqueConsensus`, or `EthashConsensus`.

`consensusAlgorithm` is an optional constructor parameter.  A user could pass in a constructor for a custom `consensusAlgorithm` as long as it implements the base `Consensus` interface.

Also added tests for both approaches.