### PR TITLE
Fix EVM test scripts

### DIFF
--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -31,7 +31,7 @@
     "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
     "coverage": "c8 --all --reporter=lcov --reporter=text --reporter=text-lcov npm run coverage:test",
-    "coverage:test": "npm run test; cd ../vm; npm run tester -- --state",
+    "coverage:test": "npm run test && cd ../vm && npm run tester -- --state",
     "docs:build": "typedoc --options typedoc.js",
     "examples": "ts-node ../../scripts/examples-runner.ts -- evm",
     "formatTest": "node ./scripts/formatTest",

--- a/packages/evm/test/memory.spec.ts
+++ b/packages/evm/test/memory.spec.ts
@@ -37,7 +37,7 @@ tape('Memory', (t) => {
   })
 
   t.test(
-    'should expand by word (32 bytes) properly when writing to previously untouched location',
+    'should expand by container (8192 bytes) properly when writing to previously untouched location',
     (st) => {
       const memory = new Memory()
       st.equal(memory._store.length, 0, 'memory should start with zero length')
@@ -48,23 +48,17 @@ tape('Memory', (t) => {
     }
   )
 
-  t.test('should expand by word (32 bytes) when reading a previously untouched location', (st) => {
-    const memory = new Memory()
-    memory.read(0, 8)
-    st.equal(memory._store.length, 8192)
+  t.test(
+    'should expand by container (8192 bytes) when reading a previously untouched location',
+    (st) => {
+      const memory = new Memory()
+      memory.read(0, 8)
+      st.equal(memory._store.length, 8192)
 
-    memory.read(1, 16)
-    st.equal(memory._store.length, 8192)
+      memory.read(8190, 8193)
+      st.equal(memory._store.length, 16384)
 
-    memory.read(1, 32)
-    st.equal(memory._store.length, 8192)
-
-    memory.read(32, 32)
-    st.equal(memory._store.length, 8192)
-
-    memory.read(33, 32)
-    st.equal(memory._store.length, 8192)
-
-    st.end()
-  })
+      st.end()
+    }
+  )
 })

--- a/packages/evm/test/memory.spec.ts
+++ b/packages/evm/test/memory.spec.ts
@@ -14,9 +14,9 @@ tape('Memory', (t) => {
     st.end()
   })
 
-  t.test('should extend capacity to word boundary', (st) => {
+  t.test('should extend capacity to 8192 bytes', (st) => {
     m.extend(0, 3)
-    st.equal(m._store.length, 32)
+    st.equal(m._store.length, 8192)
     st.end()
   })
 
@@ -40,17 +40,9 @@ tape('Memory', (t) => {
     'should expand by word (32 bytes) properly when writing to previously untouched location',
     (st) => {
       const memory = new Memory()
+      st.equal(memory._store.length, 0, 'memory should start with zero length')
       memory.write(0, 1, Buffer.from([1]))
-      st.equal(memory._store.length, 32)
-
-      memory.write(1, 3, Buffer.from([2, 2, 2]))
-      st.equal(memory._store.length, 32)
-
-      memory.write(4, 32, Buffer.allocUnsafe(32).fill(3))
-      st.equal(memory._store.length, 64)
-
-      memory.write(36, 32, Buffer.allocUnsafe(32).fill(4))
-      st.equal(memory._store.length, 96)
+      st.equal(memory._store.length, 8192, 'memory buffer length expanded to 8192 bytes')
 
       st.end()
     }
@@ -59,19 +51,19 @@ tape('Memory', (t) => {
   t.test('should expand by word (32 bytes) when reading a previously untouched location', (st) => {
     const memory = new Memory()
     memory.read(0, 8)
-    st.equal(memory._store.length, 32)
+    st.equal(memory._store.length, 8192)
 
     memory.read(1, 16)
-    st.equal(memory._store.length, 32)
+    st.equal(memory._store.length, 8192)
 
     memory.read(1, 32)
-    st.equal(memory._store.length, 64)
+    st.equal(memory._store.length, 8192)
 
     memory.read(32, 32)
-    st.equal(memory._store.length, 64)
+    st.equal(memory._store.length, 8192)
 
     memory.read(33, 32)
-    st.equal(memory._store.length, 96)
+    st.equal(memory._store.length, 8192)
 
     st.end()
   })


### PR DESCRIPTION
The `evm` tests have been failing since #2405 but the `npm run coverage` script wasn't picking this up due to the way it was constructed and missing the error code returned by the initial call to run the tests.

TODO
- [ ] - Fix broken tests in `evm/test/memory.spec.ts`