### PR TITLE
Update VM/EVM types; remove AsyncEventEmitter extension

### DIFF
--- a/packages/client/test/rpc/eth/call.spec.ts
+++ b/packages/client/test/rpc/eth/call.spec.ts
@@ -67,7 +67,7 @@ tape(`${method}: call with valid arguments`, async (t) => {
 
   // deploy contract
   let ranBlock: Block | undefined = undefined
-  vm.once('afterBlock', (result: any) => (ranBlock = result.block))
+  vm.events.once('afterBlock', (result: any) => (ranBlock = result.block))
   const result = await vm.runBlock({ block, generate: true, skipBlockValidation: true })
   const { createdAddress } = result.results[0]
   await vm.blockchain.putBlock(ranBlock!)

--- a/packages/client/test/rpc/eth/estimateGas.spec.ts
+++ b/packages/client/test/rpc/eth/estimateGas.spec.ts
@@ -68,7 +68,7 @@ tape(`${method}: call with valid arguments`, async (t) => {
 
   // deploy contract
   let ranBlock: Block | undefined = undefined
-  vm.once('afterBlock', (result: any) => (ranBlock = result.block))
+  vm.events.once('afterBlock', (result: any) => (ranBlock = result.block))
   const result = await vm.runBlock({ block, generate: true, skipBlockValidation: true })
   const { createdAddress } = result.results[0]
   await vm.blockchain.putBlock(ranBlock!)

--- a/packages/client/test/rpc/eth/getCode.spec.ts
+++ b/packages/client/test/rpc/eth/getCode.spec.ts
@@ -84,7 +84,7 @@ tape(`${method}: ensure returns correct code`, async (t) => {
 
   // deploy contract
   let ranBlock: Block | undefined = undefined
-  vm.once('afterBlock', (result: any) => (ranBlock = result.block))
+  vm.events.once('afterBlock', (result: any) => (ranBlock = result.block))
   const result = await vm.runBlock({ block, generate: true, skipBlockValidation: true })
   const { createdAddress } = result.results[0]
   await vm.blockchain.putBlock(ranBlock!)

--- a/packages/client/test/rpc/eth/getProof.spec.ts
+++ b/packages/client/test/rpc/eth/getProof.spec.ts
@@ -91,7 +91,7 @@ tape(`${method}: call with valid arguments`, async (t) => {
 
   // deploy contract
   let ranBlock: Block | undefined = undefined
-  vm.once('afterBlock', (result: any) => (ranBlock = result.block))
+  vm.events.once('afterBlock', (result: any) => (ranBlock = result.block))
   const result = await vm.runBlock({ block, generate: true, skipBlockValidation: true })
   const { createdAddress } = result.results[0]
   await vm.blockchain.putBlock(ranBlock!)
@@ -123,7 +123,7 @@ tape(`${method}: call with valid arguments`, async (t) => {
 
   // run block
   let ranBlock2: Block | undefined = undefined
-  vm.once('afterBlock', (result: any) => (ranBlock2 = result.block))
+  vm.events.once('afterBlock', (result: any) => (ranBlock2 = result.block))
   await vm.runBlock({ block: block2, generate: true, skipBlockValidation: true })
   await vm.blockchain.putBlock(ranBlock2!)
 

--- a/packages/client/test/rpc/eth/getStorageAt.spec.ts
+++ b/packages/client/test/rpc/eth/getStorageAt.spec.ts
@@ -73,7 +73,7 @@ tape(`${method}: call with valid arguments`, async (t) => {
 
   // deploy contract
   let ranBlock: Block | undefined = undefined
-  vm.once('afterBlock', (result: any) => (ranBlock = result.block))
+  vm.events.once('afterBlock', (result: any) => (ranBlock = result.block))
   const result = await vm.runBlock({ block, generate: true, skipBlockValidation: true })
   const { createdAddress } = result.results[0]
   await vm.blockchain.putBlock(ranBlock!)
@@ -105,7 +105,7 @@ tape(`${method}: call with valid arguments`, async (t) => {
 
   // run block
   let ranBlock2: Block | undefined = undefined
-  vm.once('afterBlock', (result: any) => (ranBlock2 = result.block))
+  vm.events.once('afterBlock', (result: any) => (ranBlock2 = result.block))
   await vm.runBlock({ block: block2, generate: true, skipBlockValidation: true })
   await vm.blockchain.putBlock(ranBlock2!)
 

--- a/packages/client/test/rpc/eth/getTransactionCount.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionCount.spec.ts
@@ -64,7 +64,7 @@ tape(`${method}: call with valid arguments`, async (t) => {
   block.transactions[0] = tx
 
   let ranBlock: Block | undefined = undefined
-  vm.once('afterBlock', (result: any) => (ranBlock = result.block))
+  vm.events.once('afterBlock', (result: any) => (ranBlock = result.block))
   await vm.runBlock({ block, generate: true, skipBlockValidation: true })
   await vm.blockchain.putBlock(ranBlock!)
 

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -304,7 +304,9 @@ export class EVM implements EVMInterface {
 
     // We cache this promisified function as it's called from the main execution loop, and
     // promisifying each time has a huge performance impact.
-    this._emit = <(topic: string, data: any) => Promise<void>>promisify(this.events.emit.bind(this))
+    this._emit = <(topic: string, data: any) => Promise<void>>(
+      promisify(this.events.emit.bind(this.events))
+    )
   }
 
   protected async init(): Promise<void> {

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -139,7 +139,7 @@ export interface EVMOpts {
  * and storing them to state (or discarding changes in case of exceptions).
  * @ignore
  */
-export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
+export class EVM implements EVMInterface {
   protected _tx?: {
     gasPrice: bigint
     origin: Address
@@ -151,6 +151,8 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
   public eei: EEIInterface
 
   public readonly _transientStorage: TransientStorage
+
+  public readonly events: AsyncEventEmitter<EVMEvents>
 
   /**
    * This opcode data is always set since `getActiveOpcodes()` is called in the constructor
@@ -223,7 +225,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
   }
 
   constructor(opts: EVMOpts) {
-    super()
+    this.events = new AsyncEventEmitter<EVMEvents>()
 
     this._optsCached = opts
 
@@ -302,7 +304,7 @@ export class EVM extends AsyncEventEmitter<EVMEvents> implements EVMInterface {
 
     // We cache this promisified function as it's called from the main execution loop, and
     // promisifying each time has a huge performance impact.
-    this._emit = <(topic: string, data: any) => Promise<void>>promisify(this.emit.bind(this))
+    this._emit = <(topic: string, data: any) => Promise<void>>promisify(this.events.emit.bind(this))
   }
 
   protected async init(): Promise<void> {

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -252,7 +252,7 @@ export class Interpreter {
       gas = await dynamicGasHandler(this._runState, gas, this._common)
     }
 
-    if (this._evm.listenerCount('step') > 0 || this._evm.DEBUG) {
+    if (this._evm.events.listenerCount('step') > 0 || this._evm.DEBUG) {
       // Only run this stepHook function if there is an event listener (e.g. test runner)
       // or if the vm is running in debug mode (to display opcode debug logs)
       await this._runStepHook(gas, gasLimitClone)

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -4,6 +4,7 @@ import type { Message } from './message'
 import type { OpHandler } from './opcodes'
 import type { AsyncDynamicGasHandler, SyncDynamicGasHandler } from './opcodes/gas'
 import type { Account, Address, PrefixedHexString } from '@ethereumjs/util'
+import AsyncEventEmitter from 'async-eventemitter'
 
 /**
  * API of the EVM
@@ -14,6 +15,7 @@ export interface EVMInterface {
   precompiles: Map<string, any> // Note: the `any` type is used because EVM only needs to have the addresses of the precompiles (not their functions)
   copy(): EVMInterface
   eei: EEIInterface
+  events?: AsyncEventEmitter<EVMEvents>
 }
 
 /**

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -4,7 +4,7 @@ import type { Message } from './message'
 import type { OpHandler } from './opcodes'
 import type { AsyncDynamicGasHandler, SyncDynamicGasHandler } from './opcodes/gas'
 import type { Account, Address, PrefixedHexString } from '@ethereumjs/util'
-import AsyncEventEmitter from 'async-eventemitter'
+import type AsyncEventEmitter from 'async-eventemitter'
 
 /**
  * API of the EVM

--- a/packages/evm/tests/customOpcodes.spec.ts
+++ b/packages/evm/tests/customOpcodes.spec.ts
@@ -32,7 +32,7 @@ tape('VM: custom opcodes', (t) => {
     })
     const gas = 123456
     let correctOpcodeName = false
-    evm.on('step', (e: InterpreterStep) => {
+    evm.events.on('step', (e: InterpreterStep) => {
       if (e.pc === 0) {
         correctOpcodeName = e.opcode.name === testOpcode.opcodeName
       }

--- a/packages/vm/src/types.ts
+++ b/packages/vm/src/types.ts
@@ -58,7 +58,10 @@ export type VMEvents = {
 /**
  * Options for instantiating a {@link VM}.
  */
-export interface VMOpts {
+export interface VMOpts<
+  EVMType extends EVMInterface = EVMInterface,
+  EEIType extends EEIInterface = EEIInterface
+> {
   /**
    * Use a {@link Common} instance
    * if you want to change the chain setup.
@@ -133,12 +136,12 @@ export interface VMOpts {
   /**
    * Use a custom EEI for the EVM. If this is not present, use the default EEI.
    */
-  eei?: EEIInterface
+  eei?: EEIType
 
   /**
    * Use a custom EVM to run Messages on. If this is not present, use the default EVM.
    */
-  evm?: EVMInterface
+  evm?: EVMType
 }
 
 /**

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -154,7 +154,9 @@ export class VM {
 
     // We cache this promisified function as it's called from the main execution loop, and
     // promisifying each time has a huge performance impact.
-    this._emit = <(topic: string, data: any) => Promise<void>>promisify(this.events.emit.bind(this))
+    this._emit = <(topic: string, data: any) => Promise<void>>(
+      promisify(this.events.emit.bind(this.events))
+    )
   }
 
   async init(): Promise<void> {

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -31,7 +31,7 @@ import type { StateManager } from '@ethereumjs/statemanager'
  *
  * This class is an AsyncEventEmitter, please consult the README to learn how to use it.
  */
-export class VM extends AsyncEventEmitter<VMEvents> {
+export class VM {
   /**
    * The StateManager used by the VM
    */
@@ -43,6 +43,8 @@ export class VM extends AsyncEventEmitter<VMEvents> {
   readonly blockchain: BlockchainInterface
 
   readonly _common: Common
+
+  readonly events: AsyncEventEmitter<VMEvents>
 
   /**
    * The EVM used for bytecode execution
@@ -93,7 +95,7 @@ export class VM extends AsyncEventEmitter<VMEvents> {
    * @param opts
    */
   protected constructor(opts: VMOpts = {}) {
-    super()
+    this.events = new AsyncEventEmitter<VMEvents>()
 
     this._opts = opts
 
@@ -152,7 +154,7 @@ export class VM extends AsyncEventEmitter<VMEvents> {
 
     // We cache this promisified function as it's called from the main execution loop, and
     // promisifying each time has a huge performance impact.
-    this._emit = <(topic: string, data: any) => Promise<void>>promisify(this.emit.bind(this))
+    this._emit = <(topic: string, data: any) => Promise<void>>promisify(this.events.emit.bind(this))
   }
 
   async init(): Promise<void> {

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -31,10 +31,7 @@ import type { StateManager } from '@ethereumjs/statemanager'
  *
  * This class is an AsyncEventEmitter, please consult the README to learn how to use it.
  */
-export class VM<
-  EVMType extends EVMInterface = EVMInterface,
-  EEIType extends EEIInterface = EEIInterface
-> extends AsyncEventEmitter<VMEvents> {
+export class VM<EVMType extends EVMInterface = EVM, EEIType extends EEIInterface = EEI> {
   /**
    * The StateManager used by the VM
    */
@@ -215,7 +212,7 @@ export class VM<
    *  - `generate`: false
    */
   async runBlock(opts: RunBlockOpts): Promise<RunBlockResult> {
-    return runBlock.bind(this)(opts)
+    return runBlock.bind(<any>this)(opts)
   }
 
   /**
@@ -228,7 +225,7 @@ export class VM<
    * @param {RunTxOpts} opts
    */
   async runTx(opts: RunTxOpts): Promise<RunTxResult> {
-    return runTx.bind(this)(opts)
+    return runTx.bind(<any>this)(opts)
   }
 
   /**
@@ -246,7 +243,7 @@ export class VM<
    * - {@link BlockBuilder.revert}
    */
   async buildBlock(opts: BuildBlockOpts): Promise<BlockBuilder> {
-    return buildBlock.bind(this)(opts)
+    return buildBlock.bind(<any>this)(opts)
   }
 
   /**

--- a/packages/vm/tests/api/EIPs/eip-1153.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-1153.spec.ts
@@ -27,7 +27,7 @@ tape('EIP 1153: transient storage', (t) => {
     let currentGas = initialGas
     const vm = await VM.create({ common })
 
-    ;(<EVM>vm.evm).on('step', function (step: any) {
+    ;(<EVM>vm.evm).events.on('step', function (step: any) {
       const gasUsed = currentGas - step.gasLeft
       currentGas = step.gasLeft
 

--- a/packages/vm/tests/api/EIPs/eip-2315.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-2315.spec.ts
@@ -12,7 +12,7 @@ tape('Berlin: EIP 2315 tests', (t) => {
     let i = 0
     const vm = await VM.create({ common })
 
-    ;(<EVM>vm.evm).on('step', function (step: any) {
+    ;(<EVM>vm.evm).events.on('step', function (step: any) {
       if (test.steps.length > 0) {
         st.equal(step.pc, test.steps[i].expectedPC)
         st.equal(step.opcode.name, test.steps[i].expectedOpcode)

--- a/packages/vm/tests/api/EIPs/eip-2929.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-2929.spec.ts
@@ -22,7 +22,7 @@ tape('EIP 2929: gas cost tests', (t) => {
     let currentGas = initialGas
     const vm = await VM.create({ common })
 
-    ;(<EVM>vm.evm).on('step', function (step: any) {
+    ;(<EVM>vm.evm).events.on('step', function (step: any) {
       const gasUsed = currentGas - step.gasLeft
       currentGas = step.gasLeft
 

--- a/packages/vm/tests/api/EIPs/eip-2930-accesslists.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-2930-accesslists.spec.ts
@@ -66,7 +66,7 @@ tape('EIP-2930 Optional Access Lists tests', (t) => {
 
     let trace: any = []
 
-    ;(<EVM>vm.evm).on('step', (o: any) => {
+    ;(<EVM>vm.evm).events.on('step', (o: any) => {
       trace.push([o.opcode.name, o.gasLeft])
     })
 

--- a/packages/vm/tests/api/EIPs/eip-3074-authcall.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3074-authcall.spec.ts
@@ -480,7 +480,7 @@ tape('EIP-3074 AUTHCALL', (t) => {
     const vm = await setupVM(code)
 
     let gas: bigint
-    ;(<EVM>vm.evm).on('step', (e: InterpreterStep) => {
+    ;(<EVM>vm.evm).events.on('step', (e: InterpreterStep) => {
       if (e.opcode.name === 'AUTHCALL') {
         gas = e.gasLeft
       }
@@ -523,7 +523,7 @@ tape('EIP-3074 AUTHCALL', (t) => {
     const vm = await setupVM(code)
 
     let gas: bigint
-    ;(<EVM>vm.evm).on('step', async (e: InterpreterStep) => {
+    ;(<EVM>vm.evm).events.on('step', async (e: InterpreterStep) => {
       if (e.opcode.name === 'AUTHCALL') {
         gas = e.gasLeft // This thus overrides the first time AUTHCALL is used and thus the gas for the second call is stored
       }
@@ -564,7 +564,7 @@ tape('EIP-3074 AUTHCALL', (t) => {
 
       let gas: bigint
       let gasAfterCall: bigint
-      ;(<EVM>vm.evm).on('step', async (e: InterpreterStep) => {
+      ;(<EVM>vm.evm).events.on('step', async (e: InterpreterStep) => {
         if (gas && gasAfterCall === undefined) {
           gasAfterCall = e.gasLeft
         }
@@ -609,7 +609,7 @@ tape('EIP-3074 AUTHCALL', (t) => {
       const vm = await setupVM(code)
 
       let gas: bigint
-      ;(<EVM>vm.evm).on('step', (e: InterpreterStep) => {
+      ;(<EVM>vm.evm).events.on('step', (e: InterpreterStep) => {
         if (e.opcode.name === 'AUTHCALL') {
           gas = e.gasLeft
         }

--- a/packages/vm/tests/api/EIPs/eip-3198-BaseFee.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3198-BaseFee.spec.ts
@@ -83,7 +83,7 @@ tape('EIP3198 tests', (t) => {
     // Track stack
 
     let stack: any = []
-    ;(<EVM>vm.evm).on('step', (istep: InterpreterStep) => {
+    ;(<EVM>vm.evm).events.on('step', (istep: InterpreterStep) => {
       if (istep.opcode.name === 'STOP') {
         stack = istep.stack
       }

--- a/packages/vm/tests/api/EIPs/eip-3529.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3529.spec.ts
@@ -118,7 +118,7 @@ tape('EIP-3529 tests', (t) => {
 
     let gasRefund: bigint
     let gasLeft: bigint
-    ;(<EVM>vm.evm).on('step', (step: InterpreterStep) => {
+    ;(<EVM>vm.evm).events.on('step', (step: InterpreterStep) => {
       if (step.opcode.name === 'STOP') {
         gasRefund = step.gasRefund
         gasLeft = step.gasLeft
@@ -185,7 +185,7 @@ tape('EIP-3529 tests', (t) => {
 
     let startGas: bigint
     let finalGas: bigint
-    ;(<EVM>vm.evm).on('step', (step: InterpreterStep) => {
+    ;(<EVM>vm.evm).events.on('step', (step: InterpreterStep) => {
       if (startGas === undefined) {
         startGas = step.gasLeft
       }

--- a/packages/vm/tests/api/EIPs/eip-3541.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3541.spec.ts
@@ -73,7 +73,7 @@ tape('EIP 3541 tests', (t) => {
 
     const vm = await VM.create({ common })
     let address: Address
-    ;(<EVM>vm.evm).on('step', (step: InterpreterStep) => {
+    ;(<EVM>vm.evm).events.on('step', (step: InterpreterStep) => {
       if (step.depth === 1) {
         address = step.address
       }
@@ -109,7 +109,7 @@ tape('EIP 3541 tests', (t) => {
 
     const vm = await VM.create({ common })
     let address: Address
-    ;(<EVM>vm.evm).on('step', (step: InterpreterStep) => {
+    ;(<EVM>vm.evm).events.on('step', (step: InterpreterStep) => {
       if (step.depth === 1) {
         address = step.address
       }

--- a/packages/vm/tests/api/EIPs/eip-3855.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-3855.spec.ts
@@ -18,7 +18,7 @@ tape('EIP 3541 tests', (t) => {
   t.test('should correctly use push0 opcode', async (st) => {
     const vm = await VM.create({ common })
     let stack: bigint[]
-    ;(<EVM>vm.evm).on('step', (e: InterpreterStep) => {
+    ;(<EVM>vm.evm).events.on('step', (e: InterpreterStep) => {
       if (typeof stack !== 'undefined') {
         st.fail('should only do PUSH0 once')
       }
@@ -40,7 +40,7 @@ tape('EIP 3541 tests', (t) => {
     const vm = await VM.create({ common })
     let stack: bigint[] = []
 
-    ;(<EVM>vm.evm).on('step', (e: InterpreterStep) => {
+    ;(<EVM>vm.evm).events.on('step', (e: InterpreterStep) => {
       stack = e.stack
     })
 

--- a/packages/vm/tests/api/EIPs/eip-4399-supplant-difficulty-opcode-with-prevrando.spec.ts
+++ b/packages/vm/tests/api/EIPs/eip-4399-supplant-difficulty-opcode-with-prevrando.spec.ts
@@ -27,7 +27,7 @@ tape('EIP-4399 -> 0x44 (DIFFICULTY) should return PREVRANDAO', (t) => {
 
     // Track stack
     let stack: any = []
-    ;(<EVM>vm.evm).on('step', (istep: InterpreterStep) => {
+    ;(<EVM>vm.evm).events.on('step', (istep: InterpreterStep) => {
       if (istep.opcode.name === 'STOP') {
         stack = istep.stack
       }

--- a/packages/vm/tests/api/events.spec.ts
+++ b/packages/vm/tests/api/events.spec.ts
@@ -102,7 +102,7 @@ tape('VM events', (t) => {
     const address = Address.fromPrivateKey(privKey)
     await vm.stateManager.putAccount(address, new Account(BigInt(0), BigInt(0x11111111)))
     let emitted: any
-    ;(<EVM>vm.evm).on('beforeMessage', (val: any) => {
+    ;(<EVM>vm.evm).events.on('beforeMessage', (val: any) => {
       emitted = val
     })
 
@@ -126,7 +126,7 @@ tape('VM events', (t) => {
     const address = Address.fromPrivateKey(privKey)
     await vm.stateManager.putAccount(address, new Account(BigInt(0), BigInt(0x11111111)))
     let emitted: any
-    ;(<EVM>vm.evm).on('afterMessage', (val: any) => {
+    ;(<EVM>vm.evm).events.on('afterMessage', (val: any) => {
       emitted = val
     })
 
@@ -148,7 +148,7 @@ tape('VM events', (t) => {
     const vm = await VM.create()
 
     let lastEmitted: any
-    ;(<EVM>vm.evm).on('step', (val: any) => {
+    ;(<EVM>vm.evm).events.on('step', (val: any) => {
       lastEmitted = val
     })
 
@@ -172,7 +172,7 @@ tape('VM events', (t) => {
     const vm = await VM.create()
 
     let emitted: any
-    ;(<EVM>vm.evm).on('newContract', (val: any) => {
+    ;(<EVM>vm.evm).events.on('newContract', (val: any) => {
       emitted = val
     })
 

--- a/packages/vm/tests/api/events.spec.ts
+++ b/packages/vm/tests/api/events.spec.ts
@@ -14,7 +14,7 @@ tape('VM events', (t) => {
     const vm = await VM.create()
 
     let emitted
-    vm.on('beforeBlock', (val: any) => {
+    vm.events.on('beforeBlock', (val: any) => {
       emitted = val
     })
 
@@ -35,7 +35,7 @@ tape('VM events', (t) => {
     const vm = await VM.create()
 
     let emitted
-    vm.on('afterBlock', (val: any) => {
+    vm.events.on('afterBlock', (val: any) => {
       emitted = val
     })
 
@@ -57,7 +57,7 @@ tape('VM events', (t) => {
     const vm = await VM.create()
 
     let emitted
-    vm.on('beforeTx', (val: any) => {
+    vm.events.on('beforeTx', (val: any) => {
       emitted = val
     })
 
@@ -79,7 +79,7 @@ tape('VM events', (t) => {
     const address = Address.fromPrivateKey(privKey)
     await vm.stateManager.putAccount(address, new Account(BigInt(0), BigInt(0x11111111)))
     let emitted: any
-    vm.on('afterTx', (val: any) => {
+    vm.events.on('afterTx', (val: any) => {
       emitted = val
     })
 

--- a/packages/vm/tests/api/runBlock.spec.ts
+++ b/packages/vm/tests/api/runBlock.spec.ts
@@ -384,12 +384,12 @@ async function runBlockAndGetAfterBlockEvent(
   }
 
   try {
-    vm.once('afterBlock', handler)
+    vm.events.once('afterBlock', handler)
     await vm.runBlock(runBlockOpts)
   } finally {
     // We need this in case `runBlock` throws before emitting the event.
     // Otherwise we'd be leaking the listener until the next call to runBlock.
-    vm.removeListener('afterBlock', handler)
+    vm.events.removeListener('afterBlock', handler)
   }
 
   return results!

--- a/packages/vm/tests/tester/runners/GeneralStateTestsRunner.ts
+++ b/packages/vm/tests/tester/runners/GeneralStateTestsRunner.ts
@@ -103,7 +103,7 @@ async function runTestCase(options: any, testData: any, t: tape.Test) {
       const block = makeBlockFromEnv(testData.env, { common })
 
       if (isTruthy(options.jsontrace)) {
-        vm.evm.on('step', function (e: InterpreterStep) {
+        vm.evm.events.on('step', function (e: InterpreterStep) {
           let hexStack = []
           hexStack = e.stack.map((item: bigint) => {
             return '0x' + item.toString(16)
@@ -121,7 +121,7 @@ async function runTestCase(options: any, testData: any, t: tape.Test) {
 
           t.comment(JSON.stringify(opTrace))
         })
-        vm.on('afterTx', async () => {
+        vm.events.on('afterTx', async () => {
           const stateRoot = {
             stateRoot: vm.stateManager._trie.root.toString('hex'),
           }


### PR DESCRIPTION
This PR:

- [x] Removes the AsyncEventEmitter extension from VM/EVM and instead puts it into a property `events`
- [x] Update the EVM interface such that it now has an optional `events` property
- [ ] Update VM/EVM such that it is now more typesafe (see #2182)

WIP