### PR TITLE
feat(trie): support manual setting of checkpoints

### DIFF
--- a/packages/trie/src/db/checkpoint.ts
+++ b/packages/trie/src/db/checkpoint.ts
@@ -18,6 +18,23 @@ export class CheckpointDB implements DB {
   }
 
   /**
+   * Flush the checkpoints and set the requested checkpoints.
+   *
+   * @param {Checkpoint[]} checkpoints
+   * @memberof CheckpointDB
+   */
+  setCheckpoints(checkpoints: Checkpoint[]) {
+    this.checkpoints = []
+
+    for (let i = 0; i < checkpoints.length; i++) {
+      this.checkpoints.push({
+        root: checkpoints[i].root,
+        keyValueMap: new Map(checkpoints[i].keyValueMap),
+      })
+    }
+  }
+
+  /**
    * Is the DB during a checkpoint phase?
    */
   hasCheckpoints() {

--- a/packages/trie/src/db/checkpoint.ts
+++ b/packages/trie/src/db/checkpoint.ts
@@ -18,10 +18,8 @@ export class CheckpointDB implements DB {
   }
 
   /**
-   * Flush the checkpoints and set the requested checkpoints.
-   *
+   * Flush the checkpoints and use the given checkpoints instead.
    * @param {Checkpoint[]} checkpoints
-   * @memberof CheckpointDB
    */
   setCheckpoints(checkpoints: Checkpoint[]) {
     this.checkpoints = []

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -92,7 +92,7 @@ export class Trie {
     return new Trie(opts)
   }
 
-  public database(db?: DB) {
+  database(db?: DB) {
     if (db !== undefined) {
       if (db instanceof CheckpointDB) {
         throw new Error('Cannot pass in an instance of CheckpointDB')

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -759,7 +759,7 @@ export class Trie {
       root: this.root(),
     })
     if (includeCheckpoints && this.hasCheckpoints()) {
-      trie._db.checkpoints = [...this._db.checkpoints]
+      trie._db.setCheckpoints(this._db.checkpoints)
     }
     return trie
   }

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -13,6 +13,7 @@ import { BranchNode, ExtensionNode, LeafNode, decodeNode, decodeRawNode, isRawNo
 
 import type {
   BatchDBOp,
+  DB,
   EmbeddedNode,
   FoundNodeFunction,
   Nibbles,
@@ -46,7 +47,7 @@ export class Trie {
   EMPTY_TRIE_ROOT: Buffer
 
   /** The backend DB */
-  protected _db: CheckpointDB
+  protected _db!: CheckpointDB
   protected _hashLen: number
   protected _lock = new Lock()
   protected _root: Buffer
@@ -60,11 +61,8 @@ export class Trie {
       this._opts = { ...this._opts, ...opts }
     }
 
-    if (opts?.db instanceof CheckpointDB) {
-      throw new Error('Cannot pass in an instance of CheckpointDB')
-    }
+    this.database(opts?.db ?? new MapDB())
 
-    this._db = new CheckpointDB(opts?.db ?? new MapDB())
     this.EMPTY_TRIE_ROOT = this.hash(RLP_EMPTY_STRING)
     this._hashLen = this.EMPTY_TRIE_ROOT.length
     this._root = this.EMPTY_TRIE_ROOT
@@ -92,6 +90,18 @@ export class Trie {
     }
 
     return new Trie(opts)
+  }
+
+  public database(db?: DB) {
+    if (db !== undefined) {
+      if (db instanceof CheckpointDB) {
+        throw new Error('Cannot pass in an instance of CheckpointDB')
+      }
+
+      this._db = new CheckpointDB(db)
+    }
+
+    return this._db
   }
 
   /**


### PR DESCRIPTION
## Checkpoints

This is based on https://github.com/ethereumjs/ethereumjs-monorepo/pull/2203/commits/c5fab21431fded59fe8fc050692ce263296901c6 from @jochem-brouwer but packages it with a nicer API for some upcoming additions I would need for more complex uses of the checkpointing mechanism. This also fixes the shallow copy issue mentioned in https://github.com/ethereumjs/ethereumjs-monorepo/pull/2203.

## Database

More complex use-cases of https://github.com/ethereumjs/ethereumjs-monorepo/pull/2203 like mine with a trie and multiple copies require access to the `CheckpointDB` to be able to access pending checkpoints and grab them. The new `database` function introduced in this PR serves as a `getter` and `setter` like the `root` function. This also has the added benefit of enabling the ability to change the database at run-time if someone has that requirement for some reason.

Combined with `setCheckpoints` this will allow you to do things like `trie.database().setCheckpoints(copy.database().checkpoints)` instead of having to hack around on protected and private APIs _(which they should be, don't consider changing that!)_ and it doesn't require adding more proxy functions to the `Trie` class since people with the need for advanced use-cases can access the `CheckpointDB` directly now.