### PR TITLE
block: Handle hardfork defaults consistently

### DIFF
--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -260,10 +260,11 @@ export class Block {
     withdrawals?: Withdrawal[]
   ) {
     this.header = header ?? BlockHeader.fromHeaderData({}, opts)
-    this.transactions = transactions
-    this.withdrawals = withdrawals
-    this.uncleHeaders = uncleHeaders
     this._common = this.header._common
+
+    this.transactions = transactions
+    this.withdrawals = withdrawals ?? (this._common.isActivatedEIP(4895) ? [] : undefined)
+    this.uncleHeaders = uncleHeaders
     if (uncleHeaders.length > 0) {
       this.validateUncles()
       if (this._common.consensusType() === ConsensusType.ProofOfAuthority) {
@@ -280,9 +281,7 @@ export class Block {
       }
     }
 
-    if (this._common.isActivatedEIP(4895) && withdrawals === undefined) {
-      throw new Error('Need a withdrawals field if EIP 4895 is active')
-    } else if (!this._common.isActivatedEIP(4895) && withdrawals !== undefined) {
+    if (!this._common.isActivatedEIP(4895) && withdrawals !== undefined) {
       throw new Error('Cannot have a withdrawals field if EIP 4895 is not active')
     }
 

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -154,8 +154,6 @@ export class BlockHeader {
       extraData: Buffer.from([]),
       mixHash: zeros(32),
       nonce: zeros(8),
-      baseFeePerGas: undefined,
-      withdrawalsRoot: undefined,
     }
 
     const parentHash = toType(headerData.parentHash, TypeOutput.Buffer) ?? defaults.parentHash
@@ -176,42 +174,35 @@ export class BlockHeader {
     const extraData = toType(headerData.extraData, TypeOutput.Buffer) ?? defaults.extraData
     const mixHash = toType(headerData.mixHash, TypeOutput.Buffer) ?? defaults.mixHash
     const nonce = toType(headerData.nonce, TypeOutput.Buffer) ?? defaults.nonce
-    let baseFeePerGas =
-      toType(headerData.baseFeePerGas, TypeOutput.BigInt) ?? defaults.baseFeePerGas
-    const withdrawalsRoot =
-      toType(headerData.withdrawalsRoot, TypeOutput.Buffer) ?? defaults.withdrawalsRoot
 
     const hardforkByBlockNumber = options.hardforkByBlockNumber ?? false
     if (hardforkByBlockNumber || options.hardforkByTTD !== undefined) {
       this._common.setHardforkByBlockNumber(number, options.hardforkByTTD, timestamp)
     }
 
-    if (this._common.isActivatedEIP(1559) === true) {
-      if (baseFeePerGas === undefined) {
-        if (number === this._common.hardforkBlock(Hardfork.London)) {
-          baseFeePerGas = this._common.param('gasConfig', 'initialBaseFee')
-        } else {
-          // Minimum possible value for baseFeePerGas is 7,
-          // so we use it as the default if the field is missing.
-          baseFeePerGas = BigInt(7)
-        }
-      }
-    } else {
-      if (baseFeePerGas) {
-        throw new Error('A base fee for a block can only be set with EIP1559 being activated')
-      }
+    // Hardfork defaults which couldn't be paired with earlier defaults
+    const hardforkDefaults = {
+      baseFeePerGas: this._common.isActivatedEIP(1559)
+        ? number === this._common.hardforkBlock(Hardfork.London)
+          ? this._common.param('gasConfig', 'initialBaseFee')
+          : BigInt(7)
+        : undefined,
+      withdrawalsRoot: this._common.isActivatedEIP(4895) ? KECCAK256_RLP : undefined,
     }
 
-    if (this._common.isActivatedEIP(4895)) {
-      if (withdrawalsRoot === undefined) {
-        throw new Error('invalid header. withdrawalsRoot should be provided')
-      }
-    } else {
-      if (withdrawalsRoot !== undefined) {
-        throw new Error(
-          'A withdrawalsRoot for a header can only be provied with EIP4895 being activated'
-        )
-      }
+    const baseFeePerGas =
+      toType(headerData.baseFeePerGas, TypeOutput.BigInt) ?? hardforkDefaults.baseFeePerGas
+    const withdrawalsRoot =
+      toType(headerData.withdrawalsRoot, TypeOutput.Buffer) ?? hardforkDefaults.withdrawalsRoot
+
+    if (!this._common.isActivatedEIP(1559) && baseFeePerGas !== undefined) {
+      throw new Error('A base fee for a block can only be set with EIP1559 being activated')
+    }
+
+    if (!this._common.isActivatedEIP(4895) && withdrawalsRoot !== undefined) {
+      throw new Error(
+        'A withdrawalsRoot for a header can only be provied with EIP4895 being activated'
+      )
     }
 
     this.parentHash = parentHash

--- a/packages/block/test/block.spec.ts
+++ b/packages/block/test/block.spec.ts
@@ -382,4 +382,15 @@ tape('[Block]: block functions', function (t) {
       st.end()
     }
   )
+
+  t.test(
+    'should be able to initialize shanghai blocks with correct hardfork defaults',
+    function (st) {
+      const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Shanghai })
+      const block = Block.fromBlockData({}, { common })
+      st.equal(block._common.hardfork(), Hardfork.Shanghai, 'hardfork should be set to shanghai')
+      st.deepEqual(block.withdrawals, [], 'withdrawals should be set to default empty array')
+      st.end()
+    }
+  )
 })

--- a/packages/block/test/eip4895block.spec.ts
+++ b/packages/block/test/eip4895block.spec.ts
@@ -58,14 +58,14 @@ tape('EIP4895 tests', function (t) {
         }
       )
     }, 'should throw when setting withdrawalsRoot with EIP4895 not being activated')
