### PR TITLE
Switch eventemitter2 to local asynceventemitter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8013,11 +8013,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/eventemitter2": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
-      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
-    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -19996,7 +19991,6 @@
         "@ethersproject/providers": "^5.7.1",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^1.1.2",
-        "eventemitter2": "^6.4.9",
         "mcl-wasm": "^0.7.1",
         "rustbn.js": "~0.2.0"
       },
@@ -20131,6 +20125,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/rlp": "^4.0.0-beta.2",
+        "async": "^3.2.4",
         "ethereum-cryptography": "^1.1.2"
       },
       "devDependencies": {
@@ -20157,7 +20152,6 @@
         "@ethereumjs/util": "^8.0.1",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^1.1.2",
-        "eventemitter2": "^6.4.9",
         "mcl-wasm": "^0.7.1",
         "rustbn.js": "~0.2.0"
       },
@@ -21898,7 +21892,6 @@
         "benchmark": "^2.1.4",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^1.1.2",
-        "eventemitter2": "^6.4.9",
         "level": "^8.0.0",
         "mcl-wasm": "^0.7.1",
         "memory-level": "^1.0.0",
@@ -21991,6 +21984,7 @@
         "@ethereumjs/rlp": "^4.0.0-beta.2",
         "@types/bn.js": "^5.1.0",
         "@types/secp256k1": "^4.0.1",
+        "async": "^3.2.4",
         "ethereum-cryptography": "^1.1.2"
       }
     },
@@ -22015,7 +22009,6 @@
         "benchmark": "^2.1.4",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^1.1.2",
-        "eventemitter2": "^6.4.9",
         "level": "^8.0.0",
         "mcl-wasm": "^0.7.1",
         "memory-level": "^1.0.0",
