### PR TITLE
master-vm-copy-bug

### DIFF
--- a/packages/evm/tests/customOpcodes.spec.ts
+++ b/packages/evm/tests/customOpcodes.spec.ts
@@ -102,4 +102,30 @@ tape('VM: custom opcodes', (t) => {
     st.ok(res.executionGasUsed === totalFee, 'succesfully charged correct gas')
     st.ok(res.runState!.stack._store[0] === stackPush, 'succesfully ran opcode logic')
   })
+
+  t.test('should pass the correct VM options when copying the VM', async (st) => {
+    const fee = 333
+    const stackPush = BigInt(1)
+
+    const testOpcode: AddOpcode = {
+      opcode: 0x21,
+      opcodeName: 'TEST',
+      baseFee: fee,
+      logicFunction: function (runState: RunState) {
+        runState.stack.push(BigInt(stackPush))
+      },
+    }
+
+    const evm = await EVM.create({
+      customOpcodes: [testOpcode],
+      eei: await getEEI(),
+    })
+    const evmCopy = evm.copy()
+
+    st.deepEqual(
+      (evmCopy as any)._customOpcodes,
+      (evmCopy as any)._customOpcodes,
+      'evm.copy() successfully copied customOpcodes option'
+    )
+  })
 })

--- a/packages/evm/tests/customPrecompiles.spec.ts
+++ b/packages/evm/tests/customPrecompiles.spec.ts
@@ -119,4 +119,21 @@ tape('EVM -> custom precompiles', (t) => {
       'restored sha precompile - gas correct'
     )
   })
+  t.test('shold copy custom precompiles', async (st) => {
+    const evm = await EVM.create({
+      customPrecompiles: [
+        {
+          address: shaAddress,
+          function: customPrecompile,
+        },
+      ],
+      eei: await getEEI(),
+    })
+    const evmCopy = evm.copy()
+    st.deepEqual(
+      (evm as any)._customPrecompiles,
+      (evmCopy as any)._customPrecompiles,
+      'evm.copy() successfully copied customPrecompiles option'
+    )
+  })
 })

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -230,6 +230,8 @@ export class VM extends AsyncEventEmitter<VMEvents> {
       common: commonCopy,
       evm: evmCopy,
       eei: eeiCopy,
+      hardforkByBlockNumber: this._hardforkByBlockNumber ? true : undefined,
+      hardforkByTD: this._hardforkByTD ? this._hardforkByTD : undefined,
     })
   }
 

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -215,19 +215,12 @@ export class VM extends AsyncEventEmitter<VMEvents> {
    * Returns a copy of the {@link VM} instance.
    */
   async copy(): Promise<VM> {
-    const stateCopy = this.stateManager.copy()
-    const blockchainCopy = this.blockchain.copy()
-    const commonCopy = this._common.copy()
-
-    // Instantiate a new EEI and EVM using the copies of state, blockchain, and common
-    // rather than deep copying the original ones since the copy of the `StateManager`
-    // inside the EVM and EEI will be different than the `VM` level copy otherwise
-    const eeiCopy = new EEI(stateCopy, commonCopy, blockchainCopy)
-    const evmCopy = new EVM({ eei: eeiCopy, common: commonCopy })
+    const evmCopy = this.evm.copy()
+    const eeiCopy: EEIInterface = (evmCopy as any).eei
     return VM.create({
-      stateManager: stateCopy,
-      blockchain: blockchainCopy,
-      common: commonCopy,
+      stateManager: (eeiCopy as any)._stateManager,
+      blockchain: (eeiCopy as any)._blockchain,
+      common: (eeiCopy as any)._common,
       evm: evmCopy,
       eei: eeiCopy,
       hardforkByBlockNumber: this._hardforkByBlockNumber ? true : undefined,

--- a/packages/vm/tests/api/index.spec.ts
+++ b/packages/vm/tests/api/index.spec.ts
@@ -14,6 +14,7 @@ import * as testnetMerge from './testdata/testnetMerge.json'
 // needed for karma-typescript bundling
 import * as util from 'util' // eslint-disable-line @typescript-eslint/no-unused-vars
 import { Buffer } from 'buffer' // eslint-disable-line @typescript-eslint/no-unused-vars
+import { VMOpts } from '../../src'
 
 /**
  * Tests for the main constructor API and
@@ -196,6 +197,42 @@ tape('VM -> hardforkByBlockNumber, hardforkByTD, state (deprecated), blockchain'
     st.end()
   })
 
+  t.test('should pass the correct VM options when copying the VM', async (st) => {
+    let opts: VMOpts = {
+      hardforkByBlockNumber: true,
+    }
+
+    let vm = await VM.create(opts)
+    let vmCopy = await vm.copy()
+    st.deepEqual(
+      (vmCopy as any)._hardforkByBlockNumber,
+      true,
+      'copy() correctly passes hardforkByBlockNumber option'
+    )
+    st.deepEqual(
+      (vm as any)._hardforkByBlockNumber,
+      (vmCopy as any)._hardforkByBlockNumber,
+      'hardforkByBlockNumber options match'
+    )
+
+    //
+
+    opts = {
+      hardforkByTD: BigInt(5001),
+    }
+    vm = await VM.create(opts)
+    vmCopy = await vm.copy()
+    st.deepEqual(
+      (vmCopy as any)._hardforkByTD,
+      BigInt(5001),
+      'copy() correctly passes hardforkByTD option'
+    )
+    st.deepEqual(
+      (vm as any)._hardforkByBlockNumber,
+      (vmCopy as any)._hardforkByBlockNumber,
+      'hardforkByTD options match'
+    )
+  })
   tape('Ensure that precompile activation creates non-empty accounts', async (t) => {
     // setup the accounts for this test
     const caller = new Address(Buffer.from('00000000000000000000000000000000000000ee', 'hex')) // caller addres


### PR DESCRIPTION
Edits VM.copy() to use EVM.copy() instead of running copy() on each parameter.  

Addings missing options to vm.copy().  So now options `allowUnlimitedContractSize`, `hardforkByBlockNumber`, `hardforkByTD`, `customOpcodes`, and `customPrecompiles` should successfully copy 

Adds tests to vm and evm to test copied options.