### PR TITLE
common: Update EIP-3675 to final

### DIFF
--- a/packages/common/src/eips/3675.json
+++ b/packages/common/src/eips/3675.json
@@ -3,7 +3,7 @@
   "number": 3675,
   "comment": "Upgrade consensus to Proof-of-Stake",
   "url": "https://eips.ethereum.org/EIPS/eip-3675",
-  "status": "Review",
+  "status": "Final",
   "minimumHardfork": "london",
   "requiredEIPs": [],
   "gasConfig": {},


### PR DESCRIPTION
Update status of EIP-3675 to Final since the merge is now no longer soon :tm: but here.