### PR TITLE
Common, Client: Sepolia DNS config and activation

### DIFF
--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -402,7 +402,7 @@ export class Config {
    */
   getDnsDiscovery(option: boolean | undefined): boolean {
     if (option !== undefined) return option
-    const dnsNets = ['ropsten', 'rinkeby', 'goerli']
+    const dnsNets = ['ropsten', 'rinkeby', 'goerli', 'sepolia']
     return dnsNets.includes(this.chainCommon.chainName())
   }
 

--- a/packages/common/src/chains/sepolia.json
+++ b/packages/common/src/chains/sepolia.json
@@ -121,5 +121,7 @@
       "comment": "lodestar"
     }
   ],
-  "dnsNetworks": []
+  "dnsNetworks": [
+    "enrtree://AKA3AM6LPBYEUDMVNU3BSVQJ5AD45Y7YPOHJLEF6W26QOE4VTUDPE@all.sepolia.ethdisco.net"
+  ]
 }


### PR DESCRIPTION
This PR adds Sepolia DNS discovery config to Common and DNS discovery activation to the client which solves the Sepolia initial sync connection problem.

For context see the [discv4-dns-lists](https://github.com/ethereum/discv4-dns-lists) repo and the [bootnode config](https://github.com/ethereum/go-ethereum/blob/master/params/bootnodes.go#L108) from Go Ethereum.