### PR TITLE
common: Add merge block numbers for merged networks and fix forkhash calc

### DIFF
--- a/packages/common/src/chains/goerli.json
+++ b/packages/common/src/chains/goerli.json
@@ -75,7 +75,7 @@
       "//_comment": "The forkHash will remain same as mergeForkIdTransition is post merge, terminal block: https://goerli.etherscan.io/block/7382818",
       "name": "merge",
       "ttd": "10790000",
-      "block": null,
+      "block": 7382819,
       "forkHash": "0xb8c6299d"
     },
     {

--- a/packages/common/src/chains/mainnet.json
+++ b/packages/common/src/chains/mainnet.json
@@ -91,7 +91,7 @@
       "//_comment": "The forkHash will remain same as mergeForkIdTransition is post merge, terminal block: https://etherscan.io/block/15537393",
       "name": "merge",
       "ttd": "58750000000000000000000",
-      "block": null,
+      "block": 15537394,
       "forkHash": "0xf0afd0e3"
     },
     {

--- a/packages/common/src/chains/sepolia.json
+++ b/packages/common/src/chains/sepolia.json
@@ -77,7 +77,7 @@
       "//_comment": "The forkHash will remain same as mergeForkIdTransition is post merge, terminal block: https://sepolia.etherscan.io/block/1450408",
       "name": "merge",
       "ttd": "17000000000000000",
-      "block": null,
+      "block": 1450409,
       "forkHash": "0xfe3366e7"
     },
     {

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -676,11 +676,17 @@ export class Common extends EventEmitter {
     let hfBuffer = Buffer.alloc(0)
     let prevBlock = 0
     for (const hf of this.hardforks()) {
-      const block = hf.block
+      const { block, ttd } = hf
 
       // Skip for chainstart (0), not applied HFs (null) and
       // when already applied on same block number HFs
-      if (typeof block === 'number' && block !== 0 && block !== prevBlock) {
+      // and on the merge since forkhash doesn't change on merge hf
+      if (
+        typeof block === 'number' &&
+        block !== 0 &&
+        block !== prevBlock &&
+        (ttd === null || ttd === undefined)
+      ) {
         const hfBlockBuffer = Buffer.from(block.toString(16).padStart(16, '0'), 'hex')
         hfBuffer = Buffer.concat([hfBuffer, hfBlockBuffer])
       }

--- a/packages/common/tests/hardforks.spec.ts
+++ b/packages/common/tests/hardforks.spec.ts
@@ -44,7 +44,8 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     st.equal(c.getHardforkByBlockNumber(12965000), Hardfork.London, msg)
     st.equal(c.getHardforkByBlockNumber(13773000), Hardfork.ArrowGlacier, msg)
     st.equal(c.getHardforkByBlockNumber(15050000), Hardfork.GrayGlacier, msg)
-    st.equal(c.getHardforkByBlockNumber(999999999999), Hardfork.GrayGlacier, msg)
+    // merge is now specified at 15537394 in config
+    st.equal(c.getHardforkByBlockNumber(999999999999), Hardfork.Merge, msg)
     msg = 'should set HF correctly'
 
     st.equal(c.setHardforkByBlockNumber(0), Hardfork.Chainstart, msg)
@@ -55,7 +56,8 @@ tape('[Common]: Hardfork logic', function (t: tape.Test) {
     st.equal(c.setHardforkByBlockNumber(12965000), Hardfork.London, msg)
     st.equal(c.setHardforkByBlockNumber(13773000), Hardfork.ArrowGlacier, msg)
     st.equal(c.setHardforkByBlockNumber(15050000), Hardfork.GrayGlacier, msg)
-    st.equal(c.setHardforkByBlockNumber(999999999999), Hardfork.GrayGlacier, msg)
+    // merge is now specified at 15537394 in config
+    st.equal(c.setHardforkByBlockNumber(999999999999), Hardfork.Merge, msg)
 
     c = new Common({ chain: Chain.Ropsten })
     st.equal(c.setHardforkByBlockNumber(0), 'tangerineWhistle', msg)


### PR DESCRIPTION
Add block numbers where merge hf activates in merge testnet for ease of use (without `td`) requirement.

Also fix forkhash calculation to ignore the merge hardfork even if it might have block number assigned

Tests already cover the forkhash calc change: 
- https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/common/tests/hardforks.spec.ts#L270 
as the forkhash calc tests was failing for these networks upon addition of block number