### PR TITLE
Debug - Stop relying on ENV variables

### DIFF
--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -127,6 +127,11 @@ export interface EVMOpts {
    * The External Interface Factory, used to build an External Interface when this is necessary
    */
   eei: EEIInterface
+
+  /*
+   * Activate EVM debugging.
+   */
+  debug?: boolean
 }
 
 /**
@@ -288,9 +293,9 @@ export class EVM implements EVMInterface {
       }
     }
 
-    // Safeguard if "process" is not available (browser)
-    if (typeof process?.env.DEBUG !== 'undefined') {
-      this.DEBUG = true
+    // Silence debugger if debug option not enabled
+    if (opts.debug !== true) {
+      createDebugLogger.disable()
     }
 
     // We cache this promisified function as it's called from the main execution loop, and

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -204,10 +204,12 @@ export class EVM implements EVMInterface {
    */
   public readonly _mcl: any //
 
-  private debug: { evm: Debugger; evmGas: Debugger } = {
-    evm: createDebugLogger('evm'),
-    evmGas: createDebugLogger('evm:gas'),
-  }
+  private debug?: { evm: Debugger; evmGas: Debugger }
+
+  /**
+   * EVM is run in DEBUG mode (default: false)
+   */
+  readonly DEBUG: boolean = false
 
   /**
    * EVM async constructor. Creates engine instance and initializes it.
@@ -293,9 +295,13 @@ export class EVM implements EVMInterface {
       }
     }
 
-    // Silence debugger if debug option not enabled
-    if (opts.debug !== true) {
-      createDebugLogger.disable()
+    if (opts.debug === true) {
+      this.debug = {
+        evm: createDebugLogger('evm'),
+        evmGas: createDebugLogger('evm:gas'),
+      }
+      createDebugLogger.enable('evm, evm:gas')
+      this.DEBUG = true
     }
 
     // We cache this promisified function as it's called from the main execution loop, and

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -39,9 +39,7 @@ import type {
   Log,
 } from './types'
 import type { Account } from '@ethereumjs/util'
-
-const debug = createDebugLogger('evm')
-const debugGas = createDebugLogger('evm:gas')
+import type { Debugger } from 'debug'
 
 // very ugly way to detect if we are running in a browser
 const isBrowser = new Function('try {return this===window;}catch(e){ return false;}')
@@ -201,15 +199,10 @@ export class EVM implements EVMInterface {
    */
   public readonly _mcl: any //
 
-  /**
-   * EVM is run in DEBUG mode (default: false)
-   * Taken from DEBUG environment variable
-   *
-   * Safeguards on debug() calls are added for
-   * performance reasons to avoid string literal evaluation
-   * @hidden
-   */
-  readonly DEBUG: boolean = false
+  private debug: { evm: Debugger; evmGas: Debugger } = {
+    evm: createDebugLogger('evm'),
+    evmGas: createDebugLogger('evm:gas'),
+  }
 
   /**
    * EVM async constructor. Creates engine instance and initializes it.

--- a/packages/statemanager/src/stateManager.ts
+++ b/packages/statemanager/src/stateManager.ts
@@ -61,6 +61,11 @@ export interface DefaultStateManagerOpts {
    * E.g. by putting the code `0x80` into the empty trie, will lead to a corrupted trie.
    */
   prefixCodeHashes?: boolean
+
+  /**
+   * Activate StateManager debugging
+   */
+  debug?: boolean
 }
 
 /**
@@ -139,7 +144,7 @@ export class DefaultStateManager extends BaseStateManager implements StateManage
     // @ts-expect-error
     await this._trie._db.put(key, value)
 
-    if (this.DEBUG) {
+    if (this._debug) {
       this._debug(`Update codeHash (-> ${short(codeHash)}) for account ${address}`)
     }
     await this.modifyAccountFields(address, { codeHash })
@@ -265,13 +270,13 @@ export class DefaultStateManager extends BaseStateManager implements StateManage
       if (Buffer.isBuffer(value) && value.length) {
         // format input
         const encodedValue = Buffer.from(RLP.encode(Uint8Array.from(value)))
-        if (this.DEBUG) {
+        if (this._debug) {
           this._debug(`Update contract storage for account ${address} to ${short(value)}`)
         }
         await storageTrie.put(key, encodedValue)
       } else {
         // deleting a value
-        if (this.DEBUG) {
+        if (this._debug) {
           this._debug(`Delete contract storage for account`)
         }
         await storageTrie.del(key)

--- a/packages/vm/src/types.ts
+++ b/packages/vm/src/types.ts
@@ -139,6 +139,11 @@ export interface VMOpts {
    * Use a custom EVM to run Messages on. If this is not present, use the default EVM.
    */
   evm?: EVMInterface
+
+  /**
+   * Activate VM debug logging
+   */
+  debug?: boolean
 }
 
 /**

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -4,6 +4,7 @@ import { EVM, getActivePrecompiles } from '@ethereumjs/evm'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { Account, Address, TypeOutput, toType } from '@ethereumjs/util'
 import AsyncEventEmitter = require('async-eventemitter')
+import debug from 'debug'
 import { promisify } from 'util'
 
 import { buildBlock } from './buildBlock'
@@ -147,9 +148,13 @@ export class VM {
     this._hardforkByBlockNumber = opts.hardforkByBlockNumber ?? false
     this._hardforkByTTD = toType(opts.hardforkByTTD, TypeOutput.BigInt)
 
-    // Safeguard if "process" is not available (browser)
-    if (process !== undefined && typeof process.env.DEBUG !== 'undefined') {
+    // Activate debugging from options or process.env
+    if (opts.debug === true) {
       this.DEBUG = true
+      debug.enable('vm*')
+    } else if (process.env.DEBUG !== undefined && process.env.DEBUG.includes('vm')) {
+      this.DEBUG = true
+      debug.enable(process.env.DEBUG)
     }
 
     // We cache this promisified function as it's called from the main execution loop, and


### PR DESCRIPTION
Responding to user issue #2306 `Request for EthereumJS libraries to stop using ENV variables internally`

> If a user sets the DEBUG environment variable when using CLI tools like ganache and truffle (even if they do DEBUG=false or DEBUG=0), EthereumJS libraries take that as a signal to do their own internal debug-related things.

This happens due to a flaw in a performance feature designed to reduce the overhead of debug calls if no debugging is desired.  We skip the debug calls only if `process.env.DEBUG === undefined`.  When our libraries are used within other CLI tools, setting the DEBUG environment variable for anything will override this.

The fix is to detach `debug` enable / disable from the environmental variable DEBUG, and instead add `debug?: boolean` to the constructor options, and only initializing the `debug` modules if the option is set to true, and otherwise skipping those calls.

