### PR TITLE
Change client CLI params to camelCase

### DIFF
--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -103,4 +103,4 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: cd ${{github.workspace}}/packages/client && npm run test:cli -- --network=${{matrix.network}} --syncmode=${{matrix.syncmode}} --transports rlpx
+          command: cd ${{github.workspace}}/packages/client && npm run test:cli -- --network=${{matrix.network}} --syncMode=${{matrix.syncmode}} --transports rlpx

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -43,22 +43,22 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     choices: networks.map((n) => n[1]),
     default: 'mainnet',
   })
-  .option('network-id', {
+  .option('networkId', {
     describe: 'Network ID',
     choices: networks.map((n) => parseInt(n[0])),
     default: undefined,
   })
-  .option('syncmode', {
+  .option('syncMode', {
     describe: 'Blockchain sync mode (light sync experimental)',
     choices: Object.values(SyncMode),
     default: Config.SYNCMODE_DEFAULT,
   })
-  .option('lightserv', {
+  .option('lightServe', {
     describe: 'Serve light peer requests',
     boolean: true,
     default: Config.LIGHTSERV_DEFAULT,
   })
-  .option('datadir', {
+  .option('dataDir', {
     describe: 'Data directory for the blockchain',
     default: `${homedir()}/Library/Ethereum/ethereumjs`,
   })
@@ -105,11 +105,11 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     describe: 'Enable the JSON-RPC server with HTTP endpoint',
     boolean: true,
   })
-  .option('rpcport', {
+  .option('rpcPort', {
     describe: 'HTTP-RPC server listening port',
     default: 8545,
   })
-  .option('rpcaddr', {
+  .option('rpcAddr', {
     describe: 'HTTP-RPC server listening interface address',
     default: 'localhost',
   })
@@ -154,15 +154,15 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     boolean: true,
     default: true,
   })
-  .option('jwt-secret', {
+  .option('jwtSecret', {
     describe: 'Provide a file containing a hex encoded jwt secret for Engine RPC server',
     coerce: (arg: string) => (arg ? path.resolve(arg) : undefined),
   })
-  .option('helprpc', {
+  .option('helpRpc', {
     describe: 'Display the JSON RPC help with a list of all RPC methods implemented (and exit)',
     boolean: true,
   })
-  .option('loglevel', {
+  .option('logLevel', {
     describe: 'Logging verbosity',
     choices: ['error', 'warn', 'info', 'debug'],
     default: 'info',
@@ -559,7 +559,7 @@ function generateAccount(): Account {
  * Main entry point to start a client
  */
 async function run() {
-  if (args.helprpc === true) {
+  if (args.helpRpc === true) {
     // Output RPC help and exit
     return helprpc()
   }
@@ -583,7 +583,7 @@ async function run() {
     args.discDns = false
     if (accounts.length === 0) {
       // If generating new keys delete old chain data to prevent genesis block mismatch
-      removeSync(`${args.datadir}/devnet`)
+      removeSync(`${args.dataDir}/devnet`)
       // Create new account
       accounts.push(generateAccount())
     }
@@ -638,7 +638,7 @@ async function run() {
     process.exit()
   }
 
-  const datadir = args.datadir ?? Config.DATADIR_DEFAULT
+  const datadir = args.dataDir ?? Config.DATADIR_DEFAULT
   const configDirectory = `${datadir}/${common.chainName()}/config`
   ensureDirSync(configDirectory)
   const key = await Config.getClientKey(datadir, common)
@@ -658,7 +658,7 @@ async function run() {
     dnsNetworks: args.dnsNetworks,
     extIP: args.extIP,
     key,
-    lightserv: args.lightserv,
+    lightserv: args.lightServe,
     logger,
     maxPeers: args.maxPeers,
     maxPerRequest: args.maxPerRequest,
@@ -669,7 +669,7 @@ async function run() {
     multiaddrs,
     port: args.port,
     saveReceipts: args.saveReceipts,
-    syncmode: args.syncmode,
+    syncmode: args.syncMode,
     disableBeaconSync: args.disableBeaconSync,
     forceSnapSync: args.forceSnapSync,
     transports: args.transports,

--- a/packages/client/bin/startRpc.ts
+++ b/packages/client/bin/startRpc.ts
@@ -15,8 +15,8 @@ import type { Server as RPCServer } from 'jayson/promise'
 
 export type RPCArgs = {
   rpc: boolean
-  rpcaddr: string
-  rpcport: number
+  rpcAddr: string
+  rpcPort: number
   ws: boolean
   wsPort: number
   wsAddr: string
@@ -26,8 +26,8 @@ export type RPCArgs = {
   wsEngineAddr: string
   wsEnginePort: number
   rpcDebug: boolean
-  helprpc: boolean
-  'jwt-secret'?: string
+  helpRpc: boolean
+  jwtSecret?: string
   rpcEngineAuth: boolean
   rpcCors: string
 }
@@ -78,8 +78,8 @@ export function startRPCServers(client: EthereumClient, args: RPCArgs) {
   const servers: RPCServer[] = []
   const {
     rpc,
-    rpcaddr,
-    rpcport,
+    rpcAddr,
+    rpcPort,
     ws,
     wsPort,
     wsAddr,
@@ -88,7 +88,7 @@ export function startRPCServers(client: EthereumClient, args: RPCArgs) {
     rpcEnginePort,
     wsEngineAddr,
     wsEnginePort,
-    'jwt-secret': jwtSecretPath,
+    jwtSecret: jwtSecretPath,
     rpcEngineAuth,
     rpcCors,
     rpcDebug,
@@ -107,7 +107,7 @@ export function startRPCServers(client: EthereumClient, args: RPCArgs) {
 
   if (rpc || ws) {
     let rpcHttpServer
-    withEngineMethods = rpcEngine && rpcEnginePort === rpcport && rpcEngineAddr === rpcaddr
+    withEngineMethods = rpcEngine && rpcEnginePort === rpcPort && rpcEngineAddr === rpcAddr
 
     const { server, namespaces, methods } = createRPCServer(manager, {
       methodConfig: withEngineMethods ? MethodConfig.WithEngine : MethodConfig.WithoutEngine,
@@ -131,14 +131,14 @@ export function startRPCServers(client: EthereumClient, args: RPCArgs) {
               }
             : undefined,
       })
-      rpcHttpServer.listen(rpcport)
+      rpcHttpServer.listen(rpcPort)
       logger.info(
-        `Started JSON RPC Server address=http://${rpcaddr}:${rpcport} namespaces=${namespaces}${
+        `Started JSON RPC Server address=http://${rpcAddr}:${rpcPort} namespaces=${namespaces}${
           withEngineMethods ? ' rpcEngineAuth=' + rpcEngineAuth.toString() : ''
         }`
       )
       logger.debug(
-        `Methods available at address=http://${rpcaddr}:${rpcport} namespaces=${namespaces} methods=${Object.keys(
+        `Methods available at address=http://${rpcAddr}:${rpcPort} namespaces=${namespaces} methods=${Object.keys(
           methods
         ).join(',')}`
       )
@@ -149,7 +149,7 @@ export function startRPCServers(client: EthereumClient, args: RPCArgs) {
         server,
         withEngineMiddleware: withEngineMethods && rpcEngineAuth ? { jwtSecret } : undefined,
       }
-      if (rpcaddr === wsAddr && rpcport === wsPort) {
+      if (rpcAddr === wsAddr && rpcPort === wsPort) {
         // We want to load the websocket upgrade request to the same server
         opts.httpServer = rpcHttpServer
       }
@@ -169,7 +169,7 @@ export function startRPCServers(client: EthereumClient, args: RPCArgs) {
     }
   }
 
-  if (rpcEngine && !(rpc && rpcport === rpcEnginePort && rpcaddr === rpcEngineAddr)) {
+  if (rpcEngine && !(rpc && rpcPort === rpcEnginePort && rpcAddr === rpcEngineAddr)) {
     const { server, namespaces, methods } = createRPCServer(manager, {
       methodConfig: MethodConfig.EngineOnly,
       rpcDebug,

--- a/packages/client/lib/types.ts
+++ b/packages/client/lib/types.ts
@@ -102,9 +102,9 @@ export type Libp2pMuxedStream = MuxedStream
 export interface ClientOpts {
   network?: string
   networkId?: number
-  syncmode?: SyncMode
-  lightserv?: boolean
-  datadir?: string
+  syncMode?: SyncMode
+  lightServe?: boolean
+  dataDir?: string
   customChain?: string
   customGenesisState?: string
   gethGenesis?: string
@@ -115,8 +115,8 @@ export interface ClientOpts {
   extIP?: string
   multiaddrs?: string | string[]
   rpc?: boolean
-  rpcport?: number
-  rpcaddr?: string
+  rpcPort?: number
+  rpcAddr?: string
   ws?: boolean
   wsPort?: number
   wsAddr?: string
@@ -126,9 +126,9 @@ export interface ClientOpts {
   wsEnginePort?: number
   wsEngineAddr?: string
   rpcEngineAuth?: boolean
-  'jwt-secret'?: string
-  helprpc?: boolean
-  loglevel?: string
+  jwtSecret?: string
+  helpRpc?: boolean
+  logLevel?: string
   logFile?: boolean
   logLevelFile?: string
   logRotate?: boolean

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -38,7 +38,7 @@
     "clean": "../../config/cli/clean-package.sh",
     "client:start": "ts-node bin/cli.ts",
     "client:start:dev1": "npm run client:start -- --discDns=false --discV4=false --bootnodes",
-    "client:start:dev2": "npm run client:start -- --discDns=false --discV4=false --transports=rlpx --port=30304 --datadir=datadir-dev2",
+    "client:start:dev2": "npm run client:start -- --discDns=false --discV4=false --transports=rlpx --port=30304 --dataDir=datadir-dev2",
     "coverage": "c8 --all --reporter=lcov --reporter=text npm run test:unit",
     "docs:build": "typedoc --options typedoc.js --tsconfig tsconfig.prod.json",
     "preinstall": "npm run binWorkaround",

--- a/packages/client/test/cli/cli-libp2p.spec.ts
+++ b/packages/client/test/cli/cli-libp2p.spec.ts
@@ -21,7 +21,7 @@ tape('[CLI] rpc', (t) => {
       ...[
         '--transports=libp2p',
         '--dev',
-        '--lightserv=true',
+        '--lightServe=true',
         '--multiaddrs=/ip4/127.0.0.1/tcp/50505/',
       ],
     ])
@@ -43,12 +43,12 @@ tape('[CLI] rpc', (t) => {
           ...[
             '--transports=libp2p',
             `--bootnodes=${bootNodeAddress}`,
-            '--datadir=data2',
+            '--dataDir=data2',
             '--mine=false',
             '--dev',
             '--multiaddrs=/ip4/0.0.0.0/tcp/50506',
-            '--syncmode=light',
-            '--loglevel=debug',
+            '--syncMode=light',
+            '--logLevel=debug',
           ],
         ])
         child2.stdout.on('data', async (data) => {

--- a/packages/client/test/cli/cli-sync.spec.ts
+++ b/packages/client/test/cli/cli-sync.spec.ts
@@ -3,7 +3,7 @@ import * as tape from 'tape'
 
 // get args for --network and --syncmode
 const cliArgs = process.argv.filter(
-  (arg) => arg.startsWith('--network') || arg.startsWith('--syncmode')
+  (arg) => arg.startsWith('--network') || arg.startsWith('--syncMode')
 )
 
 tape('[CLI] sync', (t) => {


### PR DESCRIPTION
A long over cleanup of the client CLI parameters to make them all camelCase.