### PR TITLE
Fix VM Nightly

### DIFF
--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -3,8 +3,6 @@ on:
   schedule:
     - cron: 0 0 * * *
   workflow_dispatch:
-  push:
-    branches: ['fix-vm-nightly-again']
 
 env:
   cwd: ${{github.workspace}}/packages/vm

--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -26,7 +26,7 @@ jobs:
       - run: rm package-lock.json
         working-directory: ${{github.workspace}}
 
-      - run: npm ci
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run test:API

--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: 0 0 * * *
   workflow_dispatch:
+  push:
+    branches: ['fix-vm-nightly-again']
 
 env:
   cwd: ${{github.workspace}}/packages/vm

--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -2,6 +2,7 @@ name: VM Nightly
 on:
   schedule:
     - cron: 0 0 * * *
+  workflow_dispatch:
 
 env:
   cwd: ${{github.workspace}}/packages/vm

--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -50,7 +50,7 @@ jobs:
       - run: rm package-lock.json
         working-directory: ${{github.workspace}}
 
-      - run: npm ci
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run test:state:allForks
@@ -72,7 +72,7 @@ jobs:
       - run: rm package-lock.json
         working-directory: ${{github.workspace}}
 
-      - run: npm ci
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run test:blockchain:allForks
@@ -95,7 +95,7 @@ jobs:
       - run: rm package-lock.json
         working-directory: ${{github.workspace}}
 
-      - run: npm ci
+      - run: npm i
         working-directory: ${{github.workspace}}
 
       - run: npm run test:state:slow

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -269,7 +269,7 @@ export class Common extends EventEmitter {
     let previousHF
     for (const hf of this.hardforks()) {
       // Skip comparison for not applied HFs
-      if (hf.block === null) {
+      if (typeof hf.block !== 'number') {
         if (td !== undefined && td !== null && hf.ttd !== undefined && hf.ttd !== null) {
           if (td >= BigInt(hf.ttd)) {
             return hf.name
@@ -611,7 +611,7 @@ export class Common extends EventEmitter {
     // a block greater than the current hfBlock set the accumulator,
     // pass on the accumulator as the final result from this time on
     const nextHfBlock = this.hardforks().reduce((acc: bigint | null, hf: HardforkConfig) => {
-      const block = BigInt(hf.block === null ? 0 : hf.block)
+      const block = BigInt(typeof hf.block !== 'number' ? 0 : hf.block)
       return block > hfBlock && acc === null ? block : acc
     }, null)
     return nextHfBlock
@@ -645,13 +645,13 @@ export class Common extends EventEmitter {
 
       // Skip for chainstart (0), not applied HFs (null) and
       // when already applied on same block number HFs
-      if (block !== 0 && block !== null && block !== prevBlock) {
+      if (typeof block === 'number' && block !== 0 && block !== prevBlock) {
         const hfBlockBuffer = Buffer.from(block.toString(16).padStart(16, '0'), 'hex')
         hfBuffer = Buffer.concat([hfBuffer, hfBlockBuffer])
       }
 
       if (hf.name === hardfork) break
-      if (block !== null) {
+      if (typeof block === 'number') {
         prevBlock = block
       }
     }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -46,7 +46,7 @@ export interface GenesisBlockConfig {
 
 export interface HardforkConfig {
   name: Hardfork | string
-  block: number | null
+  block?: number | null
   ttd?: bigint | string
   forkHash?: string | null
 }


### PR DESCRIPTION
The VM Nightly run is intended to use a fresh `package-lock.json` and so must use `npm i` to install deps.  This was accidentally changed in a recent update to the CI.  This PR:
- Reverts the changes to `npm i`
- Adds a workflow_dispatch trigger so we can manually trigger this action when testing
- Fixes a validation error in `common.setHardforkByNumber` that checks for `null` but not `undefined` that was causing some edge case tests to fail in the blockchain test runner.