### PR TITLE
allforks: Hive withdrawal fixes

### DIFF
--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -1256,7 +1256,7 @@ export class Blockchain implements BlockchainInterface {
    */
   createGenesisBlock(stateRoot: Buffer): Block {
     const common = this._common.copy()
-    common.setHardforkByBlockNumber(0)
+    common.setHardforkByBlockNumber(0, undefined, common.genesis().timestamp)
 
     const header: BlockData['header'] = {
       ...common.genesis(),

--- a/packages/blockchain/src/db/helpers.ts
+++ b/packages/blockchain/src/db/helpers.ts
@@ -69,9 +69,11 @@ function DBSetHashToNumber(blockHash: Buffer, blockNumber: bigint): DBOp {
   })
 }
 
-function DBSaveLookups(blockHash: Buffer, blockNumber: bigint): DBOp[] {
+function DBSaveLookups(blockHash: Buffer, blockNumber: bigint, skipNumIndex?: boolean): DBOp[] {
   const ops = []
-  ops.push(DBOp.set(DBTarget.NumberToHash, blockHash, { blockNumber }))
+  if (skipNumIndex !== true) {
+    ops.push(DBOp.set(DBTarget.NumberToHash, blockHash, { blockNumber }))
+  }
 
   const blockNumber8Bytes = bufBE8(blockNumber)
   ops.push(

--- a/packages/blockchain/src/db/manager.ts
+++ b/packages/blockchain/src/db/manager.ts
@@ -1,4 +1,4 @@
-import { Block, BlockHeader,valuesArrayToHeaderData } from '@ethereumjs/block'
+import { Block, BlockHeader, valuesArrayToHeaderData } from '@ethereumjs/block'
 import { RLP } from '@ethereumjs/rlp'
 import { KECCAK256_RLP, arrToBufArr, bufferToBigInt } from '@ethereumjs/util'
 
@@ -142,13 +142,15 @@ export class DBManager {
   async getHeader(blockHash: Buffer, blockNumber: bigint) {
     const encodedHeader = await this.get(DBTarget.Header, { blockHash, blockNumber })
     const headerValues = arrToBufArr(RLP.decode(Uint8Array.from(encodedHeader)))
-    const headerData = valuesArrayToHeaderData(headerValues as Buffer[])
 
     const opts: BlockOptions = { common: this._common }
     if (blockNumber === BigInt(0)) {
       opts.hardforkByBlockNumber = true
     } else {
-      const parentHash = headerData.parentHash as Buffer;
+      // Lets fetch the parent hash but not by number since this block might not
+      // be in canonical chain
+      const headerData = valuesArrayToHeaderData(headerValues as Buffer[])
+      const parentHash = headerData.parentHash as Buffer
       opts.hardforkByTTD = await this.getTotalDifficulty(parentHash, blockNumber - BigInt(1))
     }
     return BlockHeader.fromValuesArray(headerValues as Buffer[], opts)

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -640,8 +640,6 @@ async function run() {
       mergeForkIdPostMerge: args.mergeForkIdPostMerge,
     })
     customGenesisState = parseGethGenesisState(genesisFile)
-    // Set hardfork by block number 0
-    common.setHardforkByBlockNumber(0, undefined, Math.floor(Date.now() / 1000))
   }
 
   if (args.mine === true && accounts.length === 0) {

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -641,7 +641,7 @@ async function run() {
     })
     customGenesisState = parseGethGenesisState(genesisFile)
     // Set hardfork by block number 0
-    common.setHardforkByBlockNumber(0)
+    common.setHardforkByBlockNumber(0, undefined, Math.floor(Date.now() / 1000))
   }
 
   if (args.mine === true && accounts.length === 0) {

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -466,7 +466,7 @@ export class Config {
 
     this.logger.debug(
       `Client synchronized=${this.synchronized}${
-        latest ? ' height= ' + latest.number : ''
+        latest ? ' height=' + latest.number : ''
       } syncTargetHeight=${this.syncTargetHeight} lastSyncDate=${
         (Date.now() - this.lastSyncDate) / 1000
       } secs ago`

--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -150,7 +150,8 @@ export class VMExecution extends Execution {
         DBSetTD(td, num, hash),
         ...DBSetBlockOrHeader(block),
         DBSetHashToNumber(hash, num),
-        ...DBSaveLookups(hash, num),
+        // Skip the op for number to hash to not alter canonical chain
+        ...DBSaveLookups(hash, num, true),
       ])
     })
   }

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -631,7 +631,7 @@ export class Engine {
         }
       }
     } else if (parseInt(params[0].timestamp) >= shanghaiTimestamp) {
-      if (!('withdrawals' in params[0])) {
+      if (!('withdrawals' in params[0]) || params[0].withdrawals === null) {
         throw {
           code: INVALID_PARAMS,
           message: 'ExecutionPayloadV2 MUST be used after Shanghai is activated',

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -737,10 +737,11 @@ export class Eth {
             block.header.baseFeePerGas! +
             block.header.baseFeePerGas!
         : (tx as Transaction).gasPrice
+
+      const vmCopy = await this._vm!.copy()
+      vmCopy._common.setHardfork(tx.common.hardfork())
       // Run tx through copied vm to get tx gasUsed and createdAddress
-      const runBlockResult = await (
-        await this._vm!.copy()
-      ).runBlock({
+      const runBlockResult = await vmCopy.runBlock({
         block,
         root: parentBlock.header.stateRoot,
         skipBlockValidation: true,

--- a/packages/client/lib/rpc/util/CLConnectionManager.ts
+++ b/packages/client/lib/rpc/util/CLConnectionManager.ts
@@ -154,10 +154,10 @@ export class CLConnectionManager {
       payload.payload.baseFeePerGas
     )} txs=${payload.payload.transactions.length}`
 
-    if ('withdrawals' in payload.payload) {
+    if ('withdrawals' in payload.payload && payload.payload.withdrawals !== null) {
       msg += ` withdrawals=${(payload.payload as ExecutionPayloadV2).withdrawals.length}`
     }
-    if ('excessDataGas' in payload.payload) {
+    if ('excessDataGas' in payload.payload && payload.payload.excessDataGas !== null) {
       msg += ` excessDataGas=${(payload.payload as ExecutionPayloadV3).excessDataGas}`
     }
     return msg

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -696,7 +696,6 @@ export class EVM implements EVMInterface {
         gasPrice: opts.gasPrice ?? BigInt(0),
         origin: opts.origin ?? opts.caller ?? Address.zero(),
       }
-
       const caller = opts.caller ?? Address.zero()
 
       const value = opts.value ?? BigInt(0)
@@ -948,11 +947,15 @@ export class EVM implements EVMInterface {
   }
 
   public copy(): EVMInterface {
+    const common = this._common.copy()
+    common.setHardfork(this._common.hardfork())
+
     const opts = {
       ...this._optsCached,
-      common: this._common.copy(),
+      common,
       eei: this.eei.copy(),
     }
+    ;(opts.eei as any)._common = common
     return new EVM(opts)
   }
 }

--- a/packages/vm/src/eei/eei.ts
+++ b/packages/vm/src/eei/eei.ts
@@ -94,6 +94,8 @@ export class EEI extends VmState implements EEIInterface {
   }
 
   public copy() {
-    return new EEI(this._stateManager.copy(), this._common.copy(), this._blockchain.copy())
+    const common = this._common.copy()
+    common.setHardfork(this._common.hardfork())
+    return new EEI(this._stateManager.copy(), common, this._blockchain.copy())
   }
 }

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -398,7 +398,6 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   const dataGasCost = totalDataGas * dataGasPrice
   fromAccount.balance -= txCost
   fromAccount.balance -= dataGasCost
-  debug(`txCost ${txCost} -- ${dataGasCost}`)
   if (opts.skipBalance === true && fromAccount.balance < BigInt(0)) {
     fromAccount.balance = BigInt(0)
   }

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -243,8 +243,15 @@ export class VM {
    * Returns a copy of the {@link VM} instance.
    */
   async copy(): Promise<VM> {
-    const evmCopy = this.evm.copy()
-    const eeiCopy: EEIInterface = evmCopy.eei
+    const common = this._common.copy()
+    common.setHardfork(this._common.hardfork())
+    const eeiCopy = new EEI(this.stateManager.copy(), common, this.blockchain.copy())
+    const evmOpts = {
+      ...(this.evm as any)._optsCached,
+      common,
+      eei: eeiCopy,
+    }
+    const evmCopy = new EVM(evmOpts)
     return VM.create({
       stateManager: (eeiCopy as any)._stateManager,
       blockchain: (eeiCopy as any)._blockchain,

--- a/packages/vm/test/api/eei.spec.ts
+++ b/packages/vm/test/api/eei.spec.ts
@@ -10,6 +10,29 @@ import { EEI } from '../../src/eei/eei'
 
 const ZeroAddress = Address.zero()
 
+tape('EEI.copy()', async (t) => {
+  const eei = new EEI(
+    new StateManager(),
+    new Common({ chain: 'mainnet', hardfork: 'shanghai' }),
+    await Blockchain.create()
+  )
+  const nonEmptyAccount = Account.fromAccountData({ nonce: 1 })
+  await eei.putAccount(ZeroAddress, nonEmptyAccount)
+  await eei.checkpoint()
+  await eei.commit()
+  const copy = eei.copy()
+  t.equal(
+    (eei as any)._common.hardfork(),
+    (copy as any)._common.hardfork(),
+    'copied EEI should have the same hardfork'
+  )
+  t.equal(
+    (await copy.getAccount(ZeroAddress)).nonce,
+    (await eei.getAccount(ZeroAddress)).nonce,
+    'copy should have same State data'
+  )
+})
+
 tape('EEI', (t) => {
   t.test('should return false on non-existing accounts', async (st) => {
     const eei = new EEI(


### PR DESCRIPTION
Fixes regarding failing hive testvectors

Closes #2498

 - [x] tx hardfork mismatch fix where the starting client hardfork was not being properly set as the timestamp was not being used, fixed
 - [x] check for withdrawals/excessdatagas missing on newPayload
 - [x] Skip altering the canonical chain number to hash mapping on runWithoutSetHead / newPayload
 - [x] Fix setting the hardfork on vm in getTransactionReceipt
 - [x] Fix setting evm hardfork on copy
 - [x] fix loading block/header which might not be in canonical chain