### PR TITLE
Release Fixes (new Util release v8.0.1, new client release v0.6.5 (v0.6.4 broken))

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5379,64 +5379,6 @@
         "node": ">=10.12.0"
       }
     },
-    "node_modules/c8/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/c8/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
-    "node_modules/c8/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/c8/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/c8/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/cached-path-relative": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.1.0.tgz",
@@ -5544,9 +5486,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001420",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001420.tgz",
-      "integrity": "sha512-OnyeJ9ascFA9roEj72ok2Ikp7PHJTKubtEJIQ/VK3fdsS50q4KWy+Z5X0A1/GswEItKX0ctAp8n4SYDE7wTu6A==",
+      "version": "1.0.30001422",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz",
+      "integrity": "sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==",
       "dev": true,
       "funding": [
         {
@@ -5772,27 +5714,27 @@
       "dev": true
     },
     "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
+        "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/cliui/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5801,6 +5743,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -6916,9 +6859,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.283",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.283.tgz",
-      "integrity": "sha512-g6RQ9zCOV+U5QVHW9OpFR7rdk/V7xfopNXnyAamdpFgCHgZ1sjI8VuR1+zG2YG/TZk+tQ8mpNkug4P8FU0fuOA==",
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -9710,9 +9653,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -10344,9 +10287,9 @@
       }
     },
     "node_modules/it-buffer/node_modules/bl": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
-      "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
       "dependencies": {
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
@@ -10442,9 +10385,9 @@
       }
     },
     "node_modules/it-length-prefixed/node_modules/bl": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
-      "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
       "dependencies": {
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
@@ -10588,9 +10531,9 @@
       }
     },
     "node_modules/it-reader/node_modules/bl": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
-      "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
       "dependencies": {
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
@@ -11262,32 +11205,6 @@
         "node": ">=0.6.0"
       }
     },
-    "node_modules/karma/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/karma/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
-    },
-    "node_modules/karma/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/karma/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11295,38 +11212,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/karma/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/karma/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/keypair": {
@@ -12041,9 +11926,9 @@
       }
     },
     "node_modules/libp2p-mplex/node_modules/bl": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
-      "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
       "dependencies": {
         "buffer": "^6.0.3",
         "inherits": "^2.0.4",
@@ -16410,9 +16295,9 @@
       }
     },
     "node_modules/safe-stable-stringify": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.0.tgz",
-      "integrity": "sha512-eehKHKpab6E741ud7ZIMcXhKcP6TSIezPkNZhy5U8xC6+VvrRdUA2tMgxGxaGl4cz7c2Ew5+mg5+wNB16KQqrA==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
+      "integrity": "sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA==",
       "engines": {
         "node": ">=10"
       }
@@ -19712,20 +19597,21 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
-      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
       "dependencies": {
-        "cliui": "^8.0.1",
+        "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
+        "string-width": "^4.2.0",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^20.2.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       }
     },
     "node_modules/yargs-parser": {
@@ -19740,12 +19626,14 @@
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
     },
     "node_modules/yargs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -19754,6 +19642,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -19761,14 +19650,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yn": {
@@ -19800,7 +19681,7 @@
         "@ethereumjs/rlp": "^4.0.0",
         "@ethereumjs/trie": "^5.0.1",
         "@ethereumjs/tx": "^4.0.1",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "ethereum-cryptography": "^1.1.2",
         "ethers": "^5.7.1"
       },
@@ -19821,7 +19702,7 @@
         "@ethereumjs/ethash": "^2.0.1",
         "@ethereumjs/rlp": "^4.0.0",
         "@ethereumjs/trie": "^5.0.1",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "abstract-level": "^1.0.3",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^1.1.2",
@@ -19840,7 +19721,7 @@
     },
     "packages/client": {
       "name": "@ethereumjs/client",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -19849,13 +19730,13 @@
         "@ethereumjs/blockchain": "6.0.1",
         "@ethereumjs/common": "3.0.1",
         "@ethereumjs/devp2p": "5.0.1",
-        "@ethereumjs/ethash": "2.0.0",
+        "@ethereumjs/ethash": "2.0.1",
         "@ethereumjs/evm": "1.1.0",
         "@ethereumjs/rlp": "4.0.0",
         "@ethereumjs/statemanager": "1.0.1",
         "@ethereumjs/trie": "5.0.1",
         "@ethereumjs/tx": "4.0.1",
-        "@ethereumjs/util": "8.0.0",
+        "@ethereumjs/util": "8.0.1",
         "@ethereumjs/vm": "6.1.0",
         "abstract-level": "^1.0.3",
         "body-parser": "^1.19.2",
@@ -19913,20 +19794,68 @@
         "node": ">=14"
       }
     },
