### PR TITLE
New EVM Bugfix Release v1.2.2

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -61,7 +61,7 @@
     "@ethereumjs/common": "3.0.1",
     "@ethereumjs/devp2p": "5.0.1",
     "@ethereumjs/ethash": "2.0.1",
-    "@ethereumjs/evm": "1.2.1",
+    "@ethereumjs/evm": "1.2.2",
     "@ethereumjs/rlp": "4.0.0",
     "@ethereumjs/statemanager": "1.0.1",
     "@ethereumjs/trie": "5.0.1",

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 1.2.2 - 2022-10-26
 
-- Fixed `EIP-3540` bug where an EOF header combination was not rejected when calling, PR [#2381](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2381)
+- Fixed `EIP-3540` bug where EOF header validation was incorrectly applied to legacy contract code in EVM calls, PR [#2381](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2381)
 - Various non-empty "empty" account bugfixes, PR [#2383](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2383)
 
 ## 1.2.1 - 2022-10-25

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 1.2.2 - 2022-10-26
+
+- Fixed `EIP-3540` bug where an EOF header combination was not rejected when calling, PR [#2381](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2381)
+- Various non-empty "empty" account bugfixes, PR [#2383](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2383)
+
 ## 1.2.1 - 2022-10-25
 
 - Various [EIP-3540](https://eips.ethereum.org/EIPS/eip-3540) EVM Object Format (EOF) related fixes, PR [#2368](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2368)

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/evm",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "JavaScript Ethereum Virtual Machine (EVM) implementation",
   "keywords": [
     "ethereum",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -59,7 +59,7 @@
     "@ethereumjs/block": "^4.0.1",
     "@ethereumjs/blockchain": "^6.0.2",
     "@ethereumjs/common": "^3.0.1",
-    "@ethereumjs/evm": "^1.2.1",
+    "@ethereumjs/evm": "^1.2.2",
     "@ethereumjs/rlp": "^4.0.0",
     "@ethereumjs/statemanager": "^1.0.1",
     "@ethereumjs/trie": "^5.0.1",


### PR DESCRIPTION
Follow-up on #2380 

Small bugfix release for the EVM (no other code changes since last relase) to include the last two bugfixes regarding EIP-3540 and empty account handling.

Open for review. 🙂 