### PR TITLE
engine-api-validators

### DIFF
--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -367,7 +367,13 @@ export class Engine {
 
     this.newPayloadV3 = cmMiddleware(
       middleware(this.newPayloadV3.bind(this), 1, [
-        [validators.object(executionPayloadV3FieldValidators)],
+        [
+          validators.either(
+            validators.object(executionPayloadV1FieldValidators),
+            validators.object(executionPayloadV2FieldValidators),
+            validators.object(executionPayloadV3FieldValidators)
+          ),
+        ],
       ]),
       ([payload], response) => this.connectionManager.lastNewPayload({ payload, response })
     )

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -563,15 +563,15 @@ export class Engine {
 
   async newPayloadV2(params: [ExecutionPayloadV2 | ExecutionPayloadV1]): Promise<PayloadStatusV1> {
     const shanghaiTimestamp = this.chain.config.chainCommon.hardforkTimestamp('shanghai')!
-    if ('withdrawals' in params[0]) {
-      if (parseInt(params[0].timestamp) < shanghaiTimestamp) {
+    if (parseInt(params[0].timestamp) < shanghaiTimestamp) {
+      if ('withdrawals' in params[0]) {
         throw {
           code: INVALID_PARAMS,
           message: 'ExecutionPayloadV1 MUST be used before Shanghai is activated',
         }
       }
-    } else {
-      if (parseInt(params[0].timestamp) >= shanghaiTimestamp) {
+    } else if (parseInt(params[0].timestamp) >= shanghaiTimestamp) {
+      if (!('withdrawals' in params[0])) {
         throw {
           code: INVALID_PARAMS,
           message: 'ExecutionPayloadV2 MUST be used after Shanghai is activated',

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -578,6 +578,10 @@ export class Engine {
         }
       }
     }
+    const newPayload = await this.newPayload(params)
+    if (newPayload.status === Status.INVALID_BLOCK_HASH) {
+      newPayload.status = Status.INVALID
+    }
     return this.newPayload(params)
   }
 

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -28,7 +28,8 @@ export enum Status {
 type Bytes8 = string
 type Bytes20 = string
 type Bytes32 = string
-type Root = Bytes32
+// type Root = Bytes32
+type Blob = Bytes32
 type Bytes48 = string
 type Bytes256 = string
 type VariableBytes32 = string
@@ -99,7 +100,7 @@ type TransitionConfigurationV1 = {
 type BlobsBundleV1 = {
   blockHash: string
   kzgs: Bytes48[]
-  blobs: Root[]
+  blobs: Blob[]
 }
 const EngineError = {
   UnknownPayload: {

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -569,8 +569,8 @@ export class Engine {
   }
 
   async newPayloadV2(params: [ExecutionPayloadV2 | ExecutionPayloadV1]): Promise<PayloadStatusV1> {
-    const shanghaiTimestamp = this.chain.config.chainCommon.hardforkTimestamp('shanghai')!
-    if (parseInt(params[0].timestamp) < shanghaiTimestamp) {
+    const shanghaiTimestamp = this.chain.config.chainCommon.hardforkTimestamp('shanghai')
+    if (shanghaiTimestamp === null || parseInt(params[0].timestamp) < shanghaiTimestamp) {
       if ('withdrawals' in params[0]) {
         throw {
           code: INVALID_PARAMS,
@@ -589,15 +589,15 @@ export class Engine {
     if (newPayload.status === Status.INVALID_BLOCK_HASH) {
       newPayload.status = Status.INVALID
     }
-    return this.newPayload(params)
+    return newPayload
   }
 
   async newPayloadV3(
     params: [ExecutionPayloadV3 | ExecutionPayloadV2 | ExecutionPayloadV1]
   ): Promise<PayloadStatusV1> {
-    const shanghaiTimestamp = this.chain.config.chainCommon.hardforkTimestamp('shanghai')!
-    const eip4844Timestamp = this.chain.config.chainCommon.hardforkTimestamp('eip4844')!
-    if (parseInt(params[0].timestamp) < shanghaiTimestamp) {
+    const shanghaiTimestamp = this.chain.config.chainCommon.hardforkTimestamp('shanghai')
+    const eip4844Timestamp = this.chain.config.chainCommon.hardforkTimestamp('eip4844')
+    if (shanghaiTimestamp === null || parseInt(params[0].timestamp) < shanghaiTimestamp) {
       if ('withdrawals' in params[0]) {
         throw {
           code: INVALID_PARAMS,
@@ -606,7 +606,7 @@ export class Engine {
       }
     } else if (
       parseInt(params[0].timestamp) >= shanghaiTimestamp &&
-      parseInt(params[0].timestamp) < eip4844Timestamp
+      (eip4844Timestamp === null || parseInt(params[0].timestamp) < eip4844Timestamp)
     ) {
       if (!('extraDataGas' in params[0])) {
         throw {
@@ -614,7 +614,7 @@ export class Engine {
           message: 'ExecutionPayloadV2 MUST be used if Shanghai is activated and EIP-4844 is not',
         }
       }
-    } else if (parseInt(params[0].timestamp) >= eip4844Timestamp) {
+    } else if (eip4844Timestamp === null || parseInt(params[0].timestamp) >= eip4844Timestamp) {
       if (!('extraData' in params[0])) {
         throw {
           code: INVALID_PARAMS,
@@ -626,7 +626,7 @@ export class Engine {
     if (newPayload.status === Status.INVALID_BLOCK_HASH) {
       newPayload.status = Status.INVALID
     }
-    return this.newPayload(params)
+    return newPayload
   }
 
   /**

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -868,7 +868,7 @@ export class Engine {
    *   1. payloadId: DATA, 8 bytes - identifier of the payload building process
    * @returns Instance of {@link ExecutionPayloadV1} or an error
    */
-  private async getPayload(params: [string]) {
+  private async getPayload(params: [Bytes8]) {
     const payloadId = toBuffer(params[0])
     try {
       const built = await this.pendingBlock.build(payloadId)

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -101,16 +101,16 @@ const EngineError = {
 const executionPayloadV1FieldValidators = {
   parentHash: validators.blockHash,
   feeRecipient: validators.address,
-  stateRoot: validators.hex,
-  receiptsRoot: validators.hex,
-  logsBloom: validators.hex,
-  prevRandao: validators.hex,
-  blockNumber: validators.hex,
-  gasLimit: validators.hex,
-  gasUsed: validators.hex,
-  timestamp: validators.hex,
-  extraData: validators.hex,
-  baseFeePerGas: validators.hex,
+  stateRoot: validators.bytes32,
+  receiptsRoot: validators.bytes32,
+  logsBloom: validators.bytes256,
+  prevRandao: validators.bytes32,
+  blockNumber: validators.uint64,
+  gasLimit: validators.uint64,
+  gasUsed: validators.uint64,
+  timestamp: validators.uint64,
+  extraData: validators.variableBytes32,
+  baseFeePerGas: validators.uint256,
   blockHash: validators.blockHash,
   transactions: validators.array(validators.hex),
 }
@@ -120,7 +120,7 @@ const executionPayloadV2FieldValidators = {
 }
 const executionPayloadV3FieldValidators = {
   ...executionPayloadV2FieldValidators,
-  excessDataGas: validators.hex,
+  excessDataGas: validators.uint256,
 }
 
 const forkchoiceFieldValidators = {
@@ -130,8 +130,8 @@ const forkchoiceFieldValidators = {
 }
 
 const payloadAttributesFieldValidatorsV1 = {
-  timestamp: validators.hex,
-  prevRandao: validators.hex,
+  timestamp: validators.uint64,
+  prevRandao: validators.bytes32,
   suggestedFeeRecipient: validators.address,
 }
 const payloadAttributesFieldValidatorsV2 = {
@@ -389,17 +389,17 @@ export class Engine {
     )
 
     this.getPayloadV1 = cmMiddleware(
-      middleware(this.getPayloadV1.bind(this), 1, [[validators.hex]]),
+      middleware(this.getPayloadV1.bind(this), 1, [[validators.bytes8]]),
       () => this.connectionManager.updateStatus()
     )
 
     this.getPayloadV2 = cmMiddleware(
-      middleware(this.getPayloadV2.bind(this), 1, [[validators.hex]]),
+      middleware(this.getPayloadV2.bind(this), 1, [[validators.bytes8]]),
       () => this.connectionManager.updateStatus()
     )
 
     this.getPayloadV3 = cmMiddleware(
-      middleware(this.getPayloadV3.bind(this), 1, [[validators.hex]]),
+      middleware(this.getPayloadV3.bind(this), 1, [[validators.bytes8]]),
       () => this.connectionManager.updateStatus()
     )
 
@@ -407,9 +407,9 @@ export class Engine {
       middleware(this.exchangeTransitionConfigurationV1.bind(this), 1, [
         [
           validators.object({
-            terminalTotalDifficulty: validators.hex,
-            terminalBlockHash: validators.hex,
-            terminalBlockNumber: validators.hex,
+            terminalTotalDifficulty: validators.uint256,
+            terminalBlockHash: validators.bytes32,
+            terminalBlockNumber: validators.uint64,
           }),
         ],
       ]),
@@ -417,7 +417,7 @@ export class Engine {
     )
 
     this.getBlobsBundleV1 = cmMiddleware(
-      middleware(this.getBlobsBundleV1.bind(this), 1, [[validators.hex]]),
+      middleware(this.getBlobsBundleV1.bind(this), 1, [[validators.bytes8]]),
       () => this.connectionManager.updateStatus()
     )
   }

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -25,28 +25,38 @@ export enum Status {
   VALID = 'VALID',
 }
 
+type Bytes8 = string
+type Bytes20 = string
+type Bytes32 = string
+type Root = Bytes32
+type Bytes48 = string
+type Bytes256 = string
+type VariableBytes32 = string
+type Uint64 = string
+type Uint256 = string
+
 export type WithdrawalV1 = {
-  index: string // Quantity, 8 Bytes
-  validatorIndex: string // Quantity, 8 bytes
-  address: string // DATA, 20 bytes
-  amount: string // Quantity, 32 bytes
+  index: Bytes8 // Quantity, 8 Bytes
+  validatorIndex: Bytes8 // Quantity, 8 bytes
+  address: Bytes20 // DATA, 20 bytes
+  amount: Bytes32 // Quantity, 32 bytes
 }
 
 export type ExecutionPayload = {
-  parentHash: string // DATA, 32 Bytes
-  feeRecipient: string // DATA, 20 Bytes
-  stateRoot: string // DATA, 32 Bytes
-  receiptsRoot: string // DATA, 32 bytes
-  logsBloom: string // DATA, 256 Bytes
-  prevRandao: string // DATA, 32 Bytes
-  blockNumber: string // QUANTITY, 64 Bits
-  gasLimit: string // QUANTITY, 64 Bits
-  gasUsed: string // QUANTITY, 64 Bits
-  timestamp: string // QUANTITY, 64 Bits
-  extraData: string // DATA, 0 to 32 Bytes
-  baseFeePerGas: string // QUANTITY, 256 Bits
-  excessDataGas?: string // QUANTITY, 256 Bits
-  blockHash: string // DATA, 32 Bytes
+  parentHash: Bytes32 // DATA, 32 Bytes
+  feeRecipient: Bytes20 // DATA, 20 Bytes
+  stateRoot: Bytes32 // DATA, 32 Bytes
+  receiptsRoot: Bytes32 // DATA, 32 bytes
+  logsBloom: Bytes256 // DATA, 256 Bytes
+  prevRandao: Bytes32 // DATA, 32 Bytes
+  blockNumber: Uint64 // QUANTITY, 64 Bits
+  gasLimit: Uint64 // QUANTITY, 64 Bits
+  gasUsed: Uint64 // QUANTITY, 64 Bits
+  timestamp: Uint64 // QUANTITY, 64 Bits
+  extraData: VariableBytes32 // DATA, 0 to 32 Bytes
+  baseFeePerGas: Uint256 // QUANTITY, 256 Bits
+  excessDataGas?: Uint256 // QUANTITY, 256 Bits
+  blockHash: Bytes32 // DATA, 32 Bytes
   transactions: string[] // Array of DATA - Array of transaction rlp strings,
   withdrawals?: WithdrawalV1[] // Array of withdrawal objects
 }
@@ -55,15 +65,15 @@ export type ExecutionPayloadV2 = ExecutionPayload & { withdrawals: WithdrawalV1[
 export type ExecutionPayloadV3 = ExecutionPayload & { excessDataGas: string }
 
 export type ForkchoiceStateV1 = {
-  headBlockHash: string
-  safeBlockHash: string
-  finalizedBlockHash: string
+  headBlockHash: Bytes32
+  safeBlockHash: Bytes32
+  finalizedBlockHash: Bytes32
 }
 
 type PayloadAttributes = {
-  timestamp: string
-  prevRandao: string
-  suggestedFeeRecipient: string
+  timestamp: Uint64
+  prevRandao: Bytes32
+  suggestedFeeRecipient: Bytes20
   withdrawals?: WithdrawalV1[]
 }
 type PayloadAttributesV1 = Omit<PayloadAttributes, 'withdrawals'>
@@ -71,25 +81,25 @@ type PayloadAttributesV2 = PayloadAttributes & { withdrawals: WithdrawalV1[] }
 
 export type PayloadStatusV1 = {
   status: Status
-  latestValidHash: string | null
+  latestValidHash: Bytes32 | null
   validationError: string | null
 }
 
 export type ForkchoiceResponseV1 = {
   payloadStatus: PayloadStatusV1
-  payloadId: string | null
+  payloadId: Bytes8 | null
 }
 
 type TransitionConfigurationV1 = {
-  terminalTotalDifficulty: string
-  terminalBlockHash: string
-  terminalBlockNumber: string
+  terminalTotalDifficulty: Uint256
+  terminalBlockHash: Bytes32
+  terminalBlockNumber: Uint64
 }
 
 type BlobsBundleV1 = {
   blockHash: string
-  kzgs: string[]
-  blobs: string[]
+  kzgs: Bytes48[]
+  blobs: Root[]
 }
 const EngineError = {
   UnknownPayload: {
@@ -826,16 +836,16 @@ export class Engine {
     }
   }
 
-  async getPayloadV1(params: [string]) {
+  async getPayloadV1(params: [Bytes8]) {
     const { executionPayload } = await this.getPayload(params)
     return executionPayload
   }
 
-  async getPayloadV2(params: [string]) {
+  async getPayloadV2(params: [Bytes8]) {
     return this.getPayload(params)
   }
 
-  async getPayloadV3(params: [string]) {
+  async getPayloadV3(params: [Bytes8]) {
     return this.getPayload(params)
   }
   /**
@@ -874,7 +884,7 @@ export class Engine {
    * @param params a payloadId for a pending block
    * @returns a BlobsBundle consisting of the blockhash, the blobs, and the corresponding kzg commitments
    */
-  private async getBlobsBundleV1(params: [string]): Promise<BlobsBundleV1> {
+  private async getBlobsBundleV1(params: [Bytes8]): Promise<BlobsBundleV1> {
     const payloadId = params[0]
 
     const bundle = this.pendingBlock.blobBundles.get(payloadId)

--- a/packages/client/lib/rpc/validation.ts
+++ b/packages/client/lib/rpc/validation.ts
@@ -96,6 +96,220 @@ export const validators = {
     }
   },
 
+  get bytes8() {
+    return (params: any[], index: number) => {
+      if (typeof params[index] !== 'string') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
+        }
+      }
+
+      if (params[index].substr(0, 2) !== '0x') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].substr(2).length !== 16) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: expected 8 byte value`,
+        }
+      }
+    }
+  },
+  get bytes16() {
+    return (params: any[], index: number) => {
+      if (typeof params[index] !== 'string') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
+        }
+      }
+
+      if (params[index].substr(0, 2) !== '0x') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].substr(2).length !== 32) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: expected 16 byte value`,
+        }
+      }
+    }
+  },
+  get bytes20() {
+    return (params: any[], index: number) => {
+      if (typeof params[index] !== 'string') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
+        }
+      }
+
+      if (params[index].substr(0, 2) !== '0x') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].substr(2).length !== 40) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: expected 20 byte value`,
+        }
+      }
+    }
+  },
+  get bytes32() {
+    return (params: any[], index: number) => {
+      if (typeof params[index] !== 'string') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
+        }
+      }
+
+      if (params[index].substr(0, 2) !== '0x') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].substr(2).length !== 64) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: expected 32 byte value`,
+        }
+      }
+    }
+  },
+  get variableBytes32() {
+    return (params: any[], index: number) => {
+      if (typeof params[index] !== 'string') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
+        }
+      }
+
+      if (params[index].substr(0, 2) !== '0x') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].length < 3) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: expected 0 to 32 byte value`,
+        }
+      }
+      if (params[index].substr(2).length > 64) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: expected 0 to 32 byte value`,
+        }
+      }
+    }
+  },
+  get bytes48() {
+    return (params: any[], index: number) => {
+      if (typeof params[index] !== 'string') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
+        }
+      }
+
+      if (params[index].substr(0, 2) !== '0x') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].substr(2).length !== 96) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: expected 32 byte value`,
+        }
+      }
+    }
+  },
+  get bytes256() {
+    return (params: any[], index: number) => {
+      if (typeof params[index] !== 'string') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
+        }
+      }
+
+      if (params[index].substr(0, 2) !== '0x') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].substr(2).length !== 512) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: expected 32 byte value`,
+        }
+      }
+    }
+  },
+  get uint64() {
+    return (params: any[], index: number) => {
+      if (typeof params[index] !== 'string') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
+        }
+      }
+
+      if (params[index].substr(0, 2) !== '0x') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].substr(2).length !== 16) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: expected 64 bit value`,
+        }
+      }
+    }
+  },
+  get uint256() {
+    return (params: any[], index: number) => {
+      if (typeof params[index] !== 'string') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
+        }
+      }
+
+      if (params[index].substr(0, 2) !== '0x') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].substr(2).length !== 64) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: expected 256 bit value`,
+        }
+      }
+    }
+  },
+
   /**
    * hex validator to validate block hash
    * @param params parameters of method

--- a/packages/client/lib/rpc/validation.ts
+++ b/packages/client/lib/rpc/validation.ts
@@ -98,7 +98,7 @@ export const validators = {
 
   get bytes8() {
     return (params: any[], index: number) => {
-      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
+      if (typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -109,6 +109,12 @@ export const validators = {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
         }
       }
       if (params[index].substr(2).length > 16) {
@@ -121,7 +127,7 @@ export const validators = {
   },
   get bytes16() {
     return (params: any[], index: number) => {
-      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
+      if (typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -132,6 +138,12 @@ export const validators = {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
         }
       }
       if (params[index].substr(2).length > 32) {
@@ -144,7 +156,7 @@ export const validators = {
   },
   get bytes20() {
     return (params: any[], index: number) => {
-      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
+      if (typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -155,6 +167,12 @@ export const validators = {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
         }
       }
       if (params[index].substr(2).length > 40) {
@@ -167,7 +185,7 @@ export const validators = {
   },
   get bytes32() {
     return (params: any[], index: number) => {
-      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
+      if (typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -178,6 +196,12 @@ export const validators = {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
         }
       }
       if (params[index].substr(2).length > 64) {
@@ -219,7 +243,7 @@ export const validators = {
   },
   get bytes48() {
     return (params: any[], index: number) => {
-      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
+      if (typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -230,6 +254,12 @@ export const validators = {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
         }
       }
       if (params[index].substr(2).length > 96) {
@@ -242,7 +272,7 @@ export const validators = {
   },
   get bytes256() {
     return (params: any[], index: number) => {
-      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
+      if (typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -253,6 +283,12 @@ export const validators = {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
         }
       }
       if (params[index].substr(2).length > 512) {
@@ -265,7 +301,7 @@ export const validators = {
   },
   get uint64() {
     return (params: any[], index: number) => {
-      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
+      if (typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -276,6 +312,12 @@ export const validators = {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
         }
       }
       if (params[index].substr(2).length > 16) {
@@ -288,7 +330,7 @@ export const validators = {
   },
   get uint256() {
     return (params: any[], index: number) => {
-      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
+      if (typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -301,10 +343,45 @@ export const validators = {
           message: `invalid argument ${index}: hex string without 0x prefix`,
         }
       }
+      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
+        }
+      }
       if (params[index].substr(2).length > 64) {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: expected 256 bit value`,
+        }
+      }
+    }
+  },
+  get blob() {
+    return (params: any[], index: number) => {
+      if (typeof params[index] !== 'string') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
+        }
+      }
+
+      if (params[index].substr(0, 2) !== '0x') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
+        }
+      }
+      if (params[index].substr(2).length > 131072) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: value larger than 131072 bytes`,
         }
       }
     }

--- a/packages/client/lib/rpc/validation.ts
+++ b/packages/client/lib/rpc/validation.ts
@@ -190,7 +190,7 @@ export const validators = {
   },
   get variableBytes32() {
     return (params: any[], index: number) => {
-      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
+      if (typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -201,6 +201,12 @@ export const validators = {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: hex string without 0x prefix`,
+        }
+      }
+      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument must be a hex string`,
         }
       }
       if (params[index].substr(2).length > 64) {

--- a/packages/client/lib/rpc/validation.ts
+++ b/packages/client/lib/rpc/validation.ts
@@ -98,7 +98,7 @@ export const validators = {
 
   get bytes8() {
     return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
+      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -111,7 +111,7 @@ export const validators = {
           message: `invalid argument ${index}: hex string without 0x prefix`,
         }
       }
-      if (params[index].substr(2).length !== 16) {
+      if (params[index].substr(2).length > 16) {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: expected 8 byte value`,
@@ -121,7 +121,7 @@ export const validators = {
   },
   get bytes16() {
     return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
+      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -134,7 +134,7 @@ export const validators = {
           message: `invalid argument ${index}: hex string without 0x prefix`,
         }
       }
-      if (params[index].substr(2).length !== 32) {
+      if (params[index].substr(2).length > 32) {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: expected 16 byte value`,
@@ -144,7 +144,7 @@ export const validators = {
   },
   get bytes20() {
     return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
+      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -157,7 +157,7 @@ export const validators = {
           message: `invalid argument ${index}: hex string without 0x prefix`,
         }
       }
-      if (params[index].substr(2).length !== 40) {
+      if (params[index].substr(2).length > 40) {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: expected 20 byte value`,
@@ -167,7 +167,7 @@ export const validators = {
   },
   get bytes32() {
     return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
+      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -180,7 +180,7 @@ export const validators = {
           message: `invalid argument ${index}: hex string without 0x prefix`,
         }
       }
-      if (params[index].substr(2).length !== 64) {
+      if (params[index].substr(2).length > 64) {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: expected 32 byte value`,
@@ -190,7 +190,7 @@ export const validators = {
   },
   get variableBytes32() {
     return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
+      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -201,12 +201,6 @@ export const validators = {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: hex string without 0x prefix`,
-        }
-      }
-      if (params[index].length < 3) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: expected 0 to 32 byte value`,
         }
       }
       if (params[index].substr(2).length > 64) {
@@ -219,7 +213,7 @@ export const validators = {
   },
   get bytes48() {
     return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
+      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -232,7 +226,7 @@ export const validators = {
           message: `invalid argument ${index}: hex string without 0x prefix`,
         }
       }
-      if (params[index].substr(2).length !== 96) {
+      if (params[index].substr(2).length > 96) {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: expected 32 byte value`,
@@ -242,7 +236,7 @@ export const validators = {
   },
   get bytes256() {
     return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
+      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -255,7 +249,7 @@ export const validators = {
           message: `invalid argument ${index}: hex string without 0x prefix`,
         }
       }
-      if (params[index].substr(2).length !== 512) {
+      if (params[index].substr(2).length > 512) {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: expected 32 byte value`,
@@ -265,7 +259,7 @@ export const validators = {
   },
   get uint64() {
     return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
+      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -278,7 +272,7 @@ export const validators = {
           message: `invalid argument ${index}: hex string without 0x prefix`,
         }
       }
-      if (params[index].substr(2).length !== 16) {
+      if (params[index].substr(2).length > 16) {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: expected 64 bit value`,
@@ -288,7 +282,7 @@ export const validators = {
   },
   get uint256() {
     return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
+      if (!/^[0-9a-fA-F]+$/.test(params[index].substr(2)) || typeof params[index] !== 'string') {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: argument must be a hex string`,
@@ -301,7 +295,7 @@ export const validators = {
           message: `invalid argument ${index}: hex string without 0x prefix`,
         }
       }
-      if (params[index].substr(2).length !== 64) {
+      if (params[index].substr(2).length > 64) {
         return {
           code: INVALID_PARAMS,
           message: `invalid argument ${index}: expected 256 bit value`,

--- a/packages/client/lib/rpc/validation.ts
+++ b/packages/client/lib/rpc/validation.ts
@@ -37,6 +37,66 @@ export function middleware(method: any, requiredParamsCount: number, validators:
   }
 }
 
+function bytes(bytes: number, params: any[], index: number) {
+  if (typeof params[index] !== 'string') {
+    return {
+      code: INVALID_PARAMS,
+      message: `invalid argument ${index}: argument must be a hex string`,
+    }
+  }
+
+  if (params[index].substr(0, 2) !== '0x') {
+    return {
+      code: INVALID_PARAMS,
+      message: `invalid argument ${index}: hex string without 0x prefix`,
+    }
+  }
+  if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
+    return {
+      code: INVALID_PARAMS,
+      message: `invalid argument ${index}: argument must be a hex string`,
+    }
+  }
+  if (params[index].substr(2).length > bytes * 2) {
+    return {
+      code: INVALID_PARAMS,
+      message: `invalid argument ${index}: expected ${bytes} byte value`,
+    }
+  }
+}
+
+function uint(uint: number, params: any[], index: number) {
+  if (uint % 8 !== 0) {
+    // Sanity check
+    throw new Error(`Uint should be a multiple of 8, got: ${uint}`)
+  }
+  if (typeof params[index] !== 'string') {
+    return {
+      code: INVALID_PARAMS,
+      message: `invalid argument ${index}: argument must be a hex string`,
+    }
+  }
+
+  if (params[index].substr(0, 2) !== '0x') {
+    return {
+      code: INVALID_PARAMS,
+      message: `invalid argument ${index}: hex string without 0x prefix`,
+    }
+  }
+  if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
+    return {
+      code: INVALID_PARAMS,
+      message: `invalid argument ${index}: argument must be a hex string`,
+    }
+  }
+  if (params[index].substr(2).length > (uint / 8) * 2) {
+    return {
+      code: INVALID_PARAMS,
+      message: `invalid argument ${index}: expected ${uint} bit value`,
+    }
+  }
+}
+
 /**
  * @memberof module:rpc
  */
@@ -97,294 +157,36 @@ export const validators = {
   },
 
   get bytes8() {
-    return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-
-      if (params[index].substr(0, 2) !== '0x') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: hex string without 0x prefix`,
-        }
-      }
-      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-      if (params[index].substr(2).length > 16) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: expected 8 byte value`,
-        }
-      }
-    }
+    return (params: any[], index: number) => bytes(8, params, index)
   },
   get bytes16() {
-    return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-
-      if (params[index].substr(0, 2) !== '0x') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: hex string without 0x prefix`,
-        }
-      }
-      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-      if (params[index].substr(2).length > 32) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: expected 16 byte value`,
-        }
-      }
-    }
+    return (params: any[], index: number) => bytes(16, params, index)
   },
   get bytes20() {
-    return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-
-      if (params[index].substr(0, 2) !== '0x') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: hex string without 0x prefix`,
-        }
-      }
-      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-      if (params[index].substr(2).length > 40) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: expected 20 byte value`,
-        }
-      }
-    }
+    return (params: any[], index: number) => bytes(20, params, index)
   },
   get bytes32() {
-    return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-
-      if (params[index].substr(0, 2) !== '0x') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: hex string without 0x prefix`,
-        }
-      }
-      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-      if (params[index].substr(2).length > 64) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: expected 32 byte value`,
-        }
-      }
-    }
+    return (params: any[], index: number) => bytes(32, params, index)
   },
   get variableBytes32() {
-    return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-
-      if (params[index].substr(0, 2) !== '0x') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: hex string without 0x prefix`,
-        }
-      }
-      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-      if (params[index].substr(2).length > 64) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: expected 0 to 32 byte value`,
-        }
-      }
-    }
+    return (params: any[], index: number) => bytes(32, params, index)
   },
   get bytes48() {
-    return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-
-      if (params[index].substr(0, 2) !== '0x') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: hex string without 0x prefix`,
-        }
-      }
-      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-      if (params[index].substr(2).length > 96) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: expected 32 byte value`,
-        }
-      }
-    }
+    return (params: any[], index: number) => bytes(48, params, index)
   },
   get bytes256() {
-    return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-
-      if (params[index].substr(0, 2) !== '0x') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: hex string without 0x prefix`,
-        }
-      }
-      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-      if (params[index].substr(2).length > 512) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: expected 32 byte value`,
-        }
-      }
-    }
+    return (params: any[], index: number) => bytes(256, params, index)
   },
   get uint64() {
-    return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-
-      if (params[index].substr(0, 2) !== '0x') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: hex string without 0x prefix`,
-        }
-      }
-      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-      if (params[index].substr(2).length > 16) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: expected 64 bit value`,
-        }
-      }
-    }
+    return (params: any[], index: number) => uint(64, params, index)
   },
   get uint256() {
-    return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-
-      if (params[index].substr(0, 2) !== '0x') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: hex string without 0x prefix`,
-        }
-      }
-      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-      if (params[index].substr(2).length > 64) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: expected 256 bit value`,
-        }
-      }
-    }
+    return (params: any[], index: number) => uint(256, params, index)
   },
   get blob() {
-    return (params: any[], index: number) => {
-      if (typeof params[index] !== 'string') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-
-      if (params[index].substr(0, 2) !== '0x') {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: hex string without 0x prefix`,
-        }
-      }
-      if (params[index].length > 2 && !/^[0-9a-fA-F]+$/.test(params[index].substr(2))) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: argument must be a hex string`,
-        }
-      }
-      if (params[index].substr(2).length > 131072) {
-        return {
-          code: INVALID_PARAMS,
-          message: `invalid argument ${index}: value larger than 131072 bytes`,
-        }
-      }
-    }
+    // "each blob is FIELD_ELEMENTS_PER_BLOB * BYTES_PER_FIELD_ELEMENT = 4096 * 32 = 131072"
+    // See: https://github.com/ethereum/execution-apis/blob/b7c5d3420e00648f456744d121ffbd929862924d/src/engine/experimental/blob-extension.md
+    return (params: any[], index: number) => bytes(131072, params, index)
   },
 
   /**

--- a/packages/client/test/rpc/engine/newPayloadv2.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadv2.spec.ts
@@ -1,0 +1,314 @@
+import { BlockHeader } from '@ethereumjs/block'
+import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
+import { Address, bufferToHex, zeros } from '@ethereumjs/util'
+import * as tape from 'tape'
+import * as td from 'testdouble'
+
+import { INVALID_PARAMS } from '../../../lib/rpc/error-code'
+import blocks = require('../../testdata/blocks/beacon.json')
+import genesisJSON = require('../../testdata/geth-genesis/post-merge.json')
+import { baseRequest, baseSetup, params, setupChain } from '../helpers'
+import { checkError } from '../util'
+
+import type { HttpServer } from 'jayson'
+type Test = tape.Test
+
+const method = 'engine_newPayloadV2'
+
+const [blockData] = blocks
+
+const originalValidate = BlockHeader.prototype._consensusFormatValidation
+
+export const batchBlocks = async (t: Test, server: HttpServer) => {
+  for (let i = 0; i < 3; i++) {
+    const req = params(method, [blocks[i]])
+    const expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'VALID')
+    }
+    await baseRequest(t, server, req, 200, expectRes, false)
+  }
+}
+
+tape(`${method}: call with executionPayloadV1`, (v1) => {
+  v1.test(`${method}: call with invalid block hash without 0x`, async (t) => {
+    const { server } = baseSetup({ engine: true, includeVM: true })
+
+    const blockDataWithInvalidParentHash = [
+      {
+        ...blockData,
+        parentHash: blockData.parentHash.slice(2),
+      },
+    ]
+
+    const req = params(method, blockDataWithInvalidParentHash)
+    const expectRes = checkError(
+      t,
+      INVALID_PARAMS,
+      "invalid argument 0 for key 'parentHash': hex string without 0x prefix"
+    )
+    await baseRequest(t, server, req, 200, expectRes)
+  })
+
+  v1.test(`${method}: call with invalid hex string as block hash`, async (t) => {
+    const { server } = baseSetup({ engine: true, includeVM: true })
+
+    const blockDataWithInvalidBlockHash = [{ ...blockData, blockHash: '0x-invalid-block-hash' }]
+    const req = params(method, blockDataWithInvalidBlockHash)
+    const expectRes = checkError(
+      t,
+      INVALID_PARAMS,
+      "invalid argument 0 for key 'blockHash': invalid block hash"
+    )
+    await baseRequest(t, server, req, 200, expectRes)
+  })
+
+  v1.test(`${method}: call with non existent block hash`, async (t) => {
+    const { server } = await setupChain(genesisJSON, 'merge', { engine: true })
+
+    const blockDataNonExistentBlockHash = [
+      {
+        ...blockData,
+        blockHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
+      },
+    ]
+    const req = params(method, blockDataNonExistentBlockHash)
+    const expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'INVALID')
+    }
+
+    await baseRequest(t, server, req, 200, expectRes)
+  })
+
+  v1.test(`${method}: call with non existent parent hash`, async (t) => {
+    const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+
+    const blockDataNonExistentParentHash = [
+      {
+        ...blockData,
+        parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
+        blockHash: '0xf31969a769bfcdbcc1c05f2542fdc7aa9336fc1ea9a82c4925320c035095d649',
+      },
+    ]
+    const req = params(method, blockDataNonExistentParentHash)
+    const expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'ACCEPTED')
+    }
+
+    await baseRequest(t, server, req, 200, expectRes)
+  })
+
+  v1.test(
+    `${method}: call with unknown parent hash to store in remoteBlocks, then call valid ancestor in fcU`,
+    async (t) => {
+      const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+
+      let req = params(method, [blocks[1]])
+      let expectRes = (res: any) => {
+        t.equal(res.body.result.status, 'ACCEPTED')
+      }
+      await baseRequest(t, server, req, 200, expectRes, false)
+
+      req = params(method, [blocks[0]])
+      expectRes = (res: any) => {
+        t.equal(res.body.result.status, 'VALID')
+      }
+      await baseRequest(t, server, req, 200, expectRes, false)
+
+      const state = {
+        headBlockHash: blocks[1].blockHash,
+        safeBlockHash: blocks[1].blockHash,
+        finalizedBlockHash: blocks[0].blockHash,
+      }
+      req = params('engine_forkchoiceUpdatedV1', [state])
+      expectRes = (res: any) => {
+        t.equal(res.body.result.payloadStatus.status, 'VALID')
+      }
+
+      await baseRequest(t, server, req, 200, expectRes)
+    }
+  )
+
+  v1.test(`${method}: invalid terminal block`, async (t) => {
+    const genesisWithHigherTtd = {
+      ...genesisJSON,
+      config: {
+        ...genesisJSON.config,
+        terminalTotalDifficulty: 17179869185,
+      },
+    }
+
+    BlockHeader.prototype._consensusFormatValidation = td.func<any>()
+    td.replace('@ethereumjs/block', { BlockHeader })
+
+    const { server } = await setupChain(genesisWithHigherTtd, 'post-merge', {
+      engine: true,
+    })
+
+    const req = params(method, [blockData, null])
+    const expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'INVALID')
+      t.equal(res.body.result.latestValidHash, bufferToHex(zeros(32)))
+    }
+    await baseRequest(t, server, req, 200, expectRes)
+  })
+
+  v1.test(`${method}: call with valid data`, async (t) => {
+    const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+
+    const req = params(method, [blockData])
+    const expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'VALID')
+      t.equal(res.body.result.latestValidHash, blockData.blockHash)
+    }
+    await baseRequest(t, server, req, 200, expectRes)
+  })
+
+  v1.test(`${method}: call with valid data but invalid transactions`, async (t) => {
+    const { chain, server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+    chain.config.logger.silent = true
+    const blockDataWithInvalidTransaction = {
+      ...blockData,
+      transactions: ['0x1'],
+    }
+    const expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'INVALID')
+      t.equal(res.body.result.latestValidHash, blockData.parentHash)
+      t.equal(
+        res.body.result.validationError,
+        `Invalid tx at index 0: Error: Invalid serialized tx input: must be array`
+      )
+    }
+
+    const req = params(method, [blockDataWithInvalidTransaction])
+    await baseRequest(t, server, req, 200, expectRes)
+  })
+
+  v1.test(`${method}: call with valid data & valid transaction but not signed`, async (t) => {
+    const { server, common, chain } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+    chain.config.logger.silent = true
+
+    // Let's mock a non-signed transaction so execution fails
+    const tx = FeeMarketEIP1559Transaction.fromTxData(
+      {
+        gasLimit: 21_000,
+        maxFeePerGas: 10,
+        value: 1,
+        to: Address.fromString('0x61FfE691821291D02E9Ba5D33098ADcee71a3a17'),
+      },
+      { common }
+    )
+
+    const transactions = ['0x' + tx.serialize().toString('hex')]
+    const blockDataWithValidTransaction = {
+      ...blockData,
+      transactions,
+      blockHash: '0x308f490332a31fade8b2b46a8e1132cd15adeaffbb651cb523c067b3f007dd9e',
+    }
+    const expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'INVALID')
+      t.true(res.body.result.validationError.includes('Error verifying block while running:'))
+    }
+
+    const req = params(method, [blockDataWithValidTransaction])
+    await baseRequest(t, server, req, 200, expectRes)
+  })
+
+  v1.test(`${method}: call with valid data & valid transaction`, async (t) => {
+    const accountPk = Buffer.from(
+      'e331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
+      'hex'
+    )
+    const accountAddress = Address.fromPrivateKey(accountPk)
+    const newGenesisJSON = {
+      ...genesisJSON,
+      alloc: {
+        ...genesisJSON.alloc,
+        [accountAddress.toString()]: {
+          balance: '0x1000000',
+        },
+      },
+    }
+
+    const { server, common } = await setupChain(newGenesisJSON, 'post-merge', { engine: true })
+
+    const tx = FeeMarketEIP1559Transaction.fromTxData(
+      {
+        maxFeePerGas: '0x7',
+        value: 6,
+        gasLimit: 53_000,
+      },
+      { common }
+    ).sign(accountPk)
+    const transactions = ['0x' + tx.serialize().toString('hex')]
+    const blockDataWithValidTransaction = {
+      ...blockData,
+      transactions,
+      parentHash: '0xefc1993f08864165c42195966b3f12794a1a42afa84b1047a46ab6b105828c5c',
+      receiptsRoot: '0xc508745f9f8b6847a127bbc58b7c6b2c0f073c7ca778b6f020138f0d6d782adf',
+      gasUsed: '0xcf08',
+      stateRoot: '0x5a7123ab8bdd4f172438671a2a3de143f2105aa1ac3338c97e5f433e8e380d8d',
+      blockHash: '0x625f2fd36bf278f92211376cbfe5acd7ac5da694e28f3d94d59488b7dbe213a4',
+    }
+    const expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'VALID')
+    }
+    const req = params(method, [blockDataWithValidTransaction])
+    await baseRequest(t, server, req, 200, expectRes)
+  })
+
+  v1.test(`${method}: re-execute payload and verify that no errors occur`, async (t) => {
+    const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+
+    await batchBlocks(t, server)
+
+    let req = params('engine_forkchoiceUpdatedV1', [
+      {
+        headBlockHash: blocks[2].blockHash,
+        finalizedBlockHash: blocks[2].blockHash,
+        safeBlockHash: blocks[2].blockHash,
+      },
+    ])
+
+    // Let's set new head hash
+    const expectResFcu = (res: any) => {
+      t.equal(res.body.result.payloadStatus.status, 'VALID')
+    }
+    await baseRequest(t, server, req, 200, expectResFcu, false)
+
+    // Now let's try to re-execute payload
+    req = params(method, [blockData])
+
+    const expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'VALID')
+    }
+    await baseRequest(t, server, req, 200, expectRes)
+  })
+
+  v1.test(`${method}: parent hash equals to block hash`, async (t) => {
+    const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+    const blockDataHasBlockHashSameAsParentHash = [
+      {
+        ...blockData,
+        blockHash: blockData.parentHash,
+      },
+    ]
+    const req = params(method, blockDataHasBlockHashSameAsParentHash)
+    const expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'INVALID')
+    }
+
+    await baseRequest(t, server, req, 200, expectRes)
+  })
+
+  v1.test(`reset TD`, (t) => {
+    BlockHeader.prototype._consensusFormatValidation = originalValidate
+    td.reset()
+    t.end()
+  })
+  v1.end()
+})
+
+tape(`${method}: call with executionPayloadV2`, (v2) => {
+  v2.pass('TODO: add tests for executionPayloadV2')
+  // TODO: add tests for executionPayloadV2
+})

--- a/packages/client/test/rpc/engine/newPayloadv3.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadv3.spec.ts
@@ -13,7 +13,7 @@ import { checkError } from '../util'
 import type { HttpServer } from 'jayson'
 type Test = tape.Test
 
-const method = 'engine_newPayloadV2'
+const method = 'engine_newPayloadV3'
 
 const [blockData] = blocks
 
@@ -310,6 +310,11 @@ tape(`${method}: call with executionPayloadV1`, (v1) => {
 
 tape(`${method}: call with executionPayloadV2`, (v2) => {
   v2.pass('TODO: add tests for executionPayloadV2')
-  // TODO: add tests for executionPayloadV2
   v2.end()
+  // TODO: add tests for executionPayloadV2
+})
+tape(`${method}: call with executionPayloadV3`, (v2) => {
+  v2.pass('TODO: add tests for executionPayloadV2')
+  v2.end()
+  // TODO: add tests for executionPayloadV3
 })

--- a/packages/client/test/rpc/validation.spec.ts
+++ b/packages/client/test/rpc/validation.spec.ts
@@ -1,3 +1,5 @@
+import { bufferToHex } from '@ethereumjs/util'
+import { randomBytes } from 'node:crypto'
 import * as tape from 'tape'
 
 import { INVALID_PARAMS } from '../../lib/rpc/error-code'
@@ -195,6 +197,126 @@ tape(`${prefix} hex`, (t) => {
   t.notOk(validatorResult(validators.hex(['00'], 0)))
   t.notOk(validatorResult(validators.hex(['1'], 0)))
   t.notOk(validatorResult(validators.hex(['1'], 0)))
+
+  t.end()
+})
+tape(`${prefix} byteVectors`, (t) => {
+  const bytes = (byteLength: number, prefix: boolean = true) => {
+    return prefix ? '0x'.padEnd(byteLength * 2 + 2, '0') : ''.padEnd(byteLength * 2, '0')
+  }
+  t.test('Bytes8', (st) => {
+    // valid
+    st.ok(validatorResult(validators.bytes8([bufferToHex(randomBytes(8))], 0)))
+    st.ok(validatorResult(validators.bytes8([bytes(8)], 0)))
+
+    // invalid
+    st.notOk(validatorResult(validators.bytes8([bytes(1)], 0)))
+    st.notOk(validatorResult(validators.bytes8([bytes(2)], 0)))
+    st.notOk(validatorResult(validators.bytes8([bytes(4)], 0)))
+    st.notOk(validatorResult(validators.bytes8([bytes(10)], 0)))
+    st.notOk(validatorResult(validators.bytes8([bytes(8, false)], 0)))
+    st.notOk(validatorResult(validators.bytes8([randomBytes(8).toString('hex')], 0)))
+    st.end()
+  })
+  t.test('Uint64', (st) => {
+    // valid
+    st.ok(validatorResult(validators.uint64([bufferToHex(randomBytes(8))], 0)))
+    st.ok(validatorResult(validators.uint64([bytes(8)], 0)))
+
+    // invalid
+    st.notOk(validatorResult(validators.uint64([bytes(1)], 0)))
+    st.notOk(validatorResult(validators.uint64([bytes(2)], 0)))
+    st.notOk(validatorResult(validators.uint64([bytes(4)], 0)))
+    st.notOk(validatorResult(validators.uint64([bytes(10)], 0)))
+    st.notOk(validatorResult(validators.uint64([bytes(8, false)], 0)))
+    st.notOk(validatorResult(validators.uint64([randomBytes(8).toString('hex')], 0)))
+    st.end()
+  })
+  t.test('Bytes16', (st) => {
+    // valid
+    st.ok(validatorResult(validators.bytes16([bufferToHex(randomBytes(16))], 0)))
+    st.ok(validatorResult(validators.bytes16([bytes(16)], 0)))
+
+    // invalid
+    st.notOk(validatorResult(validators.bytes16([bytes(1)], 0)))
+    st.notOk(validatorResult(validators.bytes16([bytes(2)], 0)))
+    st.notOk(validatorResult(validators.bytes16([bytes(4)], 0)))
+    st.notOk(validatorResult(validators.bytes16([bytes(8)], 0)))
+    st.notOk(validatorResult(validators.bytes16([bytes(20)], 0)))
+    st.notOk(validatorResult(validators.bytes16([bytes(16, false)], 0)))
+    st.notOk(validatorResult(validators.bytes16([randomBytes(16).toString('hex')], 0)))
+    st.end()
+  })
+  t.test('Bytes20', (st) => {
+    // valid
+    st.ok(validatorResult(validators.bytes20([bytes(20)], 0)))
+    st.ok(validatorResult(validators.bytes20([bufferToHex(randomBytes(20))], 0)))
+
+    // invalid
+    st.notOk(validatorResult(validators.bytes20([bytes(8)], 0)))
+    st.notOk(validatorResult(validators.bytes20([bytes(16)], 0)))
+    st.notOk(validatorResult(validators.bytes20([bytes(20, false)], 0)))
+    st.notOk(validatorResult(validators.bytes20([bytes(32)], 0)))
+    st.notOk(validatorResult(validators.bytes20([randomBytes(20).toString('hex')], 0)))
+    st.end()
+  })
+  t.test('Bytes32', (st) => {
+    // valid
+    st.ok(validatorResult(validators.bytes32([bufferToHex(randomBytes(32))], 0)))
+    st.ok(validatorResult(validators.bytes32([bytes(32)], 0)))
+
+    // invalid
+    st.notOk(validatorResult(validators.bytes32([bytes(8)], 0)))
+    st.notOk(validatorResult(validators.bytes32([bytes(16)], 0)))
+    st.notOk(validatorResult(validators.bytes32([bytes(20)], 0)))
+    st.notOk(validatorResult(validators.bytes32([bytes(48)], 0)))
+    st.notOk(validatorResult(validators.bytes32([bytes(32, false)], 0)))
+    st.notOk(validatorResult(validators.bytes32([randomBytes(32).toString('hex')], 0)))
+    st.end()
+  })
+  t.test('Uint256', (st) => {
+    // valid
+    st.ok(validatorResult(validators.uint256([bufferToHex(randomBytes(32))], 0)))
+    st.ok(validatorResult(validators.uint256([bytes(32)], 0)))
+
+    // invalid
+    st.notOk(validatorResult(validators.uint256([bytes(8)], 0)))
+    st.notOk(validatorResult(validators.uint256([bytes(16)], 0)))
+    st.notOk(validatorResult(validators.uint256([bytes(20)], 0)))
+    st.notOk(validatorResult(validators.uint256([bytes(48)], 0)))
+    st.notOk(validatorResult(validators.uint256([bytes(32, false)], 0)))
+    st.notOk(validatorResult(validators.uint256([randomBytes(32).toString('hex')], 0)))
+    st.end()
+  })
+  t.test('Bytes48', (st) => {
+    // valid
+    st.ok(validatorResult(validators.bytes48([bufferToHex(randomBytes(48))], 0)))
+    st.ok(validatorResult(validators.bytes48([bytes(48)], 0)))
+
+    // invalid
+    st.notOk(validatorResult(validators.bytes48([bytes(8)], 0)))
+    st.notOk(validatorResult(validators.bytes48([bytes(16)], 0)))
+    st.notOk(validatorResult(validators.bytes48([bytes(20)], 0)))
+    st.notOk(validatorResult(validators.bytes48([bytes(32)], 0)))
+    st.notOk(validatorResult(validators.bytes48([bytes(64)], 0)))
+    st.notOk(validatorResult(validators.bytes48([bytes(48, false)], 0)))
+    st.notOk(validatorResult(validators.bytes48([randomBytes(48).toString('hex')], 0)))
+    st.end()
+  })
+  t.test('Bytes256', (st) => {
+    // valid
+    st.ok(validatorResult(validators.bytes256([bufferToHex(randomBytes(256))], 0)))
+    st.ok(validatorResult(validators.bytes256([bytes(256)], 0)))
+
+    // invalid
+    st.notOk(validatorResult(validators.bytes256([bytes(8)], 0)))
+    st.notOk(validatorResult(validators.bytes256([bytes(16)], 0)))
+    st.notOk(validatorResult(validators.bytes256([bytes(32)], 0)))
+    st.notOk(validatorResult(validators.bytes256([bytes(64)], 0)))
+    st.notOk(validatorResult(validators.bytes256([bytes(256, false)], 0)))
+    st.notOk(validatorResult(validators.bytes256([randomBytes(256).toString('hex')], 0)))
+    st.end()
+  })
 
   t.end()
 })

--- a/packages/client/test/rpc/validation.spec.ts
+++ b/packages/client/test/rpc/validation.spec.ts
@@ -1,5 +1,5 @@
 import { bufferToHex } from '@ethereumjs/util'
-import { randomBytes } from 'node:crypto'
+import { randomBytes } from 'crypto'
 import * as tape from 'tape'
 
 import { INVALID_PARAMS } from '../../lib/rpc/error-code'
@@ -208,11 +208,10 @@ tape(`${prefix} byteVectors`, (t) => {
     // valid
     st.ok(validatorResult(validators.bytes8([bufferToHex(randomBytes(8))], 0)))
     st.ok(validatorResult(validators.bytes8([bytes(8)], 0)))
-
+    st.ok(validatorResult(validators.bytes8([bytes(1)], 0)))
+    st.ok(validatorResult(validators.bytes8([bytes(2)], 0)))
+    st.ok(validatorResult(validators.bytes8([bytes(4)], 0)))
     // invalid
-    st.notOk(validatorResult(validators.bytes8([bytes(1)], 0)))
-    st.notOk(validatorResult(validators.bytes8([bytes(2)], 0)))
-    st.notOk(validatorResult(validators.bytes8([bytes(4)], 0)))
     st.notOk(validatorResult(validators.bytes8([bytes(10)], 0)))
     st.notOk(validatorResult(validators.bytes8([bytes(8, false)], 0)))
     st.notOk(validatorResult(validators.bytes8([randomBytes(8).toString('hex')], 0)))
@@ -222,11 +221,11 @@ tape(`${prefix} byteVectors`, (t) => {
     // valid
     st.ok(validatorResult(validators.uint64([bufferToHex(randomBytes(8))], 0)))
     st.ok(validatorResult(validators.uint64([bytes(8)], 0)))
+    st.ok(validatorResult(validators.uint64([bytes(1)], 0)))
+    st.ok(validatorResult(validators.uint64([bytes(2)], 0)))
+    st.ok(validatorResult(validators.uint64([bytes(4)], 0)))
 
     // invalid
-    st.notOk(validatorResult(validators.uint64([bytes(1)], 0)))
-    st.notOk(validatorResult(validators.uint64([bytes(2)], 0)))
-    st.notOk(validatorResult(validators.uint64([bytes(4)], 0)))
     st.notOk(validatorResult(validators.uint64([bytes(10)], 0)))
     st.notOk(validatorResult(validators.uint64([bytes(8, false)], 0)))
     st.notOk(validatorResult(validators.uint64([randomBytes(8).toString('hex')], 0)))
@@ -236,12 +235,11 @@ tape(`${prefix} byteVectors`, (t) => {
     // valid
     st.ok(validatorResult(validators.bytes16([bufferToHex(randomBytes(16))], 0)))
     st.ok(validatorResult(validators.bytes16([bytes(16)], 0)))
-
+    st.ok(validatorResult(validators.bytes16([bytes(1)], 0)))
+    st.ok(validatorResult(validators.bytes16([bytes(2)], 0)))
+    st.ok(validatorResult(validators.bytes16([bytes(4)], 0)))
+    st.ok(validatorResult(validators.bytes16([bytes(8)], 0)))
     // invalid
-    st.notOk(validatorResult(validators.bytes16([bytes(1)], 0)))
-    st.notOk(validatorResult(validators.bytes16([bytes(2)], 0)))
-    st.notOk(validatorResult(validators.bytes16([bytes(4)], 0)))
-    st.notOk(validatorResult(validators.bytes16([bytes(8)], 0)))
     st.notOk(validatorResult(validators.bytes16([bytes(20)], 0)))
     st.notOk(validatorResult(validators.bytes16([bytes(16, false)], 0)))
     st.notOk(validatorResult(validators.bytes16([randomBytes(16).toString('hex')], 0)))
@@ -251,10 +249,9 @@ tape(`${prefix} byteVectors`, (t) => {
     // valid
     st.ok(validatorResult(validators.bytes20([bytes(20)], 0)))
     st.ok(validatorResult(validators.bytes20([bufferToHex(randomBytes(20))], 0)))
-
+    st.ok(validatorResult(validators.bytes20([bytes(8)], 0)))
+    st.ok(validatorResult(validators.bytes20([bytes(16)], 0)))
     // invalid
-    st.notOk(validatorResult(validators.bytes20([bytes(8)], 0)))
-    st.notOk(validatorResult(validators.bytes20([bytes(16)], 0)))
     st.notOk(validatorResult(validators.bytes20([bytes(20, false)], 0)))
     st.notOk(validatorResult(validators.bytes20([bytes(32)], 0)))
     st.notOk(validatorResult(validators.bytes20([randomBytes(20).toString('hex')], 0)))
@@ -264,11 +261,10 @@ tape(`${prefix} byteVectors`, (t) => {
     // valid
     st.ok(validatorResult(validators.bytes32([bufferToHex(randomBytes(32))], 0)))
     st.ok(validatorResult(validators.bytes32([bytes(32)], 0)))
-
+    st.ok(validatorResult(validators.bytes32([bytes(8)], 0)))
+    st.ok(validatorResult(validators.bytes32([bytes(16)], 0)))
+    st.ok(validatorResult(validators.bytes32([bytes(20)], 0)))
     // invalid
-    st.notOk(validatorResult(validators.bytes32([bytes(8)], 0)))
-    st.notOk(validatorResult(validators.bytes32([bytes(16)], 0)))
-    st.notOk(validatorResult(validators.bytes32([bytes(20)], 0)))
     st.notOk(validatorResult(validators.bytes32([bytes(48)], 0)))
     st.notOk(validatorResult(validators.bytes32([bytes(32, false)], 0)))
     st.notOk(validatorResult(validators.bytes32([randomBytes(32).toString('hex')], 0)))
@@ -278,11 +274,10 @@ tape(`${prefix} byteVectors`, (t) => {
     // valid
     st.ok(validatorResult(validators.uint256([bufferToHex(randomBytes(32))], 0)))
     st.ok(validatorResult(validators.uint256([bytes(32)], 0)))
-
+    st.ok(validatorResult(validators.uint256([bytes(8)], 0)))
+    st.ok(validatorResult(validators.uint256([bytes(16)], 0)))
+    st.ok(validatorResult(validators.uint256([bytes(20)], 0)))
     // invalid
-    st.notOk(validatorResult(validators.uint256([bytes(8)], 0)))
-    st.notOk(validatorResult(validators.uint256([bytes(16)], 0)))
-    st.notOk(validatorResult(validators.uint256([bytes(20)], 0)))
     st.notOk(validatorResult(validators.uint256([bytes(48)], 0)))
     st.notOk(validatorResult(validators.uint256([bytes(32, false)], 0)))
     st.notOk(validatorResult(validators.uint256([randomBytes(32).toString('hex')], 0)))
@@ -292,12 +287,12 @@ tape(`${prefix} byteVectors`, (t) => {
     // valid
     st.ok(validatorResult(validators.bytes48([bufferToHex(randomBytes(48))], 0)))
     st.ok(validatorResult(validators.bytes48([bytes(48)], 0)))
+    st.ok(validatorResult(validators.bytes48([bytes(8)], 0)))
+    st.ok(validatorResult(validators.bytes48([bytes(16)], 0)))
+    st.ok(validatorResult(validators.bytes48([bytes(20)], 0)))
+    st.ok(validatorResult(validators.bytes48([bytes(32)], 0)))
 
     // invalid
-    st.notOk(validatorResult(validators.bytes48([bytes(8)], 0)))
-    st.notOk(validatorResult(validators.bytes48([bytes(16)], 0)))
-    st.notOk(validatorResult(validators.bytes48([bytes(20)], 0)))
-    st.notOk(validatorResult(validators.bytes48([bytes(32)], 0)))
     st.notOk(validatorResult(validators.bytes48([bytes(64)], 0)))
     st.notOk(validatorResult(validators.bytes48([bytes(48, false)], 0)))
     st.notOk(validatorResult(validators.bytes48([randomBytes(48).toString('hex')], 0)))
@@ -307,12 +302,14 @@ tape(`${prefix} byteVectors`, (t) => {
     // valid
     st.ok(validatorResult(validators.bytes256([bufferToHex(randomBytes(256))], 0)))
     st.ok(validatorResult(validators.bytes256([bytes(256)], 0)))
+    st.ok(validatorResult(validators.bytes256([bytes(8)], 0)))
+    st.ok(validatorResult(validators.bytes256([bytes(16)], 0)))
+    st.ok(validatorResult(validators.bytes256([bytes(32)], 0)))
+    st.ok(validatorResult(validators.bytes256([bytes(64)], 0)))
+    st.ok(validatorResult(validators.bytes256([bytes(128)], 0)))
 
     // invalid
-    st.notOk(validatorResult(validators.bytes256([bytes(8)], 0)))
-    st.notOk(validatorResult(validators.bytes256([bytes(16)], 0)))
-    st.notOk(validatorResult(validators.bytes256([bytes(32)], 0)))
-    st.notOk(validatorResult(validators.bytes256([bytes(64)], 0)))
+    st.notOk(validatorResult(validators.bytes256([bytes(512)], 0)))
     st.notOk(validatorResult(validators.bytes256([bytes(256, false)], 0)))
     st.notOk(validatorResult(validators.bytes256([randomBytes(256).toString('hex')], 0)))
     st.end()

--- a/packages/client/test/rpc/validation.spec.ts
+++ b/packages/client/test/rpc/validation.spec.ts
@@ -204,6 +204,9 @@ tape(`${prefix} byteVectors`, (t) => {
   const bytes = (byteLength: number, prefix: boolean = true) => {
     return prefix ? '0x'.padEnd(byteLength * 2 + 2, '0') : ''.padEnd(byteLength * 2, '0')
   }
+  const badhex = (byteLength: number) => {
+    return '0x'.padEnd(byteLength * 2 + 2, 'G')
+  }
   t.test('Bytes8', (st) => {
     // valid
     st.ok(validatorResult(validators.bytes8([bufferToHex(randomBytes(8))], 0)))
@@ -226,6 +229,7 @@ tape(`${prefix} byteVectors`, (t) => {
     st.ok(validatorResult(validators.uint64([bytes(4)], 0)))
 
     // invalid
+    st.notOk(validatorResult(validators.bytes8([badhex(8)], 0)))
     st.notOk(validatorResult(validators.uint64([bytes(10)], 0)))
     st.notOk(validatorResult(validators.uint64([bytes(8, false)], 0)))
     st.notOk(validatorResult(validators.uint64([randomBytes(8).toString('hex')], 0)))
@@ -240,6 +244,7 @@ tape(`${prefix} byteVectors`, (t) => {
     st.ok(validatorResult(validators.bytes16([bytes(4)], 0)))
     st.ok(validatorResult(validators.bytes16([bytes(8)], 0)))
     // invalid
+    st.notOk(validatorResult(validators.bytes16([badhex(16)], 0)))
     st.notOk(validatorResult(validators.bytes16([bytes(20)], 0)))
     st.notOk(validatorResult(validators.bytes16([bytes(16, false)], 0)))
     st.notOk(validatorResult(validators.bytes16([randomBytes(16).toString('hex')], 0)))
@@ -252,6 +257,7 @@ tape(`${prefix} byteVectors`, (t) => {
     st.ok(validatorResult(validators.bytes20([bytes(8)], 0)))
     st.ok(validatorResult(validators.bytes20([bytes(16)], 0)))
     // invalid
+    st.notOk(validatorResult(validators.bytes20([badhex(20)], 0)))
     st.notOk(validatorResult(validators.bytes20([bytes(20, false)], 0)))
     st.notOk(validatorResult(validators.bytes20([bytes(32)], 0)))
     st.notOk(validatorResult(validators.bytes20([randomBytes(20).toString('hex')], 0)))
@@ -265,6 +271,7 @@ tape(`${prefix} byteVectors`, (t) => {
     st.ok(validatorResult(validators.bytes32([bytes(16)], 0)))
     st.ok(validatorResult(validators.bytes32([bytes(20)], 0)))
     // invalid
+    st.notOk(validatorResult(validators.bytes32([badhex(32)], 0)))
     st.notOk(validatorResult(validators.bytes32([bytes(48)], 0)))
     st.notOk(validatorResult(validators.bytes32([bytes(32, false)], 0)))
     st.notOk(validatorResult(validators.bytes32([randomBytes(32).toString('hex')], 0)))
@@ -278,6 +285,7 @@ tape(`${prefix} byteVectors`, (t) => {
     st.ok(validatorResult(validators.uint256([bytes(16)], 0)))
     st.ok(validatorResult(validators.uint256([bytes(20)], 0)))
     // invalid
+    st.notOk(validatorResult(validators.uint256([badhex(32)], 0)))
     st.notOk(validatorResult(validators.uint256([bytes(48)], 0)))
     st.notOk(validatorResult(validators.uint256([bytes(32, false)], 0)))
     st.notOk(validatorResult(validators.uint256([randomBytes(32).toString('hex')], 0)))
@@ -293,6 +301,7 @@ tape(`${prefix} byteVectors`, (t) => {
     st.ok(validatorResult(validators.bytes48([bytes(32)], 0)))
 
     // invalid
+    st.notOk(validatorResult(validators.bytes48([badhex(48)], 0)))
     st.notOk(validatorResult(validators.bytes48([bytes(64)], 0)))
     st.notOk(validatorResult(validators.bytes48([bytes(48, false)], 0)))
     st.notOk(validatorResult(validators.bytes48([randomBytes(48).toString('hex')], 0)))
@@ -309,6 +318,7 @@ tape(`${prefix} byteVectors`, (t) => {
     st.ok(validatorResult(validators.bytes256([bytes(128)], 0)))
 
     // invalid
+    st.notOk(validatorResult(validators.bytes256([badhex(256)], 0)))
     st.notOk(validatorResult(validators.bytes256([bytes(512)], 0)))
     st.notOk(validatorResult(validators.bytes256([bytes(256, false)], 0)))
     st.notOk(validatorResult(validators.bytes256([randomBytes(256).toString('hex')], 0)))


### PR DESCRIPTION
Adding to work done in #2502

Adds more specific type labels and validators for engine api based on type descriptions in https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_forkchoiceupdatedv2

hex string parameters are differentiated into bytevector length (or bitlength) giving us:
- Bytes8
- Bytes20
- Bytes32
- Root
  - *Root is a Bytes32 that represents the merkle root of a nested ssz container*
- VariableBytes32
  - 0 to 32 bytes
- Bytes48
- Bytes256
- Uint64
- Uint256
- Blob
  - because `Bytes131072` is silly

Typenames are chosen to mimic those used in SSZ typing.  They are all just `type === 'string'`.  The actual bytelength check happens in the validators

A new `validator` has been created for each type, checking:
1. type === string
2. prefix === 0x
3. bytelength === expected


#### newPayloadV2 and newPayloadV3

Both of these methods were updated according to:
https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md
and
https://github.com/ethereum/execution-apis/blob/main/src/engine/experimental/blob-extension.md

`newPayloadV2` accepts either `executionPayloadV1` or `executionPayloadV2`.
`newPayloadV3` accepts either `executionPayloadV1` or `executionPayloadV2` or `executionPayloadV3`.

The methods have been updated to handle each type, and `validators.either()` used to enable validation for multiple type possibilities
