### PR TITLE
common: Add eips 3651,3855,3860 to shanghai hf for Zhejiang shanghai testnet

### DIFF
--- a/packages/client/test/sim/eof.spec.ts
+++ b/packages/client/test/sim/eof.spec.ts
@@ -111,7 +111,7 @@ tape('EOF ephemeral hardfork tests', async (t) => {
     st.end()
   })
   // ------------EIP 3855 tests-------------------------------
-  t.test('EIP 3860 tests', async (st) => {
+  t.test('EIP 3855 tests', async (st) => {
     const push1res = await runTx('0x6000')
     const push0res = await runTx('0x5F')
     st.ok(

--- a/packages/common/src/hardforks/shanghai.json
+++ b/packages/common/src/hardforks/shanghai.json
@@ -1,7 +1,7 @@
 {
   "name": "shanghai",
-  "comment": "Next feature hardfork after the merge hardfork",
+  "comment": "Next feature hardfork after the merge hardfork having withdrawals, warm coinbase, push0, limit/meter initcode",
   "url": "https://github.com/ethereum/pm/issues/356",
   "status": "Pre-Draft",
-  "eips": [4895]
+  "eips": [4895, 3651, 3855, 3860]
 }


### PR DESCRIPTION
Adding the eips for shanghai hf which are now part of the Zhejiang testnet

see discussion here: https://discord.com/channels/595666850260713488/892088344438255616/1055081293450317894