### PR TITLE
Common custom chain bugs

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { Blockchain, parseGethGenesisState } from '@ethereumjs/blockchain'
-import { Chain, Common, ConsensusAlgorithm, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, ConsensusAlgorithm, ConsensusType, Hardfork } from '@ethereumjs/common'
 import { Address, toBuffer } from '@ethereumjs/util'
 import { randomBytes } from 'crypto'
 import { existsSync, writeFileSync } from 'fs'
@@ -585,10 +585,10 @@ async function run() {
 
   // Configure common based on args given
   if (
-    typeof args.customChainParams === 'string' ||
-    typeof args.customGenesisState === 'string' ||
-    (typeof args.gethGenesis === 'string' &&
-      (args.network !== 'mainnet' || args.networkId !== undefined))
+    (typeof args.customChainParams === 'string' ||
+      typeof args.customGenesisState === 'string' ||
+      typeof args.gethGenesis === 'string') &&
+    (args.network !== 'mainnet' || args.networkId !== undefined)
   ) {
     console.error('cannot specify both custom chain parameters and preset network ID')
     process.exit()

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { Blockchain, parseGethGenesisState } from '@ethereumjs/blockchain'
-import { Chain, Common, ConsensusAlgorithm, ConsensusType, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, ConsensusAlgorithm, Hardfork } from '@ethereumjs/common'
 import { Address, toBuffer } from '@ethereumjs/util'
 import { randomBytes } from 'crypto'
 import { existsSync, writeFileSync } from 'fs'

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -923,7 +923,9 @@ export class Common extends EventEmitter {
       }
       if (hfChanges[0] === hardfork) break
     }
-    return value ?? this._chainParams['consensus'][this.consensusAlgorithm() as ConsensusAlgorithm]!
+    return (
+      value ?? this._chainParams['consensus'][this.consensusAlgorithm() as ConsensusAlgorithm] ?? {}
+    )
   }
 
   /**

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -905,10 +905,9 @@ export class Common extends EventEmitter {
    * Expected returns (parameters must be present in
    * the respective chain json files):
    *
-   * ethash: -
+   * ethash: empty object
    * clique: period, epoch
-   * aura: -
-   * casper: -
+   * casper: empty object
    *
    * Note: This value can update along a Hardfork.
    */


### PR DESCRIPTION
While researching #2436, I encountered what I think are a couple of minor logic bugs:

- When the `miner` starts in the client, if your `common` instance's consensus is set to `pow`, it errors trying to access the PoA consensus algorithm's subproperty of `period` since the `consensusConfig` object in the `common._chainParams` is undefined for PoW (this would presumably result in the same error for PoS). This resolve by just returning an empty object `{}` if no configuration parameters are defined.
- I think we had some misplaced parentheses in `cli` in lines 588 - 591.  The error should occur in any scenario where we provide custom genesis parameters and also pass in either `network` or `networkId` since those tell the `common` constructor to pull in predefined network genesis parameters.