### PR TITLE
common: Update setForkHashes to update timebased hardfork forkhashes

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -902,10 +902,10 @@ export class Common extends EventEmitter {
    */
   setForkHashes(genesisHash: Buffer) {
     for (const hf of this.hardforks()) {
+      const blockOrTime = hf.timestamp ?? hf.block
       if (
         (hf.forkHash === null || hf.forkHash === undefined) &&
-        typeof hf.block !== 'undefined' &&
-        (hf.block !== null || typeof hf.ttd !== 'undefined')
+        ((blockOrTime !== null && blockOrTime !== undefined) || typeof hf.ttd !== 'undefined')
       ) {
         hf.forkHash = this.forkHash(hf.name, genesisHash)
       }


### PR DESCRIPTION
While trying to sync the eip4844 devnet 3, ethereumjs was disconnecting from peer as it wasn't able to identiy the peer's forkhash which was on sharding hf based on time. 
On debugging realized that the we were not setting forkhashes for timestamp based hardfork.
This PR fixes the same, and as a result was able to peer successfully with the geth which was on sharding hf