### PR TITLE
common: infer latest hardfork from geth genesis file

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -183,7 +183,7 @@ export class Common extends EventEmitter {
       chain: genesisParams.name ?? 'custom',
       customChains: [genesisParams],
       eips,
-      hardfork,
+      hardfork: hardfork ?? genesisParams.hardfork,
     })
     if (genesisHash !== undefined) {
       common.setForkHashes(genesisHash)

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -19,9 +19,9 @@ export interface ChainConfig {
   name: string
   chainId: number | bigint
   networkId: number | bigint
-  defaultHardfork: string
-  comment: string
-  url: string
+  defaultHardfork?: string
+  comment?: string
+  url?: string
   genesis: GenesisBlockConfig
   hardforks: HardforkConfig[]
   bootstrapNodes: BootstrapNodeConfig[]

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -156,10 +156,6 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
     return (a.timestamp ?? genesisTimestamp) - (b.timestamp ?? genesisTimestamp)
   })
 
-  const latestHardfork = params.hardforks.length > 0 ? params.hardforks.slice(-1)[0] : undefined
-  params.hardfork = latestHardfork?.name
-  params.hardforks.unshift({ name: Hardfork.Chainstart, block: 0 })
-
   if (config.terminalTotalDifficulty !== undefined) {
     // Following points need to be considered for placement of merge hf
     // - Merge hardfork can't be placed at genesis
@@ -193,6 +189,11 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
       params.hardforks.push(mergeConfig as unknown as ConfigHardfork)
     }
   }
+
+  const latestHardfork = params.hardforks.length > 0 ? params.hardforks.slice(-1)[0] : undefined
+  params.hardfork = latestHardfork?.name
+  params.hardforks.unshift({ name: Hardfork.Chainstart, block: 0 })
+
   return params
 }
 

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -29,10 +29,27 @@ function formatNonce(nonce: string): string {
  * @returns genesis parameters in a `CommonOpts` compliant object
  */
 function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
-  const { name, config, difficulty, mixHash, gasLimit, coinbase, baseFeePerGas } = json
-  let { extraData, timestamp, nonce } = json
+  const {
+    name,
+    config,
+    difficulty,
+    mixHash,
+    gasLimit,
+    coinbase,
+    baseFeePerGas,
+  }: {
+    name: string
+    config: any
+    difficulty: string
+    mixHash: string
+    gasLimit: string
+    coinbase: string
+    baseFeePerGas: string
+  } = json
+  let { extraData, timestamp, nonce }: { extraData: string; timestamp: string; nonce: string } =
+    json
   const genesisTimestamp = Number(timestamp)
-  const { chainId } = config
+  const { chainId }: { chainId: number } = config
 
   // geth is not strictly putting empty fields with a 0x prefix
   if (extraData === '') {
@@ -55,7 +72,7 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
     )
   }
 
