### PR TITLE
Trie: implement createRangeProof

### DIFF
--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -824,8 +824,33 @@ export class Trie {
     for (let i = 0; i < keyValueItems.length; i++) {
       // TODO keys should be sorted (not sure how the promise event scheduler schedules all events)
       // Could be rather flakey, so need to sort
-      keys.push(keyValueItems[i].key)
-      values.push(keyValueItems[i].value)
+
+      // For some reason keys get added multiple times
+      // (How is this possible? Need to research, if this also happens in findPath then we need to optimize it!!)
+      let found = false
+      for (let j = 0; j < keys.length; j++) {
+        if (keys[j].equals(keyValueItems[i].key)) {
+          found = true
+          break
+        }
+      }
+      if (!found) {
+        keys.push(keyValueItems[i].key)
+      }
+    }
+
+    keys.sort((a, b) => {
+      return Buffer.compare(a, b)
+    })
+
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i]
+      for (let j = 0; j < keyValueItems.length; j++) {
+        if (keyValueItems[j].key.equals(key)) {
+          values.push(keyValueItems[j].value)
+          break
+        }
+      }
     }
 
     return {

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -746,6 +746,10 @@ export class Trie {
    * @param limitHash This is the limit (hash) key item (note on non-hashed tries this is just a key)
    */
   async createRangeProof(startingHash: Buffer, limitHash: Buffer) {
+    if (Buffer.compare(startingHash, limitHash) === 1) {
+      throw new Error('startingHash is higher than limitHash')
+    }
+
     const lowKeyNibbles = bufferToNibbles(startingHash)
     const highKeyNibbles = bufferToNibbles(limitHash)
 

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -785,8 +785,16 @@ export class Trie {
         }
       }
       if (node !== null && node.value() !== null && keyChk(keyProgress)) {
+        let targetKey: Nibbles
+        if (node instanceof BranchNode) {
+          targetKey = keyProgress
+        } else if (node instanceof ExtensionNode) {
+          targetKey = [...keyProgress, ...node._nibbles]
+        } else if (node instanceof LeafNode) {
+          targetKey = [...keyProgress, ...node._nibbles]
+        }
         keyValueItems.push({
-          key: nibblesToBuffer(keyProgress),
+          key: nibblesToBuffer(targetKey!),
           value: node.value()!,
         })
       }

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -766,6 +766,11 @@ export class Trie {
 
     const self = this
 
+    /**
+     * Helper method to walk the trie and only select nodes based upon the `keyCheck` method
+     * @param keyCheck Returns `true` if this key is interesting and this key should be checked
+     * @param initialCheck Optional check, if this returns `true` do not run any checks and immediately return
+     */
     async function walkTrie(keyCheck: (key: Nibbles) => boolean, initialCheck?: () => boolean) {
       await self.walkTrie(self.root(), async (_, node, keyProgress, walkController) => {
         if (initialCheck !== undefined && initialCheck()) {
@@ -807,9 +812,12 @@ export class Trie {
       })
     }
 
+    // Do a normal range check
     await walkTrie(keyChk)
 
     if (keyValueItems.length === 0) {
+      // If there are no key/values, then at least one key/value should be returned
+      // This is thus higher than the requested `limitHash`
       await walkTrie(
         function (key: Nibbles) {
           return nibblesCompare(highKeyNibbles, key) < 0

--- a/packages/trie/src/types.ts
+++ b/packages/trie/src/types.ts
@@ -124,3 +124,8 @@ export type Checkpoint = {
 }
 
 export const ROOT_DB_KEY = Buffer.from('__root__')
+
+export type RangeProofItem = {
+  key: Buffer
+  value: Buffer
+}

--- a/packages/trie/test/proof.spec.ts
+++ b/packages/trie/test/proof.spec.ts
@@ -161,6 +161,8 @@ tape('simple merkle proofs generation and verification', function (tester) {
       useKeyHashing: true,
     })
 
+    const proverTrie = new Trie()
+
     await trie.put(Buffer.from('1000', 'hex'), Buffer.from('a'))
     await trie.put(Buffer.from('1100', 'hex'), Buffer.from('a'))
     await trie.put(Buffer.from('1110', 'hex'), Buffer.from('a'))
@@ -173,14 +175,18 @@ tape('simple merkle proofs generation and verification', function (tester) {
     await trie.put(Buffer.from('3300', 'hex'), Buffer.from('c'))
     await trie.put(Buffer.from('3330', 'hex'), Buffer.from('c'))
 
-    const lKey = Buffer.from('')
-    const rKey = Buffer.from('FFFF', 'hex')
+    const lKey = Buffer.from('00'.repeat(32), 'hex')
+    const rKey = Buffer.from('1234' + '00'.repeat(30), 'hex')
 
     const proof = await trie.createRangeProof(lKey, rKey)
 
-    console.log(proof)
-
-    // fails, invalid key order
-    await trie.verifyRangeProof(trie.root(), lKey, rKey, proof.keys, proof.values, proof.proof)
+    await proverTrie.verifyRangeProof(
+      trie.root(),
+      lKey,
+      rKey,
+      proof.keys,
+      proof.values,
+      proof.proof
+    )
   })
 })

--- a/packages/trie/test/proof.spec.ts
+++ b/packages/trie/test/proof.spec.ts
@@ -1,6 +1,7 @@
 import * as tape from 'tape'
 
 import { Trie, decodeNode } from '../src'
+import { bufferToNibbles } from '../src/util/nibbles'
 
 tape('simple merkle proofs generation and verification', function (tester) {
   const it = tester.test
@@ -156,7 +157,9 @@ tape('simple merkle proofs generation and verification', function (tester) {
   }) */
 
   it('should create range proof', async (t) => {
-    const trie = new Trie()
+    const trie = new Trie({
+      useKeyHashing: true,
+    })
 
     await trie.put(Buffer.from('1000', 'hex'), Buffer.from('a'))
     await trie.put(Buffer.from('1100', 'hex'), Buffer.from('a'))
@@ -171,13 +174,13 @@ tape('simple merkle proofs generation and verification', function (tester) {
     await trie.put(Buffer.from('3330', 'hex'), Buffer.from('c'))
 
     const lKey = Buffer.from('')
-    const rKey = Buffer.from('2FFF', 'hex')
+    const rKey = Buffer.from('FFFF', 'hex')
 
     const proof = await trie.createRangeProof(lKey, rKey)
 
     console.log(proof)
 
     // fails, invalid key order
-    await trie.verifyRangeProof(trie.root(), lKey, rKey, proof.keys, <any>proof.values, proof.proof)
+    await trie.verifyRangeProof(trie.root(), lKey, rKey, proof.keys, proof.values, proof.proof)
   })
 })

--- a/packages/trie/test/proof.spec.ts
+++ b/packages/trie/test/proof.spec.ts
@@ -3,10 +3,11 @@ import * as tape from 'tape'
 import { Trie, decodeNode } from '../src'
 import { bufferToNibbles } from '../src/util/nibbles'
 
+/*
 tape('simple merkle proofs generation and verification', function (tester) {
   const it = tester.test
 
-  /*
+
   it('create a merkle proof and verify it', async (t) => {
     const trie = new Trie()
 
@@ -154,9 +155,14 @@ tape('simple merkle proofs generation and verification', function (tester) {
     t.equal(val!.toString('utf8'), 'c')
 
     t.end()
-  }) */
+  }) 
+})*/
 
-  it('should create range proof', async (t) => {
+tape('createRangeProof()', function (tester) {
+  const it = tester.test
+
+  it('creates one key/value proof', async (t) => {
+    // In this case, there are no key/values between the left and the right key
     const trie = new Trie({
       useKeyHashing: true,
     })
@@ -182,11 +188,13 @@ tape('simple merkle proofs generation and verification', function (tester) {
 
     await proverTrie.verifyRangeProof(
       trie.root(),
-      lKey,
-      rKey,
+      proof.keys[proof.keys.length - 1],
+      proof.keys[proof.keys.length - 1],
       proof.keys,
       proof.values,
       proof.proof
     )
+
+    t.end()
   })
 })

--- a/packages/trie/test/proof.spec.ts
+++ b/packages/trie/test/proof.spec.ts
@@ -158,6 +158,24 @@ tape('simple merkle proofs generation and verification', function (tester) {
 tape('createRangeProof()', function (tester) {
   const it = tester.test
 
+  it('throws when lKey is higher than rKey', async (t) => {
+    const trie = new Trie({
+      useKeyHashing: true,
+    })
+
+    await trie.put(Buffer.from('1000', 'hex'), Buffer.from('a'))
+    await trie.put(Buffer.from('1100', 'hex'), Buffer.from('a'))
+
+    const lKey = Buffer.from('ff'.repeat(32), 'hex')
+    const rKey = Buffer.from('00'.repeat(32), 'hex')
+    try {
+      await trie.createRangeProof(lKey, rKey)
+      t.fail('cannot reach this')
+    } catch (e) {
+      t.pass('succesfully threw')
+    }
+  })
+
   it('creates one key/value proof', async (t) => {
     // In this case, there are no key/values between the left and the right key
     // However, the first value on the right of the rKey key should be reported

--- a/packages/trie/test/proof.spec.ts
+++ b/packages/trie/test/proof.spec.ts
@@ -170,6 +170,14 @@ tape('simple merkle proofs generation and verification', function (tester) {
     await trie.put(Buffer.from('3300', 'hex'), Buffer.from('c'))
     await trie.put(Buffer.from('3330', 'hex'), Buffer.from('c'))
 
-    console.log(await trie.createRangeProof(Buffer.from(''), Buffer.from('2FFF', 'hex')))
+    const lKey = Buffer.from('')
+    const rKey = Buffer.from('2FFF', 'hex')
+
+    const proof = await trie.createRangeProof(lKey, rKey)
+
+    console.log(proof)
+
+    // fails, invalid key order
+    await trie.verifyRangeProof(trie.root(), lKey, rKey, proof.keys, <any>proof.values, proof.proof)
   })
 })

--- a/packages/trie/test/proof.spec.ts
+++ b/packages/trie/test/proof.spec.ts
@@ -1,10 +1,11 @@
 import * as tape from 'tape'
 
-import { Trie } from '../src'
+import { Trie, decodeNode } from '../src'
 
 tape('simple merkle proofs generation and verification', function (tester) {
   const it = tester.test
 
+  /*
   it('create a merkle proof and verify it', async (t) => {
     const trie = new Trie()
 
@@ -152,5 +153,23 @@ tape('simple merkle proofs generation and verification', function (tester) {
     t.equal(val!.toString('utf8'), 'c')
 
     t.end()
+  }) */
+
+  it('should create range proof', async (t) => {
+    const trie = new Trie()
+
+    await trie.put(Buffer.from('1000', 'hex'), Buffer.from('a'))
+    await trie.put(Buffer.from('1100', 'hex'), Buffer.from('a'))
+    await trie.put(Buffer.from('1110', 'hex'), Buffer.from('a'))
+
+    await trie.put(Buffer.from('2000', 'hex'), Buffer.from('b'))
+    await trie.put(Buffer.from('2200', 'hex'), Buffer.from('b'))
+    await trie.put(Buffer.from('2220', 'hex'), Buffer.from('b'))
+
+    await trie.put(Buffer.from('3000', 'hex'), Buffer.from('c'))
+    await trie.put(Buffer.from('3300', 'hex'), Buffer.from('c'))
+    await trie.put(Buffer.from('3330', 'hex'), Buffer.from('c'))
+
+    console.log(await trie.createRangeProof(Buffer.from(''), Buffer.from('2FFF', 'hex')))
   })
 })

--- a/packages/trie/test/proof.spec.ts
+++ b/packages/trie/test/proof.spec.ts
@@ -1,3 +1,5 @@
+import { arrToBufArr } from '@ethereumjs/util'
+import { keccak256 } from 'ethereum-cryptography/keccak'
 import * as tape from 'tape'
 
 import { Trie, decodeNode } from '../src'


### PR DESCRIPTION
Related to #1054 

`createRangeProof` allows users to feed a start key and an end key (unhashed), where the returned proof can be fed into `verifyRangeProof` in order to prove the range. (This can also be used in snap sync)

Note: this is not optimal, because the optimized version would require a flat key/value database. This implementation naively walks the trie, and is thus I/O heavy.

Super WIP.