### PR TITLE
evm: Remove dubious booleans in evm

### DIFF
--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -548,7 +548,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
           if (
             EOF.validOpcodes(
               result.returnValue.slice(codeStart, codeStart + eof1CodeAnalysisResults.code)
-            ) !== false
+            ) === false
           ) {
             result = {
               ...result,

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -548,9 +548,9 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
           // index 7 (if no data section is present) or index 10 (if a data section is present)
           // in the bytecode of the contract
           if (
-            !EOF.validOpcodes(
+            EOF.validOpcodes(
               result.returnValue.slice(codeStart, codeStart + eof1CodeAnalysisResults.code)
-            )
+            ) !== false
           ) {
             result = {
               ...result,
@@ -638,7 +638,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
     }
 
     const interpreter = new Interpreter(this, this.eei, env, message.gasLimit)
-    if (message.selfdestruct) {
+    if (typeof message.selfdestruct !== 'undefined') {
       interpreter._result.selfdestruct = message.selfdestruct as { [key: string]: Buffer }
     }
 
@@ -646,7 +646,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
 
     let result = interpreter._result
     let gasUsed = message.gasLimit - interpreterRes.runState!.gasLeft
-    if (interpreterRes.exceptionError) {
+    if (typeof interpreterRes.exceptionError !== 'undefined') {
       if (
         interpreterRes.exceptionError.error !== ERROR.REVERT &&
         interpreterRes.exceptionError.error !== ERROR.INVALID_EOF_FORMAT
@@ -673,7 +673,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
       gas: interpreterRes.runState?.gasLeft,
       executionGasUsed: gasUsed,
       gasRefund: interpreterRes.runState!.gasRefund,
-      returnValue: result.returnValue ? result.returnValue : Buffer.alloc(0),
+      returnValue: typeof result.returnValue !== 'undefined' ? result.returnValue : Buffer.alloc(0),
     }
   }
 
@@ -744,7 +744,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
       debug(
         `New message caller=${caller} gasLimit=${gasLimit} to=${
           to?.toString() ?? 'none'
-        } value=${value} delegatecall=${delegatecall ? 'yes' : 'no'}`
+        } value=${value} delegatecall=${typeof delegatecall !== 'undefined' ? 'yes' : 'no'}`
       )
     }
     if (message.to) {
@@ -860,7 +860,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
   }
 
   protected async _loadCode(message: Message): Promise<void> {
-    if (!message.code) {
+    if (typeof message.code === 'undefined') {
       const precompile = this.getPrecompile(message.codeAddress)
       if (precompile) {
         message.code = precompile
@@ -874,7 +874,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
 
   protected async _generateAddress(message: Message): Promise<Address> {
     let addr
-    if (message.salt) {
+    if (typeof message.salt !== 'undefined') {
       addr = generateAddress2(message.caller.buf, message.salt, message.code as Buffer)
     } else {
       const acc = await this.eei.getAccount(message.caller)

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -8,8 +8,6 @@ import {
   bigIntToBuffer,
   generateAddress,
   generateAddress2,
-  isFalsy,
-  isTruthy,
   KECCAK256_NULL,
   MAX_INTEGER,
   short,
@@ -363,7 +361,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
         debug(`Exit early on no code`)
       }
     }
-    if (isTruthy(errorMessage)) {
+    if (typeof errorMessage !== 'undefined') {
       exit = true
       if (this.DEBUG) {
         debug(`Exit early on value transfer overflowed`)
@@ -475,13 +473,13 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
     }
 
     let exit = false
-    if (isFalsy(message.code) || message.code.length === 0) {
+    if (typeof message.code === 'undefined' || message.code.length === 0) {
       exit = true
       if (this.DEBUG) {
         debug(`Exit early on no code`)
       }
     }
-    if (isTruthy(errorMessage)) {
+    if (typeof errorMessage !== 'undefined') {
       exit = true
       if (this.DEBUG) {
         debug(`Exit early on value transfer overflowed`)
@@ -587,7 +585,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
     // Save code if a new contract was created
     if (
       !result.exceptionError &&
-      isTruthy(result.returnValue) &&
+      typeof result.returnValue !== 'undefined' &&
       result.returnValue.toString() !== ''
     ) {
       await this.eei.putContractCode(message.to, result.returnValue)

--- a/packages/evm/tests/runCall.spec.ts
+++ b/packages/evm/tests/runCall.spec.ts
@@ -134,12 +134,12 @@ tape('Byzantium cannot access Constantinople opcodes', async (t) => {
   const constantinopleResult = await evmConstantinople.runCall(runCallArgs)
 
   t.assert(
-    byzantiumResult.execResult.exceptionError &&
+    typeof byzantiumResult.execResult.exceptionError !== 'undefined' &&
       byzantiumResult.execResult.exceptionError.error === 'invalid opcode',
     'byzantium cannot accept constantinople opcodes (SHL)'
   )
   t.assert(
-    !constantinopleResult.execResult.exceptionError,
+    typeof constantinopleResult.execResult.exceptionError === 'undefined',
     'constantinople can access the SHL opcode'
   )
 


### PR DESCRIPTION
Following on #2030, I noticed the linter complaining about some implicit boolean truthiness being checked in `evm.ts` so trying to come up with better typing to satisfy the new explicit boolean linter rule and also remove the `isTruthy`/`isFalsy` methods @gabrocheleau introduced for us to use as a fallback.  I'm on the fence about whether I like the "improvements."  Since alot of our booleans were previously using the existence of an object in a check as below:
```js
if (someObject.Property) {
// do something
}
```
or 
```js
if (!someObjectOrVariable) {
/// do something
}
```
we basically have to check if something is undefined or not, and according to multiple stackOverflow questions, the only correct way to do this is to make our code look like this:
```js
if (typeof someObject.Property !== 'undefined') {
// do something
}
// or
if (typeof someOjbectOrVariable === 'undefined`) {
// do something
}
```

What do y'all think?
