### PR TITLE
vm: make `touchAccount` of state manager non-protected

### DIFF
--- a/packages/vm/src/eei/vmState.ts
+++ b/packages/vm/src/eei/vmState.ts
@@ -204,7 +204,7 @@ export class VmState implements EVMStateAccess {
    * event. Touched accounts that are empty will be cleared
    * at the end of the tx.
    */
-  protected touchAccount(address: Address): void {
+  touchAccount(address: Address): void {
     this._touched.add(address.buf.toString('hex'))
   }
 


### PR DESCRIPTION
`touchAccount` is `protected` which it should not be.