### PR TITLE
refactor(trie): move `Trie#_findValueNodes` to `TrieReadStream`

### DIFF
--- a/packages/trie/docs/README.md
+++ b/packages/trie/docs/README.md
@@ -211,7 +211,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/util.ts:24](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/util.ts#L24)
+[packages/trie/src/trie/node/util.ts:25](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/util.ts#L25)
 
 ___
 
@@ -231,7 +231,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/util.ts:10](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/util.ts#L10)
+[packages/trie/src/trie/node/util.ts:11](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/util.ts#L11)
 
 ___
 
@@ -251,7 +251,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/util.ts:32](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/util.ts#L32)
+[packages/trie/src/trie/node/util.ts:33](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/util.ts#L33)
 
 ___
 
@@ -298,4 +298,4 @@ a flag to indicate whether there exists more trie node in the trie
 
 #### Defined in
 
-[packages/trie/src/proof/range.ts:409](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/proof/range.ts#L409)
+[packages/trie/src/proof/range.ts:410](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/proof/range.ts#L410)

--- a/packages/trie/docs/classes/CheckpointDB.md
+++ b/packages/trie/docs/classes/CheckpointDB.md
@@ -113,7 +113,7 @@ Performs a batch operation on db.
 
 #### Defined in
 
-[packages/trie/src/db/checkpoint.ts:123](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/db/checkpoint.ts#L123)
+[packages/trie/src/db/checkpoint.ts:125](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/db/checkpoint.ts#L125)
 
 ___
 
@@ -172,7 +172,7 @@ to the **same** underlying leveldb instance.
 
 #### Defined in
 
-[packages/trie/src/db/checkpoint.ts:140](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/db/checkpoint.ts#L140)
+[packages/trie/src/db/checkpoint.ts:142](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/db/checkpoint.ts#L142)
 
 ___
 
@@ -198,7 +198,7 @@ Removes a raw value in the underlying leveldb.
 
 #### Defined in
 
-[packages/trie/src/db/checkpoint.ts:110](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/db/checkpoint.ts#L110)
+[packages/trie/src/db/checkpoint.ts:112](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/db/checkpoint.ts#L112)
 
 ___
 
@@ -226,7 +226,7 @@ A Promise that resolves to `Buffer` if a value is found or `null` if no value is
 
 #### Defined in
 
-[packages/trie/src/db/checkpoint.ts:76](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/db/checkpoint.ts#L76)
+[packages/trie/src/db/checkpoint.ts:78](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/db/checkpoint.ts#L78)
 
 ___
 
@@ -253,7 +253,7 @@ Writes a value directly to leveldb.
 
 #### Defined in
 
-[packages/trie/src/db/checkpoint.ts:98](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/db/checkpoint.ts#L98)
+[packages/trie/src/db/checkpoint.ts:100](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/db/checkpoint.ts#L100)
 
 ___
 
@@ -269,4 +269,4 @@ Reverts the latest checkpoint
 
 #### Defined in
 
-[packages/trie/src/db/checkpoint.ts:68](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/db/checkpoint.ts#L68)
+[packages/trie/src/db/checkpoint.ts:70](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/db/checkpoint.ts#L70)

--- a/packages/trie/docs/classes/CheckpointTrie.md
+++ b/packages/trie/docs/classes/CheckpointTrie.md
@@ -70,7 +70,7 @@ Adds checkpointing to the [Trie](Trie.md)
 
 #### Defined in
 
-[packages/trie/src/trie/checkpoint.ts:12](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L12)
+[packages/trie/src/trie/checkpoint.ts:14](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L14)
 
 ## Properties
 
@@ -86,7 +86,7 @@ The root for an empty trie
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:38](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L38)
+[packages/trie/src/trie/trie.ts:40](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L40)
 
 ___
 
@@ -102,7 +102,7 @@ The backend DB
 
 #### Defined in
 
-[packages/trie/src/trie/checkpoint.ts:9](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L9)
+[packages/trie/src/trie/checkpoint.ts:11](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L11)
 
 ___
 
@@ -112,7 +112,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/checkpoint.ts:10](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L10)
+[packages/trie/src/trie/checkpoint.ts:12](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L12)
 
 ## Accessors
 
@@ -132,7 +132,7 @@ Trie.isCheckpoint
 
 #### Defined in
 
-[packages/trie/src/trie/checkpoint.ts:21](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L21)
+[packages/trie/src/trie/checkpoint.ts:23](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L23)
 
 ___
 
@@ -152,7 +152,7 @@ Trie.root
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:104](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L104)
+[packages/trie/src/trie/trie.ts:97](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L97)
 
 • `set` **root**(`value`): `void`
 
@@ -174,7 +174,7 @@ Trie.root
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:92](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L92)
+[packages/trie/src/trie/trie.ts:85](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L85)
 
 ## Methods
 
@@ -214,7 +214,7 @@ await trie.batch(ops)
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:630](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L630)
+[packages/trie/src/trie/trie.ts:623](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L623)
 
 ___
 
@@ -240,7 +240,7 @@ Checks if a given root exists.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:111](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L111)
+[packages/trie/src/trie/trie.ts:104](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L104)
 
 ___
 
@@ -257,7 +257,7 @@ After this is called, all changes can be reverted until `commit` is called.
 
 #### Defined in
 
-[packages/trie/src/trie/checkpoint.ts:29](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L29)
+[packages/trie/src/trie/checkpoint.ts:31](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L31)
 
 ___
 
@@ -278,7 +278,7 @@ If not during a checkpoint phase
 
 #### Defined in
 
-[packages/trie/src/trie/checkpoint.ts:38](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L38)
+[packages/trie/src/trie/checkpoint.ts:40](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L40)
 
 ___
 
@@ -304,7 +304,7 @@ Returns a copy of the underlying trie with the interface of CheckpointTrie.
 
 #### Defined in
 
-[packages/trie/src/trie/checkpoint.ts:69](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L69)
+[packages/trie/src/trie/checkpoint.ts:71](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L71)
 
 ___
 
@@ -330,7 +330,7 @@ Creates a proof from a trie and key that can be verified using [verifyProof](Tri
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:679](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L679)
+[packages/trie/src/trie/trie.ts:672](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L672)
 
 ___
 
@@ -352,7 +352,7 @@ Returns a [stream](https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#str
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:740](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L740)
+[packages/trie/src/trie/trie.ts:733](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L733)
 
 ___
 
@@ -381,7 +381,7 @@ A Promise that resolves once value is deleted.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:183](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L183)
+[packages/trie/src/trie/trie.ts:176](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L176)
 
 ___
 
@@ -409,7 +409,7 @@ It returns a `stack` of nodes to the closest node.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:199](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L199)
+[packages/trie/src/trie/trie.ts:192](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L192)
 
 ___
 
@@ -435,7 +435,7 @@ Saves the nodes from a proof into the trie.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:648](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L648)
+[packages/trie/src/trie/trie.ts:641](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L641)
 
 ___
 
@@ -464,7 +464,7 @@ A Promise that resolves to `Buffer` if a value was found or `null` if no value w
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:137](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L137)
+[packages/trie/src/trie/trie.ts:130](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L130)
 
 ___
 
@@ -490,7 +490,7 @@ Retrieves a node from db by hash.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:290](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L290)
+[packages/trie/src/trie/trie.ts:283](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L283)
 
 ___
 
@@ -510,7 +510,7 @@ Persists the root hash in the underlying database
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:760](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L760)
+[packages/trie/src/trie/trie.ts:753](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L753)
 
 ___
 
@@ -538,7 +538,7 @@ prove has been renamed to [createProof](Trie.md#createproof).
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:671](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L671)
+[packages/trie/src/trie/trie.ts:664](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L664)
 
 ___
 
@@ -568,7 +568,7 @@ A Promise that resolves once value is stored.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:153](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L153)
+[packages/trie/src/trie/trie.ts:146](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L146)
 
 ___
 
@@ -586,7 +586,7 @@ parent checkpoint as current.
 
 #### Defined in
 
-[packages/trie/src/trie/checkpoint.ts:54](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L54)
+[packages/trie/src/trie/checkpoint.ts:56](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L56)
 
 ___
 
@@ -620,7 +620,7 @@ The value from the key, or null if valid proof of non-existence.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:695](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L695)
+[packages/trie/src/trie/trie.ts:688](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L688)
 
 ___
 
@@ -651,7 +651,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:717](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L717)
+[packages/trie/src/trie/trie.ts:710](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L710)
 
 ___
 
@@ -680,7 +680,7 @@ Resolves when finished walking trie.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:270](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L270)
+[packages/trie/src/trie/trie.ts:263](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L263)
 
 ___
 
@@ -704,4 +704,4 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:73](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L73)
+[packages/trie/src/trie/trie.ts:70](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L70)

--- a/packages/trie/docs/classes/ExtensionNode.md
+++ b/packages/trie/docs/classes/ExtensionNode.md
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[packages/trie/src/trie/node/extension.ts:12](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L12)
+[packages/trie/src/trie/node/extension.ts:13](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L13)
 
 ## Properties
 
@@ -52,7 +52,7 @@
 
 #### Defined in
 
-[packages/trie/src/trie/node/extension.ts:9](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L9)
+[packages/trie/src/trie/node/extension.ts:10](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L10)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/extension.ts:10](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L10)
+[packages/trie/src/trie/node/extension.ts:11](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L11)
 
 ## Accessors
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/extension.ts:25](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L25)
+[packages/trie/src/trie/node/extension.ts:26](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L26)
 
 • `set` **key**(`k`): `void`
 