-  const params: any = {
+  const params = {
     name,
     chainId,
     networkId: chainId,
@@ -69,6 +86,8 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
       coinbase,
       baseFeePerGas,
     },
+    hardfork: undefined as string | undefined,
+    hardforks: [] as ConfigHardfork[],
     bootstrapNodes: [],
     consensus:
       config.clique !== undefined
@@ -118,13 +137,16 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
   params.hardforks = configHardforkNames
     .map((nameBlock) => ({
       name: forkMapRev[nameBlock],
-      block: forkMap[forkMapRev[nameBlock]].isTimestamp === true ? null : config[nameBlock],
+      block:
+        forkMap[forkMapRev[nameBlock]].isTimestamp === true || typeof config[nameBlock] !== 'number'
+          ? null
+          : config[nameBlock],
       timestamp:
-        forkMap[forkMapRev[nameBlock]].isTimestamp === true ? config[nameBlock] : undefined,
+        forkMap[forkMapRev[nameBlock]].isTimestamp === true && typeof config[nameBlock] === 'number'
+          ? config[nameBlock]
+          : undefined,
     }))
-    .filter(
-      (fork) => (fork.block !== null && fork.block !== undefined) || fork.timestamp !== undefined
-    )
+    .filter((fork) => fork.block !== null || fork.timestamp !== undefined) as ConfigHardfork[]
 
   params.hardforks.sort(function (a: ConfigHardfork, b: ConfigHardfork) {
     return (a.block ?? Infinity) - (b.block ?? Infinity)
@@ -134,6 +156,8 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
     return (a.timestamp ?? genesisTimestamp) - (b.timestamp ?? genesisTimestamp)
   })
 
+  const latestHardfork = params.hardforks.length > 0 ? params.hardforks.slice(-1)[0] : undefined
+  params.hardfork = latestHardfork?.name
   params.hardforks.unshift({ name: Hardfork.Chainstart, block: 0 })
 
   if (config.terminalTotalDifficulty !== undefined) {
@@ -164,9 +188,9 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
         (hf.block > 0 || (hf.timestamp ?? 0) > 0)
     )
     if (postMergeIndex !== -1) {
-      params.hardforks.splice(postMergeIndex, 0, mergeConfig)
+      params.hardforks.splice(postMergeIndex, 0, mergeConfig as unknown as ConfigHardfork)
     } else {
-      params.hardforks.push(mergeConfig)
+      params.hardforks.push(mergeConfig as unknown as ConfigHardfork)
     }
   }
   return params

--- a/packages/common/test/utils.spec.ts
+++ b/packages/common/test/utils.spec.ts
@@ -23,7 +23,7 @@ tape('[Utils/Parse]', (t) => {
   })
 
   t.test('should import poa network params correctly', async (t) => {
-    t.plan(3)
+    t.plan(4)
     const json = require(`../../client/test/testdata/geth-genesis/poa.json`)
     let params = parseGethGenesis(json, 'poa')
     t.equals(params.genesis.nonce, '0x0000000000000000', 'nonce is formatted correctly')
@@ -39,6 +39,7 @@ tape('[Utils/Parse]', (t) => {
       '0x0000000000000000',
       'non-hex prefixed nonce is formatted correctly'
     )
+    t.equal(params.hardfork, Hardfork.London, 'should correctly infer current hardfork')
   })
 
   t.test(
@@ -91,6 +92,8 @@ tape('[Utils/Parse]', (t) => {
       st.equal(hf.forkHash, kilnForkHashes[hf.name], `${hf.name} forkHash should match`)
     }
 
+    st.equal(common.hardfork(), Hardfork.Merge, 'should correctly infer current hardfork')
+
     // Ok lets schedule shanghai at block 0, this should force merge to be scheduled at just after
     // genesis if even mergeForkIdTransition is not confirmed to be post merge
     // This will also check if the forks are being correctly sorted based on block
@@ -119,6 +122,8 @@ tape('[Utils/Parse]', (t) => {
       ],
       'hardfork parse order should be correct'
     )
+
+    st.equal(common1.hardfork(), Hardfork.Shanghai, 'should correctly infer current hardfork')
   })
 
   t.test('should successfully parse genesis with hardfork scheduled post merge', async (st) => {
@@ -169,10 +174,13 @@ tape('[Utils/Parse]', (t) => {
     // if not post merge, then should error
     try {
       common.getHardforkByBlockNumber(8, BigInt(1), 8)
-      st.fail('should have failed since merge not compeleted before shanghai')
+      st.fail('should have failed since merge not completed before shanghai')
     } catch (e) {
-      st.pass('correctly fails if merge not compeleted before shanghai')
+      st.pass('correctly fails if merge not completed before shanghai')
     }
+
+    st.equal(common.hardfork(), Hardfork.Shanghai, 'should correctly infer common hardfork')
+
     st.end()
   })
 })


### PR DESCRIPTION
This PR solves #2414 by attempting to get the latest hardfork from the geth genesis file as a fallback when the `fromGethGenesis` constructor isn't provided with an explicit hardfork. It also adds some type improvements to the geth genesis helpers.