### PR TITLE
chore(trie): make `@types/readable-stream` a prod dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2953,7 +2953,6 @@
     },
     "node_modules/@types/readable-stream": {
       "version": "2.3.14",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -18297,12 +18296,12 @@
       "dependencies": {
         "@ethereumjs/rlp": "^4.0.0",
         "@ethereumjs/util": "^8.0.0",
+        "@types/readable-stream": "^2.3.13",
         "ethereum-cryptography": "^1.1.2",
         "readable-stream": "^3.6.0"
       },
       "devDependencies": {
         "@types/benchmark": "^1.0.33",
-        "@types/readable-stream": "^2.3.13",
         "0x": "^4.9.1",
         "abstract-level": "^1.0.3",
         "level": "^8.0.0",
@@ -20776,7 +20775,6 @@
     },
     "@types/readable-stream": {
       "version": "2.3.14",
-      "dev": true,
       "requires": {
         "@types/node": "*",
         "safe-buffer": "*"

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -47,13 +47,13 @@
   "dependencies": {
     "@ethereumjs/rlp": "^4.0.0",
     "@ethereumjs/util": "^8.0.0",
+    "@types/readable-stream": "^2.3.13",
     "ethereum-cryptography": "^1.1.2",
     "readable-stream": "^3.6.0"
   },
   "devDependencies": {
     "0x": "^4.9.1",
     "@types/benchmark": "^1.0.33",
-    "@types/readable-stream": "^2.3.13",
     "abstract-level": "^1.0.3",
     "level": "^8.0.0",
     "level-legacy": "npm:level@^7.0.0",


### PR DESCRIPTION
Fixes an issue where using `TrieReadStream` outside this repository causes type errors that require you to install the dependency mentioned in the title.