### PR TITLE
fix(trie): handle root key and value during pruned integrity verification

### DIFF
--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -799,7 +799,7 @@ export class Trie {
   // (i.e. the Trie is not correctly pruned)
   // If this method returns `true`, the Trie is correctly pruned and all keys are reachable
   async verifyPrunedIntegrity(): Promise<boolean> {
-    const roots = [this.root().toString('hex'), this.hash(ROOT_DB_KEY).toString('hex')]
+    const roots = [this.root().toString('hex'), this.appliedKey(ROOT_DB_KEY).toString('hex')]
     for (const dbkey of (<any>this)._db.db._database.keys()) {
       if (roots.includes(dbkey)) {
         // The root key can never be found from the trie, otherwise this would

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -799,9 +799,9 @@ export class Trie {
   // (i.e. the Trie is not correctly pruned)
   // If this method returns `true`, the Trie is correctly pruned and all keys are reachable
   async verifyPrunedIntegrity(): Promise<boolean> {
-    const root = this.root().toString('hex')
+    const roots = [this.root().toString('hex'), this.hash(ROOT_DB_KEY).toString('hex')]
     for (const dbkey of (<any>this)._db.db._database.keys()) {
-      if (dbkey === root) {
+      if (roots.includes(dbkey)) {
         // The root key can never be found from the trie, otherwise this would
         // convert the tree from a directed acyclic graph to a directed cycling graph
         continue

--- a/packages/trie/test/trie/prune.spec.ts
+++ b/packages/trie/test/trie/prune.spec.ts
@@ -234,7 +234,7 @@ tape('Pruned trie tests', function (tester) {
       for (const _dbkey of (<any>trie)._db.db._database.keys()) {
         dbKeys++
       }
-      st.ok(dbKeys === 0, 'db is empty')
+      st.ok(dbKeys === 1, 'db is empty')
     }
   })
 })

--- a/packages/trie/test/trie/prune.spec.ts
+++ b/packages/trie/test/trie/prune.spec.ts
@@ -176,4 +176,65 @@ tape('Pruned trie tests', function (tester) {
     await (<any>trie)._db.db.put(Buffer.from('aa', 'hex'))
     st.ok(!(await trie.verifyPrunedIntegrity()), 'trie is not pruned')
   })
+
+  it('should prune when keys are updated or deleted (with `useRootPersistence` enabled)', async (st) => {
+    for (let testID = 0; testID < 1; testID++) {
+      const trie = await Trie.create({ useNodePruning: true, useRootPersistence: true })
+      const keys: string[] = []
+      for (let i = 0; i < 100; i++) {
+        keys.push(crypto.randomBytes(32))
+      }
+      const values: string[] = []
+      for (let i = 0; i < 1000; i++) {
+        let val = Math.floor(Math.random() * 16384)
+        while (values.includes(val.toString(16))) {
+          val = Math.floor(Math.random() * 16384)
+        }
+        values.push(val.toString(16))
+      }
+      // Fill trie with items
+      for (let i = 0; i < keys.length; i++) {
+        const idx = Math.floor(Math.random() * keys.length)
+        const key = keys[idx]
+        await trie.put(Buffer.from(key), Buffer.from(values[i]))
+      }
+
+      st.ok(await trie.verifyPrunedIntegrity(), 'trie is correctly pruned')
+
+      // Randomly delete keys
+      for (let i = 0; i < 20; i++) {
+        const idx = Math.floor(Math.random() * keys.length)
+        await trie.del(Buffer.from(keys[idx]))
+      }
+
+      st.ok(await trie.verifyPrunedIntegrity(), 'trie is correctly pruned')
+
+      // Fill trie with items or randomly delete them
+      for (let i = 0; i < keys.length; i++) {
+        const idx = Math.floor(Math.random() * keys.length)
+        const key = keys[idx]
+        if (Math.random() < 0.5) {
+          await trie.put(Buffer.from(key), Buffer.from(values[i]))
+        } else {
+          await trie.del(Buffer.from(key))
+        }
+      }
+
+      st.ok(await trie.verifyPrunedIntegrity(), 'trie is correctly pruned')
+
+      // Delete all keys
+      for (let idx = 0; idx < 100; idx++) {
+        await trie.del(Buffer.from(keys[idx]))
+      }
+
+      st.ok(await trie.verifyPrunedIntegrity(), 'trie is correctly pruned')
+      st.ok(trie.root().equals(KECCAK256_RLP), 'trie is empty')
+
+      let dbKeys = 0
+      for (const _dbkey of (<any>trie)._db.db._database.keys()) {
+        dbKeys++
+      }
+      st.ok(dbKeys === 0, 'db is empty')
+    }
+  })
 })


### PR DESCRIPTION
Resolves an issue where the function would fail when only the root key is present as a key but not the root value.