### PR TITLE
EVM-State-Tests

### DIFF
--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -43,6 +43,11 @@
     "tape": "tape -r ts-node/register --stack-size=1500",
     "test": "npm run tape -- './tests/**/*.spec.ts'",
     "test:browser": "karma start karma.conf.js",
+    "tester": "ts-node ./tests/tester --stack-size=1500",
+    "test:state": "npm run tester -- --state",
+    "test:state:allForks": "echo 'Chainstart Homestead dao TangerineWhistle SpuriousDragon Byzantium Constantinople Petersburg Istanbul MuirGlacier Berlin London ByzantiumToConstantinopleFixAt5 EIP158ToByzantiumAt5 FrontierToHomesteadAt5 HomesteadToDaoAt5 HomesteadToEIP150At5 BerlinToLondonAt5' | xargs -n1 | xargs -I v1 npm run test:state -- --fork=v1 --verify-test-amount-alltests",
+    "test:state:selectedForks": "echo 'Homestead TangerineWhistle SpuriousDragon Petersburg Berlin London' | xargs -n1 | xargs -I v1 npm run test:state -- --fork=v1 --verify-test-amount-alltests",
+    "test:state:slow": "npm run test:state -- --runSkipped=slow",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/evm/tests/tester/config.ts
+++ b/packages/evm/tests/tester/config.ts
@@ -1,0 +1,504 @@
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import * as path from 'path'
+
+/**
+ * Default tests path (git submodule: ethereum-tests)
+ */
+export const DEFAULT_TESTS_PATH = path.resolve('../ethereum-tests')
+
+/**
+ * Default hardfork rules to run tests against
+ */
+export const DEFAULT_FORK_CONFIG = 'Merge'
+
+/**
+ * Tests which should be fixed
+ */
+export const SKIP_BROKEN = [
+  'ForkStressTest', // Only BlockchainTest, temporary till fixed (2020-05-23)
+  'ChainAtoChainB', // Only BlockchainTest, temporary, along expectException fixes (2020-05-23)
+
+  // In these tests, we have access to two forked chains. Their total difficulty is equal. There are errors in the second chain, but we have no reason to execute this chain if the TD remains equal.
+  'blockChainFrontierWithLargerTDvsHomesteadBlockchain2_FrontierToHomesteadAt5',
+  'blockChainFrontierWithLargerTDvsHomesteadBlockchain_FrontierToHomesteadAt5',
+  'HomesteadOverrideFrontier_FrontierToHomesteadAt5',
+]
+
+/**
+ * Tests skipped due to system specifics / design considerations
+ */
+export const SKIP_PERMANENT = [
+  'SuicidesMixingCoinbase', // suicides to the coinbase, since we run a blockLevel we create coinbase account.
+  'static_SuicidesMixingCoinbase', // suicides to the coinbase, since we run a blockLevel we create coinbase account.
+  'ForkUncle', // Only BlockchainTest, correct behavior unspecified (?)
+  'UncleFromSideChain', // Only BlockchainTest, same as ForkUncle, the TD is the same for two different branches so its not clear which one should be the finally chain
+]
+
+/**
+ * tests running slow (run from time to time)
+ */
+export const SKIP_SLOW = [
+  'Call50000',
+  'Call50000_ecrec',
+  'Call50000_identity',
+  'Call50000_identity2',
+  'Call50000_sha256',
+  'Call50000_rip160',
+  'Call50000bytesContract50_1',
+  'Call50000bytesContract50_2',
+  'Call1MB1024Calldepth',
+  'static_Call1MB1024Calldepth',
+  'static_Call50000',
+  'static_Call50000_ecrec',
+  'static_Call50000_identity',
+  'static_Call50000_identity2',
+  'static_Call50000_rip160',
+  'static_Return50000_2',
+  'Callcode50000',
+  'Return50000',
+  'Return50000_2',
+  'static_Call50000',
+  'static_Call50000_ecrec',
+  'static_Call50000_identity',
+  'static_Call50000_identity2',
+  'static_Call50000_sha256',
+  'static_Call50000_rip160',
+  'static_Call50000bytesContract50_1',
+  'static_Call50000bytesContract50_2',
+  'static_Call1MB1024Calldepth',
+  'static_Callcode50000',
+  'static_Return50000',
+  'static_Return50000_2',
+  'QuadraticComplexitySolidity_CallDataCopy',
+  'CALLBlake2f_MaxRounds',
+  'randomStatetest94_Istanbul',
+  // vmPerformance tests
+  'ackermann',
+  'fibonacci',
+  'loop-add-10M',
+  'loop-divadd-10M',
+  'loop-divadd-unr100-10M',
+  'loop-exp',
+  'loop-mul',
+  'manyFunctions100',
+  'loopMul',
+  'loopExp',
+]
+
+/**
+ * VMTests have been deprecated, see https://github.com/ethereum/tests/issues/593
+ * skipVM test list is currently not used but might be useful in the future since VMTests
+ * have now been converted to BlockchainTests, see https://github.com/ethereum/tests/pull/680
+ * Disabling this due to ESLint, but will keep it here for possible future reference
+ */
+/*const SKIP_VM = [
+  // slow performance tests
+  'loop-mul',
+  'loop-add-10M',
+  'loop-divadd-10M',
+  'loop-divadd-unr100-10M',
+  'loop-exp-16b-100k',
+  'loop-exp-1b-1M',
+  'loop-exp-2b-100k',
+  'loop-exp-32b-100k',
+  'loop-exp-4b-100k',
+  'loop-exp-8b-100k',
+  'loop-exp-nop-1M',
+  'loop-mulmod-2M',
+  'ABAcalls0',
+  'ABAcallsSuicide0',
+  'ABAcallsSuicide1',
+  'sha3_bigSize',
+  'CallRecursiveBomb0',
+  'CallToNameRegistrator0',
+  'CallToPrecompiledContract',
+  'CallToReturn1',
+  'PostToNameRegistrator0',
+  'PostToReturn1',
+  'callcodeToNameRegistrator0',
+  'callcodeToReturn1',
+  'callstatelessToNameRegistrator0',
+  'callstatelessToReturn1',
+  'createNameRegistrator',
+  'randomTest643',
+]*/
+
+/**
+ * Returns an alias for specified hardforks to meet test dependencies requirements/assumptions.
+ * @param {String} forkConfig - the name of the hardfork for which an alias should be returned
+ * @returns {String} Either an alias of the forkConfig param, or the forkConfig param itself
+ */
+export function getRequiredForkConfigAlias(forkConfig: string) {
+  // Chainstart is also called Frontier and is called as such in the tests
+  if (String(forkConfig).match(/^chainstart$/i)) {
+    return 'Frontier'
+  }
+  // TangerineWhistle is named EIP150 (attention: misleading name)
+  // in the client-independent consensus test suite
+  if (String(forkConfig).match(/^tangerineWhistle$/i)) {
+    return 'EIP150'
+  }
+  // SpuriousDragon is named EIP158 (attention: misleading name)
+  // in the client-independent consensus test suite
+  if (String(forkConfig).match(/^spuriousDragon$/i)) {
+    return 'EIP158'
+  }
+  // Run the Istanbul tests for MuirGlacier since there are no dedicated tests
+  if (String(forkConfig).match(/^muirGlacier/i)) {
+    return 'Istanbul'
+  }
+  // Petersburg is named ConstantinopleFix
+  // in the client-independent consensus test suite
+  if (String(forkConfig).match(/^petersburg$/i)) {
+    return 'ConstantinopleFix'
+  }
+  return forkConfig
+}
+
+const normalHardforks = [
+  'chainstart',
+  'homestead',
+  'dao',
+  'tangerineWhistle',
+  'spuriousDragon',
+  'byzantium',
+  'constantinople',
+  'petersburg',
+  'istanbul',
+  'muirGlacier',
+  'berlin',
+  'london',
+  'merge',
+  'arrowGlacier', // This network has no tests, but need to add it due to common generation logic
+]
+
+const transitionNetworks = {
+  ByzantiumToConstantinopleFixAt5: {
+    byzantium: 0,
+    constantinople: 5,
+    petersburg: 5,
+    dao: null,
+    finalSupportedFork: 'petersburg',
+    startFork: 'byzantium',
+  },
+  EIP158ToByzantiumAt5: {
+    spuriousDragon: 0,
+    byzantium: 5,
+    dao: null,
+    finalSupportedFork: 'byzantium',
+    startFork: 'spuriousDragon',
+  },
+  FrontierToHomesteadAt5: {
+    chainstart: 0,
+    homestead: 5,
+    dao: null,
+    finalSupportedFork: 'homestead',
+    startFork: 'chainstart',
+  },
+  HomesteadToDaoAt5: {
+    homestead: 0,
+    dao: 5,
+    finalSupportedFork: 'dao',
+    startFork: 'homestead',
+  },
+  HomesteadToEIP150At5: {
+    homestead: 0,
+    tangerineWhistle: 5,
+    dao: null,
+    finalSupportedFork: 'tangerineWhistle',
+    startFork: 'homestead',
+  },
+  BerlinToLondonAt5: {
+    berlin: 0,
+    london: 5,
+    dao: null,
+    finalSupportedFork: 'london',
+    startFork: 'berlin',
+  },
+}
+
+const retestethAlias = {
+  Frontier: 'chainstart',
+  EIP150: 'tangerineWhistle',
+  EIP158: 'spuriousDragon',
+  ConstantinopleFix: 'petersburg',
+  Merged: 'merge',
+}
+
+const testLegacy = {
+  chainstart: true,
+  homestead: true,
+  tangerineWhistle: true,
+  spuriousDragon: true,
+  byzantium: true,
+  constantinople: true,
+  petersburg: true,
+  istanbul: false,
+  muirGlacier: false,
+  berlin: false,
+  london: false,
+  merge: false,
+  ByzantiumToConstantinopleFixAt5: false,
+  EIP158ToByzantiumAt5: false,
+  FrontierToHomesteadAt5: false,
+  HomesteadToDaoAt5: false,
+  HomesteadToEIP150At5: false,
+  BerlinToLondonAt5: false,
+}
+
+/**
+ * Returns an array of dirs to run tests on
+ * @param network (fork identifier)
+ * @param testType (BlockchainTests/StateTests)
+ */
+export function getTestDirs(network: string, testType: string) {
+  const testDirs = [testType]
+  for (const key in testLegacy) {
+    if (
+      key.toLowerCase() === network.toLowerCase() &&
+      testLegacy[key as keyof typeof testLegacy] === true
+    ) {
+      // Tests for HFs before Istanbul have been moved under `LegacyTests/Constantinople`:
+      // https://github.com/ethereum/tests/releases/tag/v7.0.0-beta.1
+      testDirs.push('LegacyTests/Constantinople/' + testType)
+      break
+    }
+  }
+  return testDirs
+}
+/**
+ * Setups the common with networks
+ * @param network Network target (this can include EIPs, such as Byzantium+2537+2929)
+ * @param ttd If set: total terminal difficulty to switch to merge
+ * @returns
+ */
+function setupCommonWithNetworks(network: string, ttd?: number) {
+  let networkLowercase: string // This only consists of the target hardfork, so without the EIPs
+  if (network.includes('+')) {
+    const index = network.indexOf('+')
+    networkLowercase = network.slice(0, index).toLowerCase()
+  } else {
+    networkLowercase = network.toLowerCase()
+  }
+  // normal hard fork, return the common with this hard fork
+  // find the right upper/lowercased version
+  const hfName = normalHardforks.reduce((previousValue, currentValue) =>
+    currentValue.toLowerCase() === networkLowercase ? currentValue : previousValue
+  )
+  const mainnetCommon = new Common({ chain: Chain.Mainnet, hardfork: hfName })
+  const hardforks = mainnetCommon.hardforks()
+  const testHardforks = []
+  for (const hf of hardforks) {
+    // check if we enable this hf
+    // disable dao hf by default (if enabled at block 0 forces the first 10 blocks to have dao-hard-fork in extraData of block header)
+    if (mainnetCommon.gteHardfork(hf.name) === true && hf.name !== Hardfork.Dao) {
+      // this hardfork should be activated at block 0
+      testHardforks.push({
+        name: hf.name,
+        // Current type definition Partial<Chain> in Common is currently not allowing to pass in forkHash
+        // forkHash: hf.forkHash,
+        block: 0,
+      })
+    } else {
+      // disable hardforks newer than the test hardfork (but do add "support" for it, it just never gets activated)
+      if (ttd === undefined) {
+        testHardforks.push({
+          name: hf.name,
+          //forkHash: hf.forkHash,
+          block: null,
+        })
+      } else if (hf.name === 'merge') {
+        // merge will currently always be after a hardfork, so add it here
+        testHardforks.push({
+          name: hf.name,
+          block: null,
+          ttd: BigInt(ttd),
+        })
+      }
+    }
+  }
+  const common = Common.custom(
+    {
+      hardforks: testHardforks,
+      defaultHardfork: hfName,
+    },
+    { eips: [3607] }
+  )
+  // Activate EIPs
+  const eips = network.match(/(?<=\+)(.\d+)/g)
+  if (eips) {
+    common.setEIPs(eips.map((e: string) => parseInt(e)))
+  }
+  return common
+}
+
+/**
+ * Returns a Common for the given network (a test parameter)
+ * @param network - the network field of a test.
+ * If this network has a `+` sign, it will also include these EIPs.
+ * For instance, London+3855 will activate the network on the London hardfork, but will also activate EIP 3855.
+ * Multiple EIPs can also be activated by separating them with a `+` sign.
+ * For instance, "London+3855+3860" will also activate EIP-3855 and EIP-3860.
+ * @returns the Common which should be used
+ */
+export function getCommon(network: string): Common {
+  if (retestethAlias[network as keyof typeof retestethAlias] !== undefined) {
+    network = retestethAlias[network as keyof typeof retestethAlias]
+  }
+  let networkLowercase = network.toLowerCase()
+  if (network.includes('+')) {
+    const index = network.indexOf('+')
+    networkLowercase = network.slice(0, index).toLowerCase()
+  }
+  if (normalHardforks.map((str) => str.toLowerCase()).includes(networkLowercase)) {
+    // Case 1: normal network, such as "London" or "Byzantium" (without any EIPs enabled, and it is not a transition network)
+    return setupCommonWithNetworks(network)
+  } else if (networkLowercase.match('tomergeatdiff')) {
+    // Case 2: special case of a transition network, this setups the right common with the right Merge properties (TTD)
+    // This is a HF -> Merge transition
+    const start = networkLowercase.match('tomergeatdiff')!.index!
+    const end = start + 'tomergeatdiff'.length
+    const startNetwork = network.substring(0, start) // HF before the merge
+    const TTD = Number('0x' + network.substring(end)) // Total difficulty to transition to PoS
+    return setupCommonWithNetworks(startNetwork, TTD)
+  } else {
+    // Case 3: this is not a "default fork" network, but it is a "transition" network. Test the VM if it transitions the right way
+    const transitionForks =
+      network in transitionNetworks
+        ? transitionNetworks[network as keyof typeof transitionNetworks]
+        : transitionNetworks[
+            (network.charAt(0).toUpperCase() + network.slice(1)) as keyof typeof transitionNetworks
+          ]
+    if (transitionForks === undefined) {
+      throw new Error('network not supported: ' + network)
+    }
+    const mainnetCommon = new Common({
+      chain: Chain.Mainnet,
+      hardfork: transitionForks.finalSupportedFork,
+    })
+    const hardforks = mainnetCommon.hardforks()
+    const testHardforks = []
+    for (const hf of hardforks) {
+      if (mainnetCommon.gteHardfork(hf.name) === true) {
+        // this hardfork should be activated at block 0
+        const forkBlockNumber = transitionForks[hf.name as keyof typeof transitionForks] as
+          | number
+          | null
+          | undefined
+        testHardforks.push({
+          name: hf.name,
+          block: forkBlockNumber ?? 0, // If hardfork isn't in transitionForks, activate at 0
+        })
+      } else {
+        // disable the hardfork
+        testHardforks.push({
+          name: hf.name,
+          block: null,
+        })
+      }
+    }
+    return Common.custom(
+      {
+        hardforks: testHardforks,
+      },
+      {
+        baseChain: 'mainnet',
+        hardfork: transitionForks.startFork,
+        eips: [3607],
+      }
+    )
+  }
+}
+
+const expectedTestsFull: {
+  BlockchainTests: Record<string, number | undefined>
+  GeneralStateTests: Record<string, number | undefined>
+} = {
+  BlockchainTests: {
+    Chainstart: 4496,
+    Homestead: 7321,
+    Dao: 0,
+    TangerineWhistle: 4609,
+    SpuriousDragon: 4632,
+    Byzantium: 15703,
+    Constantinople: 33146,
+    Petersburg: 33128,
+    Istanbul: 38773,
+    MuirGlacier: 38773,
+    Berlin: 41872,
+    London: 61547,
+    ArrowGlacier: 0,
+    Merge: 60373,
+    ByzantiumToConstantinopleFixAt5: 3,
+    EIP158ToByzantiumAt5: 3,
+    FrontierToHomesteadAt5: 13,
+    HomesteadToDaoAt5: 32,
+    HomesteadToEIP150At5: 3,
+    BerlinToLondonAt5: 24,
+  },
+  GeneralStateTests: {
+    Chainstart: 1045,
+    Homestead: 2078,
+    Dao: 0,
+    TangerineWhistle: 1200,
+    SpuriousDragon: 1325,
+    Byzantium: 4857,
+    Constantinople: 10648,
+    Petersburg: 10642,
+    Istanbul: 12439,
+    MuirGlacier: 12439,
+    Berlin: 13214,
+    London: 19449,
+    ByzantiumToConstantinopleFixAt5: 0,
+    EIP158ToByzantiumAt5: 0,
+    FrontierToHomesteadAt5: 0,
+    HomesteadToDaoAt5: 0,
+    HomesteadToEIP150At5: 0,
+    BerlinToLondonAt5: 0,
+  },
+}
+
+/**
+ * Returns the amount of expected tests for a given fork, assuming all tests are ran
+ */
+export function getExpectedTests(
+  fork: string,
+  name: 'BlockchainTests' | 'GeneralStateTests'
+): number | undefined {
+  if (expectedTestsFull[name] === undefined) {
+    return
+  }
+  for (const key in expectedTestsFull[name]) {
+    if (fork.toLowerCase() === key.toLowerCase()) {
+      return expectedTestsFull[name][key]
+    }
+  }
+}
+
+/**
+ * Returns an aggregated array with the tests to skip
+ * @param choices comma-separated list with skip options, e.g. BROKEN,PERMANENT
+ * @param defaultChoice if to use `NONE` or `ALL` as default choice
+ * @returns array with test names
+ */
+export function getSkipTests(choices: string, defaultChoice: string): string[] {
+  let skipTests: string[] = []
+  if (!choices) {
+    choices = defaultChoice
+  }
+  choices = choices.toLowerCase()
+  if (choices !== 'none') {
+    const choicesList = choices.split(',')
+    const all = choicesList.includes('all')
+    if (all || choicesList.includes('broken')) {
+      skipTests = skipTests.concat(SKIP_BROKEN)
+    }
+    if (all || choicesList.includes('permanent')) {
+      skipTests = skipTests.concat(SKIP_PERMANENT)
+    }
+    if (all || choicesList.includes('slow')) {
+      skipTests = skipTests.concat(SKIP_SLOW)
+    }
+  }
+  return skipTests
+}

