### PR TITLE
trie: adds profiling script back

### DIFF
--- a/packages/trie/benchmarks/random.ts
+++ b/packages/trie/benchmarks/random.ts
@@ -1,0 +1,30 @@
+'use strict'
+import { keccak256 } from 'ethereum-cryptography/keccak'
+import { Trie } from '../dist'
+
+// References:
+// https://eth.wiki/en/fundamentals/benchmarks#the-trie
+// https://gist.github.com/heikoheiko/0fa2b322560ba7794f22
+
+const ROUNDS = 1000
+const KEY_SIZE = 32
+
+export const runTrie = async (eraSize = 9, symmetric = false) => {
+  const trie = new Trie({ useKeyHashing: true })
+  let key = Buffer.alloc(KEY_SIZE)
+
+  for (let i = 0; i <= ROUNDS; i++) {
+    key = Buffer.from(keccak256(key))
+
+    if (symmetric) {
+      await trie.put(key, key)
+    } else {
+      const val = Buffer.from(keccak256(key))
+      await trie.put(key, val)
+    }
+
+    if (i % eraSize === 0) {
+      key = trie.root()
+    }
+  }
+}

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -51,10 +51,11 @@
     "readable-stream": "^3.6.0"
   },
   "devDependencies": {
-    "0x": "^4.9.1",
     "@types/benchmark": "^1.0.33",
     "@types/readable-stream": "^2.3.13",
+    "0x": "^4.9.1",
     "abstract-level": "^1.0.3",
+    "keccak": "^3.0.2",
     "level": "^8.0.0",
     "level-legacy": "npm:level@^7.0.0",
     "level-mem": "^6.0.1",


### PR DESCRIPTION
Adds back a script used for profiling the `trie` package that seems to have been removed at some point during the latest round of breaking release work.

Now does some benchmarking with `keccak256` from `noble/hashes` vs `cryptocoin`

Run `npx ts-node benchmarks/random.ts` to see the output.