-    "packages/client/node_modules/@ethereumjs/ethash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/ethash/-/ethash-2.0.0.tgz",
-      "integrity": "sha512-U4+G1UYDCeqGW59h9FtjxVPZcQc/+nptpAMjQfGIN2nA1ZXoxtZiyVBgW0ocyofIbpySnSNMQRcUq2iqJ/7qug==",
+    "packages/client/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dependencies": {
-        "@ethereumjs/block": "^4.0.0",
-        "@ethereumjs/rlp": "^4.0.0",
-        "@ethereumjs/util": "^8.0.0",
-        "abstract-level": "^1.0.3",
-        "bigint-crypto-utils": "^3.0.23",
-        "ethereum-cryptography": "^1.1.2"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=12"
+      }
+    },
+    "packages/client/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "packages/client/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/client/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/client/node_modules/yargs": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/client/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/common": {
@@ -19934,7 +19863,7 @@
       "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "crc-32": "^1.2.0"
       }
     },
@@ -19945,7 +19874,7 @@
       "dependencies": {
         "@ethereumjs/common": "^3.0.1",
         "@ethereumjs/rlp": "^4.0.0",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "@scure/base": "1.1.1",
         "@types/bl": "^2.1.0",
         "@types/k-bucket": "^5.0.0",
@@ -20044,7 +19973,7 @@
       "dependencies": {
         "@ethereumjs/block": "^4.0.1",
         "@ethereumjs/rlp": "^4.0.0",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "abstract-level": "^1.0.3",
         "bigint-crypto-utils": "^3.0.23",
         "ethereum-cryptography": "^1.1.2"
@@ -20063,7 +19992,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/common": "^3.0.1",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "@ethersproject/providers": "^5.7.1",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^1.1.2",
@@ -20116,7 +20045,7 @@
       "devDependencies": {
         "@ethereumjs/block": "^4.0.1",
         "@ethereumjs/trie": "^5.0.1",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
         "debug": "^4.3.3",
@@ -20141,7 +20070,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/rlp": "^4.0.0",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "@types/readable-stream": "^2.3.13",
         "ethereum-cryptography": "^1.1.2",
         "readable-stream": "^3.6.0"
@@ -20182,7 +20111,7 @@
       "dependencies": {
         "@ethereumjs/common": "^3.0.1",
         "@ethereumjs/rlp": "^4.0.0",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "ethereum-cryptography": "^1.1.2",
         "ethers": "^5.7.1"
       },
@@ -20198,7 +20127,7 @@
     },
     "packages/util": {
       "name": "@ethereumjs/util",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/rlp": "^4.0.0-beta.2",
@@ -20225,7 +20154,7 @@
         "@ethereumjs/statemanager": "^1.0.1",
         "@ethereumjs/trie": "^5.0.1",
         "@ethereumjs/tx": "^4.0.1",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^1.1.2",
         "eventemitter2": "^6.4.9",
@@ -21710,7 +21639,7 @@
         "@ethereumjs/rlp": "^4.0.0",
         "@ethereumjs/trie": "^5.0.1",
         "@ethereumjs/tx": "^4.0.1",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "@types/lru-cache": "^5.1.0",
         "ethereum-cryptography": "^1.1.2",
         "ethers": "^5.7.1"
@@ -21724,7 +21653,7 @@
         "@ethereumjs/ethash": "^2.0.1",
         "@ethereumjs/rlp": "^4.0.0",
         "@ethereumjs/trie": "^5.0.1",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "@types/async": "^2.4.1",
         "@types/level-errors": "^3.0.0",
         "@types/lru-cache": "^5.1.0",
@@ -21744,13 +21673,13 @@
         "@ethereumjs/blockchain": "6.0.1",
         "@ethereumjs/common": "3.0.1",
         "@ethereumjs/devp2p": "5.0.1",
-        "@ethereumjs/ethash": "2.0.0",
+        "@ethereumjs/ethash": "2.0.1",
         "@ethereumjs/evm": "1.1.0",
         "@ethereumjs/rlp": "4.0.0",
         "@ethereumjs/statemanager": "1.0.1",
         "@ethereumjs/trie": "5.0.1",
         "@ethereumjs/tx": "4.0.1",
-        "@ethereumjs/util": "8.0.0",
+        "@ethereumjs/util": "8.0.1",
         "@ethereumjs/vm": "6.1.0",
         "@types/body-parser": "^1.19.2",
         "@types/connect": "^3.4.35",
@@ -21800,25 +21729,61 @@
         "yargs": "^17.2.1"
       },
       "dependencies": {
-        "@ethereumjs/ethash": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@ethereumjs/ethash/-/ethash-2.0.0.tgz",
-          "integrity": "sha512-U4+G1UYDCeqGW59h9FtjxVPZcQc/+nptpAMjQfGIN2nA1ZXoxtZiyVBgW0ocyofIbpySnSNMQRcUq2iqJ/7qug==",
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
           "requires": {
-            "@ethereumjs/block": "^4.0.0",
-            "@ethereumjs/rlp": "^4.0.0",
-            "@ethereumjs/util": "^8.0.0",
-            "abstract-level": "^1.0.3",
-            "bigint-crypto-utils": "^3.0.23",
-            "ethereum-cryptography": "^1.1.2"
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
           }
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "yargs": {
+          "version": "17.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+          "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
         }
       }
     },
     "@ethereumjs/common": {
       "version": "file:packages/common",
       "requires": {
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "crc-32": "^1.2.0"
       }
     },
@@ -21829,7 +21794,7 @@
         "@ethereumjs/common": "^3.0.1",
         "@ethereumjs/rlp": "^4.0.0",
         "@ethereumjs/tx": "^4.0.1",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "@scure/base": "1.1.1",
         "@types/bl": "^2.1.0",
         "@types/chalk": "^2.2.0",
@@ -21910,7 +21875,7 @@
         "@ethereumjs/block": "^4.0.1",
         "@ethereumjs/common": "^3.0.1",
         "@ethereumjs/rlp": "^4.0.0",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "abstract-level": "^1.0.3",
         "bigint-crypto-utils": "^3.0.23",
         "ethereum-cryptography": "^1.1.2",
@@ -21922,7 +21887,7 @@
       "requires": {
         "@ethereumjs/common": "^3.0.1",
         "@ethereumjs/statemanager": "^1.0.1",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "@ethersproject/abi": "^5.0.12",
         "@ethersproject/providers": "^5.7.1",
         "@types/benchmark": "^1.0.33",
@@ -21953,7 +21918,7 @@
         "@ethereumjs/common": "^3.0.1",
         "@ethereumjs/rlp": "^4.0.0",
         "@ethereumjs/trie": "^5.0.1",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "@types/node": "^16.11.7",
         "@types/tape": "^4.13.2",
         "debug": "^4.3.3",
@@ -21978,7 +21943,7 @@
       "version": "file:packages/trie",
       "requires": {
         "@ethereumjs/rlp": "^4.0.0",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "@types/benchmark": "^1.0.33",
         "@types/readable-stream": "^2.3.13",
         "0x": "^4.9.1",
@@ -22011,7 +21976,7 @@
       "requires": {
         "@ethereumjs/common": "^3.0.1",
         "@ethereumjs/rlp": "^4.0.0",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "@types/minimist": "^1.2.0",
         "@types/node-dir": "^0.0.34",
         "ethereum-cryptography": "^1.1.2",
@@ -22040,7 +22005,7 @@
         "@ethereumjs/statemanager": "^1.0.1",
         "@ethereumjs/trie": "^5.0.1",
         "@ethereumjs/tx": "^4.0.1",
-        "@ethereumjs/util": "^8.0.0",
+        "@ethereumjs/util": "^8.0.1",
         "@ethersproject/abi": "^5.0.12",
         "@types/benchmark": "^1.0.33",
         "@types/core-js": "^2.5.0",
@@ -24678,57 +24643,6 @@
         "v8-to-istanbul": "^9.0.0",
         "yargs": "^16.2.0",
         "yargs-parser": "^20.2.9"
-      },
-      "dependencies": {
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        }
       }
     },
     "cached-path-relative": {
@@ -24815,9 +24729,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001420",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001420.tgz",
-      "integrity": "sha512-OnyeJ9ascFA9roEj72ok2Ikp7PHJTKubtEJIQ/VK3fdsS50q4KWy+Z5X0A1/GswEItKX0ctAp8n4SYDE7wTu6A==",
+      "version": "1.0.30001422",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz",
+      "integrity": "sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==",
       "dev": true
     },
     "caseless": {
@@ -24982,29 +24896,33 @@
       "dev": true
     },
     "cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
       "requires": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
+        "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
       },
       "dependencies": {
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
         },
         "string-width": {
           "version": "4.2.3",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
           "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -25967,9 +25885,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.283",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.283.tgz",
-      "integrity": "sha512-g6RQ9zCOV+U5QVHW9OpFR7rdk/V7xfopNXnyAamdpFgCHgZ1sjI8VuR1+zG2YG/TZk+tQ8mpNkug4P8FU0fuOA==",
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
       "dev": true
     },
     "elliptic": {
@@ -28142,9 +28060,9 @@
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.10.0.tgz",
-      "integrity": "sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -28598,9 +28516,9 @@
       },
       "dependencies": {
         "bl": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
-          "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+          "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
           "requires": {
             "buffer": "^6.0.3",
             "inherits": "^2.0.4",
@@ -28683,9 +28601,9 @@
       },
       "dependencies": {
         "bl": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
-          "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+          "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
           "requires": {
             "buffer": "^6.0.3",
             "inherits": "^2.0.4",
@@ -28813,9 +28731,9 @@
       },
       "dependencies": {
         "bl": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
-          "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+          "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
           "requires": {
             "buffer": "^6.0.3",
             "inherits": "^2.0.4",
@@ -29177,60 +29095,11 @@
         "yargs": "^16.1.1"
       },
       "dependencies": {
-        "cliui": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
         }
       }
     },
@@ -30213,9 +30082,9 @@
       },
       "dependencies": {
         "bl": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
-          "integrity": "sha512-8vxFNZ0pflFfi0WXA3WQXlj6CaMEwsmh63I1CNp0q+wWv8sD0ARx1KovSQd0l2GkwrMIOyedq0EF1FxI+RCZLQ==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+          "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
           "requires": {
             "buffer": "^6.0.3",
             "inherits": "^2.0.4",
@@ -33536,9 +33405,9 @@
       }
     },
     "safe-stable-stringify": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.0.tgz",
