### PR TITLE
chore: generate `coverage/lcov.info` file for codecov

### DIFF
--- a/.github/workflows/block-build.yml
+++ b/.github/workflows/block-build.yml
@@ -41,7 +41,7 @@ jobs:
       - run: npm run lint
       - run: npm run coverage
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: block

--- a/.github/workflows/blockchain-build.yml
+++ b/.github/workflows/blockchain-build.yml
@@ -39,7 +39,7 @@ jobs:
       - run: npm run lint
       - run: npm run coverage
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: blockchain

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -38,7 +38,7 @@ jobs:
 
       - run: npm run coverage
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: client

--- a/.github/workflows/common-build.yml
+++ b/.github/workflows/common-build.yml
@@ -39,7 +39,7 @@ jobs:
       - run: npm run lint
       - run: npm run coverage
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: common

--- a/.github/workflows/devp2p-build.yml
+++ b/.github/workflows/devp2p-build.yml
@@ -42,7 +42,7 @@ jobs:
           max_attempts: 3
           command: cd ${{github.workspace}}/packages/devp2p && npm run coverage
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: devp2p

--- a/.github/workflows/ethash-build.yml
+++ b/.github/workflows/ethash-build.yml
@@ -39,7 +39,7 @@ jobs:
       - run: npm run lint
       - run: npm run coverage
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: ethash

--- a/.github/workflows/evm-build.yml
+++ b/.github/workflows/evm-build.yml
@@ -39,7 +39,7 @@ jobs:
       - run: npm run lint
       - run: npm run coverage
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: evm

--- a/.github/workflows/rlp-build.yml
+++ b/.github/workflows/rlp-build.yml
@@ -1,12 +1,10 @@
-name: rlp
+name: RLP
 on:
   push:
     branches: [master, develop]
     tags: ['*']
-    paths: ['packages/rlp/**']
   pull_request:
     types: [opened, reopened, synchronize]
-    paths: ['packages/rlp/**']
   workflow_dispatch:
 
 env:
@@ -38,6 +36,7 @@ jobs:
       - run: npm i
         working-directory: ${{github.workspace}}
 
+      - run: npm run lint
       - run: npm run coverage
 
       - uses: codecov/codecov-action@v2
@@ -45,5 +44,3 @@ jobs:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: rlp
         if: ${{ matrix.node-version == 16 }}
-
-      - run: npm run lint

--- a/.github/workflows/rlp-build.yml
+++ b/.github/workflows/rlp-build.yml
@@ -39,7 +39,7 @@ jobs:
       - run: npm run lint
       - run: npm run coverage
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: rlp

--- a/.github/workflows/statemanager-build.yml
+++ b/.github/workflows/statemanager-build.yml
@@ -39,7 +39,7 @@ jobs:
       - run: npm run lint
       - run: npm run coverage
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: statemanager

--- a/.github/workflows/trie-build.yml
+++ b/.github/workflows/trie-build.yml
@@ -39,7 +39,7 @@ jobs:
       - run: npm run lint
       - run: npm run coverage
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: trie

--- a/.github/workflows/tx-build.yml
+++ b/.github/workflows/tx-build.yml
@@ -41,7 +41,7 @@ jobs:
       - run: npm run lint
       - run: npm run coverage
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: tx

--- a/.github/workflows/util-build.yml
+++ b/.github/workflows/util-build.yml
@@ -38,7 +38,7 @@ jobs:
 
       - run: npm run coverage
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: util

--- a/.github/workflows/vm-build.yml
+++ b/.github/workflows/vm-build.yml
@@ -35,7 +35,7 @@ jobs:
       - run: npm run coverage
       - run: npm run test:API:browser
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: vm

--- a/.github/workflows/vm-pr.yml
+++ b/.github/workflows/vm-pr.yml
@@ -35,7 +35,7 @@ jobs:
       - run: npm run coverage
       - run: npm run test:API:browser
 
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v3
         with:
           files: ${{ env.cwd }}/coverage/lcov.info
           flags: vm

--- a/config/cli/coverage.sh
+++ b/config/cli/coverage.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -o xtrace
-exec c8 --all --reporter=lcov --reporter=text npm run test
+exec c8 --all --reporter=lcov --reporter=text --reporter=text-lcov npm run test

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -39,7 +39,7 @@
     "client:start": "ts-node bin/cli.ts",
     "client:start:dev1": "npm run client:start -- --discDns=false --discV4=false --bootnodes",
     "client:start:dev2": "npm run client:start -- --discDns=false --discV4=false --transports=rlpx --port=30304 --datadir=datadir-dev2",
-    "coverage": "c8 --all --reporter=html --reporter=lcov --reporter=text npm run test:unit",
+    "coverage": "c8 --all --reporter=lcov --reporter=text --reporter=text-lcov npm run test:unit",
     "docs:build": "typedoc --options typedoc.js --tsconfig tsconfig.prod.json",
     "preinstall": "npm run binWorkaround",
     "lint": "../../config/cli/lint.sh",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "c8 --all --reporter=html --reporter=lcov --reporter=text npm run coverage:test",
+    "coverage": "c8 --all --reporter=lcov --reporter=text --reporter=text-lcov npm run coverage:test",
     "coverage:test": "npm run test",
     "docs:build": "typedoc --options typedoc.js",
     "examples": "ts-node ../../scripts/examples-runner.ts -- vm",

--- a/packages/rlp/.nycrc
+++ b/packages/rlp/.nycrc
@@ -1,0 +1,6 @@
+{
+  "extends": "../../config/nyc.json",
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -30,7 +30,7 @@
     "build": "../../config/cli/ts-build.sh",
     "build:benchmarks": "npm run build && tsc -p tsconfig.benchmarks.json",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "c8 --all --reporter=html --reporter=lcov --reporter=text npm run coverage:test",
+    "coverage": "c8 --all --reporter=lcov --reporter=text --reporter=text-lcov npm run coverage:test",
     "coverage:test": "npm run test:API && npm run tester -- --state",
     "docs:build": "typedoc --options typedoc.js",
     "examples": "ts-node ../../scripts/examples-runner.ts -- vm",


### PR DESCRIPTION
Suspecting that codecov has problems without the `coverage/lcov.info` file because it's not able to properly parse the `coverage/lcov` directory.