### PR TITLE
client: add new shanghai  engine apis

### DIFF
--- a/packages/client/lib/rpc/error-code.ts
+++ b/packages/client/lib/rpc/error-code.ts
@@ -5,3 +5,4 @@ export const INVALID_REQUEST = -32600
 export const METHOD_NOT_FOUND = -32601
 export const INVALID_PARAMS = -32602
 export const INTERNAL_ERROR = -32603
+export const TOO_LARGE_REQUEST = -38004

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -458,13 +458,16 @@ export class Engine {
 
     this.getPayloadBodiesByHashV1 = cmMiddleware(
       middleware(this.getPayloadBodiesByHashV1.bind(this), 1, [
-        validators.array(validators.bytes32),
+        [validators.array(validators.bytes32)],
       ]),
       () => this.connectionManager.updateStatus()
     )
 
     this.getPayloadBodiesByRangeV1 = cmMiddleware(
-      middleware(this.getPayloadBodiesByRangeV1.bind(this), 2, [validators.bytes8]),
+      middleware(this.getPayloadBodiesByRangeV1.bind(this), 2, [
+        [validators.bytes8],
+        [validators.bytes8],
+      ]),
       () => this.connectionManager.updateStatus()
     )
   }

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -1016,24 +1016,8 @@ export class Engine {
    * Returns a list of engine API endpoints supported by the client
    */
   private getCapabilities(_params: []): string[] {
-    const caps = Object.getOwnPropertyNames(this)
-    // TODO: Figure out how to use RPCManager.getMethodNames to make this work since this semi-duplicates that functionality
-    const nonFunctions = [
-      'client',
-      'service',
-      'chain',
-      'config',
-      'execution',
-      'vm',
-      'connectionManager',
-      'pendingBlocks',
-      'remoteBlocks',
-      'getCapabilities',
-      'pendingBlock',
-    ]
-    const engineMethods = caps.filter(
-      (el) => nonFunctions.findIndex((innerEl) => innerEl === el) < 0
-    )
+    const caps = Object.getOwnPropertyNames(Engine.prototype)
+    const engineMethods = caps.filter((el) => el !== 'constructor' && el !== 'getCapabilities')
     return engineMethods.map((el) => 'engine_' + el)
   }
 

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -1095,6 +1095,13 @@ export class Engine {
         message: 'More than 32 execution payload bodies requested',
       }
     }