--- a/packages/evm/tests/tester/index.ts
+++ b/packages/evm/tests/tester/index.ts
@@ -1,0 +1,267 @@
+import * as minimist from 'minimist'
+import * as path from 'path'
+import * as process from 'process'
+import * as tape from 'tape'
+
+import {
+  DEFAULT_FORK_CONFIG,
+  DEFAULT_TESTS_PATH,
+  getCommon,
+  getExpectedTests,
+  getRequiredForkConfigAlias,
+  getSkipTests,
+  getTestDirs,
+} from './config'
+import { runBlockchainTest } from './runners/BlockchainTestsRunner'
+import { runStateTest } from './runners/GeneralStateTestsRunner'
+import { getTestFromSource, getTestsFromArgs } from './testLoader'
+
+import type { Common } from '@ethereumjs/common'
+
+/**
+ * Test runner
+ * CLI arguments:
+ * --state: boolean.                      Run state tests
+ * --blockchain: boolean.                 Run blockchain tests
+ * --fork: string.                        Fork to use for these tests
+ * --skip: string.                        Comma-separated list of tests to skip. choices of: all,broken,permanent,slow. Defaults to all
+ * --runSkipped: string.                  Comma-separated list of tests to skip if --skip is not set. choices of: all,broken,permanent,slow. Defaults to none
+ * --file: string.                        Test file to run
+ * --test: string.                        Test name to run
+ * --dir: string.                         Test directory to look for tests
+ * --excludeDir: string.                  Test directory to exclude from testing
+ * --testsPath: string.                   Root directory of tests to look (default: '../ethereum-tests')
+ * --customTestsPath: string.             Custom directory to look for tests (e.g. '../../my_custom_test_folder')
+ * --customStateTest: string.             Run a file with a custom state test (not in test directory)
+ * --jsontrace: boolean.                  Enable json step tracing in state tests
+ * --dist: boolean.                       Use the compiled version of the VM
+ * --data: number.                        Only run this state test if the transaction has this calldata
+ * --gas: number.                         Only run this state test if the transaction has this gasLimit
+ * --value: number.                       Only run this state test if the transaction has this call value
+ * --debug: boolean.                      Enable BlockchainTests debugger (compares post state against the expected post state)
+ * --expected-test-amount: number.        If passed, check after tests are ran if at least this amount of tests have passed (inclusive)
+ * --verify-test-amount-alltests: number. If passed, get the expected amount from tests and verify afterwards if this is the count of tests (expects tests are ran with default settings)
+ * --reps: number.                        If passed, each test case will be run the number of times indicated
+ */
+
+const argv = minimist(process.argv.slice(2))
+
+async function runTests() {
+  let name: 'GeneralStateTests' | 'BlockchainTests'
+  let runner: any
+  if ((argv.state as boolean) === true) {
+    name = 'GeneralStateTests'
+    runner = runStateTest
+  } else if ((argv.blockchain as boolean) === true) {
+    name = 'BlockchainTests'
+    runner = runBlockchainTest
+  } else {
+    console.log(`Test type not supported or provided`)
+    process.exit(1)
+  }
+
+  const FORK_CONFIG: string = argv.fork !== undefined ? argv.fork : DEFAULT_FORK_CONFIG
+  const FORK_CONFIG_TEST_SUITE = getRequiredForkConfigAlias(FORK_CONFIG)
+
+  // Examples: Istanbul -> istanbul, MuirGlacier -> muirGlacier
+  const FORK_CONFIG_VM = FORK_CONFIG.charAt(0).toLowerCase() + FORK_CONFIG.substring(1)
+
+  /**
+   * Configuration for getting the tests from the ethereum/tests repository
+   */
+  const testGetterArgs: {
+    skipTests: string[]
+    runSkipped: string[]
+    forkConfig: string
+    file?: string
+    test?: string
+    dir?: string
+    excludeDir?: string
+    testsPath?: string
+    customStateTest?: string
+    directory?: string
+  } = {
+    skipTests: getSkipTests(argv.skip, argv.runSkipped !== undefined ? 'NONE' : 'ALL'),
+    runSkipped: getSkipTests(argv.runSkipped, 'NONE'),
+    forkConfig: FORK_CONFIG_TEST_SUITE,
+    file: argv.file,
+    test: argv.test,
+    dir: argv.dir,
+    excludeDir: argv.excludeDir,
+    testsPath: argv.testsPath,
+    customStateTest: argv.customStateTest,
+  }
+
+  /**
+   * Run-time configuration
+   */
+  const runnerArgs: {
+    forkConfigVM: string
+    forkConfigTestSuite: string
+    common: Common
+    jsontrace?: boolean
+    dist?: boolean
+    data?: number
+    gasLimit?: number
+    value?: number
+    debug?: boolean
+    reps?: number
+  } = {
+    forkConfigVM: FORK_CONFIG_VM,
+    forkConfigTestSuite: FORK_CONFIG_TEST_SUITE,
+    common: getCommon(FORK_CONFIG_VM),
+    jsontrace: argv.jsontrace,
+    dist: argv.dist,
+    data: argv.data, // GeneralStateTests
+    gasLimit: argv.gas, // GeneralStateTests
+    value: argv.value, // GeneralStateTests
+    debug: argv.debug, // BlockchainTests
+    reps: argv.reps, // test repetitions
+  }
+
+  /**
+   * Modify the forkConfig string to ensure it works with RegEx (escape `+` characters)
+   */
+  if (testGetterArgs.forkConfig.includes('+')) {
+    let str = testGetterArgs.forkConfig
+    const indices = []
+    for (let i = 0; i < str.length; i++) {
+      if (str[i] === '+') {
+        indices.push(i)
+      }
+    }
+    // traverse array in reverse order to ensure indices match when we replace the '+' with '/+'
+    for (let i = indices.length - 1; i >= 0; i--) {
+      str = `${str.substr(0, indices[i])}\\${str.substr(indices[i])}`
+    }
+    testGetterArgs.forkConfig = str
+  }
+
+  const expectedTests: number | undefined =
+    argv['verify-test-amount-alltests'] > 0
+      ? getExpectedTests(FORK_CONFIG_VM, name)
+      : argv['expected-test-amount'] !== undefined && argv['expected-test-amount'] > 0
+      ? argv['expected-test-amount']
+      : undefined
+
+  /**
+   * Initialization output to console
+   */
+  const width = 50
+  const fillWidth = width
+  const fillParam = 20
+  const delimiter = `| `.padEnd(fillWidth) + ' |'
+  const formatArgs = (args: any) => {
+    return Object.assign(
+      {},
+      ...Object.entries(args)
+        .filter(([_k, v]) => typeof v === 'string' || (Array.isArray(v) && v.length !== 0))
+        .map(([k, v]) => ({
+          [k]: Array.isArray(v) && v.length > 0 ? v.length : v,
+        }))
+    )
+  }
+  const formattedGetterArgs = formatArgs(testGetterArgs)
+  const formattedRunnerArgs = formatArgs(runnerArgs)
+
+  console.log(`+${'-'.repeat(width)}+`)
+  console.log(`| VM -> ${name} `.padEnd(fillWidth) + ' |')
+  console.log(delimiter)
+  console.log(`| TestGetterArgs`.padEnd(fillWidth) + ' |')
+  for (const [key, value] of Object.entries(formattedGetterArgs)) {
+    console.log(`| ${key.padEnd(fillParam)}: ${value}`.padEnd(fillWidth) + ' |')
+  }
+  console.log(delimiter)
+  console.log(`| RunnerArgs`.padEnd(fillWidth) + ' |')
+  for (const [key, value] of Object.entries(formattedRunnerArgs)) {
+    if (key === 'common') {
+      const hf = (value as Common).hardfork()
+      console.log(`| ${key.padEnd(fillParam)}: ${hf}`.padEnd(fillWidth) + ' |')
+    } else {
+      console.log(`| ${key.padEnd(fillParam)}: ${value}`.padEnd(fillWidth) + ' |')
+    }
+  }
+  console.log(`+${'-'.repeat(width)}+`)
+  console.log()
+
+  if (argv.customStateTest !== undefined) {
+    const fileName: string = argv.customStateTest
+    tape(name, (t) => {
+      getTestFromSource(fileName, async (err: string | undefined, test: any) => {
+        if (err !== undefined) {
+          return t.fail(err)
+        }
+        t.comment(`file: ${fileName} test: ${test.testName}`)
+        await runStateTest(runnerArgs, test, t)
+        t.end()
+      })
+    })
+  } else {
+    tape(name, async (t) => {
+      let testIdentifier: string
+      const failingTests: Record<string, string[] | undefined> = {}
+
+      ;(t as any).on('result', (o: any) => {
+        if (typeof o.ok !== 'undefined' && o.ok !== null && (o.ok === '' || o.ok === 0)) {
+          if (failingTests[testIdentifier] !== undefined) {
+            ;(failingTests[testIdentifier] as string[]).push(o.name)
+          } else {
+            failingTests[testIdentifier] = [o.name]
+          }
+        }
+      })
+      // Tests for HFs before Istanbul have been moved under `LegacyTests/Constantinople`:
+      // https://github.com/ethereum/tests/releases/tag/v7.0.0-beta.1
+
+      const dirs = getTestDirs(FORK_CONFIG_VM, name)
+      for (const dir of dirs) {
+        await new Promise<void>((resolve, reject) => {
+          if (argv.customTestsPath !== undefined) {
+            testGetterArgs.directory = argv.customTestsPath as string
+          } else {
+            const testDir = testGetterArgs.dir ?? ''
+            const testsPath = testGetterArgs.testsPath ?? DEFAULT_TESTS_PATH
+            testGetterArgs.directory = path.join(testsPath, dir, testDir)
+          }
+          getTestsFromArgs(
+            dir,
+            async (fileName: string, subDir: string, testName: string, test: any) => {
+              const runSkipped = testGetterArgs.runSkipped
+              const inRunSkipped = runSkipped.includes(fileName)
+              if (runSkipped.length === 0 || inRunSkipped === true) {
+                testIdentifier = `file: ${subDir} test: ${testName}`
+                t.comment(testIdentifier)
+                await runner(runnerArgs, test, t)
+              }
+            },
+            testGetterArgs
+          )
+            .then(() => {
+              resolve()
+            })
+            .catch((error: string) => {
+              t.fail(error)
+              reject()
+            })
+        })
+      }
+
+      for (const failingTestIdentifier in failingTests) {
+        console.log(`Errors thrown in ${failingTestIdentifier}:`)
+        const errors = failingTests[failingTestIdentifier] as string[]
+        for (let i = 0; i < errors.length; i++) {
+          console.log('\t' + errors[i])
+        }
+      }
+
+      if (expectedTests !== undefined) {
+        const { assertCount } = t as any
+        t.ok(assertCount >= expectedTests, `expected ${expectedTests} checks, got ${assertCount}`)
+      }
+
+      t.end()
+    })
+  }
+}
+
+runTests() // eslint-disable-line @typescript-eslint/no-floating-promises

