### PR TITLE
Remove text-lcov reporter from coverage scripts

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -39,7 +39,7 @@
     "client:start": "ts-node bin/cli.ts",
     "client:start:dev1": "npm run client:start -- --discDns=false --discV4=false --bootnodes",
     "client:start:dev2": "npm run client:start -- --discDns=false --discV4=false --transports=rlpx --port=30304 --datadir=datadir-dev2",
-    "coverage": "c8 --all --reporter=lcov --reporter=text --reporter=text-lcov npm run test:unit",
+    "coverage": "c8 --all --reporter=lcov --reporter=text npm run test:unit",
     "docs:build": "typedoc --options typedoc.js --tsconfig tsconfig.prod.json",
     "preinstall": "npm run binWorkaround",
     "lint": "../../config/cli/lint.sh",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "c8 --all --reporter=lcov --reporter=text --reporter=text-lcov npm run coverage:test",
+    "coverage": "c8 --all --reporter=lcov --reporter=text npm run coverage:test",
     "coverage:test": "npm run test && cd ../vm && npm run tester -- --state",
     "docs:build": "typedoc --options typedoc.js",
     "examples": "ts-node ../../scripts/examples-runner.ts -- evm",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -30,7 +30,7 @@
     "build": "../../config/cli/ts-build.sh",
     "build:benchmarks": "npm run build && tsc -p tsconfig.benchmarks.json",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "c8 --all --reporter=lcov --reporter=text --reporter=text-lcov npm run coverage:test",
+    "coverage": "c8 --all --reporter=lcov --reporter=text npm run coverage:test",
     "coverage:test": "npm run test:API",
     "docs:build": "typedoc --options typedoc.js",
     "examples": "ts-node ../../scripts/examples-runner.ts -- vm",


### PR DESCRIPTION
Removes the `reporter=text-lcov` option from coverage scripts because it just dumps a bunch of indecipherable output to the terminal like below.  The same data is written to `coverage/lcov.info` and then uploaded to our Code Coverage instance but it does nothing useful for our CI runs and just makes it hard to navigate the CI output.
![image](https://user-images.githubusercontent.com/17355484/211655907-c5f3c47a-c4a3-4bb2-90f1-2d1ccc9acfcc.png)
