### PR TITLE
Monorepo RC 1 Releases

### DIFF
--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 4.0.0-rc.1 - 2022-08-29
+
+Release candidate 1 for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 and 3 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/block/CHANGELOG.md)).
+
+### Fixed Mainnet Merge HF Default
+
+Since this bug was so severe it gets its own section: `mainnet` in the underlying `@ethereumjs/common` library (`Chain.Mainnet`) was accidentally not updated yet to default to the `merge` HF (`Hardfork.Merge`) by an undiscovered overwrite back to `london`.
+
+This has been fixed in PR [#2206](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2206) and `mainnet` now default to the `merge` as well.
+
+### Other Changes
+
+- New `skipConsensusFormatValidation` option to skip consensus-related format validation checks (e.g. `extraData` checks on a `PoA` block), PRs [#2139](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2139) and [#2209](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2209)
+- Do not auto-activate `hardforkByBlockNumber` in static BlockHeader `fromRLPSerializedHeader()` constructor, PR [#2205](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2205)
+
+### Maintenance Updates
+
+- Added `engine` field to `package.json` limiting Node versions to v14 or higher, PR [#2164](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2164)
+- Replaced `nyc` (code coverage) configurations with `c8` configurations, PR [#2192](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2192)
+- Code formats improvements by adding various new linting rules, see Issue [#1935](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1935)
+
 ## 4.0.0-beta.3 - 2022-08-10
 
 Beta 3 release for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/block/CHANGELOG.md)).

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -41,7 +41,7 @@
     "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/trie": "5.0.0-rc.1",
-    "@ethereumjs/tx": "4.0.0-beta.3",
+    "@ethereumjs/tx": "4.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-rc.1",
     "ethereum-cryptography": "^1.1.2"
   },

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -38,7 +38,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/common": "3.0.0-beta.3",
+    "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/trie": "5.0.0-beta.3",
     "@ethereumjs/tx": "4.0.0-beta.3",

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/rlp": "4.0.0-rc.1",
-    "@ethereumjs/trie": "5.0.0-beta.3",
+    "@ethereumjs/trie": "5.0.0-rc.1",
     "@ethereumjs/tx": "4.0.0-beta.3",
     "@ethereumjs/util": "8.0.0-rc.1",
     "ethereum-cryptography": "^1.1.2"

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -42,7 +42,7 @@
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/trie": "5.0.0-beta.3",
     "@ethereumjs/tx": "4.0.0-beta.3",
-    "@ethereumjs/util": "8.0.0-beta.3",
+    "@ethereumjs/util": "8.0.0-rc.1",
     "ethereum-cryptography": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/block",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-rc.1",
   "description": "Provides Block serialization and help functions",
   "keywords": [
     "ethereum",

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@ethereumjs/common": "3.0.0-beta.3",
-    "@ethereumjs/rlp": "4.0.0-beta.3",
+    "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/trie": "5.0.0-beta.3",
     "@ethereumjs/tx": "4.0.0-beta.3",
     "@ethereumjs/util": "8.0.0-beta.3",

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 6.0.0-rc.1 - 2022-08-29
+
+Release candidate 1 for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 and 3 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/blockchain/CHANGELOG.md)).
+
+### Fixed Mainnet Merge HF Default
+
+Since this bug was so severe it gets its own section: `mainnet` in the underlying `@ethereumjs/common` library (`Chain.Mainnet`) was accidentally not updated yet to default to the `merge` HF (`Hardfork.Merge`) by an undiscovered overwrite back to `london`.
+
+This has been fixed in PR [#2206](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2206) and `mainnet` now default to the `merge` as well.
+
+### Maintenance Updates
+
+- Added `engine` field to `package.json` limiting Node versions to v14 or higher, PR [#2164](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2164)
+- Replaced `nyc` (code coverage) configurations with `c8` configurations, PR [#2192](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2192)
+- Code formats improvements by adding various new linting rules, see Issue [#1935](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1935)
+- Replaced `semaphore-async-await` dependency with smaller implementation, PR [#2222](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2222)
+- Renamed `Semaphore` to `Lock`, PR [#2234](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2234)
+
 ## 6.0.0-beta.3 - 2022-08-10
 
 Beta 3 release for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/blockchain/CHANGELOG.md)).

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@ethereumjs/block": "4.0.0-beta.3",
-    "@ethereumjs/common": "3.0.0-beta.3",
+    "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/ethash": "2.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/trie": "5.0.0-beta.3",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -43,7 +43,7 @@
     "@ethereumjs/ethash": "2.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/trie": "5.0.0-beta.3",
-    "@ethereumjs/util": "8.0.0-beta.3",
+    "@ethereumjs/util": "8.0.0-rc.1",
     "abstract-level": "^1.0.3",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^1.1.2",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -42,7 +42,7 @@
     "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/ethash": "2.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",
-    "@ethereumjs/trie": "5.0.0-beta.3",
+    "@ethereumjs/trie": "5.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-rc.1",
     "abstract-level": "^1.0.3",
     "debug": "^4.3.3",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/blockchain",
-  "version": "6.0.0-beta.3",
+  "version": "6.0.0-rc.1",
   "description": "A module to store and interact with blocks",
   "keywords": [
     "ethereum",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@ethereumjs/block": "4.0.0-rc.1",
     "@ethereumjs/common": "3.0.0-rc.1",
-    "@ethereumjs/ethash": "2.0.0-beta.3",
+    "@ethereumjs/ethash": "2.0.0-rc.1",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/trie": "5.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-rc.1",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -41,7 +41,7 @@
     "@ethereumjs/block": "4.0.0-beta.3",
     "@ethereumjs/common": "3.0.0-beta.3",
     "@ethereumjs/ethash": "2.0.0-beta.3",
-    "@ethereumjs/rlp": "4.0.0-beta.3",
+    "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/trie": "5.0.0-beta.3",
     "@ethereumjs/util": "8.0.0-beta.3",
     "abstract-level": "^1.0.3",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -38,7 +38,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/block": "4.0.0-beta.3",
+    "@ethereumjs/block": "4.0.0-rc.1",
     "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/ethash": "2.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.6.2 - 2022-08-29
+
+This release updates the underlying EthereumJS libraries to the newly released RC 1 versions.
+
+### Fixed Hardfork Issues in Beacon Sync
+
+This release mainly fixes various hardfork issues in beacon sync discovered after the `goerli` testnet merge, see PR [#2230](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2230):
+
+- Engine's assemble block was not using correct fork
+- Skeleton's call to getBlockHeaders wasn't resulting in correct block and hence the block bodies were also not correct because of which skeleton backfill was breaking
+- Reverse block fetcher sync was picking up a peer which seemed to be providing `london` blocks instead of merge causing the fetcher to break again and again instead of just banning that peer.
+- Skeleton's getBlock was not using the correct hardfork
+
+This will make beacon sync on Goerli and other Merge-activated chains more robust.
+
+### Other Changes
+
+- Mainnet Merge `TTD` `58750000000000000000000` has been added to the `mainnet` chain configuration of the underlying `Common` library, PR [#2185](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2185)
+
 ## 0.6.1 - 2022-08-11
 
 This release updates the underlying EthereumJS libraries to the newly released Beta 3 versions.

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -61,7 +61,7 @@
     "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/devp2p": "5.0.0-rc.1",
     "@ethereumjs/ethash": "2.0.0-rc.1",
-    "@ethereumjs/evm": "1.0.0-beta.3",
+    "@ethereumjs/evm": "1.0.0-rc.1",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/statemanager": "1.0.0-rc.1",
     "@ethereumjs/trie": "5.0.0-rc.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -60,7 +60,7 @@
     "@ethereumjs/blockchain": "6.0.0-rc.1",
     "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/devp2p": "5.0.0-beta.3",
-    "@ethereumjs/ethash": "2.0.0-beta.3",
+    "@ethereumjs/ethash": "2.0.0-rc.1",
     "@ethereumjs/evm": "1.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/statemanager": "1.0.0-beta.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -63,7 +63,7 @@
     "@ethereumjs/ethash": "2.0.0-rc.1",
     "@ethereumjs/evm": "1.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",
-    "@ethereumjs/statemanager": "1.0.0-beta.3",
+    "@ethereumjs/statemanager": "1.0.0-rc.1",
     "@ethereumjs/trie": "5.0.0-rc.1",
     "@ethereumjs/tx": "4.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-rc.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -58,7 +58,7 @@
     "@chainsafe/libp2p-noise": "^4.1.1",
     "@ethereumjs/block": "4.0.0-beta.3",
     "@ethereumjs/blockchain": "6.0.0-beta.3",
-    "@ethereumjs/common": "3.0.0-beta.3",
+    "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/devp2p": "5.0.0-beta.3",
     "@ethereumjs/ethash": "2.0.0-beta.3",
     "@ethereumjs/evm": "1.0.0-beta.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -67,7 +67,7 @@
     "@ethereumjs/trie": "5.0.0-rc.1",
     "@ethereumjs/tx": "4.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-rc.1",
-    "@ethereumjs/vm": "6.0.0-beta.3",
+    "@ethereumjs/vm": "6.0.0-rc.1",
     "abstract-level": "^1.0.3",
     "body-parser": "^1.19.2",
     "chalk": "^4.1.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -64,7 +64,7 @@
     "@ethereumjs/evm": "1.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/statemanager": "1.0.0-beta.3",
-    "@ethereumjs/trie": "5.0.0-beta.3",
+    "@ethereumjs/trie": "5.0.0-rc.1",
     "@ethereumjs/tx": "4.0.0-beta.3",
     "@ethereumjs/util": "8.0.0-rc.1",
     "@ethereumjs/vm": "6.0.0-beta.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -65,7 +65,7 @@
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/statemanager": "1.0.0-beta.3",
     "@ethereumjs/trie": "5.0.0-rc.1",
-    "@ethereumjs/tx": "4.0.0-beta.3",
+    "@ethereumjs/tx": "4.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-rc.1",
     "@ethereumjs/vm": "6.0.0-beta.3",
     "abstract-level": "^1.0.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/client",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "EthereumJS client implementation",
   "keywords": [
     "ethereum",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -62,7 +62,7 @@
     "@ethereumjs/devp2p": "5.0.0-beta.3",
     "@ethereumjs/ethash": "2.0.0-beta.3",
     "@ethereumjs/evm": "1.0.0-beta.3",
-    "@ethereumjs/rlp": "4.0.0-beta.3",
+    "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/statemanager": "1.0.0-beta.3",
     "@ethereumjs/trie": "5.0.0-beta.3",
     "@ethereumjs/tx": "4.0.0-beta.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@chainsafe/libp2p-noise": "^4.1.1",
-    "@ethereumjs/block": "4.0.0-beta.3",
+    "@ethereumjs/block": "4.0.0-rc.1",
     "@ethereumjs/blockchain": "6.0.0-beta.3",
     "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/devp2p": "5.0.0-beta.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@chainsafe/libp2p-noise": "^4.1.1",
     "@ethereumjs/block": "4.0.0-rc.1",
-    "@ethereumjs/blockchain": "6.0.0-beta.3",
+    "@ethereumjs/blockchain": "6.0.0-rc.1",
     "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/devp2p": "5.0.0-beta.3",
     "@ethereumjs/ethash": "2.0.0-beta.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -66,7 +66,7 @@
     "@ethereumjs/statemanager": "1.0.0-beta.3",
     "@ethereumjs/trie": "5.0.0-beta.3",
     "@ethereumjs/tx": "4.0.0-beta.3",
-    "@ethereumjs/util": "8.0.0-beta.3",
+    "@ethereumjs/util": "8.0.0-rc.1",
     "@ethereumjs/vm": "6.0.0-beta.3",
     "abstract-level": "^1.0.3",
     "body-parser": "^1.19.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -59,7 +59,7 @@
     "@ethereumjs/block": "4.0.0-rc.1",
     "@ethereumjs/blockchain": "6.0.0-rc.1",
     "@ethereumjs/common": "3.0.0-rc.1",
-    "@ethereumjs/devp2p": "5.0.0-beta.3",
+    "@ethereumjs/devp2p": "5.0.0-rc.1",
     "@ethereumjs/ethash": "2.0.0-rc.1",
     "@ethereumjs/evm": "1.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 3.0.0-rc.1 - 2022-08-29
+
+Release candidate 1 for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 and 3 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/CHANGELOG.md)).
+
+### Fixed Mainnet Merge HF Default
+
+Since this bug was so severe it gets its own section: `mainnet` in Common (`Chain.Mainnet`) was accidentally not updated yet to default to the `merge` HF (`Hardfork.Merge`) by an undiscovered overwrite back to `london`.
+
+This has been fixed in PR [#2206](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2206) and `mainnet` now default to the `merge` as well.
+
+### Other Changes
+
+- Mainnet Merge `TTD` `58750000000000000000000` has been added to the `mainnet` chain configuration, PR [#2185](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2185)
+- **Eventually breaking:** `Common` now throws on instantiation if a passed-in chain configuration has a HF defined with `block` set to `undefined` (use `null` for non-applied HFs), PR [#2228](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2228)
+- The `Kovan` `PoA` testnet chain is EOL and has been removed from the chain configuration, [#2206](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2206)
+
+### Maintenance Updates
+
+- Added `engine` field to `package.json` limiting Node versions to v14 or higher, PR [#2164](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2164)
+- Replaced `nyc` (code coverage) configurations with `c8` configurations, PR [#2192](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2192)
+- Code formats improvements by adding various new linting rules, see Issue [#1935](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1935)
+
 ## 3.0.0-beta.3 - 2022-08-10
 
 Beta 3 release for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/CHANGELOG.md)).

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -48,7 +48,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/util": "8.0.0-beta.3",
+    "@ethereumjs/util": "8.0.0-rc.1",
     "crc-32": "^1.2.0"
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/common",
-  "version": "3.0.0-beta.3",
+  "version": "3.0.0-rc.1",
   "description": "Resources common to all Ethereum implementations",
   "keywords": [
     "ethereum",

--- a/packages/devp2p/CHANGELOG.md
+++ b/packages/devp2p/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.0.0-rc.1 - 2022-08-29
+
+Release candidate 1 for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 and 3 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/devp2p/CHANGELOG.md)).
+
+### Fixed Mainnet Merge HF Default
+
+Since this bug was so severe it gets its own section: `mainnet` in the underlying `@ethereumjs/common` library (`Chain.Mainnet`) was accidentally not updated yet to default to the `merge` HF (`Hardfork.Merge`) by an undiscovered overwrite back to `london`.
+
+This has been fixed in PR [#2206](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2206) and `mainnet` now default to the `merge` as well.
+
+### Maintenance Updates
+
+- Added `engine` field to `package.json` limiting Node versions to v14 or higher, PR [#2164](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2164)
+- Replaced `nyc` (code coverage) configurations with `c8` configurations, PR [#2192](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2192)
+- Code formats improvements by adding various new linting rules, see Issue [#1935](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1935)
+
 ## 5.0.0-beta.3 - 2022-08-10
 
 Beta 3 release for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/devp2p/CHANGELOG.md)).

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -49,7 +49,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/common": "3.0.0-beta.3",
+    "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-rc.1",
     "@scure/base": "1.1.1",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@ethereumjs/common": "3.0.0-beta.3",
-    "@ethereumjs/rlp": "4.0.0-beta.3",
+    "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-beta.3",
     "@scure/base": "1.1.1",
     "@types/bl": "^2.1.0",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@ethereumjs/common": "3.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",
-    "@ethereumjs/util": "8.0.0-beta.3",
+    "@ethereumjs/util": "8.0.0-rc.1",
     "@scure/base": "1.1.1",
     "@types/bl": "^2.1.0",
     "@types/k-bucket": "^5.0.0",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@ethereumjs/block": "4.0.0-beta.3",
-    "@ethereumjs/tx": "4.0.0-beta.3",
+    "@ethereumjs/tx": "4.0.0-rc.1",
     "@types/chalk": "^2.2.0",
     "@types/debug": "^4.1.4",
     "@types/ip": "^1.1.0",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/devp2p",
-  "version": "5.0.0-beta.3",
+  "version": "5.0.0-rc.1",
   "description": "A JavaScript implementation of ÐΞVp2p",
   "keywords": [
     "ethereum",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -68,7 +68,7 @@
     "snappyjs": "^0.6.1"
   },
   "devDependencies": {
-    "@ethereumjs/block": "4.0.0-beta.3",
+    "@ethereumjs/block": "4.0.0-rc.1",
     "@ethereumjs/tx": "4.0.0-rc.1",
     "@types/chalk": "^2.2.0",
     "@types/debug": "^4.1.4",

--- a/packages/ethash/CHANGELOG.md
+++ b/packages/ethash/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.0.0-rc.1 - 2022-08-29
+
+Release candidate 1 for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 and 3 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/ethash/CHANGELOG.md)).
+
+### Maintenance Updates
+
+- Added `engine` field to `package.json` limiting Node versions to v14 or higher, PR [#2164](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2164)
+- Replaced `nyc` (code coverage) configurations with `c8` configurations, PR [#2192](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2192)
+- Code formats improvements by adding various new linting rules, see Issue [#1935](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1935)
+
 ## 2.0.0-beta.3 - 2022-08-10
 
 Beta 3 release for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/ethash/CHANGELOG.md)).

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -36,7 +36,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/block": "4.0.0-beta.3",
+    "@ethereumjs/block": "4.0.0-rc.1",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-rc.1",
     "abstract-level": "^1.0.3",

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@ethereumjs/block": "4.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",
-    "@ethereumjs/util": "8.0.0-beta.3",
+    "@ethereumjs/util": "8.0.0-rc.1",
     "abstract-level": "^1.0.3",
     "bigint-crypto-utils": "^3.0.23",
     "ethereum-cryptography": "^1.1.2"

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -44,7 +44,7 @@
     "ethereum-cryptography": "^1.1.2"
   },
   "devDependencies": {
-    "@ethereumjs/common": "3.0.0-beta.3",
+    "@ethereumjs/common": "3.0.0-rc.1",
     "memory-level": "^1.0.0"
   },
   "engines": {

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/ethash",
-  "version": "2.0.0-beta.3",
+  "version": "2.0.0-rc.1",
   "description": "An ethash implementation in JavaScript",
   "keywords": [
     "ethash",

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@ethereumjs/block": "4.0.0-beta.3",
-    "@ethereumjs/rlp": "4.0.0-beta.3",
+    "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-beta.3",
     "abstract-level": "^1.0.3",
     "bigint-crypto-utils": "^3.0.23",

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -6,6 +6,49 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-rc.1 - 2022-08-29
+
+Release candidate 1 for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 and 3 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/evm/CHANGELOG.md)).
+
+### Fixed Mainnet Merge HF Default
+
+Since this bug was so severe it gets its own section: `mainnet` in the underlying `@ethereumjs/common` library (`Chain.Mainnet`) was accidentally not updated yet to default to the `merge` HF (`Hardfork.Merge`) by an undiscovered overwrite back to `london`.
+
+This has been fixed in PR [#2206](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2206) and `mainnet` now default to the `merge` as well.
+
+### Removed AsyncEventEmitter / New events Property
+
+This is the biggest EVM change in this release. The inheritance structure of the EVM has been reworked and the `EVM` class has been freed from being a child class of `AsyncEventEmitter` and inheriting all its properties and methods in favor of a new `events` property cleanly separating all events logic from the core `EVM`, see PR [#2235](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2235).
+
+This allows for an easier typing of the `EVM` and makes the core EVM class leaner and not overloaded with various other partly unused properties. The new `events` property is optional.
+
+Usage code of events needs to be slighly adopted and updated from:
+
+```typescript
+evm.on('step', (e) => {
+  // Do something
+}
+```
+
+To:
+
+```typescript
+evm.events.on('step', (e) => {
+  // Do something
+}
+```
+
+### Other Changes
+
+- Reworked/adjusted `skipBalance` option semantics, PR [#2138](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2138)
+- Fixed an event signature typing bug, PR [#2184](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2184)
+
+### Maintenance Updates
+
+- Added `engine` field to `package.json` limiting Node versions to v14 or higher, PR [#2164](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2164)
+- Replaced `nyc` (code coverage) configurations with `c8` configurations, PR [#2192](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2192)
+- Code formats improvements by adding various new linting rules, see Issue [#1935](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1935)
+
 ## 1.0.0-beta.3 - 2022-08-10
 
 Beta 3 release for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/evm/CHANGELOG.md)).

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -46,7 +46,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/common": "3.0.0-beta.3",
+    "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-rc.1",
     "@types/async-eventemitter": "^0.2.1",
     "async-eventemitter": "^0.2.4",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -56,7 +56,7 @@
     "rustbn.js": "~0.2.0"
   },
   "devDependencies": {
-    "@ethereumjs/statemanager": "1.0.0-beta.3",
+    "@ethereumjs/statemanager": "1.0.0-rc.1",
     "@ethersproject/abi": "^5.0.12",
     "@types/benchmark": "^1.0.33",
     "@types/core-js": "^2.5.0",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@ethereumjs/common": "3.0.0-beta.3",
-    "@ethereumjs/util": "8.0.0-beta.3",
+    "@ethereumjs/util": "8.0.0-rc.1",
     "@types/async-eventemitter": "^0.2.1",
     "async-eventemitter": "^0.2.4",
     "debug": "^4.3.3",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/evm",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-rc.1",
   "description": "JavaScript Ethereum Virtual Machine (EVM) implementation",
   "keywords": [
     "ethereum",

--- a/packages/rlp/CHANGELOG.md
+++ b/packages/rlp/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 Release candidate 1 for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 and 3 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/rlp/CHANGELOG.md)).
 
-### Changes
+### Maintenance Updates
 
 - Added `engine` field to `package.json` limiting Node versions to v14 or higher, PR [#2164](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2164)
 - Replaced `nyc` (code coverage) configurations with `c8` configurations, PR [#2192](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2192)

--- a/packages/rlp/CHANGELOG.md
+++ b/packages/rlp/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 4.0.0-rc.1 - 2022-08-29
+
+Release candidate 1 for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 and 3 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/rlp/CHANGELOG.md)).
+
+### Changes
+
+- Added `engine` field to `package.json` limiting Node versions to v14 or higher, PR [#2164](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2164)
+- Replaced `nyc` (code coverage) configurations with `c8` configurations, PR [#2192](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2192)
+- Code formats improvements by adding various new linting rules, see Issue [#1935](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1935)
+
 ## 4.0.0-beta.3 - 2022-08-10
 
 Beta 3 release for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/rlp/CHANGELOG.md)).

--- a/packages/rlp/package.json
+++ b/packages/rlp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/rlp",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-rc.1",
   "description": "Recursive Length Prefix Encoding Module",
   "keywords": [
     "rlp",

--- a/packages/rlp/package.json
+++ b/packages/rlp/package.json
@@ -47,5 +47,8 @@
     "test:browser": "karma start karma.conf.js",
     "test:node": "npm run tape -- test/*.spec.ts",
     "tsc": "../../config/cli/ts-compile.sh"
+  },
+  "engines": {
+    "node": ">=14"
   }
 }

--- a/packages/statemanager/CHANGELOG.md
+++ b/packages/statemanager/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.0.0-rc.1 - 2022-08-29
+
+Release candidate 1 for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 and 3 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/statemanager/CHANGELOG.md)).
+
+### Other Changes
+
+- \*\*Attention:" Removed unused `common` option from `StateManager`, PR [#2197](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2197)
+- Added `prefixCodeHashes` flag defaulting to `true` which allows to deactivate prefix code hashes saved in the DB (see PR [#1438](https://github.com/ethereumjs/ethereumjs-monorepo/pull/1438) for context), PR [#2179](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2179)
+
+### Maintenance Updates
+
+- Added `engine` field to `package.json` limiting Node versions to v14 or higher, PR [#2164](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2164)
+- Replaced `nyc` (code coverage) configurations with `c8` configurations, PR [#2192](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2192)
+- Code formats improvements by adding various new linting rules, see Issue [#1935](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1935)
+
 ## 1.0.0-beta.3 - 2022-08-10
 
 Beta 3 release for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/statemanager/CHANGELOG.md)).

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -44,7 +44,7 @@
     "@ethereumjs/common": "3.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/trie": "5.0.0-beta.3",
-    "@ethereumjs/util": "8.0.0-beta.3",
+    "@ethereumjs/util": "8.0.0-rc.1",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^1.1.2",
     "functional-red-black-tree": "^1.0.1"

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/statemanager",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0-rc.1",
   "description": "An Ethereum statemanager implementation",
   "keywords": [
     "ethereum",

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/rlp": "4.0.0-rc.1",
-    "@ethereumjs/trie": "5.0.0-beta.3",
+    "@ethereumjs/trie": "5.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-rc.1",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^1.1.2",

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -41,7 +41,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/common": "3.0.0-beta.3",
+    "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/trie": "5.0.0-beta.3",
     "@ethereumjs/util": "8.0.0-rc.1",

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@ethereumjs/common": "3.0.0-beta.3",
-    "@ethereumjs/rlp": "4.0.0-beta.3",
+    "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/trie": "5.0.0-beta.3",
     "@ethereumjs/util": "8.0.0-beta.3",
     "debug": "^4.3.3",

--- a/packages/trie/UPGRADING.md
+++ b/packages/trie/UPGRADING.md
@@ -10,59 +10,19 @@ Due to the high number of breaking changes, upgrading is typically a tedious pro
 
 We have instituted several changes to the public API of this package in order to provide an improved DX and simplify the process of maintaining it.
 
-### Deprecated `root` Getter and Setter
-
-Due to the ambiguity of the `get` and `set` functions (also known as getters and setters), their status is now deprecated. This is because their ambiguity can create the impression of interacting with a property on a trie instance. For this reason, a single `root(hash?: Buffer): Buffer` function serves as their replacement and can effectively work to get and set properties. This also makes it obvious that you intend to modify an internal property of the trie that is neither accessible or mutable via any other means other than this particular function.
-
-### Getter
-
-```tsx
-// Old
-const trie = new Trie()
-trie.root
-
-// New
-const trie = new Trie()
-trie.root()
-```
-
-### Setter
-
-```tsx
-// Old
-const trie = new Trie()
-trie.root = Buffer.alloc(32)
-
-// New
-const trie = new Trie()
-trie.root(Buffer.alloc(32))
-```
-
-### Deprecated `isCheckpoint` Getter
-
-The status of the `isCheckpoint` getter function is now deprecated. The `hasCheckpoints()` function serves as its replacement and offers the same behaviour.
-
-```tsx
-// Old
-const trie = new Trie()
-trie.isCheckpoint
-
-// New
-const trie = new Trie()
-trie.hasCheckpoints()
-```
-
-### Options
-
 The 5.0.0 release comes with a variety of new options, some of which replace old behaviours or classes.
 
-#### `CheckpointTrie` is Now the Default
+### Single Trie Class
 
-The CheckpointTrie is now deprecated in order to make it a default behaviour. Every Trie instance now comes complete with checkpointing behaviour out of the box.
+There is now one single `Trie` class which contains and exposes the functionality previously split into the three separate classes `Trie` -> `CheckpointTrie` and `SecureTrie`. Class inheritance has been removed and the existing functionality has been integrated into one class. This should make it easier to extend the Trie class or customize its behavior without having to "dock" into the previous complicated inheritance structure.
 
-#### `SecureTrie` is Now an Option
+#### Default Checkpointing Behavior
 
-In v5, the `SecureTrie` class is now deprecated in favour of the constructor option `useKeyHashing` - defaulting to `false`. This effectively reduces the level of inheritance dependencies (for example, in the old structure, you could not create a secure trie without the checkpoint functionality which, in terms of logic, do not correlate in any way). This also provides more room to accommodate future design modifications and/or additions if required.
+The `CheckpointTrie` class has been removed in favor of integrating the functionality into the main `Trie` class and make it a default behaviour. Every Trie instance now comes complete with checkpointing behaviour out of the box, without giving any additional weight or performance penalty if the functionality remains unused.
+
+#### Secure Trie with an Option
+
+The `SecureTrie` class has been removed as well. Instead there is a new constructor option `useKeyHashing` - defaulting to `false`. This effectively reduces the level of inheritance dependencies (for example, in the old structure, you could not create a secure trie without the checkpoint functionality which, in terms of logic, do not correlate in any way). This also provides more room to accommodate future design modifications and/or additions if required.
 
 Updating is a straightforward process:
 
@@ -74,7 +34,53 @@ const trie = new SecureTrie()
 const trie = new Trie({ useKeyHashing: true })
 ```
 
-#### Root Persistence is Now an Option
+### Removed Getter and Setter Functions
+
+Due to the ambiguity of the `get` and `set` functions (also known as getters and setters), usage has been removed from the library. This is because their ambiguity can create the impression of interacting with a property on a trie instance.
+
+#### Trie `root` Getter/Setter
+
+For this reason, a single `root(hash?: Buffer): Buffer` function serves as a replacement for the previous `root` getter and setter and can effectively work to get and set properties. This makes it obvious that you intend to modify an internal property of the trie that is neither accessible or mutable via any other means other than this particular function.
+
+##### Getter Example
+
+```tsx
+// Old
+const trie = new Trie()
+trie.root
+
+// New
+const trie = new Trie()
+trie.root()
+```
+
+##### Setter Example
+
+```tsx
+// Old
+const trie = new Trie()
+trie.root = Buffer.alloc(32)
+
+// New
+const trie = new Trie()
+trie.root(Buffer.alloc(32))
+```
+
+#### Trie `isCheckpoint` Getter
+
+The `isCheckpoint` getter function has been removed. The `hasCheckpoints()` function serves as its replacement and offers the same behaviour.
+
+```tsx
+// Old
+const trie = new Trie()
+trie.isCheckpoint
+
+// New
+const trie = new Trie()
+trie.hasCheckpoints()
+```
+
+### Root Persistence
 
 In previous iterations, you would need to persist and restore the root of your trie and determine how to achieve this of your own accord. This behaviour is now available out of the box. You can enable persistence by setting the `useRootPersistence` option to `true` when constructing a trie by using the `Trie.create` function. As such, this value is preserved when creating copies of the trie. Moreover, upon instantiating a trie, you will not have the ability to modify said value.
 
@@ -98,7 +104,7 @@ Another significant change is that we dropped support for `LevelDB` out of the b
 
 The primary reason for this change is increase the flexibility of this package by allowing developers to select any type of storage for their unique purposes. In addition, this change renders the project far less susceptible to [supply chain attacks](https://en.wikipedia.org/wiki/Supply_chain_attack). We trust that users and developers can appreciate the value of reducing this attack surface in exchange for a little more time spent on their part for the duration of this upgrade.
 
-#### LevelDB
+#### LevelDB Removal
 
 Prior to v5, this package shipped with a LevelDB integration out of the box. With this latest version, we have introduced a database abstraction and therefore no longer ship with the aforementioned LevelDB implementation. However, for your convenience, we provide all of the necessary steps so that you can integrate it accordingly.
 

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@ethereumjs/rlp": "4.0.0-rc.1",
-    "@ethereumjs/util": "8.0.0-beta.3",
+    "@ethereumjs/util": "8.0.0-rc.1",
     "ethereum-cryptography": "^1.1.2",
     "readable-stream": "^3.6.0"
   },

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -45,7 +45,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/rlp": "4.0.0-beta.3",
+    "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-beta.3",
     "ethereum-cryptography": "^1.1.2",
     "readable-stream": "^3.6.0"

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/trie",
-  "version": "5.0.0-beta.3",
+  "version": "5.0.0-rc.1",
   "description": "This is an implementation of the modified merkle patricia tree as specified in Ethereum's yellow paper.",
   "keywords": [
     "merkle",

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 4.0.0-rc.1 - 2022-08-29
+
+Release candidate 1 for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 and 3 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/CHANGELOG.md)).
+
+### Fixed Mainnet Merge HF Default
+
+Since this bug was so severe it gets its own section: `mainnet` in the underlying `@ethereumjs/common` library (`Chain.Mainnet`) was accidentally not updated yet to default to the `merge` HF (`Hardfork.Merge`) by an undiscovered overwrite back to `london`.
+
+This has been fixed in PR [#2206](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2206) and `mainnet` now default to the `merge` as well.
+
+### Maintenance Updates
+
+- Added `engine` field to `package.json` limiting Node versions to v14 or higher, PR [#2164](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2164)
+- Replaced `nyc` (code coverage) configurations with `c8` configurations, PR [#2192](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2192)
+- Code formats improvements by adding various new linting rules, see Issue [#1935](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1935)
+
 ## 4.0.0-beta.3 - 2022-08-10
 
 Beta 3 release for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/tx/CHANGELOG.md)).

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@ethereumjs/common": "3.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",
-    "@ethereumjs/util": "8.0.0-beta.3",
+    "@ethereumjs/util": "8.0.0-rc.1",
     "ethereum-cryptography": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -50,7 +50,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/common": "3.0.0-beta.3",
+    "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-rc.1",
     "ethereum-cryptography": "^1.1.2"

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@ethereumjs/common": "3.0.0-beta.3",
-    "@ethereumjs/rlp": "4.0.0-beta.3",
+    "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-beta.3",
     "ethereum-cryptography": "^1.1.2"
   },

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/tx",
-  "version": "4.0.0-beta.3",
+  "version": "4.0.0-rc.1",
   "description": "A simple module for creating, manipulating and signing Ethereum transactions",
   "keywords": [
     "ethereum",

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 8.0.0-rc.1 - 2022-08-29
+
+Release candidate 1 for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 and 3 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/util/CHANGELOG.md)).
+
+### Changes
+
+- **Breaking:** Renamed `Account.stateRoot` to `Account.storageRoot` for clarity in `account` module, PR [#2140](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2140)
+
+### Maintenance Updates
+
+- Added `engine` field to `package.json` limiting Node versions to v14 or higher, PR [#2164](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2164)
+- Replaced `nyc` (code coverage) configurations with `c8` configurations, PR [#2192](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2192)
+- Code formats improvements by adding various new linting rules, see Issue [#1935](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1935)
+
 ## 8.0.0-beta.3 - 2022-08-10
 
 Beta 3 release for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/util/CHANGELOG.md)).

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/util",
-  "version": "8.0.0-beta.3",
+  "version": "8.0.0-rc.1",
   "description": "A collection of utility functions for Ethereum",
   "keywords": [
     "ethereum",

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -6,6 +6,57 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 6.0.0-rc.1 - 2022-08-29
+
+Release candidate 1 for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 and 3 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/evm/CHANGELOG.md)).
+
+### Fixed Mainnet Merge HF Default
+
+Since this bug was so severe it gets its own section: `mainnet` in the underlying `@ethereumjs/common` library (`Chain.Mainnet`) was accidentally not updated yet to default to the `merge` HF (`Hardfork.Merge`) by an undiscovered overwrite back to `london`.
+
+This has been fixed in PR [#2206](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2206) and `mainnet` now default to the `merge` as well.
+
+### Removed AsyncEventEmitter / New events Property
+
+This is the biggest VM change in this release. The inheritance structure of both the VM and the underlying EVM has been reworked and the `VM` and `EVM` classes have been freed from being a child class of `AsyncEventEmitter` and inheriting all its properties and methods in favor of a new `events` property cleanly separating all events logic from the core `VM`/`EVM`, see PR [#2235](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2235).
+
+This allows for an easier typing of the inner `EVM` and makes the core VM/EVM classes leaner and not overloaded with various other partly unused properties. The new `events` property is optional.
+
+Usage code of events needs to be slighly adopted and updated from:
+
+```typescript
+vm.on('beforeBlock', (val) => {
+  // Do something
+}
+vm.evm.on('step', (e) => {
+  // Do something
+}
+```
+
+To:
+
+```typescript
+vm.events.on('beforeBlock', (val) => {
+  // Do something
+}
+vm.evm.events!.on('step', (e) => {
+  // Do something
+}
+```
+
+### Other Changes
+
+- Made `touchAccount` of `VMState` public, PR [#2183](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2183)
+- **Pontentially breaking:** Removed `common` option from underlying `StateManager`, PR [#2197](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2197)
+- Reworked/adjusted underlying EVM `skipBalance` option semantics, PR [#2138](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2138)
+- Fixed an underlying EVM event signature typing bug, PR [#2184](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2184)
+
+### Maintenance Updates
+
+- Added `engine` field to `package.json` limiting Node versions to v14 or higher, PR [#2164](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2164)
+- Replaced `nyc` (code coverage) configurations with `c8` configurations, PR [#2192](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2192)
+- Code formats improvements by adding various new linting rules, see Issue [#1935](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1935)
+
 ## 6.0.0-beta.3 - 2022-08-10
 
 Beta 3 release for the upcoming breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/vm/CHANGELOG.md)).

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -62,7 +62,7 @@
     "@ethereumjs/evm": "1.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/statemanager": "1.0.0-beta.3",
-    "@ethereumjs/trie": "5.0.0-beta.3",
+    "@ethereumjs/trie": "5.0.0-rc.1",
     "@ethereumjs/tx": "4.0.0-beta.3",
     "@ethereumjs/util": "8.0.0-rc.1",
     "@types/async-eventemitter": "^0.2.1",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -56,7 +56,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/block": "4.0.0-beta.3",
+    "@ethereumjs/block": "4.0.0-rc.1",
     "@ethereumjs/blockchain": "6.0.0-beta.3",
     "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/evm": "1.0.0-beta.3",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/vm",
-  "version": "6.0.0-beta.3",
+  "version": "6.0.0-rc.1",
   "description": "An Ethereum VM implementation",
   "keywords": [
     "ethereum",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -60,7 +60,7 @@
     "@ethereumjs/blockchain": "6.0.0-beta.3",
     "@ethereumjs/common": "3.0.0-beta.3",
     "@ethereumjs/evm": "1.0.0-beta.3",
-    "@ethereumjs/rlp": "4.0.0-beta.3",
+    "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/statemanager": "1.0.0-beta.3",
     "@ethereumjs/trie": "5.0.0-beta.3",
     "@ethereumjs/tx": "4.0.0-beta.3",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -63,7 +63,7 @@
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/statemanager": "1.0.0-beta.3",
     "@ethereumjs/trie": "5.0.0-rc.1",
-    "@ethereumjs/tx": "4.0.0-beta.3",
+    "@ethereumjs/tx": "4.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-rc.1",
     "@types/async-eventemitter": "^0.2.1",
     "async-eventemitter": "^0.2.4",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@ethereumjs/block": "4.0.0-rc.1",
-    "@ethereumjs/blockchain": "6.0.0-beta.3",
+    "@ethereumjs/blockchain": "6.0.0-rc.1",
     "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/evm": "1.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@ethereumjs/block": "4.0.0-beta.3",
     "@ethereumjs/blockchain": "6.0.0-beta.3",
-    "@ethereumjs/common": "3.0.0-beta.3",
+    "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/evm": "1.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/statemanager": "1.0.0-beta.3",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -59,7 +59,7 @@
     "@ethereumjs/block": "4.0.0-rc.1",
     "@ethereumjs/blockchain": "6.0.0-rc.1",
     "@ethereumjs/common": "3.0.0-rc.1",
-    "@ethereumjs/evm": "1.0.0-beta.3",
+    "@ethereumjs/evm": "1.0.0-rc.1",
     "@ethereumjs/rlp": "4.0.0-rc.1",
     "@ethereumjs/statemanager": "1.0.0-rc.1",
     "@ethereumjs/trie": "5.0.0-rc.1",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -64,7 +64,7 @@
     "@ethereumjs/statemanager": "1.0.0-beta.3",
     "@ethereumjs/trie": "5.0.0-beta.3",
     "@ethereumjs/tx": "4.0.0-beta.3",
-    "@ethereumjs/util": "8.0.0-beta.3",
+    "@ethereumjs/util": "8.0.0-rc.1",
     "@types/async-eventemitter": "^0.2.1",
     "async-eventemitter": "^0.2.4",
     "debug": "^4.3.3",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -61,7 +61,7 @@
     "@ethereumjs/common": "3.0.0-rc.1",
     "@ethereumjs/evm": "1.0.0-beta.3",
     "@ethereumjs/rlp": "4.0.0-rc.1",
-    "@ethereumjs/statemanager": "1.0.0-beta.3",
+    "@ethereumjs/statemanager": "1.0.0-rc.1",
     "@ethereumjs/trie": "5.0.0-rc.1",
     "@ethereumjs/tx": "4.0.0-rc.1",
     "@ethereumjs/util": "8.0.0-rc.1",


### PR DESCRIPTION
Release notes and version updates for the Monorepo Release Candidate 1 breaking releases, following the Beta 3 releases from #2122.