### PR TITLE
fix(trie): explicitly check for `persistRoot` option being `true` in `SecureTrie`

### DIFF
--- a/packages/trie/src/trie/secure.ts
+++ b/packages/trie/src/trie/secure.ts
@@ -119,7 +119,7 @@ export class SecureTrie extends CheckpointTrie {
    * Persists the root hash in the underlying database
    */
   async persistRoot() {
-    if (this._persistRoot !== undefined) {
+    if (this._persistRoot === true) {
       await this.db.put(this.hash(ROOT_DB_KEY), this.root)
     }
   }


### PR DESCRIPTION
Small issue I noticed when upgrading to `beta.3` and a test with key count failing on my end. The `Trie` class already had the correct check https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L752