### PR TITLE
Setup to dev/test snapsync with sim architecture

### DIFF
--- a/packages/client/lib/sync/snapsync.ts
+++ b/packages/client/lib/sync/snapsync.ts
@@ -83,7 +83,6 @@ export class SnapSynchronizer extends Synchronizer {
 
   /**
    * Start synchronizer.
-   * If passed a block, will initialize sync starting from the block.
    */
   async start(): Promise<void> {
     if (this.running) return

--- a/packages/client/lib/types.ts
+++ b/packages/client/lib/types.ts
@@ -22,6 +22,7 @@ export enum Event {
   SYNC_SYNCHRONIZED = 'sync:synchronized',
   SYNC_ERROR = 'sync:error',
   SYNC_FETCHER_ERROR = 'sync:fetcher:error',
+  SYNC_SNAPSYNC_COMPLETE = 'sync:snapsync:complete',
   PEER_CONNECTED = 'peer:connected',
   PEER_DISCONNECTED = 'peer:disconnected',
   PEER_ERROR = 'peer:error',
@@ -40,6 +41,7 @@ export interface EventParams {
   [Event.SYNC_FETCHED_BLOCKS]: [blocks: Block[]]
   [Event.SYNC_FETCHED_HEADERS]: [headers: BlockHeader[]]
   [Event.SYNC_SYNCHRONIZED]: [chainHeight: bigint]
+  [Event.SYNC_SNAPSYNC_COMPLETE]: [stateRoot: Uint8Array]
   [Event.SYNC_ERROR]: [syncError: Error]
   [Event.SYNC_FETCHER_ERROR]: [fetchError: Error, task: any, peer: Peer | null | undefined]
   [Event.PEER_CONNECTED]: [connectedPeer: Peer]
@@ -67,6 +69,7 @@ export type EventBusType = EventBus<Event.CHAIN_UPDATED> &
   EventBus<Event.SYNC_FETCHED_BLOCKS> &
   EventBus<Event.SYNC_FETCHED_HEADERS> &
   EventBus<Event.SYNC_SYNCHRONIZED> &
+  EventBus<Event.SYNC_SNAPSYNC_COMPLETE> &
   EventBus<Event.SYNC_FETCHER_ERROR> &
   EventBus<Event.PEER_CONNECTED> &
   EventBus<Event.PEER_DISCONNECTED> &

--- a/packages/client/test/sim/simutils.ts
+++ b/packages/client/test/sim/simutils.ts
@@ -415,5 +415,6 @@ export const filterKeywords = [
   'pid',
   'Synced - slot: 0 -',
   'TxPool started',
+  'number=0',
 ]
 export const filterOutWords = ['duties', 'Low peer count', 'MaxListenersExceededWarning']

--- a/packages/client/test/sim/simutils.ts
+++ b/packages/client/test/sim/simutils.ts
@@ -136,7 +136,7 @@ export function runNetwork(
         console.log('')
         lastPrintedDot = false
       }
-      process.stdout.write(`${runProcPrefix}:el<>cl: ${runProc.pid}: ${str}`) // str already contains a new line. console.log adds a new line
+      process.stdout.write(`data:${runProcPrefix}: ${runProc.pid}: ${str}`) // str already contains a new line. console.log adds a new line
     } else {
       if (str.includes('Synchronized')) {
         process.stdout.write('.')
@@ -148,9 +148,10 @@ export function runNetwork(
   })
   runProc.stderr.on('data', (chunk) => {
     const str = Buffer.from(chunk).toString('utf8')
+    const filterStr = filterKeywords.reduce((acc, next) => acc || str.includes(next), false)
     const filterOutStr = filterOutWords.reduce((acc, next) => acc || str.includes(next), false)
-    if (!filterOutStr) {
-      process.stderr.write(`${runProcPrefix}:el<>cl: ${runProc.pid}: ${str}`) // str already contains a new line. console.log adds a new line
+    if (filterStr && !filterOutStr) {
+      process.stderr.write(`stderr:${runProcPrefix}: ${runProc.pid}: ${str}`) // str already contains a new line. console.log adds a new line
     }
   })
 

--- a/packages/client/test/sim/single-run.sh
+++ b/packages/client/test/sim/single-run.sh
@@ -34,8 +34,13 @@ then
         echo "ELCLIENT=$ELCLIENT using local ethereumjs binary from packages/client"
         ;;
       geth)
+        if [ ! -n "$NETWORKID" ]
+        then
+          echo "geth requires NETWORKID to be passed in env, exiting..."
+          exit;
+        fi;
         ELCLIENT_IMAGE="ethereum/client-go:stable"
-        echo "ELCLIENT=$ELCLIENT using ELCLIENT_IMAGE=$ELCLIENT_IMAGE"
+        echo "ELCLIENT=$ELCLIENT using ELCLIENT_IMAGE=$ELCLIENT_IMAGE NETWORKID=$NETWORKID"
         ;;
       *)
         echo "ELCLIENT=$ELCLIENT not implemented"
@@ -94,7 +99,7 @@ case $MULTIPEER in
         ;;
       geth)
         # geth will be mounted in docker with DATADIR to /data
-        EL_PORT_ARGS="--datadir /data/geth --authrpc.jwtsecret /data/jwtsecret --http --http.api engine,net,eth,web3,debug --http.corsdomain \"*\" --http.port 8545 --http.addr 0.0.0.0 --http.vhosts \"*\" --authrpc.addr 0.0.0.0 --authrpc.vhosts \"*\" --authrpc.port=8551 --syncmode full"
+        EL_PORT_ARGS="--datadir /data/geth --authrpc.jwtsecret /data/jwtsecret --http --http.api engine,net,eth,web3,debug,admin --http.corsdomain \"*\" --http.port 8545 --http.addr 0.0.0.0 --http.vhosts \"*\" --authrpc.addr 0.0.0.0 --authrpc.vhosts \"*\" --authrpc.port=8551 --syncmode full --networkid $NETWORKID"
         ;;
       *)
         echo "ELCLIENT=$ELCLIENT not implemented"

--- a/packages/client/test/sim/single-run.sh
+++ b/packages/client/test/sim/single-run.sh
@@ -24,14 +24,14 @@ case $MULTIPEER in
   syncpeer)
     echo "setting up to run as a sync only peer to peer1 (bootnode)..."
     DATADIR="$DATADIR/syncpeer"
