### PR TITLE
withdrawals and transaction inclusion logic updates

### DIFF
--- a/packages/client/lib/miner/pendingBlock.ts
+++ b/packages/client/lib/miner/pendingBlock.ts
@@ -1,6 +1,13 @@
 import { BlockHeader } from '@ethereumjs/block'
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
-import { TypeOutput, bigIntToUnpaddedBuffer, bufferToHex, toBuffer, toType } from '@ethereumjs/util'
+import {
+  TypeOutput,
+  bigIntToUnpaddedBuffer,
+  bufferToHex,
+  toBuffer,
+  toType,
+  zeros,
+} from '@ethereumjs/util'
 import { BuildStatus } from '@ethereumjs/vm/dist/buildBlock'
 import { keccak256 } from 'ethereum-cryptography/keccak'
 
@@ -86,9 +93,9 @@ export class PendingBlock {
     const { gasLimit } = parentBlock.header
 
     // payload is uniquely defined by timestamp, gasLimit and the header
-    const timestampBuf = bigIntToUnpaddedBuffer(toType(timestamp, TypeOutput.BigInt))
+    const timestampBuf = bigIntToUnpaddedBuffer(toType(timestamp ?? 0, TypeOutput.BigInt))
     const gasLimitBuf = bigIntToUnpaddedBuffer(gasLimit)
-    const mixHashBuf = toType(mixHash!, TypeOutput.Buffer)
+    const mixHashBuf = toType(mixHash!, TypeOutput.Buffer) ?? zeros(32)
     const payloadIdBuffer = toBuffer(
       keccak256(Buffer.concat([parentBlock.hash(), mixHashBuf, timestampBuf, gasLimitBuf])).slice(
         0,

--- a/packages/client/lib/miner/pendingBlock.ts
+++ b/packages/client/lib/miner/pendingBlock.ts
@@ -172,18 +172,6 @@ export class PendingBlock {
               `Pending: Assembled block full (gasLeft: ${gasLimit - builder.gasUsed})`
             )
           }
-        } else if ((error as Error).message.includes('tx has a different hardfork than the vm')) {
-          // We can here decide to keep a tx in pool if it belongs to future hf
-          // but for simplicity just remove the tx as the sender can always retransmit
-          // the tx
-          this.txPool.removeByHash(txs[index].hash().toString('hex'))
-          this.config.logger.error(
-            `Pending: Removed from txPool tx 0x${txs[index]
-              .hash()
-              .toString('hex')} having different hf=${txs[
-              index
-            ].common.hardfork()} than block vm hf=${vm._common.hardfork()}`
-          )
         } else {
           // If there is an error adding a tx, it will be skipped
           this.config.logger.debug(

--- a/packages/client/lib/miner/pendingBlock.ts
+++ b/packages/client/lib/miner/pendingBlock.ts
@@ -304,8 +304,6 @@ export class PendingBlock {
       this.constructBlobsBundle(payloadId, blobTxs, block.header.hash())
     }
 
-    // Remove from pendingPayloads
-    // this.pendingPayloads = this.pendingPayloads.filter((p) => !p[0].equals(payloadId))
 
     return [block, builder.transactionReceipts, builder.minerValue]
   }

--- a/packages/client/lib/miner/pendingBlock.ts
+++ b/packages/client/lib/miner/pendingBlock.ts
@@ -92,7 +92,8 @@ export class PendingBlock {
     const { timestamp, mixHash } = headerData
     const { gasLimit } = parentBlock.header
 
-    // payload is uniquely defined by timestamp, gasLimit and the header
+    // payload is uniquely defined by timestamp, parent and mixHash, gasLimit can also be
+    // potentially included in the fcU in future and can be safely added in uniqueness calc
     const timestampBuf = bigIntToUnpaddedBuffer(toType(timestamp ?? 0, TypeOutput.BigInt))
     const gasLimitBuf = bigIntToUnpaddedBuffer(gasLimit)
     const mixHashBuf = toType(mixHash!, TypeOutput.Buffer) ?? zeros(32)
@@ -211,7 +212,7 @@ export class PendingBlock {
     const payloadId =
       typeof payloadIdBuffer !== 'string' ? bufferToHex(payloadIdBuffer) : payloadIdBuffer
     const builder = this.pendingPayloads.get(payloadId)
-    if (!builder) return
+    if (builder === undefined) return
     // Revert blockBuilder
     void builder.revert()
     // Remove from pendingPayloads
@@ -303,7 +304,6 @@ export class PendingBlock {
     if (block._common.isActivatedEIP(4844)) {
       this.constructBlobsBundle(payloadId, blobTxs, block.header.hash())
     }
-
 
     return [block, builder.transactionReceipts, builder.minerValue]
   }

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -624,15 +624,17 @@ export class Engine {
 
   async newPayloadV2(params: [ExecutionPayloadV2 | ExecutionPayloadV1]): Promise<PayloadStatusV1> {
     const shanghaiTimestamp = this.chain.config.chainCommon.hardforkTimestamp(Hardfork.Shanghai)
+    const withdrawals = (params[0] as ExecutionPayloadV2).withdrawals
+
     if (shanghaiTimestamp === null || parseInt(params[0].timestamp) < shanghaiTimestamp) {
-      if ('withdrawals' in params[0]) {
+      if (withdrawals !== undefined && withdrawals !== null) {
         throw {
           code: INVALID_PARAMS,
           message: 'ExecutionPayloadV1 MUST be used before Shanghai is activated',
         }
       }
     } else if (parseInt(params[0].timestamp) >= shanghaiTimestamp) {
-      if (!('withdrawals' in params[0]) || params[0].withdrawals === null) {
+      if (withdrawals === undefined || withdrawals === null) {
         throw {
           code: INVALID_PARAMS,
           message: 'ExecutionPayloadV2 MUST be used after Shanghai is activated',

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -213,10 +213,14 @@ tape('[Miner]', async (t) => {
 
     // disable consensus to skip PoA block signer validation
     ;(vm.blockchain.consensus as CliqueConsensus).cliqueActiveSigners = () => [A.address] // stub
-    // tx as at Harfork.Berlin so lets change the vm's hardfork
+
     chain.putBlocks = (blocks: Block[]) => {
-      t.equal(blocks[0].transactions.length, 0, 'new block should not include tx')
-      t.equal(txPool.txsInPool, 0, 'transaction should also have been removed from pool')
+      t.equal(
+        blocks[0].transactions.length,
+        0,
+        'new block should not include tx due to hardfork mismatch'
+      )
+      t.equal(txPool.txsInPool, 1, 'transaction should remain in pool')
       miner.stop()
       txPool.stop()
     }

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -115,7 +115,7 @@ tape('[PendingBlock]', async (t) => {
     const pendingBlock = new PendingBlock({ config, txPool, skipHardForkValidation: true })
     const parentBlock = await vm.blockchain.getCanonicalHeadBlock!()
     const payloadId = await pendingBlock.start(vm, parentBlock)
-    t.equal(pendingBlock.pendingPayloads.length, 1, 'should set the pending payload')
+    t.equal(pendingBlock.pendingPayloads.size, 1, 'should set the pending payload')
     await txPool.add(txB01)
     const built = await pendingBlock.build(payloadId)
     if (!built) return t.fail('pendingBlock did not return')
@@ -123,7 +123,8 @@ tape('[PendingBlock]', async (t) => {
     t.equal(block?.header.number, BigInt(1), 'should have built block number 1')
     t.equal(block?.transactions.length, 3, 'should include txs from pool')
     t.equal(receipts.length, 3, 'receipts should match number of transactions')
-    t.equal(pendingBlock.pendingPayloads.length, 0, 'should reset the pending payload after build')
+    pendingBlock.pruneSetToMax(0)
+    t.equal(pendingBlock.pendingPayloads.size, 0, 'should reset the pending payload after build')
     t.end()
   })
 
@@ -140,7 +141,7 @@ tape('[PendingBlock]', async (t) => {
     const pendingBlock = new PendingBlock({ config, txPool })
     const parentBlock = await vm.blockchain.getCanonicalHeadBlock!()
     const payloadId = await pendingBlock.start(vm, parentBlock)
-    t.equal(pendingBlock.pendingPayloads.length, 1, 'should set the pending payload')
+    t.equal(pendingBlock.pendingPayloads.size, 1, 'should set the pending payload')
     t.equal(txPool.txsInPool, 0, 'tx should have been removed from pool')
 
     txB011.common.setHardfork(Hardfork.Merge)
@@ -152,7 +153,8 @@ tape('[PendingBlock]', async (t) => {
     t.equal(block?.header.number, BigInt(1), 'should have built block number 1')
     t.equal(block?.transactions.length, 0, 'should include txs from pool')
     t.equal(txPool.txsInPool, 0, 'txs should have been removed from pool')
-    t.equal(pendingBlock.pendingPayloads.length, 0, 'should reset the pending payload after build')
+    pendingBlock.pruneSetToMax(0)
+    t.equal(pendingBlock.pendingPayloads.size, 0, 'should reset the pending payload after build')
     t.end()
   })
 
@@ -164,13 +166,9 @@ tape('[PendingBlock]', async (t) => {
     await setBalance(vm, A.address, BigInt(5000000000000000))
     const parentBlock = await vm.blockchain.getCanonicalHeadBlock!()
     const payloadId = await pendingBlock.start(vm, parentBlock)
-    t.equal(pendingBlock.pendingPayloads.length, 1, 'should set the pending payload')
+    t.equal(pendingBlock.pendingPayloads.size, 1, 'should set the pending payload')
     pendingBlock.stop(payloadId)
-    t.equal(
-      pendingBlock.pendingPayloads.length,
-      0,
-      'should reset the pending payload after stopping'
-    )
+    t.equal(pendingBlock.pendingPayloads.size, 0, 'should reset the pending payload after stopping')
     t.end()
   })
 
@@ -194,14 +192,15 @@ tape('[PendingBlock]', async (t) => {
     await setBalance(vm, A.address, BigInt(5000000000000000))
     const parentBlock = await vm.blockchain.getCanonicalHeadBlock!()
     const payloadId = await pendingBlock.start(vm, parentBlock)
-    t.equal(pendingBlock.pendingPayloads.length, 1, 'should set the pending payload')
+    t.equal(pendingBlock.pendingPayloads.size, 1, 'should set the pending payload')
     const built = await pendingBlock.build(payloadId)
     if (!built) return t.fail('pendingBlock did not return')
     const [block, receipts] = built
     t.equal(block?.header.number, BigInt(1), 'should have built block number 1')
     t.equal(block?.transactions.length, 2, 'should include txs from pool that fit in the block')
     t.equal(receipts.length, 2, 'receipts should match number of transactions')
-    t.equal(pendingBlock.pendingPayloads.length, 0, 'should reset the pending payload after build')
+    pendingBlock.pruneSetToMax(0)
+    t.equal(pendingBlock.pendingPayloads.size, 0, 'should reset the pending payload after build')
     t.end()
   })
 
@@ -212,7 +211,7 @@ tape('[PendingBlock]', async (t) => {
     const vm = await VM.create({ common })
     const parentBlock = await vm.blockchain.getCanonicalHeadBlock!()
     const payloadId = await pendingBlock.start(vm, parentBlock)
-    t.equal(pendingBlock.pendingPayloads.length, 1, 'should set the pending payload')
+    t.equal(pendingBlock.pendingPayloads.size, 1, 'should set the pending payload')
     const built = await pendingBlock.build(payloadId)
     if (!built) return t.fail('pendingBlock did not return')
     const [block, receipts] = built
@@ -223,7 +222,8 @@ tape('[PendingBlock]', async (t) => {
       'should not include tx with sender that has insufficient funds'
     )
     t.equal(receipts.length, 0, 'receipts should match number of transactions')
-    t.equal(pendingBlock.pendingPayloads.length, 0, 'should reset the pending payload after build')
+    pendingBlock.pruneSetToMax(0)
+    t.equal(pendingBlock.pendingPayloads.size, 0, 'should reset the pending payload after build')
     t.end()
   })
 

--- a/packages/client/test/rpc/engine/withdrawals.spec.ts
+++ b/packages/client/test/rpc/engine/withdrawals.spec.ts
@@ -113,7 +113,7 @@ for (const { name, withdrawals, withdrawalsRoot, gethBlockRlp } of testCases) {
     let expectRes = checkError(
       t,
       INVALID_PARAMS,
-      "invalid argument 1 for key 'withdrawals': argument is not array"
+      'PayloadAttributesV2 MUST be used after Shanghai is activated'
     )
     await baseRequest(t, server, req, 200, expectRes, false)
 

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -229,7 +229,6 @@ export class BlockBuilder {
    * Reverts the checkpoint on the StateManager to reset the state from any transactions that have been run.
    */
   async revert() {
-    this.checkStatus()
     if (this.checkpointed) {
       await this.vm.stateManager.revert()
       this.blockStatus = { status: BuildStatus.Reverted }

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -229,10 +229,7 @@ export class BlockBuilder {
    * Reverts the checkpoint on the StateManager to reset the state from any transactions that have been run.
    */
   async revert() {
-    if (this.checkpointed) {
-      await this.vm.stateManager.revert()
-      this.blockStatus = { status: BuildStatus.Reverted }
-    }
+    this.blockStatus = { status: BuildStatus.Reverted }
   }
 
   /**

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -231,6 +231,7 @@ export class BlockBuilder {
   async revert() {
     if (this.checkpointed) {
       await this.vm.stateManager.revert()
+      this.checkpointed = false
     }
     this.blockStatus = { status: BuildStatus.Reverted }
   }

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -229,6 +229,9 @@ export class BlockBuilder {
    * Reverts the checkpoint on the StateManager to reset the state from any transactions that have been run.
    */
   async revert() {
+    if (this.checkpointed) {
+      await this.vm.stateManager.revert()
+    }
     this.blockStatus = { status: BuildStatus.Reverted }
   }
 

--- a/packages/vm/test/api/buildBlock.spec.ts
+++ b/packages/vm/test/api/buildBlock.spec.ts
@@ -235,13 +235,9 @@ tape('BlockBuilder', async (t) => {
 
     try {
       await blockBuilder.revert()
-      st.fail('should throw error')
+      st.equal(blockBuilder.getStatus().status, 'reverted', 'block should be in reverted status')
     } catch (error: any) {
-      if ((error.message as string).includes('Block has already been built')) {
-        st.pass('correct error thrown')
-      } else {
-        st.fail('wrong error thrown')
-      }
+      st.fail('shoud not throw')
     }
 
     blockBuilder = await vm.buildBlock({ parentBlock: genesisBlock })
@@ -259,13 +255,9 @@ tape('BlockBuilder', async (t) => {
 
     try {
       await blockBuilder.revert()
-      st.fail('should throw error')
+      st.equal(blockBuilder.getStatus().status, 'reverted', 'block should be in reverted status')
     } catch (error: any) {
-      if ((error.message as string).includes('State has already been reverted')) {
-        st.pass('correct error thrown')
-      } else {
-        st.fail('wrong error thrown')
-      }
+      st.fail('shoud not throw')
     }
 
     st.end()

--- a/packages/vm/test/api/buildBlock.spec.ts
+++ b/packages/vm/test/api/buildBlock.spec.ts
@@ -86,40 +86,6 @@ tape('BlockBuilder', async (t) => {
     st.end()
   })
 
-  t.test('should revert the VM state if reverted', async (st) => {
-    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
-    const genesisBlock = Block.fromBlockData({ header: { gasLimit: 50000 } }, { common })
-    const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
-    const vm = await VM.create({ common, blockchain })
-
-    const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
-    await setBalance(vm, address)
-
-    const root0 = await vm.eei.getStateRoot()
-
-    const blockBuilder = await vm.buildBlock({ parentBlock: genesisBlock })
-
-    // Set up tx
-    const tx = Transaction.fromTxData(
-      { to: Address.zero(), value: 1000, gasLimit: 21000, gasPrice: 1 },
-      { common, freeze: false }
-    )
-    tx.getSenderAddress = () => {
-      return address
-    }
-
-    await blockBuilder.addTransaction(tx)
-
-    const root1 = await vm.eei.getStateRoot()
-    st.ok(!root0.equals(root1), 'state root should change after adding a tx')
-
-    await blockBuilder.revert()
-    const root2 = await vm.eei.getStateRoot()
-
-    st.ok(root2.equals(root0), 'state root should revert to before the tx was run')
-    st.end()
-  })
-
   t.test('should correctly seal a PoW block', async (st) => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     const genesisBlock = Block.fromBlockData({ header: { gasLimit: 50000 } }, { common })

--- a/packages/vm/test/api/runTx.spec.ts
+++ b/packages/vm/test/api/runTx.spec.ts
@@ -99,13 +99,13 @@ tape('runTx() -> successful API parameter usage', async (t) => {
     await vm.eei.putAccount(caller, acc)
     const block = Block.fromBlockData({}, { common: vm._common.copy() })
 
-    tx.common.setHardfork(Hardfork.Merge)
+    block._common.setHardfork(Hardfork.Merge)
     try {
       await vm.runTx({ tx, block })
-      st.fail('vm/tx mismatched hardfork should have failed')
+      st.fail('vm/block mismatched hardfork should have failed')
     } catch (e) {
       st.equal(
-        (e as Error).message.includes('tx has a different hardfork than the vm'),
+        (e as Error).message.includes('block has a different hardfork than the vm'),
         true,
         'block has a different hardfork than the vm'
       )


### PR DESCRIPTION
- Changes `engine_forkchoiceUpdatedV2` withdrawals parameter to `optional` to ensure we return the correct error message if a preShanghai payload is sent
- Adds some caching logic for pending payloads so as to prune pending block payloads once one is built and provided to the CL
- Modifies the logic for including transactions in a pendingBlock by using the pending block's hardfork (instead of the transaction hardfork since transactions are generally hardfork agnostic) when running the transaction in the VM to ensure that it can be executed and included in the block.

Targets Hive tests that can be run using this command:
`go run ./hive.go --client ethereumjs --sim ethereum/engine --sim.limit "engine-withdrawals/Withdrawals Fork on Block 2"`