### PR TITLE
evm/vm: update event signatures

### DIFF
--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -212,10 +212,10 @@ interface NewContractEvent {
 }
 
 export type EVMEvents = {
-  newContract: (data: NewContractEvent, resolve?: (result: any) => void) => void
-  beforeMessage: (data: Message, resolve?: (result: any) => void) => void
-  afterMessage: (data: EVMResult, resolve?: (result: any) => void) => void
-  step: (data: InterpreterStep, resolve?: (result: any) => void) => void
+  newContract: (data: NewContractEvent, resolve?: (result?: any) => void) => void
+  beforeMessage: (data: Message, resolve?: (result?: any) => void) => void
+  afterMessage: (data: EVMResult, resolve?: (result?: any) => void) => void
+  step: (data: InterpreterStep, resolve?: (result?: any) => void) => void
 }
 
 /**

--- a/packages/vm/src/types.ts
+++ b/packages/vm/src/types.ts
@@ -49,10 +49,10 @@ export interface PostByzantiumTxReceipt extends BaseTxReceipt {
 }
 
 export type VMEvents = {
-  beforeBlock: (data: Block, resolve?: (result: any) => void) => void
-  afterBlock: (data: AfterBlockEvent, resolve?: (result: any) => void) => void
-  beforeTx: (data: TypedTransaction, resolve?: (result: any) => void) => void
-  afterTx: (data: AfterTxEvent, resolve?: (result: any) => void) => void
+  beforeBlock: (data: Block, resolve?: (result?: any) => void) => void
+  afterBlock: (data: AfterBlockEvent, resolve?: (result?: any) => void) => void
+  beforeTx: (data: TypedTransaction, resolve?: (result?: any) => void) => void
+  afterTx: (data: AfterTxEvent, resolve?: (result?: any) => void) => void
 }
 
 /**


### PR DESCRIPTION
If you listen to an event in `evm` or `vm` asynchronously, then you need to call a continuation function once you are done;

```typescript
vm.on('afterTx',  async (e, cont) => {
... do async stuff
cont()
})
```

However, our type signatures stated that this `cont` function should always be called with an argument, which is not the case.