-    EL_PORT_ARGS="--port 30305 --rpcEnginePort 8553 --rpcport 8947 --multiaddrs /ip4/127.0.0.1/tcp/50582/ws --logLevel debug"
-    CL_PORT_ARGS="--genesisValidators 8 --enr.tcp 9002 --port 9002 --execution.urls http://localhost:8553  --rest.port 9598 --server http://localhost:9598 --network.connectToDiscv5Bootnodes true"
+    EL_PORT_ARGS="--port 30305 --rpcEnginePort 8553 --rpcPort 8947 --multiaddrs /ip4/127.0.0.1/tcp/50582/ws --logLevel debug"
+    CL_PORT_ARGS="--genesisValidators 8 --enr.tcp 9002 --port 9002 --execution.urls http://localhost:8553  --rest.port 9598 --server http://localhost:9598 --network.connectToDiscv5Bootnodes true --logLevel debug"
     ;;
 
   peer2 )
     echo "setting up peer2 to run with peer1 (bootnode)..."
     DATADIR="$DATADIR/peer2"
-    EL_PORT_ARGS="--port 30304 --rpcEnginePort 8552 --rpcport 8946 --multiaddrs /ip4/127.0.0.1/tcp/50581/ws --bootnodes $elBootnode --logLevel debug"
+    EL_PORT_ARGS="--port 30304 --rpcEnginePort 8552 --rpcPort 8946 --multiaddrs /ip4/127.0.0.1/tcp/50581/ws --bootnodes $elBootnode --logLevel debug"
     CL_PORT_ARGS="--genesisValidators 8 --startValidators 4..7 --enr.tcp 9001 --port 9001 --execution.urls http://localhost:8552  --rest.port 9597 --server http://localhost:9597 --network.connectToDiscv5Bootnodes true --bootnodes $bootEnrs"
     ;;
 
@@ -159,7 +159,7 @@ else
   EL_PORT_ARGS="$EL_PORT_ARGS --bootnodes $elBootnode"
   CL_PORT_ARGS="$CL_PORT_ARGS --bootnodes $bootEnrs"
 
-  GENESIS_HASH=$(cat "$origDataDir/geneisHash")
+  GENESIS_HASH=$(cat "$origDataDir/genesisHash")
   genTime=$(cat "$origDataDir/genesisTime")
 
 

--- a/packages/client/test/sim/single-run.sh
+++ b/packages/client/test/sim/single-run.sh
@@ -99,7 +99,7 @@ case $MULTIPEER in
         ;;
       geth)
         # geth will be mounted in docker with DATADIR to /data
-        EL_PORT_ARGS="--datadir /data/geth --authrpc.jwtsecret /data/jwtsecret --http --http.api engine,net,eth,web3,debug,admin --http.corsdomain \"*\" --http.port 8545 --http.addr 0.0.0.0 --http.vhosts \"*\" --authrpc.addr 0.0.0.0 --authrpc.vhosts \"*\" --authrpc.port=8551 --syncmode full --networkid $NETWORKID"
+        EL_PORT_ARGS="--datadir /data/geth --authrpc.jwtsecret /data/jwtsecret --http --http.api engine,net,eth,web3,debug,admin --http.corsdomain \"*\" --http.port 8545 --http.addr 0.0.0.0 --http.vhosts \"*\" --authrpc.addr 0.0.0.0 --authrpc.vhosts \"*\" --authrpc.port=8551 --syncmode full --networkid $NETWORKID --nodiscover"
         ;;
       *)
         echo "ELCLIENT=$ELCLIENT not implemented"

--- a/packages/client/test/sim/single-run.sh
+++ b/packages/client/test/sim/single-run.sh
@@ -20,24 +20,86 @@ then
   exit;
 fi;
 
+if [ ! -n "$JWT_SECRET" ]
+then
+  JWT_SECRET="0xdc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d"
+fi;
+
+if [ -n "$ELCLIENT" ]
+then
+  if [ ! -n "$ELCLIENT_IMAGE" ]
+  then
+    case $ELCLIENT in 
+      ethereumjs)
+        echo "ELCLIENT=$ELCLIENT using local ethereumjs binary from packages/client"
+        ;;
+      geth)
+        ELCLIENT_IMAGE="ethereum/client-go:stable"
+        echo "ELCLIENT=$ELCLIENT using ELCLIENT_IMAGE=$ELCLIENT_IMAGE"
+        ;;
+      *)
+        echo "ELCLIENT=$ELCLIENT not implemented"
+    esac
+  fi
+else
+  ELCLIENT="ethereumjs"
+  echo "ELCLIENT=$ELCLIENT using local ethereumjs binary from packages/client"
+fi;
+
 case $MULTIPEER in
   syncpeer)
     echo "setting up to run as a sync only peer to peer1 (bootnode)..."
     DATADIR="$DATADIR/syncpeer"
