### PR TITLE
Various Hive related fixes

### DIFF
--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -354,8 +354,10 @@ export class BlockHeader {
     if (this._common.consensusAlgorithm() === ConsensusAlgorithm.Ethash) {
       // PoW/Ethash
       if (
+        number > BigInt(0) &&
         this.extraData.length > this._common.paramByHardfork('vm', 'maxExtraDataSize', hardfork)
       ) {
+        // Check length of data on all post-genesis blocks
         const msg = this._errorMsg('invalid amount of extra data')
         throw new Error(msg)
       }

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -422,9 +422,11 @@ export class Blockchain implements BlockchainInterface {
         canonicalHead > BigInt(0)
           ? await this.getTotalDifficulty(header.hash(), canonicalHead)
           : header.difficulty
+
       const dbOps: DBOp[] = []
-      await this._rebuildCanonical(header, dbOps)
+      await this._deleteCanonicalChainReferences(canonicalHead + BigInt(1), hash, dbOps)
       const ops = dbOps.concat(this._saveHeadOps())
+
       await this.dbManager.batch(ops)
       await this.checkAndTransitionHardForkByNumber(canonicalHead, td, header.timestamp)
     })
@@ -1078,6 +1080,10 @@ export class Blockchain implements BlockchainInterface {
       // reset stale headBlock to current canonical
       if (this._headBlockHash?.equals(hash) === true) {
         this._headBlockHash = headHash
+      }
+      // reset stale headBlock to current canonical
+      if (this._headHeaderHash?.equals(hash) === true) {
+        this._headHeaderHash = headHash
       }
 
       blockNumber++

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -414,6 +414,14 @@ export class Blockchain implements BlockchainInterface {
     await this._putBlockOrHeader(header)
   }
 
+  /**
+   * Resets the canonical chain to canonicalHead number
+   *
+   * This updates the head hashes (if affected) to the hash corresponding to
+   * canonicalHead and cleans up canonical references greater than canonicalHead
+   * @param canonicalHead - The number to which chain should be reset to
+   */
+
   async resetCanonicalHead(canonicalHead: bigint) {
     await this.runWithLock<void>(async () => {
       const hash = await this.dbManager.numberToHash(canonicalHead)

--- a/packages/blockchain/test/customConsensus.spec.ts
+++ b/packages/blockchain/test/customConsensus.spec.ts
@@ -127,19 +127,30 @@ tape('Custom consensus validation rules', async (t) => {
 })
 
 tape('consensus transition checks', async (t) => {
-  t.plan(2)
   const common = new Common({ chain: 'mainnet', hardfork: Hardfork.Chainstart })
   const consensus = new fibonacciConsensus()
   const blockchain = await Blockchain.create({ common, consensus })
 
-  t.doesNotThrow(
-    () => (blockchain as any).checkAndTransitionHardForkByNumber(5),
-    'checkAndTransitionHardForkByNumber should not throw with custom consensus'
-  )
+  try {
+    await (blockchain as any).checkAndTransitionHardForkByNumber(5)
+    t.pass('checkAndTransitionHardForkByNumber does not throw with custom consensus')
+  } catch (err: any) {
+    t.fail(
+      `checkAndTransitionHardForkByNumber should not throw with custom consensus, error=${err.message}`
+    )
+  }
+
   ;(blockchain as any).consensus = new EthashConsensus()
   ;(blockchain._common as any).consensusAlgorithm = () => 'fibonacci'
-  t.throws(
-    () => (blockchain as any).checkAndTransitionHardForkByNumber(5),
-    'checkAndTransitionHardForkByNumber should throw when using standard consensus (ethash, clique, casper) but consensus algorithm defined in common is different'
-  )
+
+  try {
+    await (blockchain as any).checkAndTransitionHardForkByNumber(5)
+    t.fail(
+      'checkAndTransitionHardForkByNumber should throw when using standard consensus (ethash, clique, casper) but consensus algorithm defined in common is different'
+    )
+  } catch (err: any) {
+    t.pass(
+      `checkAndTransitionHardForkByNumber correctly throws when using standard consensus (ethash, clique, casper) but consensus algorithm defined in common is different, error=${err.message}`
+    )
+  }
 })

--- a/packages/blockchain/test/index.spec.ts
+++ b/packages/blockchain/test/index.spec.ts
@@ -231,6 +231,13 @@ tape('blockchain test', (t) => {
     st.equal(getBlocks!.length, 5)
     st.equal(blocks[0].header.number, getBlocks[0].header.number)
     st.ok(isConsecutive(getBlocks!), 'blocks should be consecutive')
+
+    let canonicalHeader = await blockchain.getCanonicalHeadHeader()
+    st.equal(canonicalHeader.number, BigInt(24), 'block 24 should be canonical header')
+    await blockchain.resetCanonicalHead(BigInt(4))
+    canonicalHeader = await blockchain.getCanonicalHeadHeader()
+    st.equal(canonicalHeader.number, BigInt(4), 'block 4 should be new canonical header')
+
     st.end()
   })
 

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -421,7 +421,7 @@ async function startClient(config: Config, customGenesisState?: GenesisState) {
     await startBlock(client)
   }
 
-  if (typeof args.loadBlocksFromRlp === 'string') await client.open()
+  await client.open()
   // update client's sync status and start txpool if synchronized
   client.config.updateSynchronizedState(client.chain.headers.latest)
   if (client.config.synchronized) {

--- a/packages/client/lib/blockchain/chain.ts
+++ b/packages/client/lib/blockchain/chain.ts
@@ -1,10 +1,11 @@
-import { Block, BlockHeader } from '@ethereumjs/block'
+import { BlockHeader } from '@ethereumjs/block'
 import { Blockchain } from '@ethereumjs/blockchain'
 import { ConsensusAlgorithm, Hardfork } from '@ethereumjs/common'
 
 import { Event } from '../types'
 
 import type { Config } from '../config'
+import type { Block } from '@ethereumjs/block'
 import type { AbstractLevel } from 'abstract-level'
 
 /**
@@ -270,7 +271,7 @@ export class Chain {
     if (blocks.length === 0) return 0
 
     let numAdded = 0
-    for (const [i, b] of blocks.entries()) {
+    for (const [i, block] of blocks.entries()) {
       if (!fromEngine && this.config.chainCommon.gteHardfork(Hardfork.Merge)) {
         if (i > 0) {
           // emitOnLast below won't be reached, so run an update here
@@ -278,10 +279,7 @@ export class Chain {
         }
         break
       }
-      const block = Block.fromValuesArray(b.raw(), {
-        common: this.config.chainCommon,
-        hardforkByTTD: this.headers.td,
-      })
+
       await this.blockchain.putBlock(block)
       numAdded++
       const emitOnLast = blocks.length === numAdded

--- a/packages/client/lib/blockchain/chain.ts
+++ b/packages/client/lib/blockchain/chain.ts
@@ -195,6 +195,12 @@ export class Chain {
     this.opened = false
   }
 
+  async resetCanonicalHead(canonicalHead: bigint): Promise<boolean | void> {
+    if (!this.opened) return false
+    await this.blockchain.resetCanonicalHead(canonicalHead)
+    return this.update(false)
+  }
+
   /**
    * Update blockchain properties (latest block, td, height, etc...)
    * @param emit Emit a `CHAIN_UPDATED` event

--- a/packages/client/lib/blockchain/chain.ts
+++ b/packages/client/lib/blockchain/chain.ts
@@ -194,6 +194,9 @@ export class Chain {
     this.opened = false
   }
 
+  /**
+   * Resets the chain to canonicalHead number
+   */
   async resetCanonicalHead(canonicalHead: bigint): Promise<boolean | void> {
     if (!this.opened) return false
     await this.blockchain.resetCanonicalHead(canonicalHead)

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -622,6 +622,7 @@ export class Skeleton extends MetaDBManager {
         `Resetting canonicalHead for fillCanonicalChain from=${canonicalHead} to=${newHead}`
       )
       canonicalHead = newHead
+      await this.chain.resetCanonicalHead(canonicalHead)
       this.status.canonicalHeadReset = false
     }
 

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -609,9 +609,9 @@ export class Skeleton extends MetaDBManager {
     let canonicalHead = this.chain.blocks.height
     const subchain = this.status.progress.subchains[0]!
     if (this.status.canonicalHeadReset) {
-      if (subchain.tail > canonicalHead) {
+      if (subchain.tail > canonicalHead + BigInt(1)) {
         throw Error(
-          `Canonical head should already be on or ahead subchain tial canonicalHead=${canonicalHead} tail=${subchain.tail}`
+          `Canonical head should already be on or ahead subchain tail canonicalHead=${canonicalHead} tail=${subchain.tail}`
         )
       }
       let newHead = subchain.tail - BigInt(1)

--- a/packages/client/lib/types.ts
+++ b/packages/client/lib/types.ts
@@ -156,4 +156,5 @@ export interface ClientOpts {
   startBlock?: number
   isSingleNode?: boolean
   opened: boolean
+  loadBlocksFromRlp?: string
 }


### PR DESCRIPTION
New fixes related to Hive tests

- Adds a new `--loadBlocksFromRlp` CLI parameter that allows for loading RLP encoded blocks on chain start that are fed via the `./chain.rlp` path in various Hive tests.  [Needed by the Hive tests](https://github.com/ethereum/hive/blob/master/docs/clients.md#files)
- Add better handling of reorgs that go pre-merge -- fixes hive tests run by this command - `go run ./hive.go --client ethereumjs --sim ethereum/engine --sim.limit "engine-transition/Single Block PoW Re-org to Higher-Total-Difficulty Chain, Equal Height"`
- Skip extradata check on PoW genesis blocks (since some Hive tests with PoW genesis parameters have `extradata` that does not conform to PoW extradata requirements