### PR TITLE
evm: expose getActiveOpcodes

### DIFF
--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -1,7 +1,7 @@
 import type { EVM, EVMResult, ExecResult } from './evm'
 import type { InterpreterStep } from './interpreter'
 import type { Message } from './message'
-import type { OpHandler } from './opcodes'
+import type { OpHandler, OpcodeList } from './opcodes'
 import type { AsyncDynamicGasHandler, SyncDynamicGasHandler } from './opcodes/gas'
 import type { Account, Address, PrefixedHexString } from '@ethereumjs/util'
 import type { EventEmitter2 as AsyncEventEmitter } from 'eventemitter2'
@@ -16,6 +16,7 @@ export interface EVMInterface {
   copy(): EVMInterface
   eei: EEIInterface
   events?: AsyncEventEmitter
+  getActiveOpcodes?: () => OpcodeList
 }
 
 /**


### PR DESCRIPTION
This now allows to access `getActiveOpcodes` if `EVMInterface` is of type `EVM`. For instance, in VM:

`const opcodes = vm.evm.getActiveOpcodes!()`

Closes #2363