### PR TITLE
chore: remove untrue jsdoc comment on `clearWarmedAccounts`

### DIFF
--- a/packages/vm/src/eei/vmState.ts
+++ b/packages/vm/src/eei/vmState.ts
@@ -406,7 +406,6 @@ export class VmState implements VmStateAccess {
 
   /**
    * Clear the warm accounts and storage. To be called after a transaction finished.
-   * @param boolean - If true, returns an EIP-2930 access list generated
    */
   clearWarmedAccounts(): void {
     this._accessedStorage = [new Map()]


### PR DESCRIPTION
I was using the StateManager's `clearWarmedAccounts` function and noticed that the jsdoc comment says that the function takes a `boolean`, but found this to be untrue. This PR removes that jsdoc comment.