@@ -92,7 +92,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/extension.ts:29](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L29)
+[packages/trie/src/trie/node/extension.ts:30](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L30)
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/extension.ts:33](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L33)
+[packages/trie/src/trie/node/extension.ts:34](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L34)
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/extension.ts:37](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L37)
+[packages/trie/src/trie/node/extension.ts:38](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L38)
 
 • `set` **value**(`v`): `void`
 
@@ -136,7 +136,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/extension.ts:41](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L41)
+[packages/trie/src/trie/node/extension.ts:42](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L42)
 
 ## Methods
 
@@ -150,7 +150,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/extension.ts:45](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L45)
+[packages/trie/src/trie/node/extension.ts:46](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L46)
 
 ___
 
@@ -164,7 +164,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/extension.ts:49](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L49)
+[packages/trie/src/trie/node/extension.ts:50](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L50)
 
 ___
 
@@ -178,7 +178,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/extension.ts:53](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L53)
+[packages/trie/src/trie/node/extension.ts:54](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L54)
 
 ___
 
@@ -198,7 +198,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/extension.ts:21](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L21)
+[packages/trie/src/trie/node/extension.ts:22](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L22)
 
 ___
 
@@ -218,4 +218,4 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/extension.ts:17](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L17)
+[packages/trie/src/trie/node/extension.ts:18](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/extension.ts#L18)

--- a/packages/trie/docs/classes/LeafNode.md
+++ b/packages/trie/docs/classes/LeafNode.md
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[packages/trie/src/trie/node/leaf.ts:12](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L12)
+[packages/trie/src/trie/node/leaf.ts:13](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L13)
 
 ## Properties
 
@@ -52,7 +52,7 @@
 
 #### Defined in
 
-[packages/trie/src/trie/node/leaf.ts:9](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L9)
+[packages/trie/src/trie/node/leaf.ts:10](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L10)
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/leaf.ts:10](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L10)
+[packages/trie/src/trie/node/leaf.ts:11](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L11)
 
 ## Accessors
 
