### PR TITLE
devp2p: Client Peer Connection SUBPROTOCOL Error Analysis

### DIFF
--- a/packages/common/src/chains/sepolia.json
+++ b/packages/common/src/chains/sepolia.json
@@ -94,32 +94,11 @@
   ],
   "bootstrapNodes": [
     {
-      "ip": "18.168.182.86",
+      "ip": "172.105.167.71",
       "port": 30303,
-      "id": "9246d00bc8fd1742e5ad2428b80fc4dc45d786283e05ef6edbd9002cbc335d40998444732fbe921cb88e1d2c73d1b1de53bae6a2237996e9bfe14f871baf7066",
+      "id": "",
       "location": "",
-      "comment": "geth"
-    },
-    {
-      "ip": "52.14.151.177",
-      "port": 30303,
-      "id": "ec66ddcf1a974950bd4c782789a7e04f8aa7110a72569b6e65fcd51e937e74eed303b1ea734e4d19cfaec9fbff9b6ee65bf31dcb50ba79acce9dd63a6aca61c7",
-      "location": "",
-      "comment": "besu"
-    },
-    {
-      "ip": "165.22.196.173",
-      "port": 30303,
-      "id": "ce970ad2e9daa9e14593de84a8b49da3d54ccfdf83cbc4fe519cb8b36b5918ed4eab087dedd4a62479b8d50756b492d5f762367c8d20329a7854ec01547568a6",
-      "location": "",
-      "comment": "EF"
-    },
-    {
-      "ip": "65.108.95.67",
-      "port": 30303,
-      "id": "075503b13ed736244896efcde2a992ec0b451357d46cb7a8132c0384721742597fc8f0d91bbb40bb52e7d6e66728d36a1fda09176294e4a30cfac55dcce26bc6",
-      "location": "",
-      "comment": "lodestar"
+      "comment": "Nethermind"
     }
   ],
   "dnsNetworks": [

--- a/packages/devp2p/scripts/tester.ts
+++ b/packages/devp2p/scripts/tester.ts
@@ -1,0 +1,41 @@
+import { randomBytes } from 'crypto'
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import * as devp2p from '../src/index'
+
+const PEER_ADDRESS = '172.105.167.71'
+const PEER_PORT = 30303
+const ETH_PROTOCOL = devp2p.ETH.eth66
+
+const PRIVATE_KEY = randomBytes(32)
+
+const common = new Common({ chain: Chain.Sepolia })
+
+const dpt = new devp2p.DPT(PRIVATE_KEY, {
+  refreshInterval: 30000,
+  endpoint: {
+    address: '0.0.0.0',
+    udpPort: null,
+    tcpPort: null,
+  },
+  shouldFindNeighbours: false,
+  shouldGetDnsPeers: false,
+})
+
+const rlpx = new devp2p.RLPx(PRIVATE_KEY, {
+  dpt,
+  maxPeers: 1,
+  capabilities: [ETH_PROTOCOL],
+  common,
+})
+
+const run = async () => {
+  // Emits 'peer:new' on success, rlpx listens and
+  // calls into `rlpx.connect
+  await dpt.addPeer({
+    address: PEER_ADDRESS,
+    udpPort: PEER_PORT,
+    tcpPort: PEER_PORT,
+  })
+}
+
+run()

--- a/packages/devp2p/src/dpt/server.ts
+++ b/packages/devp2p/src/dpt/server.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'events'
 import LRUCache = require('lru-cache')
 import ms = require('ms')
 
-import { createDeferred, devp2pDebug, formatLogId, keccak256, pk2id } from '../util'
+import { createDeferred, devp2pDebug, formatLogId, pk2id } from '../util'
 
 import { decode, encode } from './message'
 
@@ -46,7 +46,6 @@ export class Server extends EventEmitter {
   _timeout: number
   _endpoint: PeerInfo
   _requests: Map<string, any>
-  _parityRequestMap: Map<string, string>
   _requestsCache: LRUCache<string, Promise<any>>
   _socket: DgramSocket | null
   _debug: Debugger
@@ -60,7 +59,6 @@ export class Server extends EventEmitter {
     this._timeout = options.timeout ?? ms('10s')
     this._endpoint = options.endpoint ?? { address: '0.0.0.0', udpPort: null, tcpPort: null }
     this._requests = new Map()
-    this._parityRequestMap = new Map()
     this._requestsCache = new LRUCache({ max: 1000, maxAge: ms('1s'), stale: false })
 
     const createSocket = options.createSocket ?? dgram.createSocket.bind(null, { type: 'udp4' })
@@ -149,20 +147,7 @@ export class Server extends EventEmitter {
     this.debug(typename, debugMsg)
 
     const msg = encode(typename, data, this._privateKey)
-    // Parity hack
-    // There is a bug in Parity up to at lease 1.8.10 not echoing the hash from
-    // discovery spec (hash: sha3(signature || packet-type || packet-data))
-    // but just hashing the RLP-encoded packet data (see discovery.rs, on_ping())
-    // 2018-02-28
-    if (typename === 'ping') {
-      const rkeyParity = keccak256(msg.slice(98)).toString('hex')
-      this._parityRequestMap.set(rkeyParity, msg.slice(0, 32).toString('hex'))
-      setTimeout(() => {
-        if (this._parityRequestMap.get(rkeyParity) !== undefined) {
-          this._parityRequestMap.delete(rkeyParity)
-        }
-      }, this._timeout)
-    }
+
     if (this._socket && typeof peer.udpPort === 'number')
       this._socket.send(msg, 0, msg.length, peer.udpPort, peer.address)
     return msg.slice(0, 32) // message id
@@ -201,12 +186,7 @@ export class Server extends EventEmitter {
       }
 
       case 'pong': {
-        let rkey = info.data.hash.toString('hex')
-        const rkeyParity = this._parityRequestMap.get(rkey)
-        if (typeof rkeyParity === 'string') {
-          rkey = rkeyParity
-          this._parityRequestMap.delete(rkeyParity)
-        }
+        const rkey = info.data.hash.toString('hex')
         const request = this._requests.get(rkey)
         if (request !== undefined) {
           this._requests.delete(rkey)

--- a/packages/devp2p/tsconfig.json
+++ b/packages/devp2p/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../config/tsconfig.json",
-  "include": ["src/**/*.ts", "test/**/*.ts", "examples/**/*.ts"],
+  "include": ["src/**/*.ts", "test/**/*.ts", "examples/**/*.ts", "scripts/**/*.ts"],
   "compilerOptions": {
     "baseUrl": ".",
     "typeRoots": ["node_modules/@types", "src/@types"]

--- a/packages/devp2p/tsconfig.prod.json
+++ b/packages/devp2p/tsconfig.prod.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../config/tsconfig.prod.json",
-  "exclude": ["test", "examples", "node_modules", "dist"],
+  "exclude": ["test", "examples", "scripts", "node_modules", "dist"],
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist",


### PR DESCRIPTION
This analysis has been triggered by trying to connect with the client to `Sepolia` with `npm run client:start -- --network=sepolia` and being dissatisfied by the level of connectivity getting on startup.

When doing some client runs with the devp2p logger being activated I (re-)discovered that we often have the situation with peer connections "looking good" but then nevertheless terminating with a `SUBPROTOCOL_ERROR`.

This is a problem we have for ages, and having these peer connections go through would be especially valuable, since there *are* only a few with some option for success - many many others refuse with `TOO_MANY_PEERS` - and if these few are terminating unexpectedly to some greater extend that is a substantial loss for client connectivity.

I tried to isolate one of these peer runs to a peer with IP `172.105.167.71` and the standard port `30303`.

On the devp2p side I wrote a small script which we might want to generalize/improve later on and which allows to run one peer connection in isolation.

This script can be run with:

```shell
DEBUG=ethjs,devp2p:* ts-node scripts/tester.ts
```

And gives the following output (the last DISCONNECT is expected):

![grafik](https://user-images.githubusercontent.com/931137/219664999-8d76141f-1079-4a1c-bdb5-bdf0bb0a89be.png)

The one thing which I realized at some point. On the DPT side after our `ping` answered by a `pong` from the node, there is another `ping` send from the node which we then answer back with a `pong` (so lines 5 and 6). This is not happening *at all* within a client run context (neither for this nor for other peers) (or minimally it is not logged (unlikely)).

I then went ahead and isolated the peer connection in the client context as well by manipulating the Common bootstrap nodes and then run the client with:

```shell
cd ../common && npm run build && cd ../devp2p && npm run build && cd ../client && DEBUG=ethjs,devp2p:*,devp2p:*:* npm run client:start -- --network=sepolia --discV4=false --discDns=false
```

This gives the following output:

![grafik](https://user-images.githubusercontent.com/931137/219665928-a18933ca-a6bd-432e-a2c5-f6c7ca7c40df.png)

As one can see, the second ping/pong is just not there, instead connection repeatedly halts with a received `DISCONNECT` from the remote node with no additional communication (compared to the devp2p example) in between.

So there is some larger likelihood that the missing ping/pong communication is the root cause of this lost connection.

This makes me somewhat excited since - if we got this tracked - this might substantially/sustainably improve client connectivity (might be something else as well though 😋).

If someone wants to continue with an analysis that is therefore highly welcomed, I will stop for now but leave these notes and the code as being written here.