### PR TITLE
VM, EVM, Common: Implement EIP-2330 Extsload Opcode

### DIFF
--- a/packages/common/src/eips/2330.json
+++ b/packages/common/src/eips/2330.json
@@ -1,0 +1,13 @@
+{
+  "name": "EIP-2330",
+  "number": 2330,
+  "comment": "EXTSLOAD",
+  "url": "https://eips.ethereum.org/EIPS/eip-2330",
+  "status": "Draft",
+  "minimumHardfork": "chainstart",
+  "requiredEIPs": [],
+  "gasConfig": {},
+  "gasPrices": {},
+  "vm": {},
+  "pow": {}
+}

--- a/packages/common/src/eips/index.ts
+++ b/packages/common/src/eips/index.ts
@@ -2,6 +2,7 @@ export const EIPs: { [key: number]: any } = {
   1153: require('./1153.json'),
   1559: require('./1559.json'),
   2315: require('./2315.json'),
+  2330: require('./2330.json'),
   2537: require('./2537.json'),
   2565: require('./2565.json'),
   2718: require('./2718.json'),

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -62,6 +62,7 @@ export interface EVMOpts {
    * - [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153) - Transient Storage Opcodes (`experimental`)
    * - [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) - EIP-1559 Fee Market
    * - [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) - VM simple subroutines (`experimental`)
+   * - [EIP-2330](https://eips.ethereum.org/EIPS/eip-2330) - EXTSLOAD (`experimental`)
    * - [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) - BLS12-381 precompiles (`experimental`)
    * - [EIP-2565](https://eips.ethereum.org/EIPS/eip-2565) - ModExp Gas Cost
    * - [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) - Typed Transactions
@@ -235,8 +236,8 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
 
     // Supported EIPs
     const supportedEIPs = [
-      1153, 1559, 2315, 2537, 2565, 2718, 2929, 2930, 3074, 3198, 3529, 3540, 3541, 3607, 3651,
-      3670, 3855, 3860, 4399, 5133,
+      1153, 1559, 2315, 2330, 2537, 2565, 2718, 2929, 2930, 3074, 3198, 3529, 3540, 3541, 3607,
+      3651, 3670, 3855, 3860, 4399, 5133,
     ]
 
     for (const eip of this._common.eips()) {

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -490,6 +490,16 @@ export class Interpreter {
   }
 
   /**
+   * Loads a 256-bit value to memory from persistent storage.
+   * @param address - Address of account
+   * @param key - Storage key
+   * @param original - If true, return the original storage value (default: false)
+   */
+  async externalStorageLoad(address: Address, key: Buffer, original = false): Promise<Buffer> {
+    return this._eei.storageLoad(address, key, original)
+  }
+
+  /**
    * Store 256-bit a value in memory to transient storage.
    * @param address Address to use
    * @param key Storage key

--- a/packages/evm/src/opcodes/EIP2929.ts
+++ b/packages/evm/src/opcodes/EIP2929.ts
@@ -46,24 +46,24 @@ export function accessAddressEIP2929(
  * Adjusts cost incurred for executing opcode based on whether storage read
  * is warm/cold. (EIP 2929)
  * @param {RunState} runState
+ * @param {Address} address (of the account)
  * @param {Buffer} key (to storage slot)
  * @param {Common} common
  */
 export function accessStorageEIP2929(
   runState: RunState,
+  address: Address,
   key: Buffer,
   isSstore: boolean,
   common: Common
 ): bigint {
   if (common.isActivatedEIP(2929) === false) return BigInt(0)
 
-  const eei = runState.eei
-  const address = runState.interpreter.getAddress().buf
-  const slotIsCold = !eei.isWarmedStorage(address, key)
+  const slotIsCold = !runState.eei.isWarmedStorage(address.buf, key)
 
   // Cold (SLOAD and SSTORE)
   if (slotIsCold) {
-    eei.addWarmedStorage(address, key)
+    runState.eei.addWarmedStorage(address.buf, key)
     return common.param('gasPrices', 'coldsload')
   } else if (!isSstore) {
     return common.param('gasPrices', 'warmstorageread')

--- a/packages/evm/src/opcodes/codes.ts
+++ b/packages/evm/src/opcodes/codes.ts
@@ -270,6 +270,12 @@ const eipOpcodes: { eip: number; opcodes: OpcodeEntry }[] = [
     },
   },
   {
+    eip: 2330,
+    opcodes: {
+      0x5c: { name: 'EXTSLOAD', isAsync: true, dynamicGas: true },
+    },
+  },
+  {
     eip: 3198,
     opcodes: {
       0x48: { name: 'BASEFEE', isAsync: false, dynamicGas: false },

--- a/packages/vm/tests/api/EIPs/eip-2330-extsload.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-2330-extsload.spec.ts
@@ -1,0 +1,127 @@
+import * as tape from 'tape'
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Account, Address, privateToAddress } from '@ethereumjs/util'
+import { Transaction } from '@ethereumjs/tx'
+import { EVM } from '@ethereumjs/evm'
+import { VM } from '../../../src/vm'
+
+interface Test {
+  steps: { expectedOpcode: string; expectedGasUsed: number; expectedStack: bigint[] }[]
+  contracts: { address: Address; code?: string; storage?: { key: string; value: string }[] }[]
+  transactions: Transaction[]
+}
+
+const senderKey = Buffer.from(
+  'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
+  'hex'
+)
+
+tape('EIP 2330: extsload', (t) => {
+  const initialGas = BigInt(0xffffffffff)
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin, eips: [2330] })
+
+  const runTest = async function (test: Test, st: tape.Test) {
+    let i = 0
+    let currentGas = initialGas
+    const vm = await VM.create({ common })
+
+    ;(<EVM>vm.evm).on('step', function (step: any) {
+      const gasUsed = currentGas - step.gasLeft
+      currentGas = step.gasLeft
+
+      st.equal(
+        step.opcode.name,
+        test.steps[i].expectedOpcode,
+        `Expected Opcode: ${test.steps[i].expectedOpcode}`
+      )
+
+      st.deepEqual(
+        step.stack.map((e: bigint) => e.toString()),
+        test.steps[i].expectedStack.map((e: bigint) => e.toString()),
+        `Expected stack: ${step.stack}`
+      )
+
+      if (i > 0) {
+        const expectedGasUsed = BigInt(test.steps[i - 1].expectedGasUsed)
+        st.ok(
+          gasUsed === expectedGasUsed,
+          `Opcode: ${
+            test.steps[i - 1].expectedOpcode
+          }, Gas Used: ${gasUsed}, Expected: ${expectedGasUsed}`
+        )
+      }
+      i++
+    })
+
+    for (const { code, address, storage } of test.contracts) {
+      if (code !== undefined) {
+        await vm.stateManager.putContractCode(address, Buffer.from(code, 'hex'))
+      }
+
+      if (storage) {
+        for (const { key, value } of storage) {
+          await vm.stateManager.putContractStorage(
+            address,
+            Buffer.from(key, 'hex'),
+            Buffer.from(value, 'hex')
+          )
+        }
+      }
+    }
+
+    const fromAddress = new Address(privateToAddress(senderKey))
+    await vm.stateManager.putAccount(fromAddress, new Account(BigInt(0), BigInt(0xfffffffff)))
+    const results = []
+    for (const tx of test.transactions) {
+      const result = await vm.runTx({ tx, skipBalance: true })
+      results.push(result)
+    }
+
+    return results
+  }
+
+  t.test('should extsload other contract storage', async (st) => {
+    const code = '6001626265625c60005260206000f3'
+    const returndata = Buffer.from('2'.padStart(64, '0'), 'hex')
+
+    // contract1 is triggered and it attempts to read storage from contract2
+    const contract1 = new Address(Buffer.from('626f62'.padStart(40, '0'), 'hex'))
+    const contract2 = new Address(Buffer.from('626562'.padStart(40, '0'), 'hex'))
+
+    const tx = Transaction.fromTxData({
+      gasLimit: BigInt(21000 + 9000),
+      to: contract1,
+      value: BigInt(1),
+    }).sign(senderKey)
+
+    const test = {
+      contracts: [
+        { address: contract1, code },
+        {
+          address: contract2,
+          storage: [{ key: '1'.padStart(64, '0'), value: '2'.padStart(64, '0') }],
+        },
+      ],
+      transactions: [tx],
+      steps: [
+        { expectedOpcode: 'PUSH1', expectedGasUsed: 3, expectedStack: [] },
+        { expectedOpcode: 'PUSH3', expectedGasUsed: 3, expectedStack: [BigInt(1)] },
+        {
+          expectedOpcode: 'EXTSLOAD',
+          expectedGasUsed: 4700,
+          expectedStack: [BigInt(1), BigInt(0x626562)],
+        },
+        { expectedOpcode: 'PUSH1', expectedGasUsed: 3, expectedStack: [BigInt(2)] },
+        { expectedOpcode: 'MSTORE', expectedGasUsed: 6, expectedStack: [BigInt(2), BigInt(0)] },
+        { expectedOpcode: 'PUSH1', expectedGasUsed: 3, expectedStack: [] },
+        { expectedOpcode: 'PUSH1', expectedGasUsed: 3, expectedStack: [BigInt(32)] },
+        { expectedOpcode: 'RETURN', expectedGasUsed: NaN, expectedStack: [BigInt(32), BigInt(0)] },
+      ],
+    }
+
+    const result = await runTest(test, st)
+    st.deepEqual(result[0].execResult.returnValue, returndata, 'return value should be proper')
+    st.equal(result[0].execResult.exceptionError, undefined, 'should not result an exception error')
+    st.end()
+  })
+})


### PR DESCRIPTION
This PR implements [EIP-2330](https://eips.ethereum.org/EIPS/eip-2330) Extsload at 0x5c opcode.

If the opcode is supported as an experimental opcode, it would help with easier experimentation and research on the EIP.

Currently, there is a clash at the same opcode 0x5c `BEGINSUB` from [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315), hence currently either EIP could be activated at a time. I'll discuss with EIP-2330 authors if there can be another candidate for the opcode number.

Please let me know of any changes that are needed.