### PR TITLE
client: fix validation logic for optional params in rpc

### DIFF
--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -265,7 +265,7 @@ export class Eth {
 
     this.chainId = middleware(this.chainId.bind(this), 0, [])
 
-    this.estimateGas = middleware(this.estimateGas.bind(this), 2, [
+    this.estimateGas = middleware(this.estimateGas.bind(this), 1, [
       [validators.transaction()],
       [validators.blockOption],
     ])

--- a/packages/client/lib/rpc/validation.ts
+++ b/packages/client/lib/rpc/validation.ts
@@ -21,9 +21,12 @@ export function middleware(method: any, requiredParamsCount: number, validators:
       for (let i = 0; i < validators.length; i++) {
         if (validators[i] !== undefined) {
           for (let j = 0; j < validators[i].length; j++) {
-            const error = validators[i][j](params, i)
-            if (error !== undefined) {
-              return reject(error)
+            // Only apply validators if params[i] is a required parameter or exists
+            if (i < requiredParamsCount || params[i] !== undefined) {
+              const error = validators[i][j](params, i)
+              if (error !== undefined) {
+                return reject(error)
+              }
             }
           }
         }


### PR DESCRIPTION
Fixes a bug discovered in `eth_estimateGas` where the parameter logic was being applied to an optional parameter when the optional parameter didn't exist.