### PR TITLE
common: add eip option to GethConfigOpts

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -171,17 +171,18 @@ export class Common extends EventEmitter {
   /**
    * Static method to load and set common from a geth genesis json
    * @param genesisJson json of geth configuration
-   * @param { chain, genesisHash, hardfork } to futher configure the common instance
+   * @param { chain, eips, genesisHash, hardfork, mergeForkIdPostMerge } to further configure the common instance
    * @returns Common
    */
   static fromGethGenesis(
     genesisJson: any,
-    { chain, genesisHash, hardfork, mergeForkIdPostMerge }: GethConfigOpts
+    { chain, eips, genesisHash, hardfork, mergeForkIdPostMerge }: GethConfigOpts
   ): Common {
     const genesisParams = parseGethGenesis(genesisJson, chain, mergeForkIdPostMerge)
     const common = new Common({
       chain: genesisParams.name ?? 'custom',
       customChains: [genesisParams],
+      eips,
       hardfork,
     })
     if (genesisHash !== undefined) {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -115,9 +115,8 @@ export interface CustomCommonOpts extends BaseOpts {
   baseChain?: string | number | Chain | bigint
 }
 
-export interface GethConfigOpts {
+export interface GethConfigOpts extends BaseOpts {
   chain?: string
-  hardfork?: string | Hardfork
   genesisHash?: Buffer
   mergeForkIdPostMerge?: boolean
 }

--- a/packages/vm/test/api/EIPs/eip-4895-withdrawals.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-4895-withdrawals.spec.ts
@@ -14,6 +14,7 @@ import type { WithdrawalBuffer, WithdrawalData } from '@ethereumjs/util'
 const common = new Common({
   chain: Chain.Mainnet,
   hardfork: Hardfork.Merge,
+  eips: [4895],
 })
 
 const pkey = Buffer.from('20'.repeat(32), 'hex')
@@ -23,7 +24,6 @@ const gethWithdrawals8BlockRlp =
 tape('EIP4895 tests', (t) => {
   t.test('EIP4895: withdrawals execute as expected', async (st) => {
     const vm = await VM.create({ common })
-    vm._common.setEIPs([4895])
     const withdrawals = <WithdrawalData[]>[]
     const addresses = ['20'.repeat(20), '30'.repeat(20), '40'.repeat(20)]
     const amounts = [BigInt(1000), BigInt(3000), BigInt(5000)]
@@ -117,7 +117,6 @@ tape('EIP4895 tests', (t) => {
 
   t.test('EIP4895: state updation should exclude 0 amount updates', async (st) => {
     const vm = await VM.create({ common })
-    vm._common.setEIPs([4895])
 
     await vm.eei.generateCanonicalGenesis(parseGethGenesisState(genesisJSON))
     const preState = (await vm.eei.getStateRoot()).toString('hex')


### PR DESCRIPTION
This adds the EIP option to the GethConfigOpts. This change makes the workflow a bit easier for verkle trees work (can set directly the EIPs with the `Common.fromGethConfig` helper instead of using `.setEIPs` in a second step) so I'm extracting this in a separate PR. I think this could also be useful for further testnet work. 