### PR TITLE
Revert PR #2516 Blockchain.getBlock() return Null instead of throwing

### DIFF
--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -5,7 +5,7 @@ import { MemoryLevel } from 'memory-level'
 
 import { CasperConsensus, CliqueConsensus, EthashConsensus } from './consensus'
 import { DBOp, DBSaveLookups, DBSetBlockOrHeader, DBSetHashToNumber, DBSetTD } from './db/helpers'
-import { DBManager, NotFoundError } from './db/manager'
+import { DBManager } from './db/manager'
 import { DBTarget } from './db/operation'
 import { genesisStateRoot } from './genesisStates'
 import {} from './utils'
@@ -311,9 +311,10 @@ export class Blockchain implements BlockchainInterface {
    */
   async getIteratorHead(name = 'vm'): Promise<Block> {
     return this.runWithLock<Block>(async () => {
+      // if the head is not found return the genesis hash
       const hash = this._heads[name] ?? this.genesisBlock.hash()
       const block = await this.getBlock(hash)
-      return block!
+      return block
     })
   }
 
@@ -334,7 +335,7 @@ export class Blockchain implements BlockchainInterface {
       const hash = this._heads[name] ?? this._headBlockHash
       if (hash === undefined) throw new Error('No head found.')
       const block = await this.getBlock(hash)
-      return block!
+      return block
     })
   }
 
@@ -345,9 +346,6 @@ export class Blockchain implements BlockchainInterface {
     return this.runWithLock<BlockHeader>(async () => {
       if (!this._headHeaderHash) throw new Error('No head header set')
       const block = await this.getBlock(this._headHeaderHash)
-      if (block === null) {
-        throw new Error('No head header found')
-      }
       return block.header
     })
   }
