### PR TITLE
Client trusted setup path fixes

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -579,7 +579,7 @@ async function run() {
 
   // TODO sharding: Just initialize kzg library now, in future it can be optimized to be
   // loaded and initialized on the sharding hardfork activation
-  initKZG(kzg, __dirname + '/../../client/lib/trustedSetups/devnet4.txt')
+  initKZG(kzg, __dirname + '/../lib/trustedSetups/devnet4.txt')
   // Give network id precedence over network name
   const chain = args.networkId ?? args.network ?? Chain.Mainnet
 

--- a/packages/client/devnets/4844-interop/tools/txGenerator.ts
+++ b/packages/client/devnets/4844-interop/tools/txGenerator.ts
@@ -17,7 +17,7 @@ const input = process.argv[3] // text to generate blob from
 const genesisJson = require(process.argv[4]) // Genesis parameters
 const pkey = Buffer.from(process.argv[5], 'hex') // private key of tx sender as unprefixed hex string
 
-initKZG(kzg, __dirname + '/../../../client/lib/trustedSetups/devnet4.txt')
+initKZG(kzg, __dirname + '/../../../lib/trustedSetups/devnet4.txt')
 
 const sender = Address.fromPrivateKey(pkey)
 const common = Common.fromGethGenesis(genesisJson, {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "binWorkaround": "test -f dist/bin/cli.js || echo 'install fails if bin script does not exist (https://github.com/npm/cli/issues/2632), creating placeholder file at \"dist/bin/cli.js\"' && mkdir -p 'dist/bin' && touch dist/bin/cli.js",
-    "build": "npm run build:common",
+    "build": "npm run build:common && mkdir -p ./lib/trustedSetup/ && cp -Rf ./lib/trustedSetups ./dist/lib/",
     "build:browser": "../../config/cli/ts-build.sh browser && npm run bundle && rm -rf dist.browser",
     "build:common": "../../config/cli/ts-build.sh",
     "bundle": "webpack",

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -248,7 +248,7 @@ tape('[PendingBlock]', async (t) => {
     } catch {
       /** ensure kzg is setup */
     }
-    initKZG(kzg, __dirname + '/../../../client/lib/trustedSetups/devnet4.txt')
+    initKZG(kzg, __dirname + '/../../lib/trustedSetups/devnet4.txt')
     const gethGenesis = require('../../../block/test/testdata/4844-hardfork.json')
     const common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',

--- a/packages/client/test/rpc/engine/getBlobsBundleV1.spec.ts
+++ b/packages/client/test/rpc/engine/getBlobsBundleV1.spec.ts
@@ -25,7 +25,7 @@ const validPayloadAttributes = {
 
 const validPayload = [validForkChoiceState, { ...validPayloadAttributes, withdrawals: [] }]
 
-initKZG(kzg, __dirname + '/../../../../client/lib/trustedSetups/devnet4.txt')
+initKZG(kzg, __dirname + '/../../../lib/trustedSetups/devnet4.txt')
 const method = 'engine_getBlobsBundleV1'
 
 tape(`${method}: call with invalid payloadId`, async (t) => {

--- a/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
+++ b/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
@@ -220,7 +220,7 @@ tape('blob EIP 4844 transaction', async (t) => {
   } catch {
     // NOOP - just verifying KZG is ready if not already
   }
-  initKZG(kzg, __dirname + '/../../../../client/lib/trustedSetups/devnet4.txt')
+  initKZG(kzg, __dirname + '/../../../lib/trustedSetups/devnet4.txt')
   const gethGenesis = require('../../../../block/test/testdata/4844-hardfork.json')
   const common = Common.fromGethGenesis(gethGenesis, {
     chain: 'customChain',

--- a/packages/client/test/sim/simutils.ts
+++ b/packages/client/test/sim/simutils.ts
@@ -17,7 +17,7 @@ import type { Client } from 'jayson/promise'
 
 export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
 // Initialize the kzg object with the kzg library
-initKZG(kzg, __dirname + '/../../../client/lib/trustedSetups/devnet4.txt')
+initKZG(kzg, __dirname + '/../../lib/trustedSetups/devnet4.txt')
 
 export async function waitForELOnline(client: Client): Promise<string> {
   for (let i = 0; i < 15; i++) {

--- a/packages/client/test/sim/txGenerator.ts
+++ b/packages/client/test/sim/txGenerator.ts
@@ -18,7 +18,7 @@ const MAX_BLOBS_PER_TX = 2
 const MAX_USEFUL_BYTES_PER_TX = USEFUL_BYTES_PER_BLOB * MAX_BLOBS_PER_TX - 1
 const BLOB_SIZE = BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB
 
-initKZG(kzg, __dirname + '/../../../tx/trustedSetup/devnet4.txt')
+initKZG(kzg, __dirname + '/../../lib/trustedSetup/devnet4.txt')
 const pkey = Buffer.from('45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8', 'hex')
 const sender = Address.fromPrivateKey(pkey)
 

--- a/packages/tx/src/kzg/kzg.ts
+++ b/packages/tx/src/kzg/kzg.ts
@@ -18,7 +18,7 @@ export let kzg: Kzg = {
  * @param kzgLib a KZG implementation (defaults to c-kzg)
  * @param trustedSetupPath the full path (e.g. "/home/linux/devnet4.txt") to a kzg trusted setup text file
  */
-export function initKZG(kzgLib: Kzg, trustedSetupPath = __dirname + '/devnet4.txt') {
+export function initKZG(kzgLib: Kzg, trustedSetupPath: string) {
   kzg = kzgLib
   kzg.loadTrustedSetup(trustedSetupPath)
 }


### PR DESCRIPTION
This fixes two bugs related to reading the trusted setup file updated in #2522 and breaking the client build, discovered this while trying to locally build the docker image for playing around with Hive.

1. The trusted setup file had not been included in the build, have added a script addition to the Client `npm run build`  command
2. the relative path references were not working properly especially for the trusted setup file reference in `bin/cli.ts` where path hierarchy would change when copied over to `dist/bin/cli.ts` (one level deeper). This is now mitigated by using client package internal references which - in the dist folder case - leads to taking the - now copied over, see 1. - devnet4.txt file - from `dist/trustedSetups/devnet4.txt`

Open for review. 🙂 