### PR TITLE
client: Use unpadded int/bigint to buffer in net protocols

### DIFF
--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -87,7 +87,7 @@ export class EthProtocol extends Protocol {
       name: 'NewBlockHashes',
       code: 0x01,
       encode: (hashes: any[]) => hashes.map((hn) => [hn[0], bigIntToUnpaddedBuffer(hn[1])]),
-      decode: (hashes: any[]) => hashes.map((hn) => [hn[0], bigIntToUnpaddedBuffer(hn[1])]),
+      decode: (hashes: any[]) => hashes.map((hn) => [hn[0], bufferToBigInt(hn[1])]),
     },
     {
       name: 'Transactions',

--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -4,7 +4,7 @@ import { RLP } from '@ethereumjs/rlp'
 import { TransactionFactory } from '@ethereumjs/tx'
 import {
   arrToBufArr,
-  bigIntToBuffer,
+  devP2PBigIntToBuffer as bigIntToBuffer,
   bufArrToArr,
   bufferToBigInt,
   bufferToInt,
@@ -119,9 +119,9 @@ export class EthProtocol extends Protocol {
         bigIntToBuffer(reqId ?? ++this.nextReqId),
         [
           typeof block === 'bigint' ? bigIntToBuffer(block) : block,
-          max === 0 ? Buffer.from([]) : intToBuffer(max),
-          skip === 0 ? Buffer.from([]) : intToBuffer(skip),
-          !reverse ? Buffer.from([]) : Buffer.from([1]),
+          bigIntToBuffer(max),
+          bigIntToBuffer(skip),
+          bigIntToBuffer(!reverse ? 0 : 1),
         ],
       ],
       decode: ([reqId, [block, max, skip, reverse]]: any) => ({
@@ -193,6 +193,8 @@ export class EthProtocol extends Protocol {
     {
       name: 'NewPooledTransactionHashes',
       code: 0x08,
+      encode: (hashes: Buffer[]) => hashes,
+      decode: (hashes: Buffer[]) => hashes,
     },
     {
       name: 'GetPooledTransactions',
@@ -326,8 +328,7 @@ export class EthProtocol extends Protocol {
   encodeStatus(): any {
     return {
       networkId: bigIntToBuffer(this.chain.networkId),
-      td:
-        this.chain.blocks.td === BigInt(0) ? Buffer.from([]) : bigIntToBuffer(this.chain.blocks.td),
+      td: bigIntToBuffer(this.chain.blocks.td),
       bestHash: this.chain.blocks.latest!.hash(),
       genesisHash: this.chain.genesis.hash(),
       latestBlock: bigIntToBuffer(this.chain.blocks.latest!.header.number),

--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -4,10 +4,11 @@ import { RLP } from '@ethereumjs/rlp'
 import { TransactionFactory } from '@ethereumjs/tx'
 import {
   arrToBufArr,
-  devP2PBigIntToBuffer as bigIntToBuffer,
+  bigIntToUnpaddedBuffer,
   bufArrToArr,
   bufferToBigInt,
   bufferToInt,
+  intToUnpaddedBuffer,
 } from '@ethereumjs/util'
 import { encodeReceipt } from '@ethereumjs/vm/dist/runBlock'
 
@@ -85,8 +86,8 @@ export class EthProtocol extends Protocol {
     {
       name: 'NewBlockHashes',
       code: 0x01,
-      encode: (hashes: any[]) => hashes.map((hn) => [hn[0], bigIntToBuffer(hn[1])]),
-      decode: (hashes: any[]) => hashes.map((hn) => [hn[0], bufferToBigInt(hn[1])]),
+      encode: (hashes: any[]) => hashes.map((hn) => [hn[0], bigIntToUnpaddedBuffer(hn[1])]),
+      decode: (hashes: any[]) => hashes.map((hn) => [hn[0], bigIntToUnpaddedBuffer(hn[1])]),
     },
     {
       name: 'Transactions',
@@ -115,12 +116,12 @@ export class EthProtocol extends Protocol {
       code: 0x03,
       response: 0x04,
       encode: ({ reqId, block, max, skip = 0, reverse = false }: GetBlockHeadersOpts) => [
-        bigIntToBuffer(reqId ?? ++this.nextReqId),
+        bigIntToUnpaddedBuffer(reqId ?? ++this.nextReqId),
         [
-          typeof block === 'bigint' ? bigIntToBuffer(block) : block,
-          bigIntToBuffer(max),
-          bigIntToBuffer(skip),
-          bigIntToBuffer(!reverse ? 0 : 1),
+          typeof block === 'bigint' ? bigIntToUnpaddedBuffer(block) : block,
+          intToUnpaddedBuffer(max),
+          intToUnpaddedBuffer(skip),
+          intToUnpaddedBuffer(!reverse ? 0 : 1),
         ],
       ],
       decode: ([reqId, [block, max, skip, reverse]]: any) => ({
@@ -135,7 +136,7 @@ export class EthProtocol extends Protocol {
       name: 'BlockHeaders',
       code: 0x04,
       encode: ({ reqId, headers }: { reqId: bigint; headers: BlockHeader[] }) => [
-        bigIntToBuffer(reqId),
+        bigIntToUnpaddedBuffer(reqId),
         headers.map((h) => h.raw()),
       ],
       decode: ([reqId, headers]: [Buffer, BlockHeaderBuffer[]]) => [
@@ -160,7 +161,7 @@ export class EthProtocol extends Protocol {
       code: 0x05,
       response: 0x06,
       encode: ({ reqId, hashes }: GetBlockBodiesOpts) => [
-        bigIntToBuffer(reqId ?? ++this.nextReqId),
+        bigIntToUnpaddedBuffer(reqId ?? ++this.nextReqId),
         hashes,
       ],
       decode: ([reqId, hashes]: [Buffer, Buffer[]]) => ({
@@ -172,7 +173,7 @@ export class EthProtocol extends Protocol {
       name: 'BlockBodies',
       code: 0x06,
       encode: ({ reqId, bodies }: { reqId: bigint; bodies: BlockBodyBuffer[] }) => [
-        bigIntToBuffer(reqId),
+        bigIntToUnpaddedBuffer(reqId),
         bodies,
       ],
       decode: ([reqId, bodies]: [Buffer, BlockBodyBuffer[]]) => [bufferToBigInt(reqId), bodies],
@@ -180,7 +181,7 @@ export class EthProtocol extends Protocol {
     {
       name: 'NewBlock',
       code: 0x07,
-      encode: ([block, td]: [Block, bigint]) => [block.raw(), bigIntToBuffer(td)],
+      encode: ([block, td]: [Block, bigint]) => [block.raw(), bigIntToUnpaddedBuffer(td)],
       decode: ([block, td]: [BlockBuffer, Buffer]) => [
         Block.fromValuesArray(block, {
           common: this.config.chainCommon,
@@ -200,7 +201,7 @@ export class EthProtocol extends Protocol {
       code: 0x09,
       response: 0x0a,
       encode: ({ reqId, hashes }: GetPooledTransactionsOpts) => [
-        bigIntToBuffer(reqId ?? ++this.nextReqId),
+        bigIntToUnpaddedBuffer(reqId ?? ++this.nextReqId),
         hashes,
       ],
       decode: ([reqId, hashes]: [Buffer, Buffer[]]) => ({
@@ -220,7 +221,7 @@ export class EthProtocol extends Protocol {
             serializedTxs.push(tx.serialize())
           }
         }
-        return [bigIntToBuffer(reqId), serializedTxs]
+        return [bigIntToUnpaddedBuffer(reqId), serializedTxs]
       },
       decode: ([reqId, txs]: [Buffer, any[]]) => [
         bufferToBigInt(reqId),
@@ -235,7 +236,7 @@ export class EthProtocol extends Protocol {
       code: 0x0f,
       response: 0x10,
       encode: ({ reqId, hashes }: { reqId: bigint; hashes: Buffer[] }) => [
-        bigIntToBuffer(reqId ?? ++this.nextReqId),
+        bigIntToUnpaddedBuffer(reqId ?? ++this.nextReqId),
         hashes,
       ],
       decode: ([reqId, hashes]: [Buffer, Buffer[]]) => ({
@@ -252,7 +253,7 @@ export class EthProtocol extends Protocol {
           const encodedReceipt = encodeReceipt(receipt, receipt.txType)
           serializedReceipts.push(encodedReceipt)
         }
-        return [bigIntToBuffer(reqId), serializedReceipts]
+        return [bigIntToUnpaddedBuffer(reqId), serializedReceipts]
       },
       decode: ([reqId, receipts]: [Buffer, Buffer[]]) => [
         bufferToBigInt(reqId),
@@ -326,11 +327,11 @@ export class EthProtocol extends Protocol {
    */
   encodeStatus(): any {
     return {
-      networkId: bigIntToBuffer(this.chain.networkId),
-      td: bigIntToBuffer(this.chain.blocks.td),
+      networkId: bigIntToUnpaddedBuffer(this.chain.networkId),
+      td: bigIntToUnpaddedBuffer(this.chain.blocks.td),
       bestHash: this.chain.blocks.latest!.hash(),
       genesisHash: this.chain.genesis.hash(),
-      latestBlock: bigIntToBuffer(this.chain.blocks.latest!.header.number),
+      latestBlock: bigIntToUnpaddedBuffer(this.chain.blocks.latest!.header.number),
     }
   }
 

--- a/packages/client/lib/net/protocol/ethprotocol.ts
+++ b/packages/client/lib/net/protocol/ethprotocol.ts
@@ -8,7 +8,6 @@ import {
   bufArrToArr,
   bufferToBigInt,
   bufferToInt,
-  intToBuffer,
 } from '@ethereumjs/util'
 import { encodeReceipt } from '@ethereumjs/vm/dist/runBlock'
 

--- a/packages/client/lib/net/protocol/lesprotocol.ts
+++ b/packages/client/lib/net/protocol/lesprotocol.ts
@@ -1,9 +1,9 @@
 import { BlockHeader } from '@ethereumjs/block'
 import {
+  devP2PBigIntToBuffer as bigIntToBuffer,
   bufferToBigInt,
   bufferToInt,
   intToBuffer,
-  devP2PBigIntToBuffer as bigIntToBuffer,
 } from '@ethereumjs/util'
 
 import { Protocol } from './protocol'

--- a/packages/client/lib/net/protocol/lesprotocol.ts
+++ b/packages/client/lib/net/protocol/lesprotocol.ts
@@ -1,10 +1,5 @@
 import { BlockHeader } from '@ethereumjs/block'
-import {
-  devP2PBigIntToBuffer as bigIntToBuffer,
-  bufferToBigInt,
-  bufferToInt,
-  intToBuffer,
-} from '@ethereumjs/util'
+import { bigIntToUnpaddedBuffer, bufferToBigInt, bufferToInt, intToBuffer } from '@ethereumjs/util'
 
 import { Protocol } from './protocol'
 
@@ -61,8 +56,8 @@ export class LesProtocol extends Protocol {
       encode: ({ headHash, headNumber, headTd, reorgDepth }: any) => [
         // TO DO: handle state changes
         headHash,
-        bigIntToBuffer(headNumber),
-        bigIntToBuffer(headTd),
+        bigIntToUnpaddedBuffer(headNumber),
+        bigIntToUnpaddedBuffer(headTd),
         intToBuffer(reorgDepth),
       ],
       decode: ([headHash, headNumber, headTd, reorgDepth]: any) => ({
@@ -78,8 +73,13 @@ export class LesProtocol extends Protocol {
       code: 0x02,
       response: 0x03,
       encode: ({ reqId, block, max, skip = 0, reverse = false }: GetBlockHeadersOpts) => [
-        bigIntToBuffer(reqId ?? ++this.nextReqId),
-        [typeof block === 'bigint' ? bigIntToBuffer(block) : block, max, skip, !reverse ? 0 : 1],
+        bigIntToUnpaddedBuffer(reqId ?? ++this.nextReqId),
+        [
+          typeof block === 'bigint' ? bigIntToUnpaddedBuffer(block) : block,
+          max,
+          skip,
+          !reverse ? 0 : 1,
+        ],
       ],
       decode: ([reqId, [block, max, skip, reverse]]: any) => ({
         reqId: bufferToBigInt(reqId),
@@ -93,8 +93,8 @@ export class LesProtocol extends Protocol {
       name: 'BlockHeaders',
       code: 0x03,
       encode: ({ reqId, bv, headers }: any) => [
-        bigIntToBuffer(reqId),
-        bigIntToBuffer(bv),
+        bigIntToUnpaddedBuffer(reqId),
+        bigIntToUnpaddedBuffer(bv),
         headers.map((h: BlockHeader) => h.raw()),
       ],
       decode: ([reqId, bv, headers]: any) => ({
@@ -181,13 +181,13 @@ export class LesProtocol extends Protocol {
       this.chain.genesis.hash()
     )
     const nextFork = this.config.chainCommon.nextHardforkBlock(this.config.chainCommon.hardfork())
-    const forkID = [Buffer.from(forkHash.slice(2), 'hex'), bigIntToBuffer(nextFork ?? 0n)]
+    const forkID = [Buffer.from(forkHash.slice(2), 'hex'), bigIntToUnpaddedBuffer(nextFork ?? 0n)]
 
     return {
-      networkId: bigIntToBuffer(this.chain.networkId),
-      headTd: bigIntToBuffer(this.chain.headers.td),
+      networkId: bigIntToUnpaddedBuffer(this.chain.networkId),
+      headTd: bigIntToUnpaddedBuffer(this.chain.headers.td),
       headHash: this.chain.headers.latest?.hash(),
-      headNum: bigIntToBuffer(this.chain.headers.height),
+      headNum: bigIntToUnpaddedBuffer(this.chain.headers.height),
       genesisHash: this.chain.genesis.hash(),
       forkID,
       recentTxLookup: intToBuffer(1),

--- a/packages/client/lib/net/protocol/lesprotocol.ts
+++ b/packages/client/lib/net/protocol/lesprotocol.ts
@@ -1,5 +1,10 @@
 import { BlockHeader } from '@ethereumjs/block'
-import { bigIntToBuffer, bufferToBigInt, bufferToInt, intToBuffer } from '@ethereumjs/util'
+import {
+  bufferToBigInt,
+  bufferToInt,
+  intToBuffer,
+  devP2PBigIntToBuffer as bigIntToBuffer,
+} from '@ethereumjs/util'
 
 import { Protocol } from './protocol'
 
@@ -176,12 +181,7 @@ export class LesProtocol extends Protocol {
       this.chain.genesis.hash()
     )
     const nextFork = this.config.chainCommon.nextHardforkBlock(this.config.chainCommon.hardfork())
-    const forkID = [
-      Buffer.from(forkHash.slice(2), 'hex'),
-      typeof nextFork === 'bigint' && nextFork !== BigInt(0)
-        ? bigIntToBuffer(nextFork)
-        : Buffer.from([]),
-    ]
+    const forkID = [Buffer.from(forkHash.slice(2), 'hex'), bigIntToBuffer(nextFork ?? 0n)]
 
     return {
       networkId: bigIntToBuffer(this.chain.networkId),

--- a/packages/client/lib/net/protocol/snapprotocol.ts
+++ b/packages/client/lib/net/protocol/snapprotocol.ts
@@ -1,7 +1,7 @@
 import {
   accountBodyFromSlim,
   accountBodyToSlim,
-  devP2PBigIntToBuffer as bigIntToBuffer,
+  bigIntToUnpaddedBuffer,
   bufferToBigInt,
   setLengthLeft,
 } from '@ethereumjs/util'
@@ -97,11 +97,11 @@ export class SnapProtocol extends Protocol {
       // [reqID: P, rootHash: B_32, startingHash: B_32, limitHash: B_32, responseBytes: P]
       encode: ({ reqId, root, origin, limit, bytes }: GetAccountRangeOpts) => {
         return [
-          bigIntToBuffer(reqId ?? ++this.nextReqId),
+          bigIntToUnpaddedBuffer(reqId ?? ++this.nextReqId),
           setLengthLeft(root, 32),
           setLengthLeft(origin, 32),
           setLengthLeft(limit, 32),
-          bigIntToBuffer(bytes),
+          bigIntToUnpaddedBuffer(bytes),
         ]
       },
       decode: ([reqId, root, origin, limit, bytes]: any) => {
@@ -128,7 +128,7 @@ export class SnapProtocol extends Protocol {
         proof: Buffer[]
       }) => {
         return [
-          bigIntToBuffer(reqId ?? ++this.nextReqId),
+          bigIntToUnpaddedBuffer(reqId ?? ++this.nextReqId),
           accounts.map((account) => [
             setLengthLeft(account.hash, 32),
             accountBodyToSlim(account.body),
@@ -157,12 +157,12 @@ export class SnapProtocol extends Protocol {
       // [reqID: P, rootHash: B_32, accountHashes: [B_32], startingHash: B, limitHash: B, responseBytes: P]
       encode: ({ reqId, root, accounts, origin, limit, bytes }: GetStorageRangesOpts) => {
         return [
-          bigIntToBuffer(reqId ?? ++this.nextReqId),
+          bigIntToUnpaddedBuffer(reqId ?? ++this.nextReqId),
           setLengthLeft(root, 32),
           accounts.map((acc) => setLengthLeft(acc, 32)),
           origin,
           limit,
-          bigIntToBuffer(bytes),
+          bigIntToUnpaddedBuffer(bytes),
         ]
       },
       decode: ([reqId, root, accounts, origin, limit, bytes]: any) => {
@@ -190,7 +190,7 @@ export class SnapProtocol extends Protocol {
         proof: Buffer[]
       }) => {
         return [
-          bigIntToBuffer(reqId ?? ++this.nextReqId),
+          bigIntToUnpaddedBuffer(reqId ?? ++this.nextReqId),
           slots.map((accSlots) =>
             accSlots.map((slotData) => [setLengthLeft(slotData.hash, 32), slotData.body])
           ),
@@ -214,9 +214,9 @@ export class SnapProtocol extends Protocol {
       // [reqID: P, hashes: [hash1: B_32, hash2: B_32, ...], bytes: P]
       encode: ({ reqId, hashes, bytes }: GetByteCodesOpts) => {
         return [
-          bigIntToBuffer(reqId ?? ++this.nextReqId),
+          bigIntToUnpaddedBuffer(reqId ?? ++this.nextReqId),
           hashes.map((hash) => setLengthLeft(hash, 32)),
-          bigIntToBuffer(bytes),
+          bigIntToUnpaddedBuffer(bytes),
         ]
       },
       decode: ([reqId, hashes, bytes]: any) => {
@@ -232,7 +232,7 @@ export class SnapProtocol extends Protocol {
       code: 0x05,
       // [reqID: P, codes: [code1: B, code2: B, ...]]
       encode: ({ reqId, codes }: { reqId: bigint; codes: Buffer[] }) => {
-        return [bigIntToBuffer(reqId ?? ++this.nextReqId), codes]
+        return [bigIntToUnpaddedBuffer(reqId ?? ++this.nextReqId), codes]
       },
       decode: ([reqId, codes]: any) => {
         return {
@@ -248,10 +248,10 @@ export class SnapProtocol extends Protocol {
       // [reqID: P, rootHash: B_32, paths: [[accPath: B, slotPath1: B, slotPath2: B, ...]...], bytes: P]
       encode: ({ reqId, root, paths, bytes }: GetTrieNodesOpts) => {
         return [
-          bigIntToBuffer(reqId ?? ++this.nextReqId),
+          bigIntToUnpaddedBuffer(reqId ?? ++this.nextReqId),
           setLengthLeft(root, 32),
           paths,
-          bigIntToBuffer(bytes),
+          bigIntToUnpaddedBuffer(bytes),
         ]
       },
       decode: ([reqId, root, paths, bytes]: any) => {
@@ -268,7 +268,7 @@ export class SnapProtocol extends Protocol {
       code: 0x07,
       // [reqID: P, nodes: [node1: B, node2: B, ...]]
       encode: ({ reqId, nodes }: { reqId: bigint; nodes: Buffer[] }) => {
-        return [bigIntToBuffer(reqId ?? ++this.nextReqId), nodes]
+        return [bigIntToUnpaddedBuffer(reqId ?? ++this.nextReqId), nodes]
       },
       decode: ([reqId, nodes]: any) => {
         return {

--- a/packages/client/lib/net/protocol/snapprotocol.ts
+++ b/packages/client/lib/net/protocol/snapprotocol.ts
@@ -1,7 +1,7 @@
 import {
   accountBodyFromSlim,
   accountBodyToSlim,
-  bigIntToBuffer,
+  devP2PBigIntToBuffer as bigIntToBuffer,
   bufferToBigInt,
   setLengthLeft,
 } from '@ethereumjs/util'

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -234,7 +234,7 @@ export function bigIntToBuffer(num: bigint) {
 export function devP2PBigIntToBuffer(input: bigint | number): BufferLike {
   const inputNum = BigInt(input)
   if (inputNum === 0n) {
-    return 0
+    return Buffer.alloc(0)
   } else {
     return bigIntToBuffer(inputNum)
   }

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -226,19 +226,6 @@ export function bigIntToBuffer(num: bigint) {
 }
 
 /**
- * Converts a {@link bigint} to a {@link Buffer} for devp2p rlp encodings
- * excluding `0` as rlp has its own special encoding for the same
- * see: https://github.com/ethereumjs/ethereumjs-monorepo/issues/2402
- */
-export function devP2PBigIntToBuffer(input: bigint | number): Buffer {
-  const inputNum = BigInt(input)
-  if (inputNum === 0n) {
-    return Buffer.alloc(0)
-  } else {
-    return bigIntToBuffer(inputNum)
-  }
-}
-/**
  * Converts a `Buffer` to a `Number`.
  * @param buf `Buffer` object to convert
  * @throws If the input number exceeds 53 bits.
@@ -398,4 +385,8 @@ export const bigIntToHex = (num: bigint) => {
  */
 export function bigIntToUnpaddedBuffer(value: bigint): Buffer {
   return unpadBuffer(bigIntToBuffer(value))
+}
+
+export function intToUnpaddedBuffer(value: number): Buffer {
+  return unpadBuffer(intToBuffer(value))
 }

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -7,6 +7,7 @@ import type {
   PrefixedHexString,
   TransformableToArray,
   TransformableToBuffer,
+  BufferLike,
 } from './types'
 
 /**
@@ -225,6 +226,19 @@ export function bigIntToBuffer(num: bigint) {
   return toBuffer('0x' + num.toString(16))
 }
 
+/**
+ * Converts a {@link bigint} to a {@link Buffer} for devp2p rlp encodings
+ * excluding `0` as rlp has its own special encoding for the same
+ * see: https://github.com/ethereumjs/ethereumjs-monorepo/issues/2402
+ */
+export function devP2PBigIntToBuffer(input: bigint | number): BufferLike {
+  const inputNum = BigInt(input)
+  if (inputNum === 0n) {
+    return 0
+  } else {
+    return bigIntToBuffer(inputNum)
+  }
+}
 /**
  * Converts a `Buffer` to a `Number`.
  * @param buf `Buffer` object to convert

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -2,12 +2,12 @@ import { assertIsArray, assertIsBuffer, assertIsHexString } from './helpers'
 import { isHexPrefixed, isHexString, padToEven, stripHexPrefix } from './internal'
 
 import type {
+  BufferLike,
   NestedBufferArray,
   NestedUint8Array,
   PrefixedHexString,
   TransformableToArray,
   TransformableToBuffer,
-  BufferLike,
 } from './types'
 
 /**

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -2,7 +2,6 @@ import { assertIsArray, assertIsBuffer, assertIsHexString } from './helpers'
 import { isHexPrefixed, isHexString, padToEven, stripHexPrefix } from './internal'
 
 import type {
-  BufferLike,
   NestedBufferArray,
   NestedUint8Array,
   PrefixedHexString,

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -231,7 +231,7 @@ export function bigIntToBuffer(num: bigint) {
  * excluding `0` as rlp has its own special encoding for the same
  * see: https://github.com/ethereumjs/ethereumjs-monorepo/issues/2402
  */
-export function devP2PBigIntToBuffer(input: bigint | number): BufferLike {
+export function devP2PBigIntToBuffer(input: bigint | number): Buffer {
   const inputNum = BigInt(input)
   if (inputNum === 0n) {
     return Buffer.alloc(0)

--- a/packages/util/test/bytes.spec.ts
+++ b/packages/util/test/bytes.spec.ts
@@ -15,6 +15,7 @@ import {
   fromSigned,
   intToBuffer,
   intToHex,
+  intToUnpaddedBuffer,
   isZeroAddress,
   setLengthLeft,
   setLengthRight,
@@ -483,6 +484,14 @@ tape('bigIntToUnpaddedBuffer', function (t) {
   t.test('should equal unpadded buffer value', function (st) {
     st.ok(bigIntToUnpaddedBuffer(BigInt(0)).equals(Buffer.from([])))
     st.ok(bigIntToUnpaddedBuffer(BigInt(100)).equals(Buffer.from('64', 'hex')))
+    st.end()
+  })
+})
+
+tape('intToUnpaddedBuffer', function (t) {
+  t.test('should equal unpadded buffer value', function (st) {
+    st.ok(intToUnpaddedBuffer(0).equals(Buffer.from([])))
+    st.ok(intToUnpaddedBuffer(100).equals(Buffer.from('64', 'hex')))
     st.end()
   })
 })


### PR DESCRIPTION
Extracted and a bit enhanced from shandong 
- https://github.com/ethereumjs/ethereumjs-monorepo/pull/2316

In the devp2p protocol, integer 0 is to be coded as `0x80` and not as buffered `0x00`

Closes: #2402