@@ -358,11 +356,7 @@ export class Blockchain implements BlockchainInterface {
   async getCanonicalHeadBlock(): Promise<Block> {
     return this.runWithLock<Block>(async () => {
       if (!this._headBlockHash) throw new Error('No head block set')
-      const block = await this.getBlock(this._headBlockHash)
-      if (block === null) {
-        throw new Error('No head block found.')
-      }
-      return block
+      return this.getBlock(this._headBlockHash)
     })
   }
 
@@ -552,11 +546,7 @@ export class Blockchain implements BlockchainInterface {
     if (header.isGenesis()) {
       return
     }
-    const parent = await this.getBlock(header.parentHash)
-    if (parent === null) {
-      throw new NotFoundError(header.number - BigInt(1))
-    }
-    const parentHeader = parent.header
+    const parentHeader = (await this.getBlock(header.parentHash)).header
 
     const { number } = header
     if (number !== parentHeader.number + BigInt(1)) {
@@ -619,9 +609,6 @@ export class Blockchain implements BlockchainInterface {
     // TODO: Rethink how validateHeader vs validateBlobTransactions works since the parentHeader is retrieved multiple times
     // (one for each uncle header and then for validateBlobTxs).
     const parentBlock = await this.getBlock(block.header.parentHash)
-    if (parentBlock === null) {
-      throw new NotFoundError(block.header.number - BigInt(1))
-    }
     block.validateBlobTransactions(parentBlock.header)
   }
   /**
@@ -666,7 +653,7 @@ export class Blockchain implements BlockchainInterface {
     let parentHash = block.header.parentHash
     for (let i = 0; i < getBlocks; i++) {
       const parentBlock = await this.getBlock(parentHash)
-      if (parentBlock === null) {
+      if (parentBlock === undefined) {
         throw new Error(`could not find parent block ${block.errorStr()}`)
       }
       canonicalBlockMap.push(parentBlock)
@@ -715,17 +702,13 @@ export class Blockchain implements BlockchainInterface {
    * this will be immediately looked up, otherwise it will wait until we have
    * unlocked the DB
    */
-  async getBlock(blockId: Buffer | number | bigint): Promise<Block | null> {
+  async getBlock(blockId: Buffer | number | bigint): Promise<Block> {
     // cannot wait for a lock here: it is used both in `validate` of `Block`
     // (calls `getBlock` to get `parentHash`) it is also called from `runBlock`
     // in the `VM` if we encounter a `BLOCKHASH` opcode: then a bigint is used we
     // need to then read the block from the canonical chain Q: is this safe? We
     // know it is OK if we call it from the iterator... (runBlock)
-    try {
-      return await this.dbManager.getBlock(blockId)
-    } catch {
-      return null
-    }
+    return this.dbManager.getBlock(blockId)
   }
 
   /**
@@ -757,8 +740,13 @@ export class Blockchain implements BlockchainInterface {
       let i = -1
 
       const nextBlock = async (blockId: Buffer | bigint | number): Promise<any> => {
-        const block = await this.getBlock(blockId)
-        if (block === null) {
+        let block
+        try {
+          block = await this.getBlock(blockId)
+        } catch (error: any) {
+          if (error.code !== 'LEVEL_NOT_FOUND') {
+            throw error
+          }
           return
         }
         i++
@@ -942,10 +930,7 @@ export class Blockchain implements BlockchainInterface {
       while (maxBlocks !== blocksRanCounter) {
         try {
           let nextBlock = await this.getBlock(nextBlockNumber)
-          if (nextBlock === null) {
-            break
-          }
-          const reorg = lastBlock ? !lastBlock.hash().equals(nextBlock!.header.parentHash) : false
+          const reorg = lastBlock ? !lastBlock.hash().equals(nextBlock.header.parentHash) : false
           if (reorg) {
             // If reorg has happened, the _heads must have been updated so lets reload the counters
             headHash = this._heads[name] ?? this.genesisBlock.hash()
@@ -953,13 +938,13 @@ export class Blockchain implements BlockchainInterface {
             nextBlockNumber = headBlockNumber + BigInt(1)
             nextBlock = await this.getBlock(nextBlockNumber)
           }
-          this._heads[name] = nextBlock!.hash()
-          lastBlock = nextBlock!
+          this._heads[name] = nextBlock.hash()
+          lastBlock = nextBlock
           if (releaseLockOnCallback === true) {
             this._lock.release()
           }
           try {
-            await onBlock(nextBlock!, reorg)
+            await onBlock(nextBlock, reorg)
           } finally {
             if (releaseLockOnCallback === true) {
               await this._lock.acquire()
@@ -1003,11 +988,8 @@ export class Blockchain implements BlockchainInterface {
   private async findCommonAncestor(newHeader: BlockHeader) {
     if (!this._headHeaderHash) throw new Error('No head header set')
     const ancestorHeaders = new Set<BlockHeader>()
-    const block = await this.getBlock(this._headHeaderHash)
-    if (block === null) {
-      throw new Error('Could not find block 0x' + this._headHeaderHash.toString('hex'))
-    }
-    let { header } = block
+
+    let { header } = await this.getBlock(this._headHeaderHash)
     if (header.number > newHeader.number) {
       header = await this.getCanonicalHeader(newHeader.number)
       ancestorHeaders.add(header)

--- a/packages/blockchain/src/consensus/ethash.ts
+++ b/packages/blockchain/src/consensus/ethash.ts
@@ -1,8 +1,6 @@
 import { ConsensusAlgorithm } from '@ethereumjs/common'
 import { Ethash } from '@ethereumjs/ethash'
 
-import { NotFoundError } from '..'
-
 import type { Blockchain } from '..'
 import type { Consensus, ConsensusOptions } from './interface'
 import type { Block, BlockHeader } from '@ethereumjs/block'
@@ -38,11 +36,8 @@ export class EthashConsensus implements Consensus {
     if (!this.blockchain) {
       throw new Error('blockchain not provided')
     }
-    const parent = await this.blockchain.getBlock(header.parentHash)
-    if (parent === null) {
-      throw new NotFoundError(header.number - BigInt(1))
-    }
-    if (header.ethashCanonicalDifficulty(parent.header) !== header.difficulty) {
+    const parentHeader = (await this.blockchain.getBlock(header.parentHash)).header
+    if (header.ethashCanonicalDifficulty(parentHeader) !== header.difficulty) {
       throw new Error(`invalid difficulty ${header.errorStr()}`)
     }
   }

--- a/packages/blockchain/src/db/manager.ts
+++ b/packages/blockchain/src/db/manager.ts
@@ -10,7 +10,7 @@ import type { BlockBodyBuffer, BlockBuffer, BlockOptions } from '@ethereumjs/blo
 import type { Common } from '@ethereumjs/common'
 import type { AbstractLevel } from 'abstract-level'
 
-export class NotFoundError extends Error {
+class NotFoundError extends Error {
   public code: string = 'LEVEL_NOT_FOUND'
 
   constructor(blockNumber: bigint) {

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -1,5 +1,4 @@
 export { Blockchain } from './blockchain'
 export { CasperConsensus, CliqueConsensus, Consensus, EthashConsensus } from './consensus'
-export { NotFoundError } from './db/manager'
 export { BlockchainInterface, BlockchainOptions } from './types'
 export * from './utils'

--- a/packages/blockchain/test/blockValidation.spec.ts
+++ b/packages/blockchain/test/blockValidation.spec.ts
@@ -11,22 +11,6 @@ import { Blockchain } from '../src'
 import { createBlock } from './util'
 
 tape('[Blockchain]: Block validation tests', (t) => {
-  t.test('should not be able to validate difficulty without parent', async (st) => {
-    const blockchain = await Blockchain.create({
-      validateBlocks: true,
-      validateConsensus: false,
-    })
-    try {
-      await blockchain.consensus.validateDifficulty(blockchain.genesisBlock.header)
-      st.fail('should have thrown')
-    } catch (error: any) {
-      st.equal(
-        error.message,
-        `Key ${blockchain.genesisBlock.header.number - BigInt(1)} was not found`
-      )
-    }
-    st.end()
-  })
   t.test('should throw if an uncle is included before', async function (st) {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
     const blockchain = await Blockchain.create({ common, validateConsensus: false })

--- a/packages/blockchain/test/clique.spec.ts
+++ b/packages/blockchain/test/clique.spec.ts
@@ -292,7 +292,7 @@ tape('Clique: Initialization', (t) => {
     // noturn block
     await addNextBlock(blockchain, blocks, A)
     const block = await blockchain.getBlock(1)
-    if (block && inturnBlock.hash().equals(block.hash())) {
+    if (inturnBlock.hash().equals(block.hash())) {
       st.pass('correct canonical block')
     } else {
       st.fail('invalid canonical block')

--- a/packages/blockchain/test/index.spec.ts
+++ b/packages/blockchain/test/index.spec.ts
@@ -20,32 +20,17 @@ tape('blockchain test', (t) => {
     await blockchain.getIteratorHead()
     st.end()
   })
-  t.test('should throw when validating a block without its parent', async (st) => {
-    const blockchain = await Blockchain.create({
-      validateBlocks: true,
-      validateConsensus: false,
-    })
-    const block = await blockchain.getIteratorHead()
-    try {
-      await blockchain.validateBlock(block)
-      st.fail('should throw')
-    } catch (e: any) {
-      st.equal(
-        e.message,
-        `Key ${block.header.number - BigInt(1)} was not found`,
-        'should throw during validation when no parent block is found'
-      )
-    }
-    st.end()
-  })
 
   t.test('should initialize correctly', async (st) => {
     const common = new Common({ chain: Chain.Ropsten })
     let blockchain = await Blockchain.create({ common })
 
     const iteratorHead = await blockchain.getIteratorHead()
-    const hash = iteratorHead instanceof Block ? iteratorHead.hash() : iteratorHead
-    st.ok(hash.equals(blockchain.genesisBlock.hash()), 'correct genesis hash (getIteratorHead())')
+
+    st.ok(
+      iteratorHead.hash().equals(blockchain.genesisBlock.hash()),
+      'correct genesis hash (getIteratorHead())'
+    )
 
     blockchain = await Blockchain.create({ common, hardforkByHeadBlockNumber: true })
     st.equal(
@@ -95,46 +80,6 @@ tape('blockchain test', (t) => {
       genesisBlock.hash().equals((await blockchain.getCanonicalHeadHeader()).hash()),
       'genesis block hash should be correct'
     )
-    st.end()
-  })
-
-  t.test('getCanonicalHeadHeader should throw if getBlock returns null', async (st) => {
-    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const genesisBlock = Block.fromBlockData({ header: { number: 0 } }, { common })
-    const blockchain = await Blockchain.create({
-      common,
-      validateBlocks: true,
-      validateConsensus: false,
-      genesisBlock,
-    })
-    ;(blockchain as any)._headHeaderHash = Buffer.from(
-      '3383a90a5f14b3ed85579c4e81e8f73e2f414405ecb60cdddb73bbb90d4d5a2d',
-      'hex'
-    )
-
-    try {
-      st.notOk(
-        genesisBlock.hash().equals((await blockchain.getCanonicalHeadHeader()).hash()),
-        'this test should throw'
-      )
-      st.fail('should have thrown')
-    } catch (e: any) {
-      st.equal(
-        e.message,
-        'No head header found',
-        'getCanonicalHeadHeader() should throw when block is not found'
-      )
-    }
-    try {
-      await (blockchain as any).findCommonAncestor(genesisBlock.header)
-      st.fail('should have thrown')
-    } catch (e: any) {
-      st.equal(
-        e.message,
-        'Could not find block 0x3383a90a5f14b3ed85579c4e81e8f73e2f414405ecb60cdddb73bbb90d4d5a2d',
-        'blockchain.findCommonAncestor() should throw when head block is not found'
-      )
-    }
     st.end()
   })
 
@@ -239,7 +184,7 @@ tape('blockchain test', (t) => {
     await blockchain.putBlock(block)
 
     const returnedBlock = await blockchain.getBlock(1)
-    if (returnedBlock !== null) {
+    if (typeof returnedBlock !== 'undefined') {
       st.ok(returnedBlock.hash().equals(blocks[1].hash()))
     } else {
       st.fail('block is not defined!')
@@ -259,7 +204,7 @@ tape('blockchain test', (t) => {
       genesisBlock,
     })
     const block = await blockchain.getBlock(genesisBlock.hash())
-    if (block !== null) {
+    if (typeof block !== 'undefined') {
       st.ok(block.hash().equals(genesisBlock.hash()))
     } else {
       st.fail('block is not defined!')
@@ -684,13 +629,6 @@ tape('blockchain test', (t) => {
 
     const getBlock = await blockchain.getCanonicalHeadBlock()
     st.ok(getBlock!.hash().equals(block.hash()), 'should update latest block')
-    ;(blockchain as any)._headBlockHash = Buffer.from('f000', 'hex')
-    try {
-      await blockchain.getCanonicalHeadBlock()
-      st.fail('should throw on missing head block')
-    } catch (e: any) {
-      st.equal(e.message, 'No head block found.', 'should throw on missing head block')
-    }
     st.end()
   })
 
@@ -755,19 +693,20 @@ tape('initialization tests', (t) => {
     })
     const blockchain = await Blockchain.create({ common })
     const genesisHash = blockchain.genesisBlock.hash()
-    const iteratorHead = await blockchain.getIteratorHead()
-    const iteratorHash = iteratorHead instanceof Block ? iteratorHead.hash() : iteratorHead
 
-    st.ok(iteratorHash.equals(genesisHash), 'head hash should equal expected ropsten genesis hash')
+    st.ok(
+      (await blockchain.getIteratorHead()).hash().equals(genesisHash),
+      'head hash should equal expected ropsten genesis hash'
+    )
 
     const db = blockchain.db
 
     const newBlockchain = await Blockchain.create({ db, common })
 
-    const newIteratorHead = await newBlockchain.getIteratorHead()
-    const newIteratorHash =
-      newIteratorHead instanceof Block ? newIteratorHead.hash() : newIteratorHead
-    st.ok(newIteratorHash.equals(genesisHash), 'head hash should be read from the provided db')
+    st.ok(
+      (await newBlockchain.getIteratorHead()).hash().equals(genesisHash),
+      'head hash should be read from the provided db'
+    )
     st.end()
   })
 

--- a/packages/blockchain/test/iterator.spec.ts
+++ b/packages/blockchain/test/iterator.spec.ts
@@ -1,9 +1,10 @@
-import { Block } from '@ethereumjs/block'
 import * as tape from 'tape'
 
 import { Blockchain } from '../src'
 
 import { createTestDB, generateBlockchain, generateConsecutiveBlock } from './util'
+
+import type { Block } from '@ethereumjs/block'
 
 tape('blockchain test', (t) => {
   t.test('should iterate through 24 blocks without reorg', async (st) => {
@@ -196,8 +197,7 @@ tape('blockchain test', (t) => {
     const blockchain = await Blockchain.create({ db, genesisBlock: genesis })
     const head = await blockchain.getIteratorHead()
     if (typeof genesis !== 'undefined') {
-      const headHash = head instanceof Block ? head.hash() : head
-      st.ok(headHash.equals(genesis.hash()), 'should get head')
+      st.ok(head.hash().equals(genesis.hash()), 'should get head')
       st.equal(
         (blockchain as any)._heads['head0'].toString('hex'),
         'abcd',

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -371,8 +371,8 @@ async function startBlock(client: EthereumClient) {
   try {
     const headBlock = await blockchain.getBlock(startBlock)
     const delBlock = await blockchain.getBlock(startBlock + BigInt(1))
-    await blockchain.delBlock(delBlock!.hash())
-    logger.info(`Chain height reset to ${headBlock!.header.number}`)
+    await blockchain.delBlock(delBlock.hash())
+    logger.info(`Chain height reset to ${headBlock.header.number}`)
   } catch (err: any) {
     logger.error(`Error setting back chain in startBlock: ${err}`)
     process.exit()

--- a/packages/client/lib/blockchain/chain.ts
+++ b/packages/client/lib/blockchain/chain.ts
@@ -254,10 +254,9 @@ export class Chain {
    * @param block block hash or number
    * @throws if block is not found
    */
-  async getBlock(block: Buffer | bigint): Promise<Block | null> {
+  async getBlock(block: Buffer | bigint): Promise<Block> {
     if (!this.opened) throw new Error('Chain closed')
-    const gotBlock = await this.blockchain.getBlock(block)
-    return gotBlock
+    return this.blockchain.getBlock(block)
   }
 
   /**

--- a/packages/client/lib/execution/receipt.ts
+++ b/packages/client/lib/execution/receipt.ts
@@ -1,4 +1,3 @@
-import { NotFoundError } from '@ethereumjs/blockchain'
 import { RLP } from '@ethereumjs/rlp'
 import {
   arrToBufArr,
@@ -139,9 +138,6 @@ export class ReceiptsManager extends MetaDBManager {
     }
     if (includeTxType) {
       const block = await this.chain.getBlock(blockHash)
-      if (block === null) {
-        throw new Error('Block not found')
-      }
       receipts = (receipts as TxReceiptWithType[]).map((r, i) => {
         r.txType = block.transactions[i].type
         return r
@@ -180,9 +176,6 @@ export class ReceiptsManager extends MetaDBManager {
     let returnedLogsSize = 0
     for (let i = from.header.number; i <= to.header.number; i++) {
       const block = await this.chain.getBlock(i)
-      if (block === null) {
-        throw new NotFoundError(i)
-      }
       const receipts = await this.getReceipts(block.hash())
       if (receipts.length === 0) continue
       let logs: GetLogsReturn = []
@@ -268,8 +261,7 @@ export class ReceiptsManager extends MetaDBManager {
             const limit = this.chain.headers.height - BigInt(this.config.txLookupLimit)
             if (limit < BigInt(0)) return
             const blockDelIndexes = await this.chain.getBlock(limit)
-            blockDelIndexes &&
-              void this.updateIndex(IndexOperation.Delete, IndexType.TxHash, blockDelIndexes)
+            void this.updateIndex(IndexOperation.Delete, IndexType.TxHash, blockDelIndexes)
           }
         } else if (operation === IndexOperation.Delete) {
           for (const tx of block.transactions) {

--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -205,9 +205,7 @@ export class VMExecution extends Execution {
     let canonicalHead = await blockchain.getCanonicalHeadBlock()
 
     this.config.logger.debug(
-      `Running execution startHeadBlock=${
-        startHeadBlock instanceof Buffer ? '' : startHeadBlock.header.number
-      } canonicalHead=${canonicalHead?.header.number} loop=${loop}`
+      `Running execution startHeadBlock=${startHeadBlock?.header.number} canonicalHead=${canonicalHead?.header.number} loop=${loop}`
     )
 
     let headBlock: Block | undefined
@@ -221,7 +219,6 @@ export class VMExecution extends Execution {
           canonicalHead.header.number - startHeadBlock.header.number >=
             BigInt(this.NUM_BLOCKS_PER_ITERATION))) &&
       (numExecuted === undefined || (loop && numExecuted === this.NUM_BLOCKS_PER_ITERATION)) &&
-      !(startHeadBlock instanceof Buffer) &&
       startHeadBlock.hash().equals(canonicalHead.hash()) === false
     ) {
       let txCounter = 0

--- a/packages/client/lib/rpc/modules/debug.ts
+++ b/packages/client/lib/rpc/modules/debug.ts
@@ -106,9 +106,7 @@ export class Debug {
       if (!result) return null
       const [_, blockHash, txIndex] = result
       const block = await this.service.chain.getBlock(blockHash)
-      if (block === null) return null
       const parentBlock = await this.service.chain.getBlock(block.header.parentHash)
-      if (parentBlock === null) return null
       const tx = block.transactions[txIndex]
 
       // Copy VM so as to not modify state when running transactions being traced

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -193,7 +193,7 @@ const getBlockByOption = async (blockOpt: string, chain: Chain) => {
   if (blockOpt === 'latest') {
     block = latest
   } else if (blockOpt === 'earliest') {
-    block = (await chain.getBlock(BigInt(0)))!
+    block = await chain.getBlock(BigInt(0))
   } else {
     const blockNumber = BigInt(blockOpt)
     if (blockNumber === latest.header.number) {
@@ -204,7 +204,7 @@ const getBlockByOption = async (blockOpt: string, chain: Chain) => {
         message: 'specified block greater than current height',
       }
     } else {
-      block = (await chain.getBlock(blockNumber))!
+      block = await chain.getBlock(blockNumber)
     }
   }
 
@@ -519,7 +519,7 @@ export class Eth {
 
     try {
       const block = await this._chain.getBlock(toBuffer(blockHash))
-      return await jsonRpcBlock(block!, this._chain, includeTransactions)
+      return await jsonRpcBlock(block, this._chain, includeTransactions)
     } catch (error) {
       throw {
         code: INVALID_PARAMS,
@@ -548,7 +548,7 @@ export class Eth {
     const [blockHash] = params
     try {
       const block = await this._chain.getBlock(toBuffer(blockHash))
-      return intToHex(block!.transactions.length)
+      return intToHex(block.transactions.length)
     } catch (error) {
       throw {
         code: INVALID_PARAMS,
@@ -619,22 +619,16 @@ export class Eth {
       const [blockHash, txIndexHex] = params
       const txIndex = parseInt(txIndexHex, 16)
       const block = await this._chain.getBlock(toBuffer(blockHash))
-      if (block === null) {
-        throw {
-          code: INVALID_PARAMS,
-          message: 'unknown block',
-        }
-      }
-      if (block!.transactions.length <= txIndex) {
+      if (block.transactions.length <= txIndex) {
         return null
       }
 
-      const tx = block!.transactions[txIndex]
-      return jsonRpcTx(tx, block!, txIndex)
+      const tx = block.transactions[txIndex]
+      return jsonRpcTx(tx, block, txIndex)
     } catch (error: any) {
       throw {
         code: INVALID_PARAMS,
-        message: 'unknown block',
+        message: error.message.toString(),
       }
     }
   }
@@ -653,8 +647,8 @@ export class Eth {
       if (!result) return null
       const [_receipt, blockHash, txIndex] = result
       const block = await this._chain.getBlock(blockHash)
-      const tx = block!.transactions[txIndex]
-      return jsonRpcTx(tx, block!, txIndex)
+      const tx = block.transactions[txIndex]
+      return jsonRpcTx(tx, block, txIndex)
     } catch (error: any) {
       throw {
         code: INTERNAL_ERROR,
@@ -712,7 +706,7 @@ export class Eth {
     }
 
     const block = await this._chain.getBlock(blockNumber)
-    return block!.uncleHeaders.length
+    return block.uncleHeaders.length
   }
 
   /**
@@ -732,7 +726,7 @@ export class Eth {
       const result = await this.receiptsManager.getReceiptByTxHash(toBuffer(txHash))
       if (!result) return null
       const [receipt, blockHash, txIndex, logIndex] = result
-      const block = (await this._chain.getBlock(blockHash))!
+      const block = await this._chain.getBlock(blockHash)
       const parentBlock = await this._chain.getBlock(block.header.parentHash)
       const tx = block.transactions[txIndex]
       const effectiveGasPrice = tx.supports(Capability.EIP1559FeeMarket)
@@ -748,7 +742,7 @@ export class Eth {
         await this._vm!.copy()
       ).runBlock({
         block,
-        root: parentBlock!.header.stateRoot,
+        root: parentBlock.header.stateRoot,
         skipBlockValidation: true,
       })
       const { totalGasSpent, createdAddress } = runBlockResult.results[txIndex]
@@ -786,17 +780,17 @@ export class Eth {
     }
     let from: Block, to: Block
     if (blockHash !== undefined) {
-      const block = await this._chain.getBlock(toBuffer(blockHash))
-      if (block === null) {
+      try {
+        from = to = await this._chain.getBlock(toBuffer(blockHash))
+      } catch (error: any) {
         throw {
           code: INVALID_PARAMS,
           message: 'unknown blockHash',
         }
       }
-      from = to = block
     } else {
       if (fromBlock === 'earliest') {
-        from = (await this._chain.getBlock(BigInt(0)))!
+        from = await this._chain.getBlock(BigInt(0))
       } else if (fromBlock === 'latest' || fromBlock === undefined) {
         from = this._chain.blocks.latest!
       } else {
@@ -807,7 +801,7 @@ export class Eth {
             message: 'specified `fromBlock` greater than current height',
           }
         }
-        from = (await this._chain.getBlock(blockNum))!
+        from = await this._chain.getBlock(blockNum)
       }
       if (toBlock === fromBlock) {
         to = from
@@ -821,7 +815,7 @@ export class Eth {
             message: 'specified `toBlock` greater than current height',
           }
         }
-        to = (await this._chain.getBlock(blockNum))!
+        to = await this._chain.getBlock(blockNum)
       }
     }
     if (
@@ -1039,13 +1033,13 @@ export class Eth {
       const baseFee = latest.calcNextBaseFee()
       let priorityFee = BigInt(0)
       const block = await this._chain.getBlock(latest.number)
-      for (const tx of block!.transactions) {
+      for (const tx of block.transactions) {
         const maxPriorityFeePerGas = (tx as FeeMarketEIP1559Transaction).maxPriorityFeePerGas
         priorityFee += maxPriorityFeePerGas
       }
 
       priorityFee =
-        priorityFee !== BigInt(0) ? priorityFee / BigInt(block!.transactions.length) : BigInt(1)
+        priorityFee !== BigInt(0) ? priorityFee / BigInt(block.transactions.length) : BigInt(1)
       gasPrice = baseFee + priorityFee > minGasPrice ? baseFee + priorityFee : minGasPrice
     } else {
       // For chains that don't support EIP-1559 we iterate over the last 20
@@ -1054,11 +1048,11 @@ export class Eth {
       let txCount = BigInt(0)
       for (let i = 0; i < blockIterations; i++) {
         const block = await this._chain.getBlock(latest.number - BigInt(i))
-        if (block!.transactions.length === 0) {
+        if (block.transactions.length === 0) {
           continue
         }
 
-        for (const tx of block!.transactions) {
+        for (const tx of block.transactions) {
           const txGasPrice = (tx as Transaction).gasPrice
           gasPrice += txGasPrice
           txCount++

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -126,7 +126,7 @@ export class Skeleton extends MetaDBManager {
     if (tail === BigInt(0)) return true
     if (tail <= this.chain.blocks.height + BigInt(1)) {
       const nextBlock = await this.chain.getBlock(tail - BigInt(1))
-      const linked = next.equals(nextBlock!.hash())
+      const linked = next.equals(nextBlock.hash())
       if (linked && this.status.progress.subchains.length > 1) {
         // Remove all other subchains as no more relevant
         const junkedSubChains = this.status.progress.subchains.splice(1)
@@ -715,7 +715,11 @@ export class Skeleton extends MetaDBManager {
       // If skeleton is linked, it probably has deleted the block and put it into the chain
       if (onlySkeleton || !this.linked) return undefined
       // As a fallback, try to get the block from the canonical chain in case it is available there
-      return (await this.chain.getBlock(number)) ?? undefined
+      try {
+        return await this.chain.getBlock(number)
+      } catch (error) {
+        return undefined
+      }
     }
   }
 
@@ -730,7 +734,11 @@ export class Skeleton extends MetaDBManager {
       if (onlySkeleton === true || !this.linked) {
         return undefined
       } else {
-        return (await this.chain.getBlock(hash)) ?? undefined
+        try {
+          return await this.chain.getBlock(hash)
+        } catch (e) {
+          return undefined
+        }
       }
     }
   }

--- a/packages/client/test/execution/vmexecution.spec.ts
+++ b/packages/client/test/execution/vmexecution.spec.ts
@@ -1,7 +1,5 @@
-import { Block } from '@ethereumjs/block'
 import { Blockchain } from '@ethereumjs/blockchain'
 import { Chain as ChainEnum, Common, Hardfork } from '@ethereumjs/common'
-import { toBuffer } from '@ethereumjs/util'
 import { VM } from '@ethereumjs/vm'
 import * as tape from 'tape'
 
@@ -23,47 +21,13 @@ tape('[VMExecution]', async (t) => {
   })
 
   async function testSetup(blockchain: Blockchain, common?: Common) {
-    const config = new Config({ common, transports: [], saveReceipts: true })
+    const config = new Config({ common, transports: [] })
     const chain = new Chain({ config, blockchain })
-    const exec = new VMExecution({ config, chain, metaDB: chain.chainDB })
+    const exec = new VMExecution({ config, chain })
     await chain.open()
     await exec.open()
     return exec
   }
-
-  t.test('getReceipts', async (t) => {
-    const blockchain = await Blockchain.create({
-      validateBlocks: true,
-      validateConsensus: false,
-    })
-    const fakeHash = '0xd3671e9680944e99f3a01d5d0b12803f0e472abf2006e914daa84742b6341e6c'
-    const exec = await testSetup(blockchain)
-    await exec.run()
-    await (exec.receiptsManager as any).put(0, toBuffer(fakeHash), Buffer.from([]))
-    try {
-      await exec.receiptsManager?.getReceipts(toBuffer(fakeHash), false, true)
-      t.fail('getReceipts should throw error if target block not found')
-    } catch (e: any) {
-      t.equal(
-        e.message,
-        'Block not found',
-        'getReceipts should throw error if target block not found'
-      )
-    }
-    try {
-      const block = blockchain.genesisBlock
-      const fakeBlock = Block.fromBlockData({ header: { number: BigInt(1) } })
-      await exec.receiptsManager?.getLogs(block, fakeBlock)
-      t.fail('getLogs should throw error if target block not found')
-    } catch (e: any) {
-      t.equal(
-        e.message,
-        `Key ${BigInt(1)} was not found`,
-        'getLogs should throw error if target block not found'
-      )
-    }
-    t.end()
-  })
 
   t.test('Block execution / Hardforks PoW (mainnet)', async (t) => {
     let blockchain = await Blockchain.create({
@@ -124,12 +88,9 @@ tape('[VMExecution]', async (t) => {
     })
     let exec = await testSetup(blockchain, common)
     const oldHead = await exec.vm.blockchain.getIteratorHead!()
-    const oldHeadHash = oldHead instanceof Buffer ? oldHead : oldHead.hash()
-
     await exec.run()
     let newHead = await exec.vm.blockchain.getIteratorHead!()
-    const newHeadHash = newHead instanceof Buffer ? newHead : newHead.hash()
-    t.deepEqual(newHeadHash, oldHeadHash, 'should not modify blockchain on empty run')
+    t.deepEqual(newHead.hash(), oldHead.hash(), 'should not modify blockchain on empty run')
 
     blockchain = await Blockchain.fromBlocksData(blocksDataGoerli, {
       validateBlocks: true,

--- a/packages/client/test/rpc/eth/getTransactionByBlockHashAndIndex.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionByBlockHashAndIndex.spec.ts
@@ -62,7 +62,7 @@ tape(`${method}: call with unknown block hash`, async (t) => {
   const mockTxIndex = '0x1'
 
   const req = params(method, [mockBlockHash, mockTxIndex])
-  const expectRes = checkError(t, INVALID_PARAMS, 'unknown block')
+  const expectRes = checkError(t, INVALID_PARAMS, 'NotFound')
   await baseRequest(t, server, req, 200, expectRes)
 })
 

--- a/packages/client/test/sync/skeleton.spec.ts
+++ b/packages/client/test/sync/skeleton.spec.ts
@@ -9,7 +9,6 @@ import { Config } from '../../lib/config'
 import { getLogger } from '../../lib/logging'
 import { Skeleton, errReorgDenied, errSyncMerged } from '../../lib/sync/skeleton'
 import { short } from '../../lib/util'
-import { DBKey } from '../../lib/util/metaDBManager'
 import { wait } from '../integration/util'
 import * as genesisJSON from '../testdata/geth-genesis/post-merge.json'
 type Subchain = {
@@ -394,7 +393,7 @@ tape('[Skeleton] / setHead', async (t) => {
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     await chain.open()
 
-    const genesis = (await chain.getBlock(BigInt(0)))!
+    const genesis = await chain.getBlock(BigInt(0))
     const block1 = Block.fromBlockData(
       { header: { number: 1, parentHash: genesis.hash(), difficulty: 100 } },
       { common, hardforkByBlockNumber: true }
@@ -498,7 +497,7 @@ tape('[Skeleton] / setHead', async (t) => {
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     await chain.open()
 
-    const genesis = (await chain.getBlock(BigInt(0)))!
+    const genesis = await chain.getBlock(BigInt(0))
     const block1 = Block.fromBlockData(
       { header: { number: 1, parentHash: genesis.hash(), difficulty: 100 } },
       { common, hardforkByBlockNumber: true }
@@ -570,7 +569,7 @@ tape('[Skeleton] / setHead', async (t) => {
       await chain.open()
       await skeleton.open()
 
-      const genesis = (await chain.getBlock(BigInt(0)))!
+      const genesis = await chain.getBlock(BigInt(0))
 
       const block1 = Block.fromBlockData(
         { header: { number: 1, parentHash: genesis.hash(), difficulty: 100 } },
@@ -653,7 +652,8 @@ tape('[Skeleton] / setHead', async (t) => {
       const chain = new Chain({ config })
       ;(chain.blockchain as any)._validateBlocks = false
       await chain.open()
-      const genesisBlock = (await chain.getBlock(BigInt(0)))!
+      const genesisBlock = await chain.getBlock(BigInt(0))
+
       const block1 = Block.fromBlockData(
         { header: { number: 1, parentHash: genesisBlock.hash(), difficulty: 100 } },
         { common }
@@ -731,12 +731,6 @@ tape('[Skeleton] / setHead', async (t) => {
       await skeleton.setHead(block5, true)
       await wait(200)
       st.equal(skeleton.bounds().head, BigInt(5), 'should update to new height')
-      const found = await skeleton.getBlockByHash(block5.hash())
-      st.deepEqual(found!.hash(), block5.hash(), 'should find block5')
-      await skeleton.delete(DBKey.SkeletonBlock, block5.hash())
-      const notFound = await skeleton.getBlockByHash(block5.hash(), true)
-      st.equal(notFound, undefined, 'should not find block5')
-      st.end()
     }
   )
 
@@ -764,7 +758,7 @@ tape('[Skeleton] / setHead', async (t) => {
       ;(chain.blockchain as any)._validateBlocks = false
       ;(chain.blockchain as any)._validateConsensus = false
       await chain.open()
-      const genesisBlock = (await chain.getBlock(BigInt(0)))!
+      const genesisBlock = await chain.getBlock(BigInt(0))
 
       const block1 = Block.fromBlockData(
         { header: { number: 1, parentHash: genesisBlock.hash(), difficulty: 100 } },
@@ -841,7 +835,7 @@ tape('[Skeleton] / setHead', async (t) => {
       BlockHeader.prototype._consensusFormatValidation = td.func<any>()
       td.replace('@ethereumjs/block', { BlockHeader })
       await chain.open()
-      const genesisBlock = (await chain.getBlock(BigInt(0)))!
+      const genesisBlock = await chain.getBlock(BigInt(0))
 
       const block1 = Block.fromBlockData(
         { header: { number: 1, parentHash: genesisBlock.hash(), difficulty: 100 } },

--- a/packages/vm/examples/run-blockchain.ts
+++ b/packages/vm/examples/run-blockchain.ts
@@ -35,7 +35,7 @@ async function main() {
 
   await blockchain.iterator('vm', async (block: Block, reorg: boolean) => {
     const parentBlock = await blockchain!.getBlock(block.header.parentHash)
-    const parentState = parentBlock!.header.stateRoot
+    const parentState = parentBlock.header.stateRoot
     // run block
     await vm.runBlock({ block, root: parentState, skipHardForkValidation: true })
   })

--- a/packages/vm/test/api/runTx.spec.ts
+++ b/packages/vm/test/api/runTx.spec.ts
@@ -923,7 +923,7 @@ tape('EIP 4844 transaction tests', async (t) => {
         {
           excessDataGas: 1n,
           number: 2,
-          parentHash: (await blockchain.getBlock(1n))!.hash(), // Faking parent hash with getBlock stub
+          parentHash: (await blockchain.getBlock(1n)).hash(), // Faking parent hash with getBlock stub
         },
         {
           common,

--- a/packages/vm/test/tester/runners/BlockchainTestsRunner.ts
+++ b/packages/vm/test/tester/runners/BlockchainTestsRunner.ts
@@ -181,7 +181,7 @@ export async function runBlockchainTest(options: any, testData: any, t: tape.Tes
       try {
         await blockchain.iterator('vm', async (block: Block) => {
           const parentBlock = await blockchain!.getBlock(block.header.parentHash)
-          const parentState = parentBlock!.header.stateRoot
+          const parentState = parentBlock.header.stateRoot
           // run block, update head if valid
           try {
             await vm.runBlock({ block, root: parentState, hardforkByTTD: TD })


### PR DESCRIPTION
This reverts commit c5bb62a5ac38ee052a0c4be54e77f2b37e3a6619.

After an additional analysis with @g11tech on the way we have implemented we came to the conclusion that this is too breaking in its current form, since we would have had already various necessary code changes following this in our internal code base.

We will then instead go the path and change the interface instead (removing the `null` return option), which should have substantially less side effects.

@ScottyPoi can you please go your PR #2516 and extract (and adopt a bit) valuable unrelated updates like the additional tests you wrote? Thanks! 🙏

So, some context for review: this is undoing the changes from the PR with the command:

```shell
git revert c5bb62a5ac38ee052a0c4be54e77f2b37e3a6619
```