### PR TITLE
Update @ethereumjs/vm USAGE example

### DIFF
--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -29,13 +29,12 @@ const PUSH1 = '60'
 // Note that numbers added are hex values, so '20' would be '32' as decimal e.g.
 const code = [PUSH1, '03', PUSH1, '05', ADD, STOP]
 
-vm.evm.on('step', function (data) {
+vm.on('step', function (data) {
   // Note that data.stack is not immutable, i.e. it is a reference to the vm's internal stack object
   console.log(`Opcode: ${data.opcode.name}\tStack: ${data.stack}`)
 })
 
-vm.evm
-  .runCode({
+vm.runCode({
     code: Buffer.from(code.join(''), 'hex'),
     gasLimit: BigInt(0xffff),
   })


### PR DESCRIPTION
There is no longer an `evm` field on the vm object, and `runCode` + the event emitter are defined directly on the `vm` object.