### PR TITLE
Hive: fix `engine-api/Invalid Terminal Block in ForkchoiceUpdated`

### DIFF
--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -1264,6 +1264,7 @@ export class Blockchain implements BlockchainInterface {
         throw new Error(`consensus algorithm ${this._common.consensusAlgorithm()} not supported`)
     }
     await this.consensus.setup({ blockchain: this })
+    await this.consensus.genesisInit(this.genesisBlock)
   }
 
   /**


### PR DESCRIPTION
This PR fixes `engine-api/Invalid Terminal Block in ForkchoiceUpdated`

To run in hive: 

`go run ./hive.go --client ethereumjs --sim ethereum/engine --sim.limit "engine-api/Invalid Terminal Block in ForkchoiceUpdated" --docker.output`