-      "integrity": "sha512-eehKHKpab6E741ud7ZIMcXhKcP6TSIezPkNZhy5U8xC6+VvrRdUA2tMgxGxaGl4cz7c2Ew5+mg5+wNB16KQqrA=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.1.tgz",
+      "integrity": "sha512-dVHE6bMtS/bnL2mwualjc6IxEv1F+OCUpA46pKUj6F8uDbUM0jCCulPqRNPSnWwGNKx5etqMjZYdXtrm5KJZGA=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -36125,43 +35994,42 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
-      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
       "requires": {
-        "cliui": "^8.0.1",
+        "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
+        "string-width": "^4.2.0",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^20.2.2"
       },
       "dependencies": {
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
         },
         "string-width": {
           "version": "4.2.3",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
           "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
             "strip-ansi": "^6.0.1"
           }
-        },
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
         }
       }
     },

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -42,7 +42,7 @@
     "@ethereumjs/rlp": "^4.0.0",
     "@ethereumjs/trie": "^5.0.1",
     "@ethereumjs/tx": "^4.0.1",
-    "@ethereumjs/util": "^8.0.0",
+    "@ethereumjs/util": "^8.0.1",
     "ethereum-cryptography": "^1.1.2",
     "ethers": "^5.7.1"
   },

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -43,7 +43,7 @@
     "@ethereumjs/ethash": "^2.0.1",
     "@ethereumjs/rlp": "^4.0.0",
     "@ethereumjs/trie": "^5.0.1",
