### PR TITLE
chore: enable `eqeqeq` rule for `eslint`

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -53,6 +53,7 @@ module.exports = {
     '@typescript-eslint/prefer-nullish-coalescing': 'error',
     '@typescript-eslint/restrict-plus-operands': 'off',
     '@typescript-eslint/strict-boolean-expressions': ['error'],
+    eqeqeq: 'error',
     'implicit-dependencies/no-implicit': ['error', { peer: true, dev: true, optional: true }],
     'import/default': 'error',
     'import/export': 'error',

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -623,7 +623,7 @@ export class Blockchain implements BlockchainInterface {
    */
   private async _validateUncleHeaders(block: Block) {
     const uncleHeaders = block.uncleHeaders
-    if (uncleHeaders.length == 0) {
+    if (uncleHeaders.length === 0) {
       return
     }
 

--- a/packages/blockchain/src/db/operation.ts
+++ b/packages/blockchain/src/db/operation.ts
@@ -113,7 +113,7 @@ export class DBOp {
     dbOperation.baseDBOp.value = value
     dbOperation.baseDBOp.type = 'put'
 
-    if (operationTarget == DBTarget.Heads) {
+    if (operationTarget === DBTarget.Heads) {
       dbOperation.baseDBOp.valueEncoding = 'json'
     } else {
       dbOperation.baseDBOp.valueEncoding = 'binary'
@@ -130,10 +130,10 @@ export class DBOp {
 
   public updateCache(cacheMap: CacheMap) {
     if (isTruthy(this.cacheString) && isTruthy(cacheMap[this.cacheString])) {
-      if (this.baseDBOp.type == 'put') {
+      if (this.baseDBOp.type === 'put') {
         Buffer.isBuffer(this.baseDBOp.value) &&
           cacheMap[this.cacheString].set(this.baseDBOp.key, this.baseDBOp.value)
-      } else if (this.baseDBOp.type == 'del') {
+      } else if (this.baseDBOp.type === 'del') {
         cacheMap[this.cacheString].del(this.baseDBOp.key)
       } else {
         throw new Error('unsupported db operation on cache')

--- a/packages/blockchain/test/customConsensus.spec.ts
+++ b/packages/blockchain/test/customConsensus.spec.ts
@@ -27,7 +27,7 @@ class fibonacciConsensus implements Consensus {
     if (_header.number === 1n && _header.difficulty === 1n) {
       return new Promise<void>((resolve) => resolve())
     }
-    if (_header.difficulty != _header.number - 1n + _header.number - 2n) {
+    if (_header.difficulty !== _header.number - 1n + _header.number - 2n) {
       throw new Error('invalid difficulty - must be sum of previous two block numbers')
     }
     return new Promise<void>((resolve) => resolve())

--- a/packages/client/lib/net/peer/rlpxpeer.ts
+++ b/packages/client/lib/net/peer/rlpxpeer.ts
@@ -163,7 +163,7 @@ export class RlpxPeer extends Peer {
         const protocol = this.protocols.find((p) => p.name === name)
         // Since snap is running atop/besides eth, it doesn't need a separate sender
         // handshake, and can just use the eth handshake
-        if (protocol && name != 'snap') {
+        if (protocol && name !== 'snap') {
           const sender = new RlpxSender(rlpxProtocol)
           return this.bindProtocol(protocol, sender).then(() => {
             if (name === 'eth') {

--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -188,7 +188,7 @@ export class BeaconSynchronizer extends Synchronizer {
       )
       return true
     } catch (error) {
-      if (error == errSyncReorged) {
+      if (error === errSyncReorged) {
         this.config.logger.debug(
           `Beacon sync reorged, new head number=${block.header.number} hash=${short(
             block.header.hash()

--- a/packages/client/lib/sync/fetcher/reverseblockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/reverseblockfetcher.ts
@@ -39,7 +39,7 @@ export class ReverseBlockFetcher extends BlockFetcher {
       )
       this.config.events.emit(Event.SYNC_FETCHED_BLOCKS, blocks.slice(0, num))
     } catch (e: any) {
-      if (e == errSyncMerged) {
+      if (e === errSyncMerged) {
         // Tear down the syncer to restart from new subchain segments
         this.debug('Skeleton subchains merged, restarting sync')
         this.running = false

--- a/packages/client/test/sync/skeleton.spec.ts
+++ b/packages/client/test/sync/skeleton.spec.ts
@@ -511,7 +511,7 @@ tape('[Skeleton]', async (t) => {
       try {
         await skeleton.setHead(block5, false)
       } catch (error: any) {
-        if (error != errReorgDenied) {
+        if (error !== errReorgDenied) {
           t.fail(error)
         }
       }
@@ -526,7 +526,7 @@ tape('[Skeleton]', async (t) => {
       try {
         await skeleton.putBlocks([block3PoS])
       } catch (error: any) {
-        if (error != errSyncMerged) {
+        if (error !== errSyncMerged) {
           t.fail(error)
         }
       }
@@ -680,7 +680,7 @@ tape('[Skeleton]', async (t) => {
       try {
         await skeleton.putBlocks([block2])
       } catch (error: any) {
-        if (error != errSyncMerged) {
+        if (error !== errSyncMerged) {
           t.fail(error)
         }
       }

--- a/packages/ethash/test/miner.spec.ts
+++ b/packages/ethash/test/miner.spec.ts
@@ -47,7 +47,7 @@ tape('Check if miner works as expected', async function (t) {
 
   const validBlockResult = await e.verifyPOW(validBlock)
   t.ok(validBlockResult, 'succesfully mined block')
-  t.ok((miner as any).solution != undefined, 'cached the solution')
+  t.ok((miner as any).solution !== undefined, 'cached the solution')
 
   t.end()
 })

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -767,7 +767,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
       result.execResult.gasRefund = BigInt(0)
     }
     if (err) {
-      if (this._common.gteHardfork(Hardfork.Homestead) || err.error != ERROR.CODESTORE_OUT_OF_GAS) {
+      if (this._common.gteHardfork(Hardfork.Homestead) || err.error !== ERROR.CODESTORE_OUT_OF_GAS) {
         result.execResult.logs = []
         await this.eei.revert()
         this._transientStorage.revert()

--- a/packages/evm/src/opcodes/util.ts
+++ b/packages/evm/src/opcodes/util.ts
@@ -251,7 +251,7 @@ const N = BigInt(115792089237316195423570985008687907853269984665640564039457584
 export function exponentation(bas: bigint, exp: bigint) {
   let t = BigInt(1)
   while (exp > BigInt(0)) {
-    if (exp % BigInt(2) != BigInt(0)) {
+    if (exp % BigInt(2) !== BigInt(0)) {
       t = (t * bas) % N
     }
     bas = (bas * bas) % N

--- a/packages/evm/src/precompiles/0a-bls12-g1add.ts
+++ b/packages/evm/src/precompiles/0a-bls12-g1add.ts
@@ -19,7 +19,7 @@ export async function precompile0a(opts: PrecompileInput): Promise<ExecResult> {
     return OOGResult(opts.gasLimit)
   }
 
-  if (inputData.length != 256) {
+  if (inputData.length !== 256) {
     return EvmErrorResult(new EvmError(ERROR.BLS_12_381_INVALID_INPUT_LENGTH), opts.gasLimit)
   }
 

--- a/packages/evm/src/precompiles/0b-bls12-g1mul.ts
+++ b/packages/evm/src/precompiles/0b-bls12-g1mul.ts
@@ -23,7 +23,7 @@ export async function precompile0b(opts: PrecompileInput): Promise<ExecResult> {
     return OOGResult(opts.gasLimit)
   }
 
-  if (inputData.length != 160) {
+  if (inputData.length !== 160) {
     return EvmErrorResult(new EvmError(ERROR.BLS_12_381_INVALID_INPUT_LENGTH), opts.gasLimit)
   }
 

--- a/packages/evm/src/precompiles/0c-bls12-g1multiexp.ts
+++ b/packages/evm/src/precompiles/0c-bls12-g1multiexp.ts
@@ -16,7 +16,7 @@ export async function precompile0c(opts: PrecompileInput): Promise<ExecResult> {
 
   const inputData = opts.data
 
-  if (inputData.length == 0) {
+  if (inputData.length === 0) {
     return EvmErrorResult(new EvmError(ERROR.BLS_12_381_INPUT_EMPTY), opts.gasLimit) // follow Geths implementation
   }
 
@@ -32,7 +32,7 @@ export async function precompile0c(opts: PrecompileInput): Promise<ExecResult> {
   let gasDiscountMultiplier
 
   if (numPairs <= gasDiscountArray.length) {
-    if (numPairs == 0) {
+    if (numPairs === 0) {
       gasDiscountMultiplier = 0 // this implicitly sets gasUsed to 0 as per the EIP.
     } else {
       gasDiscountMultiplier = gasDiscountArray[numPairs - 1][1]
@@ -47,7 +47,7 @@ export async function precompile0c(opts: PrecompileInput): Promise<ExecResult> {
     return OOGResult(opts.gasLimit)
   }
 
-  if (inputData.length % 160 != 0) {
+  if (inputData.length % 160 !== 0) {
     return EvmErrorResult(new EvmError(ERROR.BLS_12_381_INVALID_INPUT_LENGTH), opts.gasLimit)
   }
 

--- a/packages/evm/src/precompiles/0d-bls12-g2add.ts
+++ b/packages/evm/src/precompiles/0d-bls12-g2add.ts
@@ -19,7 +19,7 @@ export async function precompile0d(opts: PrecompileInput): Promise<ExecResult> {
     return OOGResult(opts.gasLimit)
   }
 
-  if (inputData.length != 512) {
+  if (inputData.length !== 512) {
     return EvmErrorResult(new EvmError(ERROR.BLS_12_381_INVALID_INPUT_LENGTH), opts.gasLimit)
   }
 

--- a/packages/evm/src/precompiles/0e-bls12-g2mul.ts
+++ b/packages/evm/src/precompiles/0e-bls12-g2mul.ts
@@ -23,7 +23,7 @@ export async function precompile0e(opts: PrecompileInput): Promise<ExecResult> {
     return OOGResult(opts.gasLimit)
   }
 
-  if (inputData.length != 288) {
+  if (inputData.length !== 288) {
     return EvmErrorResult(new EvmError(ERROR.BLS_12_381_INVALID_INPUT_LENGTH), opts.gasLimit)
   }
 

--- a/packages/evm/src/precompiles/0f-bls12-g2multiexp.ts
+++ b/packages/evm/src/precompiles/0f-bls12-g2multiexp.ts
@@ -17,7 +17,7 @@ export async function precompile0f(opts: PrecompileInput): Promise<ExecResult> {
 
   const inputData = opts.data
 
-  if (inputData.length == 0) {
+  if (inputData.length === 0) {
     return EvmErrorResult(new EvmError(ERROR.BLS_12_381_INPUT_EMPTY), opts.gasLimit) // follow Geths implementation
   }
 
@@ -29,7 +29,7 @@ export async function precompile0f(opts: PrecompileInput): Promise<ExecResult> {
   let gasDiscountMultiplier
 
   if (numPairs <= gasDiscountArray.length) {
-    if (numPairs == 0) {
+    if (numPairs === 0) {
       gasDiscountMultiplier = 0 // this implicitly sets gasUsed to 0 as per the EIP.
     } else {
       gasDiscountMultiplier = gasDiscountArray[numPairs - 1][1]
@@ -44,7 +44,7 @@ export async function precompile0f(opts: PrecompileInput): Promise<ExecResult> {
     return OOGResult(opts.gasLimit)
   }
 
-  if (inputData.length % 288 != 0) {
+  if (inputData.length % 288 !== 0) {
     return EvmErrorResult(new EvmError(ERROR.BLS_12_381_INVALID_INPUT_LENGTH), opts.gasLimit)
   }
 

--- a/packages/evm/src/precompiles/10-bls12-pairing.ts
+++ b/packages/evm/src/precompiles/10-bls12-pairing.ts
@@ -18,7 +18,7 @@ export async function precompile10(opts: PrecompileInput): Promise<ExecResult> {
 
   const baseGas = opts._common.paramByEIP('gasPrices', 'Bls12381PairingBaseGas', 2537) ?? BigInt(0)
 
-  if (inputData.length == 0) {
+  if (inputData.length === 0) {
     return EvmErrorResult(new EvmError(ERROR.BLS_12_381_INPUT_EMPTY), opts.gasLimit)
   }
 
@@ -27,7 +27,7 @@ export async function precompile10(opts: PrecompileInput): Promise<ExecResult> {
 
   const gasUsed = baseGas + gasUsedPerPair * BigInt(Math.floor(inputData.length / 384))
 
-  if (inputData.length % 384 != 0) {
+  if (inputData.length % 384 !== 0) {
     return EvmErrorResult(new EvmError(ERROR.BLS_12_381_INVALID_INPUT_LENGTH), opts.gasLimit)
   }
 
@@ -89,7 +89,7 @@ export async function precompile10(opts: PrecompileInput): Promise<ExecResult> {
     const G1 = pair[0]
     const G2 = pair[1]
 
-    if (index == 0) {
+    if (index === 0) {
       GT = mcl.millerLoop(G1, G2)
     } else {
       GT = mcl.mul(GT, mcl.millerLoop(G1, G2))

--- a/packages/evm/src/precompiles/11-bls12-map-fp-to-g1.ts
+++ b/packages/evm/src/precompiles/11-bls12-map-fp-to-g1.ts
@@ -19,7 +19,7 @@ export async function precompile11(opts: PrecompileInput): Promise<ExecResult> {
     return OOGResult(opts.gasLimit)
   }
 
-  if (inputData.length != 64) {
+  if (inputData.length !== 64) {
     return EvmErrorResult(new EvmError(ERROR.BLS_12_381_INVALID_INPUT_LENGTH), opts.gasLimit)
   }
 

--- a/packages/evm/src/precompiles/12-bls12-map-fp2-to-g2.ts
+++ b/packages/evm/src/precompiles/12-bls12-map-fp2-to-g2.ts
@@ -19,7 +19,7 @@ export async function precompile12(opts: PrecompileInput): Promise<ExecResult> {
     return OOGResult(opts.gasLimit)
   }
 
-  if (inputData.length != 128) {
+  if (inputData.length !== 128) {
     return EvmErrorResult(new EvmError(ERROR.BLS_12_381_INVALID_INPUT_LENGTH), opts.gasLimit)
   }
 

--- a/packages/evm/src/precompiles/index.ts
+++ b/packages/evm/src/precompiles/index.ts
@@ -150,9 +150,9 @@ function getPrecompile(address: Address, common: Common): PrecompileFunc {
   if (isTruthy(precompiles[addr])) {
     const availability = precompileAvailability[addr]
     if (
-      (availability.type == PrecompileAvailabilityCheck.Hardfork &&
+      (availability.type === PrecompileAvailabilityCheck.Hardfork &&
         common.gteHardfork(availability.param)) ||
-      (availability.type == PrecompileAvailabilityCheck.EIP &&
+      (availability.type === PrecompileAvailabilityCheck.EIP &&
         common.eips().includes(availability.param))
     ) {
       return precompiles[addr]

--- a/packages/evm/src/precompiles/util/bls12_381.ts
+++ b/packages/evm/src/precompiles/util/bls12_381.ts
@@ -146,7 +146,7 @@ function BLS12_381_ToG1Point(input: Buffer, mcl: any): any {
   const p_y = input.slice(80, 128).toString('hex')
 
   const ZeroString48Bytes = '0'.repeat(96)
-  if (p_x == p_y && p_x == ZeroString48Bytes) {
+  if (p_x === p_y && p_x === ZeroString48Bytes) {
     return new mcl.G1()
   }
 
@@ -183,11 +183,11 @@ function BLS12_381_FromG1Point(input: any): Buffer {
   const decodeStr = input.getStr(16) //return a string of pattern "1 <x_coord> <y_coord>"
   const decoded = decodeStr.match(/"?[0-9a-f]+"?/g) // match above pattern.
 
-  if (decodeStr == '0') {
+  if (decodeStr === '0') {
     return Buffer.alloc(128, 0)
   }
 
-  // note: decoded[0] == 1
+  // note: decoded[0] === 1
   const xval = padToEven(decoded[1])
   const yval = padToEven(decoded[2])
 
@@ -254,12 +254,12 @@ function BLS12_381_ToG2Point(input: Buffer, mcl: any): any {
 function BLS12_381_FromG2Point(input: any): Buffer {
   // TODO: figure out if there is a better way to decode these values.
   const decodeStr = input.getStr(16) //return a string of pattern "1 <x_coord_1> <x_coord_2> <y_coord_1> <y_coord_2>"
-  if (decodeStr == '0') {
+  if (decodeStr === '0') {
     return Buffer.alloc(256, 0)
   }
   const decoded = decodeStr.match(/"?[0-9a-f]+"?/g) // match above pattern.
 
-  // note: decoded[0] == 1
+  // note: decoded[0] === 1
   const x_1 = padToEven(decoded[1])
   const x_2 = padToEven(decoded[2])
   const y_1 = padToEven(decoded[3])

--- a/packages/evm/tests/precompiles/hardfork.spec.ts
+++ b/packages/evm/tests/precompiles/hardfork.spec.ts
@@ -57,7 +57,7 @@ tape('Precompiles: hardfork availability', (t) => {
     const commonHomestead = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Homestead })
     ECPAIRING = getActivePrecompiles(commonHomestead).get(ECPAIR_AddressStr)!
 
-    if (ECPAIRING != undefined) {
+    if (ECPAIRING !== undefined) {
       st.fail('ECPAIRING is available in homestead while it should not be available')
     } else {
       st.pass('ECPAIRING not available in homestead')

--- a/packages/evm/tests/runCall.spec.ts
+++ b/packages/evm/tests/runCall.spec.ts
@@ -29,7 +29,7 @@ tape('Create where FROM account nonce is 0', async (t) => {
 
 /*
     This test:
-        Setups a contract at address 0x00..ff 
+        Setups a contract at address 0x00..ff
         Instantiates the EVM at the Constantinople fork
         Calls the address with various arguments (callvalue is used as argument). VMs `runCall` is used.
         The CREATE2 address which the contract creates is checked against the expected CREATE2 value.
@@ -116,7 +116,7 @@ tape('Byzantium cannot access Constantinople opcodes', async (t) => {
   const code = '600160011B00'
   /*
       code:             remarks: (top of the stack is at the zero index)
-        PUSH1 0x01  
+        PUSH1 0x01
         PUSH1 0x01
         SHL
         STOP
@@ -158,19 +158,19 @@ tape('Ensure that Istanbul sstoreCleanRefundEIP2200 gas is applied correctly', a
   const code = '61000260005561000160005500'
   /*
       idea: store the original value in the storage slot, except it is now a 1-length buffer instead of a 32-length buffer
-      code:             
+      code:
         PUSH2 0x0002
         PUSH1 0x00
         SSTORE              -> make storage slot 0 "dirty"
         PUSH2 0x0001
-        PUSH1 0x00          
+        PUSH1 0x00
         SSTORE              -> -> restore it to the original storage value (refund sstoreCleanRefundEIP2200)
         STOP
-      gas cost: 
+      gas cost:
         4x PUSH                                         12
         2x SSTORE (slot is nonzero, so charge 5000): 10000
         net                                          10012
-      gas refund 
+      gas refund
         sstoreCleanRefundEIP2200                      4200
       gas used
                                                      10012 - 4200 = 5812
@@ -284,7 +284,7 @@ tape(
 
     t.equal(runCallArgs.gasLimit, result.execResult.executionGasUsed, 'gas used correct')
     t.equal(result.execResult.gasRefund, BigInt(0), 'gas refund correct')
-    t.ok(result.execResult.exceptionError!.error == ERROR.OUT_OF_GAS, 'call went out of gas')
+    t.ok(result.execResult.exceptionError!.error === ERROR.OUT_OF_GAS, 'call went out of gas')
 
     t.end()
   }
@@ -404,7 +404,7 @@ tape(
     /*
       This simple code tries to create an empty contract and then stores the address of the contract in the zero slot.
         CODE:
-          PUSH 0 
+          PUSH 0
           DUP1
           DUP1
           CREATE -> Stack is now [0,0,0] ([value, offset, length])

--- a/packages/statemanager/tests/proofStateManager.spec.ts
+++ b/packages/statemanager/tests/proofStateManager.spec.ts
@@ -170,8 +170,8 @@ tape('ProofStateManager', (t) => {
         const newField = `0x9${original.slice(3)}`
         testdata[tamper] = newField
         await stateManager.verifyProof(testdata)
-        // note: this implicitly means that newField != original,
-        // if newField == original then the proof would be valid and test would fail
+        // note: this implicitly means that newField !== original,
+        // if newField === original then the proof would be valid and test would fail
         t.fail('should throw')
       } catch (e) {
         t.pass('threw on invalid proof')
@@ -229,8 +229,8 @@ tape('ProofStateManager', (t) => {
         const newField = `0x9${original.slice(3)}`
         testdata[tamper] = newField
         await stateManager.verifyProof(testdata)
-        // note: this implicitly means that newField != original,
-        // if newField == original then the proof would be valid and test would fail
+        // note: this implicitly means that newField !== original,
+        // if newField === original then the proof would be valid and test would fail
         st.fail('should throw')
       } catch (e) {
         st.pass('threw on invalid proof')

--- a/packages/statemanager/tests/stateManager.spec.ts
+++ b/packages/statemanager/tests/stateManager.spec.ts
@@ -338,8 +338,8 @@ tape('StateManager', (t) => {
     let codeSlot1 = await codeStateManager.getContractStorage(address1, key1)
     let codeSlot2 = await codeStateManager.getContractStorage(address1, key2)
 
-    st.ok(codeSlot1.length == 0, 'slot 0 is empty')
-    st.ok(codeSlot2.length == 0, 'slot 1 is empty')
+    st.ok(codeSlot1.length === 0, 'slot 0 is empty')
+    st.ok(codeSlot2.length === 0, 'slot 1 is empty')
 
     const code = await codeStateManager.getContractCode(address1)
     st.ok(code.length > 0, 'code deposited correctly')
@@ -351,7 +351,7 @@ tape('StateManager', (t) => {
     st.ok(slot2.length > 0, 'storage key1 deposited correctly')
 
     let slotCode = await stateManager.getContractCode(address1)
-    st.ok(slotCode.length == 0, 'code cannot be loaded')
+    st.ok(slotCode.length === 0, 'code cannot be loaded')
 
     // Checks by either setting state root to codeHash, or codeHash to stateRoot
     // The knowledge of the tries should not change
@@ -361,7 +361,7 @@ tape('StateManager', (t) => {
     await stateManager.putAccount(address1, account)
 
     slotCode = await stateManager.getContractCode(address1)
-    st.ok(slotCode.length == 0, 'code cannot be loaded') // This test fails if no code prefix is used
+    st.ok(slotCode.length === 0, 'code cannot be loaded') // This test fails if no code prefix is used
 
     account = await codeStateManager.getAccount(address1)
     account.stateRoot = root
@@ -371,8 +371,8 @@ tape('StateManager', (t) => {
     codeSlot1 = await codeStateManager.getContractStorage(address1, key1)
     codeSlot2 = await codeStateManager.getContractStorage(address1, key2)
 
-    st.ok(codeSlot1.length == 0, 'slot 0 is empty')
-    st.ok(codeSlot2.length == 0, 'slot 1 is empty')
+    st.ok(codeSlot1.length === 0, 'slot 0 is empty')
+    st.ok(codeSlot2.length === 0, 'slot 1 is empty')
 
     st.end()
   })

--- a/packages/trie/src/proof/range.ts
+++ b/packages/trie/src/proof/range.ts
@@ -331,7 +331,7 @@ async function verifyProof(
       value,
     }
   } catch (err: any) {
-    if (err.message == 'Missing node in DB') {
+    if (err.message === 'Missing node in DB') {
       throw new Error('Invalid proof provided')
     } else {
       throw err

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -104,7 +104,7 @@ export class Trie {
       const value = await this.lookupNode(root)
       return value !== null
     } catch (error: any) {
-      if (error.message == 'Missing node in DB') {
+      if (error.message === 'Missing node in DB') {
         return false
       } else {
         throw error
@@ -240,7 +240,7 @@ export class Trie {
       try {
         await this.walkTrie(this.root, onFound)
       } catch (error: any) {
-        if (error.message == 'Missing node in DB' && !throwIfMissing) {
+        if (error.message === 'Missing node in DB' && !throwIfMissing) {
           // pass
         } else {
           reject(error)
@@ -694,7 +694,7 @@ export class Trie {
       const value = await proofTrie.get(key, true)
       return value
     } catch (err: any) {
-      if (err.message == 'Missing node in DB') {
+      if (err.message === 'Missing node in DB') {
         throw new Error('Invalid proof provided')
       } else {
         throw err

--- a/packages/trie/src/util/nibbles.ts
+++ b/packages/trie/src/util/nibbles.ts
@@ -35,7 +35,7 @@ export function nibblesToBuffer(arr: Nibbles): Buffer {
 
 /**
  * Compare two nibble array.
- * * `0` is returned if `n2` == `n1`.
+ * * `0` is returned if `n2` === `n1`.
  * * `1` is returned if `n2` > `n1`.
  * * `-1` is returned if `n2` < `n1`.
  * @param n1 - Nibble array

--- a/packages/trie/src/util/readStream.ts
+++ b/packages/trie/src/util/readStream.ts
@@ -30,7 +30,7 @@ export class TrieReadStream extends Readable {
         }
       })
     } catch (error: any) {
-      if (error.message == 'Missing node in DB') {
+      if (error.message === 'Missing node in DB') {
         // pass
       } else {
         throw error

--- a/packages/trie/test/index.spec.ts
+++ b/packages/trie/test/index.spec.ts
@@ -247,7 +247,7 @@ tape('shall handle the case of node not found correctly', async (t) => {
 
   let path = await trie.findPath(Buffer.from('aaa'))
 
-  t.ok(path.node != null, 'findPath should find a node')
+  t.ok(path.node !== null, 'findPath should find a node')
 
   const { stack } = await trie.findPath(Buffer.from('aaa'))
   await trie.db.del(Buffer.from(keccak256(stack[1].serialize()))) // delete the BranchNode -> value1 from the DB
@@ -256,7 +256,7 @@ tape('shall handle the case of node not found correctly', async (t) => {
 
   t.ok(path.node === null, 'findPath should not return a node now')
   t.ok(
-    path.stack.length == 1,
+    path.stack.length === 1,
     'findPath should find the first extension node which is still in the DB'
   )
 

--- a/packages/tx/src/util.ts
+++ b/packages/tx/src/util.ts
@@ -69,11 +69,11 @@ export class AccessLists {
           'Access list item cannot have 3 elements. It can only have an address, and an array of storage slots.'
         )
       }
-      if (address.length != 20) {
+      if (address.length !== 20) {
         throw new Error('Invalid EIP-2930 transaction: address length should be 20 bytes')
       }
       for (let storageSlot = 0; storageSlot < storageSlots.length; storageSlot++) {
-        if (storageSlots[storageSlot].length != 32) {
+        if (storageSlots[storageSlot].length !== 32) {
           throw new Error('Invalid EIP-2930 transaction: storage slot length should be 32 bytes')
         }
       }

--- a/packages/tx/test/legacy.spec.ts
+++ b/packages/tx/test/legacy.spec.ts
@@ -421,7 +421,7 @@ tape('[Transaction]', function (t) {
 
       st.true(signedWithoutEIP155.verifySignature())
       st.true(
-        signedWithoutEIP155.v?.toString(16) == '1c' || signedWithoutEIP155.v?.toString(16) == '1b',
+        signedWithoutEIP155.v?.toString(16) === '1c' || signedWithoutEIP155.v?.toString(16) === '1b',
         "v shouldn't be EIP155 encoded"
       )
 
@@ -431,7 +431,7 @@ tape('[Transaction]', function (t) {
 
       st.true(signedWithoutEIP155.verifySignature())
       st.true(
-        signedWithoutEIP155.v?.toString(16) == '1c' || signedWithoutEIP155.v?.toString(16) == '1b',
+        signedWithoutEIP155.v?.toString(16) === '1c' || signedWithoutEIP155.v?.toString(16) === '1b',
         "v shouldn' be EIP155 encoded"
       )
 
@@ -440,7 +440,7 @@ tape('[Transaction]', function (t) {
   )
 
   t.test(
-    'constructor: throw on legacy transactions which have v != 27 and v != 28 and v < 37',
+    'constructor: throw on legacy transactions which have v !== 27 and v !== 28 and v < 37',
     function (st) {
       function getTxData(v: number) {
         return {

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -46,7 +46,7 @@ function isValidSigRecovery(recovery: bigint): boolean {
 
 /**
  * ECDSA public key recovery from signature.
- * NOTE: Accepts `v == 0 | v == 1` for EIP1559 transactions
+ * NOTE: Accepts `v === 0 | v === 1` for EIP1559 transactions
  * @returns Recovered public key
  */
 export const ecrecover = function (
@@ -68,7 +68,7 @@ export const ecrecover = function (
 
 /**
  * Convert signature parameters into the format of `eth_sign` RPC method.
- * NOTE: Accepts `v == 0 | v == 1` for EIP1559 transactions
+ * NOTE: Accepts `v === 0 | v === 1` for EIP1559 transactions
  * @returns Signature
  */
 export const toRpcSig = function (v: bigint, r: Buffer, s: Buffer, chainId?: bigint): string {
@@ -83,7 +83,7 @@ export const toRpcSig = function (v: bigint, r: Buffer, s: Buffer, chainId?: big
 
 /**
  * Convert signature parameters into the format of Compact Signature Representation (EIP-2098).
- * NOTE: Accepts `v == 0 | v == 1` for EIP1559 transactions
+ * NOTE: Accepts `v === 0 | v === 1` for EIP1559 transactions
  * @returns Signature
  */
 export const toCompactSig = function (v: bigint, r: Buffer, s: Buffer, chainId?: bigint): string {
@@ -143,7 +143,7 @@ export const fromRpcSig = function (sig: string): ECDSASignature {
 
 /**
  * Validate a ECDSA signature.
- * NOTE: Accepts `v == 0 | v == 1` for EIP1559 transactions
+ * NOTE: Accepts `v === 0 | v === 1` for EIP1559 transactions
  * @param homesteadOrLater Indicates whether this is being used on either the homestead hardfork or a later one
  */
 export const isValidSignature = function (

--- a/packages/util/test/bytes.spec.ts
+++ b/packages/util/test/bytes.spec.ts
@@ -376,8 +376,8 @@ tape('intToHex', function (st) {
   st.throws(() => intToHex(<any>[]), 'throws on arrays')
   st.throws(() => intToHex(<any>(() => {})), 'throws on arrays')
   st.throws(() => intToHex(Number.MAX_SAFE_INTEGER + 1), 'throws on unsafe integers')
-  st.ok(intToHex(0) == '0x0', 'correctly converts 0 to a hex string')
-  st.ok(intToHex(1) == '0x1', 'correctly converts 1 to a hex string')
+  st.ok(intToHex(0) === '0x0', 'correctly converts 0 to a hex string')
+  st.ok(intToHex(1) === '0x1', 'correctly converts 1 to a hex string')
   st.end()
 })
 

--- a/packages/vm/tests/api/EIPs/eip-2930-accesslists.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-2930-accesslists.spec.ts
@@ -70,13 +70,13 @@ tape('EIP-2930 Optional Access Lists tests', (t) => {
     })
 
     await vm.runTx({ tx: txnWithAccessList })
-    st.ok(trace[1][0] == 'SLOAD')
+    st.ok(trace[1][0] === 'SLOAD')
     let gasUsed = trace[1][1] - trace[2][1]
     st.equal(gasUsed, BigInt(100), 'charge warm sload gas')
 
     trace = []
     await vm.runTx({ tx: txnWithoutAccessList, skipNonce: true })
-    st.ok(trace[1][0] == 'SLOAD')
+    st.ok(trace[1][0] === 'SLOAD')
     gasUsed = trace[1][1] - trace[2][1]
     st.equal(gasUsed, BigInt(2100), 'charge cold sload gas')
 

--- a/packages/vm/tests/api/EIPs/eip-3074-authcall.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3074-authcall.spec.ts
@@ -224,7 +224,7 @@ function flipSignature(signature: any) {
   const s = bufferToBigInt(signature.s)
   const flipped = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141n - s
 
-  if (signature.v == 27) {
+  if (signature.v === 27) {
     signature.v = 28
   } else {
     signature.v = 27

--- a/packages/vm/tests/api/EIPs/eip-3855.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3855.spec.ts
@@ -29,7 +29,7 @@ tape('EIP 3541 tests', (t) => {
       gasLimit: BigInt(10),
     })
 
-    st.ok(stack!.length == 1)
+    st.ok(stack!.length === 1)
     st.equal(stack![0], BigInt(0))
     st.equal(result.executionGasUsed, common.param('gasPrices', 'push0'))
     st.end()
@@ -50,7 +50,7 @@ tape('EIP 3541 tests', (t) => {
       gasLimit: BigInt(10000),
     })
 
-    st.ok(stack.length == depth)
+    st.ok(stack.length === depth)
     stack.forEach((elem: bigint) => {
       if (elem !== BigInt(0)) {
         st.fail('stack element is not 0')

--- a/packages/vm/tests/tester/index.ts
+++ b/packages/vm/tests/tester/index.ts
@@ -102,7 +102,7 @@ async function runTests() {
     let str = testGetterArgs.forkConfig
     const indicies = []
     for (let i = 0; i < str.length; i++) {
-      if (str[i] == '+') {
+      if (str[i] === '+') {
         indicies.push(i)
       }
     }
@@ -149,7 +149,7 @@ async function runTests() {
   console.log(delimiter)
   console.log(`| RunnerArgs`.padEnd(fillWidth) + ' |')
   for (const [key, value] of Object.entries(formattedRunnerArgs)) {
-    if (key == 'common') {
+    if (key === 'common') {
       const hf = (value as Common).hardfork()
       console.log(`| ${key.padEnd(fillParam)}: ${hf}`.padEnd(fillWidth) + ' |')
     } else {

--- a/packages/vm/tests/tester/runners/BlockchainTestsRunner.ts
+++ b/packages/vm/tests/tester/runners/BlockchainTestsRunner.ts
@@ -28,7 +28,7 @@ function formatBlockHeader(data: any) {
 
 export async function runBlockchainTest(options: any, testData: any, t: tape.Test) {
   // ensure that the test data is the right fork data
-  if (testData.network != options.forkConfigTestSuite) {
+  if (testData.network !== options.forkConfigTestSuite) {
     t.comment(`skipping test: no data available for ${options.forkConfigTestSuite}`)
     return
   }
@@ -112,7 +112,7 @@ export async function runBlockchainTest(options: any, testData: any, t: tape.Tes
     const paramAll2 = 'expectException'
     const expectException =
       // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-      raw[paramFork] || raw[paramAll1] || raw[paramAll2] || raw.blockHeader == undefined
+      raw[paramFork] || raw[paramAll1] || raw[paramAll2] || raw.blockHeader === undefined
 
     // Here we decode the rlp to extract the block number
     // The block library cannot be used, as this throws on certain EIP1559 blocks when trying to convert
@@ -147,7 +147,7 @@ export async function runBlockchainTest(options: any, testData: any, t: tape.Tes
           blockOpts: { calcDifficultyFromHeader: parentBlock.header },
         })
         for (const txData of raw.transactionSequence) {
-          const shouldFail = txData.valid == 'false'
+          const shouldFail = txData.valid === 'false'
           try {
             const txRLP = Buffer.from(txData.rawBytes.slice(2), 'hex')
             const tx = TransactionFactory.fromSerializedData(txRLP, { common })

--- a/packages/vm/tests/tester/runners/GeneralStateTestsRunner.ts
+++ b/packages/vm/tests/tester/runners/GeneralStateTestsRunner.ts
@@ -38,7 +38,7 @@ function parseTestCases(
 
       if (isTruthy(tx.accessLists)) {
         tx.accessList = testData.transaction.accessLists[testIndexes['data']]
-        if (tx.chainId == undefined) {
+        if (tx.chainId === undefined) {
           tx.chainId = 1
         }
       }
@@ -55,7 +55,7 @@ function parseTestCases(
   }
 
   testCases = testCases.filter((testCase: any) => {
-    return testCase != null
+    return testCase !== null
   })
 
   return testCases

--- a/packages/vm/tests/util.ts
+++ b/packages/vm/tests/util.ts
@@ -414,7 +414,7 @@ export function getDAOCommon(activationBlock: number) {
   const editedForks = []
   // explicitly edit the "dao" block number:
   for (const fork of forks) {
-    if (fork.name == Hardfork.Dao) {
+    if (fork.name === Hardfork.Dao) {
       editedForks.push({
         name: Hardfork.Dao,
         forkHash: fork.forkHash,


### PR DESCRIPTION
Enables the https://eslint.org/docs/latest/rules/eqeqeq rule to enforce strict comparisons.