### PR TITLE
Monorepo: fix broken eth.wiki links

### DIFF
--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -153,7 +153,7 @@ export interface JsonHeader {
 }
 
 /*
- * Based on https://eth.wiki/json-rpc/API
+ * Based on https://ethereum.org/en/developers/docs/apis/json-rpc/
  */
 export interface JsonRpcBlock {
   number: string // the block number. null when pending block.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -185,7 +185,7 @@ See also this [diagram](./diagram/client.svg) for an overview of the client stru
 
 ### Overview
 
-You can expose a [JSON-RPC](https://eth.wiki/json-rpc/API) interface along a client run with:
+You can expose a [JSON-RPC](https://ethereum.org/en/developers/docs/apis/json-rpc/) interface along a client run with:
 
 ```shell
 ethereumjs --rpc
@@ -207,7 +207,7 @@ contribution on the project *hint\* _hint_. 😄
 ### API Examples
 
 You can use `cURL` to request data from an API endpoint. Here is a simple example for
-[web3_clientVersion](https://eth.wiki/json-rpc/API#web3_clientversion):
+[web3_clientVersion](https://ethereum.org/en/developers/docs/apis/json-rpc/#web3_clientversion):
 
 ```shell
 curl -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","id":1,"method":"web3_clientVersion", "params": []}' http://localhost:8545
@@ -235,7 +235,7 @@ This will give you an output like the following:
 ```
 
 Here's an example for a call on an endpoint with the need for parameters. The following call uses
-the [eth_getBlockByNumer](https://eth.wiki/json-rpc/API#eth_getblockbynumber) endpoint
+the [eth_getBlockByNumer](https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblockbynumber) endpoint
 to request data for block number 436 (you can use a tool like
 [RapidTables](https://www.rapidtables.com/convert/number/decimal-to-hex.html) for conversion to `hex`):
 

--- a/packages/client/lib/execution/receipt.ts
+++ b/packages/client/lib/execution/receipt.ts
@@ -195,7 +195,7 @@ export class ReceiptsManager extends MetaDBManager {
         logs = logs.filter((l) => addresses.some((a) => a.equals(l.log[0])))
       }
       if (topics.length > 0) {
-        // From https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_newfilter:
+        // From https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_newfilter/:
         // Topics are order-dependent. A transaction with a log with topics
         // [A, B] will be matched by the following topic filters:
         //  * [] - anything

--- a/packages/client/lib/execution/receipt.ts
+++ b/packages/client/lib/execution/receipt.ts
@@ -195,7 +195,7 @@ export class ReceiptsManager extends MetaDBManager {
         logs = logs.filter((l) => addresses.some((a) => a.equals(l.log[0])))
       }
       if (topics.length > 0) {
-        // From https://eth.wiki/json-rpc/API:
+        // From https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_newfilter:
         // Topics are order-dependent. A transaction with a log with topics
         // [A, B] will be matched by the following topic filters:
         //  * [] - anything

--- a/packages/client/test/rpc/eth/getProof.spec.ts
+++ b/packages/client/test/rpc/eth/getProof.spec.ts
@@ -53,11 +53,11 @@ tape(`${method}: call with valid arguments`, async (t) => {
   // genesis address with balance
   const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
 
-  // contract inspired from https://eth.wiki/json-rpc/API#example-14
+  // contract inspired from https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getstorageat
   /*
     // SPDX-License-Identifier: MIT
     pragma solidity ^0.7.4;
-    
+
     contract Storage {
         uint pos0;
         mapping(address => uint) pos1;

--- a/packages/client/test/rpc/eth/getProof.spec.ts
+++ b/packages/client/test/rpc/eth/getProof.spec.ts
@@ -53,7 +53,7 @@ tape(`${method}: call with valid arguments`, async (t) => {
   // genesis address with balance
   const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
 
-  // contract inspired from https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getstorageat
+  // contract inspired from https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getstorageat/
   /*
     // SPDX-License-Identifier: MIT
     pragma solidity ^0.7.4;

--- a/packages/client/test/rpc/eth/getStorageAt.spec.ts
+++ b/packages/client/test/rpc/eth/getStorageAt.spec.ts
@@ -34,11 +34,11 @@ tape(`${method}: call with valid arguments`, async (t) => {
   // genesis address with balance
   const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
 
-  // contract inspired from https://eth.wiki/json-rpc/API#example-14
+  // contract inspired from https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getstorageat
   /*
     // SPDX-License-Identifier: MIT
     pragma solidity ^0.7.4;
-    
+
     contract Storage {
         uint pos0;
         mapping(address => uint) pos1;

--- a/packages/client/test/rpc/eth/getStorageAt.spec.ts
+++ b/packages/client/test/rpc/eth/getStorageAt.spec.ts
@@ -34,7 +34,7 @@ tape(`${method}: call with valid arguments`, async (t) => {
   // genesis address with balance
   const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
 
-  // contract inspired from https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getstorageat
+  // contract inspired from https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getstorageat/
   /*
     // SPDX-License-Identifier: MIT
     pragma solidity ^0.7.4;

--- a/packages/rlp/src/index.ts
+++ b/packages/rlp/src/index.ts
@@ -8,7 +8,7 @@ export interface Decoded {
 }
 
 /**
- * RLP Encoding based on https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp
+ * RLP Encoding based on https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/
  * This function takes in data, converts it to Uint8Array if not,
  * and adds a length for recursion.
  * @param input Will be converted to Uint8Array

--- a/packages/rlp/src/index.ts
+++ b/packages/rlp/src/index.ts
@@ -8,7 +8,7 @@ export interface Decoded {
 }
 
 /**
- * RLP Encoding based on https://eth.wiki/en/fundamentals/rlp
+ * RLP Encoding based on https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp
  * This function takes in data, converts it to Uint8Array if not,
  * and adds a length for recursion.
  * @param input Will be converted to Uint8Array
@@ -66,7 +66,7 @@ function encodeLength(len: number, offset: number): Uint8Array {
 }
 
 /**
- * RLP Decoding based on https://eth.wiki/en/fundamentals/rlp
+ * RLP Decoding based on https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/
  * @param input Will be converted to Uint8Array
  * @param stream Is the input a stream (false by default)
  * @returns decoded Array of Uint8Arrays containing the original message

--- a/packages/trie/benchmarks/suite.ts
+++ b/packages/trie/benchmarks/suite.ts
@@ -46,7 +46,7 @@ export function createSuite(db: DB) {
     }
 
     // References:
-    // https://gist.github.com/heikoheiko/0fa2b322560ba7794f22
+    // https://gist.github.com/heikoheiko/0fa2b322560ba7794f22/
     for (const samples of [100, 500, 1000, 5000]) {
       await mark(`Checkpointing: ${samples} iterations`, samples, async (i: number) => {
         checkpointTrie.checkpoint()

--- a/packages/trie/benchmarks/suite.ts
+++ b/packages/trie/benchmarks/suite.ts
@@ -18,7 +18,6 @@ export function createSuite(db: DB) {
     // Test ID is defined as: `pair_count`-`era_size`-`key_size`-`value_type`
     // where value_type = symmetric ? 'mir' : 'ran'
     // The standard secure-trie test is `1k-9-32-ran`
-    // https://eth.wiki/en/fundamentals/benchmarks#results-1
 
     for (const [title, eraSize, symmetric] of [
       ['1k-3-32-ran', 3, false],
@@ -47,7 +46,6 @@ export function createSuite(db: DB) {
     }
 
     // References:
-    // https://eth.wiki/en/fundamentals/benchmarks#the-trie
     // https://gist.github.com/heikoheiko/0fa2b322560ba7794f22
     for (const samples of [100, 500, 1000, 5000]) {
       await mark(`Checkpointing: ${samples} iterations`, samples, async (i: number) => {

--- a/packages/trie/test/index.spec.ts
+++ b/packages/trie/test/index.spec.ts
@@ -293,7 +293,7 @@ tape('it should create the genesis state root from ethereum', function (tester) 
 tape('setting back state root (deleteFromDB)', async (t) => {
   const k1 = Buffer.from('1')
   /* Testing with longer value due to `rlpNode.length >= 32` check in `_formatNode()`
-   * Reasoning from https://eth.wiki/fundamentals/patricia-tree:
+   * Reasoning from https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/:
    * "When one node is referenced inside another node, what is included is `H(rlp.encode(x))`,
    * where `H(x) = sha3(x) if len(x) >= 32 else x`"
    */


### PR DESCRIPTION
This PR fixes broken eth.wiki links where possible. And removes the few instances where corresponding docs couldn't be found.