### PR TITLE
common: use a default chain name  in fromGethGenesis if no chain name specified

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -166,7 +166,7 @@ export class Common extends EventEmitter {
   ): Common {
     const genesisParams = parseGethGenesis(genesisJson, chain)
     const common = new Common({
-      chain: genesisParams.name,
+      chain: genesisParams.name ?? 'custom',
       customChains: [genesisParams],
       hardfork,
     })

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -157,7 +157,7 @@ export class Common extends EventEmitter {
   /**
    * Static method to load and set common from a geth genesis json
    * @param genesisJson json of geth configuration
-   * @param { chain, genesisHash, hardfork } to futher configure the common instance, mandatory option: `chain` representing custom chain name`
+   * @param { chain, genesisHash, hardfork } to futher configure the common instance
    * @returns Common
    */
   static fromGethGenesis(

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -157,7 +157,7 @@ export class Common extends EventEmitter {
   /**
    * Static method to load and set common from a geth genesis json
    * @param genesisJson json of geth configuration
-   * @param { chain, genesisHash, hardfork } to futher configure the common instance
+   * @param { chain, genesisHash, hardfork } to futher configure the common instance, mandatory option: `chain` representing custom chain name`
    * @returns Common
    */
   static fromGethGenesis(

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -115,7 +115,7 @@ export interface CustomCommonOpts extends BaseOpts {
 }
 
 export interface GethConfigOpts {
-  chain: string
+  chain?: string
   hardfork?: string | Hardfork
   genesisHash?: Buffer
 }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -115,7 +115,7 @@ export interface CustomCommonOpts extends BaseOpts {
 }
 
 export interface GethConfigOpts {
-  chain?: string
+  chain: string
   hardfork?: string | Hardfork
   genesisHash?: Buffer
 }


### PR DESCRIPTION
seems like files might not have name property in them and hence would cause common constructor to error when undefined chain name gets passed.

To prevent this scenario `chain` representing custom chain name is now mandatory field