### PR TITLE
stateManager: add EthersStateManager to exports

### DIFF
--- a/packages/statemanager/src/index.ts
+++ b/packages/statemanager/src/index.ts
@@ -1,3 +1,4 @@
 export { BaseStateManager } from './baseStateManager'
+export { EthersStateManager, EthersStateManagerOpts } from './ethersStateManager'
 export { AccountFields, StateAccess, StateManager } from './interface'
 export { DefaultStateManager, Proof } from './stateManager'


### PR DESCRIPTION
Closes #2416 

Adds the `EthersStateManager` to the `statemanager` exports so people don't have to deep import it.