### PR TITLE
Integrate txpool fixes found in Shandong

### DIFF
--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -95,11 +95,7 @@ export class EthProtocol extends Protocol {
       encode: (txs: TypedTransaction[]) => {
         const serializedTxs = []
         for (const tx of txs) {
-          if (tx.type === 0) {
-            serializedTxs.push(tx.raw())
-          } else {
-            serializedTxs.push(tx.serialize())
-          }
+          serializedTxs.push(tx.serialize())
         }
         return serializedTxs
       },
@@ -197,10 +193,6 @@ export class EthProtocol extends Protocol {
     {
       name: 'NewPooledTransactionHashes',
       code: 0x08,
-      encode: ({ hashes }: { hashes: Buffer[] }) => [hashes],
-      decode: ([hashes]: [Buffer[]]) => {
-        hashes
-      },
     },
     {
       name: 'GetPooledTransactions',

--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -103,11 +103,13 @@ export class EthProtocol extends Protocol {
         }
         return serializedTxs
       },
-      decode: ([txs]: [Buffer[]]) => {
-        // TODO: add proper Common instance (problem: service not accessible)
-        //const common = this.config.chainCommon.copy()
-        //common.setHardforkByBlockNumber(this.config.syncTargetHeight, this.chain.headers.td)
-        return txs.map((txData) => TransactionFactory.fromBlockBodyData(txData))
+      decode: (txs: Buffer[]) => {
+        const common = this.config.chainCommon.copy()
+        common.setHardforkByBlockNumber(
+          this.config.syncTargetHeight ?? BigInt(0),
+          this.chain.headers.td
+        )
+        return txs.map((txData) => TransactionFactory.fromSerializedData(txData, { common }))
       },
     },
     {
@@ -192,6 +194,10 @@ export class EthProtocol extends Protocol {
     {
       name: 'NewPooledTransactionHashes',
       code: 0x08,
+      encode: ({ hashes }: { hashes: Buffer[] }) => [hashes],
+      decode: ([hashes]: [Buffer[]]) => {
+        hashes
+      },
     },
     {
       name: 'GetPooledTransactions',

--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -104,10 +104,13 @@ export class EthProtocol extends Protocol {
         return serializedTxs
       },
       decode: (txs: Buffer[]) => {
+        if (!this.config.synchronized) return
         const common = this.config.chainCommon.copy()
         common.setHardforkByBlockNumber(
-          this.config.syncTargetHeight ?? BigInt(0),
-          this.chain.headers.td
+          this.chain.headers.latest?.number ?? // Use latest header number if available OR
+            this.config.syncTargetHeight ?? // Use sync target height if available OR
+            common.hardforkBlock(common.hardfork()) ?? // Use current hardfork block number OR
+            BigInt(0) // Use chainstart
         )
         return txs.map((txData) => TransactionFactory.fromSerializedData(txData, { common }))
       },

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -709,7 +709,6 @@ export class Eth {
             block.header.baseFeePerGas! +
             block.header.baseFeePerGas!
         : (tx as Transaction).gasPrice
-
       // Run tx through copied vm to get tx gasUsed and createdAddress
       const runBlockResult = await (
         await this._vm!.copy()

--- a/packages/client/lib/service/txpool.ts
+++ b/packages/client/lib/service/txpool.ts
@@ -283,8 +283,9 @@ export class TxPool {
       )
     }
 
+    const vmCopy = await this.vm.copy()
     // Set state root to latest block so that account balance is correct when doing balance check
-    await this.vm.stateManager.setStateRoot(block.stateRoot)
+    await vmCopy.stateManager.setStateRoot(block.stateRoot)
     const account = await this.vm.stateManager.getAccount(senderAddress)
     if (account.nonce > tx.nonce) {
       throw new Error(

--- a/packages/client/lib/service/txpool.ts
+++ b/packages/client/lib/service/txpool.ts
@@ -282,6 +282,9 @@ export class TxPool {
         `Tx gaslimit of ${tx.gasLimit} exceeds block gas limit of ${block.gasLimit} (exceeds last block gas limit)`
       )
     }
+
+    // Set state root to latest block so that account balance is correct when doing balance check
+    await this.vm.stateManager.setStateRoot(block.stateRoot)
     const account = await this.vm.stateManager.getAccount(senderAddress)
     if (account.nonce > tx.nonce) {
       throw new Error(

--- a/packages/client/lib/service/txpool.ts
+++ b/packages/client/lib/service/txpool.ts
@@ -283,6 +283,7 @@ export class TxPool {
       )
     }
 
+    // Copy VM in order to not overwrite the state root of the VMExecution module which may be concurrently running blocks
     const vmCopy = await this.vm.copy()
     // Set state root to latest block so that account balance is correct when doing balance check
     await vmCopy.stateManager.setStateRoot(block.stateRoot)

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -48,12 +48,12 @@ tape('[Miner]', async (t) => {
 
   const originalSetStateRoot = VmState.prototype.setStateRoot
   VmState.prototype.setStateRoot = td.func<any>()
+  td.replace('@ethereumjs/vm/dist/vmState', { VmState })
 
   // Stub out setStateRoot so txPool.validate checks will pass since correct state root
-  // doesn't existin fakeChain state anyway
+  // doesn't exist in fakeChain state anyway
   const ogStateManagerSetStateRoot = DefaultStateManager.prototype.setStateRoot
   DefaultStateManager.prototype.setStateRoot = td.func<any>()
-  td.replace('@ethereumjs/vm/dist/vmState', { VmState })
 
   class FakeChain {
     open() {}

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -1,5 +1,6 @@
 import { Block, BlockHeader } from '@ethereumjs/block'
 import { Common, Chain as CommonChain, Hardfork } from '@ethereumjs/common'
+import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { FeeMarketEIP1559Transaction, Transaction } from '@ethereumjs/tx'
 import { Address } from '@ethereumjs/util'
 import { VmState } from '@ethereumjs/vm/dist/eei/vmState'
@@ -47,6 +48,11 @@ tape('[Miner]', async (t) => {
 
   const originalSetStateRoot = VmState.prototype.setStateRoot
   VmState.prototype.setStateRoot = td.func<any>()
+
+  // Stub out setStateRoot so txPool.validate checks will pass since correct state root
+  // doesn't existin fakeChain state anyway
+  const ogStateManagerSetStateRoot = DefaultStateManager.prototype.setStateRoot
+  DefaultStateManager.prototype.setStateRoot = td.func<any>()
   td.replace('@ethereumjs/vm/dist/vmState', { VmState })
 
   class FakeChain {
@@ -190,6 +196,7 @@ tape('[Miner]', async (t) => {
       const miner = new Miner({ config, service })
       const { txPool } = service
       const { vm } = service.execution
+
       txPool.start()
       miner.start()
 
@@ -246,6 +253,7 @@ tape('[Miner]', async (t) => {
     const miner = new Miner({ config, service })
     const { txPool } = service
     const { vm } = service.execution
+
     txPool.start()
     miner.start()
 
@@ -295,6 +303,7 @@ tape('[Miner]', async (t) => {
     const miner = new Miner({ config, service })
     const { txPool } = service
     const { vm } = service.execution
+
     txPool.start()
     miner.start()
 
@@ -341,6 +350,7 @@ tape('[Miner]', async (t) => {
 
     const { txPool } = service
     const { vm } = service.execution
+
     txPool.start()
     miner.start()
 
@@ -477,6 +487,7 @@ tape('[Miner]', async (t) => {
     // so we will replace the original functions to avoid issues in other tests that come after
     BlockHeader.prototype._consensusFormatValidation = originalValidate
     VmState.prototype.setStateRoot = originalSetStateRoot
+    DefaultStateManager.prototype.setStateRoot = ogStateManagerSetStateRoot
     t.end()
   })
 })

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -196,7 +196,6 @@ tape('[Miner]', async (t) => {
       const miner = new Miner({ config, service })
       const { txPool } = service
       const { vm } = service.execution
-
       txPool.start()
       miner.start()
 
@@ -253,7 +252,6 @@ tape('[Miner]', async (t) => {
     const miner = new Miner({ config, service })
     const { txPool } = service
     const { vm } = service.execution
-
     txPool.start()
     miner.start()
 
@@ -303,7 +301,6 @@ tape('[Miner]', async (t) => {
     const miner = new Miner({ config, service })
     const { txPool } = service
     const { vm } = service.execution
-
     txPool.start()
     miner.start()
 
@@ -350,7 +347,6 @@ tape('[Miner]', async (t) => {
 
     const { txPool } = service
     const { vm } = service.execution
-
     txPool.start()
     miner.start()
 

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -1,6 +1,5 @@
 import { BlockHeader } from '@ethereumjs/block'
 import { Common, Chain as CommonChain, Hardfork } from '@ethereumjs/common'
-import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { Transaction } from '@ethereumjs/tx'
 import { Account, Address } from '@ethereumjs/util'
 import { VM } from '@ethereumjs/vm'

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -47,7 +47,12 @@ const setup = () => {
       getCanonicalHeadHeader: () => BlockHeader.fromHeaderData({}, { common }),
     },
     execution: {
-      vm: { stateManager, eei: { getAccount: () => stateManager.getAccount() } },
+      vm: {
+        stateManager,
+        eei: { getAccount: () => stateManager.getAccount() },
+        copy: () => service.execution.vm,
+        setStateRoot: () => {},
+      },
     },
   }
   const txPool = new TxPool({ config, service })

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -1,5 +1,6 @@
 import { BlockHeader } from '@ethereumjs/block'
 import { Common, Chain as CommonChain, Hardfork } from '@ethereumjs/common'
+import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { Transaction } from '@ethereumjs/tx'
 import { Account, Address } from '@ethereumjs/util'
 import { VM } from '@ethereumjs/vm'
@@ -37,7 +38,10 @@ const common = new Common({ chain: CommonChain.Rinkeby, hardfork: Hardfork.Berli
 const config = new Config({ transports: [], common })
 
 const setup = () => {
-  const stateManager = { getAccount: () => new Account(BigInt(0), BigInt('50000000000000000000')) }
+  const stateManager = {
+    getAccount: () => new Account(BigInt(0), BigInt('50000000000000000000')),
+    setStateRoot: async () => {},
+  }
   const service: any = {
     chain: {
       headers: { height: BigInt(0) },
@@ -184,6 +188,7 @@ tape('[PendingBlock]', async (t) => {
     // so we will replace the original functions to avoid issues in other tests that come after
     BlockHeader.prototype._consensusFormatValidation = originalValidate
     VmState.prototype.setStateRoot = originalSetStateRoot
+
     t.end()
   })
 })

--- a/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
@@ -33,7 +33,6 @@ tape(`${method}: call with legacy tx`, async (t) => {
   // get the tx
   const req = params(method, [bufferToHex(tx.hash())])
   const expectRes = (res: any) => {
-    console.log(res.body)
     const msg = 'should return the correct tx'
     t.equal(res.body.result.transactionHash, bufferToHex(tx.hash()), msg)
   }

--- a/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
@@ -20,7 +20,11 @@ tape(`${method}: call with legacy tx`, async (t) => {
 
   // construct tx
   const tx = Transaction.fromTxData(
-    { gasLimit: 2000000, gasPrice: 100, to: '0x0000000000000000000000000000000000000000' },
+    {
+      gasLimit: 2000000,
+      gasPrice: 100,
+      to: '0x0000000000000000000000000000000000000000',
+    },
     { common }
   ).sign(dummy.privKey)
 
@@ -29,6 +33,7 @@ tape(`${method}: call with legacy tx`, async (t) => {
   // get the tx
   const req = params(method, [bufferToHex(tx.hash())])
   const expectRes = (res: any) => {
+    console.log(res.body)
     const msg = 'should return the correct tx'
     t.equal(res.body.result.transactionHash, bufferToHex(tx.hash()), msg)
   }

--- a/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
+++ b/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
@@ -12,11 +12,10 @@ import type { FullEthereumService } from '../../../lib/service'
 
 const method = 'eth_sendRawTransaction'
 
-// Disable stateroot validation in TxPool since valid state root isn't available
-const originalSetStateRoot = DefaultStateManager.prototype.setStateRoot
-DefaultStateManager.prototype.setStateRoot = (): any => {}
-
 tape(`${method}: call with valid arguments`, async (t) => {
+  // Disable stateroot validation in TxPool since valid state root isn't available
+  const originalSetStateRoot = DefaultStateManager.prototype.setStateRoot
+  DefaultStateManager.prototype.setStateRoot = (): any => {}
   const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlock(Hardfork.London)
   const { server, client } = baseSetup({ syncTargetHeight, includeVM: true })
 
@@ -43,9 +42,14 @@ tape(`${method}: call with valid arguments`, async (t) => {
     )
   }
   await baseRequest(t, server, req, 200, expectRes)
+  // Restore setStateRoot
+  DefaultStateManager.prototype.setStateRoot = originalSetStateRoot
 })
 
 tape(`${method}: send local tx with gasprice lower than minimum`, async (t) => {
+  // Disable stateroot validation in TxPool since valid state root isn't available
+  const originalSetStateRoot = DefaultStateManager.prototype.setStateRoot
+  DefaultStateManager.prototype.setStateRoot = (): any => {}
   const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlock(Hardfork.London)
   const { server } = baseSetup({ syncTargetHeight, includeVM: true })
 
@@ -66,9 +70,15 @@ tape(`${method}: send local tx with gasprice lower than minimum`, async (t) => {
     )
   }
   await baseRequest(t, server, req, 200, expectRes)
+
+  // Restore setStateRoot
+  DefaultStateManager.prototype.setStateRoot = originalSetStateRoot
 })
 
 tape(`${method}: call with invalid arguments: not enough balance`, async (t) => {
+  // Disable stateroot validation in TxPool since valid state root isn't available
+  const originalSetStateRoot = DefaultStateManager.prototype.setStateRoot
+  DefaultStateManager.prototype.setStateRoot = (): any => {}
   const syncTargetHeight = new Common({ chain: Chain.Mainnet }).hardforkBlock(Hardfork.London)
   const { server } = baseSetup({ syncTargetHeight, includeVM: true })
 
@@ -79,6 +89,9 @@ tape(`${method}: call with invalid arguments: not enough balance`, async (t) => 
   const req = params(method, [txData])
   const expectRes = checkError(t, INVALID_PARAMS, 'insufficient balance')
   await baseRequest(t, server, req, 200, expectRes)
+
+  // Restore setStateRoot
+  DefaultStateManager.prototype.setStateRoot = originalSetStateRoot
 })
 
 tape(`${method}: call with sync target height not set yet`, async (t) => {
@@ -133,6 +146,9 @@ tape(`${method}: call with unsigned tx`, async (t) => {
 })
 
 tape(`${method}: call with no peers`, async (t) => {
+  // Disable stateroot validation in TxPool since valid state root isn't available
+  const originalSetStateRoot = DefaultStateManager.prototype.setStateRoot
+  DefaultStateManager.prototype.setStateRoot = (): any => {}
   const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
 
   const syncTargetHeight = common.hardforkBlock(Hardfork.London)

--- a/packages/client/test/rpc/mockBlockchain.ts
+++ b/packages/client/test/rpc/mockBlockchain.ts
@@ -34,5 +34,8 @@ export function mockBlockchain(options: any = {}) {
       return Block.fromBlockData().header
     },
     genesisBlock: block,
+    copy() {
+      return this
+    },
   }
 }

--- a/packages/client/test/sync/txpool.spec.ts
+++ b/packages/client/test/sync/txpool.spec.ts
@@ -11,9 +11,6 @@ import { TxPool } from '../../lib/service/txpool'
 
 import type { StateManager } from '@ethereumjs/statemanager'
 
-const ogStateManagerSetStateRoot = DefaultStateManager.prototype.setStateRoot
-DefaultStateManager.prototype.setStateRoot = (): any => {}
-
 const setup = () => {
   const config = new Config({ transports: [] })
   const service: any = {
@@ -27,6 +24,7 @@ const setup = () => {
           getAccount: () => new Account(BigInt(0), BigInt('50000000000000000000')),
           setStateRoot: async (_root: Buffer) => {},
         },
+        copy: () => service.execution.vm,
       },
     },
   }
@@ -86,6 +84,9 @@ const handleTxs = async (
 }
 
 tape('[TxPool]', async (t) => {
+  const ogStateManagerSetStateRoot = DefaultStateManager.prototype.setStateRoot
+  DefaultStateManager.prototype.setStateRoot = (): any => {}
+
   const A = {
     address: Buffer.from('0b90087d864e82a284dca15923f3776de6bb016f', 'hex'),
     privateKey: Buffer.from(

--- a/packages/client/test/sync/txpool.spec.ts
+++ b/packages/client/test/sync/txpool.spec.ts
@@ -758,6 +758,5 @@ tape('[TxPool]', async (t) => {
     pool.stop()
     pool.close()
   })
+  DefaultStateManager.prototype.setStateRoot = ogStateManagerSetStateRoot
 })
-
-DefaultStateManager.prototype.setStateRoot = ogStateManagerSetStateRoot

--- a/packages/client/test/sync/txpool.spec.ts
+++ b/packages/client/test/sync/txpool.spec.ts
@@ -19,7 +19,10 @@ const setup = () => {
     },
     execution: {
       vm: {
-        stateManager: { getAccount: () => new Account(BigInt(0), BigInt('50000000000000000000')) },
+        stateManager: {
+          getAccount: () => new Account(BigInt(0), BigInt('50000000000000000000')),
+          setStateRoot: async (_root: Buffer) => {},
+        },
       },
     },
   }
@@ -42,6 +45,7 @@ const handleTxs = async (
   try {
     if (stateManager !== undefined) {
       ;(<any>pool).service.execution.vm.stateManager = stateManager
+      ;(<any>pool).service.execution.vm.stateManager.setStateRoot = async (_root: Buffer) => {}
     }
 
     pool.open()
@@ -165,7 +169,7 @@ tape('[TxPool]', async (t) => {
     const peer2: any = {
       id: '2',
       eth: {
-        send: () => {
+        request: () => {
           sentToPeer2++
           t.equal(sentToPeer2, 1, 'should send once to non-announcing peer')
         },
@@ -398,7 +402,7 @@ tape('[TxPool]', async (t) => {
     )
 
     t.notOk(
-      await handleTxs(txs, 'Attempting to add tx to txpool which is not signed'),
+      await handleTxs(txs, 'Cannot call hash method if transaction is not signed'),
       'successfully rejected unsigned tx'
     )
   })


### PR DESCRIPTION
- Fixes the `txPool.validate` method so it checks transactions against the correct stateroot when validating accounts
- Adds back missing `eth` protocol handlers for transaction gossip