### PR TITLE
More Interop Log Improvements

### DIFF
--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -329,6 +329,9 @@ export class Engine {
   private remoteBlocks: Map<String, Block>
   private connectionManager: CLConnectionManager
 
+  private lastNewPayloadHF: string = ''
+  private lastForkchoiceUpdatedHF: string = ''
+
   /**
    * Create engine_* RPC module
    * @param client Client to which the module binds
@@ -478,6 +481,16 @@ export class Engine {
       }
       return response
     }
+
+    const hardfork = block._common.hardfork()
+    if (hardfork !== this.lastNewPayloadHF && this.lastNewPayloadHF !== '') {
+      this.config.logger.info(
+        `Hardfork change along new payload block number=${block.header.number} hash=${short(
+          block.hash()
+        )} old=${this.lastNewPayloadHF} new=${hardfork}`
+      )
+    }
+    this.lastNewPayloadHF = hardfork
 
     // This optimistic lookup keeps skeleton updated even if for e.g. beacon sync might not have
     // been initialized here but a batch of blocks new payloads arrive, most likely during sync
@@ -692,6 +705,16 @@ export class Engine {
         this.remoteBlocks.delete(headBlockHash.slice(2))
       }
     }
+
+    const hardfork = headBlock._common.hardfork()
+    if (hardfork !== this.lastForkchoiceUpdatedHF && this.lastForkchoiceUpdatedHF !== '') {
+      this.config.logger.info(
+        `Hardfork change along forkchoice head block update number=${
+          headBlock.header.number
+        } hash=${short(headBlock.hash())} old=${this.lastForkchoiceUpdatedHF} new=${hardfork}`
+      )
+    }
+    this.lastForkchoiceUpdatedHF = hardfork
 
     // Always keep beaconSync skeleton updated so that it stays updated with any skeleton sync
     // requirements that might come later because of reorg or CL restarts

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -482,6 +482,8 @@ export class Engine {
       return response
     }
 
+    this.connectionManager.updatePayloadStats(block)
+
     const hardfork = block._common.hardfork()
     if (hardfork !== this.lastNewPayloadHF && this.lastNewPayloadHF !== '') {
       this.config.logger.info(


### PR DESCRIPTION
Some more log improvements related to understand/monitor post-Merge HF switches and get a better feeling for what happens during sync along the new payload calls by adding some comprehensive payload to payload aggregated stats (numbers of blocks processed/assembled, min/max block numbers involved, tx counts per tx types).

Open for review and merge I guess (might add more though, nevertheless: open for merge, then I'll submit on another PR).