### PR TITLE
ci: retry `devp2p` workflow up to 3 times

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 15
+          timeout_minutes: 10
           max_attempts: 3
           command: cd ${{github.workspace}}/packages/client && npm run test:integration
 
@@ -71,6 +71,6 @@ jobs:
 
       - uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 15
+          timeout_minutes: 10
           max_attempts: 3
           command: cd ${{github.workspace}}/packages/client && npm run test:cli -- --network=${{matrix.network}} --syncmode=${{matrix.syncmode}} --transports rlpx

--- a/.github/workflows/devp2p-build.yml
+++ b/.github/workflows/devp2p-build.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: nick-fields/retry@v2
         with:
-          timeout_minutes: 15
+          timeout_minutes: 10
           max_attempts: 3
           command: cd ${{github.workspace}}/packages/devp2p && npm run coverage
 

--- a/.github/workflows/devp2p-build.yml
+++ b/.github/workflows/devp2p-build.yml
@@ -36,7 +36,11 @@ jobs:
       - run: npm i
         working-directory: ${{github.workspace}}
 
-      - run: npm run coverage
+      - uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          command: npm run coverage
 
       - uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/devp2p-build.yml
+++ b/.github/workflows/devp2p-build.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           timeout_minutes: 15
           max_attempts: 3
-          command: npm run coverage
+          command: cd ${{github.workspace}}/packages/devp2p && npm run coverage
 
       - uses: codecov/codecov-action@v2
         with:


### PR DESCRIPTION
Another flaky test that I noticed so retrying that up to 3 times, same as the client syncing tests for goerli. Also lowered the timeout from 15 to 10 minutes because the jobs seem to take around 8 minutes at peak and 5 on average.