### PR TITLE
Fix invalid head block reset bug

### DIFF
--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -657,6 +657,7 @@ export class Skeleton extends MetaDBManager {
       } catch (e) {
         this.config.logger.error(`fillCanonicalChain putBlock error=${(e as Error).message}`)
         if (resetHead === true && oldHead !== null) {
+          // Put original canonical head block back if reorg fails
           await this.chain.putBlocks([oldHead], true)
         }
       }

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -608,7 +608,6 @@ export class Skeleton extends MetaDBManager {
 
     let canonicalHead = this.chain.blocks.height
     let oldHead = null
-    let resetHead = false
     const subchain = this.status.progress.subchains[0]!
     if (this.status.canonicalHeadReset) {
       oldHead = this.chain.blocks.latest // Grab previous head block in case of resettng canonical head
@@ -627,7 +626,6 @@ export class Skeleton extends MetaDBManager {
       canonicalHead = newHead
       await this.chain.resetCanonicalHead(canonicalHead)
       this.status.canonicalHeadReset = false
-      resetHead = true
     }
 
     const start = canonicalHead
@@ -656,7 +654,7 @@ export class Skeleton extends MetaDBManager {
         numBlocksInserted = await this.chain.putBlocks([block], true)
       } catch (e) {
         this.config.logger.error(`fillCanonicalChain putBlock error=${(e as Error).message}`)
-        if (oldHead !== null && oldHead >= block.header.number) {
+        if (oldHead !== null && oldHead.header.number >= block.header.number) {
           // Put original canonical head block back if reorg fails
           await this.chain.putBlocks([oldHead], true)
         }

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -656,7 +656,7 @@ export class Skeleton extends MetaDBManager {
         numBlocksInserted = await this.chain.putBlocks([block], true)
       } catch (e) {
         this.config.logger.error(`fillCanonicalChain putBlock error=${(e as Error).message}`)
-        if (oldHead !== null) {
+        if (oldHead !== null && oldHead >= block.header.number) {
           // Put original canonical head block back if reorg fails
           await this.chain.putBlocks([oldHead], true)
         }

--- a/packages/client/lib/sync/skeleton.ts
+++ b/packages/client/lib/sync/skeleton.ts
@@ -656,7 +656,7 @@ export class Skeleton extends MetaDBManager {
         numBlocksInserted = await this.chain.putBlocks([block], true)
       } catch (e) {
         this.config.logger.error(`fillCanonicalChain putBlock error=${(e as Error).message}`)
-        if (resetHead === true && oldHead !== null) {
+        if (oldHead !== null) {
           // Put original canonical head block back if reorg fails
           await this.chain.putBlocks([oldHead], true)
         }


### PR DESCRIPTION
Fixes a logic bug related to reorg in skeleton sync where during a reorg that occurs during `fillCanonicalHead` where a skeleton subchain extends backwards passed the current canonical head block (due to a reorg scenario).
Currently, we reset the canonical head block on the chain to match the new skeleton block that we're putting in the chain when a reorg occurs via skeleton sync (i.e. the CL client reports our current head block in an FcU, then reports a different head block in the next FcU and then our client finds via the `ReverseFetcher` that the new head block announced in the FcU involves a reorg away from our current head block).  If that first skeleton block on the reorg chain is invalid for whatever reason, the chain's canonical head block is left as the original head's parent block (which is incorrect since the whole reorg was invalid).  This PR puts the original head block back as the canonical head.  