### PR TITLE
EIP3860: only check max init code size on create contract tx

### DIFF
--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -192,7 +192,8 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMarketEIP155
     this._validateYParity()
     this._validateHighS()
 
-    if (this.common.isActivatedEIP(3860)) {
+    const createContract = txData.to === undefined || txData.to === null
+    if (createContract && this.common.isActivatedEIP(3860)) {
       checkMaxInitCodeSize(this.common, this.data.length)
     }
 

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -169,7 +169,8 @@ export class AccessListEIP2930Transaction extends BaseTransaction<AccessListEIP2
     this._validateYParity()
     this._validateHighS()
 
-    if (this.common.isActivatedEIP(3860)) {
+    const createContract = txData.to === undefined || txData.to === null
+    if (createContract && this.common.isActivatedEIP(3860)) {
       checkMaxInitCodeSize(this.common, this.data.length)
     }
     const freeze = opts?.freeze ?? true

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -143,7 +143,8 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
     this._validateYParity()
     this._validateHighS()
 
-    if (this.common.isActivatedEIP(3860)) {
+    const createContract = txData.to === undefined || txData.to === null
+    if (createContract && this.common.isActivatedEIP(3860)) {
       checkMaxInitCodeSize(this.common, this.data.length)
     }
 

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -134,7 +134,8 @@ export class Transaction extends BaseTransaction<Transaction> {
       }
     }
 
-    if (this.common.isActivatedEIP(3860)) {
+    const createContract = txData.to === undefined || txData.to === null
+    if (createContract && this.common.isActivatedEIP(3860)) {
       checkMaxInitCodeSize(this.common, this.data.length)
     }
 

--- a/packages/tx/test/eip3860.spec.ts
+++ b/packages/tx/test/eip3860.spec.ts
@@ -1,0 +1,69 @@
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Address } from '@ethereumjs/util'
+import * as tape from 'tape'
+
+import { TransactionFactory } from '../src'
+
+const common = new Common({
+  chain: Chain.Mainnet,
+  hardfork: Hardfork.Merge,
+  eips: [3860, 4844, 4895],
+})
+
+const maxInitCodeSize = common.param('vm', 'maxInitCodeSize')
+const txTypes = [0, 1, 2, 5]
+const addressZero = Address.zero()
+
+tape('[EIP3860 tests]', function (t) {
+  t.test('Should instantiate create txs with MAX_INITCODE_SIZE', (st) => {
+    const data = Buffer.alloc(Number(maxInitCodeSize))
+    for (const txType of txTypes) {
+      try {
+        TransactionFactory.fromTxData({ data, type: txType }, { common })
+        st.ok('Instantiated create tx with MAX_INITCODE_SIZE data')
+      } catch (e) {
+        st.fail('Did not instantiate create tx with MAX_INITCODE_SIZE')
+      }
+    }
+    st.end()
+  })
+
+  t.test('Should instantiate txs with MAX_INITCODE_SIZE data', (st) => {
+    const data = Buffer.alloc(Number(maxInitCodeSize))
+    for (const txType of txTypes) {
+      try {
+        TransactionFactory.fromTxData({ data, type: txType, to: addressZero }, { common })
+        st.ok('Instantiated tx with MAX_INITCODE_SIZE')
+      } catch (e) {
+        st.fail('Did not instantiated tx with MAX_INITCODE_SIZE')
+      }
+    }
+    st.end()
+  })
+
+  t.test('Should not instantiate create txs with MAX_INITCODE_SIZE+1 data', (st) => {
+    const data = Buffer.alloc(Number(maxInitCodeSize) + 1)
+    for (const txType of txTypes) {
+      try {
+        TransactionFactory.fromTxData({ data, type: txType }, { common })
+        st.fail('Instantiated create tx with MAX_INITCODE_SIZE+1')
+      } catch (e) {
+        st.ok('Did not instantiate create tx with MAX_INITCODE_SIZE+1')
+      }
+    }
+    st.end()
+  })
+
+  t.test('Should instantiate txs with MAX_INITCODE_SIZE+1 data', (st) => {
+    const data = Buffer.alloc(Number(maxInitCodeSize) + 1)
+    for (const txType of txTypes) {
+      try {
+        TransactionFactory.fromTxData({ data, type: txType, to: addressZero }, { common })
+        st.ok('Instantiated tx with MAX_INITCODE_SIZE+1')
+      } catch (e) {
+        st.fail('Did not instantiate tx with MAX_INITCODE_SIZE+1')
+      }
+    }
+    st.end()
+  })
+})


### PR DESCRIPTION
See: https://github.com/ethereumjs/ethereumjs-monorepo/discussions/2569

We limit tx data size to MAX_INITCODE_SIZE (of EIP 3860) previously, but this should only be checked in a CREATE-transaction (to `to` field is empty, i.e. `undefined` or `null`). This PR fixes this.

I would like two people to verify / review this before merging.

Note: apparently we have either not tested this, or we have not joined testnets, or this is not covered by the EIP tests, which should be added/tested.