### PR TITLE
Client: Move to async Blockchain constructor / fix --startBlock option bug

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -398,6 +398,7 @@ async function startClient(config: Config, customGenesisState?: GenesisState) {
   const dbs = initDBs(config)
 
   let blockchain
+  console.log(customGenesisState)
   if (customGenesisState !== undefined) {
     const validateConsensus = config.chainCommon.consensusAlgorithm() === ConsensusAlgorithm.Clique
     blockchain = await Blockchain.create({
@@ -411,7 +412,7 @@ async function startClient(config: Config, customGenesisState?: GenesisState) {
     config.chainCommon.setForkHashes(blockchain.genesisBlock.hash())
   }
 
-  const client = new EthereumClient({
+  const client = await EthereumClient.create({
     config,
     blockchain,
     ...dbs,
@@ -424,7 +425,7 @@ async function startClient(config: Config, customGenesisState?: GenesisState) {
   await client.open()
   // update client's sync status and start txpool if synchronized
   client.config.updateSynchronizedState(client.chain.headers.latest)
-  if (client.config.synchronized) {
+  if (client.config.synchronized === true) {
     const fullService = client.services.find((s) => s.name === 'eth')
     // The service might not be FullEthereumService even if we cast it as one,
     // so txPool might not exist on it

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -368,7 +368,7 @@ async function executeBlocks(client: EthereumClient) {
 async function startBlock(client: EthereumClient) {
   if (args.startBlock === undefined) return
   const startBlock = BigInt(args.startBlock)
-  const height = client.chain.headers.height;
+  const height = client.chain.headers.height
   if (height < startBlock) {
     logger.error(`Cannot start chain higher than current height ${height}`)
     process.exit()

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -398,7 +398,6 @@ async function startClient(config: Config, customGenesisState?: GenesisState) {
   const dbs = initDBs(config)
 
   let blockchain
-  console.log(customGenesisState)
   if (customGenesisState !== undefined) {
     const validateConsensus = config.chainCommon.consensusAlgorithm() === ConsensusAlgorithm.Clique
     blockchain = await Blockchain.create({

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -417,12 +417,12 @@ async function startClient(config: Config, customGenesisState?: GenesisState) {
     blockchain,
     ...dbs,
   })
+  await client.open()
 
   if (typeof args.startBlock === 'number') {
     await startBlock(client)
   }
 
-  await client.open()
   // update client's sync status and start txpool if synchronized
   client.config.updateSynchronizedState(client.chain.headers.latest)
   if (client.config.synchronized === true) {

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -368,18 +368,14 @@ async function executeBlocks(client: EthereumClient) {
 async function startBlock(client: EthereumClient) {
   if (args.startBlock === undefined) return
   const startBlock = BigInt(args.startBlock)
-  const { blockchain } = client.chain
-  const height = (await blockchain.getCanonicalHeadHeader()).number
-  if (height === startBlock) return
+  const height = client.chain.headers.height;
   if (height < startBlock) {
     logger.error(`Cannot start chain higher than current height ${height}`)
     process.exit()
   }
   try {
-    const headBlock = await blockchain.getBlock(startBlock)
-    const delBlock = await blockchain.getBlock(startBlock + BigInt(1))
-    await blockchain.delBlock(delBlock.hash())
-    logger.info(`Chain height reset to ${headBlock.header.number}`)
+    await client.chain.resetCanonicalHead(startBlock)
+    logger.info(`Chain height reset to ${client.chain.headers.height}`)
   } catch (err: any) {
     logger.error(`Error setting back chain in startBlock: ${err}`)
     process.exit()

--- a/packages/client/browser/index.ts
+++ b/packages/client/browser/index.ts
@@ -79,7 +79,7 @@ export async function createClient(args: any) {
     validateBlocks: true,
     validateConsensus: false,
   })
-  return new EthereumClient({ config, blockchain, chainDB })
+  return EthereumClient.create({ config, blockchain, chainDB })
 }
 
 export async function run(args: any) {

--- a/packages/client/lib/blockchain/chain.ts
+++ b/packages/client/lib/blockchain/chain.ts
@@ -90,25 +90,41 @@ export class Chain {
   }
 
   /**
-   * Create new chain
+   * Safe creation of a Chain object awaiting the initialization
+   * of the underlying Blockchain object.
+   *
    * @param options
    */
-  constructor(options: ChainOptions) {
-    this.config = options.config
+  public static async create(options: ChainOptions) {
     let validateConsensus = false
-    if (this.config.chainCommon.consensusAlgorithm() === ConsensusAlgorithm.Clique) {
+    if (options.config.chainCommon.consensusAlgorithm() === ConsensusAlgorithm.Clique) {
       validateConsensus = true
     }
 
-    this.blockchain =
+    options.blockchain =
       options.blockchain ??
       new (Blockchain as any)({
         db: options.chainDB,
-        common: this.config.chainCommon,
+        common: options.config.chainCommon,
         hardforkByHeadBlockNumber: true,
         validateBlocks: true,
         validateConsensus,
       })
+
+    return new this(options)
+  }
+
+  /**
+   * Creates new chain
+   *
+   * Do not use directly but instead use the static async `create()` constructor
+   * for concurrency safe initialization.
+   *
+   * @param options
+   */
+  protected constructor(options: ChainOptions) {
+    this.config = options.config
+    this.blockchain = options.blockchain!
 
     this.chainDB = this.blockchain.db
     this.opened = false

--- a/packages/client/lib/client.ts
+++ b/packages/client/lib/client.ts
@@ -71,7 +71,7 @@ export class EthereumClient {
    * of the underlying Blockchain object.
    */
   public static async create(options: EthereumClientOptions) {
-    const chain = new Chain(options)
+    const chain = await Chain.create(options)
     return new this(chain, options)
   }
 

--- a/packages/client/lib/client.ts
+++ b/packages/client/lib/client.ts
@@ -65,11 +65,22 @@ export class EthereumClient {
   public started: boolean
 
   /**
+   * Main entrypoint for client initialization.
+   *
+   * Safe creation of a Chain object awaiting the initialization
+   * of the underlying Blockchain object.
+   */
+  public static async create(options: EthereumClientOptions) {
+    const chain = new Chain(options)
+    return new this(chain, options)
+  }
+
+  /**
    * Create new node
    */
-  constructor(options: EthereumClientOptions) {
+  protected constructor(chain: Chain, options: EthereumClientOptions) {
     this.config = options.config
-    this.chain = new Chain(options)
+    this.chain = chain
 
     if (this.config.syncmode === SyncMode.Full) {
       this.services = [
@@ -78,7 +89,7 @@ export class EthereumClient {
           chainDB: options.chainDB,
           stateDB: options.stateDB,
           metaDB: options.metaDB,
-          chain: this.chain,
+          chain,
         }),
       ]
     } else {
@@ -86,7 +97,7 @@ export class EthereumClient {
         new LightEthereumService({
           config: this.config,
           chainDB: options.chainDB,
-          chain: this.chain,
+          chain,
         }),
       ]
     }

--- a/packages/client/lib/net/peer/libp2ppeer.ts
+++ b/packages/client/lib/net/peer/libp2ppeer.ts
@@ -28,7 +28,7 @@ export interface Libp2pPeerOptions extends Omit<PeerOptions, 'address' | 'transp
  * import { Chain } from './lib/blockchain'
  * import { EthProtocol } from './lib/net/protocol'
  *
- * const chain = new Chain()
+ * const chain = await Chain.create()
  * const protocols = [new EthProtocol({ chain })]
  * const id = 'QmWYhkpLFDhQBwHCMSWzEebbJ5JzXWBKLJxjEuiL8wGzUu'
  * const multiaddrs = [multiaddr('/ip4/192.0.2.1/tcp/12345')]

--- a/packages/client/lib/net/peer/rlpxpeer.ts
+++ b/packages/client/lib/net/peer/rlpxpeer.ts
@@ -40,7 +40,7 @@ export interface RlpxPeerOptions extends Omit<PeerOptions, 'address' | 'transpor
  * import { Chain } from './lib/blockchain'
  * import { EthProtocol } from './lib/net/protocol'
  *
- * const chain = new Chain()
+ * const chain = await Chain.create()
  * const protocols = [ new EthProtocol({ chain })]
  * const id = '70180a7fcca96aa013a3609fe7c23cc5c349ba82652c077be6f05b8419040560a622a4fc197a450e5e2f5f28fe6227637ccdbb3f9ba19220d1fb607505ffb455'
  * const host = '192.0.2.1'

--- a/packages/client/lib/service/ethereumservice.ts
+++ b/packages/client/lib/service/ethereumservice.ts
@@ -45,6 +45,7 @@ export class EthereumService extends Service {
     super(options)
 
     this.flow = new FlowControl()
+    // @ts-ignore TODO replace with async create constructor
     this.chain = options.chain ?? new Chain(options)
     this.interval = options.interval ?? 8000
     this.timeout = options.timeout ?? 6000

--- a/packages/client/test/blockchain/chain.spec.ts
+++ b/packages/client/test/blockchain/chain.spec.ts
@@ -15,7 +15,7 @@ const config = new Config()
 
 tape('[Chain]', (t) => {
   t.test('should test blockchain DB is initialized', async (t) => {
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
 
     const db = chain.chainDB
     const testKey = 'name'
@@ -28,7 +28,7 @@ tape('[Chain]', (t) => {
   })
 
   t.test('should retrieve chain properties', async (t) => {
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     await chain.open()
     t.equal(chain.networkId, BigInt(1), 'get chain.networkId')
     t.equal(chain.blocks.td.toString(10), '17179869184', 'get chain.blocks.td')
@@ -48,7 +48,7 @@ tape('[Chain]', (t) => {
       validateBlocks: false,
       validateConsensus: false,
     })
-    const chain = new Chain({ config, blockchain })
+    const chain = await Chain.create({ config, blockchain })
     const headerData: HeaderData = {
       number: BigInt(1),
       difficulty: BigInt(0xabcdffff),
@@ -122,7 +122,7 @@ tape('[Chain]', (t) => {
       validateBlocks: false,
       validateConsensus: false,
     })
-    const chain = new Chain({ config, blockchain })
+    const chain = await Chain.create({ config, blockchain })
     await chain.open()
     const headerData: HeaderData = {
       number: BigInt(1),

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -38,9 +38,9 @@ tape('[EthereumClient]', async (t) => {
 
   const { EthereumClient } = await import('../lib/client')
 
-  t.test('should initialize correctly', (t) => {
+  t.test('should initialize correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const client = new EthereumClient({ config })
+    const client = await EthereumClient.create({ config })
     t.ok(client.services[0] instanceof FullEthereumService, 'added service')
     t.end()
   })
@@ -49,7 +49,7 @@ tape('[EthereumClient]', async (t) => {
     t.plan(2)
     const servers = [new Server()] as any
     const config = new Config({ servers })
-    const client = new EthereumClient({ config })
+    const client = await EthereumClient.create({ config })
 
     await client.open()
     t.ok(client.opened, 'opened')
@@ -59,7 +59,7 @@ tape('[EthereumClient]', async (t) => {
   t.test('should start/stop', async (t) => {
     const servers = [new Server()] as any
     const config = new Config({ servers })
-    const client = new EthereumClient({ config })
+    const client = await EthereumClient.create({ config })
     await client.start()
     t.ok(client.started, 'started')
     t.equals(await client.start(), false, 'already started')

--- a/packages/client/test/execution/vmexecution.spec.ts
+++ b/packages/client/test/execution/vmexecution.spec.ts
@@ -14,7 +14,7 @@ tape('[VMExecution]', async (t) => {
   t.test('Initialization', async (t) => {
     const vm = await VM.create()
     const config = new Config({ vm, transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const exec = new VMExecution({ config, chain })
     t.equals(exec.vm, vm, 'should use vm provided')
     t.end()
@@ -22,7 +22,7 @@ tape('[VMExecution]', async (t) => {
 
   async function testSetup(blockchain: Blockchain, common?: Common) {
     const config = new Config({ common, transports: [] })
-    const chain = new Chain({ config, blockchain })
+    const chain = await Chain.create({ config, blockchain })
     const exec = new VMExecution({ config, chain })
     await chain.open()
     await exec.open()

--- a/packages/client/test/integration/client.spec.ts
+++ b/packages/client/test/integration/client.spec.ts
@@ -6,27 +6,27 @@ import { Event } from '../../lib/types'
 
 import { MockServer } from './mocks/mockserver'
 
-tape('[Integration:EthereumClient]', (t) => {
+tape('[Integration:EthereumClient]', async (t) => {
   const serverConfig = new Config()
   const servers = [new MockServer({ config: serverConfig }) as any]
   const config = new Config({ servers, syncmode: SyncMode.Full, lightserv: false })
 
   // attach server to centralized event bus
   ;(config.servers[0].config as any).events = config.events
-  const node = new EthereumClient({ config })
+  const client = await EthereumClient.create({ config })
 
   t.test('should start/stop', async (t) => {
     t.plan(4)
-    node.config.events.on(Event.SERVER_ERROR, (err) => t.equal(err.message, 'err0', 'got error'))
-    node.config.events.on(Event.SERVER_LISTENING, (details: any) => {
+    client.config.events.on(Event.SERVER_ERROR, (err) => t.equal(err.message, 'err0', 'got error'))
+    client.config.events.on(Event.SERVER_LISTENING, (details: any) => {
       t.deepEqual(details, { transport: 'mock', url: 'mock://127.0.0.1' }, 'server listening')
     })
-    await node.open()
-    ;(node.service('eth') as any).interval = 100
-    node.config.events.emit(Event.SERVER_ERROR, new Error('err0'), node.config.servers[0])
-    await node.start()
-    t.ok((node.service('eth') as any).synchronizer.running, 'sync running')
-    await node.stop()
-    t.pass('node stopped')
+    await client.open()
+    ;(client.service('eth') as any).interval = 100
+    client.config.events.emit(Event.SERVER_ERROR, new Error('err0'), client.config.servers[0])
+    await client.start()
+    t.ok((client.service('eth') as any).synchronizer.running, 'sync running')
+    await client.stop()
+    t.pass('client stopped')
   })
 })

--- a/packages/client/test/integration/merge.spec.ts
+++ b/packages/client/test/integration/merge.spec.ts
@@ -86,7 +86,7 @@ tape('[Integration:Merge]', async (t) => {
       mine: true,
       accounts,
     })
-    const chain = new Chain({ config: serviceConfig, blockchain })
+    const chain = await Chain.create({ config: serviceConfig, blockchain })
     // attach server to centralized event bus
     ;(server.config as any).events = serviceConfig.events
     const service = new FullEthereumService({

--- a/packages/client/test/integration/miner.spec.ts
+++ b/packages/client/test/integration/miner.spec.ts
@@ -53,7 +53,7 @@ tape('[Integration:Miner]', async (t) => {
       validateConsensus: false,
     })
     ;(blockchain.consensus as CliqueConsensus).cliqueActiveSigners = () => [accounts[0][0]] // stub
-    const chain = new Chain({ config, blockchain })
+    const chain = await Chain.create({ config, blockchain })
     const serviceConfig = new Config({
       common,
       servers: [server as any],

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -432,7 +432,7 @@ tape('[Miner]', async (t) => {
     const common = Common.custom(customChainParams, { baseChain: CommonChain.Rinkeby })
     common.setHardforkByBlockNumber(0)
     const config = new Config({ transports: [], accounts, mine: true, common })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     await chain.open()
     const service = new FullEthereumService({
       config,
@@ -499,7 +499,7 @@ tape('[Miner]', async (t) => {
     const common = new Common({ chain: CommonChain.Ropsten, hardfork: Hardfork.Istanbul })
     ;(common as any)._chainParams['genesis'].difficulty = 1
     const config = new Config({ transports: [], accounts, mine: true, common })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     await chain.open()
     const service = new FullEthereumService({
       config,

--- a/packages/client/test/net/protocol/ethprotocol.spec.ts
+++ b/packages/client/test/net/protocol/ethprotocol.spec.ts
@@ -10,9 +10,9 @@ import { Config } from '../../../lib/config'
 import { EthProtocol } from '../../../lib/net/protocol'
 
 tape('[EthProtocol]', (t) => {
-  t.test('should get properties', (t) => {
+  t.test('should get properties', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new EthProtocol({ config, chain })
     t.ok(typeof p.name === 'string', 'get name')
     t.ok(Array.isArray(p.versions), 'get versions')
@@ -22,7 +22,7 @@ tape('[EthProtocol]', (t) => {
 
   t.test('should open correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new EthProtocol({ config, chain })
     await p.open()
     t.ok(p.opened, 'opened is true')
@@ -30,9 +30,9 @@ tape('[EthProtocol]', (t) => {
     t.end()
   })
 
-  t.test('should encode/decode status', (t) => {
+  t.test('should encode/decode status', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new EthProtocol({ config, chain })
     Object.defineProperty(chain, 'networkId', {
       get: () => {
@@ -79,9 +79,9 @@ tape('[EthProtocol]', (t) => {
     t.end()
   })
 
-  t.test('verify that NewBlock handler encodes/decodes correctly', (t) => {
+  t.test('verify that NewBlock handler encodes/decodes correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new EthProtocol({ config, chain })
     const td = BigInt(100)
     const block = Block.fromBlockData({}, { common: config.chainCommon })
@@ -98,9 +98,9 @@ tape('[EthProtocol]', (t) => {
     t.end()
   })
 
-  t.test('verify that GetReceipts handler encodes/decodes correctly', (t) => {
+  t.test('verify that GetReceipts handler encodes/decodes correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new EthProtocol({ config, chain })
     const block = Block.fromBlockData({})
     const res = p.decode(p.messages.filter((message) => message.name === 'GetReceipts')[0], [
@@ -118,12 +118,12 @@ tape('[EthProtocol]', (t) => {
     t.end()
   })
 
-  t.test('verify that PooledTransactions handler encodes correctly', (t) => {
+  t.test('verify that PooledTransactions handler encodes correctly', async (t) => {
     const config = new Config({
       transports: [],
       common: new Common({ chain: Config.CHAIN_DEFAULT, hardfork: Hardfork.London }),
     })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new EthProtocol({ config, chain })
     const tx = FeeMarketEIP1559Transaction.fromTxData(
       {
@@ -143,12 +143,12 @@ tape('[EthProtocol]', (t) => {
     t.end()
   })
 
-  t.test('verify that Receipts encode/decode correctly', (t) => {
+  t.test('verify that Receipts encode/decode correctly', async (t) => {
     const config = new Config({
       transports: [],
       common: new Common({ chain: Config.CHAIN_DEFAULT, hardfork: Hardfork.London }),
     })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new EthProtocol({ config, chain })
     const receipts = [
       {
@@ -196,7 +196,7 @@ tape('[EthProtocol]', (t) => {
     t.end()
   })
 
-  t.test('verify that Transactions handler encodes/decodes correctly', (st) => {
+  t.test('verify that Transactions handler encodes/decodes correctly', async (st) => {
     const config = new Config({
       transports: [],
       common: new Common({
@@ -206,7 +206,7 @@ tape('[EthProtocol]', (t) => {
       }),
     })
     config.synchronized = true
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new EthProtocol({ config, chain })
 
     const legacyTx = TransactionFactory.fromTxData({ type: 0 })
@@ -234,12 +234,12 @@ tape('[EthProtocol]', (t) => {
     st.end()
   })
 
-  t.test('verify that NewPooledTransactionHashes encodes/decodes correctly', (st) => {
+  t.test('verify that NewPooledTransactionHashes encodes/decodes correctly', async (st) => {
     const config = new Config({
       transports: [],
       common: new Common({ chain: Config.CHAIN_DEFAULT, hardfork: Hardfork.London }),
     })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new EthProtocol({ config, chain })
     const fakeHash = randomBytes(32)
     const res = p.encode(

--- a/packages/client/test/net/protocol/lesprotocol.spec.ts
+++ b/packages/client/test/net/protocol/lesprotocol.spec.ts
@@ -5,9 +5,9 @@ import { Config } from '../../../lib/config'
 import { FlowControl, LesProtocol } from '../../../lib/net/protocol'
 
 tape('[LesProtocol]', (t) => {
-  t.test('should get properties', (t) => {
+  t.test('should get properties', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new LesProtocol({ config, chain })
     t.ok(typeof p.name === 'string', 'get name')
     t.ok(Array.isArray(p.versions), 'get versions')
@@ -17,7 +17,7 @@ tape('[LesProtocol]', (t) => {
 
   t.test('should open correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new LesProtocol({ config, chain })
     await p.open()
     t.ok(p.opened, 'opened is true')
@@ -25,9 +25,9 @@ tape('[LesProtocol]', (t) => {
     t.end()
   })
 
-  t.test('should encode/decode status', (t) => {
+  t.test('should encode/decode status', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const flow = new FlowControl({
       bl: 1000,
       mrr: 10,

--- a/packages/client/test/net/protocol/snapprotocol.spec.ts
+++ b/packages/client/test/net/protocol/snapprotocol.spec.ts
@@ -19,9 +19,9 @@ import { SnapProtocol } from '../../../lib/net/protocol'
 }
 
 tape('[SnapProtocol]', (t) => {
-  t.test('should get properties', (t) => {
+  t.test('should get properties', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
     t.ok(typeof p.name === 'string', 'get name')
     t.ok(Array.isArray(p.versions), 'get versions')
@@ -31,7 +31,7 @@ tape('[SnapProtocol]', (t) => {
 
   t.test('should open correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
     await p.open()
     t.ok(p.opened, 'opened is true')
@@ -39,9 +39,9 @@ tape('[SnapProtocol]', (t) => {
     t.end()
   })
 
-  t.test('GetAccountRange should encode/decode correctly', (t) => {
+  t.test('GetAccountRange should encode/decode correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
     const root = Buffer.from([])
     const reqId = BigInt(1)
@@ -99,9 +99,9 @@ tape('[SnapProtocol]', (t) => {
     t.end()
   })
 
-  t.test('AccountRange should encode/decode correctly', (t) => {
+  t.test('AccountRange should encode/decode correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
     /* eslint-disable @typescript-eslint/no-use-before-define */
     const data = RLP.decode(Buffer.from(contractAccountRangeRLP, 'hex')) as unknown
@@ -142,9 +142,9 @@ tape('[SnapProtocol]', (t) => {
     t.end()
   })
 
-  t.test('AccountRange encode/decode should handle account slim body correctly', (t) => {
+  t.test('AccountRange encode/decode should handle account slim body correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const pSlim = new SnapProtocol({ config, chain })
     const pFull = new SnapProtocol({ config, chain, convertSlimBody: true })
     // accountRangeRLP is the corresponding response to getAccountRangeRLP
@@ -182,7 +182,7 @@ tape('[SnapProtocol]', (t) => {
 
   t.test('AccountRange should verify a real sample', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
 
     /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -220,9 +220,9 @@ tape('[SnapProtocol]', (t) => {
     t.end()
   })
 
-  t.test('GetStorageRanges should encode/decode correctly', (t) => {
+  t.test('GetStorageRanges should encode/decode correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
     const root = Buffer.from([])
     const reqId = BigInt(1)
@@ -286,9 +286,9 @@ tape('[SnapProtocol]', (t) => {
     t.end()
   })
 
-  t.test('StorageRanges should encode/decode correctly', (t) => {
+  t.test('StorageRanges should encode/decode correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
 
     /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -322,7 +322,7 @@ tape('[SnapProtocol]', (t) => {
 
   t.test('StorageRanges should verify a real sample', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
 
     // Get the handle on the data for the account for which storageRanges has been fetched
@@ -365,9 +365,9 @@ tape('[SnapProtocol]', (t) => {
     t.end()
   })
 
-  t.test('GetByteCodes should encode/decode correctly', (t) => {
+  t.test('GetByteCodes should encode/decode correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
     const reqId = BigInt(1)
     const hashes = [
@@ -407,7 +407,7 @@ tape('[SnapProtocol]', (t) => {
 
   t.test('ByteCodes should encode/decode correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
 
     const codesRes = RLP.decode(Buffer.from(byteCodesRLP, 'hex')) as unknown
@@ -434,7 +434,7 @@ tape('[SnapProtocol]', (t) => {
 
   t.test('ByteCodes should verify a real sample', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
 
     /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -77,6 +77,7 @@ export function createClient(clientOpts: Partial<createClientArgs> = {}) {
   })
   const blockchain = clientOpts.blockchain ?? mockBlockchain()
 
+  // @ts-ignore TODO Move to async Chain.create() initialization
   const chain = clientOpts.chain ?? new Chain({ config, blockchain: blockchain as any })
   chain.opened = true
 

--- a/packages/client/test/service/fullethereumservice.spec.ts
+++ b/packages/client/test/service/fullethereumservice.spec.ts
@@ -64,18 +64,18 @@ tape('[FullEthereumService]', async (t) => {
   td.replace('@ethereumjs/block', { Block })
   const { FullEthereumService } = await import('../../lib/service/fullethereumservice')
 
-  t.test('should initialize correctly', (t) => {
+  t.test('should initialize correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     t.ok(service.synchronizer instanceof FullSynchronizer, 'full mode')
     t.equals(service.name, 'eth', 'got name')
     t.end()
   })
 
-  t.test('should get protocols', (t) => {
+  t.test('should get protocols', async (t) => {
     let config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     let service = new FullEthereumService({ config, chain })
     t.ok(service.protocols.filter((p) => p instanceof EthProtocol).length > 0, 'full protocol')
     t.notOk(
@@ -96,7 +96,7 @@ tape('[FullEthereumService]', async (t) => {
     t.plan(3)
     const server = td.object() as any
     const config = new Config({ servers: [server] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     await service.open()
     td.verify(service.synchronizer.open())
@@ -117,7 +117,7 @@ tape('[FullEthereumService]', async (t) => {
   t.test('should start/stop', async (t) => {
     const server = td.object() as any
     const config = new Config({ servers: [server] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
 
     await service.start()
@@ -131,7 +131,7 @@ tape('[FullEthereumService]', async (t) => {
 
   t.test('should correctly handle GetBlockHeaders', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     chain.getHeaders = () => [{ number: 1n }] as any
     const service = new FullEthereumService({ config, chain })
     await service.handle(
@@ -181,7 +181,7 @@ tape('[FullEthereumService]', async (t) => {
     'should call handleNewBlock on NewBlock and handleNewBlockHashes on NewBlockHashes',
     async (t) => {
       const config = new Config({ transports: [] })
-      const chain = new Chain({ config })
+      const chain = await Chain.create({ config })
       const service = new FullEthereumService({ config, chain })
       await service.handle({ name: 'NewBlock', data: [{}, BigInt(1)] }, 'eth', undefined as any)
       td.verify((service.synchronizer as any).handleNewBlock({}, undefined))
@@ -210,7 +210,7 @@ tape('[FullEthereumService]', async (t) => {
     t.plan(2)
     const common = new Common({ chain: 'mainnet', hardfork: Hardfork.Merge })
     const config = new Config({ common, transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     service.pool.ban = () => {
       t.pass('banned peer when NewBlock/NewBlockHashes announced after Merge')
@@ -222,7 +222,7 @@ tape('[FullEthereumService]', async (t) => {
 
   t.test('should send Receipts on GetReceipts', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     service.execution = {
       receiptsManager: { getReceipts: td.func<any>() },
@@ -259,7 +259,7 @@ tape('[FullEthereumService]', async (t) => {
 
   t.test('should handle Transactions', async (st) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     service.txPool.handleAnnouncedTxs = async (msg, _peer, _pool) => {
       st.deepEqual(
@@ -282,7 +282,7 @@ tape('[FullEthereumService]', async (t) => {
 
   t.test('should handle NewPooledTransactionHashes', async (st) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     service.txPool.handleAnnouncedTxHashes = async (msg, _peer, _pool) => {
       st.deepEqual(msg[0], Buffer.from('0xabcd', 'hex'), 'handled NewPooledTransactionhashes')
@@ -301,7 +301,7 @@ tape('[FullEthereumService]', async (t) => {
 
   t.test('should handle GetPooledTransactions', async (st) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     ;(service.txPool as any).validate = () => {}
 
@@ -326,7 +326,7 @@ tape('[FullEthereumService]', async (t) => {
     const common = Common.fromGethGenesis(genesisJSON, { chain: 'post-merge' })
     common.setHardforkByBlockNumber(BigInt(0), BigInt(0))
     const config = new Config({ transports: [], common })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     let service = new FullEthereumService({ config, chain })
     t.ok(service.beaconSync, 'beacon sync should be available')
     const configDisableBeaconSync = new Config({ transports: [], common, disableBeaconSync: true })

--- a/packages/client/test/service/lightethereumservice.spec.ts
+++ b/packages/client/test/service/lightethereumservice.spec.ts
@@ -34,7 +34,7 @@ tape('[LightEthereumService]', async (t) => {
 
   t.test('should initialize correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const service = new LightEthereumService({ config, chain })
     t.ok(service.synchronizer instanceof LightSynchronizer, 'light sync')
     t.equals(service.name, 'eth', 'got name')
@@ -43,7 +43,7 @@ tape('[LightEthereumService]', async (t) => {
 
   t.test('should get protocols', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const service = new LightEthereumService({ config, chain })
     t.ok(service.protocols[0] instanceof LesProtocol, 'light protocols')
     t.end()
@@ -53,7 +53,7 @@ tape('[LightEthereumService]', async (t) => {
     t.plan(3)
     const server = td.object() as any
     const config = new Config({ servers: [server] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const service = new LightEthereumService({ config, chain })
     await service.open()
     td.verify(service.synchronizer.open())
@@ -74,7 +74,7 @@ tape('[LightEthereumService]', async (t) => {
   t.test('should start/stop', async (t) => {
     const server = td.object() as any
     const config = new Config({ servers: [server] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const service = new LightEthereumService({ config, chain })
     await service.start()
     td.verify(service.synchronizer.start())

--- a/packages/client/test/sync/beaconsync.spec.ts
+++ b/packages/client/test/sync/beaconsync.spec.ts
@@ -44,7 +44,7 @@ tape('[BeaconSynchronizer]', async (t) => {
   t.test('should initialize correctly', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
     t.equal(sync.type, 'beacon', 'beacon type')
@@ -54,7 +54,7 @@ tape('[BeaconSynchronizer]', async (t) => {
   t.test('should open', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
     ;(sync as any).pool.open = td.func<PeerPool['open']>()
@@ -69,7 +69,7 @@ tape('[BeaconSynchronizer]', async (t) => {
   t.test('should get height', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
     const peer = { eth: { getBlockHeaders: td.func(), status: { bestHash: 'hash' } } }
@@ -85,7 +85,7 @@ tape('[BeaconSynchronizer]', async (t) => {
   t.test('should find best', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
     ;(sync as any).running = true
@@ -117,7 +117,7 @@ tape('[BeaconSynchronizer]', async (t) => {
       skeletonSubchainMergeMinimum: 0,
     })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     skeleton['getSyncStatus'] = td.func<typeof skeleton['getSyncStatus']>()
     await skeleton.open()
@@ -168,7 +168,7 @@ tape('[BeaconSynchronizer]', async (t) => {
       skeletonSubchainMergeMinimum: 1000,
     })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     skeleton['getSyncStatus'] = td.func<typeof skeleton['getSyncStatus']>()
     await skeleton.open()
@@ -197,7 +197,7 @@ tape('[BeaconSynchronizer]', async (t) => {
   t.test('should extend and set with a valid head', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })
     const head = Block.fromBlockData({ header: { number: BigInt(15) } })
@@ -226,7 +226,7 @@ tape('[BeaconSynchronizer]', async (t) => {
   t.test('syncWithPeer should return early if skeleton is already linked', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     skeleton.isLinked = () => true // stub
     const sync = new BeaconSynchronizer({ config, pool, chain, execution, skeleton })

--- a/packages/client/test/sync/fetcher/accountfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/accountfetcher.spec.ts
@@ -166,7 +166,7 @@ tape('[AccountFetcher]', async (t) => {
 
   t.test('should verify proof correctly', async (t) => {
     const config = new Config({ transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
     const pool = new PeerPool() as any
     const fetcher = new AccountFetcher({

--- a/packages/client/test/sync/fetcher/blockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/blockfetcher.spec.ts
@@ -22,7 +22,7 @@ tape('[BlockFetcher]', async (t) => {
   t.test('should start/stop', async (t) => {
     const config = new Config({ maxPerRequest: 5, transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const fetcher = new BlockFetcher({
       config,
       pool,
@@ -46,7 +46,7 @@ tape('[BlockFetcher]', async (t) => {
   t.test('enqueueByNumberList()', async (t) => {
     const config = new Config({ maxPerRequest: 5, transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const fetcher = new BlockFetcher({
       config,
       pool,
@@ -93,10 +93,10 @@ tape('[BlockFetcher]', async (t) => {
     t.end()
   })
 
-  t.test('should process', (t) => {
+  t.test('should process', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const fetcher = new BlockFetcher({
       config,
       pool,
@@ -110,10 +110,10 @@ tape('[BlockFetcher]', async (t) => {
     t.end()
   })
 
-  t.test('should adopt correctly', (t) => {
+  t.test('should adopt correctly', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const fetcher = new BlockFetcher({
       config,
       pool,
@@ -141,7 +141,7 @@ tape('[BlockFetcher]', async (t) => {
   t.test('should find a fetchable peer', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const fetcher = new BlockFetcher({
       config,
       pool,
@@ -157,7 +157,7 @@ tape('[BlockFetcher]', async (t) => {
   t.test('should request correctly', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const fetcher = new BlockFetcher({
       config,
       pool,
@@ -203,7 +203,7 @@ tape('[BlockFetcher]', async (t) => {
       Hardfork.Shanghai
     )
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const fetcher = new BlockFetcher({
       config,
       pool,
@@ -238,7 +238,7 @@ tape('[BlockFetcher]', async (t) => {
 
     const config = new Config({ maxPerRequest: 5, transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     chain.putBlocks = td.func<any>()
     const fetcher = new BlockFetcher({
       config,

--- a/packages/client/test/sync/fetcher/headerfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/headerfetcher.spec.ts
@@ -103,7 +103,7 @@ tape('[HeaderFetcher]', async (t) => {
 
     const config = new Config({ maxPerRequest: 5, transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     chain.putHeaders = td.func<any>()
     const fetcher = new HeaderFetcher({
       config,

--- a/packages/client/test/sync/fetcher/reverseblockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/reverseblockfetcher.spec.ts
@@ -22,7 +22,7 @@ tape('[ReverseBlockFetcher]', async (t) => {
   t.test('should start/stop', async (t) => {
     const config = new Config({ maxPerRequest: 5, transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     const fetcher = new ReverseBlockFetcher({
       config,
@@ -50,7 +50,7 @@ tape('[ReverseBlockFetcher]', async (t) => {
   t.test('should generate max tasks', async (t) => {
     const config = new Config({ maxPerRequest: 5, maxFetcherJobs: 10, transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     const fetcher = new ReverseBlockFetcher({
       config,
@@ -75,10 +75,10 @@ tape('[ReverseBlockFetcher]', async (t) => {
     t.end()
   })
 
-  t.test('should process', (t) => {
+  t.test('should process', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     const fetcher = new ReverseBlockFetcher({
       config,
@@ -94,10 +94,10 @@ tape('[ReverseBlockFetcher]', async (t) => {
     t.end()
   })
 
-  t.test('should adopt correctly', (t) => {
+  t.test('should adopt correctly', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     const fetcher = new ReverseBlockFetcher({
       config,
@@ -127,7 +127,7 @@ tape('[ReverseBlockFetcher]', async (t) => {
   t.test('should find a fetchable peer', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     const fetcher = new ReverseBlockFetcher({
       config,
@@ -145,7 +145,7 @@ tape('[ReverseBlockFetcher]', async (t) => {
   t.test('should request correctly', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     const fetcher = new ReverseBlockFetcher({
       config,
@@ -181,7 +181,7 @@ tape('[ReverseBlockFetcher]', async (t) => {
 
     const config = new Config({ maxPerRequest: 5, transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     skeleton.putBlocks = td.func<any>()
     const fetcher = new ReverseBlockFetcher({
@@ -224,7 +224,7 @@ tape('[ReverseBlockFetcher]', async (t) => {
     td.reset()
     const config = new Config({ transports: [], skeletonSubchainMergeMinimum: 0 })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
 
     const fetcher = new ReverseBlockFetcher({

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -33,7 +33,7 @@ tape('[FullSynchronizer]', async (t) => {
   t.test('should initialize correctly', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const sync = new FullSynchronizer({ config, pool, chain, txPool, execution })
     t.equals(sync.type, 'full', 'full type')
     t.end()
@@ -42,7 +42,7 @@ tape('[FullSynchronizer]', async (t) => {
   t.test('should open', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const sync = new FullSynchronizer({
       config,
       pool,
@@ -62,7 +62,7 @@ tape('[FullSynchronizer]', async (t) => {
   t.test('should get height', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const sync = new FullSynchronizer({ config, pool, chain, txPool, execution })
     const peer = { eth: { getBlockHeaders: td.func(), status: { bestHash: 'hash' } } }
     const headers = [{ number: BigInt(5) }]
@@ -77,7 +77,7 @@ tape('[FullSynchronizer]', async (t) => {
   t.test('should find best', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const sync = new FullSynchronizer({
       config,
       interval: 1,
@@ -111,7 +111,7 @@ tape('[FullSynchronizer]', async (t) => {
     t.plan(3)
     const config = new Config({ transports: [], safeReorgDistance: 0 })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const sync = new FullSynchronizer({
       config,
       interval: 1,
@@ -150,7 +150,7 @@ tape('[FullSynchronizer]', async (t) => {
   t.test('should send NewBlock/NewBlockHashes to right peers', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const sync = new FullSynchronizer({
       config,
       interval: 1,

--- a/packages/client/test/sync/lightsync.spec.ts
+++ b/packages/client/test/sync/lightsync.spec.ts
@@ -26,7 +26,7 @@ tape('[LightSynchronizer]', async (t) => {
   t.test('should initialize correctly', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const sync = new LightSynchronizer({ config, pool, chain })
     t.equals(sync.type, 'light', 'light type')
     t.end()
@@ -35,7 +35,7 @@ tape('[LightSynchronizer]', async (t) => {
   t.test('should find best', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const sync = new LightSynchronizer({
       config,
       interval: 1,
@@ -64,7 +64,7 @@ tape('[LightSynchronizer]', async (t) => {
     t.plan(3)
     const config = new Config({ transports: [], safeReorgDistance: 0 })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const sync = new LightSynchronizer({
       config,
       interval: 1,
@@ -101,7 +101,7 @@ tape('[LightSynchronizer]', async (t) => {
     st.plan(1)
     const config = new Config({ transports: [], safeReorgDistance: 0 })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const sync = new LightSynchronizer({
       config,
       interval: 1,
@@ -135,7 +135,7 @@ tape('[LightSynchronizer]', async (t) => {
     st.plan(1)
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const sync = new LightSynchronizer({
       config,
       interval: 1,

--- a/packages/client/test/sync/skeleton.spec.ts
+++ b/packages/client/test/sync/skeleton.spec.ts
@@ -195,7 +195,7 @@ tape('[Skeleton] / initSync', async (t) => {
         transports: [],
         logger: getLogger({ loglevel: 'debug' }),
       })
-      const chain = new Chain({ config })
+      const chain = await Chain.create({ config })
       const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
       await skeleton.open()
 
@@ -309,7 +309,7 @@ tape('[Skeleton] / setHead', async (t) => {
         transports: [],
         logger: getLogger({ loglevel: 'debug' }),
       })
-      const chain = new Chain({ config })
+      const chain = await Chain.create({ config })
       const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
       await skeleton.open()
       for (const block of testCase.blocks ?? []) {
@@ -376,7 +376,7 @@ tape('[Skeleton] / setHead', async (t) => {
     }
     const common = Common.fromGethGenesis(genesis, { chain: 'merge-not-set' })
     const config = new Config({ common, transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     ;(chain.blockchain as any)._validateBlocks = false
     try {
       new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -388,7 +388,7 @@ tape('[Skeleton] / setHead', async (t) => {
 
   t.test('should init/setHead properly from genesis', async (st) => {
     const config = new Config({ common, transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     ;(chain.blockchain as any)._validateBlocks = false
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     await chain.open()
@@ -492,7 +492,7 @@ tape('[Skeleton] / setHead', async (t) => {
 
   t.test('should fill the canonical chain after being linked to genesis', async (st) => {
     const config = new Config({ common, transports: [] })
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     ;(chain.blockchain as any)._validateBlocks = false
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
     await chain.open()
@@ -562,7 +562,7 @@ tape('[Skeleton] / setHead', async (t) => {
     'should fill the canonical chain after being linked to a canonical block past genesis',
     async (st) => {
       const config = new Config({ common, transports: [] })
-      const chain = new Chain({ config })
+      const chain = await Chain.create({ config })
       ;(chain.blockchain as any)._validateBlocks = false
 
       const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -649,7 +649,7 @@ tape('[Skeleton] / setHead', async (t) => {
         transports: [],
         common,
       })
-      const chain = new Chain({ config })
+      const chain = await Chain.create({ config })
       ;(chain.blockchain as any)._validateBlocks = false
       await chain.open()
       const genesisBlock = await chain.getBlock(BigInt(0))
@@ -754,7 +754,7 @@ tape('[Skeleton] / setHead', async (t) => {
         transports: [],
         common,
       })
-      const chain = new Chain({ config })
+      const chain = await Chain.create({ config })
       ;(chain.blockchain as any)._validateBlocks = false
       ;(chain.blockchain as any)._validateConsensus = false
       await chain.open()
@@ -818,7 +818,7 @@ tape('[Skeleton] / setHead', async (t) => {
         logger: getLogger({ loglevel: 'debug' }),
       })
 
-      const chain = new Chain({ config })
+      const chain = await Chain.create({ config })
       ;(chain.blockchain as any)._validateConsensus = false
       // Only add td validations to the validateBlock
       chain.blockchain.validateBlock = async (block: Block) => {

--- a/packages/client/test/sync/snapsync.spec.ts
+++ b/packages/client/test/sync/snapsync.spec.ts
@@ -18,7 +18,7 @@ tape('[SnapSynchronizer]', async (t) => {
   t.test('should initialize correctly', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const sync = new SnapSynchronizer({ config, pool, chain })
     t.equals(sync.type, 'snap', 'snap type')
     t.end()
@@ -27,7 +27,7 @@ tape('[SnapSynchronizer]', async (t) => {
   t.test('should find best', async (t) => {
     const config = new Config({ transports: [] })
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const sync = new SnapSynchronizer({
       config,
       interval: 1,

--- a/packages/client/test/sync/sync.spec.ts
+++ b/packages/client/test/sync/sync.spec.ts
@@ -30,7 +30,7 @@ tape('[Synchronizer]', async (t) => {
     const config = new Config({ transports: [] })
     config.syncTargetHeight = BigInt(1)
     const pool = new PeerPool() as any
-    const chain = new Chain({ config })
+    const chain = await Chain.create({ config })
     const sync = new SynchronizerTest({ config, pool, chain })
     ;(sync as any).sync = td.func()
     td.when((sync as any).sync()).thenResolve(true)

--- a/packages/client/test/util/rpc.spec.ts
+++ b/packages/client/test/util/rpc.spec.ts
@@ -14,9 +14,9 @@ import {
 const request = require('supertest')
 
 tape('[Util/RPC]', (t) => {
-  t.test('should return enabled RPC servers', (st) => {
+  t.test('should return enabled RPC servers', async (st) => {
     const config = new Config({ transports: [] })
-    const client = new EthereumClient({ config })
+    const client = await EthereumClient.create({ config })
     const manager = new RPCManager(client, config)
     const { logger } = config
     for (const methodConfig of Object.values(MethodConfig)) {
@@ -54,7 +54,7 @@ tape('[Util/RPC]', (t) => {
 
 tape('[Util/RPC/Engine eth methods]', async (t) => {
   const config = new Config({ transports: [], saveReceipts: true })
-  const client = new EthereumClient({ config })
+  const client = await EthereumClient.create({ config })
   const manager = new RPCManager(client, config)
   const { server } = createRPCServer(manager, {
     methodConfig: MethodConfig.EngineOnly,


### PR DESCRIPTION
This moves the client to a safe Blockchain initialization by switching to async static create() constructors for the `EthereumClient` and `Chain` classes. This should be generally beneficial to client stability cause with this safe and finalized Blockchain initialization can be guaranteed.

In this case this fixes a problem with the `--startBlock` option which does an early blockchain access and was before failing.

@g11tech Ready for review, feel free to approve and merge or alternatively push own work on top, whatever is better/more convenient.