### PR TITLE
Block: do not auto-activate hardforkByBlockNumber in static BlockHeader constructor

### DIFF
--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -95,15 +95,6 @@ export class BlockHeader {
       throw new Error('Invalid serialized header input. Must be array')
     }
 
-    // If an RLP serialized block header is provided and no `hardforkByBlockNumber` opt is provided, default true to
-    // avoid scenarios where no `opts.common` or `opts.hardforkByBlockNumber` is provided and a serialized blockheader
-    // is provided that predates London result in a default base fee being added to the block
-    // (resulting in an erroneous block hash since the default `common` hardfork is London and the blockheader constructor
-    // adds a default basefee if EIP-1559 is active and no basefee is provided in the `headerData`)
-    if (opts.hardforkByTTD === undefined) {
-      opts.hardforkByBlockNumber = opts.hardforkByBlockNumber ?? true
-    }
-
     return BlockHeader.fromValuesArray(values as Buffer[], opts)
   }
 

--- a/packages/block/test/header.spec.ts
+++ b/packages/block/test/header.spec.ts
@@ -67,16 +67,13 @@ tape('[Block]: Header functions', function (t) {
   })
 
   t.test('Initialization -> fromRLPSerializedHeader()', function (st) {
-    let header = BlockHeader.fromHeaderData({}, { freeze: false, hardforkByBlockNumber: false })
+    let header = BlockHeader.fromHeaderData({}, { freeze: false })
 
     const rlpHeader = header.serialize()
-    header = BlockHeader.fromRLPSerializedHeader(rlpHeader, { hardforkByBlockNumber: false })
+    header = BlockHeader.fromRLPSerializedHeader(rlpHeader)
     st.ok(Object.isFrozen(header), 'block should be frozen by default')
 
-    header = BlockHeader.fromRLPSerializedHeader(rlpHeader, {
-      freeze: false,
-      hardforkByBlockNumber: false,
-    })
+    header = BlockHeader.fromRLPSerializedHeader(rlpHeader, { freeze: false })
     st.ok(!Object.isFrozen(header), 'block should not be frozen when freeze deactivated in options')
 
     st.throws(
@@ -93,7 +90,8 @@ tape('[Block]: Header functions', function (t) {
       Buffer.from(
         'f90214a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a0d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000850400000000808213888080a011bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82faa00000000000000000000000000000000000000000000000000000000000000000880000000000000042',
         'hex'
-      )
+      ),
+      { hardforkByBlockNumber: true }
     )
 
     st.equal(


### PR DESCRIPTION
This PR reverts on #2081 after a discussion with @acolytec3 on Discord, some extracts:

Example posted by @acolytec3, which was not working any more after the changes:

![grafik](https://user-images.githubusercontent.com/931137/185949903-9817e38f-d17a-472e-9cf9-230f7dece1fa.png)

Reasoning to revert by @holgerd77:

---

I am coming more and more to the conclusion that this in `BlockHeader.fromRLPSerializedHeader()` was the wrong choice:

```typescript
// If an RLP serialized block header is provided and no `hardforkByBlockNumber` opt is provided, default true to
    // avoid scenarios where no `opts.common` or `opts.hardforkByBlockNumber` is provided and a serialized blockheader
    // is provided that predates London result in a default base fee being added to the block
    // (resulting in an erroneous block hash since the default `common` hardfork is London and the blockheader constructor
    // adds a default basefee if EIP-1559 is active and no basefee is provided in the `headerData`)
    if (opts.hardforkByTTD === undefined) {
      opts.hardforkByBlockNumber = opts.hardforkByBlockNumber ?? true
    }
```

This is again one of these implicit-options behaviors which is not clear from the outside and this also breaks the above example. If someone wants a `hardforkByBlockNumber` behavior, it is very much possible to set the respective option (that's where the option is for). If someone wants a "HF has precedense" behavior, he/she sets the explicit HF (here: London). There one would except that everything stays in the London realm (this expectation is broken here).

On top I am already pretty sure that there *are* these use cases out there where people (mainly these dev tool guys like HH/Ganache) have some mainnet RLP serialized block with some artificial block number which *should* behave in a London (e.g.) context. We had such cases various times. This forcing into the block number logic will likely lead to problems for them.

I would somewhat be inclined to revert (unless I might have forgotten the strong reasoning why we introduced).

---