@@ -76,7 +76,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/leaf.ts:25](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L25)
+[packages/trie/src/trie/node/leaf.ts:26](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L26)
 
 • `set` **key**(`k`): `void`
 
@@ -92,7 +92,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/leaf.ts:29](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L29)
+[packages/trie/src/trie/node/leaf.ts:30](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L30)
 
 ___
 
@@ -106,7 +106,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/leaf.ts:33](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L33)
+[packages/trie/src/trie/node/leaf.ts:34](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L34)
 
 ___
 
@@ -120,7 +120,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/leaf.ts:37](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L37)
+[packages/trie/src/trie/node/leaf.ts:38](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L38)
 
 • `set` **value**(`v`): `void`
 
@@ -136,7 +136,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/leaf.ts:41](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L41)
+[packages/trie/src/trie/node/leaf.ts:42](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L42)
 
 ## Methods
 
@@ -150,7 +150,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/leaf.ts:45](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L45)
+[packages/trie/src/trie/node/leaf.ts:46](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L46)
 
 ___
 
@@ -164,7 +164,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/leaf.ts:49](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L49)
+[packages/trie/src/trie/node/leaf.ts:50](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L50)
 
 ___
 
@@ -178,7 +178,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/leaf.ts:53](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L53)
+[packages/trie/src/trie/node/leaf.ts:54](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L54)
 
 ___
 
@@ -198,7 +198,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/leaf.ts:21](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L21)
+[packages/trie/src/trie/node/leaf.ts:22](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L22)
 
 ___
 
@@ -218,4 +218,4 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/node/leaf.ts:17](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L17)
+[packages/trie/src/trie/node/leaf.ts:18](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/node/leaf.ts#L18)

--- a/packages/trie/docs/classes/SecureTrie.md
+++ b/packages/trie/docs/classes/SecureTrie.md
@@ -70,7 +70,7 @@ It has the same methods and constructor as `Trie`.
 
 #### Defined in
 
-[packages/trie/src/trie/checkpoint.ts:12](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L12)
+[packages/trie/src/trie/checkpoint.ts:14](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L14)
 
 ## Properties
 
@@ -86,7 +86,7 @@ The root for an empty trie
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:38](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L38)
+[packages/trie/src/trie/trie.ts:40](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L40)
 
 ___
 
@@ -102,7 +102,7 @@ The backend DB
 
 #### Defined in
 
-[packages/trie/src/trie/checkpoint.ts:9](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L9)
+[packages/trie/src/trie/checkpoint.ts:11](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L11)
 
 ___
 
@@ -116,7 +116,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/checkpoint.ts:10](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L10)
+[packages/trie/src/trie/checkpoint.ts:12](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L12)
 
 ## Accessors
 
@@ -136,7 +136,7 @@ CheckpointTrie.isCheckpoint
 
 #### Defined in
 
-[packages/trie/src/trie/checkpoint.ts:21](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L21)
+[packages/trie/src/trie/checkpoint.ts:23](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L23)
 
 ___
 
@@ -156,7 +156,7 @@ CheckpointTrie.root
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:104](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L104)
+[packages/trie/src/trie/trie.ts:97](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L97)
 
 • `set` **root**(`value`): `void`
 
@@ -178,7 +178,7 @@ CheckpointTrie.root
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:92](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L92)
+[packages/trie/src/trie/trie.ts:85](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L85)
 
 ## Methods
 
