### PR TITLE
EVM: Memory Fix & Other Optimizations

### DIFF
--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -789,25 +789,15 @@ export class EVM implements EVMInterface {
       result.execResult.selfdestruct = {}
       result.execResult.gasRefund = BigInt(0)
     }
-    if (err) {
-      if (
-        this._common.gteHardfork(Hardfork.Homestead) ||
-        err.error !== ERROR.CODESTORE_OUT_OF_GAS
-      ) {
-        result.execResult.logs = []
-        await this.eei.revert()
-        this._transientStorage.revert()
-        if (this.DEBUG) {
-          debug(`message checkpoint reverted`)
-        }
-      } else {
-        // we are in chainstart and the error was the code deposit error
-        // we do like nothing happened.
-        await this.eei.commit()
-        this._transientStorage.commit()
-        if (this.DEBUG) {
-          debug(`message checkpoint committed`)
-        }
+    if (
+      err &&
+      !(this._common.hardfork() === Hardfork.Chainstart && err.error === ERROR.CODESTORE_OUT_OF_GAS)
+    ) {
+      result.execResult.logs = []
+      await this.eei.revert()
+      this._transientStorage.revert()
+      if (this.DEBUG) {
+        debug(`message checkpoint reverted`)
       }
     } else {
       await this.eei.commit()

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -745,7 +745,7 @@ export class EVM implements EVMInterface {
     }
 
     await this.eei.checkpoint()
-    this._transientStorage.checkpoint()
+    if (this._common.isActivatedEIP(1153)) this._transientStorage.checkpoint()
     if (this.DEBUG) {
       debug('-'.repeat(100))
       debug(`message checkpoint`)
@@ -795,13 +795,13 @@ export class EVM implements EVMInterface {
     ) {
       result.execResult.logs = []
       await this.eei.revert()
-      this._transientStorage.revert()
+      if (this._common.isActivatedEIP(1153)) this._transientStorage.revert()
       if (this.DEBUG) {
         debug(`message checkpoint reverted`)
       }
     } else {
       await this.eei.commit()
-      this._transientStorage.commit()
+      if (this._common.isActivatedEIP(1153)) this._transientStorage.commit()
       if (this.DEBUG) {
         debug(`message checkpoint committed`)
       }

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -364,13 +364,13 @@ export class EVM implements EVMInterface {
     if (!message.code || message.code.length === 0) {
       exit = true
       if (this.DEBUG) {
-        debug(`Exit early on no code`)
+        debug(`Exit early on no code (CALL)`)
       }
     }
     if (errorMessage !== undefined) {
       exit = true
       if (this.DEBUG) {
-        debug(`Exit early on value transfer overflowed`)
+        debug(`Exit early on value transfer overflowed (CALL)`)
       }
     }
     if (exit) {
@@ -482,13 +482,13 @@ export class EVM implements EVMInterface {
     if (message.code === undefined || message.code.length === 0) {
       exit = true
       if (this.DEBUG) {
-        debug(`Exit early on no code`)
+        debug(`Exit early on no code (CREATE)`)
       }
     }
     if (errorMessage !== undefined) {
       exit = true
       if (this.DEBUG) {
-        debug(`Exit early on value transfer overflowed`)
+        debug(`Exit early on value transfer overflowed (CREATE)`)
       }
     }
     if (exit) {

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -40,7 +40,7 @@ import type {
 } from './types'
 import type { Account } from '@ethereumjs/util'
 
-const debug = createDebugLogger('evm')
+const debug = createDebugLogger('evm:evm')
 const debugGas = createDebugLogger('evm:gas')
 
 // very ugly way to detect if we are running in a browser

--- a/packages/evm/src/memory.ts
+++ b/packages/evm/src/memory.ts
@@ -70,7 +70,7 @@ export class Memory {
     const returnBuffer = Buffer.allocUnsafe(size)
     // Copy the stored "buffer" from memory into the return Buffer
 
-    const loaded = Buffer.from(this._store.slice(offset, offset + size))
+    const loaded = this._store.slice(offset, offset + size)
     returnBuffer.fill(loaded, 0, loaded.length)
 
     if (loaded.length < size) {

--- a/packages/vm/src/eei/vmState.ts
+++ b/packages/vm/src/eei/vmState.ts
@@ -68,7 +68,7 @@ export class VmState implements EVMStateAccess {
 
     if (this.DEBUG) {
       this._debug('-'.repeat(100))
-      this._debug(`message checkpoint`)
+      this._debug(`state checkpoint`)
     }
   }
 
@@ -89,7 +89,7 @@ export class VmState implements EVMStateAccess {
     }
 
     if (this.DEBUG) {
-      this._debug(`message checkpoint committed`)
+      this._debug(`state checkpoint committed`)
     }
   }
 
@@ -127,7 +127,7 @@ export class VmState implements EVMStateAccess {
     }
 
     if (this.DEBUG) {
-      this._debug(`message checkpoint reverted`)
+      this._debug(`state checkpoint reverted`)
     }
   }
 


### PR DESCRIPTION
This cuts performance test 1 and 3 in roughly half by avoiding an additional buffer copy on memory read (so 0f0e2828c3eebe0c0f43378bb54784cb9b8df72c is the essential commit here). Additionally there are some more performance optimizations and debug logger enhancements included.