-    EL_PORT_ARGS="--port 30305 --rpcEnginePort 8553 --rpcPort 8947 --multiaddrs /ip4/127.0.0.1/tcp/50582/ws --logLevel debug"
+
+    case $ELCLIENT in 
+      ethereumjs)
+        EL_PORT_ARGS="--port 30305 --rpcEnginePort 8553 --rpcPort 8947 --multiaddrs /ip4/127.0.0.1/tcp/50582/ws --logLevel debug"
+        ;;
+      geth)
+        echo "syncpeer args not yet implemented for geth, exiting..."
+        exit;
+        ;;
+      *)
+        echo "ELCLIENT=$ELCLIENT not implemented"
+    esac
+    
     CL_PORT_ARGS="--genesisValidators 8 --enr.tcp 9002 --port 9002 --execution.urls http://localhost:8553  --rest.port 9598 --server http://localhost:9598 --network.connectToDiscv5Bootnodes true --logLevel debug"
     ;;
 
-  peer2 )
+  peer2)
     echo "setting up peer2 to run with peer1 (bootnode)..."
     DATADIR="$DATADIR/peer2"
-    EL_PORT_ARGS="--port 30304 --rpcEnginePort 8552 --rpcPort 8946 --multiaddrs /ip4/127.0.0.1/tcp/50581/ws --bootnodes $elBootnode --logLevel debug"
+
+    case $ELCLIENT in 
+      ethereumjs)
+        EL_PORT_ARGS="--port 30304 --rpcEnginePort 8552 --rpcPort 8946 --multiaddrs /ip4/127.0.0.1/tcp/50581/ws --bootnodes $elBootnode --logLevel debug"
+        ;;
+      geth)
+        echo "peer2 args not yet implemented for geth, exiting..."
+        exit;
+        ;;
+      *)
+        echo "ELCLIENT=$ELCLIENT not implemented"
+    esac
+
     CL_PORT_ARGS="--genesisValidators 8 --startValidators 4..7 --enr.tcp 9001 --port 9001 --execution.urls http://localhost:8552  --rest.port 9597 --server http://localhost:9597 --network.connectToDiscv5Bootnodes true --bootnodes $bootEnrs"
     ;;
 
   * )
     DATADIR="$DATADIR/peer1"
-    EL_PORT_ARGS="--isSingleNode --extIP 127.0.0.1 --logLevel debug"
+
+    case $ELCLIENT in 
+      ethereumjs)
+        EL_PORT_ARGS="--isSingleNode --extIP 127.0.0.1 --logLevel debug"
+        ;;
+      geth)
+        # geth will be mounted in docker with DATADIR to /data
+        EL_PORT_ARGS="--datadir /data/geth --authrpc.jwtsecret /data/jwtsecret --http --http.api engine,net,eth,web3,debug --http.corsdomain \"*\" --http.port 8545 --http.addr 0.0.0.0 --http.vhosts \"*\" --authrpc.addr 0.0.0.0 --authrpc.vhosts \"*\" --authrpc.port=8551 --syncmode full"
+        ;;
+      *)
+        echo "ELCLIENT=$ELCLIENT not implemented"
+    esac
+
     CL_PORT_ARGS="--enr.ip 127.0.0.1 --enr.tcp 9000 --enr.udp 9000"
     if [ ! -n "$MULTIPEER" ]
     then
@@ -62,11 +124,22 @@ fi;
 
 # clean these folders as old data can cause issues
 sudo rm -rf $DATADIR/ethereumjs
+sudo rm -rf $DATADIR/geth
 sudo rm -rf $DATADIR/lodestar
 
 # these two commands will harmlessly fail if folders exists
 mkdir $DATADIR/ethereumjs
+mkdir $DATADIR/geth
 mkdir $DATADIR/lodestar
+echo "$JWT_SECRET" > $DATADIR/jwtsecret
+
+# additional step for setting geth genesis now that we have datadir
+if [ "$ELCLIENT" == "geth" ]
+then
+  setupCmd="docker run --rm -v $scriptDir/configs:/config -v $DATADIR/geth:/data $ELCLIENT_IMAGE --datadir /data init /config/$NETWORK.json"
+  echo "$setupCmd"
+  $setupCmd
+fi;
 
 run_cmd(){
   execCmd=$1;
@@ -90,7 +163,12 @@ cleanup() {
   then
     ejsPidBySearch=$(ps x | grep "ts-node bin/cli.ts --dataDir $DATADIR/ethereumjs" | grep -v grep | awk '{print $1}')
     echo "cleaning ethereumjs pid:${ejsPid} ejsPidBySearch:${ejsPidBySearch}..."
-    kill $ejsPidBySearch
+    if [ -n "$ELCLIENT_IMAGE" ]
+    then
+      docker rm execution${MULTIPEER} -f
+    else
+      kill $ejsPidBySearch
+    fi;
   fi;
   if [ -n "$lodePid" ]
   then
@@ -110,7 +188,18 @@ cleanup() {
 
 if [ "$MULTIPEER" == "peer1" ]
 then
-  ejsCmd="npm run client:start -- --dataDir $DATADIR/ethereumjs --gethGenesis $scriptDir/configs/$NETWORK.json --rpc --rpcEngine --rpcEngineAuth false $EL_PORT_ARGS"
+  case $ELCLIENT in 
+    ethereumjs)
+      ejsCmd="npm run client:start -- --dataDir $DATADIR/ethereumjs --gethGenesis $scriptDir/configs/$NETWORK.json --rpc --rpcEngine --rpcEngineAuth false $EL_PORT_ARGS"
+      ;;
+    geth)
+      # geth will be mounted in docker with DATADIR to /data
+      ejsCmd="docker run --rm --name execution${MULTIPEER} -v $DATADIR:/data --network host $ELCLIENT_IMAGE $EL_PORT_ARGS"
+      ;;
+    *)
+      echo "ELCLIENT=$ELCLIENT not implemented"
+  esac
+
   run_cmd "$ejsCmd"
   ejsPid=$!
   echo "ejsPid: $ejsPid"
