### PR TITLE
tx: Handle json fields in fromTxData for eip4844 tx

### DIFF
--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -139,7 +139,7 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
       toBuffer((maxFeePerDataGas ?? '') === '' ? '0x' : maxFeePerDataGas)
     )
 
-    this.versionedHashes = txData.versionedHashes ?? []
+    this.versionedHashes = (txData.versionedHashes ?? []).map((vh) => toBuffer(vh))
     this._validateYParity()
     this._validateHighS()
 

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -164,9 +164,8 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
       throw new Error(msg)
     }
 
-    this.blobs = txData.blobs
-    this.kzgCommitments = txData.kzgCommitments
-
+    this.blobs = txData.blobs?.map((blob) => toBuffer(blob))
+    this.kzgCommitments = txData.kzgCommitments?.map((commitment) => toBuffer(commitment))
     const freeze = opts?.freeze ?? true
     if (freeze) {
       Object.freeze(this)

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -31,6 +31,7 @@ import type {
   TxOptions,
   TxValuesArray,
 } from './types'
+import type { ValueOf } from '@chainsafe/ssz'
 import type { Common } from '@ethereumjs/common'
 
 const TRANSACTION_TYPE = 0x05
@@ -310,16 +311,12 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
     throw new Error('Method not implemented.')
   }
 