@@ -26806,11 +26799,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-    },
-    "eventemitter2": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
-      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
     },
     "eventemitter3": {
       "version": "4.0.7",

--- a/packages/evm/examples/runCode.ts
+++ b/packages/evm/examples/runCode.ts
@@ -22,14 +22,10 @@ const main = async () => {
   // Note that numbers added are hex values, so '20' would be '32' as decimal e.g.
   const code = [PUSH1, '03', PUSH1, '05', ADD, STOP]
 
-  evm.events.on(
-    'step',
-    function (data) {
-      // Note that data.stack is not immutable, i.e. it is a reference to the vm's internal stack object
-      console.log(`Opcode: ${data.opcode.name}\tStack: ${data.stack}`)
-    },
-    { promisify: true }
-  )
+  evm.events.on('step', function (data) {
+    // Note that data.stack is not immutable, i.e. it is a reference to the vm's internal stack object
+    console.log(`Opcode: ${data.opcode.name}\tStack: ${data.stack}`)
+  })
 
   evm
     .runCode({

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -51,7 +51,6 @@
     "@ethersproject/providers": "^5.7.1",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^1.1.2",
-    "eventemitter2": "^6.4.9",
     "mcl-wasm": "^0.7.1",
     "rustbn.js": "~0.2.0"
   },

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -1,6 +1,7 @@
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import {
   Address,
+  AsyncEventEmitter,
   KECCAK256_NULL,
   MAX_INTEGER,
   bigIntToBuffer,
@@ -10,7 +11,7 @@ import {
   zeros,
 } from '@ethereumjs/util'
 import { debug as createDebugLogger } from 'debug'
-import { EventEmitter2 as AsyncEventEmitter } from 'eventemitter2'
+import { promisify } from 'util'
 
 import { EOF } from './eof'
 import { ERROR, EvmError } from './exceptions'
@@ -29,6 +30,7 @@ import type {
   Block,
   CustomOpcode,
   EEIInterface,
+  EVMEvents,
   EVMInterface,
   EVMRunCallOpts,
   EVMRunCodeOpts,
@@ -148,7 +150,7 @@ export class EVM implements EVMInterface {
 
   public readonly _transientStorage: TransientStorage
 
-  public readonly events: AsyncEventEmitter
+  public readonly events: AsyncEventEmitter<EVMEvents>
 
   /**
    * This opcode data is always set since `getActiveOpcodes()` is called in the constructor
@@ -201,6 +203,8 @@ export class EVM implements EVMInterface {
    * @hidden
    */
   readonly DEBUG: boolean = false
+
+  public readonly _emit: (topic: string, data: any) => Promise<void>
 
   /**
    * EVM async constructor. Creates engine instance and initializes it.
@@ -285,6 +289,12 @@ export class EVM implements EVMInterface {
         this._mcl = mcl
       }
     }
+
+    // We cache this promisified function as it's called from the main execution loop, and
+    // promisifying each time has a huge performance impact.
+    this._emit = <(topic: string, data: any) => Promise<void>>(
+      promisify(this.events.emit.bind(this.events))
+    )
 
     // Safeguard if "process" is not available (browser)
     if (typeof process?.env.DEBUG !== 'undefined') {
@@ -450,7 +460,7 @@ export class EVM implements EVMInterface {
       code: message.code,
     }
 
-    await this.events.emitAsync('newContract', newContractEvent)
+    await this._emit('newContract', newContractEvent)
 
     toAccount = await this.eei.getAccount(message.to)
     // EIP-161 on account creation and CREATE execution
@@ -711,7 +721,7 @@ export class EVM implements EVMInterface {
       })
     }
 
-    await this.events.emitAsync('beforeMessage', message)
+    await this._emit('beforeMessage', message)
 
     if (!message.to && this._common.isActivatedEIP(2929) === true) {
       message.code = message.data
@@ -787,7 +797,7 @@ export class EVM implements EVMInterface {
         debug(`message checkpoint committed`)
       }
     }
-    await this.events.emitAsync('afterMessage', result)
+    await this._emit('afterMessage', result)
 
     return result
   }

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -356,7 +356,7 @@ export class Interpreter {
      * @property {BigInt} memoryWordCount current size of memory in words
      * @property {Address} codeAddress the address of the code which is currently being ran (this differs from `address` in a `DELEGATECALL` and `CALLCODE` call)
      */
-    await this._evm.events.emitAsync('step', eventObj)
+    await this._evm._emit('step', eventObj)
   }
 
   // Returns all valid jump and jumpsub destinations.

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -3,8 +3,7 @@ import type { InterpreterStep } from './interpreter'
 import type { Message } from './message'
 import type { OpHandler, OpcodeList } from './opcodes'
 import type { AsyncDynamicGasHandler, SyncDynamicGasHandler } from './opcodes/gas'
-import type { Account, Address, PrefixedHexString } from '@ethereumjs/util'
-import type { EventEmitter2 as AsyncEventEmitter } from 'eventemitter2'
+import type { Account, Address, AsyncEventEmitter, PrefixedHexString } from '@ethereumjs/util'
 
 /**
  * API of the EVM
@@ -16,7 +15,7 @@ export interface EVMInterface {
   precompiles: Map<string, any> // Note: the `any` type is used because EVM only needs to have the addresses of the precompiles (not their functions)
   copy(): EVMInterface
   eei: EEIInterface
-  events?: AsyncEventEmitter
+  events?: AsyncEventEmitter<EVMEvents>
 }
 
 /**

--- a/packages/evm/test/asyncEvents.spec.ts
+++ b/packages/evm/test/asyncEvents.spec.ts
@@ -16,7 +16,7 @@ tape.only('async events', async (t) => {
     const startTime = Date.now()
     setTimeout(() => {
       t.ok(Date.now() > startTime, 'evm paused on step function for one second')
-      next()
+      next?.()
     }, 1000)
   })
   const runCallArgs = {

--- a/packages/evm/test/asyncEvents.spec.ts
+++ b/packages/evm/test/asyncEvents.spec.ts
@@ -6,7 +6,7 @@ import { EVM } from '../src'
 
 import { getEEI } from './utils'
 
-tape.only('async events', async (t) => {
+tape('async events', async (t) => {
   t.plan(2)
   const caller = new Address(Buffer.from('00000000000000000000000000000000000000ee', 'hex'))
   const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Constantinople })

--- a/packages/evm/test/asyncEvents.spec.ts
+++ b/packages/evm/test/asyncEvents.spec.ts
@@ -1,0 +1,28 @@
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Address } from '@ethereumjs/util'
+import * as tape from 'tape'
+
+import { EVM } from '../src'
+
+import { getEEI } from './utils'
+
+tape.only('async events', async (t) => {
+  t.plan(2)
+  const caller = new Address(Buffer.from('00000000000000000000000000000000000000ee', 'hex'))
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Constantinople })
+  const eei = await getEEI()
+  const evm = await EVM.create({ common, eei })
+  evm.events.on('step', async (event, next) => {
+    const startTime = Date.now()
+    setTimeout(() => {
+      t.ok(Date.now() > startTime, 'evm paused on step function for one second')
+      next()
+    }, 1000)
+  })
+  const runCallArgs = {
+    caller, // call address
+    gasLimit: BigInt(0xffffffffff),
+    data: Buffer.from('600000', 'hex'),
+  }
+  await evm.runCall(runCallArgs)
+})

--- a/packages/evm/test/asyncEvents.spec.ts
+++ b/packages/evm/test/asyncEvents.spec.ts
@@ -15,7 +15,7 @@ tape.only('async events', async (t) => {
   evm.events.on('step', async (event, next) => {
     const startTime = Date.now()
     setTimeout(() => {
-      t.ok(Date.now() > startTime, 'evm paused on step function for one second')
+      t.ok(Date.now() > (startTime + 999), 'evm paused on step function for one second')
       next?.()
     }, 1000)
   })

--- a/packages/evm/test/asyncEvents.spec.ts
+++ b/packages/evm/test/asyncEvents.spec.ts
@@ -15,7 +15,7 @@ tape.only('async events', async (t) => {
   evm.events.on('step', async (event, next) => {
     const startTime = Date.now()
     setTimeout(() => {
-      t.ok(Date.now() > (startTime + 999), 'evm paused on step function for one second')
+      t.ok(Date.now() > startTime + 999, 'evm paused on step function for one second')
       next?.()
     }, 1000)
   })

--- a/packages/evm/tsconfig.json
+++ b/packages/evm/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "extends": "../../config/tsconfig.json",
-  "include": ["src/**/*.ts", "src/**/*.json", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.json", "test/**/*.ts", "../util/src/asyncemitter.ts"]
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -84,6 +84,7 @@
   },
   "dependencies": {
     "@ethereumjs/rlp": "^4.0.0-beta.2",
+    "async": "^3.2.4",
     "ethereum-cryptography": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/util/src/asyncEventEmitter.ts
+++ b/packages/util/src/asyncEventEmitter.ts
@@ -1,3 +1,12 @@
+/**
+ * Ported to Typescript from original implementation below:
+ * https://github.com/ahultgren/async-eventemitter -- MIT licensed
+ *
+ * Type Definitions based on work by: patarapolw <https://github.com/patarapolw> -- MIT licensed
+ * that was contributed to Definitely Typed below:
+ * https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/async-eventemitter
+ */
+
 import { eachSeries } from 'async'
 import { EventEmitter } from 'events'
 type AsyncListener<T, R> =

--- a/packages/util/src/asyncEventEmitter.ts
+++ b/packages/util/src/asyncEventEmitter.ts
@@ -1,0 +1,60 @@
+import { eachSeries } from 'async'
+import { EventEmitter } from 'events'
+type AsyncListener<T, R> =
+  | ((data: T, callback: (result?: R) => void) => Promise<R>)
+  | ((data: T, callback: (result?: R) => void) => void)
+export interface EventMap {
+  [event: string]: AsyncListener<any, any>
+}
+
+export class AsyncEventEmitter<T extends EventMap> extends EventEmitter {
+  emit<E extends keyof T>(event: E & string, ...args: Parameters<T[E]>) {
+    let [data, callback] = args
+    const self = this
+    //@ts-ignore
+    let listeners = self._events[event] ?? []
+
+    // Optional data argument
+    if (callback === undefined && typeof data === 'function') {
+      callback = data
+      data = undefined
+    }
+
+    // Special treatment of internal newListener and removeListener events
+    if (event === 'newListener' || event === 'removeListener') {
+      data = {
+        event: data,
+        fn: callback,
+      }
+
+      callback = undefined as any
+    }
+
+    // A single listener is just a function not an array...
+    listeners = Array.isArray(listeners) ? listeners : [listeners]
+
+    eachSeries(
+      listeners.slice(),
+      function (fn: any, next) {
+        let err
+
+        // Support synchronous functions
+        if (fn.length < 2) {
+          try {
+            fn.call(self, data)
+          } catch (e: any) {
+            err = e
+          }
+
+          return next(err)
+        }
+
+        // Async
+        fn.call(self, data, next)
+      },
+      callback
+    )
+
+    return self.listenerCount(event) > 0
+  }
+}

--- a/packages/util/src/asyncEventEmitter.ts
+++ b/packages/util/src/asyncEventEmitter.ts
@@ -69,17 +69,17 @@ export class AsyncEventEmitter<T extends EventMap> extends EventEmitter {
     // Hack to support set arity
     if (listener.length >= 2) {
       g = function (e: any, next: any) {
-        self.removeListener(event, g)
+        self.removeListener(event, g as any)
         void listener(e, next)
       }
     } else {
       g = function (e) {
-        self.removeListener(event, g)
+        self.removeListener(event, g as any)
         void listener(e, g)
       }
     }
 
-    self.on(event, g)
+    self.on(event, g as any)
 
     return self
   }

--- a/packages/util/src/asyncEventEmitter.ts
+++ b/packages/util/src/asyncEventEmitter.ts
@@ -1,8 +1,8 @@
 import { eachSeries } from 'async'
 import { EventEmitter } from 'events'
 type AsyncListener<T, R> =
-  | ((data: T, callback: (result?: R) => void) => Promise<R>)
-  | ((data: T, callback: (result?: R) => void) => void)
+  | ((data: T, callback?: (result?: R) => void) => Promise<R>)
+  | ((data: T, callback?: (result?: R) => void) => void)
 export interface EventMap {
   [event: string]: AsyncListener<any, any>
 }
@@ -27,7 +27,7 @@ export class AsyncEventEmitter<T extends EventMap> extends EventEmitter {
         fn: callback,
       }
 
-      callback = undefined as any
+      callback = undefined
     }
 
     // A single listener is just a function not an array...
@@ -68,18 +68,18 @@ export class AsyncEventEmitter<T extends EventMap> extends EventEmitter {
 
     // Hack to support set arity
     if (listener.length >= 2) {
-      g = function (e: any, next: any) {
-        self.removeListener(event, g as any)
+      g = function (e: E, next: any) {
+        self.removeListener(event, g as T[E])
         void listener(e, next)
       }
     } else {
-      g = function (e) {
-        self.removeListener(event, g as any)
+      g = function (e: E) {
+        self.removeListener(event, g as T[E])
         void listener(e, g)
       }
     }
 
-    self.on(event, g as any)
+    self.on(event, g as T[E])
 
     return self
   }

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -31,6 +31,7 @@ export * from './types'
 /**
  * Export ethjs-util methods
  */
+export * from './asyncEventEmitter'
 export {
   arrayContainsArray,
   fromAscii,

--- a/packages/util/test/asyncEventEmitter.spec.ts
+++ b/packages/util/test/asyncEventEmitter.spec.ts
@@ -2,7 +2,7 @@ import * as tape from 'tape'
 
 import { AsyncEventEmitter } from '../src/asyncEventEmitter'
 
-tape('async event test', (t) => {
+tape('async event emit/on test', (t) => {
   const emitter = new AsyncEventEmitter()
   emitter.on('event', async (data, next) => {
     const startTime = Date.now()
@@ -13,4 +13,16 @@ tape('async event test', (t) => {
     }, 1000)
   })
   emitter.emit('event', 'eventData', t.end)
+})
+
+tape('async event emit/once test', (t) => {
+  const emitter = new AsyncEventEmitter()
+  emitter.once('event', async (data, next) => {
+    setTimeout(next, 1000)
+  })
+  t.equal(emitter.listenerCount('event'), 1, 'emitter has one event listener')
+  emitter.emit('event', 'eventData', () => {
+    t.equal(emitter.listenerCount('event'), 0, 'listener removed after one event emitted')
+    t.end()
+  })
 })

--- a/packages/util/test/asyncEventEmitter.spec.ts
+++ b/packages/util/test/asyncEventEmitter.spec.ts
@@ -1,0 +1,16 @@
+import * as tape from 'tape'
+
+import { AsyncEventEmitter } from '../src/asyncEventEmitter'
+
+tape('async event test', (t) => {
+  const emitter = new AsyncEventEmitter()
+  emitter.on('event', async (data, next) => {
+    const startTime = Date.now()
+    t.equal(data, 'eventData', 'Received data from an event')
+    setTimeout(() => {
+      t.ok(Date.now() > startTime, 'some time passed before event resolved')
+      next()
+    }, 1000)
+  })
+  emitter.emit('event', 'eventData', t.end)
+})

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -67,7 +67,6 @@
     "@ethereumjs/util": "^8.0.1",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^1.1.2",
-    "eventemitter2": "^6.4.9",
     "mcl-wasm": "^0.7.1",
     "rustbn.js": "~0.2.0"
   },

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -41,7 +41,7 @@ export async function runBlock(this: VM, opts: RunBlockOpts): Promise<RunBlockRe
    * @type {Object}
    * @property {Block} block emits the block that is about to be processed
    */
-  await this.events.emitAsync('beforeBlock', block)
+  await this._emit('beforeBlock', block)
 
   if (
     this._hardforkByBlockNumber ||
@@ -191,7 +191,7 @@ export async function runBlock(this: VM, opts: RunBlockOpts): Promise<RunBlockRe
    * @type {AfterBlockEvent}
    * @property {AfterBlockEvent} result emits the results of processing a block
    */
-  await this.events.emitAsync('afterBlock', afterBlockEvent)
+  await this._emit('afterBlock', afterBlockEvent)
   if (this.DEBUG) {
     debug(
       `Running block finished hash=${block.hash().toString('hex')} number=${

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -162,7 +162,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
    * @type {Object}
    * @property {Transaction} tx emits the Transaction that is about to be processed
    */
-  await this.events.emitAsync('beforeTx', tx)
+  await this._emit('beforeTx', tx)
 
   const caller = tx.getSenderAddress()
   if (this.DEBUG) {
@@ -455,7 +455,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
    * @property {Object} result result of the transaction
    */
   const event: AfterTxEvent = { transaction: tx, ...results }
-  await this.events.emitAsync('afterTx', event)
+  await this._emit('afterTx', event)
   if (this.DEBUG) {
     debug(
       `tx run finished hash=${


### PR DESCRIPTION
Fixes #2366 


This borrows code from the old `async-eventemitter` module, migrates it to typescript, and replaces `eventemitter2` with our original API usage (hopefully).