### PR TITLE
blockchain: Add extra validations for assuming nil bodies in getBlock

### DIFF
--- a/packages/blockchain/src/db/manager.ts
+++ b/packages/blockchain/src/db/manager.ts
@@ -1,6 +1,6 @@
 import { Block, BlockHeader, valuesArrayToHeaderData } from '@ethereumjs/block'
 import { RLP } from '@ethereumjs/rlp'
-import { KECCAK256_RLP, arrToBufArr, bufferToBigInt } from '@ethereumjs/util'
+import { KECCAK256_RLP, KECCAK256_RLP_ARRAY, arrToBufArr, bufferToBigInt } from '@ethereumjs/util'
 
 import { Cache } from './cache'
 import { DBOp, DBTarget } from './operation'
@@ -106,18 +106,32 @@ export class DBManager {
     }
 
     const header = await this.getHeader(hash, number)
-    let body: BlockBodyBuffer = [[], []]
+    let body: BlockBodyBuffer
     try {
       body = await this.getBody(hash, number)
     } catch (error: any) {
       if (error.code !== 'LEVEL_NOT_FOUND') {
         throw error
       }
+
+      // Do extra validations on the header since we are assuming empty transactions and uncles
+      if (
+        !header.transactionsTrie.equals(KECCAK256_RLP) ||
+        !header.uncleHash.equals(KECCAK256_RLP_ARRAY)
+      ) {
+        throw error
+      }
+      body = [[], []]
       // If this block had empty withdrawals push an empty array in body
-      if (header.withdrawalsRoot !== undefined && header.withdrawalsRoot.equals(KECCAK256_RLP)) {
+      if (header.withdrawalsRoot !== undefined) {
+        // Do extra validations for withdrawal before assuming empty withdrawals
+        if (!header.withdrawalsRoot.equals(KECCAK256_RLP)) {
+          throw error
+        }
         body.push([])
       }
     }
+
     const blockData = [header.raw(), ...body] as BlockBuffer
     const opts: BlockOptions = { common: this._common }
     if (number === BigInt(0)) {

--- a/packages/blockchain/test/index.spec.ts
+++ b/packages/blockchain/test/index.spec.ts
@@ -475,6 +475,32 @@ tape('blockchain test', (t) => {
     st.end()
   })
 
+  t.test('should test nil bodies / throw', async (st) => {
+    const blocks = generateBlocks(3)
+    const blockchain = await Blockchain.create({
+      validateBlocks: false,
+      validateConsensus: false,
+      genesisBlock: blocks[0],
+    })
+    await blockchain.putHeader(blocks[1].header)
+    // Should be able to get the block
+    await blockchain.getBlock(BigInt(1))
+
+    const block2HeaderValuesArray = blocks[2].header.raw()
+    block2HeaderValuesArray[1] = Buffer.alloc(32)
+    const block2Header = BlockHeader.fromValuesArray(block2HeaderValuesArray, {
+      common: blocks[2]._common,
+    })
+    await blockchain.putHeader(block2Header)
+    try {
+      await blockchain.getBlock(BigInt(2))
+      st.fail('block should not be constucted')
+    } catch (e) {
+      st.pass('block not constructed from empty bodies')
+    }
+    st.end()
+  })
+
   t.test('should put multiple blocks at once', async (st) => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
     const blocks: Block[] = []

--- a/packages/client/lib/sync/fetcher/blockfetcher.ts
+++ b/packages/client/lib/sync/fetcher/blockfetcher.ts
@@ -85,7 +85,9 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
         values.push(withdrawalsData)
       }
       // Supply the common from the corresponding block header already set on correct fork
-      blocks.push(Block.fromValuesArray(values, { common: headers[i]._common }))
+      const block = Block.fromValuesArray(values, { common: headers[i]._common })
+      await block.validateData()
+      blocks.push(block)
     }
     this.debug(
       `Returning blocks=${blocksRange} from ${peerInfo} (received: ${headers.length} headers / ${bodies.length} bodies)`


### PR DESCRIPTION
Add extra validations for assuming nil bodies in getBlock

While debugging for 
- https://github.com/ethereumjs/ethereumjs-monorepo/issues/2528

No discrepancy was found: 

synced two ethereumjs peers 
- peer1 from geth  to have full local chain 
  (our EF node has the bug of not serving canonical chain in beacon sync like how we discovered in shandong but should have been fixed with latest hive fixes regarding DB ops)
- peer2 from local ethereumjs and added extra validation for the downloaded block

but haven't found the nil withdrawal body issue so far.

However discovered that we need extravalidations 

i) while importing block from peer
ii) Also while assuming nil bodies when bodies not found in the DB (could be some DB bodies write bug)

Hence  PR for the same

Closes #[2528](https://github.com/ethereumjs/ethereumjs-monorepo/issues/2528)