### PR TITLE
EVM: non-empty "empty" account bugfixes

### DIFF
--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -513,15 +513,15 @@ export const handlers: Map<number, OpHandler> = new Map([
     async function (runState) {
       const addressBigInt = runState.stack.pop()
       const address = new Address(addressToBuffer(addressBigInt))
-      const empty = (await runState.eei.getAccount(address)).isEmpty()
-      if (empty) {
+      const account = await runState.eei.getAccount(address)
+      const empty = account.isEmpty()
+      const origin = runState.interpreter.getTxOrigin()
+      if (empty && origin !== addressBigInt) {
         runState.stack.push(BigInt(0))
         return
       }
 
-      const codeHash = (await runState.eei.getAccount(new Address(addressToBuffer(addressBigInt))))
-        .codeHash
-      runState.stack.push(BigInt('0x' + codeHash.toString('hex')))
+      runState.stack.push(BigInt('0x' + account.codeHash.toString('hex')))
     },
   ],
   // 0x3d: RETURNDATASIZE

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -328,7 +328,11 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         if (common.gteHardfork(Hardfork.SpuriousDragon)) {
           // We are at or after Spurious Dragon
           // Call new account gas: account is DEAD and we transfer nonzero value
-          if ((await runState.eei.getAccount(toAddress)).isEmpty() && !(value === BigInt(0))) {
+          if (
+            (await runState.eei.getAccount(toAddress)).isEmpty() &&
+            !(value === BigInt(0)) &&
+            toAddr !== runState.interpreter.getTxOrigin()
+          ) {
             gas += common.param('gasPrices', 'callNewAccount')
           }
         } else if (!(await runState.eei.accountExists(toAddress))) {
@@ -509,7 +513,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         if (value > BigInt(0)) {
           gas += common.param('gasPrices', 'authcallValueTransfer')
           const account = await runState.eei.getAccount(toAddress)
-          if (account.isEmpty()) {
+          if (account.isEmpty() && addr !== runState.interpreter.getTxOrigin()) {
             gas += common.param('gasPrices', 'callNewAccount')
           }
         }
@@ -585,7 +589,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           if (balance > BigInt(0)) {
             // This technically checks if account is empty or non-existent
             const empty = (await runState.eei.getAccount(selfdestructToAddress)).isEmpty()
-            if (empty) {
+            if (empty && selfdestructToaddressBigInt !== runState.interpreter.getTxOrigin()) {
               deductGas = true
             }
           }


### PR DESCRIPTION
Thanks to @kchojn who found this bug. It was introduced by https://github.com/ethereumjs/ethereumjs-monorepo/pull/2054

The PR fixes 4 bugs in our lib.

This is the situation:

EOA Account `A` has balance `B`, nonce 0, and (of course) no code and no storage.
Account `A` now sends a Tx to contract `C` and it forwards ALL balance upfront to pay for gas. (So, at this point, account `A` has 0 balance as it starts running the contract).

Now JS has 3 bugs in these situations:
Calling `EXTCODEHASH` on account A will put 0 on the stack, not the empty code hash, because we report that account is empty.
`CALL` will charge `callNewAccount` gas when we forward nonzero amount from the contract back into the account
`SELFDESTRUCT` will do the same if we selfdestruct nonzero value to account A.