### PR TITLE
vm: fix vm test

### DIFF
--- a/packages/vm/tests/tester/index.ts
+++ b/packages/vm/tests/tester/index.ts
@@ -187,8 +187,8 @@ async function runTests() {
   if (argv.customStateTest !== undefined) {
     const fileName: string = argv.customStateTest
     tape(name, (t) => {
-      getTestFromSource(fileName, async (err: string | undefined, test: any) => {
-        if (err !== undefined) {
+      getTestFromSource(fileName, async (err: string | null, test: any) => {
+        if (err !== null) {
           return t.fail(err)
         }
         t.comment(`file: ${fileName} test: ${test.testName}`)


### PR DESCRIPTION
[This line](https://github.com/ethereumjs/ethereumjs-monorepo/blob/9d885c9ba19fdf0a4db7b732dcb7446c1289bca1/packages/vm/tests/tester/testLoader.ts#L100) looks like it will return null when the load is successful.