### PR TITLE
Turn off libp2p transport by default

### DIFF
--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -279,7 +279,7 @@ export class Config {
   public static readonly SYNCMODE_DEFAULT = SyncMode.Full
   public static readonly LIGHTSERV_DEFAULT = false
   public static readonly DATADIR_DEFAULT = `./datadir`
-  public static readonly TRANSPORTS_DEFAULT = ['rlpx', 'libp2p']
+  public static readonly TRANSPORTS_DEFAULT = ['rlpx']
   public static readonly PORT_DEFAULT = 30303
   public static readonly MAXPERREQUEST_DEFAULT = 50
   public static readonly MAXFETCHERJOBS_DEFAULT = 100

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -38,7 +38,7 @@
     "clean": "../../config/cli/clean-package.sh",
     "client:start": "ts-node bin/cli.ts",
     "client:start:dev1": "npm run client:start -- --discDns=false --discV4=false --bootnodes",
-    "client:start:dev2": "npm run client:start -- --discDns=false --discV4=false --transports=rlpx --port=30304 --dataDir=datadir-dev2",
+    "client:start:dev2": "npm run client:start -- --discDns=false --discV4=false --port=30304 --dataDir=datadir-dev2",
     "coverage": "c8 --all --reporter=lcov --reporter=text npm run test:unit",
     "docs:build": "typedoc --options typedoc.js --tsconfig tsconfig.prod.json",
     "preinstall": "npm run binWorkaround",


### PR DESCRIPTION
Makes the default transport in the client rlpx only for now since libp2p transport is only semi-functional and can lead to hard to debug port conflicts for code that is not currently being used