@@ -218,7 +218,7 @@ await trie.batch(ops)
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:630](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L630)
+[packages/trie/src/trie/trie.ts:623](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L623)
 
 ___
 
@@ -244,7 +244,7 @@ Checks if a given root exists.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:111](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L111)
+[packages/trie/src/trie/trie.ts:104](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L104)
 
 ___
 
@@ -265,7 +265,7 @@ After this is called, all changes can be reverted until `commit` is called.
 
 #### Defined in
 
-[packages/trie/src/trie/checkpoint.ts:29](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L29)
+[packages/trie/src/trie/checkpoint.ts:31](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L31)
 
 ___
 
@@ -290,7 +290,7 @@ If not during a checkpoint phase
 
 #### Defined in
 
-[packages/trie/src/trie/checkpoint.ts:38](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L38)
+[packages/trie/src/trie/checkpoint.ts:40](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L40)
 
 ___
 
@@ -316,7 +316,7 @@ Returns a copy of the underlying trie with the interface of SecureTrie.
 
 #### Defined in
 
-[packages/trie/src/trie/secure.ts:104](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L104)
+[packages/trie/src/trie/secure.ts:107](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L107)
 
 ___
 
@@ -342,7 +342,7 @@ Creates a proof that can be verified using [verifyProof](SecureTrie.md#verifypro
 
 #### Defined in
 
-[packages/trie/src/trie/secure.ts:63](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L63)
+[packages/trie/src/trie/secure.ts:66](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L66)
 
 ___
 
@@ -364,7 +364,7 @@ Returns a [stream](https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#str
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:740](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L740)
+[packages/trie/src/trie/trie.ts:733](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L733)
 
 ___
 
@@ -390,7 +390,7 @@ Deletes a value given a `key`.
 
 #### Defined in
 
-[packages/trie/src/trie/secure.ts:46](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L46)
+[packages/trie/src/trie/secure.ts:49](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L49)
 
 ___
 
@@ -418,7 +418,7 @@ It returns a `stack` of nodes to the closest node.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:199](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L199)
+[packages/trie/src/trie/trie.ts:192](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L192)
 
 ___
 
@@ -444,7 +444,7 @@ Saves the nodes from a proof into the trie.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:648](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L648)
+[packages/trie/src/trie/trie.ts:641](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L641)
 
 ___
 
@@ -472,7 +472,7 @@ A Promise that resolves to `Buffer` if a value was found or `null` if no value w
 
 #### Defined in
 
-[packages/trie/src/trie/secure.ts:20](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L20)
+[packages/trie/src/trie/secure.ts:23](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L23)
 
 ___
 
@@ -498,7 +498,7 @@ Retrieves a node from db by hash.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:290](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L290)
+[packages/trie/src/trie/trie.ts:283](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L283)
 
 ___
 
@@ -518,7 +518,7 @@ Persists the root hash in the underlying database
 
 #### Defined in
 
-[packages/trie/src/trie/secure.ts:121](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L121)
+[packages/trie/src/trie/secure.ts:124](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L124)
 
 ___
 
@@ -546,7 +546,7 @@ prove has been renamed to [createProof](SecureTrie.md#createproof).
 
 #### Defined in
 
-[packages/trie/src/trie/secure.ts:55](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L55)
+[packages/trie/src/trie/secure.ts:58](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L58)
 
 ___
 
@@ -574,7 +574,7 @@ For a falsey value, use the original key to avoid double hashing the key.
 
 #### Defined in
 
-[packages/trie/src/trie/secure.ts:30](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L30)
+[packages/trie/src/trie/secure.ts:33](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L33)
 
 ___
 
@@ -596,7 +596,7 @@ parent checkpoint as current.
 
 #### Defined in
 
-[packages/trie/src/trie/checkpoint.ts:54](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L54)
+[packages/trie/src/trie/checkpoint.ts:56](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/checkpoint.ts#L56)
 
 ___
 
@@ -630,7 +630,7 @@ The value from the key.
 
 #### Defined in
 
-[packages/trie/src/trie/secure.ts:75](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L75)
+[packages/trie/src/trie/secure.ts:78](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L78)
 
 ___
 
@@ -661,7 +661,7 @@ Verifies a range proof.
 
 #### Defined in
 
-[packages/trie/src/trie/secure.ts:82](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L82)
+[packages/trie/src/trie/secure.ts:85](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/secure.ts#L85)
 
 ___
 
@@ -690,7 +690,7 @@ Resolves when finished walking trie.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:270](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L270)
+[packages/trie/src/trie/trie.ts:263](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L263)
 
 ___
 
@@ -714,4 +714,4 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:73](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L73)
+[packages/trie/src/trie/trie.ts:70](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L70)

--- a/packages/trie/docs/classes/Trie.md
+++ b/packages/trie/docs/classes/Trie.md
@@ -64,7 +64,7 @@ Create a new trie
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:53](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L53)
+[packages/trie/src/trie/trie.ts:55](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L55)
 
 ## Properties
 
@@ -76,7 +76,7 @@ The root for an empty trie
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:38](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L38)
+[packages/trie/src/trie/trie.ts:40](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L40)
 
 ___
 
