### PR TITLE
Client/engine: ensure payload attributes have a valid timestamp

### DIFF
--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -859,6 +859,17 @@ export class Engine {
      */
     if (payloadAttributes) {
       const { timestamp, prevRandao, suggestedFeeRecipient, withdrawals } = payloadAttributes
+      const timestampBigInt = BigInt(timestamp)
+
+      if (timestampBigInt <= headBlock.header.timestamp) {
+        throw {
+          message: `invalid timestamp in payloadAttributes, got ${timestampBigInt}, need at least ${
+            headBlock.header.timestamp + BigInt(1)
+          }`,
+          code: INVALID_PARAMS,
+        }
+      }
+
       const payloadId = await this.pendingBlock.start(
         await this.vm.copy(),
         headBlock,

--- a/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
+++ b/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
@@ -93,6 +93,21 @@ tape(`${method}: call with valid data and synced data`, async (t) => {
   await baseRequest(t, server, req, 200, expectRes)
 })
 
+tape(`${method}: call with invalid timestamp payloadAttributes`, async (t) => {
+  const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+
+  const invalidTimestampPayload: any = [{ ...validPayload[0] }, { ...validPayload[1] }]
+  invalidTimestampPayload[1].timestamp = '0x0'
+
+  const req = params(method, invalidTimestampPayload)
+  const expectRes = checkError(
+    t,
+    INVALID_PARAMS,
+    'invalid timestamp in payloadAttributes, got 0, need at least 1'
+  )
+  await baseRequest(t, server, req, 200, expectRes)
+})
+
 tape(`${method}: call with valid fork choice state without payload attributes`, async (t) => {
   const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
   const req = params(method, [validForkChoiceState])


### PR DESCRIPTION
This PR fixes:

`go run ./hive.go --client ethereumjs --sim ethereum/engine --sim.limit "engine-api/ForkchoiceUpdated Invalid Payload Attributes" --docker.output`