### PR TITLE
chore: rename `Semaphore` to `Lock`

### DIFF
--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -8,7 +8,7 @@ import { DBOp, DBSaveLookups, DBSetBlockOrHeader, DBSetHashToNumber, DBSetTD } f
 import { DBManager } from './db/manager'
 import { DBTarget } from './db/operation'
 import { genesisStateRoot } from './genesisStates'
-import { Semaphore } from './semaphore'
+import { Lock } from './lock'
 
 import type { Consensus } from './consensus'
 import type { GenesisState } from './genesisStates'
@@ -48,7 +48,7 @@ export class Blockchain implements BlockchainInterface {
   private _heads: { [key: string]: Buffer }
 
   protected _isInitialized = false
-  private _lock: Semaphore
+  private _lock: Lock
 
   _common: Common
   private _hardforkByHeadBlockNumber: boolean
@@ -152,7 +152,7 @@ export class Blockchain implements BlockchainInterface {
 
     this._heads = {}
 
-    this._lock = new Semaphore(1)
+    this._lock = new Lock()
 
     if (opts.genesisBlock && !opts.genesisBlock.isGenesis()) {
       throw 'supplied block is not a genesis block'

--- a/packages/blockchain/src/lock.ts
+++ b/packages/blockchain/src/lock.ts
@@ -1,17 +1,7 @@
 // Based on https://github.com/jsoendermann/semaphore-async-await/blob/master/src/Semaphore.ts
-export class Semaphore {
-  private permits: number
+export class Lock {
+  private permits: number = 1
   private promiseResolverQueue: Array<(v: boolean) => void> = []
-
-  /**
-   * Creates a semaphore.
-   * @param permits  The number of permits, i.e. strands of execution being allowed
-   * to run in parallel.
-   * This number can be initialized with a negative integer.
-   */
-  constructor(permits: number) {
-    this.permits = permits
-  }
 
   /**
    * Returns a promise used to wait for a permit to become available. This method should be awaited on.
@@ -37,7 +27,7 @@ export class Semaphore {
 
     if (this.permits > 1 && this.promiseResolverQueue.length > 0) {
       // eslint-disable-next-line no-console
-      console.warn('Semaphore.permits should never be > 0 when there is someone waiting.')
+      console.warn('Lock.permits should never be > 0 when there is someone waiting.')
     } else if (this.permits === 1 && this.promiseResolverQueue.length > 0) {
       // If there is someone else waiting, immediately consume the permit that was released
       // at the beginning of this function and let the waiting function resume.

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -4,9 +4,9 @@ import { keccak256 } from 'ethereum-cryptography/keccak'
 import { CheckpointDB, MapDB } from '../db'
 import { verifyRangeProof } from '../proof/range'
 import { ROOT_DB_KEY } from '../types'
+import { Lock } from '../util/lock'
 import { bufferToNibbles, doKeysMatch, matchingNibbleLength } from '../util/nibbles'
 import { TrieReadStream as ReadStream } from '../util/readStream'
-import { Semaphore } from '../util/semaphore'
 import { WalkController } from '../util/walkController'
 
 import { BranchNode, ExtensionNode, LeafNode, decodeNode, decodeRawNode, isRawNode } from './node'
@@ -48,7 +48,7 @@ export class Trie {
   /** The backend DB */
   protected _db: CheckpointDB
   protected _hashLen: number
-  protected _lock: Semaphore = new Semaphore(1)
+  protected _lock = new Lock()
   protected _root: Buffer
 
   /**

--- a/packages/trie/src/util/lock.ts
+++ b/packages/trie/src/util/lock.ts
@@ -1,17 +1,7 @@
 // Based on https://github.com/jsoendermann/semaphore-async-await/blob/master/src/Semaphore.ts
-export class Semaphore {
-  private permits: number
+export class Lock {
+  private permits: number = 1
   private promiseResolverQueue: Array<(v: boolean) => void> = []
-
-  /**
-   * Creates a semaphore.
-   * @param permits  The number of permits, i.e. strands of execution being allowed
-   * to run in parallel.
-   * This number can be initialized with a negative integer.
-   */
-  constructor(permits: number) {
-    this.permits = permits
-  }
 
   /**
    * Returns a promise used to wait for a permit to become available. This method should be awaited on.
@@ -37,7 +27,7 @@ export class Semaphore {
 
     if (this.permits > 1 && this.promiseResolverQueue.length > 0) {
       // eslint-disable-next-line no-console
-      console.warn('Semaphore.permits should never be > 0 when there is someone waiting.')
+      console.warn('Lock.permits should never be > 0 when there is someone waiting.')
     } else if (this.permits === 1 && this.promiseResolverQueue.length > 0) {
       // If there is someone else waiting, immediately consume the permit that was released
       // at the beginning of this function and let the waiting function resume.

--- a/packages/trie/test/util/lock.spec.ts
+++ b/packages/trie/test/util/lock.spec.ts
@@ -1,14 +1,14 @@
 // Based on https://github.com/jsoendermann/semaphore-async-await/blob/master/__tests__/Semaphore.spec.ts
 import * as tape from 'tape'
 
-import { Semaphore } from '../../src/util/semaphore'
+import { Lock } from '../../src/util/lock'
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms))
 
-tape('Semaphore', (t) => {
+tape('Lock', (t) => {
   t.test('should lock', async (st) => {
     let global = 0
-    const lock = new Semaphore(1)
+    const lock = new Lock()
 
     const f = async () => {
       await lock.acquire()


### PR DESCRIPTION
A semaphore with a single permit is called a lock.