### PR TITLE
client: validate CLI args

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -284,7 +284,9 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     describe:
       'Block number to start syncing from. Must be lower than the local chain tip. Note: this is destructive and removes blocks from the blockchain, please back up your datadir before using.',
     number: true,
-  }).argv
+  })
+  // strict() ensures that yargs throws when an invalid arg is provided
+  .strict().argv
 
 /**
  * Initializes and returns the databases needed for the client


### PR DESCRIPTION
This PR makes the CLI args parsing strict, meaning that unknown args will result in yargs throwing instead of them being ignored.

`npm run client:start -- --invalidOption` now results in:

![image](https://user-images.githubusercontent.com/18757482/213329207-358c4a8a-f365-4861-99ba-24b9b0f4ae27.png)