@@ -88,7 +88,7 @@ The backend DB
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:42](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L42)
+[packages/trie/src/trie/trie.ts:44](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L44)
 
 ## Accessors
 
@@ -104,7 +104,7 @@ Trie has no checkpointing so return false
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:127](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L127)
+[packages/trie/src/trie/trie.ts:120](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L120)
 
 ___
 
@@ -120,7 +120,7 @@ Gets the current root of the `trie`
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:104](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L104)
+[packages/trie/src/trie/trie.ts:97](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L97)
 
 • `set` **root**(`value`): `void`
 
@@ -138,7 +138,7 @@ Sets the current root of the `trie`
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:92](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L92)
+[packages/trie/src/trie/trie.ts:85](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L85)
 
 ## Methods
 
@@ -174,7 +174,7 @@ await trie.batch(ops)
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:630](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L630)
+[packages/trie/src/trie/trie.ts:623](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L623)
 
 ___
 
@@ -196,7 +196,7 @@ Checks if a given root exists.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:111](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L111)
+[packages/trie/src/trie/trie.ts:104](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L104)
 
 ___
 
@@ -212,7 +212,7 @@ Creates a new trie backed by the same db.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:747](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L747)
+[packages/trie/src/trie/trie.ts:740](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L740)
 
 ___
 
@@ -234,7 +234,7 @@ Creates a proof from a trie and key that can be verified using [verifyProof](Tri
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:679](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L679)
+[packages/trie/src/trie/trie.ts:672](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L672)
 
 ___
 
@@ -252,7 +252,7 @@ Returns a [stream](https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#str
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:740](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L740)
+[packages/trie/src/trie/trie.ts:733](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L733)
 
 ___
 
@@ -277,7 +277,7 @@ A Promise that resolves once value is deleted.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:183](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L183)
+[packages/trie/src/trie/trie.ts:176](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L176)
 
 ___
 
@@ -301,7 +301,7 @@ It returns a `stack` of nodes to the closest node.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:199](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L199)
+[packages/trie/src/trie/trie.ts:192](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L192)
 
 ___
 
@@ -323,7 +323,7 @@ Saves the nodes from a proof into the trie.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:648](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L648)
+[packages/trie/src/trie/trie.ts:641](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L641)
 
 ___
 
@@ -348,7 +348,7 @@ A Promise that resolves to `Buffer` if a value was found or `null` if no value w
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:137](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L137)
+[packages/trie/src/trie/trie.ts:130](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L130)
 
 ___
 
@@ -370,7 +370,7 @@ Retrieves a node from db by hash.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:290](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L290)
+[packages/trie/src/trie/trie.ts:283](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L283)
 
 ___
 
@@ -386,7 +386,7 @@ Persists the root hash in the underlying database
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:760](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L760)
+[packages/trie/src/trie/trie.ts:753](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L753)
 
 ___
 
@@ -410,7 +410,7 @@ prove has been renamed to [createProof](Trie.md#createproof).
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:671](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L671)
+[packages/trie/src/trie/trie.ts:664](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L664)
 
 ___
 
@@ -436,7 +436,7 @@ A Promise that resolves once value is stored.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:153](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L153)
+[packages/trie/src/trie/trie.ts:146](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L146)
 
 ___
 
@@ -466,7 +466,7 @@ The value from the key, or null if valid proof of non-existence.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:695](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L695)
+[packages/trie/src/trie/trie.ts:688](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L688)
 
 ___
 
@@ -493,7 +493,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:717](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L717)
+[packages/trie/src/trie/trie.ts:710](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L710)
 
 ___
 
@@ -518,7 +518,7 @@ Resolves when finished walking trie.
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:270](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L270)
+[packages/trie/src/trie/trie.ts:263](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L263)
 
 ___
 
@@ -538,4 +538,4 @@ ___
 
 #### Defined in
 
