### PR TITLE
chore: enable `@typescript-eslint/return-await` rule for `eslint`

### DIFF
--- a/config/eslint.js
+++ b/config/eslint.js
@@ -55,6 +55,7 @@ module.exports = {
     '@typescript-eslint/no-unnecessary-condition': 'off',
     '@typescript-eslint/prefer-nullish-coalescing': 'error',
     '@typescript-eslint/restrict-plus-operands': 'off',
+    '@typescript-eslint/return-await': 'error',
     '@typescript-eslint/strict-boolean-expressions': ['error'],
     eqeqeq: 'error',
     'github/array-foreach': 'error',

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -309,7 +309,7 @@ export class Blockchain implements BlockchainInterface {
    * @param name - Optional name of the iterator head (default: 'vm')
    */
   async getIteratorHead(name = 'vm'): Promise<Block> {
-    return await this.runWithLock<Block>(async () => {
+    return this.runWithLock<Block>(async () => {
       // if the head is not found return the genesis hash
       const hash = this._heads[name] ?? this.genesisBlock.hash()
       const block = await this._getBlock(hash)
@@ -329,7 +329,7 @@ export class Blockchain implements BlockchainInterface {
    * on a first run)
    */
   async getHead(name = 'vm'): Promise<Block> {
-    return await this.runWithLock<Block>(async () => {
+    return this.runWithLock<Block>(async () => {
       // if the head is not found return the headHeader
       const hash = this._heads[name] ?? this._headBlockHash
       if (hash === undefined) throw new Error('No head found.')
@@ -342,7 +342,7 @@ export class Blockchain implements BlockchainInterface {
    * Returns the latest header in the canonical chain.
    */
   async getCanonicalHeadHeader(): Promise<BlockHeader> {
-    return await this.runWithLock<BlockHeader>(async () => {
+    return this.runWithLock<BlockHeader>(async () => {
       if (!this._headHeaderHash) throw new Error('No head header set')
       const block = await this._getBlock(this._headHeaderHash)
       return block.header
@@ -703,7 +703,7 @@ export class Blockchain implements BlockchainInterface {
     // in the `VM` if we encounter a `BLOCKHASH` opcode: then a bigint is used we
     // need to then read the block from the canonical chain Q: is this safe? We
     // know it is OK if we call it from the iterator... (runBlock)
-    return await this._getBlock(blockId)
+    return this._getBlock(blockId)
   }
 
   /**
@@ -737,7 +737,7 @@ export class Blockchain implements BlockchainInterface {
     skip: number,
     reverse: boolean
   ): Promise<Block[]> {
-    return await this.runWithLock<Block[]>(async () => {
+    return this.runWithLock<Block[]>(async () => {
       const blocks: Block[] = []
       let i = -1
 
@@ -754,7 +754,7 @@ export class Blockchain implements BlockchainInterface {
         i++
         const nextBlockNumber = block.header.number + BigInt(reverse ? -1 : 1)
         if (i !== 0 && skip && i % (skip + 1) !== 0) {
-          return await nextBlock(nextBlockNumber)
+          return nextBlock(nextBlockNumber)
         }
         blocks.push(block)
         if (blocks.length < maxBlocks) {
@@ -774,7 +774,7 @@ export class Blockchain implements BlockchainInterface {
    * @param hashes - Ordered array of hashes (ordered on `number`).
    */
   async selectNeededHashes(hashes: Array<Buffer>): Promise<Buffer[]> {
-    return await this.runWithLock<Buffer[]>(async () => {
+    return this.runWithLock<Buffer[]>(async () => {
       let max: number
       let mid: number
       let min: number
@@ -918,7 +918,7 @@ export class Blockchain implements BlockchainInterface {
    * @hidden
    */
   private async _iterator(name: string, onBlock: OnBlock, maxBlocks?: number): Promise<number> {
-    return await this.runWithLock<number>(async (): Promise<number> => {
+    return this.runWithLock<number>(async (): Promise<number> => {
       const headHash = this._heads[name] ?? this.genesisBlock.hash()
 
       if (typeof maxBlocks === 'number' && maxBlocks < 0) {

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -528,7 +528,7 @@ export class Eth {
   async getBlockByNumber(params: [string, boolean]) {
     const [blockOpt, includeTransactions] = params
     const block = await getBlockByOption(blockOpt, this._chain)
-    return await jsonRpcBlock(block, this._chain, includeTransactions)
+    return jsonRpcBlock(block, this._chain, includeTransactions)
   }
 
   /**
@@ -713,7 +713,7 @@ export class Eth {
         skipBlockValidation: true,
       })
       const { totalGasSpent, createdAddress } = runBlockResult.results[txIndex]
-      return jsonRpcReceipt(
+      return await jsonRpcReceipt(
         receipt,
         totalGasSpent,
         effectiveGasPrice,

--- a/packages/client/lib/util/parse.ts
+++ b/packages/client/lib/util/parse.ts
@@ -202,7 +202,7 @@ export async function parseCustomParams(json: any, name?: string) {
     if (name !== undefined) {
       json.name = name
     }
-    return parseGethParams(json)
+    return await parseGethParams(json)
   } catch (e: any) {
     throw new Error(`Error parsing parameters file: ${e.message}`)
   }

--- a/packages/statemanager/src/stateManager.ts
+++ b/packages/statemanager/src/stateManager.ts
@@ -500,7 +500,7 @@ export class DefaultStateManager extends BaseStateManager implements StateManage
    * Checks whether there is a state corresponding to a stateRoot
    */
   async hasStateRoot(root: Buffer): Promise<boolean> {
-    return await this._trie.checkRoot(root)
+    return this._trie.checkRoot(root)
   }
 
   /**

--- a/packages/trie/src/proof/range.ts
+++ b/packages/trie/src/proof/range.ts
@@ -46,7 +46,7 @@ async function unset(
     // continue to the next node
     const next = child.getBranch(key[pos])
     const _child = next && (await trie.lookupNode(next))
-    return await unset(trie, child, _child, key, pos + 1, removeLeft, stack)
+    return unset(trie, child, _child, key, pos + 1, removeLeft, stack)
   } else if (child instanceof ExtensionNode || child instanceof LeafNode) {
     /**
      * This node is an extension node or lead node,
@@ -85,7 +85,7 @@ async function unset(
       stack.push(child)
 
       // continue to the next node
-      return await unset(trie, child, _child, key, pos + child.keyLength(), removeLeft, stack)
+      return unset(trie, child, _child, key, pos + child.keyLength(), removeLeft, stack)
     }
   } else if (child === null) {
     return pos - 1
@@ -234,18 +234,18 @@ async function unsetInternal(trie: Trie, left: Nibbles, right: Nibbles): Promise
 
     if (shortForkLeft !== 0 && shortForkRight !== 0) {
       // Unset the entire trie
-      return await removeSelfFromParentAndSaveStack(left)
+      return removeSelfFromParentAndSaveStack(left)
     }
 
     // Unset left node
     if (shortForkRight !== 0) {
       if (node instanceof LeafNode) {
-        return await removeSelfFromParentAndSaveStack(left)
+        return removeSelfFromParentAndSaveStack(left)
       }
 
       const child = await trie.lookupNode(node._value)
       if (child && child instanceof LeafNode) {
-        return await removeSelfFromParentAndSaveStack(left)
+        return removeSelfFromParentAndSaveStack(left)
       }
 
       const endPos = await unset(trie, node, child, left.slice(pos), node.keyLength(), false, stack)
@@ -257,12 +257,12 @@ async function unsetInternal(trie: Trie, left: Nibbles, right: Nibbles): Promise
     // Unset right node
     if (shortForkLeft !== 0) {
       if (node instanceof LeafNode) {
-        return await removeSelfFromParentAndSaveStack(right)
+        return removeSelfFromParentAndSaveStack(right)
       }
 
       const child = await trie.lookupNode(node._value)
       if (child && child instanceof LeafNode) {
-        return await removeSelfFromParentAndSaveStack(right)
+        return removeSelfFromParentAndSaveStack(right)
       }
 
       const endPos = await unset(trie, node, child, right.slice(pos), node.keyLength(), true, stack)

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -168,7 +168,7 @@ export class Trie {
 
     // If value is empty, delete
     if (value === null || value.length === 0) {
-      return await this.del(key)
+      return this.del(key)
     }
 
     await this._lock.acquire()

--- a/packages/trie/src/util/walkController.ts
+++ b/packages/trie/src/util/walkController.ts
@@ -48,7 +48,7 @@ export class WalkController {
 
   private async startWalk(root: Buffer): Promise<void> {
     // eslint-disable-next-line no-async-promise-executor
-    return await new Promise(async (resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       this.resolve = resolve
       this.reject = reject
       let node

--- a/packages/trie/test/proof/range.spec.ts
+++ b/packages/trie/test/proof/range.spec.ts
@@ -81,7 +81,7 @@ async function verify(
   startKey = startKey ?? entries[start][0]
   endKey = endKey ?? entries[end][0]
   const targetRange = entries.slice(start, end + 1)
-  return await trie.verifyRangeProof(
+  return trie.verifyRangeProof(
     trie.root(),
     startKey,
     endKey,

--- a/packages/vm/src/eei/vmState.ts
+++ b/packages/vm/src/eei/vmState.ts
@@ -133,7 +133,7 @@ export class VmState implements EVMStateAccess {
   }
 
   async getAccount(address: Address): Promise<Account> {
-    return await this._stateManager.getAccount(address)
+    return this._stateManager.getAccount(address)
   }
 
   async putAccount(address: Address, account: Account): Promise<void> {
@@ -155,15 +155,15 @@ export class VmState implements EVMStateAccess {
   }
 
   async getContractCode(address: Address): Promise<Buffer> {
-    return await this._stateManager.getContractCode(address)
+    return this._stateManager.getContractCode(address)
   }
 
   async putContractCode(address: Address, value: Buffer): Promise<void> {
-    return await this._stateManager.putContractCode(address, value)
+    return this._stateManager.putContractCode(address, value)
   }
 
   async getContractStorage(address: Address, key: Buffer): Promise<Buffer> {
-    return await this._stateManager.getContractStorage(address, key)
+    return this._stateManager.getContractStorage(address, key)
   }
 
   async putContractStorage(address: Address, key: Buffer, value: Buffer) {
@@ -177,22 +177,22 @@ export class VmState implements EVMStateAccess {
   }
 
   async accountExists(address: Address): Promise<boolean> {
-    return await this._stateManager.accountExists(address)
+    return this._stateManager.accountExists(address)
   }
 
   async setStateRoot(stateRoot: Buffer): Promise<void> {
     if (this._checkpointCount !== 0) {
       throw new Error('Cannot set state root with uncommitted checkpoints')
     }
-    return await this._stateManager.setStateRoot(stateRoot)
+    return this._stateManager.setStateRoot(stateRoot)
   }
 
   async getStateRoot(): Promise<Buffer> {
-    return await this._stateManager.getStateRoot()
+    return this._stateManager.getStateRoot()
   }
 
   async hasStateRoot(root: Buffer): Promise<boolean> {
-    return await this._stateManager.hasStateRoot(root)
+    return this._stateManager.hasStateRoot(root)
   }
 
   /**

--- a/packages/vm/tests/api/buildBlock.spec.ts
+++ b/packages/vm/tests/api/buildBlock.spec.ts
@@ -153,7 +153,7 @@ tape('BlockBuilder', async (t) => {
 
     st.ok(block.header.mixHash.equals(sealOpts.mixHash))
     st.ok(block.header.nonce.equals(sealOpts.nonce))
-    st.doesNotThrow(async () => await vm.blockchain.consensus.validateDifficulty(block.header))
+    st.doesNotThrow(async () => vm.blockchain.consensus.validateDifficulty(block.header))
     st.end()
   })
 


### PR DESCRIPTION
Enables https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/return-await.md which ensures that `await` is used appropriately, like for example `return await` inside a `try/catch` to make sure the catch can handle any errors.