### PR TITLE
Fix `tests` directory references 

### DIFF
--- a/packages/common/typedoc.js
+++ b/packages/common/typedoc.js
@@ -2,5 +2,5 @@ module.exports = {
   extends: '../../config/typedoc.js',
   entryPoints: ['src'],
   out: 'docs',
-  exclude: ['tests/**/**', 'src/chains/**', 'src/eips/**', 'src/hardforks/**'],
+  exclude: ['test/**/**', 'src/chains/**', 'src/eips/**', 'src/hardforks/**'],
 }

--- a/packages/evm/.eslintrc.js
+++ b/packages/evm/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['tests/util.ts', 'tests/tester/**/*.ts'],
+      files: ['test/util.ts', 'test/tester/**/*.ts'],
       rules: {
         'no-console': 'off',
       },

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -1733,7 +1733,7 @@ Changes related to Constantinople:
 
 ### Consensus Conformity
 
-This release is making a huge leap forward regarding consensus conformity, and even if you are not interested in `Constantinople` support at all, you should upgrade just for this reason. Some context: we couldn't run blockchain tests for a long time on a steady basis due to performance constraints and when we re-triggered a test run after quite some time with PR [#341](https://github.com/ethereumjs/ethereumjs-monorepo/pull/341) the result was a bit depressing with over 300 failing tests. Thanks to joined efforts from the community and core team members we could bring this down far quicker than expected and this is the first release for a long time which practically comes with complete consensus conformity - with just three recently added tests failing (see `skipBroken` list in `tests/tester.js`) and otherwise passing all blockchain tests and all state tests for both `Constantinople` and `Byzantium` rules. 🏆 🏆 🏆
+This release is making a huge leap forward regarding consensus conformity, and even if you are not interested in `Constantinople` support at all, you should upgrade just for this reason. Some context: we couldn't run blockchain tests for a long time on a steady basis due to performance constraints and when we re-triggered a test run after quite some time with PR [#341](https://github.com/ethereumjs/ethereumjs-monorepo/pull/341) the result was a bit depressing with over 300 failing tests. Thanks to joined efforts from the community and core team members we could bring this down far quicker than expected and this is the first release for a long time which practically comes with complete consensus conformity - with just three recently added tests failing (see `skipBroken` list in `test/tester.js`) and otherwise passing all blockchain tests and all state tests for both `Constantinople` and `Byzantium` rules. 🏆 🏆 🏆
 
 Consensus Conformity related changes:
 
@@ -1767,7 +1767,7 @@ Change related to the new `StateManager` interface:
 
 ### Testing and Documentation
 
-Beyond the reintegrated blockchain tests there is now a separate test suite to test the API of the library, see `tests/api`. This should largely reduce the risk of introducing new bugs on the API level on future changes, generally ease the development process by being able to develop against the specific tests and also allows using the tests as a reference for examples on how to use the API.
+Beyond the reintegrated blockchain tests there is now a separate test suite to test the API of the library, see `test/api`. This should largely reduce the risk of introducing new bugs on the API level on future changes, generally ease the development process by being able to develop against the specific tests and also allows using the tests as a reference for examples on how to use the API.
 
 On the documentation side the API documentation has also been consolidated and there is now a unified and auto-generated [API documentation](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/docs/index.md) (previously being manually edited (and too often forgotten) in `README`).
 

--- a/packages/evm/typedoc.js
+++ b/packages/evm/typedoc.js
@@ -2,5 +2,5 @@ module.exports = {
   extends: '../../config/typedoc.js',
   entryPoints: ['src'],
   out: 'docs',
-  exclude: ['tests/**/*.ts', 'src/evm/**'],
+  exclude: ['test/**/*.ts', 'src/evm/**'],
 }

