### PR TITLE
blockchain: align comment and code for getIteratorHead()

### DIFF
--- a/packages/blockchain/src/types.ts
+++ b/packages/blockchain/src/types.ts
@@ -44,19 +44,19 @@ export interface BlockchainInterface {
    * Returns a copy of the blockchain
    */
   copy(): BlockchainInterface
-
-  /**
-   * Returns the specified iterator head.
-   *
-   * @param name - Optional name of the iterator head (default: 'vm')
-   */
-
+  
   /**
    * Validates a block header, throwing if invalid. It is being validated against the reported `parentHash`.
    * @param header - header to be validated
    * @param height - If this is an uncle header, this is the height of the block that is including it
    */
   validateHeader(header: BlockHeader, height?: bigint): Promise<void>
+
+  /**
+   * Returns the specified iterator head.
+   *
+   * @param name - Optional name of the iterator head (default: 'vm')
+   */
   getIteratorHead?(name?: string): Promise<Block>
 
   /**


### PR DESCRIPTION
Fixes 
```
 Align comment and code in interface, see https://github.com/ethereumjs/ethereumjs-monorepo/pull/2069/files/48e08c9e6f6ad5956613d067b935aaf07788a23f#r938678329
```
From meta issue #2105.

Fixes misalignment.