### PR TITLE
Client/engine: ensure invalid blockhash status gets reported correctly

### DIFF
--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -305,7 +305,7 @@ const assembleBlock = async (
         payload.blockHash
       }, received: ${bufferToHex(block.hash())}`
       config.logger.debug(validationError)
-      const latestValidHash = await validHash(toBuffer(header.parentHash), chain)
+      const latestValidHash = null
       const response = { status: Status.INVALID_BLOCK_HASH, latestValidHash, validationError }
       return { error: response }
     }


### PR DESCRIPTION
This PR fixes:

`go run ./hive.go --client ethereumjs --sim ethereum/engine --sim.limit 'engine-api/ParentHash==BlockHash' --docker.output`

`go run ./hive.go --client ethereumjs --sim ethereum/engine --sim.limit 'engine-api/Bad Hash on NewPayload' --docker.output`
