### PR TITLE
client: Make fetcher typesafe in syncronizers

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -660,6 +660,7 @@ async function run() {
     saveReceipts: args.saveReceipts,
     syncmode: args.syncmode,
     disableBeaconSync: args.disableBeaconSync,
+    forceSnapSync: args.forceSnapSync,
     transports: args.transports,
     txLookupLimit: args.txLookupLimit,
   })

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -44,7 +44,7 @@ export class BeaconSynchronizer extends Synchronizer {
     return 'beacon'
   }
 
-  get fetcher():ReverseBlockFetcher|null{
+  get fetcher(): ReverseBlockFetcher | null {
     if(this._fetcher!==null && !(this._fetcher instanceof ReverseBlockFetcher)){
       throw Error(`Invalid Fetcher, expected ReverseBlockFetcher`);
     }

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -44,6 +44,17 @@ export class BeaconSynchronizer extends Synchronizer {
     return 'beacon'
   }
 
+  get fetcher():ReverseBlockFetcher|null{
+    if(this._fetcher!==null && !(this._fetcher instanceof ReverseBlockFetcher)){
+      throw Error(`Invalid Fetcher, expected ReverseBlockFetcher`);
+    }
+    return this._fetcher;
+  }
+
+  set fetcher(fetcher: ReverseBlockFetcher | null){
+    this._fetcher = fetcher;
+  }
+
   /**
    * Open synchronizer. Must be called before sync() is called
    */

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -53,6 +53,17 @@ export class FullSynchronizer extends Synchronizer {
     return 'full'
   }
 
+  get fetcher():BlockFetcher|null{
+    if(this._fetcher!==null && !(this._fetcher instanceof BlockFetcher)){
+      throw Error(`Invalid Fetcher, expected BlockFetcher`);
+    }
+    return this._fetcher;
+  }
+
+  set fetcher(fetcher: BlockFetcher | null){
+    this._fetcher = fetcher;
+  }
+
   /**
    * Open synchronizer. Must be called before sync() is called
    */

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -53,7 +53,7 @@ export class FullSynchronizer extends Synchronizer {
     return 'full'
   }
 
-  get fetcher():BlockFetcher|null{
+  get fetcher(): BlockFetcher | null {
     if(this._fetcher!==null && !(this._fetcher instanceof BlockFetcher)){
       throw Error(`Invalid Fetcher, expected BlockFetcher`);
     }

--- a/packages/client/lib/sync/lightsync.ts
+++ b/packages/client/lib/sync/lightsync.ts
@@ -27,7 +27,7 @@ export class LightSynchronizer extends Synchronizer {
     return 'light'
   }
 
-  get fetcher():HeaderFetcher|null{
+  get fetcher(): HeaderFetcher | null {
     if(this._fetcher!==null && !(this._fetcher instanceof HeaderFetcher)){
       throw Error(`Invalid Fetcher, expected HeaderFetcher`);
     }

--- a/packages/client/lib/sync/lightsync.ts
+++ b/packages/client/lib/sync/lightsync.ts
@@ -27,6 +27,18 @@ export class LightSynchronizer extends Synchronizer {
     return 'light'
   }
 
+  get fetcher():HeaderFetcher|null{
+    if(this._fetcher!==null && !(this._fetcher instanceof HeaderFetcher)){
+      throw Error(`Invalid Fetcher, expected HeaderFetcher`);
+    }
+    return this._fetcher;
+  }
+
+  set fetcher(fetcher: HeaderFetcher | null){
+    this._fetcher = fetcher;
+  }
+
+
   /**
    * Open synchronizer. Must be called before sync() is called
    */

--- a/packages/client/lib/sync/sync.ts
+++ b/packages/client/lib/sync/sync.ts
@@ -40,7 +40,7 @@ export abstract class Synchronizer {
   protected interval: number
   protected forceSync: boolean
 
-  public fetcher: BlockFetcher | HeaderFetcher | ReverseBlockFetcher | null
+  public _fetcher: BlockFetcher | HeaderFetcher | ReverseBlockFetcher | null
   public opened: boolean
   public running: boolean
   public startingBlock: bigint
@@ -57,7 +57,7 @@ export abstract class Synchronizer {
 
     this.pool = options.pool
     this.chain = options.chain
-    this.fetcher = null
+    this._fetcher = null
     this.flow = options.flow ?? new FlowControl()
     this.interval = options.interval ?? 1000
     this.opened = false
@@ -81,6 +81,14 @@ export abstract class Synchronizer {
    */
   get type() {
     return 'sync'
+  }
+
+  get fetcher(): BlockFetcher | HeaderFetcher | ReverseBlockFetcher | null{
+    return this._fetcher;
+  }
+
+  set fetcher(fetcher: BlockFetcher | HeaderFetcher | ReverseBlockFetcher | null){
+    this._fetcher = fetcher;
   }
 
   /**
@@ -179,8 +187,8 @@ export abstract class Synchronizer {
       }
       this.config.events.once(Event.SYNC_SYNCHRONIZED, resolveSync)
       try {
-        if (this.fetcher) {
-          await this.fetcher.fetch()
+        if (this._fetcher) {
+          await this._fetcher.fetch()
         }
         this.config.logger.debug(`Fetcher finished fetching...`)
         resolveSync()
@@ -198,10 +206,10 @@ export abstract class Synchronizer {
    * Clears and removes the fetcher.
    */
   clearFetcher() {
-    if (this.fetcher) {
-      this.fetcher.clear()
-      this.fetcher.destroy()
-      this.fetcher = null
+    if (this._fetcher) {
+      this._fetcher.clear()
+      this._fetcher.destroy()
+      this._fetcher = null
     }
   }
 

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -159,13 +159,14 @@ tape('[FullSynchronizer]', async (t) => {
       txPool,
       execution,
     })
-    ;(sync as any).fetcher = {
+    ;(sync as any)._fetcher = {
       enqueueByNumberList: (blockNumberList: bigint[], min: bigint) => {
         t.equal(blockNumberList[0], BigInt(0), 'enqueueing the correct block in the Fetcher')
         t.equal(blockNumberList.length, 1, 'correct number of blocks enqueued in Fetcher')
         t.equal(min, BigInt(0), 'correct start block number in Fetcher')
       },
     }
+    Object.defineProperty(sync, 'fetcher', { get() { return this._fetcher } });
 
     let timesSentToPeer2 = 0
     const peers = [


### PR DESCRIPTION
With the new fetchers for AccountRange etc in the snapsync PR https://github.com/ethereumjs/ethereumjs-monorepo/pull/2107, we need fetcher access to be typesafe in their respective synchronizers.

This PR enables the same.