### PR TITLE
Fix the fetcher errored property colliding with Readable class

### DIFF
--- a/packages/client/lib/sync/beaconsync.ts
+++ b/packages/client/lib/sync/beaconsync.ts
@@ -257,14 +257,16 @@ export class BeaconSynchronizer extends Synchronizer {
       count = first
     }
 
-    if (count > BigInt(0) && (this.fetcher === null || this.fetcher.errored !== undefined)) {
+    if (count > BigInt(0) && (this.fetcher === null || this.fetcher.syncErrored !== undefined)) {
       this.config.logger.debug(
         `syncWithPeer - new ReverseBlockFetcher peer=${
           peer?.id
         } subChainTail=${tail} first=${first} count=${count} chainHeight=${
           this.chain.blocks.height
         } ${
-          this.fetcher === null ? '' : 'previous fetcher errored=' + this.fetcher.errored?.message
+          this.fetcher === null
+            ? ''
+            : 'previous fetcher errored=' + this.fetcher.syncErrored?.message
         }`
       )
       this.fetcher = new ReverseBlockFetcher({

--- a/packages/client/lib/sync/fetcher/fetcher.ts
+++ b/packages/client/lib/sync/fetcher/fetcher.ts
@@ -60,7 +60,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
   protected running: boolean
   protected reading: boolean
   protected destroyWhenDone: boolean // Destroy the fetcher once we are finished processing each task.
-  errored?: Error
+  syncErrored?: Error
 
   private _readableState?: {
     // This property is inherited from Readable. We only need `length`.
@@ -190,7 +190,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
    * @param autoRestart
    */
   enqueueTask(task: JobTask, autoRestart = false) {
-    if (this.errored || (!this.running && !autoRestart)) {
+    if (this.syncErrored || (!this.running && !autoRestart)) {
       return
     }
     const job: Job<JobTask, JobResult, StorageItem> = {
@@ -389,7 +389,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
     }
     if (irrecoverable === true) {
       this.running = false
-      this.errored = error
+      this.syncErrored = error
       this.clear()
     }
   }
@@ -489,7 +489,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
     if (this.destroyWhenDone) {
       this.destroy()
     }
-    if (this.errored) throw this.errored
+    if (this.syncErrored) throw this.syncErrored
   }
 
   /**

--- a/packages/client/lib/sync/fullsync.ts
+++ b/packages/client/lib/sync/fullsync.ts
@@ -174,7 +174,7 @@ export class FullSynchronizer extends Synchronizer {
         : BigInt(1)
     const count = height - first + BigInt(1)
     if (count < BigInt(0)) return false
-    if (!this.fetcher || this.fetcher.errored) {
+    if (!this.fetcher || this.fetcher.syncErrored) {
       this.fetcher = new BlockFetcher({
         config: this.config,
         pool: this.pool,
@@ -354,7 +354,7 @@ export class FullSynchronizer extends Synchronizer {
    * @param data new block hash announcements
    */
   handleNewBlockHashes(data: [Buffer, bigint][]) {
-    if (!data.length || !this.fetcher || this.fetcher.errored) return
+    if (!data.length || !this.fetcher || this.fetcher.syncErrored) return
     let min = BigInt(-1)
     let newSyncHeight: [Buffer, bigint] | undefined
     const blockNumberList: bigint[] = []

--- a/packages/client/lib/sync/lightsync.ts
+++ b/packages/client/lib/sync/lightsync.ts
@@ -121,7 +121,7 @@ export class LightSynchronizer extends Synchronizer {
         : BigInt(1)
     const count = height - first + BigInt(1)
     if (count < BigInt(0)) return false
-    if (!this.fetcher || this.fetcher.errored) {
+    if (!this.fetcher || this.fetcher.syncErrored) {
       this.fetcher = new HeaderFetcher({
         config: this.config,
         pool: this.pool,

--- a/packages/client/test/sync/fetcher/fetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/fetcher.spec.ts
@@ -135,6 +135,11 @@ tape('[Fetcher]', (t) => {
     }, 20)
   })
 
+  t.test('should reset td', (st) => {
+    td.reset()
+    st.end()
+  })
+
   t.test('should handle fatal errors correctly', (st) => {
     const config = new Config({ transports: [] })
     const fetcher = new FetcherTest({ config, pool: td.object(), timeout: 5000 })
@@ -144,10 +149,7 @@ tape('[Fetcher]', (t) => {
     fetcher.error({ name: 'VeryBadError', message: 'Something very bad happened' }, job, true)
     st.equals(fetcher.syncErrored?.name, 'VeryBadError', 'fatal error has correct name')
     st.equals((fetcher as any).in.length, 0, 'fatal error clears job queue')
-  })
-
-  t.test('should reset td', (t) => {
-    td.reset()
-    t.end()
+    fetcher.clear()
+    st.end()
   })
 })

--- a/packages/client/test/sync/fetcher/fetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/fetcher.spec.ts
@@ -135,6 +135,17 @@ tape('[Fetcher]', (t) => {
     }, 20)
   })
 
+  t.test('should handle fatal errors correctly', (st) => {
+    const config = new Config({ transports: [] })
+    const fetcher = new FetcherTest({ config, pool: td.object(), timeout: 5000 })
+    const task = { first: BigInt(50), count: 10 }
+    const job: any = { peer: {}, task, state: 'active', index: 0 }
+    ;(fetcher as any).in.insert(job)
+    fetcher.error({ name: 'VeryBadError', message: 'Something very bad happened' }, job, true)
+    st.equals(fetcher.syncErrored?.name, 'VeryBadError', 'fatal error has correct name')
+    st.equals((fetcher as any).in.length, 0, 'fatal error clears job queue')
+  })
+
   t.test('should reset td', (t) => {
     td.reset()
     t.end()


### PR DESCRIPTION
As encountered by @holgerd77 , fetcher (and client) would break on error handling because seemingly `errored` property of fetcher was conflicting with the `Readable` class from which fetcher extends causing such errors:
https://nodejs.org/api/stream.html#readableerrored

![image](https://user-images.githubusercontent.com/76567250/220357991-d7016acc-59e5-4b97-a07d-80b3b3d13b58.png)



this fix renames the property to a non conflicting one which doesn't exit the client and keeps it going (forced error throw here to test)

![image](https://user-images.githubusercontent.com/76567250/220358193-15d1d62b-dafd-4c3b-a1b2-188624374adb.png)
