### PR TITLE
Remove extra computation

### DIFF
--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -662,7 +662,6 @@ export const handlers: Map<number, OpHandler> = new Map([
       const [offset, word] = runState.stack.popN(2)
       const buf = setLengthLeft(bigIntToBuffer(word), 32)
       const offsetNum = Number(offset)
-      runState.memory.extend(offsetNum, 32)
       runState.memory.write(offsetNum, 32, buf)
     },
   ],
@@ -674,7 +673,6 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       const buf = bigIntToBuffer(byte & BigInt(0xff))
       const offsetNum = Number(offset)
-      runState.memory.extend(offsetNum, 1)
       runState.memory.write(offsetNum, 1, buf)
     },
   ],

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -455,7 +455,6 @@ export const handlers: Map<number, OpHandler> = new Map([
         const data = getDataSlice(runState.interpreter.getCallData(), dataOffset, dataLength)
         const memOffsetNum = Number(memOffset)
         const dataLengthNum = Number(dataLength)
-        runState.memory.extend(memOffsetNum, dataLengthNum)
         runState.memory.write(memOffsetNum, dataLengthNum, data)
       }
     },
@@ -477,7 +476,6 @@ export const handlers: Map<number, OpHandler> = new Map([
         const data = getDataSlice(runState.interpreter.getCode(), codeOffset, dataLength)
         const memOffsetNum = Number(memOffset)
         const lengthNum = Number(dataLength)
-        runState.memory.extend(memOffsetNum, lengthNum)
         runState.memory.write(memOffsetNum, lengthNum, data)
       }
     },
@@ -505,7 +503,6 @@ export const handlers: Map<number, OpHandler> = new Map([
         const data = getDataSlice(code, codeOffset, dataLength)
         const memOffsetNum = Number(memOffset)
         const lengthNum = Number(dataLength)
-        runState.memory.extend(memOffsetNum, lengthNum)
         runState.memory.write(memOffsetNum, lengthNum, data)
       }
     },
@@ -548,7 +545,6 @@ export const handlers: Map<number, OpHandler> = new Map([
         )
         const memOffsetNum = Number(memOffset)
         const lengthNum = Number(dataLength)
-        runState.memory.extend(memOffsetNum, lengthNum)
         runState.memory.write(memOffsetNum, lengthNum, data)
       }
     },


### PR DESCRIPTION
We extend the Memory inside of the write function, so it is unnecessary to do it here.