### PR TITLE
client: allow eth_call without to for testing contract creation

### DIFF
--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -313,7 +313,7 @@ export class Eth {
     this.blockNumber = middleware(this.blockNumber.bind(this), 0)
 
     this.call = middleware(this.call.bind(this), 2, [
-      [validators.transaction(['to'])],
+      [validators.transaction()],
       [validators.blockOption],
     ])
 

--- a/packages/client/test/rpc/eth/call.spec.ts
+++ b/packages/client/test/rpc/eth/call.spec.ts
@@ -104,6 +104,13 @@ tape(`${method}: call with valid arguments`, async (t) => {
     const msg = 'should return the correct return value with no gas limit provided'
     t.equal(res.body.result, bufferToHex(execResult.returnValue), msg)
   }
+  await baseRequest(t, server, req, 200, expectRes, false)
+
+  req = params(method, [{ gasLimit, data }, 'latest'])
+  expectRes = (res: any) => {
+    const msg = `should let run call without 'to' for contract creation`
+    t.equal(res.body.result, bufferToHex(result.results[0].execResult.returnValue), msg)
+  }
   await baseRequest(t, server, req, 200, expectRes, true)
 })
 


### PR DESCRIPTION
client: allow eth_call without to for testing contract creation 

Allows contract creation via eth_call without providing `to`.

Closes #1987
