### PR TITLE
Vm-fix-copy-bug

### DIFF
--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -223,14 +223,18 @@ export class VM extends AsyncEventEmitter<VMEvents> {
     // rather than deep copying the original ones since the copy of the `StateManager`
     // inside the EVM and EEI will be different than the `VM` level copy otherwise
     const eeiCopy = new EEI(stateCopy, commonCopy, blockchainCopy)
-    const evmCopy = new EVM({ eei: eeiCopy, common: commonCopy })
+    const evmCopy = new EVM({
+      eei: eeiCopy,
+      common: commonCopy,
+      allowUnlimitedContractSize: (this.evm as any)._allowUnlimitedContractSize,
+    })
     return VM.create({
       stateManager: stateCopy,
       blockchain: blockchainCopy,
       common: commonCopy,
       evm: evmCopy,
       eei: eeiCopy,
-      hardforkByBlockNumber: this._hardforkByBlockNumber ? this._hardforkByBlockNumber : undefined,
+      hardforkByBlockNumber: this._hardforkByBlockNumber ? true : undefined,
       hardforkByTD: this._hardforkByTD ? this._hardforkByTD : undefined,
     })
   }

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -230,6 +230,8 @@ export class VM extends AsyncEventEmitter<VMEvents> {
       common: commonCopy,
       evm: evmCopy,
       eei: eeiCopy,
+      hardforkByBlockNumber: this._hardforkByBlockNumber ? this._hardforkByBlockNumber : undefined,
+      hardforkByTD: this._hardforkByTD ? this._hardforkByTD : undefined,
     })
   }
 


### PR DESCRIPTION
Fixes for #2017 on master

User found a bug in vm.copy().  Options such as `allowsUnlimitedContractSize` were not being passed on to the copy.

Fixed by editing the `VM.create({...})  ` call in `VM.copy()` to specifically include these options.