-[packages/trie/src/trie/trie.ts:73](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L73)
+[packages/trie/src/trie/trie.ts:70](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/trie/trie.ts#L70)

--- a/packages/trie/docs/classes/TrieReadStream.md
+++ b/packages/trie/docs/classes/TrieReadStream.md
@@ -17,7 +17,9 @@
 ### Properties
 
 - [\_readableState](TrieReadStream.md#_readablestate)
+- [closed](TrieReadStream.md#closed)
 - [destroyed](TrieReadStream.md#destroyed)
+- [errored](TrieReadStream.md#errored)
 - [readable](TrieReadStream.md#readable)
 - [readableAborted](TrieReadStream.md#readableaborted)
 - [readableDidRead](TrieReadStream.md#readabledidread)
@@ -79,7 +81,7 @@ Readable.constructor
 
 #### Defined in
 
-[packages/trie/src/util/readStream.ts:10](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/readStream.ts#L10)
+[packages/trie/src/util/readStream.ts:14](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/readStream.ts#L14)
 
 ## Properties
 
@@ -93,7 +95,21 @@ Readable.\_readableState
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:144
+node_modules/@types/readable-stream/index.d.ts:146
+
+___
+
+### closed
+
+• `Readonly` **closed**: `boolean`
+
+#### Inherited from
+
+Readable.closed
+
+#### Defined in
+
+node_modules/@types/readable-stream/index.d.ts:59
 
 ___
 
@@ -107,7 +123,21 @@ Readable.destroyed
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:145
+node_modules/@types/readable-stream/index.d.ts:147
+
+___
+
+### errored
+
+• `Readonly` **errored**: ``null`` \| `Error`
+
+#### Inherited from
+
+Readable.errored
+
+#### Defined in
+
+node_modules/@types/readable-stream/index.d.ts:60
 
 ___
 
@@ -135,7 +165,7 @@ Readable.readableAborted
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:290
+node_modules/@types/readable-stream/index.d.ts:292
 
 ___
 
@@ -149,7 +179,7 @@ Readable.readableDidRead
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:291
+node_modules/@types/readable-stream/index.d.ts:293
 
 ___
 
@@ -163,7 +193,7 @@ Readable.readableEncoding
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:292
+node_modules/@types/readable-stream/index.d.ts:294
 
 ___
 
@@ -177,7 +207,7 @@ Readable.readableEnded
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:293
+node_modules/@types/readable-stream/index.d.ts:295
 
 ___
 
@@ -233,7 +263,7 @@ Readable.readableObjectMode
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:294
+node_modules/@types/readable-stream/index.d.ts:296
 
 ## Methods
 
@@ -247,11 +277,11 @@ node_modules/@types/readable-stream/index.d.ts:294
 
 #### Inherited from
 
-Readable.\_\_@asyncIterator@21364
+Readable.\_\_@asyncIterator@21362
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:141
+node_modules/@types/readable-stream/index.d.ts:143
 
 ___
 
@@ -276,7 +306,7 @@ Readable.\_destroy
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:69
+node_modules/@types/readable-stream/index.d.ts:71
 
 ___
 
@@ -294,7 +324,7 @@ Readable.\_read
 
 #### Defined in
 
-[packages/trie/src/util/readStream.ts:17](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/readStream.ts#L17)
+[packages/trie/src/util/readStream.ts:21](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/readStream.ts#L21)
 
 ___
 
@@ -312,7 +342,7 @@ Readable.\_undestroy
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:149
+node_modules/@types/readable-stream/index.d.ts:151
 
 ___
 
@@ -345,7 +375,7 @@ Readable.addListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:81
+node_modules/@types/readable-stream/index.d.ts:83
 
 ▸ **addListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -366,7 +396,7 @@ Readable.addListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:82
+node_modules/@types/readable-stream/index.d.ts:84
 
 ▸ **addListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -387,7 +417,7 @@ Readable.addListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:83
+node_modules/@types/readable-stream/index.d.ts:85
 
 ▸ **addListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -408,7 +438,7 @@ Readable.addListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:84
+node_modules/@types/readable-stream/index.d.ts:86
 
 ▸ **addListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -429,7 +459,7 @@ Readable.addListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:85
+node_modules/@types/readable-stream/index.d.ts:87
 
 ▸ **addListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -450,7 +480,7 @@ Readable.addListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:86
+node_modules/@types/readable-stream/index.d.ts:88
 
 ___
 
@@ -474,7 +504,7 @@ Readable.destroy
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:70
+node_modules/@types/readable-stream/index.d.ts:72
 
 ___
 
@@ -498,7 +528,7 @@ Readable.emit
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:88
+node_modules/@types/readable-stream/index.d.ts:90
 
 ▸ **emit**(`event`, `chunk`): `boolean`
 
@@ -519,7 +549,7 @@ Readable.emit
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:89
+node_modules/@types/readable-stream/index.d.ts:91
 
 ▸ **emit**(`event`): `boolean`
 
@@ -539,7 +569,7 @@ Readable.emit
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:90
+node_modules/@types/readable-stream/index.d.ts:92
 
 ▸ **emit**(`event`): `boolean`
 
@@ -559,7 +589,7 @@ Readable.emit
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:91
+node_modules/@types/readable-stream/index.d.ts:93
 
 ▸ **emit**(`event`, `err`): `boolean`
 
@@ -580,7 +610,7 @@ Readable.emit
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:92
+node_modules/@types/readable-stream/index.d.ts:94
 
 ▸ **emit**(`event`, ...`args`): `boolean`
 
@@ -601,7 +631,7 @@ Readable.emit
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:93
+node_modules/@types/readable-stream/index.d.ts:95
 
 ___
 
@@ -619,7 +649,7 @@ Readable.eventNames
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:139
+node_modules/@types/readable-stream/index.d.ts:141
 
 ___
 
@@ -637,7 +667,7 @@ Readable.getMaxListeners
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:133
+node_modules/@types/readable-stream/index.d.ts:135
 
 ___
 
@@ -655,7 +685,7 @@ Readable.isPaused
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:64
+node_modules/@types/readable-stream/index.d.ts:66
 
 ___
 
@@ -679,7 +709,7 @@ Readable.listenerCount
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:138
+node_modules/@types/readable-stream/index.d.ts:140
 
 ___
 
@@ -703,7 +733,7 @@ Readable.listeners
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:135
+node_modules/@types/readable-stream/index.d.ts:137
 
 ___
 
@@ -728,7 +758,7 @@ Readable.off
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:131
+node_modules/@types/readable-stream/index.d.ts:133
 
 ___
 
@@ -753,7 +783,7 @@ Readable.on
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:95
+node_modules/@types/readable-stream/index.d.ts:97
 
 ▸ **on**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -774,7 +804,7 @@ Readable.on
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:96
+node_modules/@types/readable-stream/index.d.ts:98
 
 ▸ **on**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -795,7 +825,7 @@ Readable.on
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:97
+node_modules/@types/readable-stream/index.d.ts:99
 
 ▸ **on**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -816,7 +846,7 @@ Readable.on
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:98
+node_modules/@types/readable-stream/index.d.ts:100
 
 ▸ **on**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -837,7 +867,7 @@ Readable.on
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:99
+node_modules/@types/readable-stream/index.d.ts:101
 
 ▸ **on**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -858,7 +888,7 @@ Readable.on
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:100
+node_modules/@types/readable-stream/index.d.ts:102
 
 ___
 
@@ -883,7 +913,7 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:102
+node_modules/@types/readable-stream/index.d.ts:104
 
 ▸ **once**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -904,7 +934,7 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:103
+node_modules/@types/readable-stream/index.d.ts:105
 
 ▸ **once**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -925,7 +955,7 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:104
+node_modules/@types/readable-stream/index.d.ts:106
 
 ▸ **once**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -946,7 +976,7 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:105
+node_modules/@types/readable-stream/index.d.ts:107
 
 ▸ **once**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -967,7 +997,7 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:106
+node_modules/@types/readable-stream/index.d.ts:108
 
 ▸ **once**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -988,7 +1018,7 @@ Readable.once
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:107
+node_modules/@types/readable-stream/index.d.ts:109
 
 ___
 
@@ -1006,7 +1036,7 @@ Readable.pause
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:62
+node_modules/@types/readable-stream/index.d.ts:64
 
 ___
 
@@ -1038,7 +1068,7 @@ Readable.pipe
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:297
+node_modules/@types/readable-stream/index.d.ts:299
 
 ___
 
@@ -1063,7 +1093,7 @@ Readable.prependListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:109
+node_modules/@types/readable-stream/index.d.ts:111
 
 ▸ **prependListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -1084,7 +1114,7 @@ Readable.prependListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:110
+node_modules/@types/readable-stream/index.d.ts:112
 
 ▸ **prependListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -1105,7 +1135,7 @@ Readable.prependListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:111
+node_modules/@types/readable-stream/index.d.ts:113
 
 ▸ **prependListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -1126,7 +1156,7 @@ Readable.prependListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:112
+node_modules/@types/readable-stream/index.d.ts:114
 
 ▸ **prependListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -1147,7 +1177,7 @@ Readable.prependListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:113
+node_modules/@types/readable-stream/index.d.ts:115
 
 ▸ **prependListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -1168,7 +1198,7 @@ Readable.prependListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:114
+node_modules/@types/readable-stream/index.d.ts:116
 
 ___
 
@@ -1193,7 +1223,7 @@ Readable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:116
+node_modules/@types/readable-stream/index.d.ts:118
 
 ▸ **prependOnceListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -1214,7 +1244,7 @@ Readable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:117
+node_modules/@types/readable-stream/index.d.ts:119
 
 ▸ **prependOnceListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -1235,7 +1265,7 @@ Readable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:118
+node_modules/@types/readable-stream/index.d.ts:120
 
 ▸ **prependOnceListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -1256,7 +1286,7 @@ Readable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:119
+node_modules/@types/readable-stream/index.d.ts:121
 
 ▸ **prependOnceListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -1277,7 +1307,7 @@ Readable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:120
+node_modules/@types/readable-stream/index.d.ts:122
 
 ▸ **prependOnceListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -1298,7 +1328,7 @@ Readable.prependOnceListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:121
+node_modules/@types/readable-stream/index.d.ts:123
 
 ___
 
@@ -1323,7 +1353,7 @@ Readable.push
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:68
+node_modules/@types/readable-stream/index.d.ts:70
 
 ___
 
@@ -1347,7 +1377,7 @@ Readable.rawListeners
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:137
+node_modules/@types/readable-stream/index.d.ts:139
 
 ___
 
@@ -1371,7 +1401,7 @@ Readable.read
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:60
+node_modules/@types/readable-stream/index.d.ts:62
 
 ___
 
@@ -1395,7 +1425,7 @@ Readable.removeAllListeners
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:130
+node_modules/@types/readable-stream/index.d.ts:132
 
 ___
 
@@ -1420,7 +1450,7 @@ Readable.removeListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:123
+node_modules/@types/readable-stream/index.d.ts:125
 
 ▸ **removeListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -1441,7 +1471,7 @@ Readable.removeListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:124
+node_modules/@types/readable-stream/index.d.ts:126
 
 ▸ **removeListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -1462,7 +1492,7 @@ Readable.removeListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:125
+node_modules/@types/readable-stream/index.d.ts:127
 
 ▸ **removeListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -1483,7 +1513,7 @@ Readable.removeListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:126
+node_modules/@types/readable-stream/index.d.ts:128
 
 ▸ **removeListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -1504,7 +1534,7 @@ Readable.removeListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:127
+node_modules/@types/readable-stream/index.d.ts:129
 
 ▸ **removeListener**(`event`, `listener`): [`TrieReadStream`](TrieReadStream.md)
 
@@ -1525,7 +1555,7 @@ Readable.removeListener
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:128
+node_modules/@types/readable-stream/index.d.ts:130
 
 ___
 
@@ -1543,7 +1573,7 @@ Readable.resume
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:63
+node_modules/@types/readable-stream/index.d.ts:65
 
 ___
 
@@ -1567,7 +1597,7 @@ Readable.setEncoding
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:61
+node_modules/@types/readable-stream/index.d.ts:63
 
 ___
 
@@ -1591,7 +1621,7 @@ Readable.setMaxListeners
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:132
+node_modules/@types/readable-stream/index.d.ts:134
 
 ___
 
@@ -1615,7 +1645,7 @@ Readable.unpipe
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:65
+node_modules/@types/readable-stream/index.d.ts:67
 
 ___
 
@@ -1639,7 +1669,7 @@ Readable.unshift
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:66
+node_modules/@types/readable-stream/index.d.ts:68
 
 ___
 
@@ -1663,4 +1693,4 @@ Readable.wrap
 
 #### Defined in
 
-node_modules/@types/readable-stream/index.d.ts:67
+node_modules/@types/readable-stream/index.d.ts:69

--- a/packages/trie/docs/classes/WalkController.md
+++ b/packages/trie/docs/classes/WalkController.md
@@ -27,7 +27,7 @@ WalkController is an interface to control how the trie is being traversed.
 
 #### Defined in
 
-[packages/trie/src/util/walkController.ts:10](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/walkController.ts#L10)
+[packages/trie/src/util/walkController.ts:12](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/walkController.ts#L12)
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/util/walkController.ts:11](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/walkController.ts#L11)
+[packages/trie/src/util/walkController.ts:13](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/walkController.ts#L13)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[packages/trie/src/util/walkController.ts:12](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/walkController.ts#L12)
+[packages/trie/src/util/walkController.ts:14](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/walkController.ts#L14)
 
 ## Methods
 
@@ -70,7 +70,7 @@ Run all children of a node. Priority of these nodes are the key length of the ch
 
 #### Defined in
 
-[packages/trie/src/util/walkController.ts:67](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/walkController.ts#L67)
+[packages/trie/src/util/walkController.ts:69](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/walkController.ts#L69)
 
 ___
 
@@ -95,7 +95,7 @@ Push a branch of a certain BranchNode to the event queue.
 
 #### Defined in
 
-[packages/trie/src/util/walkController.ts:118](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/walkController.ts#L118)
+[packages/trie/src/util/walkController.ts:120](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/walkController.ts#L120)
 
 ___
 
@@ -119,7 +119,7 @@ Push a node to the queue. If the queue has places left for tasks, the node is ex
 
 #### Defined in
 
-[packages/trie/src/util/walkController.ts:95](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/walkController.ts#L95)
+[packages/trie/src/util/walkController.ts:97](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/walkController.ts#L97)
 
 ___
 
@@ -144,4 +144,4 @@ Async function to create and start a new walk over a trie.
 
 #### Defined in
 
-[packages/trie/src/util/walkController.ts:37](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/walkController.ts#L37)
+[packages/trie/src/util/walkController.ts:39](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/trie/src/util/walkController.ts#L39)

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -775,32 +775,6 @@ export class Trie {
     await this.walkTrie(this.root, outerOnFound)
   }
 
-  /**
-   * Finds all nodes that store k,v values
-   * called by {@link TrieReadStream}
-   * @private
-   */
-  async _findValueNodes(onFound: FoundNodeFunction): Promise<void> {
-    const outerOnFound: FoundNodeFunction = async (nodeRef, node, key, walkController) => {
-      let fullKey = key
-
-      if (node instanceof LeafNode) {
-        fullKey = key.concat(node.key)
-        // found leaf node!
-        onFound(nodeRef, node, fullKey, walkController)
-      } else if (node instanceof BranchNode && node.value) {
-        // found branch with value
-        onFound(nodeRef, node, fullKey, walkController)
-      } else {
-        // keep looking for value nodes
-        if (node !== null) {
-          walkController.allChildren(node, key)
-        }
-      }
-    }
-    await this.walkTrie(this.root, outerOnFound)
-  }
-
   protected hash(msg: Uint8Array): Buffer {
     return Buffer.from(this._hash(msg))
   }


### PR DESCRIPTION
Moves the `Trie#_findValueNodes` function to `TrieReadStream` because it is only called there.