@@ -162,8 +251,18 @@ else
   GENESIS_HASH=$(cat "$origDataDir/genesisHash")
   genTime=$(cat "$origDataDir/genesisTime")
 
+  case $ELCLIENT in 
+    ethereumjs)
+      ejsCmd="npm run client:start -- --dataDir $DATADIR/ethereumjs --gethGenesis $scriptDir/configs/$NETWORK.json --rpc --rpcEngine --rpcEngineAuth false $EL_PORT_ARGS"
+      ;;
+    geth)
+      echo "peer2/syncpeer args not yet implemented for geth, exiting..."
+      exit;
+      ;;
+    *)
+      echo "ELCLIENT=$ELCLIENT not implemented"
+  esac
 
-  ejsCmd="npm run client:start -- --dataDir $DATADIR/ethereumjs --gethGenesis $scriptDir/configs/$NETWORK.json --rpc --rpcEngine --rpcEngineAuth false $EL_PORT_ARGS"
   run_cmd "$ejsCmd"
   ejsPid=$!
   echo "ejsPid: $ejsPid"
@@ -179,9 +278,9 @@ then
   then
     LODE_IMAGE="chainsafe/lodestar:latest"
   fi;
-  lodeCmd="docker run --rm --name beacon${MULTIPEER} -v $DATADIR:/data --network host $LODE_IMAGE dev --dataDir /data/lodestar  $CL_PORT_ARGS"
+  lodeCmd="docker run --rm --name beacon${MULTIPEER} -v $DATADIR:/data --network host $LODE_IMAGE dev --dataDir /data/lodestar --jwt-secret /data/jwtsecret  $CL_PORT_ARGS"
 else
-  lodeCmd="$LODE_BINARY dev --dataDir $DATADIR/lodestar $CL_PORT_ARGS"
+  lodeCmd="$LODE_BINARY dev --dataDir $DATADIR/lodestar --jwt-secret $DATADIR/jwtsecret  $CL_PORT_ARGS"
 fi;
 run_cmd "$lodeCmd"
 lodePid=$!

--- a/packages/client/test/sim/snapsync.md
+++ b/packages/client/test/sim/snapsync.md
@@ -15,6 +15,10 @@ EXTERNAL_RUN=true TARGET_PEER=true  DATADIR=/usr/app/ethereumjs/packages/client/
 ```bash
 EXTERNAL_RUN=true SNAP_SYNC=true  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
 ```
+you may add `DEBUG_SNAP=client:*` to see client fetcher snap sync debug logs i.e.
+```bash
+EXTERNAL_RUN=true SNAP_SYNC=true DEBUG_SNAP=client:* DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
+```
 
 ## Combinations
 

--- a/packages/client/test/sim/snapsync.md
+++ b/packages/client/test/sim/snapsync.md
@@ -1,5 +1,29 @@
 ### Snapsync sim setup
 
+1. Start external geth client:
 ```bash
-ELCLIENT=geth  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
+NETWORK=mainnet NETWORKID=1337903 ELCLIENT=geth  DATADIR=/usr/app/ethereumjs/packages/client/data test
+/sim/single-run.sh
+```
+
+2. (optional) Add some txs/state to geth
+```bash
+EXTERNAL_RUN=true TARGET_PEER=true  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
+```
+
+3. Run snap sync:
+```bash
+EXTERNAL_RUN=true SNAP_SYNC=true  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
+```
+
+## Combinations
+
+Combine 2 & 3 in single step:
+```bash
+EXTERNAL_RUN=true TARGET_PEER=true SNAP_SYNC=true  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
+```
+
+Combine 1, 2, 3 in single step
+```bash
+TARGET_PEER=true SNAP_SYNC=true  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
 ```

--- a/packages/client/test/sim/snapsync.md
+++ b/packages/client/test/sim/snapsync.md
@@ -1,0 +1,5 @@
+### Snapsync sim setup
+
+```bash
+ELCLIENT=geth  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
+```

--- a/packages/client/test/sim/snapsync.md
+++ b/packages/client/test/sim/snapsync.md
@@ -8,7 +8,7 @@ NETWORK=mainnet NETWORKID=1337903 ELCLIENT=geth  DATADIR=/usr/app/ethereumjs/pac
 
 2. (optional) Add some txs/state to geth
 ```bash
-EXTERNAL_RUN=true TARGET_PEER=true  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
+EXTERNAL_RUN=true ADD_EOA_STATE=true  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
 ```
 
 3. Run snap sync:
