### PR TITLE
`getPayloadBodiesByRange` fixes

### DIFF
--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -1088,8 +1088,12 @@ export class Engine {
       }
     }
     const currentChainHeight = this.chain.headers.height
+    if (start > currentChainHeight) {
+      return []
+    }
+
     if (start + count > currentChainHeight) {
-      count = count - currentChainHeight
+      count = currentChainHeight - start + BigInt(1)
     }
     const blocks = await this.chain.getBlocks(start, Number(count))
     const payloads: (ExecutionPayloadBodyV1 | null)[] = []


### PR DESCRIPTION
A couple of small fixes identified while running the `getPayloadBodiesByRange` tests from [this PR](https://github.com/ethereum/hive/pull/700)