### PR TITLE
client: Fix Dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16-alpine as build
 WORKDIR /usr/app
-RUN apk update && apk add --no-cache bash git && rm -rf /var/cache/apk/*
+RUN apk update && apk add --no-cache bash git g++ make python3 && rm -rf /var/cache/apk/*
 
 ARG VERSION=latest
 ENV VERSION=$VERSION


### PR DESCRIPTION
The docker file build was failing because of addition of `node-gyp` which requests some more build infra. 
This PR adds the same!