-    "@ethereumjs/util": "^8.0.0",
+    "@ethereumjs/util": "^8.0.1",
     "abstract-level": "^1.0.3",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^1.1.2",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 0.6.5 - 2022-10-19
+
+- Fixes broken release v0.6.4 (wrong @ethereumjs/util dependency)
+
 ## 0.6.4 - 2022-10-18
+
+[ BROKEN] (wrong @ethereumjs/util dependency)
 
 - Fixed reorg handling in the underlying `@ethereumjs/blockchain` library `iterator()` function, PR [#2308](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2308)
 - Fixed a bug leading to exclusion of subsequent transactions build on top of previous ones, PR [#2333](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2333)

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/client",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "EthereumJS client implementation",
   "keywords": [
     "ethereum",
@@ -60,13 +60,13 @@
     "@ethereumjs/blockchain": "6.0.1",
     "@ethereumjs/common": "3.0.1",
     "@ethereumjs/devp2p": "5.0.1",
-    "@ethereumjs/ethash": "2.0.0",
+    "@ethereumjs/ethash": "2.0.1",
     "@ethereumjs/evm": "1.1.0",
     "@ethereumjs/rlp": "4.0.0",
     "@ethereumjs/statemanager": "1.0.1",
     "@ethereumjs/trie": "5.0.1",
     "@ethereumjs/tx": "4.0.1",
-    "@ethereumjs/util": "8.0.0",
+    "@ethereumjs/util": "8.0.1",
     "@ethereumjs/vm": "6.1.0",
     "abstract-level": "^1.0.3",
     "body-parser": "^1.19.2",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -48,7 +48,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/util": "^8.0.0",
+    "@ethereumjs/util": "^8.0.1",
     "crc-32": "^1.2.0"
   }
 }

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@ethereumjs/common": "^3.0.1",
     "@ethereumjs/rlp": "^4.0.0",
-    "@ethereumjs/util": "^8.0.0",
+    "@ethereumjs/util": "^8.0.1",
     "@scure/base": "1.1.1",
     "@types/bl": "^2.1.0",
     "@types/k-bucket": "^5.0.0",

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@ethereumjs/block": "^4.0.1",
     "@ethereumjs/rlp": "^4.0.0",
-    "@ethereumjs/util": "^8.0.0",
+    "@ethereumjs/util": "^8.0.1",
     "abstract-level": "^1.0.3",
     "bigint-crypto-utils": "^3.0.23",
     "ethereum-cryptography": "^1.1.2"

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@ethereumjs/common": "^3.0.1",
-    "@ethereumjs/util": "^8.0.0",
+    "@ethereumjs/util": "^8.0.1",
     "@ethersproject/providers": "^5.7.1",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^1.1.2",

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@ethereumjs/block": "^4.0.1",
     "@ethereumjs/trie": "^5.0.1",
-    "@ethereumjs/util": "^8.0.0",
+    "@ethereumjs/util": "^8.0.1",
     "@types/node": "^16.11.7",
     "@types/tape": "^4.13.2",
     "debug": "^4.3.3",

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@ethereumjs/rlp": "^4.0.0",
-    "@ethereumjs/util": "^8.0.0",
+    "@ethereumjs/util": "^8.0.1",
     "@types/readable-stream": "^2.3.13",
     "ethereum-cryptography": "^1.1.2",
     "readable-stream": "^3.6.0"

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@ethereumjs/common": "^3.0.1",
     "@ethereumjs/rlp": "^4.0.0",
-    "@ethereumjs/util": "^8.0.0",
+    "@ethereumjs/util": "^8.0.1",
     "ethereum-cryptography": "^1.1.2",
     "ethers": "^5.7.1"
   },

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 8.0.1 - 2022-10-19
+
+- Added new `Lock` functionality, PR [#2308](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2308)
+
 ## 8.0.0 - 2022-09-06
 
 Final release - tada 🎉 - of a wider breaking release round on the [EthereumJS monorepo](https://github.com/ethereumjs/ethereumjs-monorepo) libraries, see the Beta 1 release notes for the main long change set description as well as the Beta 2, Beta 3 and Release Candidate (RC) 1 release notes for notes on some additional changes ([CHANGELOG](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/util/CHANGELOG.md)).

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/util",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "A collection of utility functions for Ethereum",
   "keywords": [
     "ethereum",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -64,7 +64,7 @@
     "@ethereumjs/statemanager": "^1.0.1",
     "@ethereumjs/trie": "^5.0.1",
     "@ethereumjs/tx": "^4.0.1",
-    "@ethereumjs/util": "^8.0.0",
+    "@ethereumjs/util": "^8.0.1",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^1.1.2",
     "eventemitter2": "^6.4.9",


### PR DESCRIPTION
This PR fixes releases from #2361 by submitting a forgotten Util release v8.0.1 which caused releases from Blockchain upwards to be broken as well as doing a new Client release v0.6.5 since v0.6.4 has a hardcoded Util v8.0.0 dependency which wouldn't been updated (so v0.6.4 is also broken).

Open for review. 🙂 