### PR TITLE
client: Clean stop sync and execution to allow client shutdown

### DIFF
--- a/packages/client/lib/execution/execution.ts
+++ b/packages/client/lib/execution/execution.ts
@@ -24,6 +24,7 @@ export abstract class Execution {
   protected chain: Chain
 
   public running: boolean = false
+  public started: boolean = false
 
   /**
    * Create new excution module
@@ -44,10 +45,18 @@ export abstract class Execution {
   abstract run(): Promise<number>
 
   /**
+   * Starts execution
+   */
+  async open(): Promise<void> {
+    this.started = true
+    this.config.logger.info('Starting execution.')
+  }
+
+  /**
    * Stop execution. Returns a promise that resolves once stopped.
    */
   async stop(): Promise<boolean> {
-    this.running = false
+    this.started = false
     this.config.logger.info('Stopped execution.')
     return true
   }

--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -92,6 +92,10 @@ export class VMExecution extends Execution {
    */
   async open(): Promise<void> {
     return this.runWithLock<void>(async () => {
+      // id already opened or stopping midway
+      if (this.started || this.vmPromise !== undefined) {
+        return
+      }
       await this.vm.init()
       if (typeof this.vm.blockchain.getIteratorHead !== 'function') {
         throw new Error('cannot get iterator head: blockchain has no getIteratorHead function')
@@ -111,6 +115,7 @@ export class VMExecution extends Execution {
         }
         await this.vm.eei.generateCanonicalGenesis(this.vm.blockchain.genesisState())
       }
+      await super.open()
       // TODO: Should a run be started to execute any left over blocks?
       // void this.run()
     })
@@ -185,7 +190,7 @@ export class VMExecution extends Execution {
    * @returns number of blocks executed
    */
   async run(loop = true, runOnlybatched = false): Promise<number> {
-    if (this.running) return 0
+    if (this.running || !this.started) return 0
     this.running = true
     let numExecuted: number | undefined
 
@@ -208,6 +213,7 @@ export class VMExecution extends Execution {
     let errorBlock: Block | undefined
 
     while (
+      this.started &&
       (!runOnlybatched ||
         (runOnlybatched &&
           canonicalHead.header.number - startHeadBlock.header.number >=
@@ -259,6 +265,9 @@ export class VMExecution extends Execution {
             await this.runWithLock<void>(async () => {
               // we are skipping header validation because the block has been picked from the
               // blockchain and header should have already been validated while putBlock
+              if (!this.started) {
+                throw Error('Execution stopped')
+              }
               const result = await this.vm.runBlock({
                 block,
                 root: parentState,
@@ -378,13 +387,22 @@ export class VMExecution extends Execution {
    * Stop VM execution. Returns a promise that resolves once its stopped.
    */
   async stop(): Promise<boolean> {
+    // Stop with the lock to be concurrency safe and flip started flag so that
+    // vmPromise can resolve early
     await this.runWithLock<void>(async () => {
-      if (this.vmPromise) {
-        // ensure that we wait that the VM finishes executing the block (and flushing the trie cache)
-        await this.vmPromise
-      }
-      await this.stateDB?.close()
       await super.stop()
+    })
+    // Resolve this promise outside lock since promise also aquires the lock while
+    // running the iterator
+    if (this.vmPromise) {
+      // ensure that we wait that the VM finishes executing the block (and flushing the trie cache)
+      await this.vmPromise
+    }
+    // Since we don't allow open unless vmPromise is undefined, no opens can happen
+    // midway and we can safely close
+    await this.runWithLock<void>(async () => {
+      this.vmPromise = undefined
+      await this.stateDB?.close()
     })
     return true
   }

--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -92,7 +92,7 @@ export class VMExecution extends Execution {
    */
   async open(): Promise<void> {
     return this.runWithLock<void>(async () => {
-      // id already opened or stopping midway
+      // if already opened or stopping midway
       if (this.started || this.vmPromise !== undefined) {
         return
       }

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -163,6 +163,7 @@ export class FullEthereumService extends EthereumService {
     }
     this.txPool.stop()
     this.miner?.stop()
+    await this.synchronizer.stop()
     await this.execution.stop()
     await super.stop()
     return true

--- a/packages/client/test/execution/vmexecution.spec.ts
+++ b/packages/client/test/execution/vmexecution.spec.ts
@@ -72,6 +72,10 @@ tape('[VMExecution]', async (t) => {
     exec['vmPromise'] = undefined
     await exec.open()
     t.equal(exec.started, true, 'execution should be restarted')
+    exec['vmPromise'] = (async () => 0)()
+    await exec.stop()
+    t.equal(exec.started, false, 'execution should be restopped')
+    t.equal(exec['vmPromise'], undefined, 'vmPromise should be reset')
     t.end()
   })
 

--- a/packages/client/test/execution/vmexecution.spec.ts
+++ b/packages/client/test/execution/vmexecution.spec.ts
@@ -57,6 +57,24 @@ tape('[VMExecution]', async (t) => {
     t.end()
   })
 
+  t.test('Should fail opening if vmPromise already assigned', async (t) => {
+    const blockchain = await Blockchain.create({
+      validateBlocks: true,
+      validateConsensus: false,
+    })
+    const exec = await testSetup(blockchain)
+    t.equal(exec.started, true, 'execution should be opened')
+    await exec.stop()
+    t.equal(exec.started, false, 'execution should be stopped')
+    exec['vmPromise'] = (async () => 0)()
+    await exec.open()
+    t.equal(exec.started, false, 'execution should be stopped')
+    exec['vmPromise'] = undefined
+    await exec.open()
+    t.equal(exec.started, true, 'execution should be restarted')
+    t.end()
+  })
+
   t.test('Block execution / Hardforks PoA (goerli)', async (t) => {
     const common = new Common({ chain: ChainEnum.Goerli, hardfork: Hardfork.Chainstart })
     let blockchain = await Blockchain.create({


### PR DESCRIPTION
If the client is midway syncing, sending shutdown signal to the client via Ctrl + C for e.g. wouldn't clean stop the sync or execution leading to client hanging mid way (or sometimes just keep processing the jobs it has in queue)

This PR fixes the same by clean stopping the syncronizer and execution and resolves the problem with proper stopping on client 