### PR TITLE
common: Set goerli merge ttd to 10790000

### DIFF
--- a/packages/common/src/chains/goerli.json
+++ b/packages/common/src/chains/goerli.json
@@ -72,7 +72,14 @@
       "forkHash": "0xb8c6299d"
     },
     {
+      "//_comment": "The forkHash will remain same as mergeForkIdTransition is post merge",
       "name": "merge",
+      "ttd": "10790000",
+      "block": null,
+      "forkHash": "0xb8c6299d"
+    },
+    {
+      "name": "mergeForkIdTransition",
       "block": null,
       "forkHash": null
     },


### PR DESCRIPTION
Set goerli merge ttd to 10790000

Reference: https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/paris.md

![image](https://user-images.githubusercontent.com/76567250/181262766-b882076f-b607-4b50-af32-4e500e21df84.png)
