### PR TITLE
vm: improve tester types and remove isTruthy/isFalsy checks

### DIFF
--- a/packages/vm/tests/tester/index.ts
+++ b/packages/vm/tests/tester/index.ts
@@ -1,4 +1,3 @@
-import { isFalsy, isTruthy } from '@ethereumjs/util'
 import * as minimist from 'minimist'
 import * as path from 'path'
 import * as process from 'process'
@@ -22,38 +21,38 @@ import type { Common } from '@ethereumjs/common'
 /**
  * Test runner
  * CLI arguments:
- * --state: run state tests
- * --blockchain: run blockchain tests
- * --fork: fork to use for these tests
- * --skip: comma-separated list of tests to skip. choices of: all,broken,permanent,slow. Defaults to all
- * --runSkipped: comma-separated list of tests to skip if --skip is not set. choices of: all,broken,permanent,slow. Defaults to none
- * --file: test file to run
- * --test: test name to run
- * --dir: test directory to look for tests
- * --excludeDir: test directory to exclude from testing
- * --testsPath: root directory of tests to look (default: '../ethereum-tests')
- * --customTestsPath: custom directory to look for tests (e.g. '../../my_custom_test_folder')
- * --customStateTest: run a file with a custom state test (not in test directory)
- * --jsontrace: enable json step tracing in state tests
- * --dist: use the compiled version of the VM
- * --data: only run this state test if the transaction has this calldata
- * --gas: only run this state test if the transaction has this gasLimit
- * --value: only run this state test if the transaction has this call value
- * --debug: enable BlockchainTests debugger (compares post state against the expected post state)
- * --expected-test-amount: (optional) if present, check after tests are ran if at least this amount of tests have passed (inclusive)
- * --verify-test-amount-alltests: if this is passed, get the expected amount from tests and verify afterwards if this is the count of tests (expects tests are ran with default settings)
- * --reps: if passed, each test case will be run the number of times indicated
+ * --state: boolean.                      Run state tests
+ * --blockchain: boolean.                 Run blockchain tests
+ * --fork: string.                        Fork to use for these tests
+ * --skip: string.                        Comma-separated list of tests to skip. choices of: all,broken,permanent,slow. Defaults to all
+ * --runSkipped: string.                  Comma-separated list of tests to skip if --skip is not set. choices of: all,broken,permanent,slow. Defaults to none
+ * --file: string.                        Test file to run
+ * --test: string.                        Test name to run
+ * --dir: string.                         Test directory to look for tests
+ * --excludeDir: string.                  Test directory to exclude from testing
+ * --testsPath: string.                   Root directory of tests to look (default: '../ethereum-tests')
+ * --customTestsPath: string.             Custom directory to look for tests (e.g. '../../my_custom_test_folder')
+ * --customStateTest: string.             Run a file with a custom state test (not in test directory)
+ * --jsontrace: boolean.                  Enable json step tracing in state tests
+ * --dist: boolean.                       Use the compiled version of the VM
+ * --data: number.                        Only run this state test if the transaction has this calldata
+ * --gas: number.                         Only run this state test if the transaction has this gasLimit
+ * --value: number.                       Only run this state test if the transaction has this call value
+ * --debug: boolean.                      Enable BlockchainTests debugger (compares post state against the expected post state)
+ * --expected-test-amount: number.        If passed, check after tests are ran if at least this amount of tests have passed (inclusive)
+ * --verify-test-amount-alltests: number. If passed, get the expected amount from tests and verify afterwards if this is the count of tests (expects tests are ran with default settings)
+ * --reps: number.                        If passed, each test case will be run the number of times indicated
  */
 
 const argv = minimist(process.argv.slice(2))
 
 async function runTests() {
-  let name: string
+  let name: 'GeneralStateTests' | 'BlockchainTests'
   let runner: any
-  if (isTruthy(argv.state)) {
+  if ((argv.state as boolean) === true) {
     name = 'GeneralStateTests'
     runner = runStateTest
-  } else if (isTruthy(argv.blockchain)) {
+  } else if ((argv.blockchain as boolean) === true) {
     name = 'BlockchainTests'
     runner = runBlockchainTest
   } else {
@@ -61,7 +60,7 @@ async function runTests() {
     process.exit(1)
   }
 
-  const FORK_CONFIG: string = isTruthy(argv.fork) ? argv.fork : DEFAULT_FORK_CONFIG
+  const FORK_CONFIG: string = argv.fork !== undefined ? argv.fork : DEFAULT_FORK_CONFIG
   const FORK_CONFIG_TEST_SUITE = getRequiredForkConfigAlias(FORK_CONFIG)
 
   // Examples: Istanbul -> istanbul, MuirGlacier -> muirGlacier
@@ -70,55 +69,80 @@ async function runTests() {
   /**
    * Configuration for getting the tests from the ethereum/tests repository
    */
-  const testGetterArgs: any = {}
-  testGetterArgs.skipTests = getSkipTests(argv.skip, isTruthy(argv.runSkipped) ? 'NONE' : 'ALL')
-  testGetterArgs.runSkipped = getSkipTests(argv.runSkipped, 'NONE')
-  testGetterArgs.forkConfig = FORK_CONFIG_TEST_SUITE
-  testGetterArgs.file = argv.file
-  testGetterArgs.test = argv.test
-  testGetterArgs.dir = argv.dir
-  testGetterArgs.excludeDir = argv.excludeDir
-  testGetterArgs.testsPath = argv.testsPath
-  testGetterArgs.customStateTest = argv.customStateTest
+  const testGetterArgs: {
+    skipTests: string[]
+    runSkipped: string[]
+    forkConfig: string
+    file?: string
+    test?: string
+    dir?: string
+    excludeDir?: string
+    testsPath?: string
+    customStateTest?: string
+    directory?: string
+  } = {
+    skipTests: getSkipTests(argv.skip, argv.runSkipped !== undefined ? 'NONE' : 'ALL'),
+    runSkipped: getSkipTests(argv.runSkipped, 'NONE'),
+    forkConfig: FORK_CONFIG_TEST_SUITE,
+    file: argv.file,
+    test: argv.test,
+    dir: argv.dir,
+    excludeDir: argv.excludeDir,
+    testsPath: argv.testsPath,
+    customStateTest: argv.customStateTest,
+  }
 
   /**
    * Run-time configuration
    */
-  const runnerArgs: any = {}
-  runnerArgs.forkConfigVM = FORK_CONFIG_VM
-  runnerArgs.forkConfigTestSuite = FORK_CONFIG_TEST_SUITE
-  runnerArgs.common = getCommon(FORK_CONFIG_VM)
-  runnerArgs.jsontrace = argv.jsontrace
-  runnerArgs.dist = argv.dist
-  runnerArgs.data = argv.data // GeneralStateTests
-  runnerArgs.gasLimit = argv.gas // GeneralStateTests
-  runnerArgs.value = argv.value // GeneralStateTests
-  runnerArgs.debug = argv.debug // BlockchainTests
-  runnerArgs.reps = argv.reps // test repetitions
+  const runnerArgs: {
+    forkConfigVM: string
+    forkConfigTestSuite: string
+    common: Common
+    jsontrace?: boolean
+    dist?: boolean
+    data?: number
+    gasLimit?: number
+    value?: number
+    debug?: boolean
+    reps?: number
+  } = {
+    forkConfigVM: FORK_CONFIG_VM,
+    forkConfigTestSuite: FORK_CONFIG_TEST_SUITE,
+    common: getCommon(FORK_CONFIG_VM),
+    jsontrace: argv.jsontrace,
+    dist: argv.dist,
+    data: argv.data, // GeneralStateTests
+    gasLimit: argv.gas, // GeneralStateTests
+    value: argv.value, // GeneralStateTests
+    debug: argv.debug, // BlockchainTests
+    reps: argv.reps, // test repetitions
+  }
 
   /**
    * Modify the forkConfig string to ensure it works with RegEx (escape `+` characters)
    */
-  if ((testGetterArgs.forkConfig as string).includes('+')) {
+  if (testGetterArgs.forkConfig.includes('+')) {
     let str = testGetterArgs.forkConfig
-    const indicies = []
+    const indices = []
     for (let i = 0; i < str.length; i++) {
       if (str[i] === '+') {
-        indicies.push(i)
+        indices.push(i)
       }
     }
-    // traverse array in reverse order to ensure indicies match when we replace the '+' with '/+'
-    for (let i = indicies.length - 1; i >= 0; i--) {
-      str = `${str.substr(0, indicies[i])}\\${str.substr(indicies[i])}`
+    // traverse array in reverse order to ensure indices match when we replace the '+' with '/+'
+    for (let i = indices.length - 1; i >= 0; i--) {
+      str = `${str.substr(0, indices[i])}\\${str.substr(indices[i])}`
     }
     testGetterArgs.forkConfig = str
   }
 
-  const expectedTests: number | undefined = isTruthy(argv['verify-test-amount-alltests'])
-    ? getExpectedTests(FORK_CONFIG_VM, name)
-    : isTruthy(argv['expected-test-amount'])
-    ? argv['expected-test-amount']
-    : undefined
+  const expectedTests: number | undefined =
+    argv['verify-test-amount-alltests'] > 0
+      ? getExpectedTests(FORK_CONFIG_VM, name)
+      : argv['expected-test-amount'] !== undefined && argv['expected-test-amount'] > 0
+      ? argv['expected-test-amount']
+      : undefined
 
   /**
    * Initialization output to console
@@ -131,9 +155,9 @@ async function runTests() {
     return Object.assign(
       {},
       ...Object.entries(args)
-        .filter(([_k, v]) => isTruthy(v) && (v as any).length !== 0)
+        .filter(([_k, v]) => typeof v === 'string' || (Array.isArray(v) && v.length !== 0))
         .map(([k, v]) => ({
-          [k]: typeof v !== 'string' && isTruthy((v as any).length) ? (v as any).length : v,
+          [k]: Array.isArray(v) && v.length > 0 ? v.length : v,
         }))
     )
   }
@@ -160,11 +184,11 @@ async function runTests() {
   console.log(`+${'-'.repeat(width)}+`)
   console.log()
 
-  if (isTruthy(argv.customStateTest)) {
-    const fileName = argv.customStateTest
+  if (argv.customStateTest !== undefined) {
+    const fileName: string = argv.customStateTest
     tape(name, (t) => {
       getTestFromSource(fileName, async (err: string | undefined, test: any) => {
-        if (isTruthy(err)) {
+        if (err !== undefined) {
           return t.fail(err)
         }
         t.comment(`file: ${fileName} test: ${test.testName}`)
@@ -175,12 +199,12 @@ async function runTests() {
   } else {
     tape(name, async (t) => {
       let testIdentifier: string
-      const failingTests: any = {}
+      const failingTests: Record<string, string[] | undefined> = {}
 
       ;(t as any).on('result', (o: any) => {
-        if (typeof o.ok !== 'undefined' && o.ok !== null && isFalsy(o.ok)) {
-          if (isTruthy(failingTests[testIdentifier])) {
-            failingTests[testIdentifier].push(o.name)
+        if (typeof o.ok !== 'undefined' && o.ok !== null && (o.ok === '' || o.ok === 0)) {
+          if (failingTests[testIdentifier] !== undefined) {
+            ;(failingTests[testIdentifier] as string[]).push(o.name)
           } else {
             failingTests[testIdentifier] = [o.name]
           }
@@ -192,8 +216,8 @@ async function runTests() {
       const dirs = getTestDirs(FORK_CONFIG_VM, name)
       for (const dir of dirs) {
         await new Promise<void>((resolve, reject) => {
-          if (isTruthy(argv.customTestsPath)) {
-            testGetterArgs.directory = argv.customTestsPath
+          if (argv.customTestsPath !== undefined) {
+            testGetterArgs.directory = argv.customTestsPath as string
           } else {
             const testDir = testGetterArgs.dir ?? ''
             const testsPath = testGetterArgs.testsPath ?? DEFAULT_TESTS_PATH
@@ -224,7 +248,7 @@ async function runTests() {
 
       for (const failingTestIdentifier in failingTests) {
         console.log(`Errors thrown in ${failingTestIdentifier}:`)
-        const errors = failingTests[failingTestIdentifier]
+        const errors = failingTests[failingTestIdentifier] as string[]
         for (let i = 0; i < errors.length; i++) {
           console.log('\t' + errors[i])
         }

--- a/packages/vm/tests/tester/runners/GeneralStateTestsRunner.ts
+++ b/packages/vm/tests/tester/runners/GeneralStateTestsRunner.ts
@@ -2,7 +2,7 @@ import { Block } from '@ethereumjs/block'
 import { Blockchain } from '@ethereumjs/blockchain'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { SecureTrie } from '@ethereumjs/trie'
-import { isTruthy, toBuffer } from '@ethereumjs/util'
+import { toBuffer } from '@ethereumjs/util'
 
 import { EVM } from '../../../../evm/src'
 import { EEI } from '../../../src'
@@ -20,7 +20,7 @@ function parseTestCases(
 ) {
   let testCases = []
 
-  if (isTruthy(testData['post'][forkConfigTestSuite])) {
+  if (testData['post'][forkConfigTestSuite] !== undefined) {
     testCases = testData['post'][forkConfigTestSuite].map((testCase: any) => {
       const testIndexes = testCase['indexes']
       const tx = { ...testData.transaction }
@@ -40,7 +40,7 @@ function parseTestCases(
       tx.gasLimit = testData.transaction.gasLimit[testIndexes['gas']]
       tx.value = testData.transaction.value[testIndexes['value']]
 
-      if (isTruthy(tx.accessLists)) {
+      if (tx.accessLists !== undefined) {
         tx.accessList = testData.transaction.accessLists[testIndexes['data']]
         if (tx.chainId === undefined) {
           tx.chainId = 1
@@ -67,7 +67,7 @@ function parseTestCases(
 
 async function runTestCase(options: any, testData: any, t: tape.Test) {
   let VM
-  if (isTruthy(options.dist)) {
+  if (options.dist === true) {
     ;({ VM } = require('../../../dist'))
   } else {
     ;({ VM } = require('../../../src'))
@@ -102,7 +102,7 @@ async function runTestCase(options: any, testData: any, t: tape.Test) {
     if (tx.validate()) {
       const block = makeBlockFromEnv(testData.env, { common })
 
-      if (isTruthy(options.jsontrace)) {
+      if (options.jsontrace === true) {
         vm.evm.on('step', function (e: InterpreterStep) {
           let hexStack = []
           hexStack = e.stack.map((item: bigint) => {
@@ -164,7 +164,7 @@ export async function runStateTest(options: any, testData: any, t: tape.Test) {
       return
     }
     for (const testCase of testCases) {
-      if (isTruthy(options.reps)) {
+      if (options.reps !== undefined && options.reps > 0) {
         let totalTimeSpent = 0
         for (let x = 0; x < options.reps; x++) {
           totalTimeSpent += await runTestCase(options, testCase, t)

--- a/packages/vm/tests/tester/testLoader.ts
+++ b/packages/vm/tests/tester/testLoader.ts
@@ -1,4 +1,3 @@
-import { isTruthy } from '@ethereumjs/util'
 import * as fs from 'fs'
 import * as dir from 'node-dir'
 import * as path from 'path'
@@ -136,16 +135,16 @@ export async function getTestsFromArgs(testType: string, onFile: Function, args:
       return skipTest(name, args.skipVM)
     }
   }
-  if (isTruthy(args.singleSource)) {
+  if (args.singleSource !== undefined) {
     return getTestFromSource(args.singleSource, onFile)
   }
-  if (isTruthy(args.file)) {
+  if (args.file !== undefined) {
     fileFilter = new RegExp(args.file)
   }
-  if (isTruthy(args.excludeDir)) {
+  if (args.excludeDir !== undefined) {
     excludeDir = new RegExp(args.excludeDir)
   }
-  if (isTruthy(args.test)) {
+  if (args.test !== undefined) {
     skipFn = (testName: string) => {
       return testName !== args.test
     }


### PR DESCRIPTION
This PR:

- Improves the types from the vm/tester folder and improve the comments so that the types of the cli args are more obvious. This brings more clarity in usage and also helps document the CLI options a bit better
- Removes all isTruthy/isFalsy from the tester folder