--- a/packages/statemanager/test/ethersStateManager.spec.ts
+++ b/packages/statemanager/test/ethersStateManager.spec.ts
@@ -15,7 +15,7 @@ const isBrowser = new Function('try {return this===window;}catch(e){ return fals
 
 // To run the tests with a live provider, set the PROVIDER environmental variable with a valid provider url
 // from Infura/Alchemy or your favorite web3 provider when running the test.  Below is an example command:
-// `PROVIDER=https://mainnet.infura.io/v3/[mySuperS3cretproviderKey] npm run tape -- 'tests/ethersStateManager.spec.ts'
+// `PROVIDER=https://mainnet.infura.io/v3/[mySuperS3cretproviderKey] npm run tape -- 'test/ethersStateManager.spec.ts'
 tape('Ethers State Manager initialization tests', (t) => {
   const provider = new MockProvider()
   let state = new EthersStateManager({ provider, blockTag: 1n })

--- a/packages/statemanager/typedoc.js
+++ b/packages/statemanager/typedoc.js
@@ -2,5 +2,5 @@ module.exports = {
   extends: '../../config/typedoc.js',
   entryPoints: ['src'],
   out: 'docs',
-  exclude: ['tests/**/*.ts'],
+  exclude: ['test/**/*.ts'],
 }

--- a/packages/vm/.eslintrc.js
+++ b/packages/vm/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['tests/util.ts', 'tests/tester/**/*.ts'],
+      files: ['test/util.ts', 'test/tester/**/*.ts'],
       rules: {
         'no-console': 'off',
       },

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -1752,7 +1752,7 @@ Changes related to Constantinople:
 
 ### Consensus Conformity
 
-This release is making a huge leap forward regarding consensus conformity, and even if you are not interested in `Constantinople` support at all, you should upgrade just for this reason. Some context: we couldn't run blockchain tests for a long time on a steady basis due to performance constraints and when we re-triggered a test run after quite some time with PR [#341](https://github.com/ethereumjs/ethereumjs-monorepo/pull/341) the result was a bit depressing with over 300 failing tests. Thanks to joined efforts from the community and core team members we could bring this down far quicker than expected and this is the first release for a long time which practically comes with complete consensus conformity - with just three recently added tests failing (see `skipBroken` list in `tests/tester.js`) and otherwise passing all blockchain tests and all state tests for both `Constantinople` and `Byzantium` rules. 🏆 🏆 🏆
+This release is making a huge leap forward regarding consensus conformity, and even if you are not interested in `Constantinople` support at all, you should upgrade just for this reason. Some context: we couldn't run blockchain tests for a long time on a steady basis due to performance constraints and when we re-triggered a test run after quite some time with PR [#341](https://github.com/ethereumjs/ethereumjs-monorepo/pull/341) the result was a bit depressing with over 300 failing tests. Thanks to joined efforts from the community and core team members we could bring this down far quicker than expected and this is the first release for a long time which practically comes with complete consensus conformity - with just three recently added tests failing (see `skipBroken` list in `test/tester.js`) and otherwise passing all blockchain tests and all state tests for both `Constantinople` and `Byzantium` rules. 🏆 🏆 🏆
 
 Consensus Conformity related changes:
 
@@ -1786,7 +1786,7 @@ Change related to the new `StateManager` interface:
 
 ### Testing and Documentation
 
-Beyond the reintegrated blockchain tests there is now a separate test suite to test the API of the library, see `tests/api`. This should largely reduce the risk of introducing new bugs on the API level on future changes, generally ease the development process by being able to develop against the specific tests and also allows using the tests as a reference for examples on how to use the API.
+Beyond the reintegrated blockchain tests there is now a separate test suite to test the API of the library, see `test/api`. This should largely reduce the risk of introducing new bugs on the API level on future changes, generally ease the development process by being able to develop against the specific tests and also allows using the tests as a reference for examples on how to use the API.
 
 On the documentation side the API documentation has also been consolidated and there is now a unified and auto-generated [API documentation](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/docs/index.md) (previously being manually edited (and too often forgotten) in `README`).
 

--- a/packages/vm/DEVELOPER.md
+++ b/packages/vm/DEVELOPER.md
@@ -15,21 +15,21 @@ or the associated YouTube video introduction to [Core Development with Ethereumj
 
 Running the State tests:
 
-`ts-node ./tests/tester --state`
+`ts-node ./test/tester --state`
 
 Running the Blockchain tests:
 
-`ts-node ./tests/tester --blockchain`
+`ts-node ./test/tester --blockchain`
 
 Tests run against source by default. They can be run with the `--dist` flag:
 
-`npm run build:dist && node ./tests/tester --state --dist`
+`npm run build:dist && node ./test/tester --state --dist`
 
 See `package.json` for all the scripts in the `test:` namespace, such as `npm run test:state` which would execute the above.
 
 Use `--fork` to pass in the desired hardfork:
 
-`ts-node ./tests/tester --state --fork='Constantinople'`
+`ts-node ./test/tester --state --fork='Constantinople'`
 
 or
 
@@ -53,29 +53,29 @@ State tests run significantly faster than Blockchain tests, so it is often a goo
 
 Running all the blockchain tests in a file:
 
-`ts-node ./tests/tester --blockchain --file='randomStatetest303'`
+`ts-node ./test/tester --blockchain --file='randomStatetest303'`
 
 Running tests from a specific directory:
 
-`ts-node ./tests/tester --blockchain --dir='bcBlockGasLimitTest'`
+`ts-node ./test/tester --blockchain --dir='bcBlockGasLimitTest'`
 
 Running a specific state test case:
 
-`ts-node ./tests/tester --state --test='stackOverflow'`
+`ts-node ./test/tester --state --test='stackOverflow'`
 
 Only run test cases with selected `data`, `gas` and/or `value` values (see
 [attribute description](http://ethereum-tests.readthedocs.io/en/latest/test_types/state_tests.html) in
 test docs), provided by the index of the array element in the test `transaction` section:
 
-`ts-node ./tests/tester --state --test='CreateCollisionToEmpty' --data=0 --gas=1 --value=0`
+`ts-node ./test/tester --state --test='CreateCollisionToEmpty' --data=0 --gas=1 --value=0`
 
 Recursively run all tests from a custom directory:
 
-`ts-node ./tests/tester --state --fork='London' --customTestsPath=../../my_custom_test_folder`
+`ts-node ./test/tester --state --fork='London' --customTestsPath=../../my_custom_test_folder`
 
 Run a test from a specified source file not under the `tests` directory (only state tests):
 
-`ts-node ./tests/tester --state --customStateTest='{path_to_file}'`
+`ts-node ./test/tester --state --customStateTest='{path_to_file}'`
 
 #### Running tests with a reporter/formatter
 
@@ -86,25 +86,25 @@ Run a test from a specified source file not under the `tests` directory (only st
 
 To pipe the results of tests run with a node command to a formatter:
 
-`npm run formatTest -- -t "./tests/tester --blockchain --dir='bcBlockGasLimitTest'" -with 'tap-mocha-reporter json'`
+`npm run formatTest -- -t "./test/tester --blockchain --dir='bcBlockGasLimitTest'" -with 'tap-mocha-reporter json'`
 
 If no reporter or formatter is provided, test results will be reported by `tape` without any additional formatting.
 
 #### Skipping Tests
 
 There are three types of skip lists (`BROKEN`, `PERMANENT` and `SLOW`) which
-can be found in `tests/tester.js`. By default tests from all skip lists are omitted.
+can be found in `test/tester.js`. By default tests from all skip lists are omitted.
 
 You can change this behaviour with:
 
-`ts-node ./tests/tester --state --skip=BROKEN,PERMANENT`
+`ts-node ./test/tester --state --skip=BROKEN,PERMANENT`
 
 to skip only the `BROKEN` and `PERMANENT` tests and include the `SLOW` tests.
 There are also the keywords `NONE` or `ALL` for convenience.
 
 It is also possible to only run the tests from the skip lists:
 
-`ts-node ./tests/tester --state --runSkipped=SLOW`
+`ts-node ./test/tester --state --runSkipped=SLOW`
 
 ### CI Test Integration
 
@@ -124,7 +124,7 @@ For state tests you can use the `--jsontrace` flag to output opcode trace inform
 
 Blockchain tests support `--debug` to verify the postState:
 
-`ts-node ./tests/tester --blockchain --debug --test='ZeroValue_SELFDESTRUCT_ToOneStorageKey_OOGRevert_d0g0v0_EIP158'`
+`ts-node ./test/tester --blockchain --debug --test='ZeroValue_SELFDESTRUCT_ToOneStorageKey_OOGRevert_d0g0v0_EIP158'`
 
 All/most State tests are replicated as Blockchain tests in a `GeneralStateTests` [sub directory](https://github.com/ethereum/tests/tree/develop/BlockchainTests/GeneralStateTests) in the Ethereum tests repo, so for debugging single test cases the Blockchain test version of the State test can be used.
 
@@ -183,7 +183,7 @@ Note: this script runs by actually checking out the targeted branch, running the
 [Clinic](https://github.com/nearform/node-clinic) allows profiling the VM in the node environment. It supports various profiling methods, among them is [flame](https://github.com/nearform/node-clinic-flame) which can be used for generating flamegraphs to highlight bottlenecks and hot paths. As an example, to generate a flamegraph for the VM blockchain tests, you can run:
 
 ```sh
-NODE_OPTIONS="--max-old-space-size=4096" clinic flame -- node ./tests/tester.js --blockchain --excludeDir='GeneralStateTests'
+NODE_OPTIONS="--max-old-space-size=4096" clinic flame -- node ./test/tester.js --blockchain --excludeDir='GeneralStateTests'
 ```
 
 ## Benchmarks

--- a/packages/vm/test/retesteth/README.md
+++ b/packages/vm/test/retesteth/README.md
@@ -8,7 +8,7 @@ Configure and run `transition-tool`:
 
 Note: All paths are relative paths to the `VM` package root.
 
-1. If you change the port number in `transition-cluster.ts` to anything other than 3000 (or run `transition-cluster` on a separate machine or different IP address from retesteth), update `tests/vm/retesteth/clients/ethereumjs/start.sh` to reflect the right IP and port.
+1. If you change the port number in `transition-cluster.ts` to anything other than 3000 (or run `transition-cluster` on a separate machine or different IP address from retesteth), update `test/vm/retesteth/clients/ethereumjs/start.sh` to reflect the right IP and port.
 
 2. From VM package root directory, run `npx ts-node test/retesteth/transition-cluster.ts`
 

--- a/packages/vm/test/retesteth/README.md
+++ b/packages/vm/test/retesteth/README.md
@@ -10,7 +10,7 @@ Note: All paths are relative paths to the `VM` package root.
 
 1. If you change the port number in `transition-cluster.ts` to anything other than 3000 (or run `transition-cluster` on a separate machine or different IP address from retesteth), update `tests/vm/retesteth/clients/ethereumjs/start.sh` to reflect the right IP and port.
 
-2. From VM package root directory, run `npx ts-node tests/retesteth/transition-cluster.ts`
+2. From VM package root directory, run `npx ts-node test/retesteth/transition-cluster.ts`
 
 Configure and run `retesteth`:
 

--- a/packages/vm/test/retesteth/transition-cluster.ts
+++ b/packages/vm/test/retesteth/transition-cluster.ts
@@ -3,7 +3,7 @@ import { resolve } from 'path'
 const fork = require('child_process').fork
 const http = require('http')
 
-const program = resolve('tests/retesteth/transition-child.ts')
+const program = resolve('test/retesteth/transition-child.ts')
 const parameters: any = []
 const options = {
   //stdio: ['pipe', 'pipe', 'pipe', 'ipc'],

--- a/packages/vm/test/tester/scripts/blockchain-test-run-test.sh
+++ b/packages/vm/test/tester/scripts/blockchain-test-run-test.sh
@@ -3,9 +3,9 @@
 # Manual test file for blockchain test runner option sanity checks
 #
 # Evoke from repository root with
-# ./tests/tester/scripts/blockchain-test-run-test.sh
+# ./test/tester/scripts/blockchain-test-run-test.sh
 ##################################################################
 
-ts-node ./tests/tester --blockchain --file='randomStatetest303'
+ts-node ./test/tester --blockchain --file='randomStatetest303'
 # Test that uses the expectException properties in BlockchainTests test files
-ts-node ./tests/tester --blockchain --file='GasUsedHigherThanBlockGasLimitButNotWithRefundsSuicideLast'
+ts-node ./test/tester --blockchain --file='GasUsedHigherThanBlockGasLimitButNotWithRefundsSuicideLast'

--- a/packages/vm/test/tester/scripts/state-test-run-test.sh
+++ b/packages/vm/test/tester/scripts/state-test-run-test.sh
@@ -3,18 +3,18 @@
 # Manual test file for state test runner option sanity checks
 #
 # Evoke from repository root with
-# ./tests/tester/scripts/state-test-run-test.sh
+# ./test/tester/scripts/state-test-run-test.sh
 #############################################################
 
-ts-node ./tests/tester --state --test='stackOverflow'
-ts-node ./tests/tester --state --test='stackOverflow' --fork='Istanbul'
-ts-node ./tests/tester --state --test='CreateCollisionToEmpty' --data=0 --gas=1 --value=0
+ts-node ./test/tester --state --test='stackOverflow'
+ts-node ./test/tester --state --test='stackOverflow' --fork='Istanbul'
+ts-node ./test/tester --state --test='CreateCollisionToEmpty' --data=0 --gas=1 --value=0
 # Test should be executed
-ts-node ./tests/tester --state --test='stackOverflow' --skip=BROKEN,PERMANENT
+ts-node ./test/tester --state --test='stackOverflow' --skip=BROKEN,PERMANENT
 # Test should be executed
-ts-node ./tests/tester --state --test='stackOverflow' --skip=SLOW
+ts-node ./test/tester --state --test='stackOverflow' --skip=SLOW
 # Test should not be executed (test in skip list)
-ts-node ./tests/tester --state --test='UncleFromSideChain' --skip=BROKEN,PERMANENT
-ts-node ./tests/tester --state --customStateTest='./node_modules/ethereumjs-testing/tests/GeneralStateTests/stCreate2/create2InitCodes.json'
-ts-node ./tests/tester --state --test='CreateCollisionToEmpty' --jsontrace
+ts-node ./test/tester --state --test='UncleFromSideChain' --skip=BROKEN,PERMANENT
+ts-node ./test/tester --state --customStateTest='./node_modules/ethereumjs-testing/tests/GeneralStateTests/stCreate2/create2InitCodes.json'
+ts-node ./test/tester --state --test='CreateCollisionToEmpty' --jsontrace
  

--- a/packages/vm/typedoc.js
+++ b/packages/vm/typedoc.js
@@ -2,5 +2,5 @@ module.exports = {
   extends: '../../config/typedoc.js',
   entryPoints: ['src'],
   out: 'docs',
-  exclude: ['tests/**/*.ts', 'src/bloom/*.ts', 'src/evm/**', 'src/state/cache.ts'],
+  exclude: ['test/**/*.ts', 'src/bloom/*.ts', 'src/evm/**', 'src/state/cache.ts'],
 }


### PR DESCRIPTION
Fixes various references to `tests` in packages where the test directory was renamed from `tests` to `test`.  The most impactful one is the update to the `retesteth` configuration which I have tested and verified that it works again.