### PR TITLE
Fix kzg imports in `tx`

### DIFF
--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -34,7 +34,7 @@
     "src"
   ],
   "scripts": {
-    "build": "../../config/cli/ts-build.sh && mkdir -p dist/kzg && cp ./src/kzg/* ./dist/kzg",
+    "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
     "coverage": "../../config/cli/coverage.sh",
     "docs:build": "typedoc --options typedoc.js",

--- a/packages/tx/src/utils/blobHelpers.ts
+++ b/packages/tx/src/utils/blobHelpers.ts
@@ -1,5 +1,6 @@
-import { blobToKzgCommitment } from 'c-kzg'
 import { sha256 } from 'ethereum-cryptography/sha256'
+
+import { kzg } from '../kzg/kzg'
 
 /**
  * These utilities for constructing blobs are borrowed from https://github.com/Inphi/eip4844-interop.git
@@ -57,7 +58,7 @@ export const getBlobs = (input: string) => {
 export const blobsToCommitments = (blobs: Buffer[]) => {
   const commitments = []
   for (const blob of blobs) {
-    commitments.push(Buffer.from(blobToKzgCommitment(blob)))
+    commitments.push(Buffer.from(kzg.blobToKzgCommitment(blob)))
   }
   return commitments
 }


### PR DESCRIPTION
The latest release of `tx` breaks installs where `c-kzg` isn't also included because the `blobHelpers` file points to `c-kzg` instead of our own internal `kzg` interface.  This resolves the import breakage.