-  /**
-   * Serialize a blob transaction to the execution payload variant
-   * @returns the minimum (execution payload) serialization of a signed transaction
-   */
-  serialize(): Buffer {
+  toValue(): ValueOf<typeof SignedBlobTransactionType> {
     const to = {
       selector: this.to !== undefined ? 1 : 0,
       value: this.to?.toBuffer() ?? null,
     }
-    const sszEncodedTx = SignedBlobTransactionType.serialize({
+    return {
       message: {
         chainId: this.common.chainId(),
         nonce: this.nonce,
@@ -341,7 +338,15 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
         s: this.s ?? BigInt(0),
         yParity: this.v === BigInt(1) ? true : false,
       },
-    })
+    }
+  }
+
+  /**
+   * Serialize a blob transaction to the execution payload variant
+   * @returns the minimum (execution payload) serialization of a signed transaction
+   */
+  serialize(): Buffer {
+    const sszEncodedTx = SignedBlobTransactionType.serialize(this.toValue())
     return Buffer.concat([TRANSACTION_TYPE_BUFFER, sszEncodedTx])
   }
 
@@ -366,37 +371,23 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
   getMessageToSign(hashMessage: false): Buffer | Buffer[]
   getMessageToSign(hashMessage?: true | undefined): Buffer
   getMessageToSign(_hashMessage?: unknown): Buffer | Buffer[] {
-    return this.hash()
+    return this.unsignedHash()
   }
 
   /**
    * Returns the hash of a blob transaction
    */
-  hash(): Buffer {
-    const to = {
-      selector: this.to !== undefined ? 1 : 0,
-      value: this.to?.toBuffer() ?? null,
-    }
-    const serializedTx = BlobTransactionType.serialize({
-      chainId: this.common.chainId(),
-      nonce: this.nonce,
-      maxPriorityFeePerGas: this.maxPriorityFeePerGas,
-      maxFeePerGas: this.maxFeePerGas,
-      gas: this.gasLimit,
-      to,
-      value: this.value,
-      data: this.data,
-      accessList: this.accessList.map((listItem) => {
-        return { address: listItem[0], storageKeys: listItem[1] }
-      }),
-      blobVersionedHashes: this.versionedHashes,
-      maxFeePerDataGas: this.maxFeePerDataGas,
-    })
+  unsignedHash(): Buffer {
+    const serializedTx = BlobTransactionType.serialize(this.toValue().message)
     return Buffer.from(keccak256(Buffer.concat([TRANSACTION_TYPE_BUFFER, serializedTx])))
   }
 
+  hash(): Buffer {
+    return Buffer.from(keccak256(this.serialize()))
+  }
+
   getMessageToVerifySignature(): Buffer {
-    throw new Error('Method not implemented.')
+    return this.getMessageToSign()
   }
 
   /**
@@ -408,7 +399,7 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
       throw new Error(msg)
     }
 
-    const msgHash = this.hash()
+    const msgHash = this.getMessageToVerifySignature()
     const { v, r, s } = this
 
     this._validateHighS()

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -89,7 +89,7 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
    */
   constructor(txData: BlobEIP4844TxData, opts: TxOptions = {}) {
     super({ ...txData, type: TRANSACTION_TYPE }, opts)
-    const { chainId, accessList, maxFeePerGas, maxPriorityFeePerGas } = txData
+    const { chainId, accessList, maxFeePerGas, maxPriorityFeePerGas, maxFeePerDataGas } = txData
 
     this.common = this._getCommon(opts.common, chainId)
     this.chainId = this.common.chainId()
@@ -134,7 +134,9 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
       throw new Error(msg)
     }
 
-    this.maxFeePerDataGas = txData.maxFeePerDataGas ?? BigInt(0)
+    this.maxFeePerDataGas = bufferToBigInt(
+      toBuffer((maxFeePerDataGas ?? '') === '' ? '0x' : maxFeePerDataGas)
+    )
 
     this.versionedHashes = txData.versionedHashes ?? []
     this._validateYParity()

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -234,7 +234,7 @@ export interface BlobEIP4844TxData extends FeeMarketEIP1559TxData {
   /**
    * The versioned hashes used to validate the blobs attached to a transaction
    */
-  versionedHashes?: Buffer[]
+  versionedHashes?: BufferLike[]
   /**
    * The maximum fee per data gas paid for the transaction
    */

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -142,7 +142,7 @@ export type TxData = {
   /**
    * The transaction's gas price.
    */
-  gasPrice?: BigIntLike
+  gasPrice?: BigIntLike | null
 
   /**
    * The transaction's gas limit.
@@ -198,7 +198,7 @@ export interface AccessListEIP2930TxData extends TxData {
   /**
    * The access list which contains the addresses/storage slots which the transaction wishes to access
    */
-  accessList?: AccessListBuffer | AccessList
+  accessList?: AccessListBuffer | AccessList | null
 }
 
 /**
@@ -209,7 +209,7 @@ export interface FeeMarketEIP1559TxData extends AccessListEIP2930TxData {
    * The transaction's gas price, inherited from {@link Transaction}.  This property is not used for EIP1559
    * transactions and should always be undefined for this specific transaction type.
    */
-  gasPrice?: never
+  gasPrice?: never | null
   /**
    * The maximum inclusion fee per gas (this fee is given to the miner)
    */
@@ -231,7 +231,7 @@ export interface BlobEIP4844TxData extends FeeMarketEIP1559TxData {
   /**
    * The maximum fee per data gas paid for the transaction
    */
-  maxFeePerDataGas?: bigint
+  maxFeePerDataGas?: BigIntLike
   /**
    * The blobs associated with a transaction
    */

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -242,15 +242,15 @@ export interface BlobEIP4844TxData extends FeeMarketEIP1559TxData {
   /**
    * The blobs associated with a transaction
    */
-  blobs?: Buffer[]
+  blobs?: BufferLike[]
   /**
    * The KZG commitments corresponding to the versioned hashes for each blob
    */
-  kzgCommitments?: Buffer[]
+  kzgCommitments?: BufferLike[]
   /**
    * The aggregate KZG proof associated with the transaction
    */
-  kzgProof?: Buffer
+  kzgProof?: BufferLike
 }
 
 /**

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -26,6 +26,13 @@ import type { Transaction } from './legacyTransaction'
 import type { Common } from '@ethereumjs/common'
 import type { AddressLike, BigIntLike, BufferLike, PrefixedHexString } from '@ethereumjs/util'
 
+const Bytes20 = new ByteVectorType(20)
+const Bytes32 = new ByteVectorType(32)
+const Bytes48 = new ByteVectorType(48)
+
+const Uint64 = new UintBigintType(8)
+const Uint256 = new UintBigintType(32)
+
 /**
  * Can be used in conjunction with {@link Transaction.supports}
  * to query on tx capabilities
@@ -343,37 +350,34 @@ export interface JsonRpcTx {
 }
 
 /** EIP4844 types */
-export const AddressType = new ByteVectorType(20) // SSZ encoded address
+export const AddressType = Bytes20 // SSZ encoded address
 
 // SSZ encoded container for address and storage keys
 export const AccessTupleType = new ContainerType({
   address: AddressType,
-  storageKeys: new ListCompositeType(new ByteVectorType(32), MAX_VERSIONED_HASHES_LIST_SIZE),
+  storageKeys: new ListCompositeType(Bytes32, MAX_VERSIONED_HASHES_LIST_SIZE),
 })
 
 // SSZ encoded blob transaction
 export const BlobTransactionType = new ContainerType({
-  chainId: new UintBigintType(32),
-  nonce: new UintBigintType(8),
-  maxPriorityFeePerGas: new UintBigintType(32),
-  maxFeePerGas: new UintBigintType(32),
-  gas: new UintBigintType(8),
+  chainId: Uint256,
+  nonce: Uint64,
+  maxPriorityFeePerGas: Uint256,
+  maxFeePerGas: Uint256,
+  gas: Uint64,
   to: new UnionType([new NoneType(), AddressType]),
-  value: new UintBigintType(32),
+  value: Uint256,
   data: new ByteListType(MAX_CALLDATA_SIZE),
   accessList: new ListCompositeType(AccessTupleType, MAX_ACCESS_LIST_SIZE),
-  maxFeePerDataGas: new UintBigintType(32),
-  blobVersionedHashes: new ListCompositeType(
-    new ByteVectorType(32),
-    MAX_VERSIONED_HASHES_LIST_SIZE
-  ),
+  maxFeePerDataGas: Uint256,
+  blobVersionedHashes: new ListCompositeType(Bytes32, MAX_VERSIONED_HASHES_LIST_SIZE),
 })
 
 // SSZ encoded ECDSA Signature
 export const ECDSASignatureType = new ContainerType({
   yParity: new BooleanType(),
-  r: new UintBigintType(32),
-  s: new UintBigintType(32),
+  r: Uint256,
+  s: Uint256,
 })
 
 // SSZ encoded signed blob transaction
@@ -383,7 +387,7 @@ export const SignedBlobTransactionType = new ContainerType({
 })
 
 // SSZ encoded KZG Commitment/Proof (48 bytes)
-export const KZGCommitmentType = new ByteVectorType(48)
+export const KZGCommitmentType = Bytes48
 export const KZGProofType = KZGCommitmentType
 
 // SSZ encoded blob network transaction wrapper

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -54,6 +54,50 @@ tape('EIP4844 constructor tests - valid scenarios', (t) => {
   }
 })
 
+tape('fromTxData using from a json', (t) => {
+  if (isBrowser() === true) {
+    t.end()
+  } else {
+    const txData = {
+      type: '0x5',
+      nonce: '0x0',
+      gasPrice: null,
+      maxPriorityFeePerGas: '0x12a05f200',
+      maxFeePerGas: '0x12a05f200',
+      gas: '0x33450',
+      value: '0xbc614e',
+      input: '0x',
+      v: '0x0',
+      r: '0x8a83833ec07806485a4ded33f24f5cea4b8d4d24dc8f357e6d446bcdae5e58a7',
+      s: '0x68a2ba422a50cf84c0b5fcbda32ee142196910c97198ffd99035d920c2b557f8',
+      to: '0xffb38a7a99e3e2335be83fc74b7faa19d5531243',
+      chainId: '0x28757b3',
+      accessList: null,
+      maxFeePerDataGas: '0xb2d05e00',
+      blobVersionedHashes: ['0x01b0a4cdd5f55589f5c5b4d46c76704bb6ce95c0a8c09f77f197a57808dded28'],
+      kzgAggregatedProof:
+        '0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+      hash: '0xd5455662e76b193a84ce57d4c0a3b6fd609fdfca21cc93b93408de62be3c5708',
+    }
+    const c = common.copy()
+    c['_chainParams'] = Object.assign({}, common['_chainParams'], {
+      chainId: Number(txData.chainId),
+    })
+    try {
+      const tx = BlobEIP4844Transaction.fromTxData(txData, { common: c })
+      t.pass('Should be able to parse a json data and hash it')
+
+      t.equal(typeof tx.maxFeePerDataGas, 'bigint', 'should be able to parse correctly')
+      // TODO: fix the hash
+      // t.equal(`0x${tx.hash().toString('hex')}`, txData.hash, 'hash should match')
+    } catch (e) {
+      t.fail('failed to parse json data')
+    }
+
+    t.end()
+  }
+})
+
 tape('EIP4844 constructor tests - invalid scenarios', (t) => {
   if (isBrowser() === true) {
     t.end()

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -293,7 +293,7 @@ tape('hash() and signature verification', async (t) => {
       { common }
     )
     t.equal(
-      unsignedTx.hash().toString('hex'),
+      unsignedTx.unsignedHash().toString('hex'),
       '0fcee5b30088a9c96b4990a3914002736a50f42468209d65a93badd3d1cd0677',
       'produced the correct transaction hash'
     )

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -64,7 +64,7 @@ tape('fromTxData using from a json', (t) => {
       gasPrice: null,
       maxPriorityFeePerGas: '0x12a05f200',
       maxFeePerGas: '0x12a05f200',
-      gas: '0x33450',
+      gasLimit: '0x33450',
       value: '0xbc614e',
       input: '0x',
       v: '0x0',
@@ -74,10 +74,12 @@ tape('fromTxData using from a json', (t) => {
       chainId: '0x28757b3',
       accessList: null,
       maxFeePerDataGas: '0xb2d05e00',
-      blobVersionedHashes: ['0x01b0a4cdd5f55589f5c5b4d46c76704bb6ce95c0a8c09f77f197a57808dded28'],
+      versionedHashes: ['0x01b0a4cdd5f55589f5c5b4d46c76704bb6ce95c0a8c09f77f197a57808dded28'],
       kzgAggregatedProof:
         '0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
-      hash: '0xd5455662e76b193a84ce57d4c0a3b6fd609fdfca21cc93b93408de62be3c5708',
+      hash: 'd5455662e76b193a84ce57d4c0a3b6fd609fdfca21cc93b93408de62be3c5708',
+      serialized:
+        '054500000000a7585eaecd6b446d7e358fdc244d8d4bea5c4ff233ed4d5a480678c03e83838af857b5c220d93590d9ff9871c910691942e12ea3bdfcb5c084cf502a42baa268b357870200000000000000000000000000000000000000000000000000000000000000000000000000f2052a0100000000000000000000000000000000000000000000000000000000f2052a010000000000000000000000000000000000000000000000000000005034030000000000c00000004e61bc0000000000000000000000000000000000000000000000000000000000d5000000d5000000005ed0b200000000000000000000000000000000000000000000000000000000d500000001ffb38a7a99e3e2335be83fc74b7faa19d553124301b0a4cdd5f55589f5c5b4d46c76704bb6ce95c0a8c09f77f197a57808dded28',
     }
     const c = common.copy()
     c['_chainParams'] = Object.assign({}, common['_chainParams'], {
@@ -88,8 +90,9 @@ tape('fromTxData using from a json', (t) => {
       t.pass('Should be able to parse a json data and hash it')
 
       t.equal(typeof tx.maxFeePerDataGas, 'bigint', 'should be able to parse correctly')
+      t.equal(tx.serialize().toString('hex'), txData.serialized, 'serialization should match')
       // TODO: fix the hash
-      // t.equal(`0x${tx.hash().toString('hex')}`, txData.hash, 'hash should match')
+      t.equal(tx.hash().toString('hex'), txData.hash, 'hash should match')
     } catch (e) {
       t.fail('failed to parse json data')
     }


### PR DESCRIPTION
Handle json fields in fromTxData for eip4844 tx

A tx provided to test was not getting being loaded and giving errors on serialization as maxDataFee was still a string. This PR fixes it. 
It also adds a test for hash, which currently doesn't seem to be correct, has been commented out to be fixed in separate issue