### PR TITLE
Exclude sim from client unit tests

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -51,7 +51,7 @@
     "test:browser": "karma start karma.conf.js",
     "test:cli": "npm run tape -- 'test/cli/*.spec.ts'",
     "test:integration": "npm run tape -- 'test/integration/**/*.spec.ts'",
-    "test:unit": "npm run tape -- 'test/!(integration|cli)/**/*.spec.ts' 'test/*.spec.ts'",
+    "test:unit": "npm run tape -- 'test/!(integration|cli|sim)/**/*.spec.ts' 'test/*.spec.ts'",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {


### PR DESCRIPTION
Excludes `sim` directory from `client` tests since this isn't really a unit test but an integrated end-to-end test for validating experimental hardforks.