--- a/packages/evm/tests/tester/index.ts
+++ b/packages/evm/tests/tester/index.ts
@@ -12,7 +12,6 @@ import {
   getSkipTests,
   getTestDirs,
 } from './config'
-import { runBlockchainTest } from './runners/BlockchainTestsRunner'
 import { runStateTest } from './runners/GeneralStateTestsRunner'
 import { getTestFromSource, getTestsFromArgs } from './testLoader'
 
@@ -47,14 +46,11 @@ import type { Common } from '@ethereumjs/common'
 const argv = minimist(process.argv.slice(2))
 
 async function runTests() {
-  let name: 'GeneralStateTests' | 'BlockchainTests'
+  let name: 'GeneralStateTests'
   let runner: any
   if ((argv.state as boolean) === true) {
     name = 'GeneralStateTests'
     runner = runStateTest
-  } else if ((argv.blockchain as boolean) === true) {
-    name = 'BlockchainTests'
-    runner = runBlockchainTest
   } else {
     console.log(`Test type not supported or provided`)
     process.exit(1)
@@ -165,7 +161,7 @@ async function runTests() {
   const formattedRunnerArgs = formatArgs(runnerArgs)
 
   console.log(`+${'-'.repeat(width)}+`)
-  console.log(`| VM -> ${name} `.padEnd(fillWidth) + ' |')
+  console.log(`| EVM -> ${name} `.padEnd(fillWidth) + ' |')
   console.log(delimiter)
   console.log(`| TestGetterArgs`.padEnd(fillWidth) + ' |')
   for (const [key, value] of Object.entries(formattedGetterArgs)) {

--- a/packages/evm/tests/tester/runners/GeneralStateTestsRunner.ts
+++ b/packages/evm/tests/tester/runners/GeneralStateTestsRunner.ts
@@ -1,0 +1,181 @@
+import { Block } from '@ethereumjs/block'
+import { Blockchain } from '@ethereumjs/blockchain'
+import { DefaultStateManager } from '@ethereumjs/statemanager'
+import { Trie } from '@ethereumjs/trie'
+import { toBuffer } from '@ethereumjs/util'
+
+import { EVM } from '../../../../evm/src'
+import { EEI } from '../../../src'
+import { makeBlockFromEnv, makeTx, setupPreConditions } from '../../util'
+
+import type { InterpreterStep } from '@ethereumjs/evm/dist//interpreter'
+import type * as tape from 'tape'
+
+function parseTestCases(
+  forkConfigTestSuite: string,
+  testData: any,
+  data: string | undefined,
+  gasLimit: string | undefined,
+  value: string | undefined
+) {
+  let testCases = []
+
+  if (testData['post'][forkConfigTestSuite] !== undefined) {
+    testCases = testData['post'][forkConfigTestSuite].map((testCase: any) => {
+      const testIndexes = testCase['indexes']
+      const tx = { ...testData.transaction }
+      if (data !== undefined && testIndexes['data'] !== data) {
+        return null
+      }
+
+      if (value !== undefined && testIndexes['value'] !== value) {
+        return null
+      }
+
+      if (gasLimit !== undefined && testIndexes['gas'] !== gasLimit) {
+        return null
+      }
+
+      tx.data = testData.transaction.data[testIndexes['data']]
+      tx.gasLimit = testData.transaction.gasLimit[testIndexes['gas']]
+      tx.value = testData.transaction.value[testIndexes['value']]
+
+      if (tx.accessLists !== undefined) {
+        tx.accessList = testData.transaction.accessLists[testIndexes['data']]
+        if (tx.chainId === undefined) {
+          tx.chainId = 1
+        }
+      }
+
+      return {
+        transaction: tx,
+        postStateRoot: testCase['hash'],
+        logs: testCase['logs'],
+        env: testData['env'],
+        pre: testData['pre'],
+        expectException: testCase['expectException'],
+      }
+    })
+  }
+
+  testCases = testCases.filter((testCase: any) => {
+    return testCase !== null
+  })
+
+  return testCases
+}
+
+async function runTestCase(options: any, testData: any, t: tape.Test) {
+  let VM
+  if (options.dist === true) {
+    ;({ VM } = require('../../../dist'))
+  } else {
+    ;({ VM } = require('../../../src'))
+  }
+  const begin = Date.now()
+  const common = options.common
+
+  // Have to create a blockchain with empty block as genesisBlock for Merge
+  // Otherwise mainnet genesis will throw since this has difficulty nonzero
+  const genesisBlock = new Block(undefined, undefined, undefined, { common })
+  const blockchain = await Blockchain.create({ genesisBlock, common })
+  const state = new Trie({ useKeyHashing: true })
+  const stateManager = new DefaultStateManager({
+    trie: state,
+  })
+  const eei = new EEI(stateManager, common, blockchain)
+  const evm = new EVM({ common, eei })
+  const vm = await VM.create({ state, stateManager, common, blockchain, evm })
+
+  await setupPreConditions(vm.eei, testData)
+
+  let execInfo = ''
+  let tx
+
+  try {
+    tx = makeTx(testData.transaction, { common })
+  } catch (e: any) {
+    execInfo = 'tx instantiation exception'
+  }
+
+  if (tx) {
+    if (tx.validate()) {
+      const block = makeBlockFromEnv(testData.env, { common })
+
+      if (options.jsontrace === true) {
+        vm.evm.events.on('step', function (e: InterpreterStep) {
+          let hexStack = []
+          hexStack = e.stack.map((item: bigint) => {
+            return '0x' + item.toString(16)
+          })
+
+          const opTrace = {
+            pc: e.pc,
+            op: e.opcode.name,
+            gas: '0x' + e.gasLeft.toString(16),
+            gasCost: '0x' + e.opcode.fee.toString(16),
+            stack: hexStack,
+            depth: e.depth,
+            opName: e.opcode.name,
+          }
+
+          t.comment(JSON.stringify(opTrace))
+        })
+        vm.events.on('afterTx', async () => {
+          const stateRoot = {
+            stateRoot: vm.stateManager._trie.root.toString('hex'),
+          }
+          t.comment(JSON.stringify(stateRoot))
+        })
+      }
+      try {
+        await vm.runTx({ tx, block })
+        execInfo = 'successful tx run'
+      } catch (e: any) {
+        execInfo = `tx runtime error :${e.message}`
+      }
+    } else {
+      execInfo = 'tx validation failed'
+    }
+  }
+
+  const stateManagerStateRoot = vm.stateManager._trie.root()
+  const testDataPostStateRoot = toBuffer(testData.postStateRoot)
+  const stateRootsAreEqual = stateManagerStateRoot.equals(testDataPostStateRoot)
+
+  const end = Date.now()
+  const timeSpent = `${(end - begin) / 1000} secs`
+
+  t.ok(stateRootsAreEqual, `[ ${timeSpent} ] the state roots should match (${execInfo})`)
+  return parseFloat(timeSpent)
+}
+
+export async function runStateTest(options: any, testData: any, t: tape.Test) {
+  try {
+    const testCases = parseTestCases(
+      options.forkConfigTestSuite,
+      testData,
+      options.data,
+      options.gasLimit,
+      options.value
+    )
+    if (testCases.length === 0) {
+      t.comment(`No ${options.forkConfigTestSuite} post state defined, skip test`)
+      return
+    }
+    for (const testCase of testCases) {
+      if (options.reps !== undefined && options.reps > 0) {
+        let totalTimeSpent = 0
+        for (let x = 0; x < options.reps; x++) {
+          totalTimeSpent += await runTestCase(options, testCase, t)
+        }
+        t.comment(`Average test run: ${(totalTimeSpent / options.reps).toLocaleString()} s`)
+      } else {
+        await runTestCase(options, testCase, t)
+      }
+    }
+  } catch (e: any) {
+    console.log(e)
+    t.fail(`error running test case for fork: ${options.forkConfigTestSuite}`)
+  }
+}

--- a/packages/evm/tests/tester/runners/runTxAlt.ts
+++ b/packages/evm/tests/tester/runners/runTxAlt.ts
@@ -1,0 +1,232 @@
+import { ConsensusType } from '@ethereumjs/common'
+import { Capability } from '@ethereumjs/tx'
+import { Address, KECCAK256_NULL, toBuffer } from '@ethereumjs/util'
+
+import type { EVM } from '../../../src'
+import type { Block } from '@ethereumjs/block'
+import type {
+  AccessListEIP2930Transaction,
+  FeeMarketEIP1559Transaction,
+  Transaction,
+} from '@ethereumjs/tx'
+
+export async function runTxAlt(
+  evm: EVM,
+  block: Block,
+  tx: FeeMarketEIP1559Transaction | AccessListEIP2930Transaction | Transaction
+): Promise<void> {
+  if (block.header.gasLimit < tx.gasLimit) {
+    const msg = 'tx has a higher gas limit than the block'
+    throw new Error(msg)
+  }
+
+  const state = evm.eei
+  if (evm._common.isActivatedEIP(2929) === true) {
+    state.clearWarmedAccounts()
+  }
+  await state.checkpoint()
+
+  if (
+    tx.supports(Capability.EIP2718TypedTransaction) &&
+    evm._common.isActivatedEIP(2718) === true
+  ) {
+    if (evm._common.isActivatedEIP(2930) === false) {
+      await state.revert()
+      const msg = 'Cannot run transaction: EIP 2930 is not activated.'
+      throw new Error(msg)
+    }
+    if (tx.supports(Capability.EIP1559FeeMarket) && evm._common.isActivatedEIP(1559) === false) {
+      await state.revert()
+      const msg = 'Cannot run transaction: EIP 1559 is not activated.'
+      throw new Error(msg)
+    }
+
+    const castedTx = <AccessListEIP2930Transaction>tx
+
+    for (const accessListItem of castedTx.AccessListJSON) {
+      const address = toBuffer(accessListItem.address)
+      state.addWarmedAddress(address)
+      for (const storageKey of accessListItem.storageKeys) {
+        state.addWarmedStorage(address, toBuffer(storageKey))
+      }
+    }
+  }
+
+  try {
+    await _runTx(evm, tx, block)
+    await state.commit()
+  } catch (e: any) {
+    await state.revert()
+    throw e
+  } finally {
+    if (evm._common.isActivatedEIP(2929) === true) {
+      state.clearWarmedAccounts()
+    }
+  }
+}
+
+async function _runTx(
+  evm: EVM,
+  tx: FeeMarketEIP1559Transaction | AccessListEIP2930Transaction | Transaction,
+  block: Block,
+  opts = { skipBalance: false }
+): Promise<void> {
+  const state = evm.eei
+  const caller = tx.getSenderAddress()
+  if (evm._common.isActivatedEIP(2929) === true) {
+    const activePrecompiles = evm.precompiles
+    for (const [addressStr] of activePrecompiles.entries()) {
+      state.addWarmedAddress(Buffer.from(addressStr, 'hex'))
+    }
+    state.addWarmedAddress(caller.buf)
+    if (tx.to) {
+      state.addWarmedAddress(tx.to.buf)
+    }
+    if (evm._common.isActivatedEIP(3651) === true) {
+      state.addWarmedAddress(block.header.coinbase.buf)
+    }
+  }
+  const txBaseFee = tx.getBaseFee()
+  let gasLimit = tx.gasLimit
+  if (gasLimit < txBaseFee) {
+    const msg = 'base fee exceeds gas limit'
+    throw new Error(msg)
+  }
+  gasLimit -= txBaseFee
+
+  if (evm._common.isActivatedEIP(1559) === true) {
+    const maxFeePerGas = 'maxFeePerGas' in tx ? tx.maxFeePerGas : tx.gasPrice
+    const baseFeePerGas = block.header.baseFeePerGas!
+    if (maxFeePerGas < baseFeePerGas) {
+      const msg = `Transaction's maxFeePerGas (${maxFeePerGas}) is less than the block's baseFeePerGas (${baseFeePerGas})`
+      throw new Error(msg)
+    }
+  }
+
+  let fromAccount = await state.getAccount(caller)
+  const { nonce, balance } = fromAccount
+
+  if (evm._common.isActivatedEIP(3607) === true && !fromAccount.codeHash.equals(KECCAK256_NULL)) {
+    const msg = 'invalid sender address, address is not EOA (EIP-3607)'
+    throw new Error(msg)
+  }
+
+  const cost = tx.getUpfrontCost(block.header.baseFeePerGas)
+  if (balance < cost) {
+    if (opts.skipBalance === true && fromAccount.balance < cost) {
+      if (tx.supports(Capability.EIP1559FeeMarket) === false) {
+        // if skipBalance and not EIP1559 transaction, ensure caller balance is enough to run transaction
+        fromAccount.balance = cost
+        await evm.eei.putAccount(caller, fromAccount)
+      }
+    } else {
+      const msg = `sender doesn't have enough funds to send tx. The upfront cost is: ${cost} and the sender's account (${caller}) only has: ${balance}`
+      throw new Error(msg)
+    }
+  }
+  if (nonce !== tx.nonce) {
+    const msg = `the tx doesn't have the correct nonce. account has nonce of: ${nonce} tx has nonce of: ${tx.nonce}`
+
+    throw new Error(msg)
+  }
+
+  if (tx.supports(Capability.EIP1559FeeMarket)) {
+    const cost = tx.gasLimit * (tx as FeeMarketEIP1559Transaction).maxFeePerGas + tx.value
+    if (balance < cost) {
+      if (opts.skipBalance === true && fromAccount.balance < cost) {
+        // if skipBalance, ensure caller balance is enough to run transaction
+        fromAccount.balance = cost
+        await evm.eei.putAccount(caller, fromAccount)
+      } else {
+        const msg = `sender doesn't have enough funds to send tx. The max cost is: ${cost} and the sender's account (${caller}) only has: ${balance}`
+        throw new Error(msg)
+      }
+    }
+  }
+
+  let gasPrice: bigint
+  let inclusionFeePerGas: bigint
+  if (tx.supports(Capability.EIP1559FeeMarket)) {
+    const baseFee = block.header.baseFeePerGas!
+    inclusionFeePerGas =
+      (tx as FeeMarketEIP1559Transaction).maxPriorityFeePerGas <
+      (tx as FeeMarketEIP1559Transaction).maxFeePerGas - baseFee
+        ? (tx as FeeMarketEIP1559Transaction).maxPriorityFeePerGas
+        : (tx as FeeMarketEIP1559Transaction).maxFeePerGas - baseFee
+
+    gasPrice = inclusionFeePerGas + baseFee
+  } else {
+    gasPrice = (<Transaction>tx).gasPrice
+    if (evm._common.isActivatedEIP(1559) === true) {
+      const baseFee = block.header.baseFeePerGas!
+      inclusionFeePerGas = (<Transaction>tx).gasPrice - baseFee
+    }
+  }
+
+  const txCost = tx.gasLimit * gasPrice
+  fromAccount.balance -= txCost
+  // if (opts.skipBalance === true && fromAccount.balance < BigInt(0)) {
+  //   fromAccount.balance = BigInt(0)
+  // }
+  await state.putAccount(caller, fromAccount)
+
+  const { value, data, to } = tx
+
+  const results = await evm.runCall({
+    block,
+    gasPrice,
+    caller,
+    gasLimit,
+    to,
+    value,
+    data,
+  })
+
+  const acc = await state.getAccount(caller)
+  acc.nonce++
+  await state.putAccount(caller, acc)
+
+  let totalGasSpent = results.execResult.executionGasUsed + txBaseFee
+
+  let gasRefund = results.execResult.gasRefund ?? BigInt(0)
+  const maxRefundQuotient = evm._common.param('gasConfig', 'maxRefundQuotient')
+  if (gasRefund !== BigInt(0)) {
+    const maxRefund = totalGasSpent / maxRefundQuotient
+    gasRefund = gasRefund < maxRefund ? gasRefund : maxRefund
+    totalGasSpent -= gasRefund
+  }
+  const amountSpent = totalGasSpent * gasPrice
+
+  fromAccount = await state.getAccount(caller)
+  const actualTxCost = totalGasSpent * gasPrice
+  const txCostDiff = txCost - actualTxCost
+  fromAccount.balance += txCostDiff
+  await state.putAccount(caller, fromAccount)
+
+  let miner
+  if (evm._common.consensusType() === ConsensusType.ProofOfAuthority) {
+    miner = block.header.cliqueSigner()
+  } else {
+    miner = block.header.coinbase
+  }
+
+  const minerAccount = await state.getAccount(miner)
+  if (evm._common.isActivatedEIP(1559) === true) {
+    minerAccount.balance += totalGasSpent * inclusionFeePerGas!
+  } else {
+    minerAccount.balance += amountSpent
+  }
+
+  await state.putAccount(miner, minerAccount)
+
+  if (results.execResult.selfdestruct) {
+    const keys = Object.keys(results.execResult.selfdestruct)
+    for (const k of keys) {
+      const address = new Address(Buffer.from(k, 'hex'))
+      await state.deleteAccount(address)
+    }
+  }
+
+  await state.cleanupTouchedAccounts()
+  state.clearOriginalStorageCache()
+}

--- a/packages/evm/tests/tester/scripts/state-test-run-test.sh
+++ b/packages/evm/tests/tester/scripts/state-test-run-test.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -x
+#############################################################
+# Manual test file for state test runner option sanity checks
+#
+# Evoke from repository root with
+# ./tests/tester/scripts/state-test-run-test.sh
+#############################################################
+
+ts-node ./tests/tester --state --test='stackOverflow'
+ts-node ./tests/tester --state --test='stackOverflow' --fork='Istanbul'
+ts-node ./tests/tester --state --test='CreateCollisionToEmpty' --data=0 --gas=1 --value=0
+# Test should be executed
+ts-node ./tests/tester --state --test='stackOverflow' --skip=BROKEN,PERMANENT
+# Test should be executed
+ts-node ./tests/tester --state --test='stackOverflow' --skip=SLOW
+# Test should not be executed (test in skip list)
+ts-node ./tests/tester --state --test='UncleFromSideChain' --skip=BROKEN,PERMANENT
+ts-node ./tests/tester --state --customStateTest='./node_modules/ethereumjs-testing/tests/GeneralStateTests/stCreate2/create2InitCodes.json'
+ts-node ./tests/tester --state --test='CreateCollisionToEmpty' --jsontrace
+ 

--- a/packages/evm/tests/tester/testLoader.ts
+++ b/packages/evm/tests/tester/testLoader.ts
@@ -1,0 +1,162 @@
+import * as fs from 'fs'
+import * as dir from 'node-dir'
+import * as path from 'path'
+
+import { DEFAULT_TESTS_PATH } from './config'
+
+const falsePredicate = () => false
+
+/**
+ * Returns the list of test files matching the given parameters
+ * @param onFile a callback for each file
+ * @param fileFilter a {@code RegExp} or array to specify filenames to operate on
+ * @param skipPredicate a filtering function for test names
+ * @param directory the directory inside the {@code tests/} directory to use
+ * @param excludeDir a {@code RegExp} or array to specify directories to ignore
+ * @returns the list of test files
+ */
+export async function getTests(
+  onFile: Function,
+  fileFilter: RegExp | string[] = /.json$/,
+  skipPredicate: (...args: any[]) => boolean = falsePredicate,
+  directory: string,
+  excludeDir: RegExp | string[] = []
+): Promise<string[]> {
+  const options = {
+    match: fileFilter,
+    excludeDir,
+  }
+  return new Promise((resolve, reject) => {
+    const finishedCallback = (err: Error | undefined, files: string[]) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      resolve(files)
+    }
+    const fileCallback = async (
+      err: Error | undefined,
+      content: string | Buffer,
+      fileName: string,
+      next: Function
+    ) => {
+      if (err) {
+        reject(err)
+        return
+      }
+      const subDir = fileName.substr(directory.length + 1)
+      const parsedFileName = path.parse(fileName).name
+      content = Buffer.isBuffer(content) ? content.toString() : content
+      const testsByName = JSON.parse(content)
+      const testNames = Object.keys(testsByName)
+      for (const testName of testNames) {
+        if (!skipPredicate(testName, testsByName[testName])) {
+          await onFile(parsedFileName, subDir, testName, testsByName[testName])
+        }
+      }
+      next()
+    }
+
+    dir.readFiles(directory, options, fileCallback, finishedCallback)
+  })
+}
+
+function skipTest(testName: string, skipList = []) {
+  return skipList
+    .map((skipName) => new RegExp(`^${skipName}`).test(testName))
+    .some((isMatch) => isMatch)
+}
+
+/**
+ * Loads a single test specified in a file
+ * @param file path to load a single test from
+ * @param onFile callback function invoked with contents of specified file (or an error message)
+ */
+export function getTestFromSource(file: string, onFile: Function) {
+  const stream = fs.createReadStream(file)
+  let contents = ''
+  let test: any = null
+
+  stream
+    .on('data', function (data: string) {
+      contents += data
+    })
+    .on('error', function (err: Error) {
+      // eslint-disable-next-line no-console
+      console.warn('♦︎ [WARN] Please check if submodule `ethereum-tests` is properly loaded.')
+      onFile(err)
+    })
+    .on('end', function () {
+      try {
+        test = JSON.parse(contents)
+      } catch (e: any) {
+        onFile(e)
+      }
+
+      const testName = Object.keys(test)[0]
+      const testData = test[testName]
+      testData.testName = testName
+
+      onFile(null, testData)
+    })
+}
+
+/**
+ * Get list of test files from supported CLI args
+ * @param testType the test type (path segment)
+ * @param onFile a callback for each file
+ * @param args the CLI args
+ * @returns the list of test files
+ */
+export async function getTestsFromArgs(testType: string, onFile: Function, args: any = {}) {
+  let fileFilter, excludeDir, skipFn
+
+  skipFn = (name: string) => {
+    return skipTest(name, args.skipTests)
+  }
+  if (new RegExp(`BlockchainTests`).test(testType)) {
+    const forkFilter = new RegExp(`${args.forkConfig}$`)
+    skipFn = (name: string, test: any) => {
+      return forkFilter.test(test.network) === false || skipTest(name, args.skipTests)
+    }
+  }
+  if (new RegExp(`GeneralStateTests`).test(testType)) {
+    const forkFilter = new RegExp(`${args.forkConfig}$`)
+    skipFn = (name: string, test: any) => {
+      return (
+        Object.keys(test['post'])
+          .map((key) => forkFilter.test(key))
+          .every((e) => !e) || skipTest(name, args.skipTests)
+      )
+    }
+  }
+  if (testType === 'VMTests') {
+    skipFn = (name: string) => {
+      return skipTest(name, args.skipVM)
+    }
+  }
+  if (args.singleSource !== undefined) {
+    return getTestFromSource(args.singleSource, onFile)
+  }
+  if (args.file !== undefined) {
+    fileFilter = new RegExp(args.file)
+  }
+  if (args.excludeDir !== undefined) {
+    excludeDir = new RegExp(args.excludeDir)
+  }
+  if (args.test !== undefined) {
+    skipFn = (testName: string) => {
+      return testName !== args.test
+    }
+  }
+
+  return getTests(onFile, fileFilter, skipFn, args.directory, excludeDir)
+}
+
+/**
+ * Returns a single file from the ethereum-tests git submodule
+ * @param file
+ */
+export function getSingleFile(file: string) {
+  return require(path.join(DEFAULT_TESTS_PATH, file))
+}

--- a/packages/evm/tests/tester/testLoader.ts
+++ b/packages/evm/tests/tester/testLoader.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs'
 import * as dir from 'node-dir'
 import * as path from 'path'
 
-import { DEFAULT_TESTS_PATH } from './config'
+const DEFAULT_TESTS_PATH = path.resolve('../ethereum-tests')
 
 const falsePredicate = () => false
 
@@ -113,12 +113,6 @@ export async function getTestsFromArgs(testType: string, onFile: Function, args:
 
   skipFn = (name: string) => {
     return skipTest(name, args.skipTests)
-  }
-  if (new RegExp(`BlockchainTests`).test(testType)) {
-    const forkFilter = new RegExp(`${args.forkConfig}$`)
-    skipFn = (name: string, test: any) => {
-      return forkFilter.test(test.network) === false || skipTest(name, args.skipTests)
-    }
   }
   if (new RegExp(`GeneralStateTests`).test(testType)) {
     const forkFilter = new RegExp(`${args.forkConfig}$`)

--- a/packages/evm/tests/tester/util.ts
+++ b/packages/evm/tests/tester/util.ts
@@ -20,7 +20,7 @@ import {
 import { keccak256 } from 'ethereum-cryptography/keccak'
 import { bytesToHex } from 'ethereum-cryptography/utils'
 
-import type { VmState } from '../src/eei/vmState'
+import type { VmState } from '../../../vm/src/eei/vmState'
 import type { BlockOptions } from '@ethereumjs/block'
 import type { TxOptions } from '@ethereumjs/tx'
 import type * as tape from 'tape'

--- a/packages/evm/tests/util.ts
+++ b/packages/evm/tests/util.ts
@@ -1,0 +1,416 @@
+import { Block, BlockHeader } from '@ethereumjs/block'
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { RLP } from '@ethereumjs/rlp'
+import {
+  AccessListEIP2930Transaction,
+  FeeMarketEIP1559Transaction,
+  Transaction,
+} from '@ethereumjs/tx'
+import {
+  Account,
+  Address,
+  bigIntToBuffer,
+  bufferToBigInt,
+  bufferToHex,
+  isHexPrefixed,
+  setLengthLeft,
+  stripHexPrefix,
+  toBuffer,
+} from '@ethereumjs/util'
+import { keccak256 } from 'ethereum-cryptography/keccak'
+import { bytesToHex } from 'ethereum-cryptography/utils'
+
+import type { VmState } from '../src/eei/vmState'
+import type { BlockOptions } from '@ethereumjs/block'
+import type { TxOptions } from '@ethereumjs/tx'
+import type * as tape from 'tape'
+
+export function dumpState(state: any, cb: Function) {
+  function readAccounts(state: any) {
+    return new Promise((resolve) => {
+      const accounts: Account[] = []
+      const rs = state.createReadStream()
+      rs.on('data', function (data: any) {
+        const rlp = data.value
+        const account = Account.fromRlpSerializedAccount(rlp)
+        accounts.push(account)
+      })
+      rs.on('end', function () {
+        resolve(accounts)
+      })
+    })
+  }
+
+  function readStorage(state: any, account: Account) {
+    return new Promise((resolve) => {
+      const storage: any = {}
+      const storageTrie = state.copy(false)
+      storageTrie.root(account.storageRoot)
+      const storageRS = storageTrie.createReadStream()
+
+      storageRS.on('data', function (data: any) {
+        storage[data.key.toString('hex')] = data.value.toString('hex')
+      })
+
+      storageRS.on('end', function () {
+        resolve(storage)
+      })
+    })
+  }
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  readAccounts(state).then(async function (accounts: any) {
+    const results: any = []
+    for (let key = 0; key < accounts.length; key++) {
+      const result = await readStorage(state, accounts[key])
+      results.push(result)
+    }
+    for (let i = 0; i < results.length; i++) {
+      console.log("SHA3'd address: " + bufferToHex(results[i].address))
+      console.log('\tstorage root: ' + bufferToHex(results[i].storageRoot))
+      console.log('\tstorage: ')
+      for (const storageKey in results[i].storage) {
+        console.log('\t\t' + storageKey + ': ' + results[i].storage[storageKey])
+      }
+      console.log('\tnonce: ' + BigInt(results[i].nonce))
+      console.log('\tbalance: ' + BigInt(results[i].balance))
+    }
+    cb()
+  })
+}
+
+export function format(a: any, toZero: boolean = false, isHex: boolean = false): Buffer {
+  if (a === '') {
+    return Buffer.alloc(0)
+  }
+
+  if (typeof a === 'string' && isHexPrefixed(a)) {
+    a = a.slice(2)
+    if (a.length % 2) a = '0' + a
+    a = Buffer.from(a, 'hex')
+  } else if (!isHex) {
+    try {
+      a = bigIntToBuffer(BigInt(a))
+    } catch {
+      // pass
+    }
+  } else {
+    if (a.length % 2) a = '0' + a
+    a = Buffer.from(a, 'hex')
+  }
+
+  if (toZero && a.toString('hex') === '') {
+    a = Buffer.from([0])
+  }
+
+  return a
+}
+
+/**
+ * Make a tx using JSON from tests repo
+ * @param {Object} txData The tx object from tests repo
+ * @param {TxOptions} opts Tx opts that can include an @ethereumjs/common object
+ * @returns {FeeMarketEIP1559Transaction | AccessListEIP2930Transaction | Transaction} Transaction to be passed to VM.runTx function
+ */
+export function makeTx(
+  txData: any,
+  opts?: TxOptions
+): FeeMarketEIP1559Transaction | AccessListEIP2930Transaction | Transaction {
+  let tx
+  if (txData.maxFeePerGas !== undefined) {
+    tx = FeeMarketEIP1559Transaction.fromTxData(txData, opts)
+  } else if (txData.accessLists !== undefined) {
+    tx = AccessListEIP2930Transaction.fromTxData(txData, opts)
+  } else {
+    tx = Transaction.fromTxData(txData, opts)
+  }
+
+  if (txData.secretKey !== undefined) {
+    const privKey = toBuffer(txData.secretKey)
+    return tx.sign(privKey)
+  }
+
+  return tx
+}
+
+export async function verifyPostConditions(state: any, testData: any, t: tape.Test) {
+  return new Promise<void>((resolve) => {
+    const hashedAccounts: any = {}
+    const keyMap: any = {}
+
+    for (const key in testData) {
+      const hash = bytesToHex(keccak256(Buffer.from(stripHexPrefix(key), 'hex')))
+      hashedAccounts[hash] = testData[key]
+      keyMap[hash] = key
+    }
+
+    const queue: any = []
+
+    const stream = state.createReadStream()
+
+    stream.on('data', function (data: any) {
+      const rlp = data.value
+      const account = Account.fromRlpSerializedAccount(rlp)
+      const key = data.key.toString('hex')
+      const testData = hashedAccounts[key]
+      const address = keyMap[key]
+      delete keyMap[key]
+
+      if (testData !== undefined) {
+        const promise = verifyAccountPostConditions(state, address, account, testData, t)
+        queue.push(promise)
+      } else {
+        t.comment('invalid account in the trie: ' + <string>key)
+      }
+    })
+
+    stream.on('end', async function () {
+      await Promise.all(queue)
+      for (const [_key, address] of Object.entries(keyMap)) {
+        t.comment(`Missing account!: ${address}`)
+      }
+      resolve()
+    })
+  })
+}
+
+/**
+ * verifyAccountPostConditions using JSON from tests repo
+ * @param state    DB/trie
+ * @param address   Account Address
+ * @param account  to verify
+ * @param acctData postconditions JSON from tests repo
+ */
+export function verifyAccountPostConditions(
+  state: any,
+  address: string,
+  account: Account,
+  acctData: any,
+  t: tape.Test
+) {
+  return new Promise<void>((resolve) => {
+    t.comment('Account: ' + address)
+    if (!format(account.balance, true).equals(format(acctData.balance, true))) {
+      t.comment(
+        `Expected balance of ${bufferToBigInt(format(acctData.balance, true))}, but got ${
+          account.balance
+        }`
+      )
+    }
+    if (!format(account.nonce, true).equals(format(acctData.nonce, true))) {
+      t.comment(
+        `Expected nonce of ${bufferToBigInt(format(acctData.nonce, true))}, but got ${
+          account.nonce
+        }`
+      )
+    }
+
+    // validate storage
+    const origRoot = state.root()
+
+    const hashedStorage: any = {}
+    for (const key in acctData.storage) {
+      hashedStorage[bytesToHex(keccak256(setLengthLeft(Buffer.from(key.slice(2), 'hex'), 32)))] =
+        acctData.storage[key]
+    }
+
+    state.root(account.storageRoot)
+    const rs = state.createReadStream()
+    rs.on('data', function (data: any) {
+      let key = data.key.toString('hex')
+      const val = '0x' + Buffer.from(RLP.decode(data.value) as Uint8Array).toString('hex')
+
+      if (key === '0x') {
+        key = '0x00'
+        acctData.storage['0x00'] = acctData.storage['0x00'] ?? acctData.storage['0x']
+        delete acctData.storage['0x']
+      }
+
+      if (val !== hashedStorage[key]) {
+        t.comment(
+          `Expected storage key 0x${data.key.toString('hex')} at address ${address} to have value ${
+            hashedStorage[key] ?? '0x'
+          }, but got ${val}}`
+        )
+      }
+      delete hashedStorage[key]
+    })
+
+    rs.on('end', function () {
+      for (const key in hashedStorage) {
+        if (hashedStorage[key] !== '0x00') {
+          t.comment(`key: ${key} not found in storage at address ${address}`)
+        }
+      }
+
+      state.root(origRoot)
+      resolve()
+    })
+  })
+}
+
+/**
+ * verifyGas by computing the difference of coinbase account balance
+ * @param {Object} results  to verify
+ * @param {Object} testData from tests repo
+ */
+export function verifyGas(results: any, testData: any, t: tape.Test) {
+  const coinbaseAddr = testData.env.currentCoinbase
+  const preBal = testData.pre[coinbaseAddr] !== undefined ? testData.pre[coinbaseAddr].balance : 0
+
+  if (testData.post[coinbaseAddr] === undefined) {
+    return
+  }
+
+  const postBal = BigInt(testData.post[coinbaseAddr].balance)
+  const balance = postBal - preBal
+  if (balance !== BigInt(0)) {
+    const amountSpent = results.gasUsed * testData.transaction.gasPrice
+    t.equal(amountSpent, balance, 'correct gas')
+  } else {
+    t.equal(results, undefined)
+  }
+}
+
+export function makeBlockHeader(data: any, opts?: BlockOptions) {
+  const {
+    currentTimestamp,
+    currentGasLimit,
+    previousHash,
+    currentCoinbase,
+    currentDifficulty,
+    currentNumber,
+    currentBaseFee,
+    currentRandom,
+  } = data
+  const headerData: any = {
+    number: currentNumber,
+    coinbase: currentCoinbase,
+    parentHash: previousHash,
+    difficulty: currentDifficulty,
+    gasLimit: currentGasLimit,
+    timestamp: currentTimestamp,
+  }
+  if (opts?.common && opts.common.gteHardfork('london')) {
+    headerData['baseFeePerGas'] = currentBaseFee
+  }
+  if (opts?.common && opts.common.gteHardfork('merge')) {
+    headerData['mixHash'] = currentRandom
+    headerData['difficulty'] = 0
+  }
+  return BlockHeader.fromHeaderData(headerData, opts)
+}
+
+/**
+ * makeBlockFromEnv - helper to create a block from the env object in tests repo
+ * @param env object from tests repo
+ * @param opts block options (optional)
+ * @returns the block
+ */
+export function makeBlockFromEnv(env: any, opts?: BlockOptions): Block {
+  const header = makeBlockHeader(env, opts)
+  return new Block(header)
+}
+
+/**
+ * setupPreConditions given JSON testData
+ * @param state - the state DB/trie
+ * @param testData - JSON from tests repo
+ */
+export async function setupPreConditions(state: VmState, testData: any) {
+  await state.checkpoint()
+  for (const addressStr of Object.keys(testData.pre)) {
+    const { nonce, balance, code, storage } = testData.pre[addressStr]
+
+    const addressBuf = format(addressStr)
+    const address = new Address(addressBuf)
+
+    const codeBuf = format(code)
+    const codeHash = keccak256(codeBuf)
+
+    // Set contract storage
+    for (const storageKey of Object.keys(storage)) {
+      const val = format(storage[storageKey])
+      if (['', '00'].includes(val.toString('hex'))) {
+        continue
+      }
+      const key = setLengthLeft(format(storageKey), 32)
+      await state.putContractStorage(address, key, val)
+    }
+
+    // Put contract code
+    await state.putContractCode(address, codeBuf)
+
+    const storageRoot = (await state.getAccount(address)).storageRoot
+
+    if (testData.exec?.address === addressStr) {
+      testData.root(storageRoot)
+    }
+
+    // Put account data
+    const account = Account.fromAccountData({ nonce, balance, codeHash, storageRoot })
+    await state.putAccount(address, account)
+  }
+  await state.commit()
+  // Clear the touched stack, otherwise untouched accounts in the block which are empty (>= SpuriousDragon)
+  // will get deleted from the state, resulting in state trie errors
+  ;(<any>state)._touched.clear()
+}
+
+/**
+ * Returns an alias for specified hardforks to meet test dependencies requirements/assumptions.
+ * @param forkConfig - the name of the hardfork for which an alias should be returned
+ * @returns Either an alias of the forkConfig param, or the forkConfig param itself
+ */
+export function getRequiredForkConfigAlias(forkConfig: string): string {
+  // Run the Istanbul tests for MuirGlacier since there are no dedicated tests
+  if (String(forkConfig).match(/^muirGlacier/i)) {
+    return 'Istanbul'
+  }
+  // Petersburg is named ConstantinopleFix in the client-independent consensus test suite
+  if (String(forkConfig).match(/^petersburg$/i)) {
+    return 'ConstantinopleFix'
+  }
+  return forkConfig
+}
+
+/**
+ * Checks if in a karma test runner.
+ * @returns boolean whether running in karma
+ */
+export function isRunningInKarma(): boolean {
+  // eslint-disable-next-line no-undef
+  return typeof (<any>globalThis).window !== 'undefined' && (<any>globalThis).window.__karma__
+}
+
+/**
+ * Returns a DAO common which has a different activation block than the default block
+ */
+export function getDAOCommon(activationBlock: number) {
+  // here: get the default fork list of mainnet and only edit the DAO fork block (thus copy the rest of the "default" hardfork settings)
+  const defaultDAOCommon = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Dao })
+  // retrieve the hard forks list from defaultCommon...
+  const forks = defaultDAOCommon.hardforks()
+  const editedForks = []
+  // explicitly edit the "dao" block number:
+  for (const fork of forks) {
+    if (fork.name === Hardfork.Dao) {
+      editedForks.push({
+        name: Hardfork.Dao,
+        forkHash: fork.forkHash,
+        block: activationBlock,
+      })
+    } else {
+      editedForks.push(fork)
+    }
+  }
+  const DAOCommon = Common.custom(
+    {
+      hardforks: editedForks,
+    },
+    {
+      baseChain: 'mainnet',
+      hardfork: Hardfork.Dao,
+    }
+  )
+  return DAOCommon
+}


### PR DESCRIPTION
Referencing issue #2171

Run `State Tests` from `ethereum-tests` using just the EVM.

This PR adapts the `test runner` from VM/tests for this use.
  * tester/config.ts
  * tester/testLoader.ts
  * tester/index.ts
  * tester/util.ts
  * tester/scripts/state-test-run-test.sh


* `tester/runners/GeneralStateRunner.ts`
  * Use of `VM` was removed
  * `VM.runTX()` was replaced by `EVM.runCall()*`
    * `*EVM.runCall()` does not, on it's own, change the state.   
    * `runAltTx.ts`  is adapted from `VM.runTx()` to simulate all the state change that happens in the transaction.
