### PR TITLE
VM: Diff-based Touched Accounts Checkpointing

### DIFF
--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -657,7 +657,8 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x51,
     function (runState) {
       const pos = runState.stack.pop()
-      const word = runState.memory.read(Number(pos), 32)
+      const word = runState.memory.read(Number(pos), 32, true)
+      console.log(runState.stack.length)
       runState.stack.push(bufferToBigInt(word))
     },
   ],

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -658,7 +658,6 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const pos = runState.stack.pop()
       const word = runState.memory.read(Number(pos), 32, true)
-      console.log(runState.stack.length)
       runState.stack.push(bufferToBigInt(word))
     },
   ],

--- a/packages/vm/src/eei/journaling.ts
+++ b/packages/vm/src/eei/journaling.ts
@@ -1,0 +1,82 @@
+export class Journaling<T> {
+  public journal: Set<T>
+  protected journalStack: { [key: number]: Set<T> }
+  protected journalHeight: Map<T, number>
+  protected height: number
+
+  constructor() {
+    this.journal = new Set()
+    this.journalStack = {}
+    this.journalHeight = new Map()
+    this.height = 0
+  }
+
+  clear() {
+    this.journal.clear()
+    this.journalStack = {}
+    this.journalHeight = new Map()
+    this.height = 0
+  }
+
+  checkpoint() {
+    this.height++
+  }
+
+  revert(ignoreItem?: T) {
+    const height = this.height
+    if (height in this.journalStack) {
+      for (const key of this.journalStack[height]) {
+        // Exceptional case due to consensus issue in Geth and Parity.
+        // See [EIP issue #716](https://github.com/ethereum/EIPs/issues/716) for context.
+        // The RIPEMD precompile has to remain *touched* even when the call reverts,
+        // and be considered for deletion.
+        if (key === ignoreItem) {
+          continue
+        }
+
+        if (this.journal.has(key) && this.journalHeight.get(key)! >= height) {
+          this.journal.delete(key)
+          this.journalHeight.delete(key)
+        }
+      }
+      delete this.journalStack[height]
+    }
+    this.height--
+  }
+
+  commit() {
+    const height = this.height
+    if (height in this.journalStack) {
+      // Copy the items-to-delete in case of a revert into one level higher
+      if (height !== 1) {
+        if (this.journalStack[height - 1] === undefined) {
+          this.journalStack[height - 1] = new Set()
+        }
+        for (const address of this.journalStack[height]) {
+          this.journalStack[height - 1].add(address)
+          if (this.journalHeight.get(address) === height) {
+            this.journalHeight.set(address, height - 1)
+          }
+        }
+      } else {
+        this.journal = new Set()
+        this.journalHeight = new Map()
+      }
+      delete this.journalStack[height]
+    }
+    this.height--
+  }
+
+  addJournalItem(input: T) {
+    const height = this.height
+    if (!(height in this.journalStack)) {
+      this.journalStack[height] = new Set()
+    }
+    this.journalStack[height].add(input)
+
+    this.journal.add(input)
+    if (this.journalHeight.get(input) === undefined) {
+      this.journalHeight.set(input, height)
+    }
+  }
+}

