### PR TITLE
Debug - Remove ENV check

### DIFF
--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -298,16 +298,16 @@ export class EVM implements EVMInterface {
       }
     }
 
+    // Optimize performance by skipping debug() calls when debugging has been deactivated
+    if (typeof process?.env.DEBUG !== 'undefined' && opts.disableCLDebug !== true) {
+      this.DEBUG = true
+    }
+
     // We cache this promisified function as it's called from the main execution loop, and
     // promisifying each time has a huge performance impact.
     this._emit = <(topic: string, data: any) => Promise<void>>(
       promisify(this.events.emit.bind(this.events))
     )
-
-    // Safeguard if "process" is not available (browser)
-    if (typeof process?.env.DEBUG !== 'undefined') {
-      this.DEBUG = true
-    }
   }
 
   protected async init(): Promise<void> {

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -129,6 +129,14 @@ export interface EVMOpts {
    * The External Interface Factory, used to build an External Interface when this is necessary
    */
   eei: EEIInterface
+
+  /**
+   * Option to disable command line debugging
+   * Will take precedence over process.env.DEBUG variable usage
+   * Default: `false`
+   * Set to `true` to disable debugging.
+   */
+  disableCLDebug?: boolean
 }
 
 /**

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -206,8 +206,7 @@ export class EVM implements EVMInterface {
    * EVM is run in DEBUG mode (default: false)
    * Taken from DEBUG environment variable
    *
-   * Safeguards on debug() calls are added for
-   * performance reasons to avoid string literal evaluation
+   * debug() calls can be deactivated with deactivateCLDebug
    * @hidden
    */
   readonly DEBUG: boolean = false

--- a/packages/evm/test/debugOutput.spec.ts
+++ b/packages/evm/test/debugOutput.spec.ts
@@ -1,0 +1,26 @@
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import debug from 'debug'
+import * as tape from 'tape'
+
+import { EVM } from '../src'
+
+import { getEEI } from './utils'
+
+tape('Tests EVM constructor option to disable command line debugging output', (t) => {
+  t.test('Should default to DEBUG: true', async (t) => {
+    debug.enable('evm')
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Constantinople })
+    const eei = await getEEI()
+    const evm = await EVM.create({ eei, common })
+    t.notok(evm.DEBUG, 'DEBUG defaults to false')
+    t.end()
+  })
+  t.test('Should set DEBUG: false from `deactivateCLDebug: true` constructor option', async (t) => {
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Constantinople })
+    const eei = await getEEI()
+    const evm = await EVM.create({ eei, common, disableCLDebug: true })
+    t.notok(evm.DEBUG, 'DEBUG set to false')
+    t.end()
+  })
+  t.end()
+})

