### PR TITLE
EthJS DEBUG variable

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -309,13 +309,13 @@ ethereumjs --loglevel=debug
 For more in-depth debugging on networking the underlying [devp2p](../devp2p) library integrates with the [debug](https://github.com/visionmedia/debug) package and can also be used from within a client execution context:
 
 ```shell
-DEBUG=*,-babel [CLIENT_START_COMMAND]
+DEBUG=ethjs,*,-babel [CLIENT_START_COMMAND]
 ```
 
 The above command outputs the log messages from all `devp2p` debug loggers available. For a more targeted logging the different loggers can also be activated separately, e.g.:
 
 ```shell
-DEBUG=devp2p:rlpx,devp2p:eth,-babel [CLIENT_START_COMMAND]
+DEBUG=ethjs,devp2p:rlpx,devp2p:eth,-babel [CLIENT_START_COMMAND]
 ```
 
 ### Diagram Updates

--- a/packages/client/examples/local-debugging.md
+++ b/packages/client/examples/local-debugging.md
@@ -7,14 +7,14 @@ For debugging on networking issues there are two custom npm start scripts with a
 Start a first client listening on the default port and using the default data directory with:
 
 ```shell
-DEBUG=devp2p:* npm run client:start:dev1
-DEBUG=devp2p:* npm run client:start:dev1 -- --datadir=datadir-dev1
+DEBUG=ethjs,devp2p:* npm run client:start:dev1
+DEBUG=ethjs,devp2p:* npm run client:start:dev1 -- --datadir=datadir-dev1
 ```
 
 Then take the enode address from the started client instance (use `127.0.0.1` for the IP address) and start a second client with:
 
 ```shell
-DEBUG=devp2p:* npm run client:start:dev2 -- --bootnodes=enode://[DEV1_NODE_ID]@127.0.0.1:30303
+DEBUG=ethjs,devp2p:* npm run client:start:dev2 -- --bootnodes=enode://[DEV1_NODE_ID]@127.0.0.1:30303
 ```
 
 This second client is using './datadir-dev2' for its data directory.
@@ -24,7 +24,7 @@ This second client is using './datadir-dev2' for its data directory.
 To connect Geth to a running EthereumJS instance start a client with:
 
 ```shell
-DEBUG=devp2p:* npm run client:start:dev1
+DEBUG=ethjs,devp2p:* npm run client:start:dev1
 ```
 
 Then connect with your Geth instance via:
@@ -44,5 +44,5 @@ geth [--syncmode=full] [--verbosity=5]
 Then connect with your EthereumJS instance via:
 
 ```shell
-DEBUG=devp2p:* npm run client:start:dev2 -- --bootnodes=enode://[GETH_NODE_ID]@127.0.0.1:30303
+DEBUG=ethjs,devp2p:* npm run client:start:dev2 -- --bootnodes=enode://[GETH_NODE_ID]@127.0.0.1:30303
 ```

--- a/packages/client/lib/util/debug.ts
+++ b/packages/client/lib/util/debug.ts
@@ -19,7 +19,7 @@ export async function debugCodeReplayBlock(execution: VMExecution, block: Block)
  * Block: ${block.header.number}
  * Hardfork: ${execution.hardfork}
  *
- * Run with: DEBUG=vm:*:*,vm:*,-vm:ops:* ts-node [SCRIPT_NAME].ts
+ * Run with: DEBUG=ethjs,vm:*:*,vm:*,-vm:ops:* ts-node [SCRIPT_NAME].ts
  *
  */
 

--- a/packages/devp2p/README.md
+++ b/packages/devp2p/README.md
@@ -53,7 +53,7 @@ Communicate with peers to read new transaction and block information:
 Run an example with:
 
 ```
-DEBUG=devp2p:* node -r ts-node/register ./examples/peer-communication.ts
+DEBUG=ethjs,devp2p:* node -r ts-node/register ./examples/peer-communication.ts
 ```
 
 ## Docs
@@ -384,12 +384,12 @@ npm run test
 This library uses the [debug](https://github.com/visionmedia/debug) debugging utility package.
 
 For the debugging output to show up, set the `DEBUG` environment variable (e.g. in Linux/Mac OS:
-`export DEBUG=*,-babel`).
+`export DEBUG=ethjs,*,-babel`).
 
 Use the `DEBUG` environment variable to active the logger output you are interested in, e.g.:
 
 ```shell
-DEBUG=devp2p:dpt:\*,devp2p:eth node -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
+DEBUG=ethjs,devp2p:dpt:\*,devp2p:eth node -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
 ```
 
 The following loggers are available:
@@ -410,7 +410,7 @@ The following loggers are available:
 For more verbose output on logging (e.g. to output the entire msg payload) use the `verbose` logger
 in addition:
 
-DEBUG=devp2p:dpt:\*,devp2p:eth,verbose node -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
+DEBUG=ethjs,devp2p:dpt:\*,devp2p:eth,verbose node -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
 
 Exemplary logging output:
 
@@ -439,7 +439,7 @@ Available messages can be added to the logger base name to filter on a per messa
 on two message names along `ETH` protocol debugging:
 
 ```shell
-DEBUG=devp2p:eth:GET_BLOCK_HEADERS,devp2p:eth:BLOCK_HEADERS -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
+DEBUG=ethjs,devp2p:eth:GET_BLOCK_HEADERS,devp2p:eth:BLOCK_HEADERS -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
 ```
 
 Exemplary logging output:
@@ -461,7 +461,7 @@ There are the following ways to limit debug output to a certain peer:
 Log output can be limited to one or several certain IPs. This can be useful to follow on the message exchange with a certain remote peer (e.g. a bootstrap peer):
 
 ```shell
-DEBUG=devp2p:3.209.45.79 -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
+DEBUG=ethjs,devp2p:3.209.45.79 -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
 ```
 
 #### First Connected
@@ -469,7 +469,7 @@ DEBUG=devp2p:3.209.45.79 -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
 Logging can be limited to the peer the first successful subprotocol (e.g. `ETH`) connection could be established:
 
 ```shell
-DEBUG=devp2p:FIRST_PEER -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
+DEBUG=ethjs,devp2p:FIRST_PEER -r ts-node/register [YOUR_SCRIPT_TO_RUN.ts]
 ```
 
 This logger can be used in various practical scenarios if you want to concentrate on the message exchange with just one peer.

--- a/packages/devp2p/src/protocol/eth.ts
+++ b/packages/devp2p/src/protocol/eth.ts
@@ -41,10 +41,8 @@ export class ETH extends Protocol {
       this._nextForkBlock = c.nextHardforkBlock(this._hardfork) ?? BigInt(0)
     }
 
-    // Safeguard if "process" is not available (browser)
-    if (process !== undefined && typeof process.env.DEBUG !== 'undefined') {
-      this.DEBUG = true
-    }
+    // Skip DEBUG calls unless 'ethjs' included in environmental DEBUG variables
+    this.DEBUG = process?.env?.DEBUG?.includes('ethjs') ?? false
   }
 
   static eth62 = { name: 'eth', version: 62, length: 8, constructor: ETH }

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -212,7 +212,7 @@ event handlers.
 
 ## Understanding the EVM
 