--- a/packages/vm/src/eei/journaling.ts
+++ b/packages/vm/src/eei/journaling.ts
@@ -48,7 +48,7 @@ export class Journaling<T> {
     const height = this.height
     if (height in this.journalStack) {
       // Copy the items-to-delete in case of a revert into one level higher
-      if (height !== 1) {
+      if (height > 0) {
         if (this.journalStack[height - 1] === undefined) {
           this.journalStack[height - 1] = new Set()
         }

--- a/packages/vm/src/eei/vmState.ts
+++ b/packages/vm/src/eei/vmState.ts
@@ -150,7 +150,7 @@ export class VmState implements EVMStateAccess {
 
         if (
           this._touched.has(address) &&
-          this._touchedHeight.get(address) === this._checkpointCount
+          this._touchedHeight.get(address)! <= this._checkpointCount
         ) {
           this._touched.delete(address)
         }

--- a/packages/vm/src/eei/vmState.ts
+++ b/packages/vm/src/eei/vmState.ts
@@ -96,7 +96,13 @@ export class VmState implements EVMStateAccess {
         }
         for (const address of this._touchedStack[height]) {
           this._touchedStack[height - 1].add(address)
+          if (this._touchedHeight.get(address) === height) {
+            this._touchedHeight.set(address, height - 1)
+          }
         }
+      } else {
+        this._touched = new Set()
+        this._touchedHeight = new Map()
       }
       delete this._touchedStack[height]
     }
@@ -150,9 +156,10 @@ export class VmState implements EVMStateAccess {
 
         if (
           this._touched.has(address) &&
-          this._touchedHeight.get(address)! <= this._checkpointCount
+          this._touchedHeight.get(address)! >= this._checkpointCount
         ) {
           this._touched.delete(address)
+          this._touchedHeight.delete(address)
         }
       }
       delete this._touchedStack[height]

--- a/packages/vm/src/eei/vmState.ts
+++ b/packages/vm/src/eei/vmState.ts
@@ -86,6 +86,13 @@ export class VmState implements EVMStateAccess {
     // Remove cache items
     const height = this._checkpointCount
     if (height in this._touchedStack) {
+      // Copy the items-to-delete in case of a revert into one level higher
+      if (this._touchedStack[height - 1] === undefined) {
+        this._touchedStack[height - 1] = new Set()
+      }
+      for (const address of this._touchedStack[height]) {
+        this._touchedStack[height - 1].add(address)
+      }
       delete this._touchedStack[height]
     }
 
@@ -318,6 +325,7 @@ export class VmState implements EVMStateAccess {
       }
     }
     this._touched.clear()
+    this._touchedStack = {}
   }
 
   /**

--- a/packages/vm/test/util.ts
+++ b/packages/vm/test/util.ts
@@ -353,7 +353,7 @@ export async function setupPreConditions(state: VmState, testData: any) {
   await state.commit()
   // Clear the touched stack, otherwise untouched accounts in the block which are empty (>= SpuriousDragon)
   // will get deleted from the state, resulting in state trie errors
-  ;(<any>state)._touched.clear()
+  ;(<any>state).touchedJournal.clear()
 }
 
 /**


### PR DESCRIPTION
Part of #1536

Extracted from #2578

PR switches to diff-based touched accounts checkpointing in the VM. This helps to solve the first of Shanghai dDoS attacks going into a recursive `DELEGATECALL` starting at block `2283416` (DAO HF) and repeated in subsequent block txs (with "normally" running blocks in between) and leading our client to crash with heap out of memory ("Javascript Ineffective mark-compacts near heap limit Allocation failed") (a bit in contrast to the attack in #1536 described by me as well as just stating the block execution getting very slow interestingly, not sure if we might have added additional (memory) weight here in the meantime. So this is on an 8GB Apple MacBook Air M1 machine) (I do know about this option to just increase the Node.js memory limit but I explicity *did not* want to just do *that*, seems not a "solution" to me).

Here is a screenshot (don't get confused by block-number-misleading "Latest local block" message):

<img width="1123" alt="grafik" src="https://user-images.githubusercontent.com/931137/224655478-f45f4d54-a406-40f2-a055-bb2d62b901c9.png">

When looking at the debug logs of the block/tx run by running:

```shell
DEBUG=ethjs,evm:*,evm:*:*,vm:*,vm:*:*,statemanager:* npm run client:start -- --discDns=false --discV4=false --maxPeers=0 --executeBlocks=2283416
```

one can see that hundreds of `DELEGATECALL`s are executed subsequently, each one happening from within the previous delegate call and each creating a new checkpoint without committing for 100s of delegate calls. With the previous checkpointing implementation for touched accounts this lead to the whole account structure being copied over and over again, even when there are no changes, leading to a lot of memory bloat.

Situation will get better at the [Tangerine Whistle](https://eips.ethereum.org/EIPS/eip-608) HF at block `2463000` increasing the gas costs for call operations and other I/O heavy opcodes (in case of `DELEGATECALL` from `40` to `700`, so pretty substantially), so that such an attack is not that effective any more.

This is nevertheless a lasting and structural change improving the overall VM efficiency. The functionality (change) should be sufficiently covered by existing tests.

Note that this change alone is *not* solving the out-of-memory crash though yet, I will submit a subsequent PR with a separate cache improvement which will completely solve the issue. PR is nevertheless open for review and can be merged. 🙂

We have a structurally similar problem with the way we handle accessed storage checkpointing in the VM, which we should also tackle (also open for grasps, a bit more complex but also not too much, solution should be structurally very similar). For now I "solved" this for the current context I am working on by guarding the cache to just get used for Berlin HF and upwards, which generally makes sense since before it is just an unnecessarily build-up structure.

Small third change in this PR is to use the direct memory access (see #2573 for more context) for the `MLOAD` opcode, which should be very much safe since this will be converted to `BigInt` directly afterwards anyhow. So this just saves an unnecessary in-between copy.
