### PR TITLE
evm: fix 3860 implementation + tests

### DIFF
--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -295,6 +295,11 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           gas += accessAddressEIP2929(runState, runState.interpreter.getAddress(), common, false)
         }
 
+        if (common.isActivatedEIP(3860) === true) {
+          gas +=
+            ((length + BigInt(31)) / BigInt(32)) * common.param('gasPrices', 'initCodeWordCost')
+        }
+
         gas += subMemUsage(runState, offset, length, common)
 
         let gasLimit = BigInt(runState.interpreter.getGasLeft()) - gas
@@ -460,6 +465,11 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         if (common.isActivatedEIP(2929) === true) {
           gas += accessAddressEIP2929(runState, runState.interpreter.getAddress(), common, false)
+        }
+
+        if (common.isActivatedEIP(3860) === true) {
+          gas +=
+            ((length + BigInt(31)) / BigInt(32)) * common.param('gasPrices', 'initCodeWordCost')
         }
 
         gas += common.param('gasPrices', 'sha3Word') * divCeil(length, BigInt(32))

--- a/packages/evm/test/eips/eip-3860.spec.ts
+++ b/packages/evm/test/eips/eip-3860.spec.ts
@@ -9,7 +9,7 @@ const pkey = Buffer.from('20'.repeat(32), 'hex')
 const sender = new Address(privateToAddress(pkey))
 
 tape('EIP 3860 tests', (t) => {
-  t.test('EIP-3860 tests', async (st) => {
+  t.test('code exceeds max initcode size', async (st) => {
     const common = new Common({
       chain: Chain.Mainnet,
       hardfork: Hardfork.London,
@@ -42,7 +42,54 @@ tape('EIP 3860 tests', (t) => {
     )
   })
 
-  t.test('ensure EIP-3860 gas are applied on CREATE/CREATE2 calls', async (st) => {
+  t.test('ensure EIP-3860 gas is applied on CREATE calls', async (st) => {
+    // Transaction/Contract data taken from https://github.com/ethereum/tests/pull/990
+    const commonWith3860 = new Common({
+      chain: Chain.Mainnet,
+      hardfork: Hardfork.London,
+      eips: [3860],
+    })
+    const commonWithout3860 = new Common({
+      chain: Chain.Mainnet,
+      hardfork: Hardfork.London,
+      eips: [],
+    })
+    const caller = Address.fromString('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b')
+    const eei = await getEEI()
+    const evm = await EVM.create({ common: commonWith3860, eei })
+    const evmWithout3860 = await EVM.create({ common: commonWithout3860, eei: eei.copy() })
+    const contractFactory = Address.fromString('0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b')
+    const contractAccount = await evm.eei.getAccount(contractFactory)
+    await evm.eei.putAccount(contractFactory, contractAccount)
+    await evmWithout3860.eei.putAccount(contractFactory, contractAccount)
+    const factoryCode = Buffer.from(
+      '7f600a80600080396000f3000000000000000000000000000000000000000000006000526000355a8160006000f05a8203600a55806000556001600155505050',
+      'hex'
+    )
+
+    await evm.eei.putContractCode(contractFactory, factoryCode)
+    await evmWithout3860.eei.putContractCode(contractFactory, factoryCode)
+    const data = Buffer.from(
+      '000000000000000000000000000000000000000000000000000000000000c000',
+      'hex'
+    )
+    const runCallArgs = {
+      from: caller,
+      to: contractFactory,
+      data,
+      gasLimit: BigInt(0xfffffffff),
+    }
+    const res = await evm.runCall(runCallArgs)
+    const res2 = await evmWithout3860.runCall(runCallArgs)
+    st.ok(
+      res.execResult.executionGasUsed > res2.execResult.executionGasUsed,
+      'execution gas used is higher with EIP 3860 active'
+    )
+    st.end()
+  })
+
+  t.test('ensure EIP-3860 gas is applied on CREATE2 calls', async (st) => {
+    // Transaction/Contract data taken from https://github.com/ethereum/tests/pull/990
     const commonWith3860 = new Common({
       chain: Chain.Mainnet,
       hardfork: Hardfork.London,

--- a/packages/evm/test/eips/eip-3860.spec.ts
+++ b/packages/evm/test/eips/eip-3860.spec.ts
@@ -1,0 +1,47 @@
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
+import { Address, privateToAddress } from '@ethereumjs/util'
+import * as tape from 'tape'
+
+import { EVM } from '../../src'
+import { getEEI } from '../utils'
+
+const pkey = Buffer.from('20'.repeat(32), 'hex')
+const GWEI = BigInt('1000000000')
+const sender = new Address(privateToAddress(pkey))
+
+tape('EIP 3860 tests', (t) => {
+  const common = new Common({
+    chain: Chain.Mainnet,
+    hardfork: Hardfork.London,
+    eips: [3860],
+  })
+
+  t.test('EIP-3860 tests', async (st) => {
+    const eei = await getEEI()
+    const evm = await EVM.create({ common, eei })
+
+    const buffer = Buffer.allocUnsafe(1000000).fill(0x60)
+
+    // setup the call arguments
+    const runCallArgs = {
+      sender, // call address
+      gasLimit: BigInt(0xffffffffff), // ensure we pass a lot of gas, so we do not run out of gas
+      // Simple test, PUSH <big number> PUSH 0 RETURN
+      // It tries to deploy a contract too large, where the code is all zeros
+      // (since memory which is not allocated/resized to yet is always defaulted to 0)
+      data: Buffer.concat([
+        Buffer.from(
+          '0x7F6000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060005260206000F3',
+          'hex'
+        ),
+        buffer,
+      ]),
+    }
+    const result = await evm.runCall(runCallArgs)
+    st.ok(
+      (result.execResult.exceptionError?.error as string) === 'initcode exceeds max initcode size',
+      'initcode exceeds max size'
+    )
+  })
+})

--- a/packages/evm/test/eips/eip-3860.spec.ts
+++ b/packages/evm/test/eips/eip-3860.spec.ts
@@ -1,5 +1,4 @@
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
-import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
 import { Address, privateToAddress } from '@ethereumjs/util'
 import * as tape from 'tape'
 
@@ -7,17 +6,15 @@ import { EVM } from '../../src'
 import { getEEI } from '../utils'
 
 const pkey = Buffer.from('20'.repeat(32), 'hex')
-const GWEI = BigInt('1000000000')
 const sender = new Address(privateToAddress(pkey))
 
 tape('EIP 3860 tests', (t) => {
-  const common = new Common({
-    chain: Chain.Mainnet,
-    hardfork: Hardfork.London,
-    eips: [3860],
-  })
-
   t.test('EIP-3860 tests', async (st) => {
+    const common = new Common({
+      chain: Chain.Mainnet,
+      hardfork: Hardfork.London,
+      eips: [3860],
+    })
     const eei = await getEEI()
     const evm = await EVM.create({ common, eei })
 
@@ -43,5 +40,50 @@ tape('EIP 3860 tests', (t) => {
       (result.execResult.exceptionError?.error as string) === 'initcode exceeds max initcode size',
       'initcode exceeds max size'
     )
+  })
+
+  t.test('ensure EIP-3860 gas are applied on CREATE/CREATE2 calls', async (st) => {
+    const commonWith3860 = new Common({
+      chain: Chain.Mainnet,
+      hardfork: Hardfork.London,
+      eips: [3860],
+    })
+    const commonWithout3860 = new Common({
+      chain: Chain.Mainnet,
+      hardfork: Hardfork.London,
+      eips: [],
+    })
+    const caller = Address.fromString('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b')
+    const eei = await getEEI()
+    const evm = await EVM.create({ common: commonWith3860, eei })
+    const evmWithout3860 = await EVM.create({ common: commonWithout3860, eei: eei.copy() })
+    const contractFactory = Address.fromString('0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b')
+    const contractAccount = await evm.eei.getAccount(contractFactory)
+    await evm.eei.putAccount(contractFactory, contractAccount)
+    await evmWithout3860.eei.putAccount(contractFactory, contractAccount)
+    const factoryCode = Buffer.from(
+      '7f600a80600080396000f3000000000000000000000000000000000000000000006000526000355a60008260006000f55a8203600a55806000556001600155505050',
+      'hex'
+    )
+
+    await evm.eei.putContractCode(contractFactory, factoryCode)
+    await evmWithout3860.eei.putContractCode(contractFactory, factoryCode)
+    const data = Buffer.from(
+      '000000000000000000000000000000000000000000000000000000000000c000',
+      'hex'
+    )
+    const runCallArgs = {
+      from: caller,
+      to: contractFactory,
+      data,
+      gasLimit: BigInt(0xfffffffff),
+    }
+    const res = await evm.runCall(runCallArgs)
+    const res2 = await evmWithout3860.runCall(runCallArgs)
+    st.ok(
+      res.execResult.executionGasUsed > res2.execResult.executionGasUsed,
+      'execution gas used is higher with EIP 3860 active'
+    )
+    st.end()
   })
 })


### PR DESCRIPTION
In our [EIP 3860](https://eips.ethereum.org/EIPS/eip-3860) implementation, we have not added this rule:

"Furthermore, we introduce a charge of `2` gas for every 32-byte chunk of `initcode` to represent the cost of jumpdest-analysis."

This /does/ happen at `CREATE`s at the tx-level, but it does not happen if we have a `CREATE` or a `CREATE2`

This also passes the [current ethereum/tests tests ](https://github.com/ethereum/tests/pull/990)for EIP 3860.

To check:

```
git checkout update-3860
npm run clean && npm i
cd packages/ethereum-tests
gh pr checkout 990
cd ../vm
npm run test:blockchain -- --fork=London+3860
npm run test:state -- --fork=London+3860
```

All pass.

Note: problem found by @pk910 in block 6601 on the Shandong testnet.