### PR TITLE
Util--Signature-ecsign-ecrecover-functionality

### DIFF
--- a/packages/client/lib/miner/miner.ts
+++ b/packages/client/lib/miner/miner.ts
@@ -260,6 +260,7 @@ export class Miner {
         common: this.config.chainCommon,
         calcDifficultyFromHeader,
         putBlockIntoBlockchain: false,
+        hardforkByBlockNumber: true,
       },
     })
 

--- a/packages/client/lib/miner/miner.ts
+++ b/packages/client/lib/miner/miner.ts
@@ -257,7 +257,7 @@ export class Miner {
       },
       blockOpts: {
         cliqueSigner,
-        hardforkByBlockNumber: true,
+        common: this.config.chainCommon,
         calcDifficultyFromHeader,
         putBlockIntoBlockchain: false,
       },

--- a/packages/client/lib/miner/pendingBlock.ts
+++ b/packages/client/lib/miner/pendingBlock.ts
@@ -47,9 +47,6 @@ export class PendingBlock {
     // is based on the parent block's state
     await vm.eei.setStateRoot(parentBlock.header.stateRoot)
 
-    const td = await vm.blockchain.getTotalDifficulty(parentBlock.hash())
-    vm._common.setHardforkByBlockNumber(parentBlock.header.number, td)
-
     const builder = await vm.buildBlock({
       parentBlock,
       headerData: {
@@ -60,6 +57,7 @@ export class PendingBlock {
       },
       blockOpts: {
         putBlockIntoBlockchain: false,
+        common: vm._common,
       },
     })
 

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -378,7 +378,10 @@ tape('[Miner]', async (t) => {
         { name: 'london', block: 3 },
       ],
     }
-    const common = Common.custom(customChainParams, { baseChain: CommonChain.Rinkeby })
+    const common = Common.custom(customChainParams, {
+      baseChain: CommonChain.Rinkeby,
+      eips: [1559],
+    })
     common.setHardforkByBlockNumber(0)
     const config = new Config({ transports: [], accounts, mine: true, common })
     const chain = new Chain({ config })

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -108,6 +108,7 @@ tape('[Miner]', async (t) => {
     return signedTx
   }
 
+  common.setHardforkByBlockNumber(0)
   const txA01 = createTx() // A -> B, nonce: 0, value: 1, normal gasPrice
   const txA02 = createTx(A, B, 1, 1, 2000000000) // A -> B, nonce: 1, value: 1, 2x gasPrice
   const txA03 = createTx(A, B, 2, 1, 3000000000) // A -> B, nonce: 2, value: 1, 3x gasPrice

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -296,13 +296,7 @@ export default class Transaction extends BaseTransaction<Transaction> {
     this._validateHighS()
 
     try {
-      return ecrecover(
-        msgHash,
-        v!,
-        bigIntToUnpaddedBuffer(r!),
-        bigIntToUnpaddedBuffer(s!),
-        this.supports(Capability.EIP155ReplayProtection) ? this.common.chainId() : undefined
-      )
+      return ecrecover(msgHash, v!, bigIntToUnpaddedBuffer(r!), bigIntToUnpaddedBuffer(s!))
     } catch (e: any) {
       const msg = this._errorMsg('Invalid Signature')
       throw new Error(msg)

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -361,6 +361,15 @@ export default class Transaction extends BaseTransaction<Transaction> {
           `Legacy txs need either v = 27/28 or v >= 37 (EIP-155 replay protection), got v = ${v}`
         )
       }
+      if (
+        common?.hardfork() === 'chainstart' ||
+        common?.hardfork() === 'homestead' ||
+        common?.hardfork() === 'tangerineWhistle'
+      ) {
+        if (v > 28) {
+          throw new Error('Legacy txs need either v = 27/28 or v >= 37 (EIP-155 replay protection)')
+        }
+      }
     }
 
     // No unsigned tx and EIP-155 activated and chain ID included

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -18,17 +18,16 @@ export interface ECDSASignature {
  * accordingly, otherwise return a "static" `v` just derived from the `recovery` bit
  */
 export function ecsign(msgHash: Buffer, privateKey: Buffer, chainId?: bigint): ECDSASignature {
-  const [signature, recovery] = signSync(msgHash, privateKey, { recovered: true, der: false })
+  const [signature, _recovery] = signSync(msgHash, privateKey, { recovered: true, der: false })
 
   const r = Buffer.from(signature.slice(0, 32))
   const s = Buffer.from(signature.slice(32, 64))
-
   const v =
     chainId === undefined
-      ? BigInt(recovery + 27)
-      : BigInt(recovery + 35) + BigInt(chainId) * BigInt(2)
-
-  return { r, s, v }
+      ? BigInt(_recovery + 27)
+      : BigInt(_recovery + 35) + BigInt(chainId) * BigInt(2)
+  const recovery = BigInt(_recovery)
+  return { r, s, v, recovery }
 }
 
 function calculateSigRecovery(v: bigint, chainId?: bigint): bigint {

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -39,6 +39,21 @@ function calculateSigRecovery(v: bigint, chainId?: bigint): bigint {
   return v - (chainId * BigInt(2) + BigInt(35))
 }
 
+export function calculateSigRecoveryFromV(v: bigint) {
+  if (v === BigInt(0) || v === BigInt(1)) {
+    return v
+  } else {
+    const _v = Number(v)
+    if (Number.isInteger((0 - 35 - _v) / -2)) {
+      return BigInt(0)
+    } else if (Number.isInteger((1 - 35 - _v) / -2)) {
+      return BigInt(1)
+    } else {
+      throw new Error('Invalid v value')
+    }
+  }
+}
+
 function isValidSigRecovery(recovery: bigint): boolean {
   return recovery === BigInt(0) || recovery === BigInt(1)
 }
@@ -128,6 +143,7 @@ export const fromRpcSig = function (sig: string): ECDSASignature {
     throw new Error('Invalid signature length')
   }
 
+  const recovery: bigint = calculateSigRecoveryFromV(v)
   // support both versions of `eth_sign` responses
   if (v < 27) {
     v = v + BigInt(27)
@@ -137,6 +153,7 @@ export const fromRpcSig = function (sig: string): ECDSASignature {
     v,
     r,
     s,
+    recovery,
   }
 }
 

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -8,6 +8,7 @@ export interface ECDSASignature {
   v: bigint
   r: Buffer
   s: Buffer
+  recovery: bigint
 }
 
 /**

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -43,10 +43,9 @@ export function calculateSigRecoveryFromV(v: bigint) {
   if (v === BigInt(0) || v === BigInt(1)) {
     return v
   } else {
-    const _v = Number(v)
-    if (Number.isInteger((0 - 35 - _v) / -2)) {
+    if ((0n - 35n - v) % 2n === 0n) {
       return BigInt(0)
-    } else if (Number.isInteger((1 - 35 - _v) / -2)) {
+    } else if ((1n - 35n - v) % 2n === 0n) {
       return BigInt(1)
     } else {
       throw new Error('Invalid v value')

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -4,7 +4,19 @@ import { toBuffer, setLengthLeft, bufferToHex, bufferToInt, bufferToBigInt } fro
 import { SECP256K1_ORDER, SECP256K1_ORDER_DIV_2 } from './constants'
 import { assertIsBuffer } from './helpers'
 
+/**
+ * Interface for ECDSA signature
+ *
+ * @interface ECDSASignature
+ *
+ */
 export interface ECDSASignature {
+  /**
+   * @param {bigint} v 32 Byte Integer
+   * @param {Buffer} r 32 Byte Integer
+   * @param {Buffer} s Recovery Identifier
+   * @param {bigint} recovery yParity
+   */
   v: bigint
   r: Buffer
   s: Buffer

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -43,7 +43,7 @@ export function ecsign(msgHash: Buffer, privateKey: Buffer, chainId?: bigint): E
 }
 
 export function calculateSigRecoveryFromV(v: bigint): bigint {
-  if (v > 28n && v < 37n) {
+  if (v > 28n && v < 35n) {
     return v
   }
   if (v < BigInt(27) && v > BigInt(1)) {
@@ -54,7 +54,7 @@ export function calculateSigRecoveryFromV(v: bigint): bigint {
   }
   if (v === BigInt(0) || v === BigInt(1)) {
     return v
-  } else if ((0n - 35n - v) % -2n === 0n) {
+  } else if ((0n - 35n - v) % 2n === 0n) {
     return BigInt(0)
   } else {
     return BigInt(1)

--- a/packages/util/test/signature.spec.ts
+++ b/packages/util/test/signature.spec.ts
@@ -10,6 +10,7 @@ import {
   toCompactSig,
   bufferToBigInt,
   bigIntToBuffer,
+  calculateSigRecoveryFromV,
 } from '../src'
 
 const echash = Buffer.from(
@@ -303,23 +304,30 @@ tape('message sig', function (t) {
   t.test('should return hex strings that the RPC can use', function (st) {
     const sig =
       '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca661b'
-    st.equal(toRpcSig(BigInt(27), r, s), sig)
+    const v = BigInt(27)
+    st.equal(toRpcSig(v, r, s), sig)
+    const recovery = calculateSigRecoveryFromV(v)
     st.deepEqual(fromRpcSig(sig), {
-      v: BigInt(27),
+      v: v,
       r,
       s,
+      recovery,
     })
+
     st.end()
   })
 
   t.test('should support compact signature representation (EIP-2098)', function (st) {
     const sig =
       '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66'
-    st.equal(toCompactSig(BigInt(27), r, s), sig)
+    const v = BigInt(27)
+    const recovery = calculateSigRecoveryFromV(v)
+    st.equal(toCompactSig(v, r, s), sig)
     st.deepEqual(fromRpcSig(sig), {
       v: BigInt(27),
       r,
       s,
+      recovery,
     })
     st.end()
   })
@@ -327,23 +335,31 @@ tape('message sig', function (t) {
   t.test('should support compact signature representation (EIP-2098) (v=0)', function (st) {
     const sig =
       '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66'
+    const v = BigInt(27)
+    const recovery = calculateSigRecoveryFromV(v)
     st.equal(toCompactSig(BigInt(0), r, s), sig)
+    st.equal(toCompactSig(v, r, s), sig)
     st.deepEqual(fromRpcSig(sig), {
-      v: BigInt(27),
+      v: v,
       r,
       s,
+      recovery,
     })
+
     st.end()
   })
 
   t.test('should support compact signature representation 2 (EIP-2098)', function (st) {
     const sig =
       '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9929ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66'
-    st.equal(toCompactSig(BigInt(28), r, s), sig)
+    const v = BigInt(28)
+    const recovery = calculateSigRecoveryFromV(v)
+    st.equal(toCompactSig(v, r, s), sig)
     st.deepEqual(fromRpcSig(sig), {
-      v: BigInt(28),
+      v: v,
       r,
       s,
+      recovery,
     })
     st.end()
   })
@@ -352,10 +368,14 @@ tape('message sig', function (t) {
     const sig =
       '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9929ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66'
     st.equal(toCompactSig(BigInt(1), r, s), sig)
+    const v = BigInt(28)
+    const recovery = calculateSigRecoveryFromV(v)
+    st.equal(toCompactSig(BigInt(1), r, s), sig)
     st.deepEqual(fromRpcSig(sig), {
-      v: BigInt(28),
+      v: v,
       r,
       s,
+      recovery,
     })
     st.end()
   })
@@ -365,11 +385,13 @@ tape('message sig', function (t) {
       '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66014f'
     const chainId = BigInt(150)
     const v = chainId * BigInt(2) + BigInt(35)
+    const recovery = calculateSigRecoveryFromV(v)
     st.equal(toRpcSig(v, r, s, chainId), sig)
     st.deepEqual(fromRpcSig(sig), {
       v,
       r,
       s,
+      recovery,
     })
     st.end()
   })

--- a/packages/util/test/signature.spec.ts
+++ b/packages/util/test/signature.spec.ts
@@ -111,7 +111,7 @@ tape('ecrecover', function (t) {
     const r = Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex')
     const s = Buffer.from('129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66', 'hex')
     const v = BigInt(41)
-    const pubkey = ecrecover(echash, v, r, s, chainId)
+    const pubkey = ecrecover(echash, v, r, s)
     st.ok(pubkey.equals(privateToPublic(ecprivkey)))
     st.end()
   })
@@ -120,7 +120,7 @@ tape('ecrecover', function (t) {
     const r = Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex')
     const s = Buffer.from('129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66', 'hex')
     const v = BigInt(chainId * BigInt(2) + BigInt(35))
-    const pubkey = ecrecover(echash, v, r, s, chainId)
+    const pubkey = ecrecover(echash, v, r, s)
     st.ok(pubkey.equals(privateToPublic(ecprivkey)))
     st.end()
   })
@@ -184,8 +184,7 @@ tape('ecrecover', function (t) {
     const s = Buffer.from('4b8e02b96b94064a5aa2f8d72bd0040616ba8e482a5dd96422e38c9a4611f8d5', 'hex')
 
     const v = BigInt('68361967398315796')
-    const chainID = BigInt('34180983699157880')
-    const sender = ecrecover(msgHash, v, r, s, chainID)
+    const sender = ecrecover(msgHash, v, r, s)
     st.ok(sender.equals(senderPubKey), 'sender pubkey correct (Buffer)')
     st.end()
   })
@@ -284,7 +283,7 @@ tape('isValidSignature', function (t) {
     const r = Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex')
     const s = Buffer.from('129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66', 'hex')
     const v = BigInt(41)
-    st.ok(isValidSignature(v, r, s, false, chainId))
+    st.ok(isValidSignature(v, r, s, false))
     st.end()
   })
   t.test('should work otherwise (chainId=150)', function (st) {
@@ -292,7 +291,7 @@ tape('isValidSignature', function (t) {
     const r = Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex')
     const s = Buffer.from('129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66', 'hex')
     const v = BigInt(chainId * BigInt(2) + BigInt(35))
-    st.ok(isValidSignature(v, r, s, false, chainId))
+    st.ok(isValidSignature(v, r, s, false))
     st.end()
   })
 })
@@ -386,7 +385,7 @@ tape('message sig', function (t) {
     const chainId = BigInt(150)
     const v = chainId * BigInt(2) + BigInt(35)
     const recovery = calculateSigRecoveryFromV(v)
-    st.equal(toRpcSig(v, r, s, chainId), sig)
+    st.equal(toRpcSig(v, r, s), sig)
     st.deepEqual(fromRpcSig(sig), {
       v,
       r,
@@ -401,9 +400,8 @@ tape('message sig', function (t) {
     function (st) {
       const sig =
         '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66f2ded8deec6714'
-      const chainID = BigInt('34180983699157880')
       const v = BigInt('68361967398315796')
-      st.equal(toRpcSig(v, r, s, chainID), sig)
+      st.equal(toRpcSig(v, r, s), sig)
       st.end()
     }
   )

--- a/packages/util/test/signature.spec.ts
+++ b/packages/util/test/signature.spec.ts
@@ -355,7 +355,7 @@ tape('message sig', function (t) {
     const recovery = calculateSigRecoveryFromV(v)
     st.equal(toCompactSig(v, r, s), sig)
     st.deepEqual(fromRpcSig(sig), {
-      v: v,
+      v,
       r,
       s,
       recovery,
@@ -367,11 +367,11 @@ tape('message sig', function (t) {
     const sig =
       '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9929ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66'
     st.equal(toCompactSig(BigInt(1), r, s), sig)
-    const v = BigInt(28)
+    const v = BigInt(1)
     const recovery = calculateSigRecoveryFromV(v)
     st.equal(toCompactSig(BigInt(1), r, s), sig)
     st.deepEqual(fromRpcSig(sig), {
-      v: v,
+      v: BigInt(28),
       r,
       s,
       recovery,

--- a/packages/vm/tests/api/EIPs/eip-3074-authcall.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3074-authcall.spec.ts
@@ -675,6 +675,7 @@ tape('EIP-3074 AUTHCALL', (t) => {
       v: signature.v,
       r: signature.s,
       s: signature.s,
+      recovery: signature.recovery,
     }
     const code = Buffer.concat([
       getAuthCode(message, signature, authAddress),


### PR DESCRIPTION
Re: #1961 

Util:

- Adds `recovery` to `ECDSASignature` interface.
- Creates a new method `calculateSigRecoveryFromV(v: bigint)`
  - This includes a calculation for recovery based on the `recovery = chainId * 2 + 35` formula.
- Refactors `fromRpcSig()` to return `ECDSASignature` with `recovery`.
- Updates relevant  `signature.spec.ts` tests for new interface, methods.


TX:
For legacy transactions, `Transaction._validateTxV()` was updated to filter for hardforks that include EIP-150

Client:
- Small changes were made regarding `miner` and `pendingBlock` in response to failing tests.
