### PR TITLE
client: Fix skeleton reset scenario when head announced before subchain 0 tail

### DIFF
--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -188,7 +188,14 @@ export class Skeleton extends MetaDBManager {
       // Not a noop / double head announce, abort with a reorg
       if (force) {
         this.config.logger.warn(
-          `Beacon chain reorged tail=${lastchain.tail} head=${lastchain.head} newHead=${number}`
+          `Skeleton setHead before tail, resetting skeleton tail=${lastchain.tail} head=${lastchain.head} newHead=${number}`
+        )
+        lastchain.head = number
+        lastchain.tail = number
+        lastchain.next = head.header.parentHash
+      } else {
+        this.config.logger.warn(
+          `Skeleton announcement before tail, will reset skeleton tail=${lastchain.tail} head=${lastchain.head} newHead=${number}`
         )
       }
       return true


### PR DESCRIPTION
Extracted from shandong:
- https://github.com/ethereumjs/ethereumjs-monorepo/pull/2316

In the scenario for e.g. when the CL might start from genesis it will signal head which might be before subchain 0's tail. This fix appropriately rests the chain to new head declaration