### PR TITLE
Adjust `skipBalance` logic

### DIFF
--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -699,10 +699,12 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
 
       const value = opts.value ?? BigInt(0)
       if (opts.skipBalance === true) {
-        // if skipBalance, add `value` to caller balance to ensure sufficient funds
         const callerAccount = await this.eei.getAccount(caller)
-        callerAccount.balance += value
-        await this.eei.putAccount(caller, callerAccount)
+        if (callerAccount.balance < value) {
+          // if skipBalance and balance less than value, set caller balance to `value` to ensure sufficient funds
+          callerAccount.balance = value
+          await this.eei.putAccount(caller, callerAccount)
+        }
       }
 
       message = new Message({

--- a/packages/vm/tests/api/runTx.spec.ts
+++ b/packages/vm/tests/api/runTx.spec.ts
@@ -3,7 +3,7 @@ import { Blockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import type { FeeMarketEIP1559TxData } from '@ethereumjs/tx'
 import { FeeMarketEIP1559Transaction, Transaction, TransactionFactory } from '@ethereumjs/tx'
-import { Account, Address, isTruthy, MAX_INTEGER } from '@ethereumjs/util'
+import { Account, Address, MAX_INTEGER } from '@ethereumjs/util'
 import * as tape from 'tape'
 
 import { VM } from '../../src/vm'
@@ -658,7 +658,7 @@ tape('runTx() -> skipBalance behavior', async (t) => {
   const sender = Address.fromPrivateKey(senderKey)
 
   for (const balance of [undefined, BigInt(5)]) {
-    if (isTruthy(balance)) {
+    if (balance !== undefined) {
       await vm.stateManager.modifyAccountFields(sender, { nonce: BigInt(0), balance })
     }
     const tx = Transaction.fromTxData({
@@ -668,12 +668,12 @@ tape('runTx() -> skipBalance behavior', async (t) => {
     }).sign(senderKey)
 
     const res = await vm.runTx({ tx, skipBalance: true })
-    t.pass('runTx should not throw with no balance and skipBalance')
+    t.pass(`runTx should not throw with balance ${balance ?? 0} and skipBalance`)
     const afterTxBalance = (await vm.stateManager.getAccount(sender)).balance
     t.equal(
       afterTxBalance,
-      balance ?? BigInt(0),
-      `sender balance before and after transaction should be equal with skipBalance`
+      balance !== undefined ? balance - 1n : BigInt(0),
+      `sender balance should be >= 0 after transaction with skipBalance`
     )
     t.equal(res.execResult.exceptionError, undefined, 'no exceptionError with skipBalance')
   }


### PR DESCRIPTION
Updates changes in #1849 with some recommendations from hardhat.  Primarily, instead of just adding the tx cost or message value to the `caller` balance when `skipBalance` is set, we now only touch the balance if it's less than the transaction's cost (i.e. gasLimit *gasPrice + tx.value or maxFeePerGas * gasLimit + value if an EIP 1559 tx).  