### PR TITLE
ci: use `npm ci` instead of `npm i` to install dependencies

### DIFF
--- a/.github/workflows/block-build.yml
+++ b/.github/workflows/block-build.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run lint

--- a/.github/workflows/blockchain-build.yml
+++ b/.github/workflows/blockchain-build.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run lint

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run coverage
@@ -68,7 +68,7 @@ jobs:
           node-version: 16
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - uses: nick-fields/retry@v2

--- a/.github/workflows/common-build.yml
+++ b/.github/workflows/common-build.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run lint

--- a/.github/workflows/devp2p-build.yml
+++ b/.github/workflows/devp2p-build.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - uses: nick-fields/retry@v2

--- a/.github/workflows/e2e-hardhat.yml.old
+++ b/.github/workflows/e2e-hardhat.yml.old
@@ -29,7 +29,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       # Publish all packages to virtual npm registry

--- a/.github/workflows/ethash-build.yml
+++ b/.github/workflows/ethash-build.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run lint

--- a/.github/workflows/evm-build.yml
+++ b/.github/workflows/evm-build.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run lint

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -22,5 +22,5 @@ jobs:
           node-version: 16
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
       - run: npm run examples

--- a/.github/workflows/node-versions.yml
+++ b/.github/workflows/node-versions.yml
@@ -42,7 +42,7 @@ jobs:
         run: npm i -g npm@7
         if: ${{ matrix.node-version < 16 }}
 
-      - run: npm i
+      - run: npm ci
 
       # Added a check to ensure we only run on NodeJS 14 or later to all jobs until the `node-testable-versions` script stops picking up 12.
 

--- a/.github/workflows/rlp-build.yml
+++ b/.github/workflows/rlp-build.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run lint

--- a/.github/workflows/statemanager-build.yml
+++ b/.github/workflows/statemanager-build.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run lint

--- a/.github/workflows/trie-build.yml
+++ b/.github/workflows/trie-build.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run lint
@@ -55,7 +55,7 @@ jobs:
   #         node-version: 16
   #         cache: 'npm'
 
-  #     - run: npm i
+  #     - run: npm ci
   #       working-directory: ${{github.workspace}}
 
   #     - run: npm run benchmarks | tee output.txt

--- a/.github/workflows/tx-build.yml
+++ b/.github/workflows/tx-build.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run lint

--- a/.github/workflows/util-build.yml
+++ b/.github/workflows/util-build.yml
@@ -33,7 +33,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run coverage

--- a/.github/workflows/vm-build.yml
+++ b/.github/workflows/vm-build.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 16
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run lint
@@ -52,7 +52,7 @@ jobs:
           node-version: 16
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run test:state:selectedForks
@@ -69,7 +69,7 @@ jobs:
           node-version: 16
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run test:blockchain
@@ -84,7 +84,7 @@ jobs:
           node-version: 16
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run build:benchmarks

--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -26,7 +26,7 @@ jobs:
       - run: rm package-lock.json
         working-directory: ${{github.workspace}}
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run test:API
@@ -49,7 +49,7 @@ jobs:
       - run: rm package-lock.json
         working-directory: ${{github.workspace}}
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run test:state:allForks
@@ -71,7 +71,7 @@ jobs:
       - run: rm package-lock.json
         working-directory: ${{github.workspace}}
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run test:blockchain:allForks
@@ -94,7 +94,7 @@ jobs:
       - run: rm package-lock.json
         working-directory: ${{github.workspace}}
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run test:state:slow

--- a/.github/workflows/vm-pr.yml
+++ b/.github/workflows/vm-pr.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: 16
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run lint
@@ -56,7 +56,7 @@ jobs:
           node-version: 16
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run test:state -- --fork=${{ matrix.fork }} --verify-test-amount-alltests
@@ -90,7 +90,7 @@ jobs:
           node-version: 16
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run test:state -- --fork=${{ matrix.fork }} --verify-test-amount-alltests
@@ -126,7 +126,7 @@ jobs:
           node-version: 16
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run test:blockchain -- ${{ matrix.args }}
@@ -167,7 +167,7 @@ jobs:
           node-version: 16
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run test:blockchain -- ${{ matrix.args }}
@@ -182,7 +182,7 @@ jobs:
           node-version: 16
           cache: 'npm'
 
-      - run: npm i
+      - run: npm ci
         working-directory: ${{github.workspace}}
 
       - run: npm run build:benchmarks


### PR DESCRIPTION
> https://docs.npmjs.com/cli/v8/commands/npm-ci

This command is similar to [npm install](https://docs.npmjs.com/cli/v8/commands/npm-install), except it's meant to be used in automated environments such as test platforms, continuous integration, and deployment -- or any situation where you want to make sure you're doing a clean install of your dependencies.