### PR TITLE
Verify that hardforks without block number or ttd are not applied in common

### DIFF
--- a/packages/common/tests/customChains.spec.ts
+++ b/packages/common/tests/customChains.spec.ts
@@ -164,3 +164,22 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
     st.end()
   })
 })
+
+tape.only('custom chain setup with hardforks with undefined/null block numbers', (t) => {
+  const undefinedHardforks = [
+    {
+      name: 'chainstart',
+      block: 0,
+    },
+    { name: 'homestead' },
+    { name: 'byzantium', block: null },
+    { name: 'tangerineWhistle', block: 10 },
+  ]
+
+  const common = Common.custom({ hardforks: undefinedHardforks })
+  common.setHardforkByBlockNumber(10)
+  t.equal('tangerineWhistle', common.hardfork(), 'set correct hardfork')
+  common.setHardforkByBlockNumber(3)
+  t.equal('chainstart', common.hardfork(), 'set correct hardfork')
+  t.end()
+})

--- a/packages/vm/tests/tester/config.ts
+++ b/packages/vm/tests/tester/config.ts
@@ -375,14 +375,12 @@ export function getCommon(network: string): Common {
           | null
         testHardforks.push({
           name: hf.name,
-          // forkHash: hf.forkHash,
-          block: forkBlockNumber,
+          block: forkBlockNumber ?? 0, // If hardfork isn't in transitionForks, activate at 0
         })
       } else {
         // disable the hardfork
         testHardforks.push({
           name: hf.name,
-          // forkHash: hf.forkHash,
           block: null,
         })
       }

--- a/packages/vm/tests/tester/config.ts
+++ b/packages/vm/tests/tester/config.ts
@@ -373,6 +373,7 @@ export function getCommon(network: string): Common {
         const forkBlockNumber = transitionForks[hf.name as keyof typeof transitionForks] as
           | number
           | null
+          | undefined
         testHardforks.push({
           name: hf.name,
           block: forkBlockNumber ?? 0, // If hardfork isn't in transitionForks, activate at 0


### PR DESCRIPTION
#2213 slightly changed the way that hardforks are checked in `common` when calling `getHardforkBlockNumber` or `setHardforkByBlockNumber` so that a hardfork can be passed in the `ChainConfig` object with either `null` or `undefined` set for the `block` property and these hardforks will be treated as being "not applied" in that `common` instance.  This addresses a change introduced in #2207 that broke certain edge cases in the `vm` test runner where some hardforks were getting set to `undefined` in the transition network tests due to missed type checking.

This PR does two things:
- Updates the test runner to explicitly set a hardfork block to 0 when transitionTests are being run and the hardfork is earlier than the last applied hardfork in the `transitionNetworks` set (which was being done implicitly before #2207).
- Adds new tests in `common` to validate that hardforks passed in the `ChainConfig` object with no defined or null `block` property are tried as "not applied".