### PR TITLE
refactor(trie): always use `CheckpointDB` as internal database

### DIFF
--- a/packages/statemanager/src/stateManager.ts
+++ b/packages/statemanager/src/stateManager.ts
@@ -175,7 +175,7 @@ export class DefaultStateManager extends BaseStateManager implements StateManage
     const account = await this.getAccount(address)
     const storageTrie = this._trie.copy(false)
     storageTrie.root = account.storageRoot
-    ;(storageTrie.db as CheckpointDB).checkpoints = []
+    storageTrie.db.checkpoints = []
     return storageTrie
   }
 

--- a/packages/trie/test/trie/checkpoint.spec.ts
+++ b/packages/trie/test/trie/checkpoint.spec.ts
@@ -57,7 +57,7 @@ tape('testing checkpoints', function (tester) {
   it('should copy trie and get upstream and cache values after checkpoint', async function (t) {
     trieCopy = trie.copy()
     t.equal(trieCopy.root.toString('hex'), postRoot)
-    t.equal((trieCopy.db as CheckpointDB).checkpoints.length, 1)
+    t.equal(trieCopy.db.checkpoints.length, 1)
     t.ok(trieCopy.isCheckpoint)
     const res = await trieCopy.get(Buffer.from('do'))
     t.ok(Buffer.from('verb').equals(Buffer.from(res!)))


### PR DESCRIPTION
The `CheckpointDB` class contains internal checks to either checkpoint data in-memory or call the `DB` implementation so we can always rely on it as the internal database of the trie which will enable some further refactors.