### PR TITLE
Client: Small Debug Helpers and CLI Improvements

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -227,7 +227,7 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     array: true,
   })
   .option('numBlocksPerIteration', {
-    describe: 'Number of blocks to execute in batch mode and logged to CL',
+    describe: 'Number of blocks to execute in batch mode and logged to console',
     number: true,
     default: Config.NUM_BLOCKS_PER_ITERATION,
   })

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -226,6 +226,11 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     describe: 'EIP-1459 ENR tree urls to query for peer discovery targets',
     array: true,
   })
+  .option('numBlocksPerIteration', {
+    describe: 'Number of blocks to execute in batch mode and logged to CL',
+    number: true,
+    default: Config.NUM_BLOCKS_PER_ITERATION,
+  })
   .option('executeBlocks', {
     describe:
       'Debug mode for reexecuting existing blocks (no services will be started), allowed input formats: 5,5-10',
@@ -708,6 +713,7 @@ async function run() {
     discDns: args.discDns,
     discV4: args.discV4,
     dnsAddr: args.dnsAddr,
+    numBlocksPerIteration: args.numBlocksPerIteration,
     dnsNetworks: args.dnsNetworks,
     extIP: args.extIP,
     key,

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -189,7 +189,7 @@ export interface ConfigOptions {
   dnsNetworks?: string[]
 
   /**
-   * Number of blocks to execute in batch mode and logged to CL
+   * Number of blocks to execute in batch mode and logged to console
    */
   numBlocksPerIteration?: number
 

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -189,6 +189,11 @@ export interface ConfigOptions {
   dnsNetworks?: string[]
 
   /**
+   * Number of blocks to execute in batch mode and logged to CL
+   */
+  numBlocksPerIteration?: number
+
+  /**
    * Generate code for local debugging, currently providing a
    * code snippet which can be used to run blocks on the
    * EthereumJS VM on execution errors
@@ -287,6 +292,7 @@ export class Config {
   public static readonly MINPEERS_DEFAULT = 1
   public static readonly MAXPEERS_DEFAULT = 25
   public static readonly DNSADDR_DEFAULT = '8.8.8.8'
+  public static readonly NUM_BLOCKS_PER_ITERATION = 50
   public static readonly DEBUGCODE_DEFAULT = false
   public static readonly SAFE_REORG_DISTANCE = 100
   public static readonly SKELETON_FILL_CANONICAL_BACKSTEP = 100
@@ -315,6 +321,7 @@ export class Config {
   public readonly minPeers: number
   public readonly maxPeers: number
   public readonly dnsAddr: string
+  public readonly numBlocksPerIteration: number
   public readonly debugCode: boolean
   public readonly discDns: boolean
   public readonly discV4: boolean
@@ -367,6 +374,7 @@ export class Config {
     this.minPeers = options.minPeers ?? Config.MINPEERS_DEFAULT
     this.maxPeers = options.maxPeers ?? Config.MAXPEERS_DEFAULT
     this.dnsAddr = options.dnsAddr ?? Config.DNSADDR_DEFAULT
+    this.numBlocksPerIteration = options.numBlocksPerIteration ?? Config.NUM_BLOCKS_PER_ITERATION
     this.debugCode = options.debugCode ?? Config.DEBUGCODE_DEFAULT
     this.mine = options.mine ?? false
     this.isSingleNode = options.isSingleNode ?? false

--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -31,7 +31,7 @@ export class VMExecution extends Execution {
   private pendingReceipts?: Map<string, TxReceipt[]>
   private vmPromise?: Promise<number>
 
-  /** Maximally tolerated block time before giving a warning on CL */
+  /** Maximally tolerated block time before giving a warning on console */
   private MAX_TOLERATED_BLOCK_TIME = 12
 
   /**

--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -31,9 +31,6 @@ export class VMExecution extends Execution {
   private pendingReceipts?: Map<string, TxReceipt[]>
   private vmPromise?: Promise<number>
 
-  /** Number of maximum blocks to run per iteration of {@link VMExecution.run} */
-  private NUM_BLOCKS_PER_ITERATION = 50
-
   /** Maximally tolerated block time before giving a warning on CL */
   private MAX_TOLERATED_BLOCK_TIME = 12
 
@@ -221,8 +218,8 @@ export class VMExecution extends Execution {
       (!runOnlybatched ||
         (runOnlybatched &&
           canonicalHead.header.number - startHeadBlock.header.number >=
-            BigInt(this.NUM_BLOCKS_PER_ITERATION))) &&
-      (numExecuted === undefined || (loop && numExecuted === this.NUM_BLOCKS_PER_ITERATION)) &&
+            BigInt(this.config.numBlocksPerIteration))) &&
+      (numExecuted === undefined || (loop && numExecuted === this.config.numBlocksPerIteration)) &&
       startHeadBlock.hash().equals(canonicalHead.hash()) === false
     ) {
       let txCounter = 0
@@ -342,7 +339,7 @@ export class VMExecution extends Execution {
             errorBlock = block
           }
         },
-        this.NUM_BLOCKS_PER_ITERATION,
+        this.config.numBlocksPerIteration,
         // release lock on this callback so other blockchain ops can happen while this block is being executed
         true
       )

--- a/packages/client/lib/net/peerpool.ts
+++ b/packages/client/lib/net/peerpool.ts
@@ -232,7 +232,7 @@ export class PeerPool {
     if (this.config.chainCommon.gteHardfork(Hardfork.Merge)) {
       NO_PEER_PERIOD_COUNT = 6
     }
-    if (this.size === 0) {
+    if (this.size === 0 && this.config.maxPeers > 0) {
       this.noPeerPeriods += 1
       if (this.noPeerPeriods >= NO_PEER_PERIOD_COUNT) {
         this.noPeerPeriods = 0

--- a/packages/client/lib/types.ts
+++ b/packages/client/lib/types.ts
@@ -140,6 +140,7 @@ export interface ClientOpts {
   minPeers?: number
   maxPeers?: number
   dnsAddr?: string
+  numBlocksPerIteration?: number
   dnsNetworks?: string[]
   executeBlocks?: string
   debugCode?: boolean


### PR DESCRIPTION
These are some small things I need for mainnet debugging respectively which are generally useful or improve/optimize on the CLI experience.

First thing is a new constanst MAX_TOLERATED_BLOCK time together with some appropriate logging for too slowly executed blocks. This is particulary helpful if things come to a halt with block execution generally going down to 30+ seconds subsequently (e.g. in some parts of the Shanghai dDoS blocks), but should also be generally valuable information along "normal" execution flows.

Second is a new config option `numBlocksPerIteration` which makes the previously statically set to 50 blocks option in VM execution customizable. Generally useful - before I always edited the code - in particular again in slow-execution phases.

Third thing is a small optimization to not restart the RLPx server or do peer logs to the console if `maxPeers` is set to 0. Also particularly noticeable in slow execution flows, since - with not much other activity happening - these unnecessary restarts become even more apparent. 😋

Open for review and merge.