### PR TITLE
EVM: Avoid memory.read() Memory Copy

### DIFF
--- a/packages/evm/src/memory.ts
+++ b/packages/evm/src/memory.ts
@@ -72,15 +72,10 @@ export class Memory {
     // Copy the stored "buffer" from memory into the return Buffer
 
     const loaded = this._store.slice(offset, offset + size)
-    if (avoidCopy === true && loaded.length === size) {
+    if (avoidCopy === true) {
       return loaded
     }
     returnBuffer.fill(loaded, 0, loaded.length)
-
-    if (loaded.length < size) {
-      // fill the remaining part of the Buffer with zeros
-      returnBuffer.fill(0, loaded.length, size)
-    }
 
     return returnBuffer
   }

--- a/packages/evm/src/memory.ts
+++ b/packages/evm/src/memory.ts
@@ -63,14 +63,18 @@ export class Memory {
    * It fills up the difference between memory's length and `offset + size` with zeros.
    * @param offset - Starting position
    * @param size - How many bytes to read
+   * @param avoidCopy - Avoid memory copy if possible for performance reasons (optional)
    */
-  read(offset: number, size: number): Buffer {
+  read(offset: number, size: number, avoidCopy?: boolean): Buffer {
     this.extend(offset, size)
 
     const returnBuffer = Buffer.allocUnsafe(size)
     // Copy the stored "buffer" from memory into the return Buffer
 
     const loaded = this._store.slice(offset, offset + size)
+    if (avoidCopy === true && loaded.length === size) {
+      return loaded
+    }
     returnBuffer.fill(loaded, 0, loaded.length)
 
     if (loaded.length < size) {

--- a/packages/evm/src/memory.ts
+++ b/packages/evm/src/memory.ts
@@ -68,15 +68,11 @@ export class Memory {
   read(offset: number, size: number, avoidCopy?: boolean): Buffer {
     this.extend(offset, size)
 
-    const returnBuffer = Buffer.allocUnsafe(size)
-    // Copy the stored "buffer" from memory into the return Buffer
-
     const loaded = this._store.slice(offset, offset + size)
     if (avoidCopy === true) {
       return loaded
     }
-    returnBuffer.fill(loaded, 0, loaded.length)
 
-    return returnBuffer
+    return Buffer.from(loaded)
   }
 }

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -940,7 +940,7 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       let data = Buffer.alloc(0)
       if (length !== BigInt(0)) {
-        data = runState.memory.read(Number(offset), Number(length))
+        data = runState.memory.read(Number(offset), Number(length), true)
       }
 
       const ret = await runState.interpreter.create2(
@@ -962,7 +962,7 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       let data = Buffer.alloc(0)
       if (inLength !== BigInt(0)) {
-        data = runState.memory.read(Number(inOffset), Number(inLength))
+        data = runState.memory.read(Number(inOffset), Number(inLength), true)
       }
 
       const gasLimit = runState.messageGasLimit!
@@ -987,7 +987,7 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       let data = Buffer.alloc(0)
       if (inLength !== BigInt(0)) {
-        data = runState.memory.read(Number(inOffset), Number(inLength))
+        data = runState.memory.read(Number(inOffset), Number(inLength), true)
       }
 
       const ret = await runState.interpreter.callCode(gasLimit, toAddress, value, data)
@@ -1007,7 +1007,7 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       let data = Buffer.alloc(0)
       if (inLength !== BigInt(0)) {
-        data = runState.memory.read(Number(inOffset), Number(inLength))
+        data = runState.memory.read(Number(inOffset), Number(inLength), true)
       }
 
       const gasLimit = runState.messageGasLimit!
@@ -1121,7 +1121,7 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       let data = Buffer.alloc(0)
       if (inLength !== BigInt(0)) {
-        data = runState.memory.read(Number(inOffset), Number(inLength))
+        data = runState.memory.read(Number(inOffset), Number(inLength), true)
       }
 
       const ret = await runState.interpreter.callStatic(gasLimit, toAddress, value, data)

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -918,7 +918,7 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       let data = Buffer.alloc(0)
       if (length !== BigInt(0)) {
-        data = runState.memory.read(Number(offset), Number(length))
+        data = runState.memory.read(Number(offset), Number(length), true)
       }
 
       const ret = await runState.interpreter.create(gasLimit, value, data)

--- a/packages/evm/src/precompiles/04-identity.ts
+++ b/packages/evm/src/precompiles/04-identity.ts
@@ -31,6 +31,6 @@ export function precompile04(opts: PrecompileInput): ExecResult {
 
   return {
     executionGasUsed: gasUsed,
-    returnValue: data,
+    returnValue: Buffer.from(data), // Copy the memory (`Buffer.from()`)
   }
 }


### PR DESCRIPTION
This is a first cautious test to avoid copying memory buffers on `memory.read()` calls, realized by a new parameter `avoidCopy` which allows to directly return the memory slice in case there is no need for 0-filling.

First PR submit activates this for CREATE opcode to see what this will do to the tests, also generally direct read will likely have the biggest effect for these calling opcodes, since there potentially large chunks of data are read from memory.