### PR TITLE
Common: Add explicit HF block number null checks back, throw on undefined

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -224,6 +224,11 @@ export class Common extends EventEmitter {
     } else {
       throw new Error('Wrong input format')
     }
+    for (const hf of this.hardforks()) {
+      if (hf.block === undefined) {
+        throw new Error(`Hardfork cannot have undefined block number`)
+      }
+    }
     return this._chainParams
   }
 
@@ -269,7 +274,7 @@ export class Common extends EventEmitter {
     let previousHF
     for (const hf of this.hardforks()) {
       // Skip comparison for not applied HFs
-      if (typeof hf.block !== 'number') {
+      if (hf.block === null) {
         if (td !== undefined && td !== null && hf.ttd !== undefined && hf.ttd !== null) {
           if (td >= BigInt(hf.ttd)) {
             return hf.name

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -46,7 +46,7 @@ export interface GenesisBlockConfig {
 
 export interface HardforkConfig {
   name: Hardfork | string
-  block?: number | null
+  block: number | null // null is used for hardforks that should not be applied -- since `undefined` isn't a valid value in JSON
   ttd?: bigint | string
   forkHash?: string | null
 }

--- a/packages/common/tests/customChains.spec.ts
+++ b/packages/common/tests/customChains.spec.ts
@@ -165,7 +165,7 @@ tape('[Common]: Custom chains', function (t: tape.Test) {
   })
 })
 
-tape.only('custom chain setup with hardforks with undefined/null block numbers', (t) => {
+tape('custom chain setup with hardforks with undefined/null block numbers', (t) => {
   const undefinedHardforks = [
     {
       name: 'chainstart',
@@ -176,7 +176,22 @@ tape.only('custom chain setup with hardforks with undefined/null block numbers',
     { name: 'tangerineWhistle', block: 10 },
   ]
 
-  const common = Common.custom({ hardforks: undefinedHardforks })
+  t.throws(
+    //@ts-expect-error -- Disabling type check to verify that error is thrown
+    () => Common.custom({ hardforks: undefinedHardforks }),
+    'throws when a hardfork with an undefined block number is passed'
+  )
+
+  const nullHardforks = [
+    {
+      name: 'chainstart',
+      block: 0,
+    },
+    { name: 'homestead', block: null },
+    { name: 'tangerineWhistle', block: 10 },
+  ]
+
+  const common = Common.custom({ hardforks: nullHardforks })
   common.setHardforkByBlockNumber(10)
   t.equal('tangerineWhistle', common.hardfork(), 'set correct hardfork')
   common.setHardforkByBlockNumber(3)


### PR DESCRIPTION
Reverts previous changes made in #2217 that allowed a `hardfork.block` value of `undefined` to indicate a not applied hardfork.

Also explicitly checks all the hardforks in the `common.custom` constructor to verify that there are no `undefined` block numbers and throws if so.