### PR TITLE
Fix blockchain interface getBlock() signature (remove null return option)

### DIFF
--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -708,7 +708,18 @@ export class Blockchain implements BlockchainInterface {
     // in the `VM` if we encounter a `BLOCKHASH` opcode: then a bigint is used we
     // need to then read the block from the canonical chain Q: is this safe? We
     // know it is OK if we call it from the iterator... (runBlock)
-    return this.dbManager.getBlock(blockId)
+    try {
+      return await this.dbManager.getBlock(blockId)
+    } catch (error: any) {
+      if (error.code === 'LEVEL_NOT_FOUND') {
+        if (typeof blockId === 'object') {
+          error.message = `Block with hash ${blockId.toString('hex')} not found in DB (NotFound)`
+        } else {
+          error.message = `Block number ${blockId} not found in DB (NotFound)`
+        }
+      }
+      throw error
+    }
   }
 
   /**

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -653,9 +653,6 @@ export class Blockchain implements BlockchainInterface {
     let parentHash = block.header.parentHash
     for (let i = 0; i < getBlocks; i++) {
       const parentBlock = await this.getBlock(parentHash)
-      if (parentBlock === undefined) {
-        throw new Error(`could not find parent block ${block.errorStr()}`)
-      }
       canonicalBlockMap.push(parentBlock)
 
       // mark block hash as part of the canonical chain

--- a/packages/blockchain/src/types.ts
+++ b/packages/blockchain/src/types.ts
@@ -26,7 +26,7 @@ export interface BlockchainInterface {
   /**
    * Returns a block by its hash or number.
    */
-  getBlock(blockId: Buffer | number | bigint): Promise<Block | null>
+  getBlock(blockId: Buffer | number | bigint): Promise<Block>
 
   /**
    * Iterates through blocks starting at the specified iterator head and calls

--- a/packages/blockchain/test/index.spec.ts
+++ b/packages/blockchain/test/index.spec.ts
@@ -153,7 +153,7 @@ tape('blockchain test', (t) => {
     await addNextBlock(1)
   })
 
-  t.test('should get block by number', async (st) => {
+  t.test('getBlock(): should get block by number', async (st) => {
     const blocks: Block[] = []
     const gasLimit = 8000000
     const common = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Istanbul })
@@ -192,7 +192,7 @@ tape('blockchain test', (t) => {
     st.end()
   })
 
-  t.test('should get block by hash', async (st) => {
+  t.test('getBlock(): should get block by hash / not existing', async (st) => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
     const gasLimit = 8000000
     const genesisBlock = Block.fromBlockData({ header: { gasLimit } }, { common })
@@ -204,11 +204,15 @@ tape('blockchain test', (t) => {
       genesisBlock,
     })
     const block = await blockchain.getBlock(genesisBlock.hash())
-    if (typeof block !== 'undefined') {
-      st.ok(block.hash().equals(genesisBlock.hash()))
-    } else {
-      st.fail('block is not defined!')
+    st.ok(block.hash().equals(genesisBlock.hash()))
+
+    try {
+      await blockchain.getBlock(5)
+      st.fail('should throw an exception')
+    } catch (e) {
+      st.ok(`should throw for non-existing block request`)
     }
+
     st.end()
   })
 

--- a/packages/blockchain/test/index.spec.ts
+++ b/packages/blockchain/test/index.spec.ts
@@ -209,8 +209,15 @@ tape('blockchain test', (t) => {
     try {
       await blockchain.getBlock(5)
       st.fail('should throw an exception')
-    } catch (e) {
-      st.ok(`should throw for non-existing block request`)
+    } catch (e: any) {
+      st.ok(e.message.includes('NotFound'), `should throw for non-existing block-by-number request`)
+    }
+
+    try {
+      await blockchain.getBlock(Buffer.from('1234', 'hex'))
+      st.fail('should throw an exception')
+    } catch (e: any) {
+      st.ok(e.message.includes('NotFound'), `should throw for non-existing block-by-hash request`)
     }
 
     st.end()

--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -233,7 +233,6 @@ export class VMExecution extends Execution {
           // if we are just starting or if a chain reorg has happened
           if (!headBlock || reorg) {
             const headBlock = await blockchain.getBlock(block.header.parentHash)
-            if (headBlock === null) throw new Error('No parent block found')
             parentState = headBlock.header.stateRoot
           }
           // run block, update head if valid
@@ -422,9 +421,7 @@ export class VMExecution extends Execution {
 
     for (let blockNumber = first; blockNumber <= last; blockNumber++) {
       const block = await vm.blockchain.getBlock(blockNumber)
-      if (block === null) throw new Error('No block found')
       const parentBlock = await vm.blockchain.getBlock(block.header.parentHash)
-      if (parentBlock === null) throw new Error('No block found')
       // Set the correct state root
       await vm.stateManager.setStateRoot(parentBlock.header.stateRoot)
       if (typeof vm.blockchain.getTotalDifficulty !== 'function') {

--- a/packages/vm/src/eei/eei.ts
+++ b/packages/vm/src/eei/eei.ts
@@ -12,7 +12,7 @@ type Block = {
 }
 
 type Blockchain = {
-  getBlock(blockId: number): Promise<Block | null>
+  getBlock(blockId: number): Promise<Block>
   copy(): Blockchain
 }
 

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -326,15 +326,6 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
       throw new Error(msg)
     }
     const parentBlock = await this.blockchain.getBlock(opts.block?.header.parentHash)
-    if (parentBlock === null) {
-      const msg = _errorMsg(
-        `Parent block not found in blockchain so cannot compute data gas price`,
-        this,
-        block,
-        tx
-      )
-      throw new Error(msg)
-    }
     dataGasPrice = getDataGasPrice(parentBlock.header)
     if (castTx.maxFeePerDataGas < dataGasPrice) {
       const msg = _errorMsg(


### PR DESCRIPTION
Replacement candidate for reverted #2516 after some additional discussion on the breaking implications of this.

This PR now instead adjusts the Blockchain getBlock() interface signature, adds some tests and removes some non-reachable null asserting conditional clauses.

PR also improves on the error message of `getBlock()` as suggested in #2511.

Open for review.