@@ -24,10 +24,25 @@ EXTERNAL_RUN=true SNAP_SYNC=true DEBUG_SNAP=client:* DATADIR=/usr/app/ethereumjs
 
 Combine 2 & 3 in single step:
 ```bash
-EXTERNAL_RUN=true TARGET_PEER=true SNAP_SYNC=true  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
+EXTERNAL_RUN=true ADD_EOA_STATE=true SNAP_SYNC=true  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
 ```
 
 Combine 1, 2, 3 in single step
 ```bash
-TARGET_PEER=true SNAP_SYNC=true  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
+NETWORK=mainnet NETWORKID=1337903 ELCLIENT=geth ADD_EOA_STATE=true SNAP_SYNC=true DEBUG_SNAP=client:*  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
 ```
+
+### Fully combined scenarios
+
+1. Test syncing genesis state from geth:
+```bash
+NETWORK=mainnet NETWORKID=1337903 ELCLIENT=geth SNAP_SYNC=true DEBUG_SNAP=client:*  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
+```
+
+2. Add some EOA account states to geth (just add `ADD_EOA_STATE=true` flag to the command)
+```bash
+NETWORK=mainnet NETWORKID=1337903 ELCLIENT=geth ADD_EOA_STATE=true SNAP_SYNC=true DEBUG_SNAP=client:*  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
+```
+
+3. Add EOA as well as some contract states (just add `ADD_CONTRACT_STATE=true` flag to the command)
+TBD

