### PR TITLE
Fix consensus validation bugs

### DIFF
--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -258,7 +258,6 @@ export class BlockHeader {
     this.baseFeePerGas = baseFeePerGas
 
     this._genericFormatValidation()
-    this._consensusFormatValidation()
     this._validateDAOExtraData()
 
     // Now we have set all the values of this Header, we possibly have set a dummy
@@ -282,6 +281,9 @@ export class BlockHeader {
 
       this.extraData = this.cliqueSealBlock(options.cliqueSigner)
     }
+
+    // Validate consensus format after block is sealed (if applicable) so extraData checks will pass
+    this._consensusFormatValidation()
 
     const freeze = options?.freeze ?? true
     if (freeze) {

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -445,7 +445,8 @@ async function setupDevnet(prefundAddress: Address) {
     parentHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
     baseFeePerGas: 7,
   }
-  const extraData = '0x' + '0'.repeat(64) + addr + '0'.repeat(130)
+  const extraData =
+    args.dev === 'pow' ? '0x' + '0'.repeat(32) : '0x' + '0'.repeat(64) + addr + '0'.repeat(130)
   const chainData = {
     ...defaultChainData,
     extraData,


### PR DESCRIPTION
Fixes two bugs related to consensus validation that were introduced when we merged #1959 
- Fixes handling of `extraData` in genesis parameters for `client` devnet start-up
- Moves location of `_consensusFormatValidation` in `block` constructor so that `extraData` can be correctly constructed for PoA blocks.