### PR TITLE
common: Update the mergeForkIdTransition hardfork schedule for sepolia

### DIFF
--- a/packages/common/src/chains/sepolia.json
+++ b/packages/common/src/chains/sepolia.json
@@ -82,8 +82,8 @@
     },
     {
       "name": "mergeForkIdTransition",
-      "block": null,
-      "forkHash": null
+      "block": 1735371,
+      "forkHash": "0xb96cbd13"
     },
     {
       "name": "shanghai",


### PR DESCRIPTION
Update `mergeForkIdTransition` hardfork schedule

![image](https://user-images.githubusercontent.com/76567250/182674584-09197a54-eea4-4c60-98fd-7ff9d5a968fc.png)



Reference: https://github.com/ethereum/execution-specs/pull/564