### PR TITLE
common: Ignore merge hf in nextHardforkBlock

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -646,7 +646,17 @@ export class Common extends EventEmitter {
    */
   nextHardforkBlock(hardfork?: string | Hardfork): bigint | null {
     hardfork = hardfork ?? this._hardfork
-    const hfBlock = this.hardforkBlock(hardfork)
+    let hfBlock = this.hardforkBlock(hardfork)
+    // If this is a merge hardfork with block not set, then we fallback to previous hardfork
+    // to find the nextHardforkBlock
+    if (hfBlock === null && hardfork === Hardfork.Merge) {
+      const hfs = this.hardforks()
+      const mergeIndex = hfs.findIndex((hf) => hf.ttd !== null && hf.ttd !== undefined)
+      if (mergeIndex < 0) {
+        throw Error(`Merge hardfork should have been found`)
+      }
+      hfBlock = this.hardforkBlock(hfs[mergeIndex - 1].name)
+    }
     if (hfBlock === null) {
       return null
     }
@@ -655,8 +665,12 @@ export class Common extends EventEmitter {
     // a block greater than the current hfBlock set the accumulator,
     // pass on the accumulator as the final result from this time on
     const nextHfBlock = this.hardforks().reduce((acc: bigint | null, hf: HardforkConfig) => {
-      const block = BigInt(hf.block === null || hf.ttd !== undefined ? 0 : hf.block)
-      return block > hfBlock && acc === null ? block : acc
+      // We need to ignore the merge block in our next hardfork calc
+      const block = BigInt(
+        hf.block === null || (hf.ttd !== undefined && hf.ttd !== null) ? 0 : hf.block
+      )
+      // Typescript can't seem to follow that the hfBlock is not null at this point
+      return block > hfBlock! && acc === null ? block : acc
     }, null)
     return nextHfBlock
   }

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -655,7 +655,7 @@ export class Common extends EventEmitter {
     // a block greater than the current hfBlock set the accumulator,
     // pass on the accumulator as the final result from this time on
     const nextHfBlock = this.hardforks().reduce((acc: bigint | null, hf: HardforkConfig) => {
-      const block = BigInt(typeof hf.block !== 'number' ? 0 : hf.block)
+      const block = BigInt(hf.block === null || hf.ttd !== undefined ? 0 : hf.block)
       return block > hfBlock && acc === null ? block : acc
     }, null)
     return nextHfBlock

--- a/packages/common/test/mergePOS.spec.ts
+++ b/packages/common/test/mergePOS.spec.ts
@@ -231,6 +231,19 @@ tape('[Common]: Merge/POS specific logic', function (t: tape.Test) {
       Hardfork.MergeForkIdTransition,
       msg
     )
+
+    // Check nextHardforkBlock should be MergeForkIdTransition's block on london and merge both
+    st.equal(
+      c.nextHardforkBlock(Hardfork.London),
+      1735371n,
+      `should get nextHardforkBlock correctly`
+    )
+    st.equal(
+      c.nextHardforkBlock(Hardfork.Merge),
+      1735371n,
+      `should get nextHardforkBlock correctly`
+    )
+
     try {
       st.equal(
         c.getHardforkByBlockNumber(1735371, BigInt('15000000000000000')),
@@ -294,6 +307,19 @@ tape('[Common]: Merge/POS specific logic', function (t: tape.Test) {
         Hardfork.MergeForkIdTransition,
         msg
       )
+
+      // Check nextHardforkBlock should be MergeForkIdTransition's block on london and merge both
+      st.equal(
+        c.nextHardforkBlock(Hardfork.London),
+        1735371n,
+        `should get nextHardforkBlock correctly`
+      )
+      st.equal(
+        c.nextHardforkBlock(Hardfork.Merge),
+        1735371n,
+        `should get nextHardforkBlock correctly`
+      )
+
       // restore value
       mergeHf.block = prevMergeBlockVal
 


### PR DESCRIPTION
One side effect of providing merge block in the config is the `nextHardforkBlock`, which resulted into this error on peer connections on Sepolia
```typescript
[10-17|15:51:51] DEBUG Peer connected: id=7dbed138 address=184.169.161.146:30303 transport=rlpx protocols=eth,snap inbound=true 
[10-17|15:51:51] DEBUG Found full peer: id=7dbed138 address=184.169.161.146:30303 transport=rlpx protocols=eth,snap inbound=true 
[10-17|15:51:51] DEBUG Peer added: id=7dbed138 address=184.169.161.146:30303 transport=rlpx protocols=eth,snap inbound=true 
[10-17|15:51:52] DEBUG Peer disconnected (SUBPROTOCOL_ERROR): id=7dbed138 address=184.169.161.146:30303 transport=rlpx protocols=eth,snap inbound=true 
```
with no peer actually connecting when starting sync before merge.

On investigating the reason found turned out to be:

If merge hf block number is kept at null, then the nextHardforkBlock at `london` gives `mergeForkIdTransition`'s block.
But post setting the merge hf block, it gives `merge`'s block, which causes no peer to pair.

This PR fixes the same and ignores the merge's block number to calculate nexthardfork block