--- a/packages/client/test/sim/snapsync.spec.ts
+++ b/packages/client/test/sim/snapsync.spec.ts
@@ -63,41 +63,45 @@ tape('simple mainnet test run', async (t) => {
   }
 
   // ------------Sanity checks--------------------------------
-  t.test('add some EOA transfers', { skip: process.env.TARGET_PEER === undefined }, async (st) => {
-    const startBalance = await client.request('eth_getBalance', [
-      '0x3dA33B9A0894b908DdBb00d96399e506515A1009',
-      'latest',
-    ])
-    st.ok(
-      startBalance.result !== undefined,
-      `fetched 0x3dA33B9A0894b908DdBb00d96399e506515A1009 balance=${startBalance.result}`
-    )
-    await runTx('', '0x3dA33B9A0894b908DdBb00d96399e506515A1009', 1000000n)
-    let balance = await client.request('eth_getBalance', [
-      '0x3dA33B9A0894b908DdBb00d96399e506515A1009',
-      'latest',
-    ])
-    st.equal(
-      BigInt(balance.result),
-      BigInt(startBalance.result) + 1000000n,
-      'sent a simple ETH transfer'
-    )
-    await runTx('', '0x3dA33B9A0894b908DdBb00d96399e506515A1009', 1000000n)
-    balance = await client.request('eth_getBalance', [
-      '0x3dA33B9A0894b908DdBb00d96399e506515A1009',
-      'latest',
-    ])
-    balance = await client.request('eth_getBalance', [
-      '0x3dA33B9A0894b908DdBb00d96399e506515A1009',
-      'latest',
-    ])
-    st.equal(
-      BigInt(balance.result),
-      BigInt(startBalance.result) + 2000000n,
-      'sent a simple ETH transfer 2x'
-    )
-    st.end()
-  })
+  t.test(
+    'add some EOA transfers',
+    { skip: process.env.ADD_EOA_STATE === undefined },
+    async (st) => {
+      const startBalance = await client.request('eth_getBalance', [
+        '0x3dA33B9A0894b908DdBb00d96399e506515A1009',
+        'latest',
+      ])
+      st.ok(
+        startBalance.result !== undefined,
+        `fetched 0x3dA33B9A0894b908DdBb00d96399e506515A1009 balance=${startBalance.result}`
+      )
+      await runTx('', '0x3dA33B9A0894b908DdBb00d96399e506515A1009', 1000000n)
+      let balance = await client.request('eth_getBalance', [
+        '0x3dA33B9A0894b908DdBb00d96399e506515A1009',
+        'latest',
+      ])
+      st.equal(
+        BigInt(balance.result),
+        BigInt(startBalance.result) + 1000000n,
+        'sent a simple ETH transfer'
+      )
+      await runTx('', '0x3dA33B9A0894b908DdBb00d96399e506515A1009', 1000000n)
+      balance = await client.request('eth_getBalance', [
+        '0x3dA33B9A0894b908DdBb00d96399e506515A1009',
+        'latest',
+      ])
+      balance = await client.request('eth_getBalance', [
+        '0x3dA33B9A0894b908DdBb00d96399e506515A1009',
+        'latest',
+      ])
+      st.equal(
+        BigInt(balance.result),
+        BigInt(startBalance.result) + 2000000n,
+        'sent a simple ETH transfer 2x'
+      )
+      st.end()
+    }
+  )
 
   t.test('setup snap sync', { skip: process.env.SNAP_SYNC === undefined }, async (st) => {
     // start client inline here for snap sync, no need for beacon

--- a/packages/client/test/sim/snapsync.spec.ts
+++ b/packages/client/test/sim/snapsync.spec.ts
@@ -19,6 +19,7 @@ import {
 } from './simutils'
 
 import type { EthereumClient } from '../../lib/client'
+import type { RlpxServer } from '../../lib/net/server'
 
 const pkey = Buffer.from('ae557af4ceefda559c924516cabf029bedc36b68109bf8d6183fe96e04121f4e', 'hex')
 const sender = '0x' + privateToAddress(pkey).toString('hex')
@@ -116,6 +117,11 @@ tape('simple mainnet test run', async (t) => {
     })) ?? { ejsInlineClient: null, peerConnectedPromise: Promise.reject('Client creation error') }
     ejsClient = ejsInlineClient
     st.ok(ejsClient !== null, 'ethereumjs client started')
+
+    const enode = (ejsClient!.server('rlpx') as RlpxServer)!.getRlpxInfo().enode
+    const res = await client.request('admin_addPeer', [enode])
+    st.equal(res.result, true, 'successfully requested Geth add EthereumJS as peer')
+
     const peerConnectTimeout = new Promise((_resolve, reject) => setTimeout(reject, 10000))
     try {
       await Promise.race([peerConnectedPromise, peerConnectTimeout])

--- a/packages/client/test/sim/snapsync.spec.ts
+++ b/packages/client/test/sim/snapsync.spec.ts
@@ -1,7 +1,14 @@
+import { Blockchain, parseGethGenesisState } from '@ethereumjs/blockchain'
 import { Common } from '@ethereumjs/common'
 import { privateToAddress } from '@ethereumjs/util'
+import debug from 'debug'
 import { Client } from 'jayson/promise'
+import { Level } from 'level'
 import * as tape from 'tape'
+
+import { EthereumClient } from '../../lib/client'
+import { Config } from '../../lib/config'
+import { getLogger } from '../../lib/logging'
 
 import {
   filterKeywords,
@@ -18,12 +25,16 @@ const client = Client.http({ port: 8545 })
 const network = 'mainnet'
 const networkJson = require(`./configs/${network}.json`)
 const common = Common.fromGethGenesis(networkJson, { chain: network })
+const customGenesisState = parseGethGenesisState(networkJson)
+let ejsClient: EthereumClient | null = null
 
 export async function runTx(data: string, to?: string, value?: bigint) {
   return runTxHelper({ client, common, sender, pkey }, data, to, value)
 }
 
 tape('simple mainnet test run', async (t) => {
+  // Better add it as a option in startnetwork
+  process.env.NETWORKID = `${common.networkId()}`
   const { teardownCallBack, result } = await startNetwork(network, client, {
     filterKeywords,
     filterOutWords,
@@ -37,6 +48,9 @@ tape('simple mainnet test run', async (t) => {
     t.fail('connected to wrong client')
   }
 
+  const nodeInfo = (await client.request('admin_nodeInfo', [])).result
+  t.ok(nodeInfo.enode !== undefined, 'fetched enode for peering')
+
   console.log(`Waiting for network to start...`)
   try {
     await waitForELStart(client)
@@ -46,20 +60,26 @@ tape('simple mainnet test run', async (t) => {
     throw e
   }
 
-  t.test('snap sync empty state', async (st) => {
-    // start client inline here for snap sync, no need for beacon
-    st.end()
-  })
-
-  const blockHashes: string[] = []
   // ------------Sanity checks--------------------------------
-  t.test('add some EOA transfers', async (st) => {
+  t.test('add some EOA transfers', { skip: process.env.TARGET_PEER === undefined }, async (st) => {
+    const startBalance = await client.request('eth_getBalance', [
+      '0x3dA33B9A0894b908DdBb00d96399e506515A1009',
+      'latest',
+    ])
+    st.ok(
+      startBalance.result !== undefined,
+      `fetched 0x3dA33B9A0894b908DdBb00d96399e506515A1009 balance=${startBalance.result}`
+    )
     await runTx('', '0x3dA33B9A0894b908DdBb00d96399e506515A1009', 1000000n)
     let balance = await client.request('eth_getBalance', [
       '0x3dA33B9A0894b908DdBb00d96399e506515A1009',
       'latest',
     ])
-    st.equal(BigInt(balance.result), 1000000n, 'sent a simple ETH transfer')
+    st.equal(
+      BigInt(balance.result),
+      BigInt(startBalance.result) + 1000000n,
+      'sent a simple ETH transfer'
+    )
     await runTx('', '0x3dA33B9A0894b908DdBb00d96399e506515A1009', 1000000n)
     balance = await client.request('eth_getBalance', [
       '0x3dA33B9A0894b908DdBb00d96399e506515A1009',
@@ -69,19 +89,30 @@ tape('simple mainnet test run', async (t) => {
       '0x3dA33B9A0894b908DdBb00d96399e506515A1009',
       'latest',
     ])
-    st.equal(BigInt(balance.result), 2000000n, 'sent a simple ETH transfer 2x')
-    const latestBlock = await client.request('eth_getBlockByNumber', ['latest', false])
-    blockHashes.push(latestBlock.result.hash)
+    st.equal(
+      BigInt(balance.result),
+      BigInt(startBalance.result) + 2000000n,
+      'sent a simple ETH transfer 2x'
+    )
     st.end()
   })
 
-  t.test('snap sync state with EOA states', async (st) => {
+  t.test('snap sync state', { skip: process.env.SNAP_SYNC === undefined }, async (st) => {
     // start client inline here for snap sync, no need for beacon
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    ejsClient = await createClient(common, customGenesisState, [nodeInfo.enode]).catch((e) => {
+      console.log(e)
+      return null
+    })
+    st.ok(ejsClient !== null, 'ethereumjs client started')
     st.end()
   })
 
   t.test('should reset td', async (st) => {
     try {
+      if (ejsClient !== null) {
+        await ejsClient.stop()
+      }
       await teardownCallBack()
       st.pass('network cleaned')
     } catch (e) {
@@ -91,4 +122,50 @@ tape('simple mainnet test run', async (t) => {
   })
 
   t.end()
+})
+
+export async function createClient(common: any, customGenesisState: any, bootnodes: any) {
+  // Turn on `debug` logs, defaults to all client logging
+  debug.enable('devp2p:*')
+  const logger = getLogger({ logLevel: 'debug' })
+  const datadir = Config.DATADIR_DEFAULT
+  const config = new Config({
+    common,
+    transports: ['rlpx'],
+    bootnodes,
+    multiaddrs: [],
+    logger,
+    discDns: false,
+    discV4: false,
+    port: 30304,
+  })
+  config.events.setMaxListeners(50)
+  const chainDB = new Level<string | Buffer, string | Buffer>(
+    `${datadir}/${common.chainName()}/chainDB`
+  )
+  const stateDB = new Level<string | Buffer, string | Buffer>(
+    `${datadir}/${common.chainName()}/stateDB`
+  )
+  const metaDB = new Level<string | Buffer, string | Buffer>(
+    `${datadir}/${common.chainName()}/metaDB`
+  )
+
+  const blockchain = await Blockchain.create({
+    db: chainDB,
+    genesisState: customGenesisState,
+    common: config.chainCommon,
+    hardforkByHeadBlockNumber: true,
+    validateBlocks: true,
+    validateConsensus: false,
+  })
+  config.chainCommon.setForkHashes(blockchain.genesisBlock.hash())
+  const inlineClient = await EthereumClient.create({ config, blockchain, chainDB, stateDB, metaDB })
+  await inlineClient.open()
+  await inlineClient.start()
+  return inlineClient
+}
+
+process.on('uncaughtException', (err, origin) => {
+  console.log({ err, origin })
+  process.exit()
 })

--- a/packages/client/test/sim/snapsync.spec.ts
+++ b/packages/client/test/sim/snapsync.spec.ts
@@ -138,6 +138,7 @@ async function createSnapClient(common: any, customGenesisState: any, bootnodes:
     discDns: false,
     discV4: false,
     port: 30304,
+    forceSnapSync: true,
   })
   return createInlineClient(config, common, customGenesisState)
 }

--- a/packages/client/test/sim/snapsync.spec.ts
+++ b/packages/client/test/sim/snapsync.spec.ts
@@ -1,0 +1,94 @@
+import { Common } from '@ethereumjs/common'
+import { privateToAddress } from '@ethereumjs/util'
+import { Client } from 'jayson/promise'
+import * as tape from 'tape'
+
+import {
+  filterKeywords,
+  filterOutWords,
+  runTxHelper,
+  startNetwork,
+  waitForELStart,
+} from './simutils'
+
+const pkey = Buffer.from('ae557af4ceefda559c924516cabf029bedc36b68109bf8d6183fe96e04121f4e', 'hex')
+const sender = '0x' + privateToAddress(pkey).toString('hex')
+const client = Client.http({ port: 8545 })
+
+const network = 'mainnet'
+const networkJson = require(`./configs/${network}.json`)
+const common = Common.fromGethGenesis(networkJson, { chain: network })
+
+export async function runTx(data: string, to?: string, value?: bigint) {
+  return runTxHelper({ client, common, sender, pkey }, data, to, value)
+}
+
+tape('simple mainnet test run', async (t) => {
+  const { teardownCallBack, result } = await startNetwork(network, client, {
+    filterKeywords,
+    filterOutWords,
+    externalRun: process.env.EXTERNAL_RUN,
+    withPeer: process.env.WITH_PEER,
+  })
+
+  if (result.includes('Geth')) {
+    t.pass('connected to Geth')
+  } else {
+    t.fail('connected to wrong client')
+  }
+
+  console.log(`Waiting for network to start...`)
+  try {
+    await waitForELStart(client)
+    t.pass('geth<>lodestar started successfully')
+  } catch (e) {
+    t.fail('geth<>lodestar failed to start')
+    throw e
+  }
+
+  t.test('snap sync empty state', async (st) => {
+    // start client inline here for snap sync, no need for beacon
+    st.end()
+  })
+
+  const blockHashes: string[] = []
+  // ------------Sanity checks--------------------------------
+  t.test('add some EOA transfers', async (st) => {
+    await runTx('', '0x3dA33B9A0894b908DdBb00d96399e506515A1009', 1000000n)
+    let balance = await client.request('eth_getBalance', [
+      '0x3dA33B9A0894b908DdBb00d96399e506515A1009',
+      'latest',
+    ])
+    st.equal(BigInt(balance.result), 1000000n, 'sent a simple ETH transfer')
+    await runTx('', '0x3dA33B9A0894b908DdBb00d96399e506515A1009', 1000000n)
+    balance = await client.request('eth_getBalance', [
+      '0x3dA33B9A0894b908DdBb00d96399e506515A1009',
+      'latest',
+    ])
+    balance = await client.request('eth_getBalance', [
+      '0x3dA33B9A0894b908DdBb00d96399e506515A1009',
+      'latest',
+    ])
+    st.equal(BigInt(balance.result), 2000000n, 'sent a simple ETH transfer 2x')
+    const latestBlock = await client.request('eth_getBlockByNumber', ['latest', false])
+    blockHashes.push(latestBlock.result.hash)
+    st.end()
+  })
+
+  t.test('snap sync state with EOA states', async (st) => {
+    // start client inline here for snap sync, no need for beacon
+    st.end()
+  })
+
+  t.test('should reset td', async (st) => {
+    try {
+      await teardownCallBack()
+      st.pass('network cleaned')
+    } catch (e) {
+      st.fail('network not cleaned properly')
+    }
+    st.end()
+  })
+
+  t.end()
+})

--- a/packages/client/test/sync/snapsync.spec.ts
+++ b/packages/client/test/sync/snapsync.spec.ts
@@ -9,9 +9,32 @@ tape('[SnapSynchronizer]', async (t) => {
   class PeerPool {
     open() {}
     close() {}
+    idle() {}
+    ban(_peer: any) {}
+    peers: any[]
+
+    constructor(_opts = undefined) {
+      this.peers = []
+    }
   }
   PeerPool.prototype.open = td.func<any>()
   PeerPool.prototype.close = td.func<any>()
+  PeerPool.prototype.idle = td.func<any>()
+  class AccountFetcher {
+    first: bigint
+    count: bigint
+    constructor(opts: any) {
+      this.first = opts.first
+      this.count = opts.count
+    }
+    fetch() {}
+    clear() {}
+    destroy() {}
+  }
+  AccountFetcher.prototype.fetch = td.func<any>()
+  AccountFetcher.prototype.clear = td.func<any>()
+  AccountFetcher.prototype.destroy = td.func<any>()
+  td.replace('../../lib/sync/fetcher', { AccountFetcher })
 
   const { SnapSynchronizer } = await import('../../lib/sync/snapsync')
 
@@ -21,6 +44,20 @@ tape('[SnapSynchronizer]', async (t) => {
     const chain = await Chain.create({ config })
     const sync = new SnapSynchronizer({ config, pool, chain })
     t.equals(sync.type, 'snap', 'snap type')
+    t.end()
+  })
+
+  t.test('should open', async (t) => {
+    const config = new Config({ transports: [] })
+    const pool = new PeerPool() as any
+    const chain = await Chain.create({ config })
+    const sync = new SnapSynchronizer({ config, pool, chain })
+    ;(sync as any).pool.open = td.func<PeerPool['open']>()
+    ;(sync as any).pool.peers = []
+    td.when((sync as any).pool.open()).thenResolve(null)
+    await sync.open()
+    t.pass('opened')
+    await sync.close()
     t.end()
   })
 
@@ -34,7 +71,6 @@ tape('[SnapSynchronizer]', async (t) => {
       pool,
       chain,
     })
-    ;(sync as any).running = true
     ;(sync as any).chain = { blocks: { height: 1 } }
     const getBlockHeaders1 = td.func<any>()
     td.when(getBlockHeaders1(td.matchers.anything())).thenReturn([
@@ -61,6 +97,8 @@ tape('[SnapSynchronizer]', async (t) => {
     ;(sync as any).pool = { peers }
     ;(sync as any).forceSync = true
     t.equal(await sync.best(), peers[1], 'found best')
+    await sync.start()
+
     t.end()
   })
 })


### PR DESCRIPTION
Setup to dev/test snapsync with sim architecture (The aim of this PR is to setup snapsync sim test/dev infra and not really resolve any snap sync issues which are to be addressed seprately)

tl-dr: run sim like this in build repo from packages/client (supply full path to your `DATADIR` in below command)
```bash
NETWORK=mainnet NETWORKID=1337903 ELCLIENT=geth ADD_EOA_STATE=true SNAP_SYNC=true DEBUG_SNAP=client:*  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
```
and see snap sync sim from geth peer:
![image](https://user-images.githubusercontent.com/76567250/224388237-5cc254a6-81b5-4f75-8942-a9ec4477368f.png)
 



In detail:
FROM: `test/sim/snapsync.md`:

### Snapsync sim setup

1. Start external geth client:
```bash
NETWORK=mainnet NETWORKID=1337903 ELCLIENT=geth  DATADIR=/usr/app/ethereumjs/packages/client/data test
/sim/single-run.sh
```

2. (optional) Add some txs/state to geth
```bash
EXTERNAL_RUN=true ADD_EOA_STATE=true  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
```

3. Run snap sync:
```bash
EXTERNAL_RUN=true SNAP_SYNC=true  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
```
you may add `DEBUG_SNAP=client:*` to see client fetcher snap sync debug logs i.e.
```bash
EXTERNAL_RUN=true SNAP_SYNC=true DEBUG_SNAP=client:* DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
```

## Combinations

Combine 2 & 3 in single step:
```bash
EXTERNAL_RUN=true ADD_EOA_STATE=true SNAP_SYNC=true  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
```

Combine 1, 2, 3 in single step
```bash
NETWORK=mainnet NETWORKID=1337903 ELCLIENT=geth ADD_EOA_STATE=true SNAP_SYNC=true DEBUG_SNAP=client:*  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
```

### Fully combined scenarios

1. Test syncing genesis state from geth:
```bash
NETWORK=mainnet NETWORKID=1337903 ELCLIENT=geth SNAP_SYNC=true DEBUG_SNAP=client:*  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
```

2. Add some EOA account states to geth (just add `ADD_EOA_STATE=true` flag to the command)
```bash
NETWORK=mainnet NETWORKID=1337903 ELCLIENT=geth ADD_EOA_STATE=true SNAP_SYNC=true DEBUG_SNAP=client:*  DATADIR=/usr/app/ethereumjs/packages/client/data npm run tape -- test/sim/snapsync.spec.ts
```

3. Add EOA as well as some contract states (just add `ADD_CONTRACT_STATE=true` flag to the command)
TBD