### PR TITLE
statemanager: remove eslint-disable from imports

### DIFF
--- a/packages/statemanager/src/cache.ts
+++ b/packages/statemanager/src/cache.ts
@@ -1,9 +1,7 @@
 import { Account } from '@ethereumjs/util'
-// eslint-disable-next-line implicit-dependencies/no-implicit
 import { OrderedMap } from 'js-sdsl'
 
 import type { Address } from '@ethereumjs/util'
-// eslint-disable-next-line implicit-dependencies/no-implicit
 import type { OrderedMapIterator } from 'js-sdsl'
 
 export type getCb = (address: Address) => Promise<Account | undefined>


### PR DESCRIPTION
Fixes tiny issue from #2105

* See if eslint-disable-next-line implicit-dependencies/no-implicit for js-sdsl depdendency import from PR #2285 can be removed (should be possible)

Removing the eslint-disable comments had no effect as expected.
