### PR TITLE
Trie: allow customizing hash algorithm

### DIFF
--- a/packages/statemanager/src/stateManager.ts
+++ b/packages/statemanager/src/stateManager.ts
@@ -320,14 +320,14 @@ export class DefaultStateManager extends BaseStateManager implements StateManage
    */
   async getProof(address: Address, storageSlots: Buffer[] = []): Promise<Proof> {
     const account = await this.getAccount(address)
-    const accountProof: PrefixedHexString[] = (await Trie.createProof(this._trie, address.buf)).map(
-      (p) => bufferToHex(p)
+    const accountProof: PrefixedHexString[] = (await this._trie.createProof(address.buf)).map((p) =>
+      bufferToHex(p)
     )
     const storageProof: StorageProof[] = []
     const storageTrie = await this._getStorageTrie(address)
 
     for (const storageKey of storageSlots) {
-      const proof = (await Trie.createProof(storageTrie, storageKey)).map((p) => bufferToHex(p))
+      const proof = (await storageTrie.createProof(storageKey)).map((p) => bufferToHex(p))
       let value = bufferToHex(await this.getContractStorage(address, storageKey))
       if (value === '0x') {
         value = '0x0'
@@ -365,7 +365,7 @@ export class DefaultStateManager extends BaseStateManager implements StateManage
 
     // This returns the account if the proof is valid.
     // Verify that it matches the reported account.
-    const value = await Trie.verifyProof(rootHash, key, accountProof)
+    const value = await new Trie().verifyProof(rootHash, key, accountProof)
 
     if (value === null) {
       // Verify that the account is empty in the proof.
@@ -411,7 +411,7 @@ export class DefaultStateManager extends BaseStateManager implements StateManage
       const storageProof = stProof.proof.map((value: PrefixedHexString) => toBuffer(value))
       const storageValue = setLengthLeft(toBuffer(stProof.value), 32)
       const storageKey = toBuffer(stProof.key)
-      const proofValue = await Trie.verifyProof(storageRoot, storageKey, storageProof)
+      const proofValue = await new Trie().verifyProof(storageRoot, storageKey, storageProof)
       const reportedValue = setLengthLeft(
         Buffer.from(RLP.decode(Uint8Array.from((proofValue as Buffer) ?? [])) as Uint8Array),
         32

--- a/packages/trie/README.md
+++ b/packages/trie/README.md
@@ -73,8 +73,8 @@ const trie = new Trie()
 
 async function test() {
   await trie.put(Buffer.from('test'), Buffer.from('one'))
-  const proof = await Trie.createProof(trie, Buffer.from('test'))
-  const value = await Trie.verifyProof(trie.root, Buffer.from('test'), proof)
+  const proof = await trie.createProof(Buffer.from('test'))
+  const value = await trie.verifyProof(trie.root, Buffer.from('test'), proof)
   console.log(value.toString()) // 'one'
 }
 
@@ -91,8 +91,8 @@ const trie = new Trie()
 async function test() {
   await trie.put(Buffer.from('test'), Buffer.from('one'))
   await trie.put(Buffer.from('test2'), Buffer.from('two'))
-  const proof = await Trie.createProof(trie, Buffer.from('test3'))
-  const value = await Trie.verifyProof(trie.root, Buffer.from('test3'), proof)
+  const proof = await trie.createProof(Buffer.from('test3'))
+  const value = await trie.verifyProof(trie.root, Buffer.from('test3'), proof)
   console.log(value.toString()) // null
 }
 
@@ -109,10 +109,10 @@ const trie = new Trie()
 async function test() {
   await trie.put(Buffer.from('test'), Buffer.from('one'))
   await trie.put(Buffer.from('test2'), Buffer.from('two'))
-  const proof = await Trie.createProof(trie, Buffer.from('test2'))
+  const proof = await trie.createProof(Buffer.from('test2'))
   proof[1].reverse()
   try {
-    const value = await Trie.verifyProof(trie.root, Buffer.from('test2'), proof)
+    const value = await trie.verifyProof(trie.root, Buffer.from('test2'), proof)
     console.log(value.toString()) // results in error
   } catch (err) {
     console.log(err) // Missing node in DB

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -30,7 +30,7 @@
     "tape": "tape -r ts-node/register",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "karma start karma.conf.js",
-    "test:node": "tape -r ts-node/register test/**/*.ts"
+    "test:node": "tape -r ts-node/register 'test/**/*.ts'"
   },
   "dependencies": {
     "@ethereumjs/util": "8.0.0-beta.1",

--- a/packages/trie/src/trie/node/branch.ts
+++ b/packages/trie/src/trie/node/branch.ts
@@ -1,4 +1,3 @@
-import { keccak256 } from 'ethereum-cryptography/keccak'
 import { bufArrToArr } from '@ethereumjs/util'
 import { RLP } from 'rlp'
 import { EmbeddedNode } from '../../types'
@@ -37,10 +36,6 @@ export class BranchNode {
 
   serialize(): Buffer {
     return Buffer.from(RLP.encode(bufArrToArr(this.raw() as Buffer[])))
-  }
-
-  hash(): Buffer {
-    return Buffer.from(keccak256(this.serialize()))
   }
 
   getBranch(i: number) {

--- a/packages/trie/src/trie/node/extension.ts
+++ b/packages/trie/src/trie/node/extension.ts
@@ -1,4 +1,3 @@
-import { keccak256 } from 'ethereum-cryptography/keccak'
 import { bufArrToArr } from '@ethereumjs/util'
 import { RLP } from 'rlp'
 import { nibblesToBuffer } from '../../util/nibbles'
@@ -52,9 +51,5 @@ export class ExtensionNode {
 
   serialize(): Buffer {
     return Buffer.from(RLP.encode(bufArrToArr(this.raw())))
-  }
-
-  hash(): Buffer {
-    return Buffer.from(keccak256(this.serialize()))
   }
 }

--- a/packages/trie/src/trie/node/leaf.ts
+++ b/packages/trie/src/trie/node/leaf.ts
@@ -1,4 +1,3 @@
-import { keccak256 } from 'ethereum-cryptography/keccak'
 import { bufArrToArr } from '@ethereumjs/util'
 import { RLP } from 'rlp'
 import { nibblesToBuffer } from '../../util/nibbles'
@@ -52,9 +51,5 @@ export class LeafNode {
 
   serialize(): Buffer {
     return Buffer.from(RLP.encode(bufArrToArr(this.raw())))
-  }
-
-  hash(): Buffer {
-    return Buffer.from(keccak256(this.serialize()))
   }
 }

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -1,6 +1,6 @@
 import Semaphore from 'semaphore-async-await'
 import { keccak256 } from 'ethereum-cryptography/keccak'
-import { isFalsy, isTruthy, KECCAK256_RLP } from '@ethereumjs/util'
+import { isFalsy, isTruthy, RLP_EMPTY_STRING } from '@ethereumjs/util'
 import { DB, BatchDBOp, PutBatch, TrieNode, Nibbles, EmbeddedNode } from '../types'
 import { LevelDB } from '../db'
 import { TrieReadStream as ReadStream } from '../util/readStream'
@@ -25,21 +25,27 @@ export class Trie {
   /** The root for an empty trie */
   EMPTY_TRIE_ROOT: Buffer
   protected lock: Semaphore
+  protected hash: (msg: Uint8Array) => Buffer
 
   /** The backend DB */
   db: DB
   private _root: Buffer
   private _deleteFromDB: boolean
+  private _hashLen: number
 
   /**
    * Create a new trie
    * @param opts Options for instantiating the trie
    */
   constructor(opts?: TrieOpts) {
-    this.EMPTY_TRIE_ROOT = KECCAK256_RLP
     this.lock = new Semaphore(1)
-
+    this.hash = (msg) => {
+      const _hash = opts?.hash ?? keccak256
+      return Buffer.from(_hash(msg))
+    }
     this.db = opts?.db ?? new LevelDB()
+    this.EMPTY_TRIE_ROOT = this.hash(RLP_EMPTY_STRING)
+    this._hashLen = this.EMPTY_TRIE_ROOT.length
     this._root = this.EMPTY_TRIE_ROOT
     this._deleteFromDB = opts?.deleteFromDB ?? false
 
@@ -55,7 +61,8 @@ export class Trie {
     if (isFalsy(value)) {
       value = this.EMPTY_TRIE_ROOT
     }
-    if (value.length !== 32) throw new Error('Invalid root length. Roots are 32 bytes')
+    if (value.length !== this._hashLen)
+      throw new Error(`Invalid root length. Roots are ${this._hashLen} bytes`)
     this._root = value
   }
 
@@ -118,7 +125,7 @@ export class Trie {
     }
 
     await this.lock.wait()
-    if (this.root.equals(KECCAK256_RLP)) {
+    if (this.root.equals(this.EMPTY_TRIE_ROOT)) {
       // If no root, initialize this trie
       await this._createInitialNode(key, value)
     } else {
@@ -232,8 +239,10 @@ export class Trie {
    */
   async _createInitialNode(key: Buffer, value: Buffer): Promise<void> {
     const newNode = new LeafNode(bufferToNibbles(key), value)
-    this.root = newNode.hash()
-    await this.db.put(this.root, newNode.serialize())
+
+    const encoded = newNode.serialize()
+    this.root = this.hash(encoded)
+    await this.db.put(this.root, encoded)
   }
 
   /**
@@ -538,12 +547,10 @@ export class Trie {
     opStack: BatchDBOp[],
     remove: boolean = false
   ): Buffer | (EmbeddedNode | null)[] {
-    const rlpNode = node.serialize()
+    const encoded = node.serialize()
 
-    if (rlpNode.length >= 32 || topLevel) {
-      // Do not use TrieNode.hash() here otherwise serialize()
-      // is applied twice (performance)
-      const hashRoot = Buffer.from(keccak256(rlpNode))
+    if (encoded.length >= 32 || topLevel) {
+      const hashRoot = Buffer.from(this.hash(encoded))
 
       if (remove) {
         if (this._deleteFromDB) {
@@ -556,7 +563,7 @@ export class Trie {
         opStack.push({
           type: 'put',
           key: hashRoot,
-          value: rlpNode,
+          value: encoded,
         })
       }
 
@@ -594,47 +601,41 @@ export class Trie {
   }
 
   /**
-   * Saves the nodes from a proof into the trie. If no trie is provided a new one wil be instantiated.
+   * Saves the nodes from a proof into the trie.
    * @param proof
-   * @param trie
    */
-  static async fromProof(proof: Proof, trie?: Trie): Promise<Trie> {
+  async fromProof(proof: Proof): Promise<void> {
     const opStack = proof.map((nodeValue) => {
       return {
         type: 'put',
-        key: Buffer.from(keccak256(nodeValue)),
+        key: Buffer.from(this.hash(nodeValue)),
         value: nodeValue,
       } as PutBatch
     })
 
-    if (!trie) {
-      trie = new Trie()
-      if (isTruthy(opStack[0])) {
-        trie.root = opStack[0].key
-      }
+    if (this.root === this.EMPTY_TRIE_ROOT && isTruthy(opStack[0])) {
+      this.root = opStack[0].key
     }
 
-    await trie.db.batch(opStack)
-    return trie
+    await this.db.batch(opStack)
+    return
   }
 
   /**
    * prove has been renamed to {@link Trie.createProof}.
    * @deprecated
-   * @param trie
    * @param key
    */
-  static async prove(trie: Trie, key: Buffer): Promise<Proof> {
-    return this.createProof(trie, key)
+  async prove(key: Buffer): Promise<Proof> {
+    return this.createProof(key)
   }
 
   /**
    * Creates a proof from a trie and key that can be verified using {@link Trie.verifyProof}.
-   * @param trie
    * @param key
    */
-  static async createProof(trie: Trie, key: Buffer): Promise<Proof> {
-    const { stack } = await trie.findPath(key)
+  async createProof(key: Buffer): Promise<Proof> {
+    const { stack } = await this.findPath(key)
     const p = stack.map((stackElem) => {
       return stackElem.serialize()
     })
@@ -649,10 +650,10 @@ export class Trie {
    * @throws If proof is found to be invalid.
    * @returns The value from the key, or null if valid proof of non-existence.
    */
-  static async verifyProof(rootHash: Buffer, key: Buffer, proof: Proof): Promise<Buffer | null> {
-    let proofTrie = new Trie({ root: rootHash })
+  async verifyProof(rootHash: Buffer, key: Buffer, proof: Proof): Promise<Buffer | null> {
+    const proofTrie = new Trie({ root: rootHash, hash: this.hash })
     try {
-      proofTrie = await Trie.fromProof(proof, proofTrie)
+      await proofTrie.fromProof(proof)
     } catch (e: any) {
       throw new Error('Invalid proof nodes given')
     }
@@ -671,7 +672,7 @@ export class Trie {
   /**
    * {@link verifyRangeProof}
    */
-  static verifyRangeProof(
+  verifyRangeProof(
     rootHash: Buffer,
     firstKey: Buffer | null,
     lastKey: Buffer | null,
@@ -685,7 +686,8 @@ export class Trie {
       lastKey && bufferToNibbles(lastKey),
       keys.map(bufferToNibbles),
       values,
-      proof
+      proof,
+      this.hash
     )
   }
 
@@ -701,7 +703,12 @@ export class Trie {
    * Creates a new trie backed by the same db.
    */
   copy(): Trie {
-    return new Trie({ db: this.db.copy(), root: this.root, deleteFromDB: this._deleteFromDB })
+    return new Trie({
+      db: this.db.copy(),
+      root: this.root,
+      deleteFromDB: this._deleteFromDB,
+      hash: this.hash,
+    })
   }
 
   /**

--- a/packages/trie/src/types.ts
+++ b/packages/trie/src/types.ts
@@ -18,6 +18,8 @@ export type FoundNodeFunction = (
   walkController: WalkController
 ) => void
 
+export type HashFunc = (msg: Uint8Array) => Uint8Array
+
 export interface TrieOpts {
   /**
    * A database instance.
@@ -32,6 +34,11 @@ export interface TrieOpts {
    * Default: `false`
    */
   deleteFromDB?: boolean
+
+  /**
+   * Hash function used for hashing trie node and securing key.
+   */
+  hash?: HashFunc
 }
 
 export type BatchDBOp = PutBatch | DelBatch

--- a/packages/trie/test/proof.spec.ts
+++ b/packages/trie/test/proof.spec.ts
@@ -11,48 +11,48 @@ tape('simple merkle proofs generation and verification', function (tester) {
     await trie.put(Buffer.from('key2bb'), Buffer.from('aval2'))
     await trie.put(Buffer.from('key3cc'), Buffer.from('aval3'))
 
-    let proof = await CheckpointTrie.createProof(trie, Buffer.from('key2bb'))
-    let val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key2bb'), proof)
+    let proof = await trie.createProof(Buffer.from('key2bb'))
+    let val = await trie.verifyProof(trie.root, Buffer.from('key2bb'), proof)
     t.equal(val!.toString('utf8'), 'aval2')
 
-    proof = await CheckpointTrie.createProof(trie, Buffer.from('key1aa'))
-    val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key1aa'), proof)
+    proof = await trie.createProof(Buffer.from('key1aa'))
+    val = await trie.verifyProof(trie.root, Buffer.from('key1aa'), proof)
     t.equal(val!.toString('utf8'), '0123456789012345678901234567890123456789xx')
 
-    proof = await CheckpointTrie.createProof(trie, Buffer.from('key2bb'))
-    val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key2'), proof)
+    proof = await trie.createProof(Buffer.from('key2bb'))
+    val = await trie.verifyProof(trie.root, Buffer.from('key2'), proof)
     // In this case, the proof _happens_ to contain enough nodes to prove `key2` because
     // traversing into `key22` would touch all the same nodes as traversing into `key2`
     t.equal(val, null, 'Expected value at a random key to be null')
 
     let myKey = Buffer.from('anyrandomkey')
-    proof = await CheckpointTrie.createProof(trie, myKey)
-    val = await CheckpointTrie.verifyProof(trie.root, myKey, proof)
+    proof = await trie.createProof(myKey)
+    val = await trie.verifyProof(trie.root, myKey, proof)
     t.equal(val, null, 'Expected value to be null')
 
     myKey = Buffer.from('anothergarbagekey') // should generate a valid proof of null
-    proof = await CheckpointTrie.createProof(trie, myKey)
+    proof = await trie.createProof(myKey)
     proof.push(Buffer.from('123456')) // extra nodes are just ignored
-    val = await CheckpointTrie.verifyProof(trie.root, myKey, proof)
+    val = await trie.verifyProof(trie.root, myKey, proof)
     t.equal(val, null, 'Expected value to be null')
 
     await trie.put(Buffer.from('another'), Buffer.from('3498h4riuhgwe'))
 
     // to fail our proof we can request a proof for one key
-    proof = await CheckpointTrie.createProof(trie, Buffer.from('another'))
+    proof = await trie.createProof(Buffer.from('another'))
     // and try to use that proof on another key
     try {
-      await CheckpointTrie.verifyProof(trie.root, Buffer.from('key1aa'), proof)
+      await trie.verifyProof(trie.root, Buffer.from('key1aa'), proof)
       t.fail('expected error: Invalid proof provided')
     } catch (e: any) {
       t.equal(e.message, 'Invalid proof provided')
     }
 
     // we can also corrupt a valid proof
-    proof = await CheckpointTrie.createProof(trie, Buffer.from('key2bb'))
+    proof = await trie.createProof(Buffer.from('key2bb'))
     proof[0].reverse()
     try {
-      await CheckpointTrie.verifyProof(trie.root, Buffer.from('key2bb'), proof)
+      await trie.verifyProof(trie.root, Buffer.from('key2bb'), proof)
       t.fail('expected error: Invalid proof provided')
     } catch (e: any) {
       t.equal(e.message, 'Invalid proof provided')
@@ -61,13 +61,13 @@ tape('simple merkle proofs generation and verification', function (tester) {
     // test an invalid exclusion proof by creating
     // a valid exclusion proof then making it non-null
     myKey = Buffer.from('anyrandomkey')
-    proof = await CheckpointTrie.createProof(trie, myKey)
-    val = await CheckpointTrie.verifyProof(trie.root, myKey, proof)
+    proof = await trie.createProof(myKey)
+    val = await trie.verifyProof(trie.root, myKey, proof)
     t.equal(val, null, 'Expected value to be null')
     // now make the key non-null so the exclusion proof becomes invalid
     await trie.put(myKey, Buffer.from('thisisavalue'))
     try {
-      await CheckpointTrie.verifyProof(trie.root, myKey, proof)
+      await trie.verifyProof(trie.root, myKey, proof)
       t.fail('expected error: Invalid proof provided')
     } catch (e: any) {
       t.equal(e.message, 'Invalid proof provided')
@@ -81,8 +81,8 @@ tape('simple merkle proofs generation and verification', function (tester) {
 
     await trie.put(Buffer.from('key1aa'), Buffer.from('0123456789012345678901234567890123456789xx'))
 
-    const proof = await CheckpointTrie.createProof(trie, Buffer.from('key1aa'))
-    const val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key1aa'), proof)
+    const proof = await trie.createProof(Buffer.from('key1aa'))
+    const val = await trie.verifyProof(trie.root, Buffer.from('key1aa'), proof)
     t.equal(val!.toString('utf8'), '0123456789012345678901234567890123456789xx')
 
     t.end()
@@ -93,8 +93,8 @@ tape('simple merkle proofs generation and verification', function (tester) {
 
     await trie.put(Buffer.from('key1aa'), Buffer.from('01234'))
 
-    const proof = await CheckpointTrie.createProof(trie, Buffer.from('key1aa'))
-    const val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key1aa'), proof)
+    const proof = await trie.createProof(Buffer.from('key1aa'))
+    const val = await trie.verifyProof(trie.root, Buffer.from('key1aa'), proof)
     t.equal(val!.toString('utf8'), '01234')
 
     t.end()
@@ -116,16 +116,16 @@ tape('simple merkle proofs generation and verification', function (tester) {
     await trie.put(Buffer.from('key3cc'), Buffer.from('aval3'))
     await trie.put(Buffer.from('key3'), Buffer.from('1234567890123456789012345678901'))
 
-    let proof = await CheckpointTrie.createProof(trie, Buffer.from('key1'))
-    let val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key1'), proof)
+    let proof = await trie.createProof(Buffer.from('key1'))
+    let val = await trie.verifyProof(trie.root, Buffer.from('key1'), proof)
     t.equal(val!.toString('utf8'), '0123456789012345678901234567890123456789Very_Long')
 
-    proof = await CheckpointTrie.createProof(trie, Buffer.from('key2'))
-    val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key2'), proof)
+    proof = await trie.createProof(Buffer.from('key2'))
+    val = await trie.verifyProof(trie.root, Buffer.from('key2'), proof)
     t.equal(val!.toString('utf8'), 'short')
 
-    proof = await CheckpointTrie.createProof(trie, Buffer.from('key3'))
-    val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('key3'), proof)
+    proof = await trie.createProof(Buffer.from('key3'))
+    val = await trie.verifyProof(trie.root, Buffer.from('key3'), proof)
     t.equal(val!.toString('utf8'), '1234567890123456789012345678901')
 
     t.end()
@@ -138,16 +138,16 @@ tape('simple merkle proofs generation and verification', function (tester) {
     await trie.put(Buffer.from('b'), Buffer.from('b'))
     await trie.put(Buffer.from('c'), Buffer.from('c'))
 
-    let proof = await CheckpointTrie.createProof(trie, Buffer.from('a'))
-    let val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('a'), proof)
+    let proof = await trie.createProof(Buffer.from('a'))
+    let val = await trie.verifyProof(trie.root, Buffer.from('a'), proof)
     t.equal(val!.toString('utf8'), 'a')
 
-    proof = await CheckpointTrie.createProof(trie, Buffer.from('b'))
-    val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('b'), proof)
+    proof = await trie.createProof(Buffer.from('b'))
+    val = await trie.verifyProof(trie.root, Buffer.from('b'), proof)
     t.equal(val!.toString('utf8'), 'b')
 
-    proof = await CheckpointTrie.createProof(trie, Buffer.from('c'))
-    val = await CheckpointTrie.verifyProof(trie.root, Buffer.from('c'), proof)
+    proof = await trie.createProof(Buffer.from('c'))
+    val = await trie.verifyProof(trie.root, Buffer.from('c'), proof)
     t.equal(val!.toString('utf8'), 'c')
 
     t.end()

--- a/packages/trie/test/proof/range.spec.ts
+++ b/packages/trie/test/proof/range.spec.ts
@@ -78,13 +78,13 @@ async function verify(
   startKey = startKey ?? entries[start][0]
   endKey = endKey ?? entries[end][0]
   const targetRange = entries.slice(start, end + 1)
-  return await Trie.verifyRangeProof(
+  return await trie.verifyRangeProof(
     trie.root,
     startKey,
     endKey,
     keys ?? targetRange.map(([key]) => key),
     vals ?? targetRange.map(([, val]) => val),
-    [...(await Trie.createProof(trie, startKey)), ...(await Trie.createProof(trie, endKey))]
+    [...(await trie.createProof(startKey)), ...(await trie.createProof(endKey))]
   )
 }
 
@@ -195,7 +195,7 @@ tape('simple merkle range proofs generation and verification', function (tester)
     const { trie, entries } = await randomTrie(new LevelDB())
 
     t.equal(
-      await Trie.verifyRangeProof(
+      await trie.verifyRangeProof(
         trie.root,
         null,
         null,
@@ -456,7 +456,7 @@ tape('simple merkle range proofs generation and verification', function (tester)
 
     let bloatedProof: Buffer[] = []
     for (let i = 0; i < TRIE_SIZE; i++) {
-      bloatedProof = bloatedProof.concat(await Trie.createProof(trie, entries[i][0]))
+      bloatedProof = bloatedProof.concat(await trie.createProof(entries[i][0]))
     }
 
     t.equal(await verify(trie, entries, 0, entries.length - 1), false)

--- a/packages/trie/test/trie/secure.spec.ts
+++ b/packages/trie/test/trie/secure.spec.ts
@@ -26,8 +26,8 @@ tape('SecureTrie', function (t) {
       const trie = new SecureTrie({ db: new LevelDB() })
       await trie.put(Buffer.from('key1aa'), Buffer.from('01234'))
 
-      const proof = await SecureTrie.createProof(trie, Buffer.from('key1aa'))
-      const val = await SecureTrie.verifyProof(trie.root, Buffer.from('key1aa'), proof)
+      const proof = await trie.createProof(Buffer.from('key1aa'))
+      const val = await trie.verifyProof(trie.root, Buffer.from('key1aa'), proof)
       st.equal(val!.toString('utf8'), '01234')
       st.end()
     })

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -58,3 +58,8 @@ export const KECCAK256_RLP_S = '56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc0
  * Keccak-256 hash of the RLP of null
  */
 export const KECCAK256_RLP = Buffer.from(KECCAK256_RLP_S, 'hex')
+
+/**
+ *  RLP encoded empty string
+ */
+export const RLP_EMPTY_STRING = Buffer.from([0x80])


### PR DESCRIPTION
Keccak256 is the default hash algorithm for Ethereum, I use blake2b256 in my case. It's would be better that the underlying package supports customizing the hash algorithm rather than forking it.So I added the package level configurable hash function, by default it's keccak256.