### PR TITLE
client: Add blockValue to the getPayload response

### DIFF
--- a/packages/client/lib/miner/pendingBlock.ts
+++ b/packages/client/lib/miner/pendingBlock.ts
@@ -126,7 +126,9 @@ export class PendingBlock {
   /**
    * Returns the completed block
    */
-  async build(payloadId: Buffer): Promise<void | [block: Block, receipts: TxReceipt[]]> {
+  async build(
+    payloadId: Buffer
+  ): Promise<void | [block: Block, receipts: TxReceipt[], value: bigint]> {
     const payload = this.pendingPayloads.find((p) => p[0].equals(payloadId))
     if (!payload) {
       return
@@ -180,6 +182,6 @@ export class PendingBlock {
     // Remove from pendingPayloads
     this.pendingPayloads = this.pendingPayloads.filter((p) => !p[0].equals(payloadId))
 
-    return [block, builder.transactionReceipts]
+    return [block, builder.transactionReceipts, builder.minerValue]
   }
 }

--- a/packages/client/test/rpc/engine/withdrawals.spec.ts
+++ b/packages/client/test/rpc/engine/withdrawals.spec.ts
@@ -131,9 +131,11 @@ for (const { name, withdrawals, withdrawalsRoot, gethBlockRlp } of testCases) {
     let payload: ExecutionPayload | undefined = undefined
     req = params('engine_getPayloadV2', [payloadId])
     expectRes = (res: any) => {
-      payload = res.body.result
-      t.equal(payload!.blockNumber, '0x1')
-      t.equal(payload!.withdrawals!.length, withdrawals.length, 'withdrawals should match')
+      const { executionPayload, blockValue } = res.body.result
+      t.equal(executionPayload!.blockNumber, '0x1')
+      t.equal(executionPayload!.withdrawals!.length, withdrawals.length, 'withdrawals should match')
+      t.equal(blockValue, '0x0', 'No value should be returned')
+      payload = executionPayload
     }
     await baseRequest(t, server, req, 200, expectRes, false)
 

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -17,6 +17,11 @@ export class BlockBuilder {
    * The cumulative gas used by the transactions added to the block.
    */
   gasUsed = BigInt(0)
+  /**
+   * Value of the block, represented by the final transaction fees
+   * acruing to the miner.
+   */
+  private _minerValue = BigInt(0)
 
   private readonly vm: VM
   private blockOpts: BuilderOpts
@@ -30,6 +35,10 @@ export class BlockBuilder {
 
   get transactionReceipts() {
     return this.transactionResults.map((result) => result.receipt)
+  }
+
+  get minerValue() {
+    return this._minerValue
   }
 
   constructor(vm: VM, opts: BuildBlockOpts) {
@@ -158,6 +167,7 @@ export class BlockBuilder {
     this.transactions.push(tx)
     this.transactionResults.push(result)
     this.gasUsed += result.totalGasSpent
+    this._minerValue += result.minerValue
 
     return result
   }

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -406,11 +406,11 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
 
   const minerAccount = await state.getAccount(miner)
   // add the amount spent on gas to the miner's account
-  if (this._common.isActivatedEIP(1559) === true) {
-    minerAccount.balance += results.totalGasSpent * inclusionFeePerGas!
-  } else {
-    minerAccount.balance += results.amountSpent
-  }
+  results.minerValue =
+    this._common.isActivatedEIP(1559) === true
+      ? results.totalGasSpent * inclusionFeePerGas!
+      : results.amountSpent
+  minerAccount.balance += results.minerValue
 
   // Put the miner account into the state. If the balance of the miner account remains zero, note that
   // the state.putAccount function puts this into the "touched" accounts. This will thus be removed when

--- a/packages/vm/src/types.ts
+++ b/packages/vm/src/types.ts
@@ -359,6 +359,11 @@ export interface RunTxResult extends EVMResult {
    * EIP-2930 access list generated for the tx (see `reportAccessList` option)
    */
   accessList?: AccessList
+
+  /**
+   * The value that accrues to the miner by this transaction
+   */
+  minerValue: bigint
 }
 
 export interface AfterTxEvent extends RunTxResult {


### PR DESCRIPTION
on/post shanghai i.e. getPayloadV2 onwards, the getPayload should also return blockValue which natively is to be implemented as fees accrued  to the miner

See 
- https://github.com/ethereum/execution-apis/pull/314/files

This is going to be part of next withdrawal testnet amongst other things 