### PR TITLE
Add "recovery" to ECDSA Signature Interface

### DIFF
--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -223,10 +223,12 @@ export interface ConfigOptions {
    */
   minerCoinbase?: Address
 
+  disableMinerHardforkByBlockNumber?: boolean
   /**
    * If there is a reorg, this is a safe distance from which
    * to try to refetch and refeed the blocks.
    */
+  
   safeReorgDistance?: number
 
   /**
@@ -291,6 +293,7 @@ export class Config {
   public readonly mine: boolean
   public readonly accounts: [address: Address, privKey: Buffer][]
   public readonly minerCoinbase?: Address
+  public readonly disableMinerHardforkByBlockNumber: boolean
 
   public readonly safeReorgDistance: number
   public readonly skeletonFillCanonicalBackStep: number
@@ -341,7 +344,7 @@ export class Config {
       options.skeletonSubchainMergeMinimum ?? Config.SKELETON_SUBCHAIN_MERGE_MINIMUM
     this.disableBeaconSync = options.disableBeaconSync ?? false
     this.forceSnapSync = options.forceSnapSync ?? false
-
+    this.disableMinerHardforkByBlockNumber = options.disableMinerHardforkByBlockNumber ?? false
     this.synchronized = false
     this.lastSyncDate = 0
 

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -223,6 +223,10 @@ export interface ConfigOptions {
    */
   minerCoinbase?: Address
 
+  /**
+   * Option to disable hardForkByBlockNumber during 
+   * Miner block building
+   */
   disableMinerHardforkByBlockNumber?: boolean
   /**
    * If there is a reorg, this is a safe distance from which

--- a/packages/client/lib/miner/miner.ts
+++ b/packages/client/lib/miner/miner.ts
@@ -259,7 +259,6 @@ export class Miner {
       },
       blockOpts: {
         cliqueSigner,
-        hardforkByBlockNumber: true,
         calcDifficultyFromHeader,
         putBlockIntoBlockchain: false,
       },

--- a/packages/client/lib/miner/miner.ts
+++ b/packages/client/lib/miner/miner.ts
@@ -247,7 +247,7 @@ export class Miner {
       calcDifficultyFromHeader = parentBlock.header
       coinbase = this.config.minerCoinbase ?? this.config.accounts[0][0]
     }
-
+    
     const blockBuilder = await vmCopy.buildBlock({
       parentBlock,
       headerData: {
@@ -260,6 +260,7 @@ export class Miner {
       blockOpts: {
         cliqueSigner,
         calcDifficultyFromHeader,
+        hardforkByBlockNumber: !this.config.disableMinerHardforkByBlockNumber,
         putBlockIntoBlockchain: false,
       },
     })

--- a/packages/client/lib/miner/pendingBlock.ts
+++ b/packages/client/lib/miner/pendingBlock.ts
@@ -49,6 +49,8 @@ export class PendingBlock {
     if (typeof vm.blockchain.getTotalDifficulty !== 'function') {
       throw new Error('cannot get iterator head: blockchain has no getTotalDifficulty function')
     }
+    const td = await vm.blockchain.getTotalDifficulty(parentBlock.hash())
+    !this.config.disableMinerHardforkByBlockNumber && vm._common.setHardforkByBlockNumber(parentBlock.header.number, td)
 
     const builder = await vm.buildBlock({
       parentBlock,

--- a/packages/client/lib/miner/pendingBlock.ts
+++ b/packages/client/lib/miner/pendingBlock.ts
@@ -49,8 +49,6 @@ export class PendingBlock {
     if (typeof vm.blockchain.getTotalDifficulty !== 'function') {
       throw new Error('cannot get iterator head: blockchain has no getTotalDifficulty function')
     }
-    const td = await vm.blockchain.getTotalDifficulty(parentBlock.hash())
-    vm._common.setHardforkByBlockNumber(parentBlock.header.number, td)
 
     const builder = await vm.buildBlock({
       parentBlock,

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -152,11 +152,11 @@ tape('[Miner]', async (t) => {
     const service = new FullEthereumService({
       config,
       chain,
-    })
+    })    
     const miner = new Miner({ config, service })
     const { txPool } = service
     const { vm } = service.execution
-
+    
     txPool.start()
     miner.start()
 
@@ -378,7 +378,7 @@ tape('[Miner]', async (t) => {
         { name: 'london', block: 3 },
       ],
     }
-    const common = Common.custom(customChainParams, { baseChain: CommonChain.Rinkeby })
+    const common = Common.custom(customChainParams, { baseChain: CommonChain.Rinkeby, eips: [1559] })
     common.setHardforkByBlockNumber(0)
     const config = new Config({ transports: [], accounts, mine: true, common })
     const chain = new Chain({ config })

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -85,7 +85,7 @@ tape('[Miner]', async (t) => {
   const common = new Common({ chain: CommonChain.Rinkeby, hardfork: Hardfork.Berlin })
   common.setMaxListeners(50)
   const accounts: [Address, Buffer][] = [[A.address, A.privateKey]]
-  const config = new Config({ transports: [], accounts, mine: true, common })
+  const config = new Config({ transports: [], accounts, mine: true, common, disableMinerHardforkByBlockNumber: true })
   config.events.setMaxListeners(50)
 
   const createTx = (
@@ -156,7 +156,7 @@ tape('[Miner]', async (t) => {
     const miner = new Miner({ config, service })
     const { txPool } = service
     const { vm } = service.execution
-    
+
     txPool.start()
     miner.start()
 
@@ -380,7 +380,7 @@ tape('[Miner]', async (t) => {
     }
     const common = Common.custom(customChainParams, { baseChain: CommonChain.Rinkeby, eips: [1559] })
     common.setHardforkByBlockNumber(0)
-    const config = new Config({ transports: [], accounts, mine: true, common })
+    const config = new Config({ transports: [], accounts, mine: true, common, disableMinerHardforkByBlockNumber: true })
     const chain = new Chain({ config })
     await chain.open()
     const service = new FullEthereumService({

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -34,7 +34,7 @@ const setBalance = async (vm: VM, address: Address, balance: bigint) => {
 }
 
 const common = new Common({ chain: CommonChain.Rinkeby, hardfork: Hardfork.Berlin })
-const config = new Config({ transports: [], common })
+const config = new Config({ transports: [], common, disableMinerHardforkByBlockNumber: true })
 
 const setup = () => {
   const stateManager = { getAccount: () => new Account(BigInt(0), BigInt('50000000000000000000')) }

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -372,25 +372,24 @@ export class Transaction extends BaseTransaction<Transaction> {
     // No unsigned tx and EIP-155 activated and chain ID included
     if (
       v !== undefined &&
-      v !== 0 &&
-      (!common || common.gteHardfork('spuriousDragon')) &&
-      v !== 27 &&
-      v !== 28
+      v !== 28 &&
+      v !== 27
     ) {
       if (common) {
-        if (!meetsEIP155(BigInt(v), common.chainId())) {
+
+        if (!meetsEIP155(BigInt(v), common.chainId()) || !common.gteHardfork('spuriousDragon')) {
           throw new Error(
             `Incompatible EIP155-based V ${v} and chain id ${common.chainId()}. See the Common parameter of the Transaction constructor to set the chain id.`
-          )
-        }
-      } else {
-        // Derive the original chain ID
-        let numSub
-        if ((v - 35) % 2 === 0) {
-          numSub = 35
+            )
+          } 
         } else {
-          numSub = 36
-        }
+          // Derive the original chain ID
+          let numSub
+          if ((v - 35) % 2 === 0) {
+            numSub = 35
+          } else {
+            numSub = 36
+          }
         // Use derived chain ID to create a proper Common
         chainIdBigInt = BigInt(v - numSub) / BigInt(2)
       }

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -302,7 +302,6 @@ export class Transaction extends BaseTransaction<Transaction> {
         v!,
         bigIntToUnpaddedBuffer(r!),
         bigIntToUnpaddedBuffer(s!),
-        this.supports(Capability.EIP155ReplayProtection) ? this.common.chainId() : undefined
       )
     } catch (e: any) {
       const msg = this._errorMsg('Invalid Signature')

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -52,33 +52,19 @@ export function ecsign(msgHash: Buffer, privateKey: Buffer, chainId?: bigint): E
  */
 
 export function calculateSigRecovery(v: bigint): bigint {
-    if (v === BigInt(0) || v === BigInt(1)) {
-      return v
-    } else if (v === BigInt(27) || v === BigInt(28)) {
-      return v - BigInt(27)
-    } else {
-      return v - (chainId * BigInt(2) + BigInt(35))
-    }
-  } else {
-    if (v === BigInt(0) || v === BigInt(1)) {
-      return v
-    } else if (v < BigInt(27)) {
-      throw new Error('invlaid v value < 27')
-    } else if (v > BigInt(28) && v < BigInt(35)) {
-      throw new Error('invlaid v value >28 & <35 ')
-    } else if (v > BigInt(36)) {
-      throw new Error('invlaid v value > 36')
-    }
-
-    if (v === BigInt(27) || v === BigInt(28)) {
-      return v - BigInt(27)
-    } else if ((v - BigInt(35)) % BigInt(2) === BigInt(0)) {
-      return BigInt(1)
-    } else if ((v - BigInt(35)) % BigInt(2) === BigInt(1)) {
+  if (v === BigInt(0) || v === BigInt(1)) {
+    return v
+  } else if (v === BigInt(27) || v === BigInt(28)) {
+    return v - BigInt(27)
+  } 
+  if (v >= BigInt(35)) {
+    if ((v - BigInt(35)) % BigInt(2) === BigInt(0)) {
       return BigInt(0)
     } else {
-      throw new Error(`Invalid v value`)
-    }
+      return BigInt(1)
+  }
+  } else {
+    throw new Error(`Invalid V value ${v}`)
   }
 }
 

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -52,36 +52,25 @@ export function ecsign(msgHash: Buffer, privateKey: Buffer, chainId?: bigint): E
  */
 
 export function calculateSigRecovery(v: bigint, chainId?: bigint): bigint {
-  if (chainId !== undefined) {
     if (v === BigInt(0) || v === BigInt(1)) {
       return v
-    } else if (v === BigInt(27) || v === BigInt(28)) {
+  }
+  if (v === BigInt(27) || v === BigInt(28)) {
       return v - BigInt(27)
-    } else {
+  }
+  if (chainId !== undefined) {
       return v - (chainId * BigInt(2) + BigInt(35))
-    }
-  } else if (chainId === undefined) {
-    if (v === BigInt(0) || v === BigInt(1)) {
-      return v
-    } else if (v < BigInt(27)) {
+  } else {
+    if (v < BigInt(27)) {
       // Returns an invalid signature value instead of throwing error
-      throw new Error('invlaid v value < 27')
+      throw new Error('invlaid v value')
     } else if (v > BigInt(28) && v < BigInt(35)) {
       // Returns an invalid signature value instead of throwing error
-      throw new Error('invlaid v value >28 & <35 ')
-    } else if (v > BigInt(36)) {
-      throw new Error('invlaid v value > 36')
-    }
-
-    if (v === BigInt(27) || v === BigInt(28)) {
-      return v - BigInt(27)
-    } else if ((((v - BigInt(35) - BigInt(0)) / BigInt(2)) * BigInt(2)) % BigInt(2) === BigInt(0)) {
-      return BigInt(0)
-    } else {
+      throw new Error('invlaid v value')
+    } else if (v % BigInt(2) === BigInt(1)) {
       return BigInt(1)
-    }
   } else {
-    throw new Error('unknown signature error')
+      return BigInt(0)
   }
 }
 

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -52,25 +52,33 @@ export function ecsign(msgHash: Buffer, privateKey: Buffer, chainId?: bigint): E
  */
 
 export function calculateSigRecovery(v: bigint, chainId?: bigint): bigint {
-  if (v === BigInt(0) || v === BigInt(1)) {
-    return v
-  }
-  if (v === BigInt(27) || v === BigInt(28)) {
-    return v - BigInt(27)
-  }
   if (chainId !== undefined) {
-    return v - (chainId * BigInt(2) + BigInt(35))
-  } else {
-    if (v < BigInt(27)) {
-      // Returns an invalid signature value instead of throwing error
-      throw new Error('invlaid v value')
-    } else if (v > BigInt(28) && v < BigInt(35)) {
-      // Returns an invalid signature value instead of throwing error
-      throw new Error('invlaid v value')
-    } else if (v % BigInt(2) === BigInt(1)) {
-      return BigInt(1)
+    if (v === BigInt(0) || v === BigInt(1)) {
+      return v
+    } else if (v === BigInt(27) || v === BigInt(28)) {
+      return v - BigInt(27)
     } else {
+      return v - (chainId * BigInt(2) + BigInt(35))
+    }
+  } else {
+    if (v === BigInt(0) || v === BigInt(1)) {
+      return v
+    } else if (v < BigInt(27)) {
+      throw new Error('invlaid v value < 27')
+    } else if (v > BigInt(28) && v < BigInt(35)) {
+      throw new Error('invlaid v value >28 & <35 ')
+    } else if (v > BigInt(36)) {
+      throw new Error('invlaid v value > 36')
+    }
+
+    if (v === BigInt(27) || v === BigInt(28)) {
+      return v - BigInt(27)
+    } else if ((v - BigInt(35)) % BigInt(2) === BigInt(0)) {
+      return BigInt(1)
+    } else if ((v - BigInt(35)) % BigInt(2) === BigInt(1)) {
       return BigInt(0)
+    } else {
+      throw new Error(`Invalid v value`)
     }
   }
 }

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -52,14 +52,14 @@ export function ecsign(msgHash: Buffer, privateKey: Buffer, chainId?: bigint): E
  */
 
 export function calculateSigRecovery(v: bigint, chainId?: bigint): bigint {
-    if (v === BigInt(0) || v === BigInt(1)) {
-      return v
+  if (v === BigInt(0) || v === BigInt(1)) {
+    return v
   }
   if (v === BigInt(27) || v === BigInt(28)) {
-      return v - BigInt(27)
+    return v - BigInt(27)
   }
   if (chainId !== undefined) {
-      return v - (chainId * BigInt(2) + BigInt(35))
+    return v - (chainId * BigInt(2) + BigInt(35))
   } else {
     if (v < BigInt(27)) {
       // Returns an invalid signature value instead of throwing error
@@ -69,10 +69,10 @@ export function calculateSigRecovery(v: bigint, chainId?: bigint): bigint {
       throw new Error('invlaid v value')
     } else if (v % BigInt(2) === BigInt(1)) {
       return BigInt(1)
-  } else {
+    } else {
       return BigInt(0)
+    }
   }
-}
 }
 
 /**
@@ -125,7 +125,6 @@ export const toCompactSig = function (v: bigint, r: Buffer, s: Buffer): string {
 
 /**
  * Convert signature format of the `eth_sign` RPC method to signature parameters
- *
  * NOTE: For an extracted `v` value < 27 (see Geth bug https://github.com/ethereum/go-ethereum/issues/2053)
  * `v + 27` is returned for the `v` value
  * NOTE: After EIP1559, `v` could be `0` or `1` but this function assumes

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -21,7 +21,7 @@ export interface ECDSASignature {
   /**
    * yParity: either 0 or 1, depending on which point on the elliptic curve should be used.
    */
-  recovery: bigint
+  recovery?: bigint
 }
 
 /**

--- a/packages/util/test/signature.spec.ts
+++ b/packages/util/test/signature.spec.ts
@@ -11,6 +11,7 @@ import {
   privateToPublic,
   toCompactSig,
   toRpcSig,
+  calculateSigRecovery,
 } from '../src'
 
 const echash = Buffer.from(
@@ -108,6 +109,7 @@ tape('ecrecover', function (t) {
     st.end()
   })
   t.test('should recover a public key (chainId = 3)', function (st) {
+    const chainId = BigInt(3)
     const r = Buffer.from('99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9', 'hex')
     const s = Buffer.from('129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66', 'hex')
     const v = BigInt(41)
@@ -305,10 +307,12 @@ tape('message sig', function (t) {
     const sig =
       '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca661b'
     st.equal(toRpcSig(BigInt(27), r, s), sig)
+    const recovery = calculateSigRecovery(BigInt(27))
     st.deepEqual(fromRpcSig(sig), {
       v: BigInt(27),
       r,
       s,
+      recovery,
     })
     st.end()
   })
@@ -316,11 +320,14 @@ tape('message sig', function (t) {
   t.test('should support compact signature representation (EIP-2098)', function (st) {
     const sig =
       '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66'
-    st.equal(toCompactSig(BigInt(27), r, s), sig)
+    const v = BigInt(27)
+    const recovery = calculateSigRecovery(v)
+    st.equal(toCompactSig(v, r, s), sig)
     st.deepEqual(fromRpcSig(sig), {
-      v: BigInt(27),
+      v,
       r,
       s,
+      recovery,
     })
     st.end()
   })
@@ -329,10 +336,12 @@ tape('message sig', function (t) {
     const sig =
       '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66'
     st.equal(toCompactSig(BigInt(0), r, s), sig)
+    const recovery = calculateSigRecovery(BigInt(0), chainId)
     st.deepEqual(fromRpcSig(sig), {
       v: BigInt(27),
       r,
       s,
+      recovery,
     })
     st.end()
   })
@@ -340,11 +349,14 @@ tape('message sig', function (t) {
   t.test('should support compact signature representation 2 (EIP-2098)', function (st) {
     const sig =
       '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9929ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66'
-    st.equal(toCompactSig(BigInt(28), r, s), sig)
+    const v = BigInt(28)
+    const recovery = calculateSigRecovery(v)
+    st.equal(toCompactSig(v, r, s), sig)
     st.deepEqual(fromRpcSig(sig), {
-      v: BigInt(28),
+      v,
       r,
       s,
+      recovery,
     })
     st.end()
   })
@@ -353,10 +365,14 @@ tape('message sig', function (t) {
     const sig =
       '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9929ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66'
     st.equal(toCompactSig(BigInt(1), r, s), sig)
+    const v = BigInt(1)
+    const recovery = calculateSigRecovery(v)
+    st.equal(toCompactSig(BigInt(1), r, s), sig)
     st.deepEqual(fromRpcSig(sig), {
       v: BigInt(28),
       r,
       s,
+      recovery,
     })
     st.end()
   })
@@ -366,11 +382,13 @@ tape('message sig', function (t) {
       '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66014f'
     const chainId = BigInt(150)
     const v = chainId * BigInt(2) + BigInt(35)
+    const recovery = calculateSigRecovery(v, chainId)
     st.equal(toRpcSig(v, r, s, chainId), sig)
-    st.deepEqual(fromRpcSig(sig), {
+    st.deepEqual(fromRpcSig(sig, chainId), {
       v,
       r,
       s,
+      recovery,
     })
     st.end()
   })

--- a/packages/vm/tests/api/EIPs/eip-3074-authcall.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3074-authcall.spec.ts
@@ -683,6 +683,7 @@ tape('EIP-3074 AUTHCALL', (t) => {
       v: signature.v,
       r: signature.s,
       s: signature.s,
+      recovery: signature.recovery,
     }
     const code = Buffer.concat([
       getAuthCode(message, signature, authAddress),


### PR DESCRIPTION
Fixes Issue #1961

Adds `recovery: bigint` as a value in `ECDSA Signature` interface.

`recovery` is calculated from `v` and `chainId`, or just `v` if no chainId is provided, and `EIP-155 Replay Protection` is enabled.

Updates `signature.spec.ts` test in `util`
and `eip-3074-authcall.spec.ts` in `vm` to use new interface/API

Resubmit of PR #1995 and PR #2012