-    st.throws(() => {
+    st.doesNotThrow(() => {
       BlockHeader.fromHeaderData(
         {},
         {
           common,
         }
       )
-    }, 'should throw when withdrawalsRoot is undefined with EIP4895 being activated')
+    }, 'should not throw when withdrawalsRoot is undefined with EIP4895 being activated')
     st.doesNotThrow(() => {
       BlockHeader.fromHeaderData(
         {
@@ -90,14 +90,14 @@ tape('EIP4895 tests', function (t) {
         }
       )
     }, 'should throw when setting withdrawals with EIP4895 not being activated')
-    st.throws(() => {
+    st.doesNotThrow(() => {
       Block.fromBlockData(
         {},
         {
           common,
         }
       )
-    }, 'should throw when withdrawals is undefined with EIP4895 being activated')
+    }, 'should not throw when withdrawals is undefined with EIP4895 being activated')
     st.doesNotThrow(() => {
       Block.fromBlockData(
         {

--- a/packages/block/test/header.spec.ts
+++ b/packages/block/test/header.spec.ts
@@ -482,4 +482,20 @@ tape('[Block]: Header functions', function (t) {
     )
     st.end()
   })
+
+  t.test(
+    'should be able to initialize shanghai header with correct hardfork defaults',
+    function (st) {
+      const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Shanghai })
+      const header = BlockHeader.fromHeaderData({}, { common })
+      st.equal(header._common.hardfork(), Hardfork.Shanghai, 'hardfork should be set to shanghai')
+      st.equal(header.baseFeePerGas, BigInt(7), 'baseFeePerGas should be set to minimun default')
+      st.deepEqual(
+        header.withdrawalsRoot,
+        KECCAK256_RLP,
+        'withdrawalsRoot should be set to KECCAK256_RLP'
+      )
+      st.end()
+    }
+  )
 })


### PR DESCRIPTION
Noticed in eip4844 and elsewhere that its better to set defaults properly for the required fields which makes the UX of initializing a default object easy with just `Block.fromBlockData/Block.fromHeaderData` with correct hardfork defaults.

This fixes the  addTransaction flow in the `vm/src/buildBlock.ts` which has this code flow: 
```
    const blockData = { header, transactions: this.transactions }
    const block = Block.fromBlockData(blockData, this.blockOpts)
```
where withdrawal defaults are not being explicity added in and hence resulting into the block building failure in shanghai with txs.