### PR TITLE
util: remove isTruthy and isFalsy

### DIFF
--- a/packages/util/src/account.ts
+++ b/packages/util/src/account.ts
@@ -15,7 +15,6 @@ import {
 import { KECCAK256_NULL, KECCAK256_RLP } from './constants'
 import { assertIsBuffer, assertIsHexString, assertIsString } from './helpers'
 import { stripHexPrefix } from './internal'
-import { isTruthy } from './types'
 
 import type { BigIntLike, BufferLike } from './types'
 
@@ -38,10 +37,10 @@ export class Account {
     const { nonce, balance, storageRoot, codeHash } = accountData
 
     return new Account(
-      isTruthy(nonce) ? bufferToBigInt(toBuffer(nonce)) : undefined,
-      isTruthy(balance) ? bufferToBigInt(toBuffer(balance)) : undefined,
-      isTruthy(storageRoot) ? toBuffer(storageRoot) : undefined,
-      isTruthy(codeHash) ? toBuffer(codeHash) : undefined
+      nonce !== undefined ? bufferToBigInt(toBuffer(nonce)) : undefined,
+      balance !== undefined ? bufferToBigInt(toBuffer(balance)) : undefined,
+      storageRoot !== undefined ? toBuffer(storageRoot) : undefined,
+      codeHash !== undefined ? toBuffer(codeHash) : undefined
     )
   }
 
@@ -158,7 +157,7 @@ export const toChecksumAddress = function (
   const address = stripHexPrefix(hexAddress).toLowerCase()
 
   let prefix = ''
-  if (isTruthy(eip1191ChainId)) {
+  if (eip1191ChainId !== undefined) {
     const chainId = bufferToBigInt(toBuffer(eip1191ChainId))
     prefix = chainId.toString() + '0x'
   }

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -120,35 +120,3 @@ export function toType<T extends TypeOutput>(
       throw new Error('unknown outputType')
   }
 }
-
-type Falsy = false | '' | 0 | null | undefined | 0n
-
-/**
- * Returns true if a value is falsy
- *
- * @param value - Value to check for falseness
- *
- * @deprecated This helper function should only be used temporarily until the monorepo types are explicit enough
- */
-export function isFalsy(value: unknown): value is Falsy {
-  return !!(
-    value === false ||
-    value === '' ||
-    value === 0 ||
-    Number.isNaN(value) ||
-    value === null ||
-    typeof value === 'undefined' ||
-    value === BigInt(0)
-  )
-}
-
-/**
- * Returns true if a value is truthy
- *
- * @param value - Value to check for truthiness
- *
- * @deprecated This helper function should only be used temporarily until the monorepo types are explicit enough
- */
-export function isTruthy<T>(value: T | Falsy): value is T {
-  return !isFalsy(value)
-}

--- a/packages/util/test/types.spec.ts
+++ b/packages/util/test/types.spec.ts
@@ -8,8 +8,6 @@ import {
   bufferToHex,
   intToBuffer,
   intToHex,
-  isFalsy,
-  isTruthy,
   toBuffer,
   toType,
 } from '../src'
@@ -135,37 +133,5 @@ tape('toType', function (t) {
       }, /^Error: A string must be provided with a 0x-prefix, given: 1$/)
       st.end()
     })
-  })
-})
-
-tape('isFalsy and isTruthy', function (t) {
-  const falsyValues = [false, '', 0, NaN, null, undefined, BigInt(0)]
-  const truthyValues = [true, 'test', -1, 1, BigInt(1), [], {}]
-  t.test('isFalsy should return true for all falsy values', function (st) {
-    for (const falsyValue of falsyValues) {
-      st.ok(isFalsy(falsyValue) === true)
-    }
-    st.end()
-  })
-
-  t.test('isFalsy should return false for truthy values', function (st) {
-    for (const truthyValue of truthyValues) {
-      st.ok(isFalsy(truthyValue) === false)
-    }
-    st.end()
-  })
-
-  t.test('isTruthy should return false for all falsy values', function (st) {
-    for (const falsyValue of falsyValues) {
-      st.ok(isTruthy(falsyValue) === false)
-    }
-    st.end()
-  })
-
-  t.test('isTruthy should return true for truthy values', function (st) {
-    for (const truthyValue of truthyValues) {
-      st.ok(isTruthy(truthyValue) === true)
-    }
-    st.end()
   })
 })


### PR DESCRIPTION
Extracts the util package from #2233. Removes the utils themselves so should be merged once all other packages are merged.