--- a/packages/vm/src/eei/vmState.ts
+++ b/packages/vm/src/eei/vmState.ts
@@ -55,8 +55,8 @@ export class VmState implements EVMStateAccess {
     this._accessedStorage = [new Map()]
     this._accessedStorageReverted = [new Map()]
 
-    // Safeguard if "process" is not available (browser)
-    if (process !== undefined && typeof process.env.DEBUG !== 'undefined') {
+    // Skip debug() calls if
+    if (!disableCLDebug && typeof process.env.DEBUG !== 'undefined') {
       this.DEBUG = true
     }
     this._debug = createDebugLogger('vm:state')

--- a/packages/vm/src/eei/vmState.ts
+++ b/packages/vm/src/eei/vmState.ts
@@ -37,7 +37,15 @@ export class VmState implements EVMStateAccess {
 
   protected readonly DEBUG: boolean = false
 
-  constructor({ common, stateManager }: { common?: Common; stateManager: StateManager }) {
+  constructor({
+    common,
+    stateManager,
+    disableCLDebug = false,
+  }: {
+    common?: Common
+    stateManager: StateManager
+    disableCLDebug?: boolean
+  }) {
     this._checkpointCount = 0
     this._stateManager = stateManager
     this._common = common ?? new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Petersburg })

--- a/packages/vm/src/types.ts
+++ b/packages/vm/src/types.ts
@@ -139,6 +139,14 @@ export interface VMOpts {
    * Use a custom EVM to run Messages on. If this is not present, use the default EVM.
    */
   evm?: EVMInterface
+
+  /**
+   * Disable command line debugging.
+   * This setting will override DEBUG environment variables
+   *
+   * Default: 'undefined'
+   */
+  disableCLDebug?: boolean
 }
 
 /**

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -145,16 +145,15 @@ export class VM {
     this._hardforkByBlockNumber = opts.hardforkByBlockNumber ?? false
     this._hardforkByTTD = toType(opts.hardforkByTTD, TypeOutput.BigInt)
 
+    if (typeof process.env.DEBUG !== 'undefined' && opts.disableCLDebug !== true) {
+      this.DEBUG = true
+    }
+
     // We cache this promisified function as it's called from the main execution loop, and
     // promisifying each time has a huge performance impact.
     this._emit = <(topic: string, data: any) => Promise<void>>(
       promisify(this.events.emit.bind(this.events))
     )
-
-    // Safeguard if "process" is not available (browser)
-    if (process !== undefined && typeof process.env.DEBUG !== 'undefined') {
-      this.DEBUG = true
-    }
   }
 
   async init(): Promise<void> {

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -67,8 +67,9 @@ export class VM {
    * VM is run in DEBUG mode (default: false)
    * Taken from DEBUG environment variable
    *
-   * Safeguards on debug() calls are added for
-   * performance reasons to avoid string literal evaluation
+   * debug() calls can be skipped when to optimize performance
+   * By setting VMOpts.disableCLDebug: true
+   * This setting will override the environment variable
    * @hidden
    */
   readonly DEBUG: boolean = false

--- a/packages/vm/test/api/index.spec.ts
+++ b/packages/vm/test/api/index.spec.ts
@@ -45,6 +45,12 @@ tape('VM -> basic instantiation / boolean switches', (t) => {
     st.end()
   })
 
+  t.test('deactivateCLDebug option should set vm.DEBUG: false', async (t) => {
+    const vm = await VM.create({ disableCLDebug: true })
+    t.notok(vm.DEBUG, 'DEBUG should be disabled')
+    t.end()
+  })
+
   t.test('should be able to activate precompiles', async (st) => {
     const vm = await VM.create({ activatePrecompiles: true })
     st.notDeepEqual(

--- a/packages/vm/test/api/vmState.spec.ts
+++ b/packages/vm/test/api/vmState.spec.ts
@@ -34,6 +34,21 @@ tape('vmState', (t) => {
     }
   )*/
 
+  t.test('Should default to DEBUG: true', async (st) => {
+    const common = new Common({ chain: Chain.Mainnet })
+    const stateManager = new StateManager({})
+    const vmState = new VmState({ common, stateManager })
+    st.notok((vmState as any).DEBUG, 'DEBUG set to true')
+    st.end()
+  })
+  t.test('DEBUG should be disabled by constructor option', (st) => {
+    const common = new Common({ chain: Chain.Mainnet })
+    const stateManager = new StateManager({})
+    const vmState = new VmState({ common, stateManager, disableCLDebug: true })
+    st.notok((vmState as any).DEBUG, 'DEBUG set to false')
+    st.end()
+  })
+
   t.test('should generate the genesis state root correctly for mainnet from common', async (st) => {
     if (isRunningInKarma()) {
       st.skip('skip slow test when running in karma')


### PR DESCRIPTION
##### Responding to ***user issue***
 
#### #2306 
### Request for EthereumJS libraries to stop using ENV variables internally

> If a user sets the DEBUG environment variable when using CLI tools like ganache and truffle (even if they do DEBUG=false or DEBUG=0), EthereumJS libraries take that as a signal to do their own internal debug-related things.

This happens due to a *performance feature* designed to reduce the overhead of debug calls if `process` does not exist.  

Rather than execute lines of code - 
#####  `this.debugger("some debug output")`  
when there was no such debug log enabled...

- `this.DEBUG` would default to `false`, and
- all `this.debugger()` calls would be wrapped inside a `if (this.DEBUG === true)...` conditional

#### Issue

Users may also want to utilize the performance feature while operating in an environment where `process` does exist, and `DEBUG` variables are being set for other reasons.  

Currently, the "skip debug" mode only checks if process is `undefined`

```
    // Safeguard if "process" is not available (browser)
    if (typeof process?.env.DEBUG !== 'undefined') {
      this.DEBUG = true
    }
```

This PR introduces a constructor option `disableCLDebugOutput` to `VM`, `EVM`, and `VmState`.

```

  /**
   * Option to disable command line debugging
   * Will take precedence over process.env.DEBUG variable usage
   * Default: `undefined`
   * Set to `true` to disable debugging.
   */
  disableCLDebug?: boolean
```

Setting this option to `true` will allow users to set `env.DEBUG` variables while still enabling this performance feature.
```
    // Optimize performance by skipping debug() calls when debugging has been deactivated
    if (typeof process?.env.DEBUG !== 'undefined' && opts.disableCLDebug !== true) {
      this.DEBUG = true
    }
```

