### PR TITLE
evm: add error which triggers if code size deposit exceeds the maximum size

### DIFF
--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -577,7 +577,7 @@ export class EVM implements EVMInterface {
         if (this.DEBUG) {
           debug(`Not enough gas or code size not allowed (>= Homestead)`)
         }
-        result = { ...result, ...OOGResult(message.gasLimit) }
+        result = { ...result, ...CodesizeExceedsMaximumError(message.gasLimit) }
       } else {
         // we are in Frontier
         if (this.DEBUG) {
@@ -1020,6 +1020,14 @@ export function INVALID_EOF_RESULT(gasLimit: bigint): ExecResult {
     returnValue: Buffer.alloc(0),
     executionGasUsed: gasLimit,
     exceptionError: new EvmError(ERROR.INVALID_EOF_FORMAT),
+  }
+}
+
+export function CodesizeExceedsMaximumError(gasUsed: bigint): ExecResult {
+  return {
+    returnValue: Buffer.alloc(0),
+    executionGasUsed: gasUsed,
+    exceptionError: new EvmError(ERROR.CODESIZE_EXCEEDS_MAXIMUM),
   }
 }
 

--- a/packages/evm/src/exceptions.ts
+++ b/packages/evm/src/exceptions.ts
@@ -1,6 +1,7 @@
 export enum ERROR {
   OUT_OF_GAS = 'out of gas',
   CODESTORE_OUT_OF_GAS = 'code store out of gas',
+  CODESIZE_EXCEEDS_MAXIMUM = 'code size to deposit exceeds maximum code size',
   STACK_UNDERFLOW = 'stack underflow',
   STACK_OVERFLOW = 'stack overflow',
   INVALID_JUMP = 'invalid JUMP',

--- a/packages/evm/tests/runCall.spec.ts
+++ b/packages/evm/tests/runCall.spec.ts
@@ -562,6 +562,9 @@ tape('runCall() => allows to detect for max code size deposit errors', async (t)
   const runCallArgs = {
     caller, // call address
     gasLimit: BigInt(0xffffffffff), // ensure we pass a lot of gas, so we do not run out of gas
+    // Simple test, PUSH <big number> PUSH 0 RETURN
+    // It tries to deploy a contract too large, where the code is all zeros
+    // (since memory which is not allocated/resized to yet is always defaulted to 0)
     data: Buffer.from('62FFFFFF6000F3', 'hex'),
   }
 

--- a/packages/evm/tests/runCall.spec.ts
+++ b/packages/evm/tests/runCall.spec.ts
@@ -549,3 +549,26 @@ tape('runCall() -> skipBalance behavior', async (t) => {
     'runCall reverts when insufficient sender balance and skipBalance is false'
   )
 })
+
+tape('runCall() => allows to detect for max code size deposit errors', async (t) => {
+  // setup the accounts for this test
+  const caller = new Address(Buffer.from('00000000000000000000000000000000000000ee', 'hex')) // caller addres
+  // setup the evm
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
+  const eei = await getEEI()
+  const evm = await EVM.create({ common, eei })
+
+  // setup the call arguments
+  const runCallArgs = {
+    caller, // call address
+    gasLimit: BigInt(0xffffffffff), // ensure we pass a lot of gas, so we do not run out of gas
+    data: Buffer.from('62FFFFFF6000F3', 'hex'),
+  }
+
+  const result = await evm.runCall(runCallArgs)
+  t.equal(
+    result.execResult.exceptionError?.error,
+    ERROR.CODESIZE_EXCEEDS_MAXIMUM,
+    'reported error is correct'
+  )
+})


### PR DESCRIPTION
Closes #2065

Adds a new error type to EVM, which allows EVM consumers to figure out the difference between (Homestead or later) contract creation goes OOG, or if the deposited code is too large (exceeds maximum code size).

Checked other errors too, but did not find anything "weird" there.

CC @alcuadrado 