### PR TITLE
Remove lcov-text param from coverage script

### DIFF
--- a/config/cli/coverage.sh
+++ b/config/cli/coverage.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -o xtrace
-exec c8 --all --reporter=lcov --reporter=text --reporter=text-lcov npm run test
+exec c8 --all --reporter=lcov --reporter=text npm run test


### PR DESCRIPTION
Remove one more instance of `lcov-text` to clean up CI logs