+
+    if (count < BigInt(1) || start < BigInt(1)) {
+      throw {
+        code: INVALID_PARAMS,
+        message: 'Start and Count parameters cannot be less than 1',
+      }
+    }
     const currentChainHeight = (await this.chain.getCanonicalHeadHeader()).number
     if (start + count > currentChainHeight) {
       count = count - currentChainHeight

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -321,19 +321,9 @@ const assembleBlock = async (
 }
 
 const getPayloadBody = (block: Block): ExecutionPayloadBodyV1 => {
-  const transactions: string[] = []
-  for (const txn of block.transactions) {
-    transactions.push('0x' + txn.serialize().toString('hex'))
-  }
-  let withdrawals
-  if (block._common.gteHardfork(Hardfork.Shanghai)) {
-    withdrawals = []
-    for (const withdrawal of block.withdrawals!) {
-      withdrawals.push(withdrawal.toJSON() as WithdrawalV1)
-    }
-  } else {
-    withdrawals = null
-  }
+  const transactions = block.transactions.map((tx) => bufferToHex(tx.serialize()))
+  const withdrawals = block.withdrawals?.map((wt) => wt.toJSON()) ?? null
+
   return {
     transactions,
     withdrawals,

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -1019,9 +1019,9 @@ export class Engine {
    * @param params a list of block hashes as hex prefixed strings
    * @returns an array of ExecutionPayloadBodyV1 objects or null if a given execution payload isn't stored locally
    */
-  private getPayloadBodiesByHashV1 = async (
+  private async getPayloadBodiesByHashV1(
     params: [[Bytes32]]
-  ): Promise<(ExecutionPayloadBodyV1 | null)[]> => {
+  ): Promise<(ExecutionPayloadBodyV1 | null)[]> {
     if (params[0].length > 32) {
       throw {
         code: TOO_LARGE_REQUEST,
@@ -1061,9 +1061,9 @@ export class Engine {
    *    2.  count: Bytes8 - the number of blocks requested
    * @returns an array of ExecutionPayloadBodyV1 objects or null if a given execution payload isn't stored locally
    */
-  private getPayloadBodiesByRangeV1 = async (
+  private async getPayloadBodiesByRangeV1(
     params: [Bytes8, Bytes8]
-  ): Promise<(ExecutionPayloadBodyV1 | null)[]> => {
+  ): Promise<(ExecutionPayloadBodyV1 | null)[]> {
     const start = BigInt(params[0])
     let count = BigInt(params[1])
     if (count > BigInt(32)) {

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -461,9 +461,7 @@ export class Engine {
     )
 
     this.getPayloadBodiesByRangeV1 = cmMiddleware(
-      middleware(this.getPayloadBodiesByRangeV1.bind(this), 2, [
-        validators.array(validators.bytes8),
-      ]),
+      middleware(this.getPayloadBodiesByRangeV1.bind(this), 2, [validators.bytes8]),
       () => this.connectionManager.updateStatus()
     )
   }
@@ -1035,7 +1033,7 @@ export class Engine {
         const block = await this.chain.getBlock(hash)
         const transactions: string[] = []
         for (const txn of block.transactions) {
-          transactions.push('0x' + txn.serialize())
+          transactions.push('0x' + txn.serialize().toString('hex'))
         }
         let withdrawals
         if (block._common.gteHardfork(Hardfork.Shanghai)) {
@@ -1072,10 +1070,9 @@ export class Engine {
         message: 'More than 32 execution payload bodies requested',
       }
     }
-
     const currentChainHeight = (await this.chain.getCanonicalHeadHeader()).number
     if (start + count > currentChainHeight) {
-      count = currentChainHeight - count
+      count = count - currentChainHeight
     }
     const blocks = await this.chain.getBlocks(start, Number(count))
     const payloads: (ExecutionPayloadBodyV1 | null)[] = []
@@ -1083,7 +1080,7 @@ export class Engine {
       try {
         const transactions: string[] = []
         for (const txn of block.transactions) {
-          transactions.push('0x' + txn.serialize())
+          transactions.push('0x' + txn.serialize().toString('hex'))
         }
         let withdrawals
         if (block._common.gteHardfork(Hardfork.Shanghai)) {

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -1087,7 +1087,7 @@ export class Engine {
         message: 'Start and Count parameters cannot be less than 1',
       }
     }
-    const currentChainHeight = (await this.chain.getCanonicalHeadHeader()).number
+    const currentChainHeight = this.chain.headers.height
     if (start + count > currentChainHeight) {
       count = count - currentChainHeight
     }

--- a/packages/client/lib/rpc/validation.ts
+++ b/packages/client/lib/rpc/validation.ts
@@ -17,13 +17,12 @@ export function middleware(method: any, requiredParamsCount: number, validators:
         }
         return reject(error)
       }
-
-      for (let i = 0; i < params.length; i++) {
-        if (params[i] !== undefined) {
-          for (let j = 0; j < validators.length; j++) {
+      for (let i = 0; i < validators.length; i++) {
+        if (validators[i] !== undefined) {
+          for (let j = 0; j < validators[i].length; j++) {
             // Only apply validators if params[i] is a required parameter or exists
-            if (i < requiredParamsCount) {
-              const error = validators[j](params, i)
+            if (i < requiredParamsCount || params[i] !== undefined) {
+              const error = validators[i][j](params, i)
               if (error !== undefined) {
                 return reject(error)
               }
@@ -31,6 +30,7 @@ export function middleware(method: any, requiredParamsCount: number, validators:
           }
         }
       }
+
       resolve(method(params))
     })
   }
@@ -418,6 +418,7 @@ export const validators = {
   get array() {
     return (validator: Function) => {
       return (params: any[], index: number) => {
+        console.log(params, index)
         if (!Array.isArray(params[index])) {
           return {
             code: INVALID_PARAMS,

--- a/packages/client/lib/rpc/validation.ts
+++ b/packages/client/lib/rpc/validation.ts
@@ -18,12 +18,12 @@ export function middleware(method: any, requiredParamsCount: number, validators:
         return reject(error)
       }
 
-      for (let i = 0; i < validators.length; i++) {
-        if (validators[i] !== undefined) {
-          for (let j = 0; j < validators[i].length; j++) {
+      for (let i = 0; i < params.length; i++) {
+        if (params[i] !== undefined) {
+          for (let j = 0; j < validators.length; j++) {
             // Only apply validators if params[i] is a required parameter or exists
-            if (i < requiredParamsCount || params[i] !== undefined) {
-              const error = validators[i][j](params, i)
+            if (i < requiredParamsCount) {
+              const error = validators[j](params, i)
               if (error !== undefined) {
                 return reject(error)
               }
@@ -31,7 +31,6 @@ export function middleware(method: any, requiredParamsCount: number, validators:
           }
         }
       }
-
       resolve(method(params))
     })
   }

--- a/packages/client/lib/rpc/validation.ts
+++ b/packages/client/lib/rpc/validation.ts
@@ -418,7 +418,6 @@ export const validators = {
   get array() {
     return (validator: Function) => {
       return (params: any[], index: number) => {
-        console.log(params, index)
         if (!Array.isArray(params[index])) {
           return {
             code: INVALID_PARAMS,

--- a/packages/client/test/rpc/engine/getCapabilities.spec.ts
+++ b/packages/client/test/rpc/engine/getCapabilities.spec.ts
@@ -1,0 +1,21 @@
+import * as tape from 'tape'
+
+import { baseRequest, baseSetup, params } from '../helpers'
+
+const method = 'engine_getCapabilities'
+
+tape(`${method}: call with invalid payloadId`, async (t) => {
+  const { server } = baseSetup({ engine: true })
+
+  const req = params(method, [])
+  const expectRes = (res: any) => {
+    t.ok(res.body.result.length > 0, 'got more than 1 engine capability')
+    console.log(res.body.result)
+    t.equal(
+      res.body.result.findIndex((el: string) => el === 'engine_getCapabilities'),
+      -1,
+      'should not include engine_getCapabilities in response'
+    )
+  }
+  await baseRequest(t, server, req, 200, expectRes)
+})

--- a/packages/client/test/rpc/engine/getCapabilities.spec.ts
+++ b/packages/client/test/rpc/engine/getCapabilities.spec.ts
@@ -10,7 +10,6 @@ tape(`${method}: call with invalid payloadId`, async (t) => {
   const req = params(method, [])
   const expectRes = (res: any) => {
     t.ok(res.body.result.length > 0, 'got more than 1 engine capability')
-    console.log(res.body.result)
     t.equal(
       res.body.result.findIndex((el: string) => el === 'engine_getCapabilities'),
       -1,

--- a/packages/client/test/rpc/engine/getPayloadBodiesByHashV1.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadBodiesByHashV1.spec.ts
@@ -1,0 +1,28 @@
+import { Hardfork } from '@ethereumjs/common'
+import { DefaultStateManager } from '@ethereumjs/statemanager'
+import { TransactionFactory, initKZG } from '@ethereumjs/tx'
+import { Address } from '@ethereumjs/util'
+import * as kzg from 'c-kzg'
+import { randomBytes } from 'crypto'
+import * as tape from 'tape'
+
+import { TOO_LARGE_REQUEST } from '../../../lib/rpc/error-code'
+import { baseRequest, baseSetup, params } from '../helpers'
+import { checkError } from '../util'
+
+const method = 'engine_getPayloadBodiesByHashV1'
+
+tape(`${method}: call with too many hashes`, async (t) => {
+  const { server } = baseSetup({ engine: true, includeVM: true })
+  const tooManyHashes: string[] = []
+  for (let x = 0; x < 35; x++) {
+    tooManyHashes.push('0x' + randomBytes(32).toString('hex'))
+  }
+  const req = params(method, [tooManyHashes])
+  const expectRes = checkError(
+    t,
+    TOO_LARGE_REQUEST,
+    'More than 32 execution payload bodies requested'
+  )
+  await baseRequest(t, server, req, 200, expectRes)
+})

--- a/packages/client/test/rpc/engine/getPayloadBodiesByHashV1.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadBodiesByHashV1.spec.ts
@@ -1,13 +1,14 @@
+import { Block, BlockHeader } from '@ethereumjs/block'
 import { Hardfork } from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
-import { TransactionFactory, initKZG } from '@ethereumjs/tx'
+import { TransactionFactory } from '@ethereumjs/tx'
 import { Address } from '@ethereumjs/util'
-import * as kzg from 'c-kzg'
 import { randomBytes } from 'crypto'
 import * as tape from 'tape'
 
 import { TOO_LARGE_REQUEST } from '../../../lib/rpc/error-code'
-import { baseRequest, baseSetup, params } from '../helpers'
+import genesisJSON = require('../../testdata/geth-genesis/eip4844.json')
+import { baseRequest, baseSetup, params, setupChain } from '../helpers'
 import { checkError } from '../util'
 
 const method = 'engine_getPayloadBodiesByHashV1'
@@ -25,4 +26,84 @@ tape(`${method}: call with too many hashes`, async (t) => {
     'More than 32 execution payload bodies requested'
   )
   await baseRequest(t, server, req, 200, expectRes)
+})
+
+tape.only(`${method}: call with valid parameters`, async (t) => {
+  // Disable stateroot validation in TxPool since valid state root isn't available
+  const originalSetStateRoot = DefaultStateManager.prototype.setStateRoot
+  const originalStateManagerCopy = DefaultStateManager.prototype.copy
+  DefaultStateManager.prototype.setStateRoot = function (): any {}
+  DefaultStateManager.prototype.copy = function () {
+    return this
+  }
+  const { chain, service, server, common } = await setupChain(genesisJSON, 'post-merge', {
+    engine: true,
+    hardfork: Hardfork.ShardingForkDev,
+  })
+  common.setHardfork(Hardfork.ShardingForkDev)
+  const pkey = Buffer.from(
+    '9c9996335451aab4fc4eac58e31a8c300e095cdbcee532d53d09280e83360355',
+    'hex'
+  )
+  const address = Address.fromPrivateKey(pkey)
+  const account = await service.execution.vm.stateManager.getAccount(address)
+
+  account.balance = 0xfffffffffffffffn
+  await service.execution.vm.stateManager.putAccount(address, account)
+  const tx = TransactionFactory.fromTxData(
+    {
+      type: 0x01,
+      maxFeePerDataGas: 1n,
+      maxFeePerGas: 10000000000n,
+      maxPriorityFeePerGas: 100000000n,
+      gasLimit: 30000000n,
+    },
+    { common }
+  ).sign(pkey)
+  const tx2 = TransactionFactory.fromTxData(
+    {
+      type: 0x01,
+      maxFeePerDataGas: 1n,
+      maxFeePerGas: 10000000000n,
+      maxPriorityFeePerGas: 100000000n,
+      gasLimit: 30000000n,
+      nonce: 1n,
+    },
+    { common }
+  ).sign(pkey)
+  const block = Block.fromBlockData(
+    {
+      transactions: [tx],
+      header: BlockHeader.fromHeaderData(
+        { parentHash: chain.genesis.hash(), number: 1n },
+        { common, skipConsensusFormatValidation: true }
+      ),
+    },
+    { common, skipConsensusFormatValidation: true }
+  )
+  const block2 = Block.fromBlockData(
+    {
+      transactions: [tx2],
+      header: BlockHeader.fromHeaderData(
+        { parentHash: block.hash(), number: 2n },
+        { common, skipConsensusFormatValidation: true }
+      ),
+    },
+    { skipConsensusFormatValidation: true }
+  )
+
+  const num = await chain.putBlocks([block, block2], true)
+
+  const req = params(method, [['0x' + block.hash().toString('hex')]])
+  const expectRes = (res: any) => {
+    t.equal(
+      res.body.result.blockHash,
+      '0x467ffd05100e34088fbc3eee3966304a3330ac37fe5d85c1873a867f514112e6',
+      'got expected blockHash'
+    )
+  }
+  await baseRequest(t, server, req, 200, expectRes, false)
+  // Restore setStateRoot
+  DefaultStateManager.prototype.setStateRoot = originalSetStateRoot
+  DefaultStateManager.prototype.copy = originalStateManagerCopy
 })

--- a/packages/client/test/rpc/engine/getPayloadBodiesByRangeV1.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadBodiesByRangeV1.spec.ts
@@ -126,7 +126,7 @@ tape(`${method}: call with valid parameters`, async (t) => {
       'got empty array when start of requested range is beyond current chain head'
     )
   }
-  await baseRequest(t, server, req2, 200, expectRes2, false)
+  await baseRequest(t, server, req2, 200, expectRes2)
   // Restore setStateRoot
   DefaultStateManager.prototype.setStateRoot = originalSetStateRoot
   DefaultStateManager.prototype.copy = originalStateManagerCopy
@@ -207,7 +207,7 @@ tape(`${method}: call with valid parameters on pre-Shanghai hardfork`, async (t)
     )
   }
   service.execution.vm._common.setHardfork(Hardfork.London)
-  await baseRequest(t, server, req, 200, expectRes, false)
+  await baseRequest(t, server, req, 200, expectRes)
   // Restore setStateRoot
   DefaultStateManager.prototype.setStateRoot = originalSetStateRoot
   DefaultStateManager.prototype.copy = originalStateManagerCopy

--- a/packages/client/test/rpc/engine/getPayloadBodiesByRangeV1.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadBodiesByRangeV1.spec.ts
@@ -3,11 +3,11 @@ import { Hardfork } from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { TransactionFactory } from '@ethereumjs/tx'
 import { Address } from '@ethereumjs/util'
-import { randomBytes } from 'crypto'
 import * as tape from 'tape'
 
-import { TOO_LARGE_REQUEST } from '../../../lib/rpc/error-code'
+import { INVALID_PARAMS, TOO_LARGE_REQUEST } from '../../../lib/rpc/error-code'
 import genesisJSON = require('../../testdata/geth-genesis/eip4844.json')
+import preShanghaiGenesisJSON = require('../../testdata/geth-genesis/post-merge.json')
 import { baseRequest, baseSetup, params, setupChain } from '../helpers'
 import { checkError } from '../util'
 
@@ -15,15 +15,24 @@ const method = 'engine_getPayloadBodiesByRangeV1'
 
 tape(`${method}: call with too many hashes`, async (t) => {
   const { server } = baseSetup({ engine: true, includeVM: true })
-  const tooManyHashes: string[] = []
-  for (let x = 0; x < 35; x++) {
-    tooManyHashes.push('0x' + randomBytes(32).toString('hex'))
-  }
-  const req = params(method, [tooManyHashes])
+
+  const req = params(method, ['0x1', '0x55'])
   const expectRes = checkError(
     t,
     TOO_LARGE_REQUEST,
     'More than 32 execution payload bodies requested'
+  )
+  await baseRequest(t, server, req, 200, expectRes)
+})
+
+tape(`${method}: call with invalid parameters`, async (t) => {
+  const { server } = baseSetup({ engine: true, includeVM: true })
+
+  const req = params(method, ['0x0', '0x0'])
+  const expectRes = checkError(
+    t,
+    INVALID_PARAMS,
+    'Start and Count parameters cannot be less than 1'
   )
   await baseRequest(t, server, req, 200, expectRes)
 })
@@ -118,6 +127,87 @@ tape(`${method}: call with valid parameters`, async (t) => {
     )
   }
   await baseRequest(t, server, req2, 200, expectRes2, false)
+  // Restore setStateRoot
+  DefaultStateManager.prototype.setStateRoot = originalSetStateRoot
+  DefaultStateManager.prototype.copy = originalStateManagerCopy
+})
+
+tape(`${method}: call with valid parameters on pre-Shanghai hardfork`, async (t) => {
+  // Disable stateroot validation in TxPool since valid state root isn't available
+  const originalSetStateRoot = DefaultStateManager.prototype.setStateRoot
+  const originalStateManagerCopy = DefaultStateManager.prototype.copy
+  DefaultStateManager.prototype.setStateRoot = function (): any {}
+  DefaultStateManager.prototype.copy = function () {
+    return this
+  }
+  const { chain, service, server, common } = await setupChain(preShanghaiGenesisJSON, 'london', {
+    engine: true,
+    hardfork: Hardfork.London,
+  })
+  common.setHardfork(Hardfork.London)
+  const pkey = Buffer.from(
+    '9c9996335451aab4fc4eac58e31a8c300e095cdbcee532d53d09280e83360355',
+    'hex'
+  )
+  const address = Address.fromPrivateKey(pkey)
+  const account = await service.execution.vm.stateManager.getAccount(address)
+
+  account.balance = 0xfffffffffffffffn
+  await service.execution.vm.stateManager.putAccount(address, account)
+  const tx = TransactionFactory.fromTxData(
+    {
+      type: 0x01,
+      maxFeePerDataGas: 1n,
+      maxFeePerGas: 10000000000n,
+      maxPriorityFeePerGas: 100000000n,
+      gasLimit: 30000000n,
+    },
+    { common }
+  ).sign(pkey)
+  const tx2 = TransactionFactory.fromTxData(
+    {
+      type: 0x01,
+      maxFeePerDataGas: 1n,
+      maxFeePerGas: 10000000000n,
+      maxPriorityFeePerGas: 100000000n,
+      gasLimit: 30000000n,
+      nonce: 1n,
+    },
+    { common }
+  ).sign(pkey)
+  const block = Block.fromBlockData(
+    {
+      transactions: [tx],
+      header: BlockHeader.fromHeaderData(
+        { parentHash: chain.genesis.hash(), number: 1n },
+        { common, skipConsensusFormatValidation: true }
+      ),
+    },
+    { common, skipConsensusFormatValidation: true }
+  )
+  const block2 = Block.fromBlockData(
+    {
+      transactions: [tx2],
+      header: BlockHeader.fromHeaderData(
+        { parentHash: block.hash(), number: 2n },
+        { common, skipConsensusFormatValidation: true }
+      ),
+    },
+    { common, skipConsensusFormatValidation: true }
+  )
+
+  await chain.putBlocks([block, block2], true)
+
+  const req = params(method, ['0x1', '0x4'])
+  const expectRes = (res: any) => {
+    t.equal(
+      res.body.result[0].withdrawals,
+      null,
+      'withdrawals field is null for pre-shanghai blocks'
+    )
+  }
+  service.execution.vm._common.setHardfork(Hardfork.London)
+  await baseRequest(t, server, req, 200, expectRes, false)
   // Restore setStateRoot
   DefaultStateManager.prototype.setStateRoot = originalSetStateRoot
   DefaultStateManager.prototype.copy = originalStateManagerCopy

--- a/packages/client/test/rpc/engine/getPayloadBodiesByRangeV1.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadBodiesByRangeV1.spec.ts
@@ -28,7 +28,7 @@ tape(`${method}: call with too many hashes`, async (t) => {
   await baseRequest(t, server, req, 200, expectRes)
 })
 
-tape.only(`${method}: call with valid parameters`, async (t) => {
+tape(`${method}: call with valid parameters`, async (t) => {
   // Disable stateroot validation in TxPool since valid state root isn't available
   const originalSetStateRoot = DefaultStateManager.prototype.setStateRoot
   const originalStateManagerCopy = DefaultStateManager.prototype.copy


### PR DESCRIPTION
Adds new engine apis
- `getCapabilties` endpoint defined here [https://github.com/ethereum/execution-apis/pull/364](https://github.com/ethereum/execution-apis/pull/364)
- `getPayloadBodiesByHashV1` from [here](https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_getpayloadbodiesbyhashv1)
- `getPayloadBodiesByRangeV1` from [here](https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#engine_getpayloadbodiesbyrangev1)