### PR TITLE
Monorepo: eslint strict boolean expressions

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -45,7 +45,8 @@ module.exports = {
     'no-redeclare': 'off',
     '@typescript-eslint/no-redeclare': ['error'],
     '@typescript-eslint/restrict-plus-operands': 'off',
-    'import/no-default-export' : ['error']
+    'import/no-default-export' : ['error'],
+    '@typescript-eslint/strict-boolean-expressions': ['error']
   },
   parserOptions: {
     sourceType: 'module',

--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -1,6 +1,6 @@
 import { Trie } from '@ethereumjs/trie'
 import { keccak256 } from 'ethereum-cryptography/keccak'
-import { arrToBufArr, bufArrToArr, KECCAK256_RLP, bufferToHex } from '@ethereumjs/util'
+import { arrToBufArr, bufArrToArr, KECCAK256_RLP, bufferToHex, isTruthy } from '@ethereumjs/util'
 import { RLP } from 'rlp'
 import { Common, ConsensusType } from '@ethereumjs/common'
 import {
@@ -98,7 +98,7 @@ export class Block {
 
     // parse transactions
     const transactions = []
-    for (const txData of txsData || []) {
+    for (const txData of isTruthy(txsData) ? txsData : []) {
       transactions.push(
         TransactionFactory.fromBlockBodyData(txData, {
           ...opts,
@@ -118,10 +118,10 @@ export class Block {
       // Disable this option here (all other options carried over), since this overwrites the provided Difficulty to an incorrect value
       calcDifficultyFromHeader: undefined,
     }
-    if (uncleOpts.hardforkByTD) {
+    if (isTruthy(uncleOpts.hardforkByTD)) {
       delete uncleOpts.hardforkByBlockNumber
     }
-    for (const uncleHeaderData of uhsData || []) {
+    for (const uncleHeaderData of isTruthy(uhsData) ? uhsData : []) {
       uncleHeaders.push(BlockHeader.fromValuesArray(uncleHeaderData, uncleOpts))
     }
 
@@ -241,7 +241,7 @@ export class Block {
     const errors: string[] = []
     this.transactions.forEach((tx, i) => {
       const errs = <string[]>tx.validate(true)
-      if (this._common.isActivatedEIP(1559)) {
+      if (this._common.isActivatedEIP(1559) === true) {
         if (tx.supports(Capability.EIP1559FeeMarket)) {
           tx = tx as FeeMarketEIP1559Transaction
           if (tx.maxFeePerGas < this.header.baseFeePerGas!) {

--- a/packages/block/src/from-rpc.ts
+++ b/packages/block/src/from-rpc.ts
@@ -1,5 +1,5 @@
 import { TransactionFactory, TypedTransaction, TxData } from '@ethereumjs/tx'
-import { toBuffer, setLengthLeft } from '@ethereumjs/util'
+import { toBuffer, setLengthLeft, isTruthy } from '@ethereumjs/util'
 import { Block, BlockOptions } from './index'
 import { numberToHex } from './helpers'
 
@@ -16,7 +16,7 @@ function normalizeTxParams(_txParams: any) {
   txParams.value = numberToHex(txParams.value)
 
   // strict byte length checking
-  txParams.to = txParams.to ? setLengthLeft(toBuffer(txParams.to), 20) : null
+  txParams.to = isTruthy(txParams.to) ? setLengthLeft(toBuffer(txParams.to), 20) : null
 
   // v as raw signature value {0,1}
   // v is the recovery bit and can be either {0,1} or {27,28}.
@@ -32,13 +32,13 @@ function normalizeTxParams(_txParams: any) {
  *
  * @param blockParams - Ethereum JSON RPC of block (eth_getBlockByNumber)
  * @param uncles - Optional list of Ethereum JSON RPC of uncles (eth_getUncleByBlockHashAndIndex)
- * @param chainOptions - An object describing the blockchain
+ * @param options - An object describing the blockchain
  */
 export function blockFromRpc(blockParams: any, uncles: any[] = [], options?: BlockOptions) {
   const header = blockHeaderFromRpc(blockParams, options)
 
   const transactions: TypedTransaction[] = []
-  if (blockParams.transactions) {
+  if (isTruthy(blockParams.transactions)) {
     const opts = { common: header._common }
     for (const _txParams of blockParams.transactions) {
       const txParams = normalizeTxParams(_txParams)

--- a/packages/block/src/header-from-rpc.ts
+++ b/packages/block/src/header-from-rpc.ts
@@ -1,12 +1,13 @@
 import { BlockHeader } from './header'
 import { BlockOptions } from './types'
 import { numberToHex } from './helpers'
+import { isTruthy } from '@ethereumjs/util'
 
 /**
  * Creates a new block header object from Ethereum JSON RPC.
  *
  * @param blockParams - Ethereum JSON RPC of block (eth_getBlockByNumber)
- * @param chainOptions - An object describing the blockchain
+ * @param options - An object describing the blockchain
  */
 export function blockHeaderFromRpc(blockParams: any, options?: BlockOptions) {
   const {
@@ -36,7 +37,7 @@ export function blockHeaderFromRpc(blockParams: any, options?: BlockOptions) {
       coinbase: miner,
       stateRoot,
       transactionsTrie: transactionsRoot,
-      receiptTrie: receiptRoot || receiptsRoot,
+      receiptTrie: isTruthy(receiptRoot) ? receiptRoot : receiptsRoot,
       logsBloom,
       difficulty: numberToHex(difficulty),
       number,

--- a/packages/block/src/helpers.ts
+++ b/packages/block/src/helpers.ts
@@ -1,11 +1,11 @@
-import { isHexString } from '@ethereumjs/util'
+import { isFalsy, isHexString } from '@ethereumjs/util'
 
 /**
  * Returns a 0x-prefixed hex number string from a hex string or string integer.
  * @param {string} input string to check, convert, and return
  */
 export const numberToHex = function (input?: string) {
-  if (!input) return undefined
+  if (isFalsy(input)) return undefined
   if (!isHexString(input)) {
     const regex = new RegExp(/^\d+$/) // test to make sure input contains only digits
     if (!regex.test(input)) {

--- a/packages/block/test/block.spec.ts
+++ b/packages/block/test/block.spec.ts
@@ -193,7 +193,7 @@ tape('[Block]: block functions', function (t) {
       await block.validateData()
       st.fail('should throw')
     } catch (error: any) {
-      st.ok(error.message.includes('invalid transaction trie'))
+      st.ok((error.message as string).includes('invalid transaction trie'))
     }
   })
 
@@ -225,7 +225,7 @@ tape('[Block]: block functions', function (t) {
       await block.validateData()
       st.fail('should throw')
     } catch (error: any) {
-      st.ok(error.message.includes('invalid uncle hash'))
+      st.ok((error.message as string).includes('invalid uncle hash'))
     }
   })
 

--- a/packages/block/test/header.spec.ts
+++ b/packages/block/test/header.spec.ts
@@ -187,7 +187,7 @@ tape('[Block]: Header functions', function (t) {
       BlockHeader.fromHeaderData({ ...data, extraData }, opts)
       st.fail(testCase)
     } catch (error: any) {
-      st.ok(error.message.includes('invalid amount of extra data'), testCase)
+      st.ok((error.message as string).includes('invalid amount of extra data'), testCase)
     }
 
     // PoA
@@ -218,7 +218,7 @@ tape('[Block]: Header functions', function (t) {
       t.fail(testCase)
     } catch (error: any) {
       t.ok(
-        error.message.includes(
+        (error.message as string).includes(
           'extraData must be 97 bytes on non-epoch transition blocks, received 32 bytes'
         ),
         testCase
@@ -239,7 +239,7 @@ tape('[Block]: Header functions', function (t) {
       st.fail(testCase)
     } catch (error: any) {
       st.ok(
-        error.message.includes(
+        (error.message as string).includes(
           'invalid signer list length in extraData, received signer length of 41 (not divisible by 20)'
         ),
         testCase
@@ -272,7 +272,7 @@ tape('[Block]: Header functions', function (t) {
       await header.validate(blockchain)
       st.fail(testCase)
     } catch (error: any) {
-      st.ok(error.message.includes('invalid timestamp diff (lower than period)'), testCase)
+      st.ok((error.message as string).includes('invalid timestamp diff (lower than period)'), testCase)
     }
 
     testCase = 'should not throw on timestamp diff equal to period'
@@ -293,7 +293,7 @@ tape('[Block]: Header functions', function (t) {
       await header.validate(blockchain)
       st.fail('should throw')
     } catch (error: any) {
-      if (error.message.includes('coinbase must be filled with zeros on epoch transition blocks')) {
+      if ((error.message as string).includes('coinbase must be filled with zeros on epoch transition blocks')) {
         st.pass('error thrown')
       } else {
         st.fail('should throw with appropriate error')
@@ -309,7 +309,7 @@ tape('[Block]: Header functions', function (t) {
       await header.validate(blockchain)
       st.fail('should throw')
     } catch (error: any) {
-      if (error.message.includes('mixHash must be filled with zeros')) {
+      if ((error.message as string).includes('mixHash must be filled with zeros')) {
         st.pass('error thrown')
       } else {
         st.fail('should throw with appropriate error')
@@ -324,7 +324,7 @@ tape('[Block]: Header functions', function (t) {
       header.validateCliqueDifficulty(blockchain)
       st.fail(testCase)
     } catch (error: any) {
-      if (error.message.includes('difficulty for clique block must be INTURN (2) or NOTURN (1)')) {
+      if ((error.message as string).includes('difficulty for clique block must be INTURN (2) or NOTURN (1)')) {
         st.pass('error thrown on invalid clique difficulty')
       } else {
         st.fail('should throw with appropriate error')

--- a/packages/block/test/util.ts
+++ b/packages/block/test/util.ts
@@ -1,6 +1,6 @@
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { keccak256 } from 'ethereum-cryptography/keccak'
-import { bufArrToArr } from '@ethereumjs/util'
+import { bufArrToArr, isTruthy } from '@ethereumjs/util'
 import { RLP } from 'rlp'
 import { Block, BlockHeader } from '../src'
 
@@ -30,7 +30,9 @@ function createBlock(
 
   const londonHfBlock = common.hardforkBlock(Hardfork.London)
   const baseFeePerGas =
-    londonHfBlock && number > londonHfBlock ? parentBlock.header.calcNextBaseFee() : undefined
+    isTruthy(londonHfBlock) && number > londonHfBlock
+      ? parentBlock.header.calcNextBaseFee()
+      : undefined
 
   return Block.fromBlockData(
     {

--- a/packages/blockchain/src/consensus/clique.ts
+++ b/packages/blockchain/src/consensus/clique.ts
@@ -139,7 +139,7 @@ export class CliqueConsensus implements Consensus {
       const checkpointSigners = header.cliqueEpochTransitionSigners()
       const activeSigners = this.cliqueActiveSigners()
       for (const [i, cSigner] of checkpointSigners.entries()) {
-        if (!activeSigners[i] || !activeSigners[i].equals(cSigner)) {
+        if (activeSigners[i]?.equals(cSigner) !== true) {
           throw new Error(
             `checkpoint signer not found in active signers list at index ${i}: ${cSigner}`
           )

--- a/packages/blockchain/src/db/manager.ts
+++ b/packages/blockchain/src/db/manager.ts
@@ -1,4 +1,4 @@
-import { arrToBufArr, bufferToBigInt } from '@ethereumjs/util'
+import { arrToBufArr, bufferToBigInt, isFalsy, isTruthy } from '@ethereumjs/util'
 import { RLP } from 'rlp'
 import { Block, BlockHeader, BlockOptions, BlockBuffer, BlockBodyBuffer } from '@ethereumjs/block'
 import { Common } from '@ethereumjs/common'
@@ -12,7 +12,8 @@ class NotFoundError extends Error {
   constructor(blockNumber: bigint) {
     super(`Key ${blockNumber.toString()} was not found`)
 
-    if (Error.captureStackTrace) {
+    // `Error.captureStackTrace` is not defined in some browser contexts
+    if (typeof Error.captureStackTrace !== 'undefined') {
       Error.captureStackTrace(this, this.constructor)
     }
   }
@@ -181,8 +182,8 @@ export class DBManager {
     const dbKey = dbGetOperation.baseDBOp.key
     const dbOpts = dbGetOperation.baseDBOp
 
-    if (cacheString) {
-      if (!this._cache[cacheString]) {
+    if (isTruthy(cacheString)) {
+      if (isFalsy(this._cache[cacheString])) {
         throw new Error(`Invalid cache: ${cacheString}`)
       }
 

--- a/packages/blockchain/src/db/operation.ts
+++ b/packages/blockchain/src/db/operation.ts
@@ -1,3 +1,4 @@
+import { isTruthy } from '@ethereumjs/util'
 import {
   HEADS_KEY,
   HEAD_HEADER_KEY,
@@ -128,7 +129,7 @@ export class DBOp {
   }
 
   public updateCache(cacheMap: CacheMap) {
-    if (this.cacheString && cacheMap[this.cacheString]) {
+    if (isTruthy(this.cacheString) && isTruthy(cacheMap[this.cacheString])) {
       if (this.baseDBOp.type == 'put') {
         Buffer.isBuffer(this.baseDBOp.value) &&
           cacheMap[this.cacheString].set(this.baseDBOp.key, this.baseDBOp.value)

--- a/packages/blockchain/src/genesisStates/index.ts
+++ b/packages/blockchain/src/genesisStates/index.ts
@@ -1,6 +1,13 @@
 import { SecureTrie as Trie } from '@ethereumjs/trie'
 import { keccak256 } from 'ethereum-cryptography/keccak'
-import { Account, isHexPrefixed, toBuffer, unpadBuffer, PrefixedHexString } from '@ethereumjs/util'
+import {
+  Account,
+  isHexPrefixed,
+  toBuffer,
+  unpadBuffer,
+  PrefixedHexString,
+  isTruthy,
+} from '@ethereumjs/util'
 import { RLP } from 'rlp'
 
 export type StoragePair = [key: PrefixedHexString, value: PrefixedHexString]
@@ -26,14 +33,14 @@ export async function genesisStateRoot(genesisState: GenesisState) {
     if (typeof value === 'string') {
       account.balance = BigInt(value)
     } else {
-      const [balance, code, storage] = value as AccountState
-      if (balance) {
+      const [balance, code, storage] = value as Partial<AccountState>
+      if (isTruthy(balance)) {
         account.balance = BigInt(balance)
       }
-      if (code) {
+      if (isTruthy(code)) {
         account.codeHash = Buffer.from(keccak256(toBuffer(code)))
       }
-      if (storage) {
+      if (isTruthy(storage)) {
         const storageTrie = new Trie()
         for (const [k, val] of storage) {
           const storageKey = isHexPrefixed(k) ? toBuffer(k) : Buffer.from(k, 'hex')

--- a/packages/blockchain/test/blockValidation.spec.ts
+++ b/packages/blockchain/test/blockValidation.spec.ts
@@ -86,7 +86,7 @@ tape('[Blockchain]: Block validation tests', (t) => {
       await blockchain.putBlock(blockWithUnclesTooOld)
       st.fail('cannot reach this')
     } catch (e: any) {
-      if (e.message.includes('uncle block has a parent that is too old'))
+      if ((e.message as string).includes('uncle block has a parent that is too old'))
         st.pass('block throws uncle is too old')
       else st.fail(`threw with wrong error ${e.message}`)
     }
@@ -107,7 +107,7 @@ tape('[Blockchain]: Block validation tests', (t) => {
       await blockchain.putBlock(block1)
       st.fail('cannot reach this')
     } catch (e: any) {
-      if (e.message.includes('uncle block has a parent that is too old or too young'))
+      if ((e.message as string).includes('uncle block has a parent that is too old or too young'))
         st.pass('block throws uncle is too young')
       else st.fail(`threw with wrong error ${e.message}`)
     }
@@ -140,7 +140,7 @@ tape('[Blockchain]: Block validation tests', (t) => {
       await blockchain.putBlock(block2)
       st.fail('cannot reach this')
     } catch (e: any) {
-      if (e.message.includes('invalid difficulty block header number=1 '))
+      if ((e.message as string).includes('invalid difficulty block header number=1 '))
         st.pass('block throws when uncle header is invalid')
       else st.fail(`threw with wrong error ${e.message}`)
     }
@@ -162,7 +162,7 @@ tape('[Blockchain]: Block validation tests', (t) => {
 
       st.fail('cannot reach this')
     } catch (e: any) {
-      if (e.message.includes('The uncle is a canonical block'))
+      if ((e.message as string).includes('The uncle is a canonical block'))
         st.pass('block throws if an uncle is a canonical block')
       else st.fail(`threw with wrong error ${e.message}`)
     }
@@ -243,7 +243,10 @@ tape('[Blockchain]: Block validation tests', (t) => {
       await blockchain.putBlock(block2)
     } catch (e: any) {
       const expectedError = 'Invalid block: base fee not correct'
-      st.ok(e.message.includes(expectedError), 'should throw when base fee is not correct')
+      st.ok(
+        (e.message as string).includes(expectedError),
+        'should throw when base fee is not correct'
+      )
     }
   })
 

--- a/packages/blockchain/test/clique.spec.ts
+++ b/packages/blockchain/test/clique.spec.ts
@@ -212,7 +212,9 @@ tape('Clique: Initialization', (t) => {
       await blockchain.putBlock(block)
       st.fail('should fail')
     } catch (error: any) {
-      if (error.message.includes('checkpoint signer not found in active signers list')) {
+      if (
+        (error.message as string).includes('checkpoint signer not found in active signers list')
+      ) {
         st.pass('correct error')
       } else {
         st.fail('should fail with appropriate error')
@@ -245,7 +247,11 @@ tape('Clique: Initialization', (t) => {
       await blockchain.putBlock(block)
       st.fail('should fail')
     } catch (error: any) {
-      if (error.message.includes('difficulty for clique block must be INTURN (2) or NOTURN (1)')) {
+      if (
+        (error.message as string).includes(
+          'difficulty for clique block must be INTURN (2) or NOTURN (1)'
+        )
+      ) {
         st.pass('correct error')
       } else {
         st.fail('should fail with appropriate error')
@@ -271,7 +277,7 @@ tape('Clique: Initialization', (t) => {
       await blockchain.putBlock(block)
       st.fail('should fail')
     } catch (error: any) {
-      if (error.message.includes('invalid clique difficulty')) {
+      if ((error.message as string).includes('invalid clique difficulty')) {
         st.pass('correct error')
       } else {
         st.fail('should fail with appropriate error')
@@ -649,7 +655,7 @@ tape('Clique: Initialization', (t) => {
       await addNextBlock(blockchain, blocks, B)
       st.fail('should throw error')
     } catch (error: any) {
-      if (error.message.includes('invalid PoA block signature (clique)')) {
+      if ((error.message as string).includes('invalid PoA block signature (clique)')) {
         st.pass('correct error thrown')
       } else {
         st.fail('correct error not thrown')
@@ -667,7 +673,7 @@ tape('Clique: Initialization', (t) => {
         await addNextBlock(blockchain, blocks, A)
         st.fail('should throw error')
       } catch (error: any) {
-        if (error.message.includes('recently signed')) {
+        if ((error.message as string).includes('recently signed')) {
           st.pass('correct error thrown')
         } else {
           st.fail('correct error not thrown')
@@ -704,7 +710,7 @@ tape('Clique: Initialization', (t) => {
         await addNextBlock(blockchain, blocks, A, undefined, undefined, common)
         st.fail('should throw error')
       } catch (error: any) {
-        if (error.message.includes('recently signed')) {
+        if ((error.message as string).includes('recently signed')) {
           st.pass('correct error thrown')
         } else {
           st.fail('correct error not thrown')

--- a/packages/blockchain/test/index.spec.ts
+++ b/packages/blockchain/test/index.spec.ts
@@ -181,7 +181,7 @@ tape('blockchain test', (t) => {
     await blockchain.putBlock(block)
 
     const returnedBlock = await blockchain.getBlock(1)
-    if (returnedBlock) {
+    if (typeof returnedBlock !== 'undefined') {
       st.ok(returnedBlock.hash().equals(blocks[1].hash()))
     } else {
       st.fail('block is not defined!')
@@ -201,7 +201,7 @@ tape('blockchain test', (t) => {
       genesisBlock,
     })
     const block = await blockchain.getBlock(genesisBlock.hash())
-    if (block) {
+    if (typeof block !== 'undefined') {
       st.ok(block.hash().equals(genesisBlock.hash()))
     } else {
       st.fail('block is not defined!')
@@ -616,7 +616,7 @@ tape('blockchain test', (t) => {
     const [db, genesis] = await createTestDB()
     const blockchain = await Blockchain.create({ db, genesisBlock: genesis })
     const head = await blockchain.getIteratorHead()
-    if (genesis) {
+    if (typeof genesis !== 'undefined') {
       st.ok(head.hash().equals(genesis.hash()), 'should get head')
       st.equal(
         (blockchain as any)._heads['head0'].toString('hex'),
@@ -665,7 +665,7 @@ tape('blockchain test', (t) => {
 
   t.test('uncached db ops', async (st) => {
     const [db, genesis] = await createTestDB()
-    if (!genesis) {
+    if (typeof genesis === 'undefined') {
       return st.fail('genesis not defined!')
     }
     const blockchain = await Blockchain.create({ db, genesisBlock: genesis })

--- a/packages/blockchain/test/reorg.spec.ts
+++ b/packages/blockchain/test/reorg.spec.ts
@@ -36,7 +36,7 @@ tape('reorg tests', (t) => {
       while (TD_High < TD_Low) {
         blocks_lowTD.push(generateConsecutiveBlock(blocks_lowTD[blocks_lowTD.length - 1], 0))
         blocks_highTD.push(
-          generateConsecutiveBlock(blocks_highTD[blocks_highTD.length - 1] || genesis, 1)
+          generateConsecutiveBlock(blocks_highTD[blocks_highTD.length - 1] ?? genesis, 1)
         )
 
         TD_Low += blocks_lowTD[blocks_lowTD.length - 1].header.difficulty

--- a/packages/blockchain/test/util.ts
+++ b/packages/blockchain/test/util.ts
@@ -1,4 +1,4 @@
-import { bufArrToArr, toBuffer } from '@ethereumjs/util'
+import { bufArrToArr, isTruthy, toBuffer } from '@ethereumjs/util'
 import { RLP } from 'rlp'
 import { Block, BlockHeader } from '@ethereumjs/block'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
@@ -207,7 +207,9 @@ function createBlock(
 
   const londonHfBlock = common.hardforkBlock(Hardfork.London)
   const baseFeePerGas =
-    londonHfBlock && number > londonHfBlock ? parentBlock.header.calcNextBaseFee() : undefined
+    isTruthy(londonHfBlock) && number > londonHfBlock
+      ? parentBlock.header.calcNextBaseFee()
+      : undefined
 
   return Block.fromBlockData(
     {

--- a/packages/client/browser/index.ts
+++ b/packages/client/browser/index.ts
@@ -44,13 +44,14 @@ import { Config } from '../lib/config'
 export * from './logging'
 import { getLogger } from './logging'
 import { Level } from 'level'
+import { isTruthy } from '@ethereumjs/util'
 
 export async function createClient(args: any) {
   const logger = getLogger({ loglevel: args.loglevel })
   const datadir = args.datadir ?? Config.DATADIR_DEFAULT
   const common = new Common({ chain: args.network ?? Chain.Mainnet })
   const key = await Config.getClientKey(datadir, common)
-  const bootnodes = args.bootnodes ? parseMultiaddrs(args.bootnodes) : undefined
+  const bootnodes = isTruthy(args.bootnodes) ? parseMultiaddrs(args.bootnodes) : undefined
   const config = new Config({
     common,
     key,

--- a/packages/client/lib/execution/receipt.ts
+++ b/packages/client/lib/execution/receipt.ts
@@ -111,12 +111,12 @@ export class ReceiptsManager extends MetaDBManager {
    */
   async getReceipts(
     blockHash: Buffer,
-    calcBloom?: Boolean,
+    calcBloom?: boolean,
     includeTxType?: true
   ): Promise<TxReceiptWithType[]>
   async getReceipts(
     blockHash: Buffer,
-    calcBloom?: Boolean,
+    calcBloom?: boolean,
     includeTxType?: false
   ): Promise<TxReceipt[]>
   async getReceipts(

--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -6,7 +6,7 @@ import {
 } from '@ethereumjs/blockchain/dist/db/helpers'
 import { ConsensusType, Hardfork } from '@ethereumjs/common'
 import { VM } from '@ethereumjs/vm'
-import { bufferToHex } from '@ethereumjs/util'
+import { bufferToHex, isFalsy, isTruthy } from '@ethereumjs/util'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { LevelDB, SecureTrie as Trie } from '@ethereumjs/trie'
 import { short } from '../util'
@@ -34,7 +34,7 @@ export class VMExecution extends Execution {
   constructor(options: ExecutionOptions) {
     super(options)
 
-    if (!this.config.vm) {
+    if (isFalsy(this.config.vm)) {
       const trie = new Trie({ db: new LevelDB(this.stateDB) })
 
       const stateManager = new DefaultStateManager({
@@ -92,7 +92,7 @@ export class VMExecution extends Execution {
       const result = await this.vm.runBlock(opts)
       receipts = result.receipts
     }
-    if (receipts) {
+    if (isTruthy(receipts)) {
       // Save receipts
       this.pendingReceipts?.set(block.hash().toString('hex'), receipts)
     }
@@ -147,7 +147,7 @@ export class VMExecution extends Execution {
 
     while (
       (numExecuted === undefined || (loop && numExecuted === this.NUM_BLOCKS_PER_ITERATION)) &&
-      !startHeadBlock.hash().equals(canonicalHead.hash())
+      startHeadBlock.hash().equals(canonicalHead.hash()) === false
     ) {
       let txCounter = 0
       headBlock = undefined
@@ -242,23 +242,28 @@ export class VMExecution extends Execution {
       )
       numExecuted = await this.vmPromise
 
-      if (errorBlock) {
-        await this.chain.blockchain.setIteratorHead('vm', (errorBlock as Block).header.parentHash)
+      if (isTruthy(errorBlock)) {
+        await this.chain.blockchain.setIteratorHead(
+          'vm',
+          (errorBlock as unknown as Block).header.parentHash
+        )
         return 0
       }
 
       const endHeadBlock = await this.vm.blockchain.getIteratorHead('vm')
-      if (numExecuted && numExecuted > 0) {
+      if (isTruthy(numExecuted && numExecuted > 0)) {
         const firstNumber = startHeadBlock.header.number
         const firstHash = short(startHeadBlock.hash())
         const lastNumber = endHeadBlock.header.number
         const lastHash = short(endHeadBlock.hash())
-        const baseFeeAdd = this.config.execCommon.gteHardfork(Hardfork.London)
-          ? `baseFee=${endHeadBlock.header.baseFeePerGas} `
-          : ''
-        const tdAdd = this.config.execCommon.gteHardfork(Hardfork.Merge)
-          ? ''
-          : `td=${this.chain.blocks.td} `
+        const baseFeeAdd =
+          this.config.execCommon.gteHardfork(Hardfork.London) === true
+            ? `baseFee=${endHeadBlock.header.baseFeePerGas} `
+            : ''
+        const tdAdd =
+          this.config.execCommon.gteHardfork(Hardfork.Merge) === true
+            ? ''
+            : `td=${this.chain.blocks.td} `
         this.config.logger.info(
           `Executed blocks count=${numExecuted} first=${firstNumber} hash=${firstHash} ${tdAdd}${baseFeeAdd}hardfork=${this.hardfork} last=${lastNumber} hash=${lastHash} txs=${txCounter}`
         )

--- a/packages/client/lib/logging.ts
+++ b/packages/client/lib/logging.ts
@@ -1,3 +1,4 @@
+import { isFalsy, isTruthy } from '@ethereumjs/util'
 import * as chalk from 'chalk'
 import { createLogger, format, transports as wTransports, Logger as WinstonLogger } from 'winston'
 const DailyRotateFile = require('winston-daily-rotate-file')
@@ -28,10 +29,10 @@ enum LevelColors {
  * Adds stack trace to error message if included
  */
 const errorFormat = format((info: any) => {
-  if (info.message instanceof Error && info.message.stack) {
+  if (info.message instanceof Error && isTruthy(info.message.stack)) {
     return { ...info, message: info.message.stack }
   }
-  if (info instanceof Error && info.stack) {
+  if (info instanceof Error && isTruthy(info.stack)) {
     return { ...info, message: info.stack }
   }
   return info
@@ -51,7 +52,7 @@ function logFormat(colors = false) {
   return printf((info: any) => {
     let level = info.level.toUpperCase()
 
-    if (!info.message) info.message = '(empty message)'
+    if (isFalsy(info.message)) info.message = '(empty message)'
 
     if (colors) {
       const colorLevel = LevelColors[info.level as keyof typeof LevelColors]
@@ -61,8 +62,8 @@ function logFormat(colors = false) {
       const regex = /(\w+)=(.+?)(?:\s|$)/g
       const replaceFn = (_: any, tag: string, char: string) => `${color(tag)}=${char} `
       info.message = info.message.replace(regex, replaceFn)
-      if (info.attentionCL) info.attentionCL = info.attentionCL.replace(regex, replaceFn)
-      if (info.attentionHF) info.attentionHF = info.attentionHF.replace(regex, replaceFn)
+      if (isTruthy(info.attentionCL)) info.attentionCL = info.attentionCL.replace(regex, replaceFn)
+      if (isTruthy(info.attentionHF)) info.attentionHF = info.attentionHF.replace(regex, replaceFn)
     }
 
     if (info.attentionCL !== undefined) attentionCL = info.attentionCL
@@ -97,7 +98,7 @@ function logFileTransport(args: any) {
     level: args.logLevelFile,
     format: formatConfig(),
   }
-  if (!args.logRotate) {
+  if (isFalsy(args.logRotate)) {
     return new wTransports.File({
       ...opts,
       filename,
@@ -125,7 +126,7 @@ export function getLogger(args: { [key: string]: any } = { loglevel: 'info' }) {
       format: formatConfig(true),
     }),
   ]
-  if (args.logFile) {
+  if (isTruthy(args.logFile)) {
     transports.push(logFileTransport(args))
   }
   const logger = createLogger({

--- a/packages/client/lib/miner/miner.ts
+++ b/packages/client/lib/miner/miner.ts
@@ -2,6 +2,7 @@ import { Ethash, Solution, Miner as EthashMiner } from '@ethereumjs/ethash'
 import { BlockHeader } from '@ethereumjs/block'
 import { CliqueConsensus } from '@ethereumjs/blockchain'
 import { ConsensusType, Hardfork, CliqueConfig } from '@ethereumjs/common'
+import { isFalsy, isTruthy } from '@ethereumjs/util'
 import { Event } from '../types'
 import { Config } from '../config'
 import { FullEthereumService } from '../service'
@@ -75,7 +76,7 @@ export class Miner {
     if (!this.running) {
       return
     }
-    if (this.config.chainCommon.gteHardfork(Hardfork.Merge)) {
+    if (this.config.chainCommon.gteHardfork(Hardfork.Merge) === true) {
       this.config.logger.info('Miner: reached merge hardfork - stopping')
       this.stop()
       return
@@ -91,7 +92,7 @@ export class Miner {
       const inTurn = await (blockchain.consensus as CliqueConsensus).cliqueSignerInTurn(
         signerAddress
       )
-      if (!inTurn) {
+      if (isFalsy(inTurn)) {
         const signerCount = (blockchain.consensus as CliqueConsensus).cliqueActiveSigners().length
         timeout += Math.random() * signerCount * 500
       }
@@ -109,7 +110,7 @@ export class Miner {
    * Finds the next PoW solution.
    */
   private async findNextSolution() {
-    if (!this.ethash) {
+    if (typeof this.ethash === 'undefined') {
       return
     }
     this.config.logger.info('Miner: Finding next PoW solution 🔨')
@@ -190,7 +191,9 @@ export class Miner {
         { number },
         { common: this.config.chainCommon, cliqueSigner }
       )
-      if ((this.service.chain.blockchain as any).consensus.cliqueCheckRecentlySigned(header)) {
+      if (
+        (this.service.chain.blockchain as any).consensus.cliqueCheckRecentlySigned(header) === true
+      ) {
         this.config.logger.info(`Miner: We have too recently signed, waiting for next block`)
         this.assembling = false
         return
@@ -198,7 +201,7 @@ export class Miner {
     }
 
     if (this.config.chainCommon.consensusType() === ConsensusType.ProofOfWork) {
-      while (!this.nextSolution) {
+      while (isFalsy(this.nextSolution)) {
         this.config.logger.info(`Miner: Waiting to find next PoW solution 🔨`)
         await new Promise((r) => setTimeout(r, 1000))
       }
@@ -223,19 +226,18 @@ export class Miner {
       inTurn = await (vmCopy.blockchain.consensus as CliqueConsensus).cliqueSignerInTurn(
         signerAddress
       )
-      difficulty = inTurn ? 2 : 1
+      difficulty = isTruthy(inTurn) ? 2 : 1
     }
 
     let baseFeePerGas
     const londonHardforkBlock = this.config.chainCommon.hardforkBlock(Hardfork.London)
-    const isInitialEIP1559Block = londonHardforkBlock && number === londonHardforkBlock
-    if (isInitialEIP1559Block) {
+    if (isTruthy(londonHardforkBlock) && number === londonHardforkBlock) {
       // Get baseFeePerGas from `paramByEIP` since 1559 not currently active on common
       baseFeePerGas =
         this.config.chainCommon.paramByEIP('gasConfig', 'initialBaseFee', 1559) ?? BigInt(0)
       // Set initial EIP1559 block gas limit to 2x parent gas limit per logic in `block.validateGasLimit`
       gasLimit = gasLimit * BigInt(2)
-    } else if (this.config.chainCommon.isActivatedEIP(1559)) {
+    } else if (this.config.chainCommon.isActivatedEIP(1559) === true) {
       baseFeePerGas = parentBlock.header.calcNextBaseFee()
     }
 
@@ -266,7 +268,7 @@ export class Miner {
     const txs = await this.service.txPool.txsByPriceAndNonce(baseFeePerGas)
     this.config.logger.info(
       `Miner: Assembling block from ${txs.length} eligible txs ${
-        baseFeePerGas ? `(baseFee: ${baseFeePerGas})` : ''
+        isTruthy(baseFeePerGas) ? `(baseFee: ${baseFeePerGas})` : ''
       }`
     )
     let index = 0
@@ -300,7 +302,7 @@ export class Miner {
       `Miner: Sealed block with ${block.transactions.length} txs ${
         this.config.chainCommon.consensusType() === ConsensusType.ProofOfWork
           ? `(difficulty: ${block.header.difficulty})`
-          : `(${inTurn ? 'in turn' : 'not in turn'})`
+          : `(${isTruthy(inTurn) ? 'in turn' : 'not in turn'})`
       }`
     )
     this.assembling = false

--- a/packages/client/lib/miner/pendingBlock.ts
+++ b/packages/client/lib/miner/pendingBlock.ts
@@ -39,9 +39,8 @@ export class PendingBlock {
   async start(vm: VM, parentBlock: Block, headerData: Partial<HeaderData> = {}) {
     const number = parentBlock.header.number + BigInt(1)
     const { gasLimit } = parentBlock.header
-    const baseFeePerGas = vm._common.isActivatedEIP(1559)
-      ? parentBlock.header.calcNextBaseFee()
-      : undefined
+    const baseFeePerGas =
+      vm._common.isActivatedEIP(1559) === true ? parentBlock.header.calcNextBaseFee() : undefined
 
     // Set the state root to ensure the resulting state
     // is based on the parent block's state
@@ -126,7 +125,8 @@ export class PendingBlock {
       await this.txPool.txsByPriceAndNonce((builder as any).headerData.baseFeePerGas)
     ).filter(
       (tx) =>
-        !(builder as any).transactions.some((t: TypedTransaction) => t.hash().equals(tx.hash()))
+        (builder as any).transactions.some((t: TypedTransaction) => t.hash().equals(tx.hash())) ===
+        false
     )
     this.config.logger.info(`Pending: Adding ${txs.length} additional eligible txs`)
     let index = 0

--- a/packages/client/lib/net/peer/rlpxpeer.ts
+++ b/packages/client/lib/net/peer/rlpxpeer.ts
@@ -10,6 +10,7 @@ import { Protocol, RlpxSender } from '../protocol'
 import { Peer, PeerOptions } from './peer'
 import { RlpxServer } from '../server'
 import { Event } from '../../types'
+import { isTruthy } from '@ethereumjs/util'
 const devp2pCapabilities: any = {
   eth66: Devp2pETH.eth66,
   les2: Devp2pLES.les2,
@@ -83,7 +84,7 @@ export class RlpxPeer extends Peer {
       const keys = versions.map((v: number) => name + String(v))
       keys.forEach((key: any) => {
         const capability = devp2pCapabilities[key]
-        if (capability) {
+        if (isTruthy(capability)) {
           capabilities.push(capability)
         }
       })

--- a/packages/client/lib/net/protocol/boundprotocol.ts
+++ b/packages/client/lib/net/protocol/boundprotocol.ts
@@ -3,6 +3,7 @@ import { Peer } from '../peer/peer'
 import { Sender } from './sender'
 import { Config } from '../../config'
 import { Event } from '../../types'
+import { isTruthy } from '@ethereumjs/util'
 
 export interface BoundProtocolOptions {
   /* Config */
@@ -98,7 +99,7 @@ export class BoundProtocol {
       error = new Error(`Could not decode message ${message.name}: ${e}`)
     }
     const resolver = this.resolvers.get(incoming.code)
-    if (resolver) {
+    if (isTruthy(resolver)) {
       clearTimeout(resolver.timeout)
       this.resolvers.delete(incoming.code)
       if (error) {
@@ -159,7 +160,7 @@ export class BoundProtocol {
       resolve: null,
       reject: null,
     }
-    if (this.resolvers.get(message.response!)) {
+    if (isTruthy(this.resolvers.get(message.response!))) {
       throw new Error(`Only one active request allowed per message type (${name})`)
     }
     this.resolvers.set(message.response!, resolver)

--- a/packages/client/lib/net/protocol/flowcontrol.ts
+++ b/packages/client/lib/net/protocol/flowcontrol.ts
@@ -1,4 +1,5 @@
 import { Peer } from '../peer/peer'
+import { isTruthy } from '@ethereumjs/util'
 
 interface Mrc {
   [key: string]: {
@@ -66,7 +67,7 @@ export class FlowControl {
     const mrr = peer.les!.status.mrr
     const bl = peer.les!.status.bl
     const params = this.in.get(peer.id) ?? ({ ble: bl } as FlowParams)
-    if (params.last) {
+    if (isTruthy(params.last)) {
       // recharge BLE at rate of MRR when less than BL
       params.ble = Math.min(params.ble! + mrr * (now - params.last), bl)
     }
@@ -88,7 +89,7 @@ export class FlowControl {
   handleRequest(peer: Peer, messageName: string, count: number): number {
     const now = Date.now()
     const params = this.out.get(peer.id) ?? {}
-    if (params.bv && params.last) {
+    if (isTruthy(params.bv) && isTruthy(params.last)) {
       params.bv = Math.min(params.bv + this.mrr * (now - params.last), this.bl)
     } else {
       params.bv = this.bl

--- a/packages/client/lib/net/protocol/lesprotocol.ts
+++ b/packages/client/lib/net/protocol/lesprotocol.ts
@@ -1,4 +1,10 @@
-import { bigIntToBuffer, bufferToBigInt, bufferToInt, intToBuffer } from '@ethereumjs/util'
+import {
+  bigIntToBuffer,
+  bufferToBigInt,
+  bufferToInt,
+  intToBuffer,
+  isTruthy,
+} from '@ethereumjs/util'
 import { BlockHeader, BlockHeaderBuffer } from '@ethereumjs/block'
 import { Chain } from './../../blockchain'
 import { Message, Protocol, ProtocolOptions } from './protocol'
@@ -174,7 +180,7 @@ export class LesProtocol extends Protocol {
     const nextFork = this.config.chainCommon.nextHardforkBlock(this.config.chainCommon.hardfork())
     const forkID = [
       Buffer.from(forkHash.slice(2), 'hex'),
-      nextFork ? bigIntToBuffer(nextFork) : Buffer.from([]),
+      isTruthy(nextFork) ? bigIntToBuffer(nextFork) : Buffer.from([]),
     ]
 
     return {
@@ -194,9 +200,9 @@ export class LesProtocol extends Protocol {
    * @param status status message payload
    */
   decodeStatus(status: any): any {
-    this.isServer = !!status.serveHeaders
+    this.isServer = isTruthy(status.serveHeaders)
     const mrc: any = {}
-    if (status['flowControl/MRC']) {
+    if (isTruthy(status['flowControl/MRC'])) {
       for (let entry of status['flowControl/MRC']) {
         entry = entry.map((e: any) => bufferToInt(e))
         mrc[entry[0]] = { base: entry[1], req: entry[2] }
@@ -217,9 +223,9 @@ export class LesProtocol extends Protocol {
       serveHeaders: this.isServer,
       serveChainSince: status.serveChainSince ?? 0,
       serveStateSince: status.serveStateSince ?? 0,
-      txRelay: !!status.txRelay,
-      bl: status['flowControl/BL'] ? bufferToInt(status['flowControl/BL']) : undefined,
-      mrr: status['flowControl/MRR'] ? bufferToInt(status['flowControl/MRR']) : undefined,
+      txRelay: isTruthy(status.txRelay),
+      bl: isTruthy(status['flowControl/BL']) ? bufferToInt(status['flowControl/BL']) : undefined,
+      mrr: isTruthy(status['flowControl/MRR']) ? bufferToInt(status['flowControl/MRR']) : undefined,
       mrc: mrc,
     }
   }

--- a/packages/client/lib/net/protocol/protocol.ts
+++ b/packages/client/lib/net/protocol/protocol.ts
@@ -1,3 +1,4 @@
+import { isTruthy } from '@ethereumjs/util'
 import { Config } from '../../config'
 import { Peer } from '../peer/peer'
 import { BoundProtocol } from './boundprotocol'
@@ -71,12 +72,12 @@ export class Protocol {
         reject(new Error(`Handshake timed out after ${this.timeout}ms`))
       }, this.timeout)
       const handleStatus = (status: any) => {
-        if (timeout) {
+        if (isTruthy(timeout)) {
           clearTimeout(timeout)
           resolve(this.decodeStatus(status))
         }
       }
-      if (sender.status) {
+      if (isTruthy(sender.status)) {
         handleStatus(sender.status)
       } else {
         sender.once('status', handleStatus)

--- a/packages/client/lib/net/server/libp2pserver.ts
+++ b/packages/client/lib/net/server/libp2pserver.ts
@@ -6,6 +6,7 @@ import { Event, Libp2pConnection as Connection } from '../../types'
 import { Libp2pNode } from '../peer/libp2pnode'
 import { Libp2pPeer } from '../peer'
 import { Server, ServerOptions } from './server'
+import { isTruthy } from '@ethereumjs/util'
 
 export interface Libp2pServerOptions extends ServerOptions {
   /* Multiaddrs to listen on */
@@ -135,7 +136,7 @@ export class Libp2pServer extends Server {
    */
   isBanned(peerId: string): boolean {
     const expireTime = this.banned.get(peerId)
-    if (expireTime && expireTime > Date.now()) {
+    if (isTruthy(expireTime) && expireTime > Date.now()) {
       return true
     }
     this.banned.delete(peerId)

--- a/packages/client/lib/net/server/rlpxserver.ts
+++ b/packages/client/lib/net/server/rlpxserver.ts
@@ -2,6 +2,7 @@ import { RLPx as Devp2pRLPx, Peer as Devp2pRLPxPeer, DPT as Devp2pDPT } from '@e
 import { RlpxPeer } from '../peer/rlpxpeer'
 import { Server, ServerOptions } from './server'
 import { Event } from '../../types'
+import { isFalsy, isTruthy } from '@ethereumjs/util'
 
 export interface RlpxServerOptions extends ServerOptions {
   /* List of supported clients */
@@ -84,7 +85,7 @@ export class RlpxServer extends Server {
    */
   getRlpxInfo() {
     // TODO: return undefined? note that this.rlpx might be undefined if called before initRlpx
-    if (!this.rlpx) {
+    if (isFalsy(this.rlpx)) {
       return {
         enode: undefined,
         id: undefined,
@@ -216,7 +217,7 @@ export class RlpxServer extends Server {
         resolve()
       })
 
-      if (this.config.port) {
+      if (isTruthy(this.config.port)) {
         this.dpt.bind(this.config.port, '0.0.0.0')
       }
     })
@@ -245,7 +246,7 @@ export class RlpxServer extends Server {
           protocols: Array.from(this.protocols),
           // @ts-ignore: Property 'server' does not exist on type 'Socket'.
           // TODO: check this error
-          inbound: !!rlpxPeer._socket.server,
+          inbound: isTruthy(rlpxPeer._socket?.server),
         })
         try {
           await peer.accept(rlpxPeer, this)
@@ -270,8 +271,8 @@ export class RlpxServer extends Server {
       })
 
       this.rlpx.on('peer:error', (rlpxPeer: any, error: Error) => {
-        const peerId = rlpxPeer && rlpxPeer.getId()
-        if (!peerId) {
+        const peerId = isTruthy(rlpxPeer) && rlpxPeer.getId()
+        if (isFalsy(peerId)) {
           return this.error(error)
         }
         this.error(error)
@@ -287,7 +288,7 @@ export class RlpxServer extends Server {
         resolve()
       })
 
-      if (this.config.port) {
+      if (isTruthy(this.config.port)) {
         this.rlpx.listen(this.config.port, '0.0.0.0')
       }
     })

--- a/packages/client/lib/net/server/server.ts
+++ b/packages/client/lib/net/server/server.ts
@@ -1,3 +1,4 @@
+import { isTruthy } from '@ethereumjs/util'
 import { Multiaddr } from 'multiaddr'
 import { Config } from '../../config'
 import { MultiaddrLike, KeyLike, DnsNetwork } from '../../types'
@@ -41,8 +42,8 @@ export class Server {
    */
   constructor(options: ServerOptions) {
     this.config = options.config
-    this.key = options.key ? parseKey(options.key) : this.config.key
-    this.bootnodes = options.bootnodes ? parseMultiaddrs(options.bootnodes) : []
+    this.key = isTruthy(options.key) ? parseKey(options.key) : this.config.key
+    this.bootnodes = isTruthy(options.bootnodes) ? parseMultiaddrs(options.bootnodes) : []
     this.dnsNetworks = options.dnsNetworks ?? []
     this.refreshInterval = options.refreshInterval ?? 30000
 

--- a/packages/client/lib/rpc/util/CLConnectionManager.ts
+++ b/packages/client/lib/rpc/util/CLConnectionManager.ts
@@ -9,6 +9,7 @@ import {
   ForkchoiceStateV1,
   PayloadStatusV1,
 } from '../modules/engine'
+import { isTruthy } from '@ethereumjs/util'
 
 export enum ConnectionStatus {
   Connected = 'connected',
@@ -79,11 +80,11 @@ export class CLConnectionManager {
       maximumFractionDigits: 1,
     })
 
-    if (this.config.chainCommon.gteHardfork(Hardfork.MergeForkIdTransition)) {
+    if (this.config.chainCommon.gteHardfork(Hardfork.MergeForkIdTransition) === true) {
       this.start()
     } else {
       this.config.events.on(Event.CHAIN_UPDATED, () => {
-        if (this.config.chainCommon.gteHardfork(Hardfork.MergeForkIdTransition)) {
+        if (this.config.chainCommon.gteHardfork(Hardfork.MergeForkIdTransition) === true) {
           this.start()
         }
       })
@@ -149,7 +150,7 @@ export class CLConnectionManager {
     if (update.headBlock) {
       msg += ` timestampDiff=${this.timeDiffStr(update.headBlock)}`
     }
-    if (update.error) {
+    if (isTruthy(update.error)) {
       msg += ` error=${update.error}`
     }
     return msg

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -1,5 +1,5 @@
 import { Block, BlockBuffer } from '@ethereumjs/block'
-import { KECCAK256_RLP, KECCAK256_RLP_ARRAY } from '@ethereumjs/util'
+import { isFalsy, KECCAK256_RLP, KECCAK256_RLP_ARRAY } from '@ethereumjs/util'
 import { Peer } from '../../net/peer'
 import { Job } from './types'
 import { BlockFetcherBase, JobTask, BlockFetcherOptions } from './blockfetcherbase'
@@ -40,14 +40,14 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
       max: count,
       reverse: this.reverse,
     })
-    if (!headersResult || headersResult[1].length === 0) {
+    if (isFalsy(headersResult) || headersResult[1].length === 0) {
       // Catch occasional null or empty responses
       this.debug(`Peer ${peerInfo} returned no headers for blocks=${blocksRange}`)
       return []
     }
     const headers = headersResult[1]
     const bodiesResult = await peer!.eth!.getBlockBodies({ hashes: headers.map((h) => h.hash()) })
-    if (!bodiesResult || bodiesResult[1].length === 0) {
+    if (isFalsy(bodiesResult) || bodiesResult[1].length === 0) {
       // Catch occasional null or empty responses
       this.debug(`Peer ${peerInfo} returned no bodies for blocks=${blocksRange}`)
       return []

--- a/packages/client/lib/sync/lightsync.ts
+++ b/packages/client/lib/sync/lightsync.ts
@@ -5,6 +5,7 @@ import { Synchronizer, SynchronizerOptions } from './sync'
 import { HeaderFetcher } from './fetcher'
 import { Event } from '../types'
 import type { BlockHeader } from '@ethereumjs/block'
+import { isFalsy } from '@ethereumjs/util'
 
 /**
  * Implements an ethereum light sync synchronizer
@@ -89,7 +90,7 @@ export class LightSynchronizer extends Synchronizer {
     if (!latest) return false
 
     const height = peer!.les!.status.headNum
-    if (!this.config.syncTargetHeight || this.config.syncTargetHeight < height) {
+    if (isFalsy(this.config.syncTargetHeight) || this.config.syncTargetHeight < height) {
       this.config.syncTargetHeight = height
       this.config.logger.info(`New sync target height=${height} hash=${short(latest.hash())}`)
     }
@@ -133,9 +134,10 @@ export class LightSynchronizer extends Synchronizer {
     }
     const first = headers[0].number
     const hash = short(headers[0].hash())
-    const baseFeeAdd = this.config.chainCommon.gteHardfork(Hardfork.London)
-      ? `baseFee=${headers[0].baseFeePerGas} `
-      : ''
+    const baseFeeAdd =
+      this.config.chainCommon.gteHardfork(Hardfork.London) === true
+        ? `baseFee=${headers[0].baseFeePerGas} `
+        : ''
     this.config.logger.info(
       `Imported headers count=${headers.length} number=${first} hash=${hash} ${baseFeeAdd}peers=${this.pool.size}`
     )

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -165,7 +165,7 @@ export class Skeleton extends MetaDBManager {
         const lastchain = this.status.progress.subchains[0]
         if (lastchain.head === headchain.tail - BigInt(1)) {
           const lasthead = await this.getBlock(lastchain.head)
-          if (lasthead?.hash().equals(head.header.parentHash)) {
+          if (lasthead?.hash().equals(head.header.parentHash) === true) {
             this.config.logger.debug(
               `Extended skeleton subchain with new head=${headchain.tail} tail=${lastchain.tail}`
             )
@@ -208,7 +208,7 @@ export class Skeleton extends MetaDBManager {
       // once more, ignore it instead of tearing down sync for a noop.
       if (lastchain.head === lastchain.tail) {
         const block = await this.getBlock(number)
-        if (block?.hash().equals(head.hash())) {
+        if (block?.hash().equals(head.hash()) === true) {
           return false
         }
       }
@@ -326,7 +326,7 @@ export class Skeleton extends MetaDBManager {
         if (
           (await this.getBlock(this.status.progress.subchains[1].head))
             ?.hash()
-            .equals(this.status.progress.subchains[0].next)
+            .equals(this.status.progress.subchains[0].next) === true
         ) {
           this.config.logger.debug(
             `Previous subchain merged head=${head} tail=${tail} next=${short(next)}`

--- a/packages/client/lib/util/index.ts
+++ b/packages/client/lib/util/index.ts
@@ -1,6 +1,7 @@
 /**
  * @module util
  */
+import { isFalsy } from '@ethereumjs/util'
 import { platform } from 'os'
 import { version as packageVersion } from '../../package.json'
 
@@ -8,7 +9,7 @@ export * from './parse'
 export * from './rpc'
 
 export function short(buf: Buffer | string): string {
-  if (!buf) return ''
+  if (isFalsy(buf)) return ''
   const bufStr = Buffer.isBuffer(buf) ? `0x${buf.toString('hex')}` : buf
   let str = bufStr.substring(0, 6) + '…'
   if (bufStr.length === 66) {

--- a/packages/client/lib/util/rpc.ts
+++ b/packages/client/lib/util/rpc.ts
@@ -7,6 +7,7 @@ import * as cors from 'cors'
 import { inspect } from 'util'
 import { RPCManager } from '../rpc'
 import { Logger } from '../logging'
+import { isTruthy } from '@ethereumjs/util'
 
 type IncomingMessage = Connect.IncomingMessage
 const algorithm: TAlgorithm = 'HS256'
@@ -43,7 +44,7 @@ export function inspectParams(params: any, shorten?: number) {
     colors: true,
     maxStringLength: 100,
   } as any)
-  if (shorten) {
+  if (isTruthy(shorten)) {
     inspected = inspected.replace(/\n/g, '').replace(/ {2}/g, ' ')
     if (inspected.length > shorten) {
       inspected = inspected.slice(0, shorten) + '...'
@@ -74,10 +75,10 @@ export function createRPCServer(
       msg = `${request.method}${batchAddOn} responded with:\n${inspectParams(response)}`
     } else {
       msg = `${request.method}${batchAddOn} responded with: `
-      if (response.result) {
+      if (isTruthy(response.result)) {
         msg += inspectParams(response, 125)
       }
-      if (response.error) {
+      if (isTruthy(response.error)) {
         msg += `error: ${response.error.message}`
       }
     }
@@ -127,7 +128,7 @@ export function createRPCServer(
       ]
       const ethEngineSubsetMethods: { [key: string]: Function } = {}
       for (const method of ethMethodsToBeIncluded) {
-        if (ethMethods[method]) ethEngineSubsetMethods[method] = ethMethods[method]
+        if (isTruthy(ethMethods[method])) ethEngineSubsetMethods[method] = ethMethods[method]
       }
       methods = { ...ethEngineSubsetMethods, ...manager.getMethods(true) }
       break
@@ -157,7 +158,7 @@ export function createRPCServerListener(opts: CreateRPCServerListenerOpts): Http
   const { server, withEngineMiddleware, rpcCors } = opts
 
   const app = Connect()
-  if (rpcCors) app.use(cors({ origin: rpcCors }))
+  if (isTruthy(rpcCors)) app.use(cors({ origin: rpcCors }))
   // GOSSIP_MAX_SIZE_BELLATRIX is proposed to be 10MiB
   app.use(jsonParser({ limit: '11mb' }))
 
@@ -193,7 +194,7 @@ export function createWsRPCServerListener(opts: CreateWSServerOpts): HttpServer 
     const app = Connect()
     // In case browser pre-flights the upgrade request with an options request
     // more likely in case of wss connection
-    if (rpcCors) app.use(cors({ origin: rpcCors }))
+    if (isTruthy(rpcCors)) app.use(cors({ origin: rpcCors }))
     httpServer = createServer(app)
   }
 

--- a/packages/client/test/cli/cli-libp2p.spec.ts
+++ b/packages/client/test/cli/cli-libp2p.spec.ts
@@ -27,7 +27,7 @@ tape('[CLI] rpc', (t) => {
     const hasEnded = false
 
     child.stdout.on('data', async (data) => {
-      const message = data.toString()
+      const message: string = data.toString()
 
       if (message.includes('transport=libp2p')) {
         st.pass('libp2p server started')
@@ -50,7 +50,7 @@ tape('[CLI] rpc', (t) => {
           ],
         ])
         child2.stdout.on('data', async (data) => {
-          const message = data.toString()
+          const message: string = data.toString()
           if (message.includes('Peer added')) {
             st.pass('connected to peer over libp2p')
             child2.kill('SIGINT')
@@ -62,13 +62,13 @@ tape('[CLI] rpc', (t) => {
     })
 
     child.stderr.on('data', (data) => {
-      const message = data.toString()
+      const message: string = data.toString()
       st.fail(`stderr: ${message}`)
       end(child, hasEnded, st)
     })
 
     child.on('close', (code) => {
-      if (code && code > 0) {
+      if (typeof code === 'number' && code > 0) {
         st.fail(`child process exited with code ${code}`)
         end(child, hasEnded, st)
       }

--- a/packages/client/test/cli/cli-rpc.spec.ts
+++ b/packages/client/test/cli/cli-rpc.spec.ts
@@ -21,7 +21,7 @@ tape('[CLI] rpc', (t) => {
     const hasEnded = false
 
     child.stdout.on('data', async (data) => {
-      const message = data.toString()
+      const message: string = data.toString()
       if (message.includes('http://')) {
         // if http endpoint startup message detected, call http endpoint with RPC method
         const client = Client.http({ port: 8545 })
@@ -42,13 +42,13 @@ tape('[CLI] rpc', (t) => {
     })
 
     child.stderr.on('data', (data) => {
-      const message = data.toString()
+      const message: string = data.toString()
       st.fail(`stderr: ${message}`)
       end(child, hasEnded, st)
     })
 
     child.on('close', (code) => {
-      if (code && code > 0) {
+      if (typeof code === 'number' && code > 0) {
         st.fail(`child process exited with code ${code}`)
         end(child, hasEnded, st)
       }
@@ -62,7 +62,7 @@ tape('[CLI] rpc', (t) => {
     const hasEnded = false
 
     child.stdout.on('data', async (data) => {
-      const message = data.toString()
+      const message: string = data.toString()
       if (message.includes('address=http://')) {
         st.fail('http endpoint should not be enabled')
       }
@@ -76,13 +76,13 @@ tape('[CLI] rpc', (t) => {
     })
 
     child.stderr.on('data', (data) => {
-      const message = data.toString()
+      const message: string = data.toString()
       st.fail(`stderr: ${message}`)
       end(child, hasEnded, st)
     })
 
     child.on('close', (code) => {
-      if (code && code > 0) {
+      if (typeof code === 'number' && code > 0) {
         st.fail(`child process exited with code ${code}`)
         end(child, hasEnded, st)
       }

--- a/packages/client/test/cli/cli-sync.spec.ts
+++ b/packages/client/test/cli/cli-sync.spec.ts
@@ -22,7 +22,7 @@ tape('[CLI] sync', (t) => {
     }
 
     child.stdout.on('data', (data) => {
-      const message = data.toString()
+      const message: string = data.toString()
 
       // log message for easier debugging
       // eslint-disable-next-line no-console
@@ -39,7 +39,7 @@ tape('[CLI] sync', (t) => {
     })
 
     child.stderr.on('data', (data) => {
-      const message = data.toString()
+      const message: string = data.toString()
       if (message.includes('Possible EventEmitter memory leak detected')) {
         // This is okay.
         return
@@ -49,7 +49,7 @@ tape('[CLI] sync', (t) => {
     })
 
     child.on('close', (code) => {
-      if (code && code > 0) {
+      if (typeof code === 'number' && code > 0) {
         st.fail(`child process exited with code ${code}`)
         end()
       }

--- a/packages/client/test/integration/merge.spec.ts
+++ b/packages/client/test/integration/merge.spec.ts
@@ -7,7 +7,7 @@ import {
   ConsensusAlgorithm,
   Hardfork,
 } from '@ethereumjs/common'
-import { Address } from '@ethereumjs/util'
+import { Address, isFalsy, isTruthy } from '@ethereumjs/util'
 import { Config } from '../../lib/config'
 import { Chain } from '../../lib/blockchain'
 import { FullEthereumService } from '../../lib/service'
@@ -141,7 +141,7 @@ tape('[Integration:Merge]', async (t) => {
     remoteService.config.events.on(Event.CHAIN_UPDATED, async () => {
       const { height, td } = remoteService.chain.headers
       if (td > targetTTD) {
-        if (!terminalHeight) {
+        if (isFalsy(terminalHeight)) {
           terminalHeight = height
         }
         t.equal(
@@ -155,7 +155,7 @@ tape('[Integration:Merge]', async (t) => {
         await destroy(remoteServer, remoteService)
         t.end()
       }
-      if (terminalHeight && terminalHeight < height) {
+      if (isTruthy(terminalHeight) && terminalHeight < height) {
         t.fail('chain should not exceed merge terminal block')
       }
     })

--- a/packages/client/test/integration/mocks/mockpeer.ts
+++ b/packages/client/test/integration/mocks/mockpeer.ts
@@ -63,7 +63,7 @@ export class MockPeer extends Peer {
     })
     await Promise.all(
       this.protocols.map(async (p) => {
-        if (!stream.protocols.includes(`${p.name}/${p.versions[0]}`)) return
+        if (!(stream.protocols as string[]).includes(`${p.name}/${p.versions[0]}`)) return
         await p.open()
         await this.bindProtocol(p, new MockSender(p.name, pushableFn, receiver))
       })

--- a/packages/client/test/integration/mocks/mockserver.ts
+++ b/packages/client/test/integration/mocks/mockserver.ts
@@ -1,3 +1,4 @@
+import { isTruthy } from '@ethereumjs/util'
 import { Server, ServerOptions } from '../../../lib/net/server'
 import { Event } from '../../../lib/types'
 import { MockPeer } from './mockpeer'
@@ -45,7 +46,7 @@ export class MockServer extends Server {
     // This wait is essential to clear out the pending setTimeout in the
     // createStream in ./network.ts
     await this.wait(20)
-    while (servers[this.location]) {
+    while (isTruthy(servers[this.location])) {
       await destroyServer(this.location)
     }
     await super.stop()
@@ -84,7 +85,7 @@ export class MockServer extends Server {
 
   disconnect(id: string) {
     const peer = this.peers[id]
-    if (peer) this.config.events.emit(Event.PEER_DISCONNECTED, peer)
+    if (isTruthy(peer)) this.config.events.emit(Event.PEER_DISCONNECTED, peer)
   }
 
   async wait(delay?: number) {

--- a/packages/client/test/integration/mocks/network.ts
+++ b/packages/client/test/integration/mocks/network.ts
@@ -1,3 +1,4 @@
+import { isFalsy, isTruthy } from '@ethereumjs/util'
 import { EventEmitter } from 'events'
 const DuplexPair = require('it-pair/duplex')
 
@@ -24,7 +25,7 @@ interface ServerDetails {
 export const servers: ServerDetails = {}
 
 export function createServer(location: string) {
-  if (servers[location]) {
+  if (isTruthy(servers[location])) {
     throw new Error(`Already running a server at ${location}`)
   }
   servers[location] = {
@@ -37,9 +38,9 @@ export function createServer(location: string) {
 }
 
 export function destroyStream(id: string, location: string) {
-  if (servers[location]) {
+  if (isTruthy(servers[location])) {
     const stream = servers[location].streams[id]
-    if (stream) {
+    if (isTruthy(stream)) {
       delete servers[location].streams[id]
     }
   }
@@ -56,7 +57,7 @@ export async function destroyServer(location: string) {
 }
 
 export function createStream(id: string, location: string, protocols: string[]) {
-  if (!servers[location]) {
+  if (isFalsy(servers[location])) {
     throw new Error(`There is no server at ${location}`)
   }
   const stream = Stream(protocols)

--- a/packages/client/test/logging.spec.ts
+++ b/packages/client/test/logging.spec.ts
@@ -1,3 +1,4 @@
+import { isTruthy } from '@ethereumjs/util'
 import * as tape from 'tape'
 import { getLogger } from '../lib/logging'
 
@@ -23,7 +24,7 @@ tape('[Logging]', (t) => {
   })
 
   t.test('should colorize key=value pairs', (st) => {
-    if (process.env.GITHUB_ACTION) {
+    if (isTruthy(process.env.GITHUB_ACTION)) {
       st.skip('no color functionality in ci')
       return st.end()
     }

--- a/packages/client/test/rpc/admin/nodeInfo.spec.ts
+++ b/packages/client/test/rpc/admin/nodeInfo.spec.ts
@@ -1,3 +1,4 @@
+import { isTruthy } from '@ethereumjs/util'
 import * as tape from 'tape'
 import { startRPC, createManager, createClient, params, baseRequest } from '../helpers'
 
@@ -11,7 +12,7 @@ tape(method, async (t) => {
 
   const expectRes = (res: any) => {
     const { result } = res.body
-    if (result) {
+    if (isTruthy(result)) {
       t.pass('admin_nodeInfo returns a value')
     } else {
       throw new Error('no return value')

--- a/packages/client/test/rpc/eth/getLogs.spec.ts
+++ b/packages/client/test/rpc/eth/getLogs.spec.ts
@@ -116,7 +116,7 @@ tape(`${method}: call with valid arguments`, async (t) => {
     const msg = 'should return the correct logs (filter by single address)'
     if (
       res.body.result.length === 10 &&
-      res.body.result.every((r: any) => r.address === contractAddr1.toString())
+      res.body.result.every((r: any) => r.address === contractAddr1.toString()) === true
     ) {
       t.pass(msg)
     } else {
@@ -132,7 +132,7 @@ tape(`${method}: call with valid arguments`, async (t) => {
     const msg = 'should return the correct logs (filter by multiple addresses)'
     if (
       res.body.result.length === 20 &&
-      res.body.result.every((r: any) => addresses.includes(r.address))
+      res.body.result.every((r: any) => addresses.includes(r.address)) === true
     ) {
       t.pass(msg)
     } else {

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -3,7 +3,7 @@ import { Server as RPCServer, HttpServer } from 'jayson/promise'
 import { BlockHeader } from '@ethereumjs/block'
 import { Blockchain } from '@ethereumjs/blockchain'
 import { Chain as ChainEnum, Common } from '@ethereumjs/common'
-import { Address } from '@ethereumjs/util'
+import { Address, isTruthy } from '@ethereumjs/util'
 import { RPCManager as Manager } from '../../lib/rpc'
 import { getLogger } from '../../lib/logging'
 import { Config } from '../../lib/config'
@@ -35,11 +35,11 @@ export function startRPC(
 ) {
   const { port, wsServer } = opts
   const server = new RPCServer(methods)
-  const httpServer = wsServer
+  const httpServer = isTruthy(wsServer)
     ? createWsRPCServerListener({ server, withEngineMiddleware })
     : createRPCServerListener({ server, withEngineMiddleware })
   if (!httpServer) throw Error('Could not create server')
-  if (port) httpServer.listen(port)
+  if (isTruthy(port)) httpServer.listen(port)
   return httpServer
 }
 
@@ -71,7 +71,7 @@ export function createClient(clientOpts: any = {}) {
   const clientConfig = { ...defaultClientConfig, ...clientOpts }
 
   chain.getTd = async (_hash: Buffer, _num: bigint) => BigInt(1000)
-  if (chain._headers) {
+  if (isTruthy(chain._headers)) {
     chain._headers.latest = BlockHeader.fromHeaderData({}, { common })
   }
 
@@ -98,8 +98,8 @@ export function createClient(clientOpts: any = {}) {
   }
 
   let execution
-  if (clientOpts.includeVM) {
-    const metaDB: any = clientOpts.enableMetaDB ? new MemoryLevel() : undefined
+  if (isTruthy(clientOpts.includeVM)) {
+    const metaDB: any = isTruthy(clientOpts.enableMetaDB) ? new MemoryLevel() : undefined
     execution = new VMExecution({ config, chain, metaDB })
   }
 
@@ -137,7 +137,7 @@ export function createClient(clientOpts: any = {}) {
     },
   }
 
-  if (clientOpts.includeVM) {
+  if (isTruthy(clientOpts.includeVM)) {
     client.services[0].txPool = new TxPool({ config, service: client.services[0] })
   }
 

--- a/packages/client/test/rpc/rpc.spec.ts
+++ b/packages/client/test/rpc/rpc.spec.ts
@@ -2,6 +2,7 @@ import * as tape from 'tape'
 import { encode, TAlgorithm } from 'jwt-simple'
 import { startRPC, closeRPC } from './helpers'
 import { METHOD_NOT_FOUND } from '../../lib/rpc/error-code'
+import { isFalsy } from '@ethereumjs/util'
 const request = require('supertest')
 
 const jwtSecret = Buffer.from(Array.from({ length: 32 }, () => Math.round(Math.random() * 255)))
@@ -128,7 +129,7 @@ tape('call JSON RPC with nonexistent method', (t) => {
     .set('Content-Type', 'application/json')
     .send(req)
     .expect((res: any) => {
-      if (!res.body.error) {
+      if (isFalsy(res.body.error)) {
         throw new Error('should return an error object')
       }
       if (res.body.error.code !== METHOD_NOT_FOUND) {
@@ -168,7 +169,7 @@ tape('call JSON-RPC auth protected server with unprotected method without token'
 tape('call JSON-RPC auth protected server with protected method without token', (t) => {
   const server = startRPC({}, undefined, {
     jwtSecret,
-    unlessFn: (req: any) => !req.body.method.includes('protected_'),
+    unlessFn: (req: any) => !(req.body.method as string).includes('protected_'),
   })
 
   const req = {
@@ -192,7 +193,7 @@ tape('call JSON-RPC auth protected server with protected method without token', 
 tape('call JSON-RPC auth protected server with protected method with token', (t) => {
   const server = startRPC({}, undefined, {
     jwtSecret,
-    unlessFn: (req: any) => !req.body.method.includes('protected_'),
+    unlessFn: (req: any) => !(req.body.method as string).includes('protected_'),
   })
 
   const req = {

--- a/packages/client/test/rpc/util.ts
+++ b/packages/client/test/rpc/util.ts
@@ -1,14 +1,18 @@
+import { isFalsy, isTruthy } from '@ethereumjs/util'
 import * as tape from 'tape'
 
-export function checkError(t: tape.Test, expectedCode: any, expectedMessage?: any) {
+export function checkError(t: tape.Test, expectedCode: number, expectedMessage?: string) {
   return (res: any) => {
-    if (!res.body.error) {
+    if (isFalsy(res.body.error)) {
       throw new Error('should return an error object')
     }
     if (res.body.error.code !== expectedCode) {
       throw new Error(`should have an error code ${expectedCode}, got ${res.body.error.code}`)
     }
-    if (expectedMessage && !res.body.error.message.includes(expectedMessage)) {
+    if (
+      isTruthy(expectedMessage) &&
+      !(res.body.error.message as string).includes(expectedMessage)
+    ) {
       throw new Error(
         `should have an error message "${expectedMessage}", got "${res.body.error.message}"`
       )

--- a/packages/client/test/rpc/util/CLConnectionManager.spec.ts
+++ b/packages/client/test/rpc/util/CLConnectionManager.spec.ts
@@ -76,10 +76,10 @@ tape('[CLConnectionManager]', (t) => {
     const config = new Config()
     const manager = new CLConnectionManager({ config: config })
     config.logger.on('data', (chunk) => {
-      if (chunk.message.includes('consensus forkchoice update head=0x67b9')) {
+      if ((chunk.message as string).includes('consensus forkchoice update head=0x67b9')) {
         st.pass('received last fork choice message')
       }
-      if (chunk.message.includes('consensus payload received number=55504')) {
+      if ((chunk.message as string).includes('consensus payload received number=55504')) {
         st.pass('received last payload message')
         manager.stop()
         config.logger.removeAllListeners()

--- a/packages/client/test/sync/lightsync.spec.ts
+++ b/packages/client/test/sync/lightsync.spec.ts
@@ -119,7 +119,7 @@ tape('[LightSynchronizer]', async (t) => {
       config.events.emit(Event.SYNC_FETCHED_HEADERS, [BlockHeader.fromHeaderData({})])
     )
     config.logger.on('data', async (data) => {
-      if (data.message.includes('Imported headers count=1')) {
+      if ((data.message as string).includes('Imported headers count=1')) {
         st.pass('successfully imported new header')
         config.logger.removeAllListeners()
         await sync.stop()
@@ -153,7 +153,7 @@ tape('[LightSynchronizer]', async (t) => {
       config.events.emit(Event.SYNC_FETCHED_HEADERS, [] as BlockHeader[])
     )
     config.logger.on('data', async (data) => {
-      if (data.message.includes('No headers fetched are applicable for import')) {
+      if ((data.message as string).includes('No headers fetched are applicable for import')) {
         st.pass('generated correct warning message when no headers received')
         config.logger.removeAllListeners()
         await sync.stop()

--- a/packages/client/test/sync/skeleton.spec.ts
+++ b/packages/client/test/sync/skeleton.spec.ts
@@ -269,7 +269,10 @@ tape('[Skeleton]', async (t) => {
           st.pass(`test ${testCaseIndex}: successfully passed`)
         }
       } catch (error: any) {
-        if (error.message.includes(testCase.err?.message)) {
+        if (
+          typeof testCase.err?.message === 'string' &&
+          (error.message as string).includes(testCase.err.message)
+        ) {
           st.pass(`test ${testCaseIndex}: passed with correct error`)
         } else {
           st.fail(`test ${testCaseIndex}: received wrong error`)

--- a/packages/client/test/util/rpc.spec.ts
+++ b/packages/client/test/util/rpc.spec.ts
@@ -9,6 +9,7 @@ import {
 import { EthereumClient } from '../../lib/client'
 import { Config } from '../../lib/config'
 import { METHOD_NOT_FOUND } from '../../lib/rpc/error-code'
+import { isTruthy } from '@ethereumjs/util'
 const request = require('supertest')
 
 tape('[Util/RPC]', (t) => {
@@ -40,7 +41,7 @@ tape('[Util/RPC]', (t) => {
         server.emit('response', req, []) // empty
         server.emit('response', [req], respBulk) // mismatch length
 
-        st.ok(httpServer && wsServer, 'should return http and ws servers')
+        st.ok(isTruthy(httpServer) && isTruthy(wsServer), 'should return http and ws servers')
       }
     }
     st.end()
@@ -80,7 +81,7 @@ tape('[Util/RPC/Engine eth methods]', async (t) => {
         .set('Content-Type', 'application/json')
         .send(req)
         .expect((res: any) => {
-          if (res.body.error && res.body.error.code === METHOD_NOT_FOUND) {
+          if (res.body.error?.code === METHOD_NOT_FOUND) {
             throw new Error(`should have an error code ${METHOD_NOT_FOUND}`)
           }
         })

--- a/packages/common/tests/hardforks.spec.ts
+++ b/packages/common/tests/hardforks.spec.ts
@@ -278,7 +278,7 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     for (const [chain, genesisHash] of chains) {
       c = new Common({ chain })
       for (const hf of c.hardforks()) {
-        if (hf.forkHash && hf.forkHash !== null) {
+        if (typeof hf.forkHash === 'string') {
           const msg = `Verify forkHash calculation for: ${Chain[chain]} -> ${hf.name}`
           st.equal(c._calcForkHash(hf.name, genesisHash), hf.forkHash, msg)
         }

--- a/packages/devp2p/examples/peer-communication-les.ts
+++ b/packages/devp2p/examples/peer-communication-les.ts
@@ -6,6 +6,7 @@ import { Block, BlockHeader } from '@ethereumjs/block'
 import ms from 'ms'
 import chalk from 'chalk'
 import { randomBytes } from 'crypto'
+import { isTruthy } from '@ethereumjs/util'
 
 const PRIVATE_KEY = randomBytes(32)
 
@@ -63,7 +64,9 @@ const rlpx = new devp2p.RLPx(PRIVATE_KEY, {
   remoteClientIdFilter: REMOTE_CLIENTID_FILTER,
 })
 
-rlpx.on('error', (err) => console.error(chalk.red(`RLPx error: ${err.stack || err}`)))
+rlpx.on('error', (err) =>
+  console.error(chalk.red(`RLPx error: ${isTruthy(err.stack) ? err.stack : err}`))
+)
 
 rlpx.on('peer:added', (peer) => {
   const addr = getPeerAddr(peer)
@@ -146,7 +149,7 @@ rlpx.on('peer:added', (peer) => {
 })
 
 rlpx.on('peer:removed', (peer, reasonCode, disconnectWe) => {
-  const who = disconnectWe ? 'we disconnect' : 'peer disconnect'
+  const who = isTruthy(disconnectWe) ? 'we disconnect' : 'peer disconnect'
   const total = rlpx.getPeers().length
   console.log(
     chalk.yellow(
@@ -168,7 +171,9 @@ rlpx.on('peer:error', (peer, err) => {
     return
   }
 
-  console.error(chalk.red(`Peer error (${getPeerAddr(peer)}): ${err.stack || err}`))
+  console.error(
+    chalk.red(`Peer error (${getPeerAddr(peer)}): ${isTruthy(err.stack) ? err.stack : err}`)
+  )
 })
 
 // uncomment, if you want accept incoming connections
@@ -177,7 +182,7 @@ rlpx.on('peer:error', (peer, err) => {
 
 for (const bootnode of BOOTNODES) {
   dpt.bootstrap(bootnode).catch((err) => {
-    console.error(chalk.bold.red(`DPT bootstrap error: ${err.stack || err}`))
+    console.error(chalk.bold.red(`DPT bootstrap error: ${isTruthy(err.stack) ? err.stack : err}`))
   })
 }
 
@@ -192,7 +197,7 @@ dpt.addPeer({ address: '127.0.0.1', udpPort: 30303, tcpPort: 30303 })
       udpPort: peer.tcpPort
     })
   })
-  .catch((err) => console.log(`error on connection to local node: ${err.stack || err}`)) */
+  .catch((err) => console.log(`error on connection to local node: ${isTruthy(err.stack) ? err.stack :  err}`)) */
 
 function onNewBlock(block: Block, peer: Peer) {
   const blockHashHex = block.hash().toString('hex')

--- a/packages/devp2p/examples/peer-communication.ts
+++ b/packages/devp2p/examples/peer-communication.ts
@@ -5,7 +5,7 @@ import chalk from 'chalk'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { TypedTransaction, TransactionFactory } from '@ethereumjs/tx'
 import { Block, BlockHeader } from '@ethereumjs/block'
-import { arrToBufArr } from '@ethereumjs/util'
+import { arrToBufArr, isTruthy } from '@ethereumjs/util'
 import { RLP } from 'rlp'
 import * as devp2p from '../src/index'
 import { ETH, Peer } from '../src/index'
@@ -68,7 +68,9 @@ const rlpx = new devp2p.RLPx(PRIVATE_KEY, {
   remoteClientIdFilter: REMOTE_CLIENTID_FILTER,
 })
 
-rlpx.on('error', (err) => console.error(chalk.red(`RLPx error: ${err.stack || err}`)))
+rlpx.on('error', (err) =>
+  console.error(chalk.red(`RLPx error: ${isTruthy(err.stack) ? err.stack : err}`))
+)
 
 rlpx.on('peer:added', (peer) => {
   const addr = getPeerAddr(peer)
@@ -286,7 +288,7 @@ rlpx.on('peer:added', (peer) => {
 })
 
 rlpx.on('peer:removed', (peer, reasonCode, disconnectWe) => {
-  const who = disconnectWe ? 'we disconnect' : 'peer disconnect'
+  const who = isTruthy(disconnectWe) ? 'we disconnect' : 'peer disconnect'
   const total = rlpx.getPeers().length
   console.log(
     chalk.yellow(
@@ -308,7 +310,9 @@ rlpx.on('peer:error', (peer, err) => {
     return
   }
 
-  console.error(chalk.red(`Peer error (${getPeerAddr(peer)}): ${err.stack || err}`))
+  console.error(
+    chalk.red(`Peer error (${getPeerAddr(peer)}): ${isTruthy(err.stack) ? err.stack : err}`)
+  )
 })
 
 // uncomment, if you want accept incoming connections
@@ -317,7 +321,7 @@ rlpx.on('peer:error', (peer, err) => {
 
 for (const bootnode of BOOTNODES) {
   dpt.bootstrap(bootnode).catch((err) => {
-    console.error(chalk.bold.red(`DPT bootstrap error: ${err.stack || err}`))
+    console.error(chalk.bold.red(`DPT bootstrap error: ${isTruthy(err.stack) ? err.stack : err}`))
   })
 }
 
@@ -332,7 +336,7 @@ dpt.addPeer({ address: '127.0.0.1', udpPort: 30303, tcpPort: 30303 })
       udpPort: peer.tcpPort
     })
   })
-  .catch((err) => console.log(`error on connection to local node: ${err.stack || err}`))
+  .catch((err) => console.log(`error on connection to local node: ${isTruthy(err.stack) ? err.stack : err}`))
 */
 
 const txCache = new LRUCache({ max: 1000 })

--- a/packages/devp2p/examples/simple.ts
+++ b/packages/devp2p/examples/simple.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import { Chain, Common } from '@ethereumjs/common'
 import { DPT } from '../src/index'
+import { isTruthy } from '@ethereumjs/util'
 
 const PRIVATE_KEY = 'd772e3d6a001a38064dd23964dd2836239fa0e6cec8b28972a87460a17210fe9'
 
@@ -23,7 +24,7 @@ const dpt = new DPT(Buffer.from(PRIVATE_KEY, 'hex'), {
 })
 
 /* eslint-disable no-console */
-dpt.on('error', (err) => console.error(chalk.red(err.stack || err)))
+dpt.on('error', (err) => console.error(chalk.red(isTruthy(err.stack) ? err.stack : err)))
 
 dpt.on('peer:added', (peer) => {
   const info = `(${peer.id.toString('hex')},${peer.address},${peer.udpPort},${peer.tcpPort})`
@@ -40,5 +41,7 @@ dpt.on('peer:removed', (peer) => {
 // dpt.bind(30303, '0.0.0.0')
 
 for (const bootnode of BOOTNODES) {
-  dpt.bootstrap(bootnode).catch((err) => console.error(chalk.bold.red(err.stack || err)))
+  dpt
+    .bootstrap(bootnode)
+    .catch((err) => console.error(chalk.bold.red(isTruthy(err.stack) ? err.stack : err)))
 }

--- a/packages/devp2p/src/dns/dns.ts
+++ b/packages/devp2p/src/dns/dns.ts
@@ -1,6 +1,7 @@
 import { PeerInfo } from '../dpt'
 import { ENR } from './enr'
 import { debug as createDebugLogger } from 'debug'
+import { isFalsy, isTruthy } from '@ethereumjs/util'
 
 let dns: any
 try {
@@ -34,7 +35,7 @@ export class DNS {
   constructor(options: DNSOptions = {}) {
     this._DNSTreeCache = {}
 
-    if (options.dnsServerAddress) {
+    if (isTruthy(options.dnsServerAddress)) {
       dns.setServers([options.dnsServerAddress])
     }
   }
@@ -173,8 +174,9 @@ export class DNS {
 
     const response = await dns.promises.resolve(location, 'TXT')
 
-    if (!response.length) throw new Error('Received empty result array while fetching TXT record')
-    if (!response[0].length) throw new Error('Received empty TXT record')
+    if (response.length === 0)
+      throw new Error('Received empty result array while fetching TXT record')
+    if (response[0].length === 0) throw new Error('Received empty TXT record')
     // Branch entries can be an array of strings of comma delimited subdomains, with
     // some subdomain strings split across the array elements
     // (e.g btw end of arr[0] and beginning of arr[1])
@@ -194,7 +196,7 @@ export class DNS {
    * @return {boolean}
    */
   private _isNewPeer(peer: PeerInfo | null, peers: PeerInfo[]): boolean {
-    if (!peer || !peer!.address) return false
+    if (isFalsy(peer) || isFalsy(peer.address)) return false
 
     for (const existingPeer of peers) {
       if (peer.address === existingPeer.address) {

--- a/packages/devp2p/src/dpt/kbucket.ts
+++ b/packages/devp2p/src/dpt/kbucket.ts
@@ -1,3 +1,4 @@
+import { isTruthy } from '@ethereumjs/util'
 import { EventEmitter } from 'events'
 import _KBucket = require('k-bucket')
 import { PeerInfo } from './dpt'
@@ -43,7 +44,7 @@ export class KBucket extends EventEmitter {
 
     const keys = []
     if (Buffer.isBuffer(obj.id)) keys.push(obj.id.toString('hex'))
-    if (obj.address && obj.tcpPort) keys.push(`${obj.address}:${obj.tcpPort}`)
+    if (isTruthy(obj.address) && isTruthy(obj.tcpPort)) keys.push(`${obj.address}:${obj.tcpPort}`)
     return keys
   }
 

--- a/packages/devp2p/src/dpt/server.ts
+++ b/packages/devp2p/src/dpt/server.ts
@@ -7,6 +7,7 @@ import { encode, decode } from './message'
 import { keccak256, pk2id, createDeferred, formatLogId, devp2pDebug } from '../util'
 import { DPT, PeerInfo } from './dpt'
 import { Socket as DgramSocket, RemoteInfo } from 'dgram'
+import { isTruthy } from '@ethereumjs/util'
 
 const DEBUG_BASE_NAME = 'dpt:server'
 const verbose = createDebugLogger('verbose').enabled
@@ -159,7 +160,7 @@ export class Server extends EventEmitter {
         }
       }, this._timeout)
     }
-    if (this._socket && peer.udpPort)
+    if (this._socket && isTruthy(peer.udpPort))
       this._socket.send(msg, 0, msg.length, peer.udpPort, peer.address)
     return msg.slice(0, 32) // message id
   }
@@ -199,12 +200,12 @@ export class Server extends EventEmitter {
       case 'pong': {
         let rkey = info.data.hash.toString('hex')
         const rkeyParity = this._parityRequestMap.get(rkey)
-        if (rkeyParity) {
+        if (isTruthy(rkeyParity)) {
           rkey = rkeyParity
           this._parityRequestMap.delete(rkeyParity)
         }
         const request = this._requests.get(rkey)
-        if (request) {
+        if (isTruthy(request)) {
           this._requests.delete(rkey)
           request.deferred.resolve({
             id: peerId,

--- a/packages/devp2p/src/protocol/les.ts
+++ b/packages/devp2p/src/protocol/les.ts
@@ -1,4 +1,4 @@
-import { arrToBufArr, bigIntToBuffer, bufArrToArr } from '@ethereumjs/util'
+import { arrToBufArr, bigIntToBuffer, bufArrToArr, isFalsy, isTruthy } from '@ethereumjs/util'
 import { RLP } from 'rlp'
 import ms = require('ms')
 import * as snappy from 'snappyjs'
@@ -131,18 +131,20 @@ export class LES extends Protocol {
     )}, `
     sStr += `HeadH:${status['headHash'].toString('hex')}, HeadN:${buffer2int(status['headNum'])}, `
     sStr += `GenH:${status['genesisHash'].toString('hex')}`
-    if (status['serveHeaders']) sStr += `, serveHeaders active`
-    if (status['serveChainSince']) sStr += `, ServeCS: ${buffer2int(status['serveChainSince'])}`
-    if (status['serveStateSince']) sStr += `, ServeSS: ${buffer2int(status['serveStateSince'])}`
-    if (status['txRelay']) sStr += `, txRelay active`
-    if (status['flowControl/BL']) sStr += `, flowControl/BL set`
-    if (status['flowControl/MRR']) sStr += `, flowControl/MRR set`
-    if (status['flowControl/MRC']) sStr += `, flowControl/MRC set`
-    if (status['forkID'])
+    if (isTruthy(status['serveHeaders'])) sStr += `, serveHeaders active`
+    if (isTruthy(status['serveChainSince']))
+      sStr += `, ServeCS: ${buffer2int(status['serveChainSince'])}`
+    if (isTruthy(status['serveStateSince']))
+      sStr += `, ServeSS: ${buffer2int(status['serveStateSince'])}`
+    if (isTruthy(status['txRelay'])) sStr += `, txRelay active`
+    if (isTruthy(status['flowControl/BL)'])) sStr += `, flowControl/BL set`
+    if (isTruthy(status['flowControl/MRR)'])) sStr += `, flowControl/MRR set`
+    if (isTruthy(status['flowControl/MRC)'])) sStr += `, flowControl/MRC set`
+    if (isTruthy(status['forkID']))
       sStr += `, forkID: [crc32: ${status['forkID'][0].toString('hex')}, nextFork: ${buffer2int(
         status['forkID'][1]
       )}]`
-    if (status['recentTxLookup'])
+    if (isTruthy(status['recentTxLookup']))
       sStr += `, recentTxLookup: ${buffer2int(status['recentTxLookup'])}`
     sStr += `]`
     return sStr
@@ -151,7 +153,7 @@ export class LES extends Protocol {
   sendStatus(status: LES.Status) {
     if (this._status !== null) return
 
-    if (!status.announceType) {
+    if (isFalsy(status.announceType)) {
       status['announceType'] = int2buffer(DEFAULT_ANNOUNCE_TYPE)
     }
     status['protocolVersion'] = int2buffer(this._version)
@@ -174,7 +176,11 @@ export class LES extends Protocol {
     let payload = Buffer.from(RLP.encode(bufArrToArr(statusList)))
 
     // Use snappy compression if peer supports DevP2P >=v5
-    if (this._peer._hello?.protocolVersion && this._peer._hello?.protocolVersion >= 5) {
+    if (
+      isTruthy(this._peer._hello) &&
+      isTruthy(this._peer._hello.protocolVersion) &&
+      this._peer._hello?.protocolVersion >= 5
+    ) {
       payload = snappy.compress(payload)
     }
 
@@ -237,7 +243,11 @@ export class LES extends Protocol {
     payload = Buffer.from(RLP.encode(payload))
 
     // Use snappy compression if peer supports DevP2P >=v5
-    if (this._peer._hello?.protocolVersion && this._peer._hello?.protocolVersion >= 5) {
+    if (
+      isTruthy(this._peer._hello) &&
+      isTruthy(this._peer._hello.protocolVersion) &&
+      this._peer._hello?.protocolVersion >= 5
+    ) {
       payload = snappy.compress(payload)
     }
 

--- a/packages/devp2p/src/protocol/protocol.ts
+++ b/packages/devp2p/src/protocol/protocol.ts
@@ -3,6 +3,7 @@ import { debug as createDebugLogger, Debugger } from 'debug'
 import { EventEmitter } from 'events'
 import { devp2pDebug } from '../util'
 import { Peer, DISCONNECT_REASONS } from '../rlpx/peer'
+import { isTruthy } from '@ethereumjs/util'
 
 export enum EthProtocol {
   ETH = 'eth',
@@ -63,7 +64,7 @@ export class Protocol extends EventEmitter {
 
     // Remote Peer IP logger
     const ip = this._peer._socket.remoteAddress
-    if (ip) {
+    if (isTruthy(ip)) {
       this.msgDebuggers[ip] = devp2pDebug.extend(ip)
     }
   }
@@ -76,7 +77,7 @@ export class Protocol extends EventEmitter {
    */
   _addFirstPeerDebugger() {
     const ip = this._peer._socket.remoteAddress
-    if (ip) {
+    if (isTruthy(ip)) {
       this.msgDebuggers[ip] = devp2pDebug.extend('FIRST_PEER')
       this._peer._addFirstPeerDebugger()
       this._firstPeer = ip
@@ -91,11 +92,11 @@ export class Protocol extends EventEmitter {
    */
   protected debug(messageName: string, msg: string) {
     this._debug(msg)
-    if (this.msgDebuggers[messageName]) {
+    if (isTruthy(this.msgDebuggers[messageName])) {
       this.msgDebuggers[messageName](msg)
     }
     const ip = this._peer._socket.remoteAddress
-    if (ip && this.msgDebuggers[ip]) {
+    if (isTruthy(ip) && isTruthy(this.msgDebuggers[ip])) {
       this.msgDebuggers[ip](msg)
     }
   }

--- a/packages/devp2p/src/rlpx/peer.ts
+++ b/packages/devp2p/src/rlpx/peer.ts
@@ -6,7 +6,7 @@ import * as snappy from 'snappyjs'
 import { debug as createDebugLogger, Debugger } from 'debug'
 import { devp2pDebug } from '../util'
 import { Common } from '@ethereumjs/common'
-import { arrToBufArr, bufArrToArr } from '@ethereumjs/util'
+import { arrToBufArr, bufArrToArr, isFalsy, isTruthy } from '@ethereumjs/util'
 import { RLP } from 'rlp'
 import { ETH, LES } from '../'
 import { int2buffer, buffer2int, formatLogData } from '../util'
@@ -136,7 +136,7 @@ export class Peer extends EventEmitter {
     this._socket.on('data', this._onSocketData.bind(this))
     this._socket.on('error', (err: Error) => this.emit('error', err))
     this._socket.once('close', this._onSocketClose.bind(this))
-    this._logger = this._socket.remoteAddress
+    this._logger = isTruthy(this._socket.remoteAddress)
       ? devp2pDebug.extend(this._socket.remoteAddress).extend(DEBUG_BASE_NAME)
       : devp2pDebug.extend(DEBUG_BASE_NAME)
     this._connected = false
@@ -163,7 +163,7 @@ export class Peer extends EventEmitter {
     this._logger(
       `Send auth (EIP8: ${this._EIP8}) to ${this._socket.remoteAddress}:${this._socket.remotePort}`
     )
-    if (this._EIP8) {
+    if (isTruthy(this._EIP8)) {
       const authEIP8 = this._eciesSession.createAuthEIP8()
       if (!authEIP8) return
       this._socket.write(authEIP8)
@@ -240,7 +240,7 @@ export class Peer extends EventEmitter {
         this._sendMessage(
           PREFIXES.HELLO,
           Buffer.from(RLP.encode(bufArrToArr(payload as unknown as Buffer[])))
-        )
+        ) === true
       ) {
         this._weHello = payload
       }
@@ -259,7 +259,7 @@ export class Peer extends EventEmitter {
     const debugMsg = `Send DISCONNECT to ${this._socket.remoteAddress}:${this._socket.remotePort} (reason: ${reasonName})`
     this.debug('DISCONNECT', debugMsg, reasonName)
     const data = Buffer.from(RLP.encode(reason))
-    if (!this._sendMessage(PREFIXES.DISCONNECT, data)) return
+    if (this._sendMessage(PREFIXES.DISCONNECT, data) !== true) return
 
     this._disconnectReason = reason
     this._disconnectWe = true
@@ -274,11 +274,15 @@ export class Peer extends EventEmitter {
     const debugMsg = `Send PING to ${this._socket.remoteAddress}:${this._socket.remotePort}`
     this.debug('PING', debugMsg)
     let data = Buffer.from(RLP.encode([]))
-    if (this._hello?.protocolVersion && this._hello.protocolVersion >= 5) {
+    if (
+      isTruthy(this._hello) &&
+      isTruthy(this._hello.protocolVersion) &&
+      this._hello.protocolVersion >= 5
+    ) {
       data = snappy.compress(data)
     }
 
-    if (!this._sendMessage(PREFIXES.PING, data)) return
+    if (this._sendMessage(PREFIXES.PING, data) !== true) return
 
     clearTimeout(this._pingTimeoutId!)
     this._pingTimeoutId = setTimeout(() => {
@@ -294,7 +298,11 @@ export class Peer extends EventEmitter {
     this.debug('PONG', debugMsg)
     let data = Buffer.from(RLP.encode([]))
 
-    if (this._hello?.protocolVersion && this._hello.protocolVersion >= 5) {
+    if (
+      isTruthy(this._hello) &&
+      isTruthy(this._hello.protocolVersion) &&
+      this._hello.protocolVersion >= 5
+    ) {
       data = snappy.compress(data)
     }
     this._sendMessage(PREFIXES.PONG, data)
@@ -372,7 +380,7 @@ export class Peer extends EventEmitter {
       return this.disconnect(DISCONNECT_REASONS.INVALID_IDENTITY)
     }
 
-    if (this._remoteClientIdFilter) {
+    if (isTruthy(this._remoteClientIdFilter)) {
       for (const filterStr of this._remoteClientIdFilter) {
         if (this._hello.clientId.toLowerCase().includes(filterStr.toLowerCase())) {
           return this.disconnect(DISCONNECT_REASONS.USELESS_PEER)
@@ -384,7 +392,7 @@ export class Peer extends EventEmitter {
     for (const item of this._hello.capabilities) {
       for (const obj of this._capabilities!) {
         if (obj.name !== item.name || obj.version !== item.version) continue
-        if (shared[obj.name] && shared[obj.name].version > obj.version) continue
+        if (isTruthy(shared[obj.name]) && shared[obj.name].version > obj.version) continue
         shared[obj.name] = obj
       }
     }
@@ -484,7 +492,7 @@ export class Peer extends EventEmitter {
     const parseData = this._socketData.slice(0, bytesCount)
     this._logger(`Received header ${this._socket.remoteAddress}:${this._socket.remotePort}`)
     const size = this._eciesSession.parseHeader(parseData)
-    if (!size) {
+    if (isFalsy(size)) {
       this._logger('invalid header size!')
       return
     }
@@ -544,7 +552,11 @@ export class Peer extends EventEmitter {
       // Use snappy uncompression if peer supports DevP2P >=v5
       let compressed = false
       const origPayload = payload
-      if (this._hello?.protocolVersion && this._hello?.protocolVersion >= 5) {
+      if (
+        isTruthy(this._hello) &&
+        isTruthy(this._hello.protocolVersion) &&
+        this._hello?.protocolVersion >= 5
+      ) {
         payload = snappy.uncompress(payload)
         compressed = true
       }
@@ -673,7 +685,7 @@ export class Peer extends EventEmitter {
    */
   _addFirstPeerDebugger() {
     const ip = this._socket.remoteAddress
-    if (ip) {
+    if (isTruthy(ip)) {
       this._logger = devp2pDebug.extend(ip).extend(`FIRST_PEER`).extend(DEBUG_BASE_NAME)
     }
   }
@@ -686,7 +698,7 @@ export class Peer extends EventEmitter {
    * @param disconnectReason Capitalized disconnect reason (e.g. 'TIMEOUT')
    */
   private debug(messageName: string, msg: string, disconnectReason?: string) {
-    if (disconnectReason) {
+    if (isTruthy(disconnectReason)) {
       this._logger.extend(messageName).extend(disconnectReason)(msg)
     } else {
       this._logger.extend(messageName)(msg)

--- a/packages/devp2p/src/rlpx/rlpx.ts
+++ b/packages/devp2p/src/rlpx/rlpx.ts
@@ -12,6 +12,7 @@ const { version: pVersion } = require('../../package.json')
 import { pk2id, createDeferred, formatLogId, buffer2int } from '../util'
 import { Peer, DISCONNECT_REASONS, Capabilities } from './peer'
 import { DPT, PeerInfo } from '../dpt'
+import { isFalsy, isTruthy } from '@ethereumjs/util'
 
 const DEBUG_BASE_NAME = 'rlpx'
 const verbose = createDebugLogger('verbose').enabled
@@ -73,7 +74,7 @@ export class RLPx extends EventEmitter {
     this._dpt = options.dpt ?? null
     if (this._dpt !== null) {
       this._dpt.on('peer:new', (peer: PeerInfo) => {
-        if (!peer.tcpPort) {
+        if (isFalsy(peer.tcpPort)) {
           this._dpt!.banPeer(peer, ms('5m'))
           this._debug(`banning peer with missing tcp port: ${peer.address}`)
           return
@@ -101,8 +102,9 @@ export class RLPx extends EventEmitter {
     this._server.once('close', () => this.emit('close'))
     this._server.on('error', (err) => this.emit('error', err))
     this._server.on('connection', (socket) => this._onConnect(socket, null))
-    this._debug = this._server.address()
-      ? devp2pDebug.extend(DEBUG_BASE_NAME).extend(this._server.address() as string)
+    const serverAddress = this._server.address()
+    this._debug = isTruthy(serverAddress)
+      ? devp2pDebug.extend(DEBUG_BASE_NAME).extend(serverAddress as string)
       : devp2pDebug.extend(DEBUG_BASE_NAME)
     this._peers = new Map()
     this._peersQueue = []
@@ -132,7 +134,7 @@ export class RLPx extends EventEmitter {
   }
 
   async connect(peer: PeerInfo) {
-    if (!peer.tcpPort || !peer.address) return
+    if (isFalsy(peer.tcpPort) || isFalsy(peer.address)) return
     this._isAliveCheck()
 
     if (!Buffer.isBuffer(peer.id)) throw new TypeError('Expected peer.id as Buffer')
@@ -187,7 +189,7 @@ export class RLPx extends EventEmitter {
   _connectToPeer(peer: PeerInfo) {
     this.connect(peer).catch((err) => {
       if (this._dpt === null) return
-      if (err.code === 'ECONNRESET' || err.toString().includes('Connection timeout')) {
+      if (err.code === 'ECONNRESET' || (err.toString() as string).includes('Connection timeout')) {
         this._dpt.banPeer(peer, ms('5m'))
       }
     })
@@ -242,14 +244,14 @@ export class RLPx extends EventEmitter {
     })
 
     peer.once('close', (reason, disconnectWe) => {
-      if (disconnectWe) {
+      if (isTruthy(disconnectWe)) {
         this._debug(
           `disconnect from ${socket.remoteAddress}:${socket.remotePort}, reason: ${DISCONNECT_REASONS[reason]}`,
           `disconnect`
         )
       }
 
-      if (!disconnectWe && reason === DISCONNECT_REASONS.TOO_MANY_PEERS) {
+      if (isFalsy(disconnectWe) && reason === DISCONNECT_REASONS.TOO_MANY_PEERS) {
         // hack
         if (this._getOpenQueueSlots() > 0) {
           this._peersQueue.push({

--- a/packages/devp2p/src/util.ts
+++ b/packages/devp2p/src/util.ts
@@ -1,4 +1,4 @@
-import { arrToBufArr } from '@ethereumjs/util'
+import { arrToBufArr, isTruthy } from '@ethereumjs/util'
 import { RLP } from 'rlp'
 import { utils } from 'ethereum-cryptography/secp256k1'
 import { publicKeyConvert } from 'ethereum-cryptography/secp256k1-compat'
@@ -75,7 +75,7 @@ export function assertEq(
     if (expected.equals(actual)) return
     fullMsg = `${msg}: ${expected.toString('hex')} / ${actual.toString('hex')}`
     const debugMsg = `[ERROR] ${fullMsg}`
-    if (messageName) {
+    if (isTruthy(messageName)) {
       debug(messageName, debugMsg)
     } else {
       debug(debugMsg)
@@ -85,7 +85,7 @@ export function assertEq(
 
   if (expected === actual) return
   fullMsg = `${msg}: ${expected} / ${actual}`
-  if (messageName) {
+  if (isTruthy(messageName)) {
     debug(messageName, fullMsg)
   } else {
     debug(fullMsg)

--- a/packages/devp2p/test/integration/util.ts
+++ b/packages/devp2p/test/integration/util.ts
@@ -1,7 +1,8 @@
 import * as test from 'tape'
-import { DPT, ETH, RLPx, genPrivateKey } from '../../src'
+import { Capabilities, DPT, ETH, RLPx, genPrivateKey } from '../../src'
 import { Chain, Common } from '@ethereumjs/common'
 import * as testdata from '../testdata.json'
+import { isTruthy } from '@ethereumjs/util'
 
 type Test = test.Test
 
@@ -66,11 +67,11 @@ export function destroyDPTs(dpts: DPT[]) {
 export function getTestRLPXs(
   numRLPXs: number,
   maxPeers: number = 10,
-  capabilities?: any,
+  capabilities?: Capabilities[],
   common?: Object | Common
 ) {
   const rlpxs = []
-  if (!capabilities) {
+  if (typeof capabilities === 'undefined') {
     capabilities = [ETH.eth66, ETH.eth65, ETH.eth64, ETH.eth63, ETH.eth62]
   }
   if (!common) {
@@ -123,13 +124,13 @@ export function twoPeerMsgExchange(
     protocol.sendStatus(opts.status0) // (1 ->)
 
     protocol.once('status', () => {
-      if (opts.onOnceStatus0) opts.onOnceStatus0(rlpxs, protocol)
+      if (isTruthy(opts.onOnceStatus0)) opts.onOnceStatus0(rlpxs, protocol)
     }) // (-> 2)
     protocol.on('message', async (code: any, payload: any) => {
-      if (opts.onOnMsg0) opts.onOnMsg0(rlpxs, protocol, code, payload)
+      if (isTruthy(opts.onOnMsg0)) opts.onOnMsg0(rlpxs, protocol, code, payload)
     })
     peer.on('error', (err: Error) => {
-      if (opts.onPeerError0) {
+      if (isTruthy(opts.onPeerError0)) {
         opts.onPeerError0(err, rlpxs)
       } else {
         t.fail(`Unexpected peer 0 error: ${err}`)
@@ -148,10 +149,10 @@ export function twoPeerMsgExchange(
           protocol.sendStatus(opts.status1) // (2 ->)
           break
       }
-      if (opts.onOnMsg1) opts.onOnMsg1(rlpxs, protocol, code, payload)
+      if (isTruthy(opts.onOnMsg1)) opts.onOnMsg1(rlpxs, protocol, code, payload)
     })
     peer.on('error', (err: any) => {
-      if (opts.onPeerError1) {
+      if (isTruthy(opts.onPeerError1)) {
         opts.onPeerError1(err, rlpxs)
       } else {
         t.fail(`Unexpected peer 1 error: ${err}`)

--- a/packages/devp2p/test/rlpx-ecies.ts
+++ b/packages/devp2p/test/rlpx-ecies.ts
@@ -10,7 +10,12 @@ type Test = test.Test
 
 declare module 'tape' {
   export interface Test {
-    context: any
+    context: {
+      a: ECIES
+      b: ECIES
+      h0?: { auth: Buffer; ack: Buffer }
+      h1?: { auth: Buffer; ack: Buffer }
+    }
   }
 }
 
@@ -59,7 +64,7 @@ test(
   randomBefore((t: Test) => {
     const message = Buffer.from('The Magic Words are Squeamish Ossifrage')
     const encrypted = t.context.a._encryptMessage(message)
-    const decrypted = t.context.b._decryptMessage(encrypted)
+    const decrypted = t.context.b._decryptMessage(encrypted as Buffer)
     t.same(message, decrypted, 'encryptMessage -> decryptMessage should lead to same')
     t.end()
   })
@@ -71,20 +76,21 @@ test(
     t.doesNotThrow(() => {
       const auth = t.context.a.createAuthNonEIP8()
       t.context.b._gotEIP8Auth = false
-      t.context.b.parseAuthPlain(auth)
+      t.context.b.parseAuthPlain(auth as Buffer)
     }, 'should not throw on auth creation/parsing')
 
     t.doesNotThrow(() => {
       t.context.b._gotEIP8Ack = false
       const ack = t.context.b.createAckOld()
-      t.context.a.parseAckPlain(ack)
+      t.context.a.parseAckPlain(ack as Buffer)
     }, 'should not throw on ack creation/parsing')
 
     const body = randomBytes(600)
-    const header = t.context.b.parseHeader(t.context.a.createHeader(body.length))
+
+    const header = t.context.b.parseHeader(t.context.a.createHeader(body.length) as Buffer)
     t.same(header, body.length, 'createHeader -> parseHeader should lead to same')
 
-    const parsedBody = t.context.b.parseBody(t.context.a.createBody(body))
+    const parsedBody = t.context.b.parseBody(t.context.a.createBody(body) as Buffer)
     t.same(parsedBody, body, 'createBody -> parseBody should lead to same')
 
     t.end()
@@ -97,13 +103,13 @@ test(
     t.doesNotThrow(() => {
       const auth = t.context.a.createAuthEIP8()
       t.context.b._gotEIP8Auth = true
-      t.context.b.parseAuthEIP8(auth)
+      t.context.b.parseAuthEIP8(auth as Buffer)
     }, 'should not throw on auth creation/parsing')
 
     t.doesNotThrow(() => {
       const ack = t.context.b.createAckEIP8()
       t.context.a._gotEIP8Ack = true
-      t.context.a.parseAckEIP8(ack)
+      t.context.a.parseAckEIP8(ack as Buffer)
     }, 'should not throw on ack creation/parsing')
 
     t.end()
@@ -115,13 +121,13 @@ test(
   testdataBefore((t: Test) => {
     t.doesNotThrow(() => {
       t.context.b._gotEIP8Auth = false
-      t.context.b.parseAuthPlain(t.context.h0.auth)
-      t.context.a._initMsg = t.context.h0.auth
+      t.context.b.parseAuthPlain(t.context.h0?.auth as Buffer)
+      t.context.a._initMsg = t.context.h0?.auth
     }, 'should not throw on auth parsing')
 
     t.doesNotThrow(() => {
       t.context.a._gotEIP8Ack = false
-      t.context.a.parseAckPlain(t.context.h0.ack)
+      t.context.a.parseAckPlain(t.context.h0?.ack as Buffer)
     }, 'should not throw on ack parsing')
 
     t.end()
@@ -133,12 +139,12 @@ test(
   testdataBefore((t: Test) => {
     t.doesNotThrow(() => {
       t.context.b._gotEIP8Auth = true
-      t.context.b.parseAuthEIP8(t.context.h1.auth)
-      t.context.a._initMsg = t.context.h1.auth
+      t.context.b.parseAuthEIP8(t.context.h1?.auth as Buffer)
+      t.context.a._initMsg = t.context.h1?.auth
     }, 'should not throw on auth parsing')
     t.doesNotThrow(() => {
       t.context.a._gotEIP8Ack = true
-      t.context.a.parseAckEIP8(t.context.h1.ack)
+      t.context.a.parseAckEIP8(t.context.h1?.ack as Buffer)
     }, 'should not throw on ack parsing')
 
     t.end()

--- a/packages/ethash/src/index.ts
+++ b/packages/ethash/src/index.ts
@@ -6,6 +6,8 @@ import {
   bufArrToArr,
   bufferToBigInt,
   setLengthLeft,
+  isTruthy,
+  isFalsy,
 } from '@ethereumjs/util'
 import { RLP } from 'rlp'
 import {
@@ -133,7 +135,7 @@ export class Miner {
         }, 0)
       })
 
-      if (solution) {
+      if (isTruthy(solution)) {
         return <Solution>solution
       }
     }
@@ -203,10 +205,10 @@ export class Ethash {
   }
 
   run(val: Buffer, nonce: Buffer, fullSize?: number) {
-    if (!fullSize && this.fullSize) {
+    if (isFalsy(fullSize) && isTruthy(this.fullSize)) {
       fullSize = this.fullSize
     }
-    if (!fullSize) {
+    if (isFalsy(fullSize)) {
       throw new Error('fullSize needed')
     }
     const n = Math.floor(fullSize / params.HASH_BYTES)

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -8,6 +8,8 @@ import {
   bigIntToBuffer,
   generateAddress,
   generateAddress2,
+  isFalsy,
+  isTruthy,
   KECCAK256_NULL,
   MAX_INTEGER,
   short,
@@ -43,7 +45,7 @@ const isBrowser = new Function('try {return this===window;}catch(e){ return fals
 let mcl: any
 let mclInitPromise: any
 
-if (!isBrowser()) {
+if (isBrowser() === false) {
   mcl = require('mcl-wasm')
   mclInitPromise = mcl.init(mcl.BLS12_381)
 }
@@ -280,7 +282,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
     this._precompiles = getActivePrecompiles(this._common, this._customPrecompiles)
 
     if (this._common.isActivatedEIP(2537)) {
-      if (isBrowser()) {
+      if (isBrowser() === true) {
         throw new Error('EIP-2537 is currently not supported in browsers')
       } else {
         this._mcl = mcl
@@ -288,7 +290,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
     }
 
     // Safeguard if "process" is not available (browser)
-    if (process !== undefined && process.env.DEBUG) {
+    if (typeof process?.env.DEBUG !== 'undefined') {
       this.DEBUG = true
     }
 
@@ -303,7 +305,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
     }
 
     if (this._common.isActivatedEIP(2537)) {
-      if (isBrowser()) {
+      if (isBrowser() === true) {
         throw new Error('EIP-2537 is currently not supported in browsers')
       } else {
         const mcl = this._mcl
@@ -360,7 +362,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
         debug(`Exit early on no code`)
       }
     }
-    if (errorMessage) {
+    if (isTruthy(errorMessage)) {
       exit = true
       if (this.DEBUG) {
         debug(`Exit early on value transfer overflowed`)
@@ -472,13 +474,13 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
     }
 
     let exit = false
-    if (!message.code || message.code.length === 0) {
+    if (isFalsy(message.code) || message.code.length === 0) {
       exit = true
       if (this.DEBUG) {
         debug(`Exit early on no code`)
       }
     }
-    if (errorMessage) {
+    if (isTruthy(errorMessage)) {
       exit = true
       if (this.DEBUG) {
         debug(`Exit early on value transfer overflowed`)
@@ -533,7 +535,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
         // Begin EOF1 contract code checks
         // EIP-3540 EOF1 header check
         const eof1CodeAnalysisResults = EOF.codeAnalysis(result.returnValue)
-        if (!eof1CodeAnalysisResults?.code) {
+        if (typeof eof1CodeAnalysisResults?.code === 'undefined') {
           result = {
             ...result,
             ...INVALID_EOF_RESULT(message.gasLimit),
@@ -582,7 +584,11 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
     }
 
     // Save code if a new contract was created
-    if (!result.exceptionError && result.returnValue && result.returnValue.toString() !== '') {
+    if (
+      !result.exceptionError &&
+      isTruthy(result.returnValue) &&
+      result.returnValue.toString() !== ''
+    ) {
       await this.eei.putContractCode(message.to, result.returnValue)
       if (this.DEBUG) {
         debug(`Code saved on new contract creation`)
@@ -686,7 +692,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
 
       const caller = opts.caller ?? Address.zero()
       const value = opts.value ?? BigInt(0)
-      if (opts.skipBalance) {
+      if (opts.skipBalance === true) {
         // if skipBalance, add `value` to caller balance to ensure sufficient funds
         const callerAccount = await this.eei.getAccount(caller)
         callerAccount.balance += value
@@ -711,7 +717,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
 
     await this._emit('beforeMessage', message)
 
-    if (!message.to && this._common.isActivatedEIP(2929)) {
+    if (!message.to && this._common.isActivatedEIP(2929) === true) {
       message.code = message.data
       this.eei.addWarmedAddress((await this._generateAddress(message)).buf)
     }

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -5,6 +5,8 @@ import {
   bigIntToHex,
   bufferToBigInt,
   intToHex,
+  isFalsy,
+  isTruthy,
   MAX_UINT64,
 } from '@ethereumjs/util'
 
@@ -398,7 +400,11 @@ export class Interpreter {
   useGas(amount: bigint, context?: string): void {
     this._runState.gasLeft -= amount
     if (this._evm.DEBUG) {
-      debugGas(`${context ? context + ': ' : ''}used ${amount} gas (-> ${this._runState.gasLeft})`)
+      debugGas(
+        `${typeof context === 'string' ? context + ': ' : ''}used ${amount} gas (-> ${
+          this._runState.gasLeft
+        })`
+      )
     }
     if (this._runState.gasLeft < BigInt(0)) {
       this._runState.gasLeft = BigInt(0)
@@ -414,7 +420,9 @@ export class Interpreter {
   refundGas(amount: bigint, context?: string): void {
     if (this._evm.DEBUG) {
       debugGas(
-        `${context ? context + ': ' : ''}refund ${amount} gas (-> ${this._runState.gasRefund})`
+        `${typeof context === 'string' ? context + ': ' : ''}refund ${amount} gas (-> ${
+          this._runState.gasRefund
+        })`
       )
     }
     this._runState.gasRefund += amount
@@ -428,7 +436,9 @@ export class Interpreter {
   subRefund(amount: bigint, context?: string): void {
     if (this._evm.DEBUG) {
       debugGas(
-        `${context ? context + ': ' : ''}sub gas refund ${amount} (-> ${this._runState.gasRefund})`
+        `${typeof context === 'string' ? context + ': ' : ''}sub gas refund ${amount} (-> ${
+          this._runState.gasRefund
+        })`
       )
     }
     this._runState.gasRefund -= amount
@@ -823,7 +833,7 @@ export class Interpreter {
 
     // Set return value
     if (
-      results.execResult.returnValue &&
+      isTruthy(results.execResult.returnValue) &&
       (!results.execResult.exceptionError ||
         results.execResult.exceptionError.error === ERROR.REVERT)
     ) {
@@ -940,7 +950,7 @@ export class Interpreter {
 
   async _selfDestruct(toAddress: Address): Promise<void> {
     // only add to refund if this is the first selfdestruct for the address
-    if (!this._result.selfdestruct[this._env.address.buf.toString('hex')]) {
+    if (isFalsy(this._result.selfdestruct[this._env.address.buf.toString('hex')])) {
       this.refundGas(this._common.param('gasPrices', 'selfdestructRefund'))
     }
 

--- a/packages/evm/src/opcodes/EIP2929.ts
+++ b/packages/evm/src/opcodes/EIP2929.ts
@@ -19,7 +19,7 @@ export function accessAddressEIP2929(
   chargeGas = true,
   isSelfdestructOrAuthcall = false
 ): bigint {
-  if (!common.isActivatedEIP(2929)) return BigInt(0)
+  if (common.isActivatedEIP(2929) === false) return BigInt(0)
 
   const eei = runState.eei
   const addressStr = address.buf
@@ -54,7 +54,7 @@ export function accessStorageEIP2929(
   isSstore: boolean,
   common: Common
 ): bigint {
-  if (!common.isActivatedEIP(2929)) return BigInt(0)
+  if (common.isActivatedEIP(2929) === false) return BigInt(0)
 
   const eei = runState.eei
   const address = runState.interpreter.getAddress().buf
@@ -87,7 +87,7 @@ export function adjustSstoreGasEIP2929(
   costName: string,
   common: Common
 ): bigint {
-  if (!common.isActivatedEIP(2929)) return defaultCost
+  if (common.isActivatedEIP(2929) === false) return defaultCost
 
   const eei = runState.eei
   const address = runState.interpreter.getAddress().buf

--- a/packages/evm/src/opcodes/codes.ts
+++ b/packages/evm/src/opcodes/codes.ts
@@ -3,6 +3,7 @@ import { CustomOpcode } from '../types'
 import { getFullname } from './util'
 import { AsyncDynamicGasHandler, dynamicGasHandlers, SyncDynamicGasHandler } from './gas'
 import { handlers, OpHandler } from './functions'
+import { isTruthy } from '@ethereumjs/util'
 
 export class Opcode {
   readonly code: number
@@ -373,7 +374,7 @@ export function getOpcodesForHF(common: Common, customOpcodes?: CustomOpcode[]):
         },
       }
       opcodeBuilder = { ...opcodeBuilder, ...entry }
-      if (code.gasFunction) {
+      if (isTruthy(code.gasFunction)) {
         dynamicGasHandlersCopy.set(code.opcode, code.gasFunction)
       }
       // logicFunction is never undefined

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -68,7 +68,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* BALANCE */
       0x31,
       async function (runState, gas, common): Promise<bigint> {
-        if (common.isActivatedEIP(2929)) {
+        if (common.isActivatedEIP(2929) === true) {
           const addressBigInt = runState.stack.peek()[0]
           const address = new Address(addressToBuffer(addressBigInt))
           gas += accessAddressEIP2929(runState, address, common)
@@ -106,7 +106,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* EXTCODESIZE */
       0x3b,
       async function (runState, gas, common): Promise<bigint> {
-        if (common.isActivatedEIP(2929)) {
+        if (common.isActivatedEIP(2929) === true) {
           const addressBigInt = runState.stack.peek()[0]
           const address = new Address(addressToBuffer(addressBigInt))
           gas += accessAddressEIP2929(runState, address, common)
@@ -122,7 +122,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         gas += subMemUsage(runState, memOffset, dataLength, common)
 
-        if (common.isActivatedEIP(2929)) {
+        if (common.isActivatedEIP(2929) === true) {
           const address = new Address(addressToBuffer(addressBigInt))
           gas += accessAddressEIP2929(runState, address, common)
         }
@@ -155,7 +155,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* EXTCODEHASH */
       0x3f,
       async function (runState, gas, common): Promise<bigint> {
-        if (common.isActivatedEIP(2929)) {
+        if (common.isActivatedEIP(2929) === true) {
           const addressBigInt = runState.stack.peek()[0]
           const address = new Address(addressToBuffer(addressBigInt))
           gas += accessAddressEIP2929(runState, address, common)
@@ -197,7 +197,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         const key = runState.stack.peek()[0]
         const keyBuf = setLengthLeft(bigIntToBuffer(key), 32)
 
-        if (common.isActivatedEIP(2929)) {
+        if (common.isActivatedEIP(2929) === true) {
           gas += accessStorageEIP2929(runState, keyBuf, false, common)
         }
         return gas
@@ -246,7 +246,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           gas += updateSstoreGas(runState, currentStorage, setLengthLeftStorage(value), common)
         }
 
-        if (common.isActivatedEIP(2929)) {
+        if (common.isActivatedEIP(2929) === true) {
           // We have to do this after the Istanbul (EIP2200) checks.
           // Otherwise, we might run out of gas, due to "sentry check" of 2300 gas,
           // if we deduct extra gas first.
@@ -287,7 +287,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         }
         const [_value, offset, length] = runState.stack.peek(3)
 
-        if (common.isActivatedEIP(2929)) {
+        if (common.isActivatedEIP(2929) === true) {
           gas += accessAddressEIP2929(runState, runState.interpreter.getAddress(), common, false)
         }
 
@@ -313,7 +313,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         }
         gas += subMemUsage(runState, inOffset, inLength, common)
         gas += subMemUsage(runState, outOffset, outLength, common)
-        if (common.isActivatedEIP(2929)) {
+        if (common.isActivatedEIP(2929) === true) {
           gas += accessAddressEIP2929(runState, toAddress, common)
         }
 
@@ -369,7 +369,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         gas += subMemUsage(runState, inOffset, inLength, common)
         gas += subMemUsage(runState, outOffset, outLength, common)
 
-        if (common.isActivatedEIP(2929)) {
+        if (common.isActivatedEIP(2929) === true) {
           const toAddress = new Address(addressToBuffer(toAddr))
           gas += accessAddressEIP2929(runState, toAddress, common)
         }
@@ -417,7 +417,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         gas += subMemUsage(runState, inOffset, inLength, common)
         gas += subMemUsage(runState, outOffset, outLength, common)
 
-        if (common.isActivatedEIP(2929)) {
+        if (common.isActivatedEIP(2929) === true) {
           const toAddress = new Address(addressToBuffer(toAddr))
           gas += accessAddressEIP2929(runState, toAddress, common)
         }
@@ -450,7 +450,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         gas += subMemUsage(runState, offset, length, common)
 
-        if (common.isActivatedEIP(2929)) {
+        if (common.isActivatedEIP(2929) === true) {
           gas += accessAddressEIP2929(runState, runState.interpreter.getAddress(), common, false)
         }
 
@@ -537,7 +537,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         gas += subMemUsage(runState, inOffset, inLength, common)
         gas += subMemUsage(runState, outOffset, outLength, common)
 
-        if (common.isActivatedEIP(2929)) {
+        if (common.isActivatedEIP(2929) === true) {
           const toAddress = new Address(addressToBuffer(toAddr))
           gas += accessAddressEIP2929(runState, toAddress, common)
         }
@@ -596,7 +596,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           gas += common.param('gasPrices', 'callNewAccount')
         }
 
-        if (common.isActivatedEIP(2929)) {
+        if (common.isActivatedEIP(2929) === true) {
           gas += accessAddressEIP2929(runState, selfdestructToAddress, common, true, true)
         }
         return gas

--- a/packages/evm/src/precompiles/01-ecrecover.ts
+++ b/packages/evm/src/precompiles/01-ecrecover.ts
@@ -4,12 +4,13 @@ import {
   ecrecover,
   publicToAddress,
   bufferToBigInt,
+  isFalsy,
 } from '@ethereumjs/util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
 
 export function precompile01(opts: PrecompileInput): ExecResult {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const gasUsed = opts._common.param('gasPrices', 'ecRecover')
 

--- a/packages/evm/src/precompiles/02-sha256.ts
+++ b/packages/evm/src/precompiles/02-sha256.ts
@@ -1,10 +1,10 @@
 import { sha256 } from 'ethereum-cryptography/sha256'
-import { toBuffer } from '@ethereumjs/util'
+import { isFalsy, toBuffer } from '@ethereumjs/util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
 
 export function precompile02(opts: PrecompileInput): ExecResult {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const data = opts.data
 

--- a/packages/evm/src/precompiles/03-ripemd160.ts
+++ b/packages/evm/src/precompiles/03-ripemd160.ts
@@ -1,10 +1,10 @@
 import { ripemd160 } from 'ethereum-cryptography/ripemd160'
-import { setLengthLeft, toBuffer } from '@ethereumjs/util'
+import { isFalsy, setLengthLeft, toBuffer } from '@ethereumjs/util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
 
 export function precompile03(opts: PrecompileInput): ExecResult {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const data = opts.data
 

--- a/packages/evm/src/precompiles/04-identity.ts
+++ b/packages/evm/src/precompiles/04-identity.ts
@@ -1,8 +1,9 @@
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
+import { isFalsy } from '@ethereumjs/util'
 
 export function precompile04(opts: PrecompileInput): ExecResult {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const data = opts.data
 

--- a/packages/evm/src/precompiles/05-modexp.ts
+++ b/packages/evm/src/precompiles/05-modexp.ts
@@ -1,4 +1,10 @@
-import { setLengthRight, setLengthLeft, bufferToBigInt, bigIntToBuffer } from '@ethereumjs/util'
+import {
+  setLengthRight,
+  setLengthLeft,
+  bufferToBigInt,
+  bigIntToBuffer,
+  isFalsy,
+} from '@ethereumjs/util'
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
 
@@ -74,7 +80,7 @@ export function expmod(a: bigint, power: bigint, modulo: bigint) {
 }
 
 export function precompile05(opts: PrecompileInput): ExecResult {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const data = opts.data
 

--- a/packages/evm/src/precompiles/06-ecadd.ts
+++ b/packages/evm/src/precompiles/06-ecadd.ts
@@ -1,9 +1,10 @@
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
+import { isFalsy } from '@ethereumjs/util'
 const bn128 = require('rustbn.js')
 
 export function precompile06(opts: PrecompileInput): ExecResult {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const inputData = opts.data
 

--- a/packages/evm/src/precompiles/07-ecmul.ts
+++ b/packages/evm/src/precompiles/07-ecmul.ts
@@ -1,9 +1,10 @@
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
+import { isFalsy } from '@ethereumjs/util'
 const bn128 = require('rustbn.js')
 
 export function precompile07(opts: PrecompileInput): ExecResult {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const inputData = opts.data
   const gasUsed = opts._common.param('gasPrices', 'ecMul')

--- a/packages/evm/src/precompiles/08-ecpairing.ts
+++ b/packages/evm/src/precompiles/08-ecpairing.ts
@@ -1,9 +1,10 @@
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
+import { isFalsy } from '@ethereumjs/util'
 const bn128 = require('rustbn.js')
 
 export function precompile08(opts: PrecompileInput): ExecResult {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const inputData = opts.data
   // no need to care about non-divisible-by-192, because bn128.pairing will properly fail in that case

--- a/packages/evm/src/precompiles/09-blake2f.ts
+++ b/packages/evm/src/precompiles/09-blake2f.ts
@@ -1,6 +1,7 @@
 import { PrecompileInput } from './types'
 import { OOGResult, ExecResult } from '../evm'
 import { EvmError, ERROR } from '../exceptions'
+import { isFalsy } from '@ethereumjs/util'
 
 // The following blake2 code has been taken from (license: Creative Commons CC0):
 // https://github.com/dcposch/blakejs/blob/410c640d0f08d3b26904c6d1ab3d81df3619d282/blake2b.js
@@ -154,7 +155,7 @@ export function F(h: Uint32Array, m: Uint32Array, t: Uint32Array, f: boolean, ro
 }
 
 export function precompile09(opts: PrecompileInput): ExecResult {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const data = opts.data
   if (data.length !== 213) {

--- a/packages/evm/src/precompiles/0a-bls12-g1add.ts
+++ b/packages/evm/src/precompiles/0a-bls12-g1add.ts
@@ -1,10 +1,11 @@
 import { PrecompileInput } from './types'
 import { EvmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, EvmError } from '../exceptions'
+import { isFalsy } from '@ethereumjs/util'
 const { BLS12_381_ToG1Point, BLS12_381_FromG1Point } = require('./util/bls12_381')
 
 export async function precompile0a(opts: PrecompileInput): Promise<ExecResult> {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const mcl = (<any>opts._EVM)._mcl!
 

--- a/packages/evm/src/precompiles/0b-bls12-g1mul.ts
+++ b/packages/evm/src/precompiles/0b-bls12-g1mul.ts
@@ -1,6 +1,7 @@
 import { PrecompileInput } from './types'
 import { EvmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, EvmError } from '../exceptions'
+import { isFalsy } from '@ethereumjs/util'
 const {
   BLS12_381_ToG1Point,
   BLS12_381_FromG1Point,
@@ -8,7 +9,7 @@ const {
 } = require('./util/bls12_381')
 
 export async function precompile0b(opts: PrecompileInput): Promise<ExecResult> {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const mcl = (<any>opts._EVM)._mcl!
 

--- a/packages/evm/src/precompiles/0c-bls12-g1multiexp.ts
+++ b/packages/evm/src/precompiles/0c-bls12-g1multiexp.ts
@@ -1,6 +1,7 @@
 import { PrecompileInput } from './types'
 import { EvmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, EvmError } from '../exceptions'
+import { isFalsy } from '@ethereumjs/util'
 const {
   BLS12_381_ToG1Point,
   BLS12_381_ToFrPoint,
@@ -8,7 +9,7 @@ const {
 } = require('./util/bls12_381')
 
 export async function precompile0c(opts: PrecompileInput): Promise<ExecResult> {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const mcl = (<any>opts._EVM)._mcl!
 

--- a/packages/evm/src/precompiles/0d-bls12-g2add.ts
+++ b/packages/evm/src/precompiles/0d-bls12-g2add.ts
@@ -1,10 +1,11 @@
 import { PrecompileInput } from './types'
 import { EvmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, EvmError } from '../exceptions'
+import { isFalsy } from '@ethereumjs/util'
 const { BLS12_381_ToG2Point, BLS12_381_FromG2Point } = require('./util/bls12_381')
 
 export async function precompile0d(opts: PrecompileInput): Promise<ExecResult> {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const mcl = (<any>opts._EVM)._mcl!
 

--- a/packages/evm/src/precompiles/0e-bls12-g2mul.ts
+++ b/packages/evm/src/precompiles/0e-bls12-g2mul.ts
@@ -1,6 +1,7 @@
 import { PrecompileInput } from './types'
 import { EvmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, EvmError } from '../exceptions'
+import { isFalsy } from '@ethereumjs/util'
 const {
   BLS12_381_ToG2Point,
   BLS12_381_FromG2Point,
@@ -8,7 +9,7 @@ const {
 } = require('./util/bls12_381')
 
 export async function precompile0e(opts: PrecompileInput): Promise<ExecResult> {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const mcl = (<any>opts._EVM)._mcl!
 

--- a/packages/evm/src/precompiles/0f-bls12-g2multiexp.ts
+++ b/packages/evm/src/precompiles/0f-bls12-g2multiexp.ts
@@ -2,6 +2,7 @@ import { PrecompileInput } from './types'
 import { EvmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, EvmError } from '../exceptions'
 import { gasDiscountPairs } from './util/bls12_381'
+import { isFalsy } from '@ethereumjs/util'
 const {
   BLS12_381_ToG2Point,
   BLS12_381_ToFrPoint,
@@ -9,7 +10,7 @@ const {
 } = require('./util/bls12_381')
 
 export async function precompile0f(opts: PrecompileInput): Promise<ExecResult> {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const mcl = (<any>opts._EVM)._mcl!
 

--- a/packages/evm/src/precompiles/10-bls12-pairing.ts
+++ b/packages/evm/src/precompiles/10-bls12-pairing.ts
@@ -1,6 +1,7 @@
 import { PrecompileInput } from './types'
 import { EvmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, EvmError } from '../exceptions'
+import { isFalsy } from '@ethereumjs/util'
 
 const { BLS12_381_ToG1Point, BLS12_381_ToG2Point } = require('./util/bls12_381')
 
@@ -8,7 +9,7 @@ const zeroBuffer = Buffer.alloc(32, 0)
 const oneBuffer = Buffer.concat([Buffer.alloc(31, 0), Buffer.from('01', 'hex')])
 
 export async function precompile10(opts: PrecompileInput): Promise<ExecResult> {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const mcl = (<any>opts._EVM)._mcl!
 
@@ -98,7 +99,7 @@ export async function precompile10(opts: PrecompileInput): Promise<ExecResult> {
 
   let returnValue
 
-  if (GT.isOne()) {
+  if (GT.isOne() === true) {
     returnValue = oneBuffer
   } else {
     returnValue = zeroBuffer

--- a/packages/evm/src/precompiles/11-bls12-map-fp-to-g1.ts
+++ b/packages/evm/src/precompiles/11-bls12-map-fp-to-g1.ts
@@ -1,10 +1,11 @@
 import { PrecompileInput } from './types'
 import { EvmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, EvmError } from '../exceptions'
+import { isFalsy } from '@ethereumjs/util'
 const { BLS12_381_ToFpPoint, BLS12_381_FromG1Point } = require('./util/bls12_381')
 
 export async function precompile11(opts: PrecompileInput): Promise<ExecResult> {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const mcl = (<any>opts._EVM)._mcl!
 

--- a/packages/evm/src/precompiles/12-bls12-map-fp2-to-g2.ts
+++ b/packages/evm/src/precompiles/12-bls12-map-fp2-to-g2.ts
@@ -1,10 +1,11 @@
 import { PrecompileInput } from './types'
 import { EvmErrorResult, ExecResult, OOGResult } from '../evm'
 import { ERROR, EvmError } from '../exceptions'
+import { isFalsy } from '@ethereumjs/util'
 const { BLS12_381_ToFp2Point, BLS12_381_FromG2Point } = require('./util/bls12_381')
 
 export async function precompile12(opts: PrecompileInput): Promise<ExecResult> {
-  if (!opts.data) throw new Error('opts.data missing but required')
+  if (isFalsy(opts.data)) throw new Error('opts.data missing but required')
 
   const mcl = (<any>opts._EVM)._mcl!
 

--- a/packages/evm/src/precompiles/index.ts
+++ b/packages/evm/src/precompiles/index.ts
@@ -1,4 +1,4 @@
-import { Address } from '@ethereumjs/util'
+import { Address, isTruthy } from '@ethereumjs/util'
 import { Common, Hardfork } from '@ethereumjs/common'
 import { PrecompileInput, PrecompileFunc } from './types'
 import { precompile01 } from './01-ecrecover'
@@ -146,7 +146,7 @@ const precompileAvailability: PrecompileAvailability = {
 
 function getPrecompile(address: Address, common: Common): PrecompileFunc {
   const addr = address.buf.toString('hex')
-  if (precompiles[addr]) {
+  if (isTruthy(precompiles[addr])) {
     const availability = precompileAvailability[addr]
     if (
       (availability.type == PrecompileAvailabilityCheck.Hardfork &&
@@ -190,7 +190,7 @@ function getActivePrecompiles(
     }
     const address = new Address(Buffer.from(addressString, 'hex'))
     const precompileFunc = getPrecompile(address, common)
-    if (precompileFunc) {
+    if (isTruthy(precompileFunc)) {
       precompileMap.set(addressString, precompileFunc)
     }
   }

--- a/packages/evm/src/precompiles/util/bls12_381.ts
+++ b/packages/evm/src/precompiles/util/bls12_381.ts
@@ -163,12 +163,12 @@ function BLS12_381_ToG1Point(input: Buffer, mcl: any): any {
   G1.setY(Fp_Y)
   G1.setZ(One)
 
-  if (!G1.isValidOrder()) {
+  if (G1.isValidOrder() === false) {
     throw new EvmError(ERROR.BLS_12_381_POINT_NOT_ON_CURVE)
   }
 
   // Check if these coordinates are actually on the curve.
-  if (!G1.isValid()) {
+  if (G1.isValid() === false) {
     throw new EvmError(ERROR.BLS_12_381_POINT_NOT_ON_CURVE)
   }
 
@@ -237,11 +237,11 @@ function BLS12_381_ToG2Point(input: Buffer, mcl: any): any {
   mclPoint.setY(Fp2Y)
   mclPoint.setZ(Fp2One)
 
-  if (!mclPoint.isValidOrder()) {
+  if (mclPoint.isValidOrder() === false) {
     throw new EvmError(ERROR.BLS_12_381_POINT_NOT_ON_CURVE)
   }
 
-  if (!mclPoint.isValid()) {
+  if (mclPoint.isValid() === false) {
     throw new EvmError(ERROR.BLS_12_381_POINT_NOT_ON_CURVE)
   }
 

--- a/packages/evm/tests/precompiles/hardfork.spec.ts
+++ b/packages/evm/tests/precompiles/hardfork.spec.ts
@@ -1,5 +1,5 @@
 import * as tape from 'tape'
-import { Address } from '@ethereumjs/util'
+import { Address, isFalsy } from '@ethereumjs/util'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { EVM } from '../../src'
 import { getActivePrecompiles } from '../../src/precompiles'
@@ -35,7 +35,7 @@ tape('Precompiles: hardfork availability', (t) => {
     // Check if ECPAIR is available in future hard forks.
     const commonPetersburg = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Petersburg })
     ECPAIRING = getActivePrecompiles(commonPetersburg).get(ECPAIR_AddressStr)!
-    if (!ECPAIRING) {
+    if (isFalsy(ECPAIRING)) {
       st.fail('ECPAIRING is not available in petersburg while it should be available')
     } else {
       st.pass('ECPAIRING available in petersburg')

--- a/packages/evm/tests/runCode.spec.ts
+++ b/packages/evm/tests/runCode.spec.ts
@@ -1,6 +1,7 @@
 import * as tape from 'tape'
 import { getEEI } from './utils'
 import { EVM } from '../src'
+import { isFalsy, isTruthy } from '@ethereumjs/util'
 
 const STOP = '00'
 const JUMP = '56'
@@ -43,13 +44,13 @@ tape('VM.runCode: initial program counter', async (t) => {
       err = e
     }
 
-    if (testData.error) {
-      err = err ? err.message : 'no error thrown'
+    if (isTruthy(testData.error)) {
+      err = isTruthy(err) ? err.message : 'no error thrown'
       t.equal(err, testData.error, 'error message should match')
       err = false
     }
 
-    t.assert(!err)
+    t.assert(isFalsy(err))
   }
 })
 

--- a/packages/evm/tests/utils.ts
+++ b/packages/evm/tests/utils.ts
@@ -1,7 +1,7 @@
 import { Blockchain } from '../../blockchain/src'
 import { Chain, Common } from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
-import { Account } from '@ethereumjs/util'
+import { Account, isTruthy } from '@ethereumjs/util'
 import path from 'path'
 import { EEI } from '../../vm/src/eei/eei'
 
@@ -21,9 +21,9 @@ export function createAccount(nonce = BigInt(0), balance = BigInt(0xfff384)) {
  * Checks if in a karma test runner.
  * @returns boolean whether running in karma
  */
-export function isRunningInKarma(): Boolean {
+export function isRunningInKarma(): boolean {
   // eslint-disable-next-line no-undef
-  return typeof (<any>globalThis).window !== 'undefined' && (<any>globalThis).window.__karma__
+  return isTruthy((<any>globalThis).window?.__karma__)
 }
 
 /**

--- a/packages/rlp/src/index.ts
+++ b/packages/rlp/src/index.ts
@@ -74,7 +74,7 @@ function encodeLength(len: number, offset: number): Uint8Array {
 export function decode(input: Input, stream?: false): Uint8Array | NestedUint8Array
 export function decode(input: Input, stream?: true): Decoded
 export function decode(input: Input, stream = false): Uint8Array | NestedUint8Array | Decoded {
-  if (!input || (input as any).length === 0) {
+  if (typeof input === 'undefined' || input === null || (input as any).length === 0) {
     return Uint8Array.from([])
   }
 

--- a/packages/rlp/test/dataTypes.spec.ts
+++ b/packages/rlp/test/dataTypes.spec.ts
@@ -27,7 +27,7 @@ tape('invalid RLPs', (t) => {
         RLP.decode(input)
         st.ok(false)
       } catch (e: any) {
-        if (msg) {
+        if (typeof msg !== 'undefined') {
           st.deepEqual(e.message, msg)
         } else {
           // FIXME: check for exception name

--- a/packages/statemanager/src/baseStateManager.ts
+++ b/packages/statemanager/src/baseStateManager.ts
@@ -43,7 +43,7 @@ export abstract class BaseStateManager {
     this._common = common
 
     // Safeguard if "process" is not available (browser)
-    if (process !== undefined && process.env.DEBUG) {
+    if (typeof process?.env.DEBUG !== 'undefined') {
       this.DEBUG = true
     }
     this._debug = createDebugLogger('statemanager:statemanager')

--- a/packages/statemanager/src/stateManager.ts
+++ b/packages/statemanager/src/stateManager.ts
@@ -12,6 +12,8 @@ import {
   KECCAK256_RLP,
   setLengthLeft,
   short,
+  isFalsy,
+  isTruthy,
 } from '@ethereumjs/util'
 import { Common } from '@ethereumjs/common'
 import { RLP } from 'rlp'
@@ -176,7 +178,7 @@ export class DefaultStateManager extends BaseStateManager implements StateManage
     // from storage cache
     const addressHex = address.buf.toString('hex')
     let storageTrie = this._storageTries[addressHex]
-    if (!storageTrie) {
+    if (isFalsy(storageTrie)) {
       // lookup from state
       storageTrie = await this._lookupStorageTrie(address)
     }
@@ -251,7 +253,7 @@ export class DefaultStateManager extends BaseStateManager implements StateManage
     value = unpadBuffer(value)
 
     await this._modifyContractStorage(address, async (storageTrie, done) => {
-      if (value && value.length) {
+      if (isTruthy(value) && value.length) {
         // format input
         const encodedValue = Buffer.from(RLP.encode(Uint8Array.from(value)))
         if (this.DEBUG) {
@@ -496,7 +498,7 @@ export class DefaultStateManager extends BaseStateManager implements StateManage
    */
   async accountExists(address: Address): Promise<boolean> {
     const account = this._cache.lookup(address)
-    if (account && !(account as any).virtual && !this._cache.keyIsDeleted(address)) {
+    if (account && isFalsy((account as any).virtual) && !this._cache.keyIsDeleted(address)) {
       return true
     }
     if (await this._trie.get(address.buf)) {

--- a/packages/trie/src/db/level.ts
+++ b/packages/trie/src/db/level.ts
@@ -1,4 +1,5 @@
 // eslint-disable-next-line implicit-dependencies/no-implicit
+import { isTruthy } from '@ethereumjs/util'
 import { AbstractLevel } from 'abstract-level'
 import { MemoryLevel } from 'memory-level'
 import { BatchDBOp, DB } from '../types'
@@ -31,7 +32,7 @@ export class LevelDB implements DB {
     try {
       value = await this._leveldb.get(key, ENCODING_OPTS)
     } catch (error: any) {
-      if (error.notFound) {
+      if (isTruthy(error.notFound)) {
         // not found, returning null
       } else {
         throw error

--- a/packages/trie/src/trie/secure.ts
+++ b/packages/trie/src/trie/secure.ts
@@ -1,6 +1,7 @@
 import { keccak256 } from 'ethereum-cryptography/keccak'
 import { CheckpointTrie } from './checkpoint'
 import { Proof } from '../types'
+import { isFalsy } from '@ethereumjs/util'
 
 /**
  * You can create a secure Trie where the keys are automatically hashed
@@ -29,7 +30,7 @@ export class SecureTrie extends CheckpointTrie {
    * @param value
    */
   async put(key: Buffer, val: Buffer): Promise<void> {
-    if (!val || val.toString() === '') {
+    if (isFalsy(val) || val.toString() === '') {
       await this.del(key)
     } else {
       const hash = Buffer.from(keccak256(key))

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -1,6 +1,6 @@
 import Semaphore from 'semaphore-async-await'
 import { keccak256 } from 'ethereum-cryptography/keccak'
-import { KECCAK256_RLP } from '@ethereumjs/util'
+import { isFalsy, isTruthy, KECCAK256_RLP } from '@ethereumjs/util'
 import { DB, BatchDBOp, PutBatch, TrieNode, Nibbles, EmbeddedNode } from '../types'
 import { LevelDB } from '../db'
 import { TrieReadStream as ReadStream } from '../util/readStream'
@@ -52,7 +52,7 @@ export class Trie {
    * Sets the current root of the `trie`
    */
   set root(value: Buffer) {
-    if (!value) {
+    if (isFalsy(value)) {
       value = this.EMPTY_TRIE_ROOT
     }
     if (value.length !== 32) throw new Error('Invalid root length. Roots are 32 bytes')
@@ -113,7 +113,7 @@ export class Trie {
    */
   async put(key: Buffer, value: Buffer): Promise<void> {
     // If value is empty, delete
-    if (!value || value.toString() === '') {
+    if (isFalsy(value) || value.toString() === '') {
       return await this.del(key)
     }
 
@@ -375,9 +375,9 @@ export class Trie {
       stack: TrieNode[]
     ) => {
       // branchNode is the node ON the branch node not THE branch node
-      if (!parentNode || parentNode instanceof BranchNode) {
+      if (isFalsy(parentNode) || parentNode instanceof BranchNode) {
         // branch->?
-        if (parentNode) {
+        if (isTruthy(parentNode)) {
           stack.push(parentNode)
         }
 
@@ -425,7 +425,7 @@ export class Trie {
     }
 
     let lastNode = stack.pop() as TrieNode
-    if (!lastNode) throw new Error('missing last node')
+    if (isFalsy(lastNode)) throw new Error('missing last node')
     let parentNode = stack.pop()
     const opStack: BatchDBOp[] = []
 
@@ -583,7 +583,7 @@ export class Trie {
   async batch(ops: BatchDBOp[]): Promise<void> {
     for (const op of ops) {
       if (op.type === 'put') {
-        if (!op.value) {
+        if (isFalsy(op.value)) {
           throw new Error('Invalid batch db operation')
         }
         await this.put(op.key, op.value)
@@ -609,7 +609,7 @@ export class Trie {
 
     if (!trie) {
       trie = new Trie()
-      if (opStack[0]) {
+      if (isTruthy(opStack[0])) {
         trie.root = opStack[0].key
       }
     }

--- a/packages/trie/test/official.spec.ts
+++ b/packages/trie/test/official.spec.ts
@@ -1,3 +1,4 @@
+import { isTruthy } from '@ethereumjs/util'
 import * as tape from 'tape'
 import { CheckpointTrie, LevelDB } from '../src'
 
@@ -11,9 +12,9 @@ tape('official tests', async function (t) {
     const expect = jsonTests[testName].root
     for (const input of inputs) {
       for (let i = 0; i < 2; i++) {
-        if (input[i] && input[i].slice(0, 2) === '0x') {
+        if (isTruthy(input[i]) && input[i].slice(0, 2) === '0x') {
           input[i] = Buffer.from(input[i].slice(2), 'hex')
-        } else if (input[i] && typeof input[i] === 'string') {
+        } else if (isTruthy(input[i]) && typeof input[i] === 'string') {
           input[i] = Buffer.from(input[i])
         }
         await trie.put(Buffer.from(input[0]), input[1])
@@ -40,7 +41,7 @@ tape('official tests any order', async function (t) {
         key = Buffer.from(key.slice(2), 'hex')
       }
 
-      if (val && val.slice(0, 2) === '0x') {
+      if (isTruthy(val) && val.slice(0, 2) === '0x') {
         val = Buffer.from(val.slice(2), 'hex')
       }
 

--- a/packages/trie/test/trie/secure.spec.ts
+++ b/packages/trie/test/trie/secure.spec.ts
@@ -1,3 +1,4 @@
+import { isTruthy } from '@ethereumjs/util'
 import * as tape from 'tape'
 import { LevelDB, SecureTrie } from '../../src'
 
@@ -38,7 +39,7 @@ tape('SecureTrie', function (t) {
 
     it.test('empty values', async function (t) {
       for (const row of jsonTests.emptyValues.in) {
-        const val = row[1] ? Buffer.from(row[1]) : (null as unknown as Buffer)
+        const val = isTruthy(row[1]) ? Buffer.from(row[1]) : (null as unknown as Buffer)
         await trie.put(Buffer.from(row[0]), val)
       }
       t.equal('0x' + trie.root.toString('hex'), jsonTests.emptyValues.root)
@@ -48,7 +49,7 @@ tape('SecureTrie', function (t) {
     it.test('branchingTests', async function (t) {
       trie = new SecureTrie({ db: new LevelDB() })
       for (const row of jsonTests.branchingTests.in) {
-        const val = row[1] ? Buffer.from(row[1]) : (null as unknown as Buffer)
+        const val = isTruthy(row[1]) ? Buffer.from(row[1]) : (null as unknown as Buffer)
         await trie.put(Buffer.from(row[0]), val)
       }
       t.equal('0x' + trie.root.toString('hex'), jsonTests.branchingTests.root)
@@ -58,7 +59,7 @@ tape('SecureTrie', function (t) {
     it.test('jeff', async function (t) {
       for (const row of jsonTests.jeff.in) {
         let val = row[1]
-        if (val) {
+        if (isTruthy(val)) {
           val = Buffer.from(row[1].slice(2), 'hex')
         }
         await trie.put(Buffer.from(row[0].slice(2), 'hex'), val)

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -1,4 +1,5 @@
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { isTruthy } from '@ethereumjs/util'
 import {
   Address,
   BigIntLike,
@@ -359,7 +360,7 @@ export abstract class BaseTransaction<TransactionObject> {
    */
   protected _getCommon(common?: Common, chainId?: BigIntLike) {
     // Chain ID provided
-    if (chainId) {
+    if (isTruthy(chainId)) {
       const chainIdBigInt = bufferToBigInt(toBuffer(chainId))
       if (common) {
         if (common.chainId() !== chainIdBigInt) {

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -150,7 +150,7 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMarketEIP155
     this.common = this._getCommon(opts.common, chainId)
     this.chainId = this.common.chainId()
 
-    if (!this.common.isActivatedEIP(1559)) {
+    if (this.common.isActivatedEIP(1559) === false) {
       throw new Error('EIP-1559 not enabled on Common')
     }
     this.activeCapabilities = this.activeCapabilities.concat([1559, 2718, 2930])

--- a/packages/tx/src/util.ts
+++ b/packages/tx/src/util.ts
@@ -18,7 +18,7 @@ export class AccessLists {
   public static getAccessListData(accessList: AccessListBuffer | AccessList) {
     let AccessListJSON
     let bufferAccessList
-    if (accessList && isAccessList(accessList)) {
+    if (isAccessList(accessList)) {
       AccessListJSON = accessList
       const newAccessList: AccessListBuffer = []
 

--- a/packages/tx/test/base.spec.ts
+++ b/packages/tx/test/base.spec.ts
@@ -16,6 +16,7 @@ import {
   SECP256K1_ORDER,
   bufferToBigInt,
 } from '@ethereumjs/util'
+import { isTruthy } from '@ethereumjs/util'
 
 tape('[BaseTransaction]', function (t) {
   // EIP-2930 is not enabled in Common by default (2021-03-06)
@@ -274,7 +275,7 @@ tape('[BaseTransaction]', function (t) {
     for (const txType of txTypes) {
       txType.txs.forEach(function (tx: any, i: number) {
         const { privateKey } = txType.fixtures[i]
-        if (privateKey) {
+        if (isTruthy(privateKey)) {
           st.ok(tx.sign(Buffer.from(privateKey, 'hex')), `${txType.name}: should sign tx`)
         }
 
@@ -316,7 +317,7 @@ tape('[BaseTransaction]', function (t) {
     for (const txType of txTypes) {
       txType.txs.forEach(function (tx: any, i: number) {
         const { privateKey, sendersAddress } = txType.fixtures[i]
-        if (privateKey) {
+        if (isTruthy(privateKey)) {
           const signedTx = tx.sign(Buffer.from(privateKey, 'hex'))
           st.equal(
             signedTx.getSenderAddress().toString(),
@@ -333,7 +334,7 @@ tape('[BaseTransaction]', function (t) {
     for (const txType of txTypes) {
       txType.txs.forEach(function (tx: any, i: number) {
         const { privateKey } = txType.fixtures[i]
-        if (privateKey) {
+        if (isTruthy(privateKey)) {
           const signedTx = tx.sign(Buffer.from(privateKey, 'hex'))
           const txPubKey = signedTx.getSenderPublicKey()
           const pubKeyFromPriv = privateToPublic(Buffer.from(privateKey, 'hex'))
@@ -355,7 +356,7 @@ tape('[BaseTransaction]', function (t) {
       for (const txType of txTypes) {
         txType.txs.forEach(function (tx: any, i: number) {
           const { privateKey } = txType.fixtures[i]
-          if (privateKey) {
+          if (isTruthy(privateKey)) {
             let signedTx = tx.sign(Buffer.from(privateKey, 'hex'))
             signedTx = JSON.parse(JSON.stringify(signedTx)) // deep clone
             ;(signedTx as any).s = SECP256K1_ORDER + BigInt(1)
@@ -373,7 +374,7 @@ tape('[BaseTransaction]', function (t) {
     for (const txType of txTypes) {
       txType.txs.forEach(function (tx: any, i: number) {
         const { privateKey } = txType.fixtures[i]
-        if (privateKey) {
+        if (isTruthy(privateKey)) {
           const signedTx = tx.sign(Buffer.from(privateKey, 'hex'))
           st.ok(signedTx.verifySignature(), `${txType.name}: should verify signing it`)
         }

--- a/packages/tx/test/index.ts
+++ b/packages/tx/test/index.ts
@@ -1,19 +1,20 @@
+import { isTruthy } from '@ethereumjs/util'
 import * as minimist from 'minimist'
 
 const argv = minimist(process.argv.slice(2))
 
-if (argv.b) {
+if (isTruthy(argv.b)) {
   require('./base.spec')
-} else if (argv.l) {
+} else if (isTruthy(argv.l)) {
   require('./legacy.spec')
-} else if (argv.e) {
+} else if (isTruthy(argv.e)) {
   require('./typedTxsAndEIP2930.spec')
   require('./eip1559.spec')
-} else if (argv.t) {
+} else if (isTruthy(argv.t)) {
   require('./transactionRunner')
-} else if (argv.f) {
+} else if (isTruthy(argv.f)) {
   require('./transactionFactory.spec')
-} else if (argv.a) {
+} else if (isTruthy(argv.a)) {
   // All manual API tests
   require('./base.spec')
   require('./legacy.spec')

--- a/packages/tx/test/testLoader.ts
+++ b/packages/tx/test/testLoader.ts
@@ -20,7 +20,7 @@ export const DEFAULT_TESTS_PATH = path.resolve('../ethereum-tests')
 export async function getTests(
   onFile: Function,
   fileFilter: RegExp | string[] = /.json$/,
-  skipPredicate: Function = falsePredicate,
+  skipPredicate: (...args: any[]) => boolean = falsePredicate,
   directory: string,
   excludeDir: RegExp | string[] = []
 ): Promise<string[]> {
@@ -52,7 +52,7 @@ export async function getTests(
       const testsByName = JSON.parse(content)
       const testNames = Object.keys(testsByName)
       for (const testName of testNames) {
-        if (!skipPredicate(testName, testsByName[testName])) {
+        if (skipPredicate(testName, testsByName[testName]) === false) {
           await onFile(parsedFileName, subDir, testName, testsByName[testName])
         }
       }

--- a/packages/tx/test/transactionRunner.ts
+++ b/packages/tx/test/transactionRunner.ts
@@ -5,6 +5,7 @@ import { Common } from '@ethereumjs/common'
 import { TransactionFactory } from '../src'
 import { ForkName, ForkNamesMap, OfficialTransactionTestData } from './types'
 import { getTests } from './testLoader'
+import { isTruthy } from '@ethereumjs/util'
 
 const argv = minimist(process.argv.slice(2))
 const file: string | undefined = argv.file
@@ -42,7 +43,7 @@ const EIPs: any = {
 }
 
 tape('TransactionTests', async (t) => {
-  const fileFilterRegex = file ? new RegExp(file + '[^\\w]') : undefined
+  const fileFilterRegex = isTruthy(file) ? new RegExp(file + '[^\\w]') : undefined
   await getTests(
     (
       _filename: string,
@@ -56,14 +57,14 @@ tape('TransactionTests', async (t) => {
             continue
           }
           const forkTestData = testData.result[forkName]
-          const shouldBeInvalid = !!forkTestData.exception
+          const shouldBeInvalid = isTruthy(forkTestData.exception)
 
           try {
             const rawTx = toBuffer(testData.txbytes)
             const hardfork = forkNameMap[forkName]
             const common = new Common({ chain: 1, hardfork })
             const activateEIPs = EIPs[forkName]
-            if (activateEIPs) {
+            if (isTruthy(activateEIPs)) {
               common.setEIPs(activateEIPs)
             }
             const tx = TransactionFactory.fromSerializedData(rawTx, { common })
@@ -73,7 +74,7 @@ tape('TransactionTests', async (t) => {
             const senderIsCorrect = forkTestData.sender === sender
             const hashIsCorrect = forkTestData.hash?.slice(2) === hash
 
-            const hashAndSenderAreCorrect = forkTestData && senderIsCorrect && hashIsCorrect
+            const hashAndSenderAreCorrect = senderIsCorrect && hashIsCorrect
             if (shouldBeInvalid) {
               st.assert(!txIsValid, `Transaction should be invalid on ${forkName}`)
             } else {

--- a/packages/util/src/account.ts
+++ b/packages/util/src/account.ts
@@ -14,7 +14,7 @@ import {
   zeros,
 } from './bytes'
 import { assertIsString, assertIsHexString, assertIsBuffer } from './helpers'
-import { BigIntLike, BufferLike } from './types'
+import { BigIntLike, BufferLike, isTruthy } from './types'
 
 const _0n = BigInt(0)
 
@@ -35,10 +35,10 @@ export class Account {
     const { nonce, balance, stateRoot, codeHash } = accountData
 
     return new Account(
-      nonce ? bufferToBigInt(toBuffer(nonce)) : undefined,
-      balance ? bufferToBigInt(toBuffer(balance)) : undefined,
-      stateRoot ? toBuffer(stateRoot) : undefined,
-      codeHash ? toBuffer(codeHash) : undefined
+      isTruthy(nonce) ? bufferToBigInt(toBuffer(nonce)) : undefined,
+      isTruthy(balance) ? bufferToBigInt(toBuffer(balance)) : undefined,
+      isTruthy(stateRoot) ? toBuffer(stateRoot) : undefined,
+      isTruthy(codeHash) ? toBuffer(codeHash) : undefined
     )
   }
 
@@ -155,7 +155,7 @@ export const toChecksumAddress = function (
   const address = stripHexPrefix(hexAddress).toLowerCase()
 
   let prefix = ''
-  if (eip1191ChainId) {
+  if (isTruthy(eip1191ChainId)) {
     const chainId = bufferToBigInt(toBuffer(eip1191ChainId))
     prefix = chainId.toString() + '0x'
   }

--- a/packages/util/src/internal.ts
+++ b/packages/util/src/internal.ts
@@ -102,7 +102,7 @@ export function arrayContainsArray(
     )
   }
 
-  return subset[some ? 'some' : 'every']((value) => superset.indexOf(value) >= 0)
+  return subset[some === true ? 'some' : 'every']((value) => superset.indexOf(value) >= 0)
 }
 
 /**
@@ -182,7 +182,7 @@ export function getKeys(params: Record<string, string>[], key: string, allowEmpt
 
   for (let i = 0; i < params.length; i++) {
     let value = params[i][key]
-    if (allowEmpty && !value) {
+    if (allowEmpty === true && !value) {
       value = ''
     } else if (typeof value !== 'string') {
       throw new Error(`invalid abi - expected type 'string', received ${typeof value}`)
@@ -203,7 +203,7 @@ export function getKeys(params: Record<string, string>[], key: string, allowEmpt
 export function isHexString(value: string, length?: number): boolean {
   if (typeof value !== 'string' || !value.match(/^0x[0-9A-Fa-f]*$/)) return false
 
-  if (length && value.length !== 2 + 2 * length) return false
+  if (typeof length !== 'undefined' && length > 0 && value.length !== 2 + 2 * length) return false
 
   return true
 }

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -118,3 +118,35 @@ export function toType<T extends TypeOutput>(
       throw new Error('unknown outputType')
   }
 }
+
+type Falsy = false | '' | 0 | null | undefined | 0n
+
+/**
+ * Returns true if a value is falsy
+ *
+ * @param value - Value to check for falseness
+ *
+ * @deprecated This helper function should only be used temporarily until the monorepo types are explicit enough
+ */
+export function isFalsy(value: unknown): value is Falsy {
+  return !!(
+    value === false ||
+    value === '' ||
+    value === 0 ||
+    Number.isNaN(value) ||
+    value === null ||
+    typeof value === 'undefined' ||
+    value === BigInt(0)
+  )
+}
+
+/**
+ * Returns true if a value is truthy
+ *
+ * @param value - Value to check for truthiness
+ *
+ * @deprecated This helper function should only be used temporarily until the monorepo types are explicit enough
+ */
+export function isTruthy<T>(value: T | Falsy): value is T {
+  return !isFalsy(value)
+}

--- a/packages/util/test/types.spec.ts
+++ b/packages/util/test/types.spec.ts
@@ -9,6 +9,8 @@ import {
   bigIntToHex,
   bigIntToBuffer,
   bufferToBigInt,
+  isFalsy,
+  isTruthy,
 } from '../src'
 
 tape('toType', function (t) {
@@ -132,5 +134,37 @@ tape('toType', function (t) {
       }, /^Error: A string must be provided with a 0x-prefix, given: 1$/)
       st.end()
     })
+  })
+})
+
+tape('isFalsy and isTruthy', function (t) {
+  const falsyValues = [false, '', 0, NaN, null, undefined, BigInt(0)]
+  const truthyValues = [true, 'test', -1, 1, BigInt(1), [], {}]
+  t.test('isFalsy should return true for all falsy values', function (st) {
+    falsyValues.forEach((falsyValue) => {
+      st.ok(isFalsy(falsyValue) === true)
+    })
+    st.end()
+  })
+
+  t.test('isFalsy should return false for truthy values', function (st) {
+    truthyValues.forEach((truthyValue) => {
+      st.ok(isFalsy(truthyValue) === false)
+    })
+    st.end()
+  })
+
+  t.test('isTruthy should return false for all falsy values', function (st) {
+    falsyValues.forEach((falsyValue) => {
+      st.ok(isTruthy(falsyValue) === false)
+    })
+    st.end()
+  })
+
+  t.test('isTruthy should return true for truthy values', function (st) {
+    truthyValues.forEach((truthyValue) => {
+      st.ok(isTruthy(truthyValue) === true)
+    })
+    st.end()
   })
 })

--- a/packages/vm/src/bloom/index.ts
+++ b/packages/vm/src/bloom/index.ts
@@ -1,5 +1,5 @@
 import { keccak256 } from 'ethereum-cryptography/keccak'
-import { zeros } from '@ethereumjs/util'
+import { isTruthy, zeros } from '@ethereumjs/util'
 
 const BYTE_SIZE = 256
 
@@ -67,7 +67,7 @@ export class Bloom {
    * Bitwise or blooms together.
    */
   or(bloom: Bloom) {
-    if (bloom) {
+    if (isTruthy(bloom)) {
       for (let i = 0; i <= BYTE_SIZE; i++) {
         this.bitvector[i] = this.bitvector[i] | bloom.bitvector[i]
       }

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -1,4 +1,4 @@
-import { Address, toBuffer, toType, TypeOutput } from '@ethereumjs/util'
+import { Address, isTruthy, toBuffer, toType, TypeOutput } from '@ethereumjs/util'
 import { Trie } from '@ethereumjs/trie'
 import { RLP } from 'rlp'
 import { Block, HeaderData } from '@ethereumjs/block'
@@ -39,7 +39,10 @@ export class BlockBuilder {
       gasLimit: opts.headerData?.gasLimit ?? opts.parentBlock.header.gasLimit,
     }
 
-    if (this.vm._common.isActivatedEIP(1559) && this.headerData.baseFeePerGas === undefined) {
+    if (
+      this.vm._common.isActivatedEIP(1559) === true &&
+      typeof this.headerData.baseFeePerGas === 'undefined'
+    ) {
       this.headerData.baseFeePerGas = opts.parentBlock.header.calcNextBaseFee()
     }
   }
@@ -98,7 +101,7 @@ export class BlockBuilder {
   private async rewardMiner() {
     const minerReward = this.vm._common.param('pow', 'minerReward')
     const reward = calculateMinerReward(minerReward, 0)
-    const coinbase = this.headerData.coinbase
+    const coinbase = isTruthy(this.headerData.coinbase)
       ? new Address(toBuffer(this.headerData.coinbase))
       : Address.zero()
     await rewardAccount(this.vm.eei, coinbase, reward)
@@ -198,7 +201,7 @@ export class BlockBuilder {
     const blockData = { header: headerData, transactions: this.transactions }
     const block = Block.fromBlockData(blockData, blockOpts)
 
-    if (this.blockOpts.putBlockIntoBlockchain) {
+    if (this.blockOpts.putBlockIntoBlockchain === true) {
       await this.vm.blockchain.putBlock(block)
     }
 

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -1,4 +1,4 @@
-import { Account, Address, toType, TypeOutput } from '@ethereumjs/util'
+import { Account, Address, isTruthy, toType, TypeOutput } from '@ethereumjs/util'
 import { Blockchain } from '@ethereumjs/blockchain'
 import { Chain, Common } from '@ethereumjs/common'
 import { StateManager, DefaultStateManager } from '@ethereumjs/statemanager'
@@ -129,7 +129,7 @@ export class VM extends AsyncEventEmitter<VMEvents> {
     this._hardforkByTD = toType(opts.hardforkByTD, TypeOutput.BigInt)
 
     // Safeguard if "process" is not available (browser)
-    if (process !== undefined && process.env.DEBUG) {
+    if (typeof process?.env.DEBUG !== 'undefined') {
       this.DEBUG = true
     }
 
@@ -143,12 +143,12 @@ export class VM extends AsyncEventEmitter<VMEvents> {
     await (this.blockchain as any)._init()
 
     if (!this._opts.stateManager) {
-      if (this._opts.activateGenesisState) {
+      if (this._opts.activateGenesisState === true) {
         await this.eei.generateCanonicalGenesis(this.blockchain.genesisState())
       }
     }
 
-    if (this._opts.activatePrecompiles && !this._opts.stateManager) {
+    if (this._opts.activatePrecompiles === true && typeof this._opts.stateManager === 'undefined') {
       await this.eei.checkpoint()
       // put 1 wei in each of the precompiles in order to make the accounts non-empty and thus not have them deduct `callNewAccount` gas.
       for (const [addressStr] of getActivePrecompiles(this._common)) {
@@ -224,7 +224,7 @@ export class VM extends AsyncEventEmitter<VMEvents> {
       evm: evmCopy,
       eei: eeiCopy,
       hardforkByBlockNumber: this._hardforkByBlockNumber ? true : undefined,
-      hardforkByTD: this._hardforkByTD ? this._hardforkByTD : undefined,
+      hardforkByTD: isTruthy(this._hardforkByTD) ? this._hardforkByTD : undefined,
     })
   }
 

--- a/packages/vm/tests/api/EIPs/eip-2315.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-2315.spec.ts
@@ -11,7 +11,7 @@ tape('Berlin: EIP 2315 tests', (t) => {
     const vm = await VM.create({ common })
 
     ;(<EVM>vm.evm).on('step', function (step: any) {
-      if (test.steps.length) {
+      if (test.steps.length > 0) {
         st.equal(step.pc, test.steps[i].expectedPC)
         st.equal(step.opcode.name, test.steps[i].expectedOpcode)
       }

--- a/packages/vm/tests/api/EIPs/eip-2929.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-2929.spec.ts
@@ -24,7 +24,7 @@ tape('EIP 2929: gas cost tests', (t) => {
       const gasUsed = currentGas - step.gasLeft
       currentGas = step.gasLeft
 
-      if (test.steps.length) {
+      if (test.steps.length > 0) {
         st.equal(
           step.opcode.name,
           test.steps[i].expectedOpcode,

--- a/packages/vm/tests/api/EIPs/eip-3074-authcall.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3074-authcall.spec.ts
@@ -6,6 +6,7 @@ import {
   bufferToBigInt,
   ECDSASignature,
   ecsign,
+  isTruthy,
   privateToAddress,
   setLengthLeft,
   toBuffer,
@@ -169,24 +170,30 @@ function MSTORE(position: Buffer, value: Buffer) {
  */
 function getAuthCallCode(data: AuthcallData) {
   const ZEROS32 = zeros(32)
-  const gasLimitBuffer = setLengthLeft(data.gasLimit ? bigIntToBuffer(data.gasLimit) : ZEROS32, 32)
+  const gasLimitBuffer = setLengthLeft(
+    isTruthy(data.gasLimit) ? bigIntToBuffer(data.gasLimit) : ZEROS32,
+    32
+  )
   const addressBuffer = setLengthLeft(data.address.buf, 32)
-  const valueBuffer = setLengthLeft(data.value ? bigIntToBuffer(data.value) : ZEROS32, 32)
-  const valueExtBuffer = setLengthLeft(data.valueExt ? bigIntToBuffer(data.valueExt) : ZEROS32, 32)
+  const valueBuffer = setLengthLeft(isTruthy(data.value) ? bigIntToBuffer(data.value) : ZEROS32, 32)
+  const valueExtBuffer = setLengthLeft(
+    isTruthy(data.valueExt) ? bigIntToBuffer(data.valueExt) : ZEROS32,
+    32
+  )
   const argsOffsetBuffer = setLengthLeft(
-    data.argsOffset ? bigIntToBuffer(data.argsOffset) : ZEROS32,
+    isTruthy(data.argsOffset) ? bigIntToBuffer(data.argsOffset) : ZEROS32,
     32
   )
   const argsLengthBuffer = setLengthLeft(
-    data.argsLength ? bigIntToBuffer(data.argsLength) : ZEROS32,
+    isTruthy(data.argsLength) ? bigIntToBuffer(data.argsLength) : ZEROS32,
     32
   )
   const retOffsetBuffer = setLengthLeft(
-    data.retOffset ? bigIntToBuffer(data.retOffset) : ZEROS32,
+    isTruthy(data.retOffset) ? bigIntToBuffer(data.retOffset) : ZEROS32,
     32
   )
   const retLengthBuffer = setLengthLeft(
-    data.retLength ? bigIntToBuffer(data.retLength) : ZEROS32,
+    isTruthy(data.retLength) ? bigIntToBuffer(data.retLength) : ZEROS32,
     32
   )
   const PUSH32 = Buffer.from('7f', 'hex')

--- a/packages/vm/tests/api/EIPs/eip-3607.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3607.spec.ts
@@ -18,7 +18,7 @@ tape('EIP-3607 tests', (t) => {
       await vm.runTx({ tx })
       st.fail('runTx should have thrown')
     } catch (error: any) {
-      if (error.message.includes('EIP-3607')) {
+      if ((error.message as string).includes('EIP-3607')) {
         st.pass('threw correct error')
       } else {
         st.fail('did not throw correct error')

--- a/packages/vm/tests/api/EIPs/eip-3855.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3855.spec.ts
@@ -17,7 +17,7 @@ tape('EIP 3541 tests', (t) => {
     const vm = await VM.create({ common })
     let stack: bigint[]
     ;(<EVM>vm.evm).on('step', (e: InterpreterStep) => {
-      if (stack) {
+      if (typeof stack !== 'undefined') {
         st.fail('should only do PUSH0 once')
       }
       stack = e.stack

--- a/packages/vm/tests/api/buildBlock.spec.ts
+++ b/packages/vm/tests/api/buildBlock.spec.ts
@@ -66,7 +66,11 @@ tape('BlockBuilder', async (t) => {
       await blockBuilder.addTransaction(tx)
       st.fail('should throw error')
     } catch (error: any) {
-      if (error.message.includes('tx has a higher gas limit than the remaining gas in the block')) {
+      if (
+        (error.message as string).includes(
+          'tx has a higher gas limit than the remaining gas in the block'
+        )
+      ) {
         st.pass('correct error thrown')
       } else {
         st.fail('wrong error thrown')
@@ -231,7 +235,7 @@ tape('BlockBuilder', async (t) => {
       await blockBuilder.revert()
       st.fail('should throw error')
     } catch (error: any) {
-      if (error.message.includes('Block has already been built')) {
+      if ((error.message as string).includes('Block has already been built')) {
         st.pass('correct error thrown')
       } else {
         st.fail('wrong error thrown')
@@ -255,7 +259,7 @@ tape('BlockBuilder', async (t) => {
       await blockBuilder.revert()
       st.fail('should throw error')
     } catch (error: any) {
-      if (error.message.includes('State has already been reverted')) {
+      if ((error.message as string).includes('State has already been reverted')) {
         st.pass('correct error thrown')
       } else {
         st.fail('wrong error thrown')
@@ -330,7 +334,7 @@ tape('BlockBuilder', async (t) => {
         st.fail('should throw error')
       } catch (error: any) {
         st.ok(
-          error.message.includes("is less than the block's baseFeePerGas"),
+          (error.message as string).includes("is less than the block's baseFeePerGas"),
           'should fail with appropriate error'
         )
       }

--- a/packages/vm/tests/api/istanbul/eip-152.spec.ts
+++ b/packages/vm/tests/api/istanbul/eip-152.spec.ts
@@ -80,7 +80,7 @@ const testCases = [
 tape('Istanbul: EIP-152', (t) => {
   t.test('Blake2f', async (st) => {
     // eslint-disable-next-line no-undef
-    if ((<any>globalThis).navigator?.userAgent.includes('Firefox')) {
+    if ((globalThis.navigator?.userAgent as string).includes('Firefox')) {
       // TODO: investigate why this test hangs in karma with firefox
       return st.end()
     }

--- a/packages/vm/tests/api/istanbul/eip-1884.spec.ts
+++ b/packages/vm/tests/api/istanbul/eip-1884.spec.ts
@@ -1,5 +1,5 @@
 import * as tape from 'tape'
-import { Address, bufferToBigInt } from '@ethereumjs/util'
+import { Address, bufferToBigInt, isTruthy } from '@ethereumjs/util'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { VM } from '../../../src/vm'
 import { createAccount } from '../utils'
@@ -26,7 +26,7 @@ tape('Istanbul: EIP-1884', async (t) => {
       const common = new Common({ chain, hardfork })
       const vm = await VM.create({ common })
 
-      const balance = testCase.selfbalance ? BigInt(testCase.selfbalance) : undefined
+      const balance = isTruthy(testCase.selfbalance) ? BigInt(testCase.selfbalance) : undefined
       const account = createAccount(BigInt(0), balance)
 
       await vm.stateManager.putAccount(addr, account)

--- a/packages/vm/tests/api/istanbul/eip-2200.spec.ts
+++ b/packages/vm/tests/api/istanbul/eip-2200.spec.ts
@@ -63,13 +63,13 @@ tape('Istanbul: EIP-2200', async (t) => {
 
       const runCallArgs = {
         caller,
-        gasLimit: testCase.gas ? testCase.gas : BigInt(0xffffffffff),
+        gasLimit: testCase.gas ?? BigInt(0xffffffffff),
         to: addr,
       }
 
       try {
         const res = await vm.evm.runCall(runCallArgs)
-        if (testCase.err) {
+        if (typeof testCase.err !== 'undefined') {
           st.equal(res.execResult.exceptionError?.error, testCase.err)
         } else {
           st.equal(res.execResult.exceptionError, undefined)

--- a/packages/vm/tests/api/runTx.spec.ts
+++ b/packages/vm/tests/api/runTx.spec.ts
@@ -1,5 +1,5 @@
 import * as tape from 'tape'
-import { Account, Address, MAX_INTEGER } from '@ethereumjs/util'
+import { Account, Address, isTruthy, MAX_INTEGER } from '@ethereumjs/util'
 import { Block } from '@ethereumjs/block'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import {
@@ -168,9 +168,10 @@ tape('runTx() -> successful API parameter usage', async (t) => {
               ? tx.maxPriorityFeePerGas
               : tx.maxFeePerGas - baseFee
             : tx.gasPrice - baseFee
-        const expectedCoinbaseBalance = common.isActivatedEIP(1559)
-          ? result.totalGasSpent * inclusionFeePerGas
-          : result.amountSpent
+        const expectedCoinbaseBalance =
+          common.isActivatedEIP(1559) === true
+            ? result.totalGasSpent * inclusionFeePerGas
+            : result.amountSpent
 
         t.equals(
           coinbaseAccount.balance,
@@ -660,7 +661,7 @@ tape('runTx() -> skipBalance behavior', async (t) => {
   const sender = Address.fromPrivateKey(senderKey)
 
   for (const balance of [undefined, BigInt(5)]) {
-    if (balance) {
+    if (isTruthy(balance)) {
       await vm.stateManager.modifyAccountFields(sender, { nonce: BigInt(0), balance })
     }
     const tx = Transaction.fromTxData({

--- a/packages/vm/tests/api/utils.ts
+++ b/packages/vm/tests/api/utils.ts
@@ -104,7 +104,7 @@ export function getTransaction(
  * Checks if in a karma test runner.
  * @returns boolean whether running in karma
  */
-export function isRunningInKarma(): Boolean {
+export function isRunningInKarma(): boolean {
   // eslint-disable-next-line no-undef
   return typeof (<any>globalThis).window !== 'undefined' && (<any>globalThis).window.__karma__
 }

--- a/packages/vm/tests/tester/runners/GeneralStateTestsRunner.ts
+++ b/packages/vm/tests/tester/runners/GeneralStateTestsRunner.ts
@@ -1,6 +1,6 @@
 import * as tape from 'tape'
 import { SecureTrie as Trie } from '@ethereumjs/trie'
-import { toBuffer } from '@ethereumjs/util'
+import { isTruthy, toBuffer } from '@ethereumjs/util'
 import { setupPreConditions, makeTx, makeBlockFromEnv } from '../../util'
 import { InterpreterStep } from '@ethereumjs/evm/dist//interpreter'
 
@@ -13,7 +13,7 @@ function parseTestCases(
 ) {
   let testCases = []
 
-  if (testData['post'][forkConfigTestSuite]) {
+  if (isTruthy(testData['post'][forkConfigTestSuite])) {
     testCases = testData['post'][forkConfigTestSuite].map((testCase: any) => {
       const testIndexes = testCase['indexes']
       const tx = { ...testData.transaction }
@@ -33,7 +33,7 @@ function parseTestCases(
       tx.gasLimit = testData.transaction.gasLimit[testIndexes['gas']]
       tx.value = testData.transaction.value[testIndexes['value']]
 
-      if (tx.accessLists) {
+      if (isTruthy(tx.accessLists)) {
         tx.accessList = testData.transaction.accessLists[testIndexes['data']]
         if (tx.chainId == undefined) {
           tx.chainId = 1
@@ -60,7 +60,7 @@ function parseTestCases(
 
 async function runTestCase(options: any, testData: any, t: tape.Test) {
   let VM
-  if (options.dist) {
+  if (isTruthy(options.dist)) {
     ;({ VM } = require('../../../dist'))
   } else {
     ;({ VM } = require('../../../src'))
@@ -86,7 +86,7 @@ async function runTestCase(options: any, testData: any, t: tape.Test) {
     if (tx.validate()) {
       const block = makeBlockFromEnv(testData.env, { common })
 
-      if (options.jsontrace) {
+      if (isTruthy(options.jsontrace)) {
         vm.evm.on('step', function (e: InterpreterStep) {
           let hexStack = []
           hexStack = e.stack.map((item: bigint) => {
@@ -148,7 +148,7 @@ export async function runStateTest(options: any, testData: any, t: tape.Test) {
       return
     }
     for (const testCase of testCases) {
-      if (options.reps) {
+      if (isTruthy(options.reps)) {
         let totalTimeSpent = 0
         for (let x = 0; x < options.reps; x++) {
           totalTimeSpent += await runTestCase(options, testCase, t)

--- a/packages/vm/tests/tester/testLoader.ts
+++ b/packages/vm/tests/tester/testLoader.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs'
 import * as path from 'path'
 import * as dir from 'node-dir'
 import { DEFAULT_TESTS_PATH } from './config'
+import { isTruthy } from '@ethereumjs/util'
 
 const falsePredicate = () => false
 
@@ -17,7 +18,7 @@ const falsePredicate = () => false
 export async function getTests(
   onFile: Function,
   fileFilter: RegExp | string[] = /.json$/,
-  skipPredicate: Function = falsePredicate,
+  skipPredicate: (...args: any[]) => boolean = falsePredicate,
   directory: string,
   excludeDir: RegExp | string[] = []
 ): Promise<string[]> {
@@ -134,16 +135,16 @@ export async function getTestsFromArgs(testType: string, onFile: Function, args:
       return skipTest(name, args.skipVM)
     }
   }
-  if (args.singleSource) {
+  if (isTruthy(args.singleSource)) {
     return getTestFromSource(args.singleSource, onFile)
   }
-  if (args.file) {
+  if (isTruthy(args.file)) {
     fileFilter = new RegExp(args.file)
   }
-  if (args.excludeDir) {
+  if (isTruthy(args.excludeDir)) {
     excludeDir = new RegExp(args.excludeDir)
   }
-  if (args.test) {
+  if (isTruthy(args.test)) {
     skipFn = (testName: string) => {
       return testName !== args.test
     }


### PR DESCRIPTION
This PR adds the [strict-boolean-expressions](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md) eslint rule and applies it throughout the monorepo. I also added `isTruthy` and `isFalsy` type guard utils for convenience. Eventually, I think we can refactor most of those  `isTruthy` and `isFalsy` by providing more accurate types upstream and explicitly checking for truthy/falsy cases instead of relying on JS truthiness.  

 Related to #1935 