-If you want to understand your EVM runs we have added a hierarchically structured list of debug loggers for your convenience which can be activated in arbitrary combinations. We also use these loggers internally for development and testing. These loggers use the [debug](https://github.com/visionmedia/debug) library and can be activated on the CL with `DEBUG=[Logger Selection] node [Your Script to Run].js` and produce output like the following:
+If you want to understand your EVM runs we have added a hierarchically structured list of debug loggers for your convenience which can be activated in arbitrary combinations. We also use these loggers internally for development and testing. These loggers use the [debug](https://github.com/visionmedia/debug) library and can be activated on the CL with `DEBUG=ethjs,[Logger Selection] node [Your Script to Run].js` and produce output like the following:
 
 ![EthereumJS EVM Debug Logger](./debug.png?raw=true)
 
@@ -231,31 +231,31 @@ Here are some examples for useful logger combinations.
 Run one specific logger:
 
 ```shell
-DEBUG=evm ts-node test.ts
+DEBUG=ethjs,evm ts-node test.ts
 ```
 
 Run all loggers currently available:
 
 ```shell
-DEBUG=evm:*,evm:*:* ts-node test.ts
+DEBUG=ethjs,evm:*,evm:*:* ts-node test.ts
 ```
 
 Run only the gas loggers:
 
 ```shell
-DEBUG=evm:*:gas ts-node test.ts
+DEBUG=ethjs,evm:*:gas ts-node test.ts
 ```
 
 Excluding the ops logger:
 
 ```shell
-DEBUG=evm:*,evm:*:*,-evm:ops ts-node test.ts
+DEBUG=ethjs,evm:*,evm:*:*,-evm:ops ts-node test.ts
 ```
 
 Run some specific loggers including a logger specifically logging the `SSTORE` executions from the EVM (this is from the screenshot above):
 
 ```shell
-DEBUG=evm,evm:ops:sstore,evm:*:gas ts-node test.ts
+DEBUG=ethjs,evm,evm:ops:sstore,evm:*:gas ts-node test.ts
 ```
 
 ### Internal Structure

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -298,10 +298,8 @@ export class EVM implements EVMInterface {
       promisify(this.events.emit.bind(this.events))
     )
 
-    // Safeguard if "process" is not available (browser)
-    if (typeof process?.env.DEBUG !== 'undefined') {
-      this.DEBUG = true
-    }
+    // Skip DEBUG calls unless 'ethjs' included in environmental DEBUG variables
+    this.DEBUG = process?.env?.DEBUG?.includes('ethjs') ?? false
   }
 
   protected async init(): Promise<void> {

--- a/packages/statemanager/src/baseStateManager.ts
+++ b/packages/statemanager/src/baseStateManager.ts
@@ -36,10 +36,9 @@ export abstract class BaseStateManager {
    * Needs to be called from the subclass constructor
    */
   constructor(_opts: DefaultStateManagerOpts) {
-    // Safeguard if "process" is not available (browser)
-    if (typeof process?.env.DEBUG !== 'undefined') {
-      this.DEBUG = true
-    }
+    // Skip DEBUG calls unless 'ethjs' included in environmental DEBUG variables
+    this.DEBUG = process?.env?.DEBUG?.includes('ethjs') ?? false
+
     this._debug = createDebugLogger('statemanager:statemanager')
   }
 

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -212,7 +212,7 @@ event handlers.
 
 ## Understanding the VM
 
-If you want to understand your VM runs we have added a hierarchically structured list of debug loggers for your convenience which can be activated in arbitrary combinations. We also use these loggers internally for development and testing. These loggers use the [debug](https://github.com/visionmedia/debug) library and can be activated on the CL with `DEBUG=[Logger Selection] node [Your Script to Run].js` and produce output like the following:
+If you want to understand your VM runs we have added a hierarchically structured list of debug loggers for your convenience which can be activated in arbitrary combinations. We also use these loggers internally for development and testing. These loggers use the [debug](https://github.com/visionmedia/debug) library and can be activated on the CL with `DEBUG=ethjs,[Logger Selection] node [Your Script to Run].js` and produce output like the following:
 
 ![EthereumJS VM Debug Logger](./debug.png?raw=true)
 
@@ -232,31 +232,31 @@ Here are some examples for useful logger combinations.
 Run one specific logger:
 
 ```shell
-DEBUG=vm:tx ts-node test.ts
+DEBUG=ethjs,vm:tx ts-node test.ts
 ```
 
 Run all loggers currently available:
 
 ```shell
-DEBUG=vm:*,vm:*:* ts-node test.ts
+DEBUG=ethjs,vm:*,vm:*:* ts-node test.ts
 ```
 
 Run only the gas loggers:
 
 ```shell
-DEBUG=vm:*:gas ts-node test.ts
+DEBUG=ethjs,vm:*:gas ts-node test.ts
 ```
 
 Excluding the state logger:
 
 ```shell
-DEBUG=vm:*,vm:*:*,-vm:state ts-node test.ts
+DEBUG=ethjs,vm:*,vm:*:*,-vm:state ts-node test.ts
 ```
 
 Run some specific loggers including a logger specifically logging the `SSTORE` executions from the VM (this is from the screenshot above):
 
 ```shell
-DEBUG=vm:tx,vm:evm,vm:ops:sstore,vm:*:gas ts-node test.ts
+DEBUG=ethjs,vm:tx,vm:evm,vm:ops:sstore,vm:*:gas ts-node test.ts
 ```
 
 ## Internal Structure

--- a/packages/vm/src/eei/vmState.ts
+++ b/packages/vm/src/eei/vmState.ts
@@ -47,10 +47,9 @@ export class VmState implements EVMStateAccess {
     this._accessedStorage = [new Map()]
     this._accessedStorageReverted = [new Map()]
 
-    // Safeguard if "process" is not available (browser)
-    if (process !== undefined && typeof process.env.DEBUG !== 'undefined') {
-      this.DEBUG = true
-    }
+    // Skip DEBUG calls unless 'ethjs' included in environmental DEBUG variables
+    this.DEBUG = process?.env?.DEBUG?.includes('ethjs') ?? false
+
     this._debug = createDebugLogger('vm:state')
   }
 

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -151,10 +151,8 @@ export class VM {
       promisify(this.events.emit.bind(this.events))
     )
 
-    // Safeguard if "process" is not available (browser)
-    if (process !== undefined && typeof process.env.DEBUG !== 'undefined') {
-      this.DEBUG = true
-    }
+    // Skip DEBUG calls unless 'ethjs' included in environmental DEBUG variables
+    this.DEBUG = process?.env?.DEBUG?.includes('ethjs') ?? false
   }
 
   async init(): Promise<void> {


### PR DESCRIPTION
Followup to PR #2325 
Addressing issue #2306 

The EVM, VM, StateManager, and devp2p packages all contain a performance feature that will skip calls to debug logging if the Debug output is not desired.

This was implemented like:
```
this.DEBUG = false
if (process.env.DEBUG !== undefined) { 
   this.DEBUG === true 
}
```
with a wrapper around calls to debug()
```
if (this.DEBUG) { 
    debug('message') 
}
```
This proved problematic for users who wish to enable DEBUG variables for other reasons without incidentally enabling EthJS debuggers.

----
This PR changes the way this.DEBUG is set, by checking instead for a master variable `ethjs`, and enabling this.DEBUG only if that variable is present.
```
    this.DEBUG = process?.env?.DEBUG?.includes('ethjs') ?? false
```

The example scripts in the various `README.md` files were updated to include the `ethjs` variable.

`DEBUG=devp2p:* npx ts-node ./examples/script.ts` 
becomes
`DEBUG=ethjs,devp2p:* npx ts-node ./examples/script.ts`