### PR TITLE
evm: Remove vm example links

### DIFF
--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -58,9 +58,6 @@ evm
 
 This projects contain the following examples:
 
-1. [./examples/run-blockchain](./examples/run-blockchain.ts): Loads tests data, including accounts and blocks, and runs all of them in the VM.
-1. [./examples/run-code-browser](./examples/run-code-browser.js): Show how to use this library in a browser.
-1. [./examples/run-solidity-contract](./examples/run-solidity-contract.ts): Compiles a Solidity contract, and calls constant and non-constant functions.
 1. [./examples/decode-opcodes](./examples/decode-opcodes.ts): Decodes a binary EVM program into its opcodes.
 
 All of the examples have their own `README.md` explaining how to run them.


### PR DESCRIPTION
Related to #2008, this removes duplicate examples from the EVM readme that really depend on the VM to execute so should remain solely in the `vm` package.