### PR TITLE
feat(trie): implement root hash persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19413,15 +19413,15 @@
     },
     "packages/block": {
       "name": "@ethereumjs/block",
-      "version": "4.0.0-beta.1",
+      "version": "4.0.0-beta.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/trie": "5.0.0-beta.1",
-        "@ethereumjs/tx": "4.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/trie": "5.0.0-beta.2",
+        "@ethereumjs/tx": "4.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "ethereum-cryptography": "^1.1.2",
-        "rlp": "4.0.0-beta.1"
+        "rlp": "4.0.0-beta.2"
       },
       "devDependencies": {
         "@types/lru-cache": "^5.1.0",
@@ -19505,21 +19505,21 @@
     },
     "packages/blockchain": {
       "name": "@ethereumjs/blockchain",
-      "version": "6.0.0-beta.1",
+      "version": "6.0.0-beta.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/block": "4.0.0-beta.1",
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/ethash": "2.0.0-beta.1",
-        "@ethereumjs/trie": "5.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/block": "4.0.0-beta.2",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/ethash": "2.0.0-beta.2",
+        "@ethereumjs/trie": "5.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "abstract-level": "^1.0.3",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^1.1.2",
         "level": "^8.0.0",
         "lru-cache": "^5.1.1",
         "memory-level": "^1.0.0",
-        "rlp": "4.0.0-beta.1",
+        "rlp": "4.0.0-beta.2",
         "semaphore-async-await": "^1.5.1"
       },
       "devDependencies": {
@@ -19606,22 +19606,22 @@
     },
     "packages/client": {
       "name": "@ethereumjs/client",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {
         "@chainsafe/libp2p-noise": "^4.1.1",
-        "@ethereumjs/block": "4.0.0-beta.1",
-        "@ethereumjs/blockchain": "6.0.0-beta.1",
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/devp2p": "5.0.0-beta.1",
-        "@ethereumjs/ethash": "2.0.0-beta.1",
-        "@ethereumjs/evm": "1.0.0-beta.1",
-        "@ethereumjs/statemanager": "1.0.0-beta.1",
-        "@ethereumjs/trie": "5.0.0-beta.1",
-        "@ethereumjs/tx": "4.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
-        "@ethereumjs/vm": "6.0.0-beta.1",
+        "@ethereumjs/block": "4.0.0-beta.2",
+        "@ethereumjs/blockchain": "6.0.0-beta.2",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/devp2p": "5.0.0-beta.2",
+        "@ethereumjs/ethash": "2.0.0-beta.2",
+        "@ethereumjs/evm": "1.0.0-beta.2",
+        "@ethereumjs/statemanager": "1.0.0-beta.2",
+        "@ethereumjs/trie": "5.0.0-beta.2",
+        "@ethereumjs/tx": "4.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
+        "@ethereumjs/vm": "6.0.0-beta.2",
         "abstract-level": "^1.0.3",
         "body-parser": "^1.19.2",
         "chalk": "^4.1.2",
@@ -19646,7 +19646,7 @@
         "multiaddr": "^10.0.1",
         "peer-id": "^0.14.3",
         "qheap": "^1.4.0",
-        "rlp": "4.0.0-beta.1",
+        "rlp": "4.0.0-beta.2",
         "winston": "^3.3.3",
         "winston-daily-rotate-file": "^4.5.5",
         "yargs": "^17.2.1"
@@ -19759,10 +19759,10 @@
     },
     "packages/common": {
       "name": "@ethereumjs/common",
-      "version": "3.0.0-beta.1",
+      "version": "3.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "crc-32": "^1.2.0"
       },
       "devDependencies": {
@@ -19846,11 +19846,11 @@
     },
     "packages/devp2p": {
       "name": "@ethereumjs/devp2p",
-      "version": "5.0.0-beta.1",
+      "version": "5.0.0-beta.2",
       "license": "MIT",
       "dependencies": {
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "@scure/base": "1.1.1",
         "@types/bl": "^2.1.0",
         "@types/k-bucket": "^5.0.0",
@@ -19864,13 +19864,13 @@
         "lru-cache": "^5.1.1",
         "ms": "^0.7.1",
         "multiaddr": "^10.0.1",
-        "rlp": "4.0.0-beta.1",
+        "rlp": "4.0.0-beta.2",
         "scanf": "^1.1.2",
         "snappyjs": "^0.6.1"
       },
       "devDependencies": {
-        "@ethereumjs/block": "4.0.0-beta.1",
-        "@ethereumjs/tx": "4.0.0-beta.1",
+        "@ethereumjs/block": "4.0.0-beta.2",
+        "@ethereumjs/tx": "4.0.0-beta.2",
         "@types/chalk": "^2.2.0",
         "@types/debug": "^4.1.4",
         "@types/ip": "^1.1.0",
@@ -20017,20 +20017,20 @@
     },
     "packages/ethash": {
       "name": "@ethereumjs/ethash",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/block": "4.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/block": "4.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "abstract-level": "^1.0.3",
         "bigint-crypto-utils": "^3.0.23",
         "buffer-xor": "^2.0.1",
         "ethereum-cryptography": "^1.1.2",
         "miller-rabin": "^4.0.0",
-        "rlp": "4.0.0-beta.1"
+        "rlp": "4.0.0-beta.2"
       },
       "devDependencies": {
-        "@ethereumjs/common": "3.0.0-beta.1",
+        "@ethereumjs/common": "3.0.0-beta.2",
         "@types/tape": "^4.13.2",
         "eslint": "^6.8.0",
         "memory-level": "^1.0.0",
@@ -20106,11 +20106,11 @@
     },
     "packages/evm": {
       "name": "@ethereumjs/evm",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "async-eventemitter": "^0.2.4",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^1.1.2",
@@ -20118,7 +20118,7 @@
         "rustbn.js": "~0.2.0"
       },
       "devDependencies": {
-        "@ethereumjs/statemanager": "1.0.0-beta.1",
+        "@ethereumjs/statemanager": "1.0.0-beta.2",
         "@ethersproject/abi": "^5.0.12",
         "@types/async-eventemitter": "^0.2.1",
         "@types/benchmark": "^1.0.33",
@@ -20212,7 +20212,7 @@
       }
     },
     "packages/rlp": {
-      "version": "4.0.0-beta.1",
+      "version": "4.0.0-beta.2",
       "license": "MPL-2.0",
       "bin": {
         "rlp": "bin/rlp"
@@ -20234,16 +20234,16 @@
     },
     "packages/statemanager": {
       "name": "@ethereumjs/statemanager",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0-beta.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/trie": "5.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/trie": "5.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^1.1.2",
         "functional-red-black-tree": "^1.0.1",
-        "rlp": "4.0.0-beta.1"
+        "rlp": "4.0.0-beta.2"
       },
       "devDependencies": {
         "@types/node": "^16.11.7",
@@ -20327,16 +20327,16 @@
     },
     "packages/trie": {
       "name": "@ethereumjs/trie",
-      "version": "5.0.0-beta.1",
+      "version": "5.0.0-beta.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "abstract-level": "^1.0.3",
         "ethereum-cryptography": "^1.1.2",
         "level": "^8.0.0",
         "memory-level": "^1.0.0",
         "readable-stream": "^3.6.0",
-        "rlp": "4.0.0-beta.1",
+        "rlp": "4.0.0-beta.2",
         "semaphore-async-await": "^1.5.1"
       },
       "devDependencies": {
@@ -20424,13 +20424,13 @@
     },
     "packages/tx": {
       "name": "@ethereumjs/tx",
-      "version": "4.0.0-beta.1",
+      "version": "4.0.0-beta.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "ethereum-cryptography": "^1.1.2",
-        "rlp": "4.0.0-beta.1"
+        "rlp": "4.0.0-beta.2"
       },
       "devDependencies": {
         "@types/minimist": "^1.2.0",
@@ -20516,11 +20516,11 @@
     },
     "packages/util": {
       "name": "@ethereumjs/util",
-      "version": "8.0.0-beta.1",
+      "version": "8.0.0-beta.2",
       "license": "MPL-2.0",
       "dependencies": {
         "ethereum-cryptography": "^1.1.2",
-        "rlp": "4.0.0-beta.1"
+        "rlp": "4.0.0-beta.2"
       },
       "devDependencies": {
         "@types/bn.js": "^5.1.0",
@@ -20588,24 +20588,24 @@
     },
     "packages/vm": {
       "name": "@ethereumjs/vm",
-      "version": "6.0.0-beta.1",
+      "version": "6.0.0-beta.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/block": "4.0.0-beta.1",
-        "@ethereumjs/blockchain": "6.0.0-beta.1",
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/evm": "1.0.0-beta.1",
-        "@ethereumjs/statemanager": "1.0.0-beta.1",
-        "@ethereumjs/trie": "5.0.0-beta.1",
-        "@ethereumjs/tx": "4.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/block": "4.0.0-beta.2",
+        "@ethereumjs/blockchain": "6.0.0-beta.2",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/evm": "1.0.0-beta.2",
+        "@ethereumjs/statemanager": "1.0.0-beta.2",
+        "@ethereumjs/trie": "5.0.0-beta.2",
+        "@ethereumjs/tx": "4.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "async-eventemitter": "^0.2.4",
         "core-js-pure": "^3.0.1",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^1.1.2",
         "functional-red-black-tree": "^1.0.1",
         "mcl-wasm": "^0.7.1",
-        "rlp": "4.0.0-beta.1",
+        "rlp": "4.0.0-beta.2",
         "rustbn.js": "~0.2.0"
       },
       "devDependencies": {
@@ -21117,10 +21117,10 @@
     "@ethereumjs/block": {
       "version": "file:packages/block",
       "requires": {
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/trie": "5.0.0-beta.1",
-        "@ethereumjs/tx": "4.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/trie": "5.0.0-beta.2",
+        "@ethereumjs/tx": "4.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "@types/lru-cache": "^5.1.0",
         "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
@@ -21133,7 +21133,7 @@
         "karma-typescript": "^5.5.3",
         "nyc": "^15.1.0",
         "prettier": "^2.0.5",
-        "rlp": "4.0.0-beta.1",
+        "rlp": "4.0.0-beta.2",
         "tape": "^5.3.1",
         "ts-node": "^10.2.1",
         "typedoc": "^0.22.4",
@@ -21189,11 +21189,11 @@
     "@ethereumjs/blockchain": {
       "version": "file:packages/blockchain",
       "requires": {
-        "@ethereumjs/block": "4.0.0-beta.1",
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/ethash": "2.0.0-beta.1",
-        "@ethereumjs/trie": "5.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/block": "4.0.0-beta.2",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/ethash": "2.0.0-beta.2",
+        "@ethereumjs/trie": "5.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "@types/async": "^2.4.1",
         "@types/level-errors": "^3.0.0",
         "@types/lru-cache": "^5.1.0",
@@ -21213,7 +21213,7 @@
         "memory-level": "^1.0.0",
         "nyc": "^15.1.0",
         "prettier": "^2.0.5",
-        "rlp": "4.0.0-beta.1",
+        "rlp": "4.0.0-beta.2",
         "semaphore-async-await": "^1.5.1",
         "tape": "^5.3.1",
         "ts-node": "^10.2.1",
@@ -21272,17 +21272,17 @@
       "requires": {
         "@babel/plugin-transform-spread": "^7.10.1",
         "@chainsafe/libp2p-noise": "^4.1.1",
-        "@ethereumjs/block": "4.0.0-beta.1",
-        "@ethereumjs/blockchain": "6.0.0-beta.1",
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/devp2p": "5.0.0-beta.1",
-        "@ethereumjs/ethash": "2.0.0-beta.1",
-        "@ethereumjs/evm": "1.0.0-beta.1",
-        "@ethereumjs/statemanager": "1.0.0-beta.1",
-        "@ethereumjs/trie": "5.0.0-beta.1",
-        "@ethereumjs/tx": "4.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
-        "@ethereumjs/vm": "6.0.0-beta.1",
+        "@ethereumjs/block": "4.0.0-beta.2",
+        "@ethereumjs/blockchain": "6.0.0-beta.2",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/devp2p": "5.0.0-beta.2",
+        "@ethereumjs/ethash": "2.0.0-beta.2",
+        "@ethereumjs/evm": "1.0.0-beta.2",
+        "@ethereumjs/statemanager": "1.0.0-beta.2",
+        "@ethereumjs/trie": "5.0.0-beta.2",
+        "@ethereumjs/tx": "4.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
+        "@ethereumjs/vm": "6.0.0-beta.2",
         "@types/body-parser": "^1.19.2",
         "@types/connect": "^3.4.35",
         "@types/fs-extra": "^8.1.0",
@@ -21330,7 +21330,7 @@
         "process": "^0.11.10",
         "pull-pair": "^1.1.0",
         "qheap": "^1.4.0",
-        "rlp": "4.0.0-beta.1",
+        "rlp": "4.0.0-beta.2",
         "stream-browserify": "^3.0.0",
         "supertest": "^6.1.3",
         "superwstest": "^2.0.1",
@@ -21396,7 +21396,7 @@
     "@ethereumjs/common": {
       "version": "file:packages/common",
       "requires": {
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
         "crc-32": "^1.2.0",
@@ -21463,10 +21463,10 @@
     "@ethereumjs/devp2p": {
       "version": "file:packages/devp2p",
       "requires": {
-        "@ethereumjs/block": "4.0.0-beta.1",
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/tx": "4.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/block": "4.0.0-beta.2",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/tx": "4.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "@scure/base": "1.1.1",
         "@types/bl": "^2.1.0",
         "@types/chalk": "^2.2.0",
@@ -21490,7 +21490,7 @@
         "multiaddr": "^10.0.1",
         "nyc": "^15.1.0",
         "prettier": "^2.0.5",
-        "rlp": "4.0.0-beta.1",
+        "rlp": "4.0.0-beta.2",
         "scanf": "^1.1.2",
         "snappyjs": "^0.6.1",
         "tape": "^5.3.1",
@@ -21599,9 +21599,9 @@
     "@ethereumjs/ethash": {
       "version": "file:packages/ethash",
       "requires": {
-        "@ethereumjs/block": "4.0.0-beta.1",
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/block": "4.0.0-beta.2",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "@types/tape": "^4.13.2",
         "abstract-level": "^1.0.3",
         "bigint-crypto-utils": "^3.0.23",
@@ -21612,7 +21612,7 @@
         "miller-rabin": "^4.0.0",
         "nyc": "^15.1.0",
         "prettier": "^2.0.5",
-        "rlp": "4.0.0-beta.1",
+        "rlp": "4.0.0-beta.2",
         "tape": "^5.3.1",
         "ts-node": "^10.2.1",
         "typedoc": "^0.22.4",
@@ -21668,9 +21668,9 @@
     "@ethereumjs/evm": {
       "version": "file:packages/evm",
       "requires": {
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/statemanager": "1.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/statemanager": "1.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "@ethersproject/abi": "^5.0.12",
         "@types/async-eventemitter": "^0.2.1",
         "@types/benchmark": "^1.0.33",
@@ -21755,9 +21755,9 @@
     "@ethereumjs/statemanager": {
       "version": "file:packages/statemanager",
       "requires": {
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/trie": "5.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/trie": "5.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
         "debug": "^4.3.3",
@@ -21771,7 +21771,7 @@
         "karma-typescript": "^5.5.3",
         "nyc": "^15.1.0",
         "prettier": "^2.0.5",
-        "rlp": "4.0.0-beta.1",
+        "rlp": "4.0.0-beta.2",
         "standard": "^10.0.0",
         "tape": "^5.3.1",
         "ts-node": "^10.2.1",
@@ -21828,7 +21828,7 @@
     "@ethereumjs/trie": {
       "version": "file:packages/trie",
       "requires": {
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "@types/benchmark": "^1.0.33",
         "@types/node": "^16.11.7",
         "@types/readable-stream": "^2.3.13",
@@ -21848,7 +21848,7 @@
         "nyc": "^15.1.0",
         "prettier": "^2.0.5",
         "readable-stream": "^3.6.0",
-        "rlp": "4.0.0-beta.1",
+        "rlp": "4.0.0-beta.2",
         "semaphore-async-await": "^1.5.1",
         "tape": "^5.3.1",
         "ts-node": "^10.2.1",
@@ -21905,8 +21905,8 @@
     "@ethereumjs/tx": {
       "version": "file:packages/tx",
       "requires": {
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "@types/minimist": "^1.2.0",
         "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
@@ -21921,7 +21921,7 @@
         "node-dir": "^0.1.16",
         "nyc": "^15.1.0",
         "prettier": "^2.0.5",
-        "rlp": "4.0.0-beta.1",
+        "rlp": "4.0.0-beta.2",
         "tape": "^5.3.1",
         "ts-node": "^10.2.1",
         "typedoc": "^0.22.4",
@@ -21990,7 +21990,7 @@
         "karma-typescript": "^5.5.3",
         "nyc": "^15.1.0",
         "prettier": "^2.0.5",
-        "rlp": "4.0.0-beta.1",
+        "rlp": "4.0.0-beta.2",
         "tape": "^4.10.1",
         "ts-node": "^10.2.1",
         "typescript": "^4.4.2"
@@ -22038,14 +22038,14 @@
     "@ethereumjs/vm": {
       "version": "file:packages/vm",
       "requires": {
-        "@ethereumjs/block": "4.0.0-beta.1",
-        "@ethereumjs/blockchain": "6.0.0-beta.1",
-        "@ethereumjs/common": "3.0.0-beta.1",
-        "@ethereumjs/evm": "1.0.0-beta.1",
-        "@ethereumjs/statemanager": "1.0.0-beta.1",
-        "@ethereumjs/trie": "5.0.0-beta.1",
-        "@ethereumjs/tx": "4.0.0-beta.1",
-        "@ethereumjs/util": "8.0.0-beta.1",
+        "@ethereumjs/block": "4.0.0-beta.2",
+        "@ethereumjs/blockchain": "6.0.0-beta.2",
+        "@ethereumjs/common": "3.0.0-beta.2",
+        "@ethereumjs/evm": "1.0.0-beta.2",
+        "@ethereumjs/statemanager": "1.0.0-beta.2",
+        "@ethereumjs/trie": "5.0.0-beta.2",
+        "@ethereumjs/tx": "4.0.0-beta.2",
+        "@ethereumjs/util": "8.0.0-beta.2",
         "@ethersproject/abi": "^5.0.12",
         "@types/async-eventemitter": "^0.2.1",
         "@types/benchmark": "^1.0.33",
@@ -22074,7 +22074,7 @@
         "node-dir": "^0.1.17",
         "nyc": "^15.1.0",
         "prettier": "^2.0.5",
-        "rlp": "4.0.0-beta.1",
+        "rlp": "4.0.0-beta.2",
         "rustbn.js": "~0.2.0",
         "solc": "^0.8.1",
         "standard": "^10.0.0",

--- a/packages/trie/src/db/index.ts
+++ b/packages/trie/src/db/index.ts
@@ -1,2 +1,4 @@
 export * from './checkpoint'
 export * from './level'
+
+export const ROOT_DB_KEY = Buffer.from('__root__')

--- a/packages/trie/src/trie/checkpoint.ts
+++ b/packages/trie/src/trie/checkpoint.ts
@@ -42,6 +42,7 @@ export class CheckpointTrie extends Trie {
 
     await this.lock.wait()
     await this.db.commit()
+    await this.persistRoot()
     this.lock.signal()
   }
 
@@ -57,6 +58,7 @@ export class CheckpointTrie extends Trie {
 
     await this.lock.wait()
     this.root = await this.db.revert()
+    await this.persistRoot()
     this.lock.signal()
   }
 
@@ -69,6 +71,7 @@ export class CheckpointTrie extends Trie {
       db: this.dbStorage.copy(),
       root: this.root,
       deleteFromDB: (this as any)._deleteFromDB,
+      persistRoot: (this as any)._persistRoot,
     })
     if (includeCheckpoints && this.isCheckpoint) {
       trie.db.checkpoints = [...this.db.checkpoints]

--- a/packages/trie/src/trie/secure.ts
+++ b/packages/trie/src/trie/secure.ts
@@ -1,6 +1,7 @@
 import { CheckpointTrie } from './checkpoint'
 import { Proof } from '../types'
 import { isFalsy } from '@ethereumjs/util'
+import { ROOT_DB_KEY } from '../db'
 
 /**
  * You can create a secure Trie where the keys are automatically hashed
@@ -107,10 +108,20 @@ export class SecureTrie extends CheckpointTrie {
       db: this.dbStorage.copy(),
       root: this.root,
       deleteFromDB: (this as any)._deleteFromDB,
+      persistRoot: (this as any)._persistRoot,
     })
     if (includeCheckpoints && this.isCheckpoint) {
       secureTrie.db.checkpoints = [...this.db.checkpoints]
     }
     return secureTrie
+  }
+
+  /**
+   * Persists the root hash in the underlying database
+   */
+  async persistRoot() {
+    if (this._persistRoot !== undefined) {
+      await this.db.put(this.hash(ROOT_DB_KEY), this.root)
+    }
   }
 }

--- a/packages/trie/src/types.ts
+++ b/packages/trie/src/types.ts
@@ -20,6 +20,11 @@ export type FoundNodeFunction = (
 
 export type HashFunc = (msg: Uint8Array) => Uint8Array
 
+export interface TrieOptsPersistentRoot {
+  enabled: boolean
+  key: Buffer
+}
+
 export interface TrieOpts {
   /**
    * A database instance.
@@ -39,6 +44,11 @@ export interface TrieOpts {
    * Hash function used for hashing trie node and securing key.
    */
   hash?: HashFunc
+
+  /**
+   * Store the root inside the database after every `write` operation
+   */
+  persistRoot?: boolean
 }
 
 export type BatchDBOp = PutBatch | DelBatch


### PR DESCRIPTION
> Resolves https://github.com/ethereumjs/ethereumjs-monorepo/issues/2061

**Please don't update the branch via UI because I'll be squashing my commits as I keep pushing.**

A few question before I continue this and add tests:

- ~One of the requirements is `It should default to true if a DB is passed into the constructor and be hardcoded to false if not.` so what should the conditional be. Something like `this._persistRoot = (opts?.db ? true : opts?.persistRoot) ?? false`? The requirement sounds a bit confusing because what if the user doesn't want root persistence but they still passed in a database? The boolean flag seems a bit unnecessary if we make it dependent on `opts.db` being defined.~
- I added `const ROOT_DB_KEY = Buffer.from('__root__')` and wanted to add another constant for the keccak256 key but then realised that the hashing function is now modular. Should I do the hashing on the fly?
- Should I throw an exception if `put` methods of any trie are called with the `ROOT_DB_KEY` key, meaning a user manually wanted to modify that value?
- I used `__root__` instead of `__persistedRootHash__` since the `__` prefix and suffix should already distinguish it enough from user space wording.