### PR TITLE
EVM: Cleanup EEI

### DIFF
--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -74,7 +74,7 @@ export class VMExecution extends Execution {
     this.hardfork = this.config.execCommon.hardfork()
     this.config.logger.info(`Initializing VM execution hardfork=${this.hardfork}`)
     if (number === BigInt(0)) {
-      await this.vm.eei.state.generateCanonicalGenesis(this.vm.blockchain.genesisState())
+      await this.vm.eei.generateCanonicalGenesis(this.vm.blockchain.genesisState())
     }
   }
 

--- a/packages/client/lib/miner/miner.ts
+++ b/packages/client/lib/miner/miner.ts
@@ -211,7 +211,7 @@ export class Miner {
 
     // Set the state root to ensure the resulting state
     // is based on the parent block's state
-    await vmCopy.eei.state.setStateRoot(parentBlock.header.stateRoot)
+    await vmCopy.eei.setStateRoot(parentBlock.header.stateRoot)
 
     let difficulty
     let cliqueSigner

--- a/packages/client/lib/miner/pendingBlock.ts
+++ b/packages/client/lib/miner/pendingBlock.ts
@@ -45,7 +45,7 @@ export class PendingBlock {
 
     // Set the state root to ensure the resulting state
     // is based on the parent block's state
-    await vm.eei.state.setStateRoot(parentBlock.header.stateRoot)
+    await vm.eei.setStateRoot(parentBlock.header.stateRoot)
 
     const td = await vm.blockchain.getTotalDifficulty(parentBlock.hash())
     vm._common.setHardforkByBlockNumber(parentBlock.header.number, td)

--- a/packages/client/lib/service/txpool.ts
+++ b/packages/client/lib/service/txpool.ts
@@ -639,7 +639,7 @@ export class TxPool {
         .map((obj) => obj.tx)
         .sort((a, b) => Number(a.nonce - b.nonce))
       // Check if the account nonce matches the lowest known tx nonce
-      const { nonce } = await this.vm.eei.state.getAccount(new Address(Buffer.from(address, 'hex')))
+      const { nonce } = await this.vm.eei.getAccount(new Address(Buffer.from(address, 'hex')))
       if (txsSortedByNonce[0].nonce !== nonce) {
         // Account nonce does not match the lowest known tx nonce,
         // therefore no txs from this address are currently executable

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -34,9 +34,9 @@ const B = {
 }
 
 const setBalance = async (vm: VM, address: Address, balance: bigint) => {
-  await vm.eei.state.checkpoint()
-  await vm.eei.state.modifyAccountFields(address, { balance })
-  await vm.eei.state.commit()
+  await vm.eei.checkpoint()
+  await vm.eei.modifyAccountFields(address, { balance })
+  await vm.eei.commit()
 }
 
 tape('[Miner]', async (t) => {

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -43,7 +43,7 @@ const setup = () => {
       getCanonicalHeadHeader: () => BlockHeader.fromHeaderData({}, { common }),
     },
     execution: {
-      vm: { stateManager, eei: { state: { getAccount: () => stateManager.getAccount() } } },
+      vm: { stateManager, eei: { getAccount: () => stateManager.getAccount() } },
     },
   }
   const txPool = new TxPool({ config, service })

--- a/packages/client/test/rpc/eth/estimateGas.spec.ts
+++ b/packages/client/test/rpc/eth/estimateGas.spec.ts
@@ -26,7 +26,7 @@ tape(`${method}: call with valid arguments`, async (t) => {
   const { execution } = client.services.find((s) => s.name === 'eth') as FullEthereumService
   t.notEqual(execution, undefined, 'should have valid execution')
   const { vm } = execution
-  await vm.eei.state.generateCanonicalGenesis(blockchain.genesisState())
+  await vm.eei.generateCanonicalGenesis(blockchain.genesisState())
 
   // genesis address with balance
   const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')

--- a/packages/client/test/rpc/eth/getBalance.spec.ts
+++ b/packages/client/test/rpc/eth/getBalance.spec.ts
@@ -26,7 +26,7 @@ tape(`${method}: ensure balance deducts after a tx`, async (t) => {
 
   // since synchronizer.run() is not executed in the mock setup,
   // manually run stateManager.generateCanonicalGenesis()
-  await vm.eei.state.generateCanonicalGenesis(blockchain.genesisState())
+  await vm.eei.generateCanonicalGenesis(blockchain.genesisState())
 
   // genesis address with balance
   const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')

--- a/packages/client/test/rpc/eth/getCode.spec.ts
+++ b/packages/client/test/rpc/eth/getCode.spec.ts
@@ -23,7 +23,7 @@ tape(`${method}: call with valid arguments`, async (t) => {
   const { execution } = client.services.find((s) => s.name === 'eth') as FullEthereumService
   t.notEqual(execution, undefined, 'should have valid execution')
   const { vm } = execution
-  await vm.eei.state.generateCanonicalGenesis(blockchain.genesisState())
+  await vm.eei.generateCanonicalGenesis(blockchain.genesisState())
 
   // genesis address
   const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')

--- a/packages/client/test/rpc/eth/getTransactionCount.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionCount.spec.ts
@@ -30,7 +30,7 @@ tape(`${method}: call with valid arguments`, async (t) => {
 
   // since synchronizer.run() is not executed in the mock setup,
   // manually run stateManager.generateCanonicalGenesis()
-  await vm.eei.state.generateCanonicalGenesis(blockchain.genesisState())
+  await vm.eei.generateCanonicalGenesis(blockchain.genesisState())
 
   // a genesis address
   const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -459,7 +459,7 @@ export default class Interpreter {
       return this._env.contract.balance
     }
 
-    return this._eei.getExternalBalance(address)
+    return (await this._eei.getAccount(address)).balance
   }
 
   /**

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -17,7 +17,7 @@ import Common, { ConsensusAlgorithm } from '@ethereumjs/common'
 import EVM, { EVMResult } from './evm'
 import Message from './message'
 import { Log } from './types'
-import { EEIInterface, EVMStateAccess, Block } from './types'
+import { EEIInterface, Block } from './types'
 
 const debugGas = createDebugLogger('vm:eei:gas')
 
@@ -64,7 +64,6 @@ export interface RunState {
   code: Buffer
   shouldDoJumpAnalysis: boolean
   validJumps: Uint8Array // array of values where validJumps[index] has value 0 (default), 1 (jumpdest), 2 (beginsub)
-  vmState: EVMStateAccess
   eei: EEIInterface
   env: Env
   messageGasLimit?: bigint // Cache value from `gas.ts` to save gas limit for a message call
@@ -83,7 +82,7 @@ export interface InterpreterResult {
 export interface InterpreterStep {
   gasLeft: bigint
   gasRefund: bigint
-  vmState: EVMStateAccess
+  eei: EEIInterface
   stack: bigint[]
   returnStack: bigint[]
   pc: number
@@ -136,7 +135,6 @@ export default class Interpreter {
       returnStack: new Stack(1023), // 1023 return stack height limit per EIP 2315 spec
       code: Buffer.alloc(0),
       validJumps: Uint8Array.from([]),
-      vmState: this._eei.state,
       eei: this._eei,
       env: env,
       shouldDoJumpAnalysis: true,
@@ -309,10 +307,10 @@ export default class Interpreter {
       depth: this._env.depth,
       address: this._env.address,
       account: this._env.contract,
-      vmState: this._runState.vmState,
       memory: this._runState.memory._store,
       memoryWordCount: this._runState.memoryWordCount,
       codeAddress: this._env.codeAddress,
+      eei: this._runState.eei,
     }
 
     if (this._evm.DEBUG) {
@@ -469,7 +467,7 @@ export default class Interpreter {
    */
   async storageStore(key: Buffer, value: Buffer): Promise<void> {
     await this._eei.storageStore(this._env.address, key, value)
-    const account = await this._eei.state.getAccount(this._env.address)
+    const account = await this._eei.getAccount(this._env.address)
     this._env.contract = account
   }
 
@@ -835,7 +833,7 @@ export default class Interpreter {
     if (!results.execResult.exceptionError) {
       Object.assign(this._result.selfdestruct, selfdestruct)
       // update stateRoot on current contract
-      const account = await this._eei.state.getAccount(this._env.address)
+      const account = await this._eei.getAccount(this._env.address)
       this._env.contract = account
       this._runState.gasRefund = results.execResult.gasRefund ?? BigInt(0)
     }
@@ -868,7 +866,7 @@ export default class Interpreter {
     }
 
     this._env.contract.nonce += BigInt(1)
-    await this._eei.state.putAccount(this._env.address, this._env.contract)
+    await this._eei.putAccount(this._env.address, this._env.contract)
 
     if (this._common.isActivatedEIP(3860)) {
       if (data.length > Number(this._common.param('vm', 'maxInitCodeSize'))) {
@@ -910,7 +908,7 @@ export default class Interpreter {
     ) {
       Object.assign(this._result.selfdestruct, selfdestruct)
       // update stateRoot on current contract
-      const account = await this._eei.state.getAccount(this._env.address)
+      const account = await this._eei.getAccount(this._env.address)
       this._env.contract = account
       this._runState.gasRefund = results.execResult.gasRefund ?? BigInt(0)
       if (results.createdAddress) {
@@ -949,12 +947,12 @@ export default class Interpreter {
     this._result.selfdestruct[this._env.address.buf.toString('hex')] = toAddress.buf
 
     // Add to beneficiary balance
-    const toAccount = await this._eei.state.getAccount(toAddress)
+    const toAccount = await this._eei.getAccount(toAddress)
     toAccount.balance += this._env.contract.balance
-    await this._eei.state.putAccount(toAddress, toAccount)
+    await this._eei.putAccount(toAddress, toAccount)
 
     // Subtract from contract balance
-    await this._eei.state.modifyAccountFields(this._env.address, {
+    await this._eei.modifyAccountFields(this._env.address, {
       balance: BigInt(0),
     })
 

--- a/packages/evm/src/opcodes/EIP2929.ts
+++ b/packages/evm/src/opcodes/EIP2929.ts
@@ -21,12 +21,12 @@ export function accessAddressEIP2929(
 ): bigint {
   if (!common.isActivatedEIP(2929)) return BigInt(0)
 
-  const vmState = runState.vmState
+  const eei = runState.eei
   const addressStr = address.buf
 
   // Cold
-  if (!vmState.isWarmedAddress(addressStr)) {
-    vmState.addWarmedAddress(addressStr)
+  if (!eei.isWarmedAddress(addressStr)) {
+    eei.addWarmedAddress(addressStr)
 
     // CREATE, CREATE2 opcodes have the address warmed for free.
     // selfdestruct beneficiary address reads are charged an *additional* cold access
@@ -56,13 +56,13 @@ export function accessStorageEIP2929(
 ): bigint {
   if (!common.isActivatedEIP(2929)) return BigInt(0)
 
-  const vmState = runState.vmState
+  const eei = runState.eei
   const address = runState.interpreter.getAddress().buf
-  const slotIsCold = !vmState.isWarmedStorage(address, key)
+  const slotIsCold = !eei.isWarmedStorage(address, key)
 
   // Cold (SLOAD and SSTORE)
   if (slotIsCold) {
-    vmState.addWarmedStorage(address, key)
+    eei.addWarmedStorage(address, key)
     return common.param('gasPrices', 'coldsload')
   } else if (!isSstore) {
     return common.param('gasPrices', 'warmstorageread')
@@ -89,12 +89,12 @@ export function adjustSstoreGasEIP2929(
 ): bigint {
   if (!common.isActivatedEIP(2929)) return defaultCost
 
-  const vmState = runState.vmState
+  const eei = runState.eei
   const address = runState.interpreter.getAddress().buf
   const warmRead = common.param('gasPrices', 'warmstorageread')
   const coldSload = common.param('gasPrices', 'coldsload')
 
-  if (vmState.isWarmedStorage(address, key)) {
+  if (eei.isWarmedStorage(address, key)) {
     switch (costName) {
       case 'noop':
         return warmRead

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -485,7 +485,9 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x3b,
     async function (runState) {
       const addressBigInt = runState.stack.pop()
-      const size = await runState.eei.getExternalCodeSize(addressBigInt)
+      const size = await runState.eei.getExternalCodeSize(
+        new Address(addressToBuffer(addressBigInt))
+      )
       runState.stack.push(size)
     },
   ],
@@ -496,7 +498,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       const [addressBigInt, memOffset, codeOffset, dataLength] = runState.stack.popN(4)
 
       if (dataLength !== BigInt(0)) {
-        const code = await runState.eei.getExternalCode(addressBigInt)
+        const code = await runState.eei.getExternalCode(new Address(addressToBuffer(addressBigInt)))
 
         const data = getDataSlice(code, codeOffset, dataLength)
         const memOffsetNum = Number(memOffset)
@@ -512,13 +514,13 @@ export const handlers: Map<number, OpHandler> = new Map([
     async function (runState) {
       const addressBigInt = runState.stack.pop()
       const address = new Address(addressToBuffer(addressBigInt))
-      const empty = await runState.eei.isAccountEmpty(address)
+      const empty = (await runState.eei.getAccount(address)).isEmpty()
       if (empty) {
         runState.stack.push(BigInt(0))
         return
       }
 
-      const code = await runState.eei.getExternalCode(addressBigInt)
+      const code = await runState.eei.getExternalCode(new Address(addressToBuffer(addressBigInt)))
       if (code.length === 0) {
         runState.stack.push(bufferToBigInt(KECCAK256_NULL))
         return

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -3,7 +3,6 @@ import { keccak256 } from 'ethereum-cryptography/keccak'
 import { bytesToHex } from 'ethereum-cryptography/utils'
 import {
   Address,
-  KECCAK256_NULL,
   TWO_POW256,
   MAX_INTEGER_BIGINT,
   bufferToBigInt,
@@ -520,9 +519,8 @@ export const handlers: Map<number, OpHandler> = new Map([
         return
       }
 
-      const codeHash = await (
-        await runState.eei.getAccount(new Address(addressToBuffer(addressBigInt)))
-      ).codeHash
+      const codeHash = (await runState.eei.getAccount(new Address(addressToBuffer(addressBigInt))))
+        .codeHash
       runState.stack.push(BigInt('0x' + codeHash.toString('hex')))
     },
   ],

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -324,7 +324,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         if (common.gteHardfork(Hardfork.SpuriousDragon)) {
           // We are at or after Spurious Dragon
           // Call new account gas: account is DEAD and we transfer nonzero value
-          if ((await runState.eei.isAccountEmpty(toAddress)) && !(value === BigInt(0))) {
+          if ((await runState.eei.getAccount(toAddress)).isEmpty() && !(value === BigInt(0))) {
             gas += common.param('gasPrices', 'callNewAccount')
           }
         } else if (!(await runState.eei.accountExists(toAddress))) {
@@ -504,7 +504,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         if (value > BigInt(0)) {
           gas += common.param('gasPrices', 'authcallValueTransfer')
-          const account = await runState.vmState.getAccount(toAddress)
+          const account = await runState.eei.getAccount(toAddress)
           if (account.isEmpty()) {
             gas += common.param('gasPrices', 'callNewAccount')
           }
@@ -580,14 +580,14 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           )
           if (balance > BigInt(0)) {
             // This technically checks if account is empty or non-existent
-            const empty = await runState.eei.isAccountEmpty(selfdestructToAddress)
+            const empty = (await runState.eei.getAccount(selfdestructToAddress)).isEmpty()
             if (empty) {
               deductGas = true
             }
           }
         } else if (common.gteHardfork(Hardfork.TangerineWhistle)) {
           // EIP-150 (Tangerine Whistle) gas semantics
-          const exists = await runState.vmState.accountExists(selfdestructToAddress)
+          const exists = await runState.eei.accountExists(selfdestructToAddress)
           if (!exists) {
             deductGas = true
           }

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -24,9 +24,6 @@ export interface EVMInterface {
  * `@ethereumjs/vm` package.
  */
 export interface EEIInterface extends EVMStateAccess {
-  getExternalBalance(address: Address): Promise<bigint>
-  getExternalCodeSize(address: Address): Promise<bigint>
-  getExternalCode(address: Address): Promise<Buffer>
   getBlockHash(num: bigint): Promise<bigint>
   storageStore(address: Address, key: Buffer, value: Buffer): Promise<void>
   storageLoad(address: Address, key: Buffer, original: boolean): Promise<Buffer>

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -23,16 +23,13 @@ export interface EVMInterface {
  * environment (`mainnet`, `sepolia`,...) can be found in the
  * `@ethereumjs/vm` package.
  */
-export interface EEIInterface {
-  state: EVMStateAccess
+export interface EEIInterface extends EVMStateAccess {
   getExternalBalance(address: Address): Promise<bigint>
-  getExternalCodeSize(address: bigint): Promise<bigint>
-  getExternalCode(address: bigint): Promise<Buffer>
+  getExternalCodeSize(address: Address): Promise<bigint>
+  getExternalCode(address: Address): Promise<Buffer>
   getBlockHash(num: bigint): Promise<bigint>
   storageStore(address: Address, key: Buffer, value: Buffer): Promise<void>
   storageLoad(address: Address, key: Buffer, original: boolean): Promise<Buffer>
-  isAccountEmpty(address: Address): Promise<boolean>
-  accountExists(address: Address): Promise<boolean>
   copy(): EEIInterface
 }
 
@@ -44,14 +41,12 @@ export interface EEIInterface {
  * An implementation of this can be found in the `@ethereumjs/vm` package.
  */
 export interface EVMStateAccess extends StateAccess {
-  touchAccount(address: Address): void
   addWarmedAddress(address: Buffer): void
   isWarmedAddress(address: Buffer): boolean
   addWarmedStorage(address: Buffer, slot: Buffer): void
   isWarmedStorage(address: Buffer, slot: Buffer): boolean
   clearWarmedAccounts(): void
   generateAccessList?(addressesRemoved: Address[], addressesOnlyStorage: Address[]): AccessList
-  getOriginalContractStorage(address: Address, key: Buffer): Promise<Buffer>
   clearOriginalStorageCache(): void
   cleanupTouchedAccounts(): Promise<void>
   generateCanonicalGenesis(initState: any): Promise<void>

--- a/packages/evm/tests/runCall.spec.ts
+++ b/packages/evm/tests/runCall.spec.ts
@@ -47,8 +47,8 @@ tape('Constantinople: EIP-1014 CREATE2 creates the right contract address', asyn
         RETURN          [0x00, 0x20]
     */
 
-  await eei.state.putContractCode(contractAddress, Buffer.from(code, 'hex')) // setup the contract code
-  await eei.state.putAccount(caller, new Account(BigInt(0), BigInt(0x11111111))) // give the calling account a big balance so we don't run out of funds
+  await eei.putContractCode(contractAddress, Buffer.from(code, 'hex')) // setup the contract code
+  await eei.putAccount(caller, new Account(BigInt(0), BigInt(0x11111111))) // give the calling account a big balance so we don't run out of funds
   const codeHash = Buffer.from(keccak256(Buffer.from('')))
   for (let value = 0; value <= 1000; value += 20) {
     // setup the call arguments
@@ -109,8 +109,8 @@ tape('Byzantium cannot access Constantinople opcodes', async (t) => {
         STOP
     */
 
-  await eeiByzantium.state.putContractCode(contractAddress, Buffer.from(code, 'hex')) // setup the contract code
-  await eeiConstantinople.state.putContractCode(contractAddress, Buffer.from(code, 'hex')) // setup the contract code
+  await eeiByzantium.putContractCode(contractAddress, Buffer.from(code, 'hex')) // setup the contract code
+  await eeiConstantinople.putContractCode(contractAddress, Buffer.from(code, 'hex')) // setup the contract code
 
   const runCallArgs = {
     caller: caller, // call address
@@ -164,8 +164,8 @@ tape('Ensure that Istanbul sstoreCleanRefundEIP2200 gas is applied correctly', a
 
     */
 
-  await eei.state.putContractCode(address, Buffer.from(code, 'hex'))
-  await eei.state.putContractStorage(
+  await eei.putContractCode(address, Buffer.from(code, 'hex'))
+  await eei.putContractStorage(
     address,
     Buffer.alloc(32, 0),
     Buffer.from('00'.repeat(31) + '01', 'hex')
@@ -197,7 +197,7 @@ tape('ensure correct gas for pre-constantinople sstore', async (t) => {
   // push 1 push 0 sstore stop
   const code = '600160015500'
 
-  await eei.state.putContractCode(address, Buffer.from(code, 'hex'))
+  await eei.putContractCode(address, Buffer.from(code, 'hex'))
 
   // setup the call arguments
   const runCallArgs = {
@@ -225,7 +225,7 @@ tape('ensure correct gas for calling non-existent accounts in homestead', async 
   // code to call 0x00..00dd, which does not exist
   const code = '6000600060006000600060DD61FFFF5A03F100'
 
-  await eei.state.putContractCode(address, Buffer.from(code, 'hex'))
+  await eei.putContractCode(address, Buffer.from(code, 'hex'))
 
   // setup the call arguments
   const runCallArgs = {
@@ -258,7 +258,7 @@ tape(
     // but using too much memory
     const code = '61FFFF60FF60006000600060EE6000F200'
 
-    await eei.state.putContractCode(address, Buffer.from(code, 'hex'))
+    await eei.putContractCode(address, Buffer.from(code, 'hex'))
 
     // setup the call arguments
     const runCallArgs = {
@@ -290,7 +290,7 @@ tape('ensure selfdestruct pays for creating new accounts', async (t) => {
   // this should thus go OOG
   const code = '60FEFF'
 
-  await eei.state.putContractCode(address, Buffer.from(code, 'hex'))
+  await eei.putContractCode(address, Buffer.from(code, 'hex'))
 
   // setup the call arguments
   const runCallArgs = {
@@ -321,11 +321,11 @@ tape('ensure that sstores pay for the right gas costs pre-byzantium', async (t) 
   // this should thus go OOG
   const code = '3460005500'
 
-  await eei.state.putContractCode(address, Buffer.from(code, 'hex'))
+  await eei.putContractCode(address, Buffer.from(code, 'hex'))
 
-  const account = await eei.state.getAccount(caller)
+  const account = await eei.getAccount(caller)
   account.balance = BigInt(100)
-  await eei.state.putAccount(caller, account)
+  await eei.putAccount(caller, account)
 
   /*
     Situation:
@@ -400,11 +400,11 @@ tape(
           STOP
     */
 
-    await eei.state.putContractCode(address, Buffer.from(code, 'hex'))
+    await eei.putContractCode(address, Buffer.from(code, 'hex'))
 
-    const account = await eei.state.getAccount(address)
+    const account = await eei.getAccount(address)
     account.nonce = MAX_UINT64 - BigInt(1)
-    await eei.state.putAccount(address, account)
+    await eei.putAccount(address, account)
 
     // setup the call arguments
     const runCallArgs = {
@@ -414,7 +414,7 @@ tape(
     }
 
     await evm.runCall(runCallArgs)
-    let storage = await eei.state.getContractStorage(address, slot)
+    let storage = await eei.getContractStorage(address, slot)
 
     // The nonce is MAX_UINT64 - 1, so we are allowed to create a contract (nonce of creating contract is now MAX_UINT64)
     t.ok(!storage.equals(emptyBuffer), 'succesfully created contract')
@@ -422,7 +422,7 @@ tape(
     await evm.runCall(runCallArgs)
 
     // The nonce is MAX_UINT64, so we are NOT allowed to create a contract (nonce of creating contract is now MAX_UINT64)
-    storage = await eei.state.getContractStorage(address, slot)
+    storage = await eei.getContractStorage(address, slot)
     t.ok(
       storage.equals(emptyBuffer),
       'failed to create contract; nonce of creating contract is too high (MAX_UINT64)'
@@ -444,10 +444,10 @@ tape('Ensure that IDENTITY precompile copies the memory', async (t) => {
   const evm = await VM.create({ common, eei })
   const code = '3034526020600760203460045afa602034343e604034f3'
 
-  const account = await eei.state.getAccount(caller)
+  const account = await eei.getAccount(caller)
   account.nonce = BigInt(1) // ensure nonce for contract is correct
   account.balance = BigInt(10000000000000000)
-  await eei.state.putAccount(caller, account)
+  await eei.putAccount(caller, account)
 
   // setup the call arguments
   const runCallArgs = {
@@ -466,7 +466,7 @@ tape('Ensure that IDENTITY precompile copies the memory', async (t) => {
   )
 
   t.ok(result.createdAddress?.buf.equals(expectedAddress), 'created address correct')
-  const deployedCode = await eei.state.getContractCode(result.createdAddress!)
+  const deployedCode = await eei.getContractCode(result.createdAddress!)
   t.ok(deployedCode.equals(expectedCode), 'deployed code correct')
 
   t.end()
@@ -503,7 +503,7 @@ tape('runCall() -> skipBalance behavior', async (t) => {
   // runCall against a contract to reach `_reduceSenderBalance`
   const contractCode = Buffer.from('00', 'hex') // 00: STOP
   const contractAddress = Address.fromString('0x000000000000000000000000636F6E7472616374')
-  await eei.state.putContractCode(contractAddress, contractCode)
+  await eei.putContractCode(contractAddress, contractCode)
   const senderKey = Buffer.from(
     'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
     'hex'
@@ -519,10 +519,10 @@ tape('runCall() -> skipBalance behavior', async (t) => {
   }
 
   for (const balance of [undefined, BigInt(5)]) {
-    await eei.state.modifyAccountFields(sender, { nonce: BigInt(0), balance })
+    await eei.modifyAccountFields(sender, { nonce: BigInt(0), balance })
     const res = await evm.runCall(runCallArgs)
     t.pass('runCall should not throw with no balance and skipBalance')
-    const senderBalance = (await eei.state.getAccount(sender)).balance
+    const senderBalance = (await eei.getAccount(sender)).balance
     t.equal(
       senderBalance,
       balance ?? BigInt(0),

--- a/packages/evm/tests/runCode.spec.ts
+++ b/packages/evm/tests/runCode.spec.ts
@@ -77,7 +77,7 @@ tape('VM.runCode: interpreter', (t) => {
 
   t.test('should throw on non-EvmError', async (st) => {
     const eei = await getEEI()
-    eei.state.putContractStorage = (..._args) => {
+    eei.putContractStorage = (..._args) => {
       throw new Error('Test')
     }
     const evm = await EVM.create({ eei })

--- a/packages/evm/tests/stack.spec.ts
+++ b/packages/evm/tests/stack.spec.ts
@@ -149,9 +149,9 @@ tape('Stack', (t) => {
           PUSH1 0x00
           RETURN        stack: [0, 0x20] (we thus return the stack item which was originally pushed as 0, and then DUPed)
     */
-    await eei.state.putAccount(addr, account)
-    await eei.state.putContractCode(addr, Buffer.from(code, 'hex'))
-    await eei.state.putAccount(caller, new Account(BigInt(0), BigInt(0x11)))
+    await eei.putAccount(addr, account)
+    await eei.putContractCode(addr, Buffer.from(code, 'hex'))
+    await eei.putAccount(caller, new Account(BigInt(0), BigInt(0x11)))
     const runCallArgs = {
       caller: caller,
       gasLimit: BigInt(0xffffffffff),

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -101,7 +101,7 @@ export class BlockBuilder {
     const coinbase = this.headerData.coinbase
       ? new Address(toBuffer(this.headerData.coinbase))
       : Address.zero()
-    await rewardAccount(this.vm.eei.state, coinbase, reward)
+    await rewardAccount(this.vm.eei, coinbase, reward)
   }
 
   /**

--- a/packages/vm/src/eei/vmState.ts
+++ b/packages/vm/src/eei/vmState.ts
@@ -203,7 +203,7 @@ export class VmState implements EVMStateAccess {
    * event. Touched accounts that are empty will be cleared
    * at the end of the tx.
    */
-  touchAccount(address: Address): void {
+  protected touchAccount(address: Address): void {
     this._touched.add(address.buf.toString('hex'))
   }
 
@@ -298,7 +298,7 @@ export class VmState implements EVMStateAccess {
    * @param address - Address of the account to get the storage for
    * @param key - Key in the account's storage to get the value for. Must be 32 bytes long.
    */
-  async getOriginalContractStorage(address: Address, key: Buffer): Promise<Buffer> {
+  protected async getOriginalContractStorage(address: Address, key: Buffer): Promise<Buffer> {
     if (key.length !== 32) {
       throw new Error('Storage key must be 32 bytes long')
     }

--- a/packages/vm/src/eei/vmState.ts
+++ b/packages/vm/src/eei/vmState.ts
@@ -12,13 +12,13 @@ import { EVMStateAccess } from '@ethereumjs/evm/dist/types'
 type AddressHex = string
 
 export class VmState implements EVMStateAccess {
-  _common: Common
-  _debug: Debugger
+  protected _common: Common
+  protected _debug: Debugger
 
-  _checkpointCount: number
-  _stateManager: StateManager
-  _touched: Set<AddressHex>
-  _touchedStack: Set<AddressHex>[]
+  protected _checkpointCount: number
+  protected _stateManager: StateManager
+  protected _touched: Set<AddressHex>
+  protected _touchedStack: Set<AddressHex>[]
 
   // EIP-2929 address/storage trackers.
   // This maps both the accessed accounts and the accessed storage slots.
@@ -28,13 +28,13 @@ export class VmState implements EVMStateAccess {
   // Each call level tracks their access themselves.
   // In case of a commit, copy everything if the value does not exist, to the level above
   // In case of a revert, discard any warm slots.
-  _accessedStorage: Map<string, Set<string>>[]
+  protected _accessedStorage: Map<string, Set<string>>[]
 
   // Backup structure for address/storage tracker frames on reverts
   // to also include on access list generation
-  _accessedStorageReverted: Map<string, Set<string>>[]
+  protected _accessedStorageReverted: Map<string, Set<string>>[]
 
-  _originalStorageCache: Map<AddressHex, Map<AddressHex, Buffer>>
+  protected _originalStorageCache: Map<AddressHex, Map<AddressHex, Buffer>>
 
   protected readonly DEBUG: boolean = false
 

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -27,7 +27,7 @@ const DAORefundContract = DAOConfig.DAORefundContract
  * @ignore
  */
 export default async function runBlock(this: VM, opts: RunBlockOpts): Promise<RunBlockResult> {
-  const state = this.eei.state
+  const state = this.eei
   const { root } = opts
   let { block } = opts
   const generateFields = !!opts.generate
@@ -312,7 +312,7 @@ async function assignBlockRewards(this: VM, block: Block): Promise<void> {
   if (this.DEBUG) {
     debug(`Assign block rewards`)
   }
-  const state = this.eei.state
+  const state = this.eei
   const minerReward = this._common.param('pow', 'minerReward')
   const ommers = block.uncleHeaders
   // Reward ommers

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -42,7 +42,7 @@ export default async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxRes
     throw new Error(msg)
   }
 
-  const state = this.eei.state
+  const state = this.eei
 
   if (opts.reportAccessList && !('generateAccessList' in state)) {
     const msg = _errorMsg(
@@ -145,7 +145,7 @@ export default async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxRes
 }
 
 async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
-  const state = this.eei.state
+  const state = this.eei
 
   const { tx, block } = opts
 

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -144,24 +144,24 @@ export class VM extends AsyncEventEmitter<VMEvents> {
 
     if (!this._opts.stateManager) {
       if (this._opts.activateGenesisState) {
-        await this.eei.state.generateCanonicalGenesis(this.blockchain.genesisState())
+        await this.eei.generateCanonicalGenesis(this.blockchain.genesisState())
       }
     }
 
     if (this._opts.activatePrecompiles && !this._opts.stateManager) {
-      await this.eei.state.checkpoint()
+      await this.eei.checkpoint()
       // put 1 wei in each of the precompiles in order to make the accounts non-empty and thus not have them deduct `callNewAccount` gas.
       for (const [addressStr] of getActivePrecompiles(this._common)) {
         const address = new Address(Buffer.from(addressStr, 'hex'))
-        const account = await this.eei.state.getAccount(address)
+        const account = await this.eei.getAccount(address)
         // Only do this if it is not overridden in genesis
         // Note: in the case that custom genesis has storage fields, this is preserved
         if (account.isEmpty()) {
           const newAccount = Account.fromAccountData({ balance: 1, stateRoot: account.stateRoot })
-          await this.eei.state.putAccount(address, newAccount)
+          await this.eei.putAccount(address, newAccount)
         }
       }
-      await this.eei.state.commit()
+      await this.eei.commit()
     }
     this._isInitialized = true
   }

--- a/packages/vm/tests/api/EIPs/eip-3529.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3529.spec.ts
@@ -136,7 +136,7 @@ tape('EIP-3529 tests', (t) => {
       )
 
       await vm.stateManager.getContractStorage(address, key)
-      vm.eei.state.addWarmedStorage(address.toBuffer(), key)
+      vm.eei.addWarmedStorage(address.toBuffer(), key)
 
       await vm.evm.runCode!({
         code,
@@ -150,7 +150,7 @@ tape('EIP-3529 tests', (t) => {
       st.equal(gasUsed, BigInt(testCase.usedGas), 'correct used gas')
 
       // clear the storage cache, otherwise next test will use current original value
-      vm.eei.state.clearOriginalStorageCache()
+      vm.eei.clearOriginalStorageCache()
     }
 
     st.end()

--- a/packages/vm/tests/api/buildBlock.spec.ts
+++ b/packages/vm/tests/api/buildBlock.spec.ts
@@ -89,7 +89,7 @@ tape('BlockBuilder', async (t) => {
     const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
     await setBalance(vm, address)
 
-    const root0 = await vm.eei.state.getStateRoot()
+    const root0 = await vm.eei.getStateRoot()
 
     const blockBuilder = await vm.buildBlock({ parentBlock: genesisBlock })
 
@@ -104,11 +104,11 @@ tape('BlockBuilder', async (t) => {
 
     await blockBuilder.addTransaction(tx)
 
-    const root1 = await vm.eei.state.getStateRoot()
+    const root1 = await vm.eei.getStateRoot()
     st.ok(!root0.equals(root1), 'state root should change after adding a tx')
 
     await blockBuilder.revert()
-    const root2 = await vm.eei.state.getStateRoot()
+    const root2 = await vm.eei.getStateRoot()
 
     st.ok(root2.equals(root0), 'state root should revert to before the tx was run')
     st.end()
@@ -176,7 +176,7 @@ tape('BlockBuilder', async (t) => {
     const vm = await VM.create({ common, blockchain })
 
     // add balance for tx
-    await vm.eei.state.putAccount(signer.address, Account.fromAccountData({ balance: 100000 }))
+    await vm.eei.putAccount(signer.address, Account.fromAccountData({ balance: 100000 }))
 
     const blockBuilder = await vm.buildBlock({
       parentBlock: genesisBlock,

--- a/packages/vm/tests/api/eei.spec.ts
+++ b/packages/vm/tests/api/eei.spec.ts
@@ -15,7 +15,7 @@ tape('EEI', (t) => {
       await Blockchain.create()
     ) // create a dummy EEI (no VM, no EVM, etc.)
     st.notOk(await eei.accountExists(ZeroAddress))
-    st.ok(await eei.isAccountEmpty(ZeroAddress))
+    st.ok(await eei.accountIsEmpty(ZeroAddress))
     st.end()
   })
 
@@ -28,14 +28,14 @@ tape('EEI', (t) => {
         await Blockchain.create()
       ) // create a dummy EEI (no VM, no EVM, etc.)
       // create empty account
-      await eei.state.putAccount(ZeroAddress, new Account())
+      await eei.putAccount(ZeroAddress, new Account())
       st.ok(await eei.accountExists(ZeroAddress))
-      st.ok(await eei.isAccountEmpty(ZeroAddress))
+      st.ok(await eei.accountIsEmpty(ZeroAddress))
       // now put a non-empty account
       const nonEmptyAccount = Account.fromAccountData({ nonce: 1 })
-      await eei.state.putAccount(ZeroAddress, nonEmptyAccount)
+      await eei.putAccount(ZeroAddress, nonEmptyAccount)
       st.ok(await eei.accountExists(ZeroAddress))
-      st.notOk(await eei.isAccountEmpty(ZeroAddress))
+      st.notOk(await eei.accountIsEmpty(ZeroAddress))
       st.end()
     }
   )
@@ -47,12 +47,12 @@ tape('EEI', (t) => {
       await Blockchain.create()
     ) // create a dummy EEI (no VM, no EVM, etc.)
     // create empty account
-    await eei.state.putAccount(ZeroAddress, new Account())
+    await eei.putAccount(ZeroAddress, new Account())
     st.ok(await eei.accountExists(ZeroAddress)) // sanity check: account exists before we delete it
-    st.ok(await eei.isAccountEmpty(ZeroAddress)) // it is obviously empty
-    await eei.state.deleteAccount(ZeroAddress) // delete the account
+    st.ok(await eei.accountIsEmpty(ZeroAddress)) // it is obviously empty
+    await eei.deleteAccount(ZeroAddress) // delete the account
     st.notOk(await eei.accountExists(ZeroAddress)) // account should not exist
-    st.ok(await eei.isAccountEmpty(ZeroAddress)) // account is empty
+    st.ok(await eei.accountIsEmpty(ZeroAddress)) // account is empty
     st.end()
   })
 })

--- a/packages/vm/tests/api/runBlock.spec.ts
+++ b/packages/vm/tests/api/runBlock.spec.ts
@@ -30,7 +30,7 @@ tape('runBlock() -> successful API parameter usage', async (t) => {
     const block = Block.fromRLPSerializedBlock(blockRlp)
 
     //@ts-ignore
-    await setupPreConditions(vm.eei.state, testData)
+    await setupPreConditions(vm.eei, testData)
 
     st.ok(
       //@ts-ignore
@@ -56,7 +56,7 @@ tape('runBlock() -> successful API parameter usage', async (t) => {
     const testData = require('./testdata/uncleData.json')
 
     //@ts-ignore
-    await setupPreConditions(vm.eei.state, testData)
+    await setupPreConditions(vm.eei, testData)
 
     const block1Rlp = toBuffer(testData.blocks[0].rlp)
     const block1 = Block.fromRLPSerializedBlock(block1Rlp)
@@ -263,7 +263,7 @@ tape('runBlock() -> runtime behavior', async (t) => {
     block1[0][12] = Buffer.from('dao-hard-fork')
     const block = Block.fromValuesArray(block1, { common })
     // @ts-ignore
-    await setupPreConditions(vm.eei.state, testData)
+    await setupPreConditions(vm.eei, testData)
 
     // fill two original DAO child-contracts with funds and the recovery account with funds in order to verify that the balance gets summed correctly
     const fundBalance1 = BigInt('0x1111')
@@ -404,7 +404,7 @@ async function runWithHf(hardfork: string) {
   const block = Block.fromRLPSerializedBlock(blockRlp, { common })
 
   // @ts-ignore
-  await setupPreConditions(vm.eei.state, testData)
+  await setupPreConditions(vm.eei, testData)
 
   const res = await vm.runBlock({
     block,
@@ -449,7 +449,7 @@ tape('runBlock() -> tx types', async (t) => {
     }
 
     //@ts-ignore
-    await setupPreConditions(vm.eei.state, testData)
+    await setupPreConditions(vm.eei, testData)
 
     const res = await vm.runBlock({
       block,

--- a/packages/vm/tests/api/runTx.spec.ts
+++ b/packages/vm/tests/api/runTx.spec.ts
@@ -37,7 +37,7 @@ tape('runTx() -> successful API parameter usage', async (t) => {
 
       const caller = tx.getSenderAddress()
       const acc = createAccount()
-      await vm.eei.state.putAccount(caller, acc)
+      await vm.eei.putAccount(caller, acc)
       let block
       if (vm._common.consensusType() === 'poa') {
         // Setup block with correct extraData for POA
@@ -75,7 +75,7 @@ tape('runTx() -> successful API parameter usage', async (t) => {
 
     const caller = tx.getSenderAddress()
     const acc = createAccount()
-    await vm.eei.state.putAccount(caller, acc)
+    await vm.eei.putAccount(caller, acc)
 
     const blockGasUsed = BigInt(1000)
     const res = await vm.runTx({ tx, blockGasUsed })
@@ -95,7 +95,7 @@ tape('runTx() -> successful API parameter usage', async (t) => {
 
     const caller = tx.getSenderAddress()
     const acc = createAccount()
-    await vm.eei.state.putAccount(caller, acc)
+    await vm.eei.putAccount(caller, acc)
 
     const res = await vm.runTx({ tx })
     t.true(
@@ -119,8 +119,8 @@ tape('runTx() -> successful API parameter usage', async (t) => {
         const address = Address.fromPrivateKey(privateKey)
         const initialBalance = BigInt(10) ** BigInt(18)
 
-        const account = await vm.eei.state.getAccount(address)
-        await vm.eei.state.putAccount(
+        const account = await vm.eei.getAccount(address)
+        await vm.eei.putAccount(
           address,
           Account.fromAccountData({ ...account, balance: initialBalance })
         )
@@ -158,7 +158,7 @@ tape('runTx() -> successful API parameter usage', async (t) => {
           skipBlockGasLimitValidation: true,
         })
 
-        const coinbaseAccount = await vm.eei.state.getAccount(new Address(coinbase))
+        const coinbaseAccount = await vm.eei.getAccount(new Address(coinbase))
 
         // calculate expected coinbase balance
         const baseFee = block.header.baseFeePerGas!
@@ -202,7 +202,7 @@ tape('runTx() -> API parameter usage/data errors', (t) => {
 
     const caller = tx.getSenderAddress()
     const acc = createAccount()
-    await vm.eei.state.putAccount(caller, acc)
+    await vm.eei.putAccount(caller, acc)
 
     try {
       await vm.runTx({ tx })
@@ -225,7 +225,7 @@ tape('runTx() -> API parameter usage/data errors', (t) => {
 
     const caller = tx.getSenderAddress()
     const acc = createAccount()
-    await vm.eei.state.putAccount(caller, acc)
+    await vm.eei.putAccount(caller, acc)
 
     const res = await vm.runTx({ tx, reportAccessList: true })
     t.true(
@@ -268,7 +268,7 @@ tape('runTx() -> API parameter usage/data errors', (t) => {
     const address = tx.getSenderAddress()
     tx = Object.create(tx)
     const maxCost: bigint = tx.gasLimit * tx.maxFeePerGas
-    await vm.eei.state.putAccount(address, createAccount(BigInt(0), maxCost - BigInt(1)))
+    await vm.eei.putAccount(address, createAccount(BigInt(0), maxCost - BigInt(1)))
     try {
       await vm.runTx({ tx })
       t.fail('should throw error')
@@ -276,7 +276,7 @@ tape('runTx() -> API parameter usage/data errors', (t) => {
       t.ok(e.message.toLowerCase().includes('max cost'), `should fail if max cost exceeds balance`)
     }
     // set sufficient balance
-    await vm.eei.state.putAccount(address, createAccount(BigInt(0), maxCost))
+    await vm.eei.putAccount(address, createAccount(BigInt(0), maxCost))
     const res = await vm.runTx({ tx })
     t.ok(res, 'should pass if balance is sufficient')
 
@@ -287,12 +287,12 @@ tape('runTx() -> API parameter usage/data errors', (t) => {
     const vm = await VM.create({ common })
     const tx = getTransaction(common, 2, true, '0x0', false)
     const address = tx.getSenderAddress()
-    const account = await vm.eei.state.getAccount(address)
+    const account = await vm.eei.getAccount(address)
     account.balance = BigInt(9000000) // This is the maxFeePerGas multiplied with the gasLimit of 90000
-    await vm.eei.state.putAccount(address, account)
+    await vm.eei.putAccount(address, account)
     await vm.runTx({ tx })
     account.balance = BigInt(9000000)
-    await vm.eei.state.putAccount(address, account)
+    await vm.eei.putAccount(address, account)
     const tx2 = getTransaction(common, 2, true, '0x64', false) // Send 100 wei; now balance < maxFeePerGas*gasLimit + callvalue
     try {
       await vm.runTx({ tx: tx2 })
@@ -307,10 +307,10 @@ tape('runTx() -> API parameter usage/data errors', (t) => {
     const vm = await VM.create({ common })
     const tx = getTransaction(common, 2, true, '0x0', false)
     const address = tx.getSenderAddress()
-    const account = await vm.eei.state.getAccount(address)
+    const account = await vm.eei.getAccount(address)
     account.balance = BigInt(9000000) // This is the maxFeePerGas multiplied with the gasLimit of 90000
     account.nonce = BigInt(1)
-    await vm.eei.state.putAccount(address, account)
+    await vm.eei.putAccount(address, account)
     try {
       await vm.runTx({ tx })
       t.fail('cannot reach this')
@@ -358,8 +358,8 @@ tape('runTx() -> runtime behavior', async (t) => {
       */
       const code = Buffer.from('6001600055FE', 'hex')
       const address = new Address(Buffer.from('00000000000000000000000000000000000000ff', 'hex'))
-      await vm.eei.state.putContractCode(address, code)
-      await vm.eei.state.putContractStorage(
+      await vm.eei.putContractCode(address, code)
+      await vm.eei.putContractStorage(
         address,
         Buffer.from('00'.repeat(32), 'hex'),
         Buffer.from('00'.repeat(31) + '01', 'hex')
@@ -377,12 +377,12 @@ tape('runTx() -> runtime behavior', async (t) => {
       }
       const tx = TransactionFactory.fromTxData(txParams, { common }).sign(privateKey)
 
-      await vm.eei.state.putAccount(tx.getSenderAddress(), createAccount())
+      await vm.eei.putAccount(tx.getSenderAddress(), createAccount())
 
       await vm.runTx({ tx }) // this tx will fail, but we have to ensure that the cache is cleared
 
       t.equal(
-        (<any>vm.eei.state)._originalStorageCache.size,
+        (<any>vm.eei)._originalStorageCache.size,
         0,
         `should clear storage cache after every ${txType.name}`
       )
@@ -399,10 +399,10 @@ tape('runTx() -> runtime errors', async (t) => {
 
       const caller = tx.getSenderAddress()
       const from = createAccount()
-      await vm.eei.state.putAccount(caller, from)
+      await vm.eei.putAccount(caller, from)
 
       const to = createAccount(BigInt(0), MAX_INTEGER)
-      await vm.eei.state.putAccount(tx.to!, to)
+      await vm.eei.putAccount(tx.to!, to)
 
       const res = await vm.runTx({ tx })
 
@@ -411,11 +411,7 @@ tape('runTx() -> runtime errors', async (t) => {
         'value overflow',
         `result should have 'value overflow' error set (${txType.name})`
       )
-      t.equal(
-        (<any>vm.eei.state)._checkpointCount,
-        0,
-        `checkpoint count should be 0 (${txType.name})`
-      )
+      t.equal((<any>vm.eei)._checkpointCount, 0, `checkpoint count should be 0 (${txType.name})`)
     }
     t.end()
   })
@@ -427,13 +423,13 @@ tape('runTx() -> runtime errors', async (t) => {
 
       const caller = tx.getSenderAddress()
       const from = createAccount()
-      await vm.eei.state.putAccount(caller, from)
+      await vm.eei.putAccount(caller, from)
 
       const contractAddress = new Address(
         Buffer.from('61de9dc6f6cff1df2809480882cfd3c2364b28f7', 'hex')
       )
       const to = createAccount(BigInt(0), MAX_INTEGER)
-      await vm.eei.state.putAccount(contractAddress, to)
+      await vm.eei.putAccount(contractAddress, to)
 
       const res = await vm.runTx({ tx })
 
@@ -442,11 +438,7 @@ tape('runTx() -> runtime errors', async (t) => {
         'value overflow',
         `result should have 'value overflow' error set (${txType.name})`
       )
-      t.equal(
-        (<any>vm.eei.state)._checkpointCount,
-        0,
-        `checkpoint count should be 0 (${txType.name})`
-      )
+      t.equal((<any>vm.eei)._checkpointCount, 0, `checkpoint count should be 0 (${txType.name})`)
     }
     t.end()
   })
@@ -461,7 +453,7 @@ tape('runTx() -> API return values', async (t) => {
 
       const caller = tx.getSenderAddress()
       const acc = createAccount()
-      await vm.eei.state.putAccount(caller, acc)
+      await vm.eei.putAccount(caller, acc)
 
       const res = await vm.runTx({ tx })
       t.equal(
@@ -491,7 +483,7 @@ tape('runTx() -> API return values', async (t) => {
 
       const caller = tx.getSenderAddress()
       const acc = createAccount()
-      await vm.eei.state.putAccount(caller, acc)
+      await vm.eei.putAccount(caller, acc)
 
       const res = await vm.runTx({ tx })
 
@@ -572,15 +564,15 @@ tape('runTx() -> consensus bugs', async (t) => {
     const vm = await VM.create({ common })
 
     const addr = Address.fromString('0xd3563d8f19a85c95beab50901fd59ca4de69174c')
-    const acc = await vm.eei.state.getAccount(addr)
+    const acc = await vm.eei.getAccount(addr)
     acc.balance = beforeBalance
     acc.nonce = BigInt(2)
-    await vm.eei.state.putAccount(addr, acc)
+    await vm.eei.putAccount(addr, acc)
 
     const tx = Transaction.fromTxData(txData, { common })
     await vm.runTx({ tx })
 
-    const newBalance = (await vm.eei.state.getAccount(addr)).balance
+    const newBalance = (await vm.eei.getAccount(addr)).balance
     t.equals(newBalance, afterBalance)
     t.end()
   })
@@ -610,9 +602,9 @@ tape('runTx() -> consensus bugs', async (t) => {
     const vm = await VM.create({ common })
 
     const addr = Address.fromPrivateKey(pkey)
-    const acc = await vm.eei.state.getAccount(addr)
+    const acc = await vm.eei.getAccount(addr)
     acc.balance = BigInt(10000000000000)
-    await vm.eei.state.putAccount(addr, acc)
+    await vm.eei.putAccount(addr, acc)
 
     const tx = FeeMarketEIP1559Transaction.fromTxData(txData, { common }).sign(pkey)
 

--- a/packages/vm/tests/api/utils.ts
+++ b/packages/vm/tests/api/utils.ts
@@ -14,9 +14,9 @@ export function createAccount(nonce = BigInt(0), balance = BigInt(0xfff384)) {
 
 export async function setBalance(vm: VM, address: Address, balance = BigInt(100000000)) {
   const account = createAccount(BigInt(0), balance)
-  await vm.eei.state.checkpoint()
-  await vm.eei.state.putAccount(address, account)
-  await vm.eei.state.commit()
+  await vm.eei.checkpoint()
+  await vm.eei.putAccount(address, account)
+  await vm.eei.commit()
 }
 
 export async function setupVM(opts: VMOpts & { genesisBlock?: Block } = {}) {

--- a/packages/vm/tests/api/vmState.spec.ts
+++ b/packages/vm/tests/api/vmState.spec.ts
@@ -114,7 +114,7 @@ tape('Original storage cache', async (t) => {
     const res = await vmState.getContractStorage(address, key)
     st.deepEqual(res, Buffer.alloc(0))
 
-    const origRes = await vmState.getOriginalContractStorage(address, key)
+    const origRes = await (<any>vmState).getOriginalContractStorage(address, key)
     st.deepEqual(origRes, Buffer.alloc(0))
 
     await vmState.commit()
@@ -131,7 +131,7 @@ tape('Original storage cache', async (t) => {
   })
 
   t.test('should get original storage value', async (st) => {
-    const res = await vmState.getOriginalContractStorage(address, key)
+    const res = await (<any>vmState).getOriginalContractStorage(address, key)
     st.deepEqual(res, value)
     st.end()
   })
@@ -142,7 +142,7 @@ tape('Original storage cache', async (t) => {
     const res = await vmState.getContractStorage(address, key)
     st.deepEqual(res, newValue)
 
-    const origRes = await vmState.getOriginalContractStorage(address, key)
+    const origRes = await (<any>vmState).getOriginalContractStorage(address, key)
     st.deepEqual(origRes, value)
     st.end()
   })
@@ -158,20 +158,20 @@ tape('Original storage cache', async (t) => {
 
     let res = await vmState.getContractStorage(address, key2)
     st.deepEqual(res, value2)
-    let origRes = await vmState.getOriginalContractStorage(address, key2)
+    let origRes = await (<any>vmState).getOriginalContractStorage(address, key2)
     st.deepEqual(origRes, value2)
 
     await vmState.putContractStorage(address, key2, value3)
 
     res = await vmState.getContractStorage(address, key2)
     st.deepEqual(res, value3)
-    origRes = await vmState.getOriginalContractStorage(address, key2)
+    origRes = await (<any>vmState).getOriginalContractStorage(address, key2)
     st.deepEqual(origRes, value2)
 
     // Check previous key
     res = await vmState.getContractStorage(address, key)
     st.deepEqual(res, Buffer.from('1235', 'hex'))
-    origRes = await vmState.getOriginalContractStorage(address, key)
+    origRes = await (<any>vmState).getOriginalContractStorage(address, key)
     st.deepEqual(origRes, value)
 
     st.end()
@@ -179,7 +179,7 @@ tape('Original storage cache', async (t) => {
 
   t.test("getOriginalContractStorage should validate the key's length", async (st) => {
     try {
-      await vmState.getOriginalContractStorage(address, Buffer.alloc(12))
+      await (<any>vmState).getOriginalContractStorage(address, Buffer.alloc(12))
     } catch (e: any) {
       st.equal(e.message, 'Storage key must be 32 bytes long')
       st.end()

--- a/packages/vm/tests/tester/runners/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/tester/runners/BlockchainTestsRunner.ts
@@ -82,7 +82,7 @@ export default async function runBlockchainTest(options: any, testData: any, t: 
   })
 
   // set up pre-state
-  await setupPreConditions(vm.eei.state, testData)
+  await setupPreConditions(vm.eei, testData)
 
   t.ok(vm.stateManager._trie.root.equals(genesisBlock.header.stateRoot), 'correct pre stateRoot')
 

--- a/packages/vm/tests/tester/runners/GeneralStateTestsRunner.ts
+++ b/packages/vm/tests/tester/runners/GeneralStateTestsRunner.ts
@@ -71,7 +71,7 @@ async function runTestCase(options: any, testData: any, t: tape.Test) {
   const state = new Trie()
   const vm = await VM.create({ state, common })
 
-  await setupPreConditions(vm.eei.state, testData)
+  await setupPreConditions(vm.eei, testData)
 
   let execInfo = ''
   let tx


### PR DESCRIPTION
This PR cleanups the EEI interface.

In particular, it provides a minimal interface for the EEI. The EEI encapsulates everything with which the EVM tries to interact externally with, such as getting/setting contract code, storage, updating accounts, or retrieving blockhashes (BLOCKHASH opcode). It can be noted that the EEI is kind-of an extension of StateManager - in here, we have additional logic for touched accounts and warm storage.

(In an ideal world, i.e. V7 of VM see #1976, the touched accounts and warm account logic all moves into EVM, then we essentially only need the StateManager and we need access to the blockchain to retrieve the blockhashes).

This cleanup cleans up some of the EEI (interface) methods which are not necessary or only used internally. Some of them, i.e. `accountExists` are also removed since this logic can easily be done inside the EVM (and in fact, in some cases, was either done there already or it called into this "helper method" of EEI)

WIP. Needs another round of cleanup.