### PR TITLE
EVM+Tx: Add `allowUnlimitedInitcodeSize` option to partially disable EIP-3860

### DIFF
--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -875,7 +875,10 @@ export class Interpreter {
     await this._eei.putAccount(this._env.address, this._env.contract)
 
     if (this._common.isActivatedEIP(3860)) {
-      if (data.length > Number(this._common.param('vm', 'maxInitCodeSize'))) {
+      if (
+        data.length > Number(this._common.param('vm', 'maxInitCodeSize')) &&
+        this._evm._allowUnlimitedInitcodeSize === false
+      ) {
         return BigInt(0)
       }
     }

--- a/packages/evm/test/eips/eip-3860.spec.ts
+++ b/packages/evm/test/eips/eip-3860.spec.ts
@@ -133,4 +133,116 @@ tape('EIP 3860 tests', (t) => {
     )
     st.end()
   })
+
+  t.test('code exceeds max initcode size: allowUnlimitedInitcodeSize active', async (st) => {
+    const common = new Common({
+      chain: Chain.Mainnet,
+      hardfork: Hardfork.London,
+      eips: [3860],
+    })
+    const eei = await getEEI()
+    const evm = await EVM.create({ common, eei, allowUnlimitedInitcodeSize: true })
+
+    const buffer = Buffer.allocUnsafe(1000000).fill(0x60)
+
+    // setup the call arguments
+    const runCallArgs = {
+      sender, // call address
+      gasLimit: BigInt(0xffffffffff), // ensure we pass a lot of gas, so we do not run out of gas
+      // Simple test, PUSH <big number> PUSH 0 RETURN
+      // It tries to deploy a contract too large, where the code is all zeros
+      // (since memory which is not allocated/resized to yet is always defaulted to 0)
+      data: Buffer.concat([
+        Buffer.from('00'.repeat(Number(common.param('vm', 'maxInitCodeSize')) + 1), 'hex'),
+        buffer,
+      ]),
+    }
+    const result = await evm.runCall(runCallArgs)
+    st.ok(
+      result.execResult.exceptionError === undefined,
+      'succesfully created a contract with data size > MAX_INITCODE_SIZE and allowUnlimitedInitcodeSize active'
+    )
+  })
+
+  t.test('CREATE with MAX_INITCODE_SIZE+1, allowUnlimitedContractSize active', async (st) => {
+    const commonWith3860 = new Common({
+      chain: Chain.Mainnet,
+      hardfork: Hardfork.London,
+      eips: [3860],
+    })
+    const caller = Address.fromString('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b')
+    for (const code of ['F0', 'F5']) {
+      const eei = await getEEI()
+      const evm = await EVM.create({
+        common: commonWith3860,
+        eei,
+        allowUnlimitedInitcodeSize: true,
+      })
+      const evmDisabled = await EVM.create({
+        common: commonWith3860,
+        eei: eei.copy(),
+        allowUnlimitedInitcodeSize: false,
+      })
+      const contractFactory = Address.fromString('0xb94f5374fce5edbc8e2a8697c15331677e6ebf0b')
+      const contractAccount = await evm.eei.getAccount(contractFactory)
+      await evm.eei.putAccount(contractFactory, contractAccount)
+      await evmDisabled.eei.putAccount(contractFactory, contractAccount)
+      // This factory code:
+      // -> reads 32 bytes from the calldata (X)
+      // Attempts to create a contract of X size
+      // (the initcode of this contract is just zeros, so STOP opcode
+      // It stores the topmost stack item of this CREATE(2) at slot 0
+      // This is either the contract address if it was succesful, or 0 in case of error
+      const factoryCode = Buffer.from('600060003560006000' + code + '600055', 'hex')
+
+      await evm.eei.putContractCode(contractFactory, factoryCode)
+      await evmDisabled.eei.putContractCode(contractFactory, factoryCode)
+
+      const runCallArgs = {
+        from: caller,
+        to: contractFactory,
+        gasLimit: BigInt(0xfffffffff),
+        data: Buffer.from('00'.repeat(30) + 'C001', 'hex'),
+      }
+
+      await evm.runCall(runCallArgs)
+      await evmDisabled.runCall(runCallArgs)
+
+      const key0 = Buffer.from('00'.repeat(32), 'hex')
+      const storageActive = await evm.eei.getContractStorage(contractFactory, key0)
+      const storageInactive = await evmDisabled.eei.getContractStorage(contractFactory, key0)
+
+      st.ok(
+        !storageActive.equals(Buffer.from('')),
+        'created contract with MAX_INITCODE_SIZE + 1 length, allowUnlimitedInitcodeSize=true'
+      )
+      st.ok(
+        storageInactive.equals(Buffer.from('')),
+        'did not create contract with MAX_INITCODE_SIZE + 1 length, allowUnlimitedInitcodeSize=false'
+      )
+
+      // gas check
+
+      const runCallArgs2 = {
+        from: caller,
+        to: contractFactory,
+        gasLimit: BigInt(0xfffffffff),
+        data: Buffer.from('00'.repeat(30) + 'C000', 'hex'),
+      }
+
+      // Test:
+      // On the `allowUnlimitedInitCodeSize = true`, create contract with MAX_INITCODE_SIZE + 1
+      // On `allowUnlimitedInitCodeSize = false`, create contract with MAX_INITCODE_SIZE
+      // Verify that the gas cost on the prior one is higher than the first one
+
+      const res = await evm.runCall(runCallArgs2)
+      const res2 = await evmDisabled.runCall(runCallArgs)
+
+      st.ok(
+        res.execResult.executionGasUsed > res2.execResult.executionGasUsed,
+        'charged initcode analysis gas cost on both allowUnlimitedCodeSize=true, allowUnlimitedInitcodeSize=false'
+      )
+    }
+    st.end()
+  })
 })

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -13,6 +13,7 @@ import {
 } from '@ethereumjs/util'
 
 import { Capability } from './types'
+import { checkMaxInitCodeSize } from './util'
 
 import type {
   AccessListEIP2930TxData,
@@ -116,6 +117,13 @@ export abstract class BaseTransaction<TransactionObject> {
 
     // EIP-2681 limits nonce to 2^64-1 (cannot equal 2^64-1)
     this._validateCannotExceedMaxInteger({ nonce: this.nonce }, 64, true)
+
+    const createContract = txData.to === undefined || txData.to === null
+    const allowUnlimitedInitcodeSize = opts.allowUnlimitedInitcodeSize ?? false
+    const common = opts.common ?? this._getCommon()
+    if (createContract && common.isActivatedEIP(3860) && allowUnlimitedInitcodeSize === false) {
+      checkMaxInitCodeSize(common, this.data.length)
+    }
   }
 
   /**

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -13,7 +13,7 @@ import {
 import { keccak256 } from 'ethereum-cryptography/keccak'
 
 import { BaseTransaction } from './baseTransaction'
-import { AccessLists, checkMaxInitCodeSize } from './util'
+import { AccessLists } from './util'
 
 import type {
   AccessList,
@@ -191,11 +191,6 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMarketEIP155
 
     this._validateYParity()
     this._validateHighS()
-
-    const createContract = txData.to === undefined || txData.to === null
-    if (createContract && this.common.isActivatedEIP(3860)) {
-      checkMaxInitCodeSize(this.common, this.data.length)
-    }
 
     const freeze = opts?.freeze ?? true
     if (freeze) {

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -13,7 +13,7 @@ import {
 import { keccak256 } from 'ethereum-cryptography/keccak'
 
 import { BaseTransaction } from './baseTransaction'
-import { AccessLists, checkMaxInitCodeSize } from './util'
+import { AccessLists } from './util'
 
 import type {
   AccessList,
@@ -169,10 +169,6 @@ export class AccessListEIP2930Transaction extends BaseTransaction<AccessListEIP2
     this._validateYParity()
     this._validateHighS()
 
-    const createContract = txData.to === undefined || txData.to === null
-    if (createContract && this.common.isActivatedEIP(3860)) {
-      checkMaxInitCodeSize(this.common, this.data.length)
-    }
     const freeze = opts?.freeze ?? true
     if (freeze) {
       Object.freeze(this)

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -19,7 +19,7 @@ import {
   BlobTransactionType,
   SignedBlobTransactionType,
 } from './types'
-import { AccessLists, blobTxToNetworkWrapperDataFormat, checkMaxInitCodeSize } from './util'
+import { AccessLists, blobTxToNetworkWrapperDataFormat } from './util'
 import { computeVersionedHash } from './utils/blobHelpers'
 
 import type {
@@ -142,11 +142,6 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
     this.versionedHashes = (txData.versionedHashes ?? []).map((vh) => toBuffer(vh))
     this._validateYParity()
     this._validateHighS()
-
-    const createContract = txData.to === undefined || txData.to === null
-    if (createContract && this.common.isActivatedEIP(3860)) {
-      checkMaxInitCodeSize(this.common, this.data.length)
-    }
 
     for (const hash of this.versionedHashes) {
       if (hash.length !== 32) {

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -15,7 +15,6 @@ import { keccak256 } from 'ethereum-cryptography/keccak'
 
 import { BaseTransaction } from './baseTransaction'
 import { Capability } from './types'
-import { checkMaxInitCodeSize } from './util'
 
 import type { JsonTx, TxData, TxOptions, TxValuesArray } from './types'
 import type { Common } from '@ethereumjs/common'
@@ -132,11 +131,6 @@ export class Transaction extends BaseTransaction<Transaction> {
           this.activeCapabilities.push(Capability.EIP155ReplayProtection)
         }
       }
-    }
-
-    const createContract = txData.to === undefined || txData.to === null
-    if (createContract && this.common.isActivatedEIP(3860)) {
-      checkMaxInitCodeSize(this.common, this.data.length)
     }
 
     const freeze = opts?.freeze ?? true

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -90,6 +90,12 @@ export interface TxOptions {
    * Default: true
    */
   freeze?: boolean
+
+  /**
+   * Allows unlimited contract code-size init while debugging. This (partially) disables EIP-3860.
+   * Gas cost for initcode size analysis will still be charged. Use with caution.
+   */
+  allowUnlimitedInitcodeSize?: boolean
 }
 
 /*

--- a/packages/tx/test/eip3860.spec.ts
+++ b/packages/tx/test/eip3860.spec.ts
@@ -66,4 +66,42 @@ tape('[EIP3860 tests]', function (t) {
     }
     st.end()
   })
+
+  tape(
+    'Should allow txs with MAX_INITCODE_SIZE+1 data if allowUnlimitedInitcodeSize is active',
+    (st) => {
+      const data = Buffer.alloc(Number(maxInitCodeSize) + 1)
+      for (const txType of txTypes) {
+        try {
+          TransactionFactory.fromTxData(
+            { data, type: txType },
+            { common, allowUnlimitedInitcodeSize: true }
+          )
+          st.ok('Instantiated create tx with MAX_INITCODE_SIZE+1')
+        } catch (e) {
+          st.fail('Did not instantiate tx with MAX_INITCODE_SIZE+1')
+        }
+      }
+      st.end()
+    }
+  )
+
+  tape('Should charge initcode analysis gas is allowUnlimitedInitcodeSize is active', (st) => {
+    const data = Buffer.alloc(Number(maxInitCodeSize))
+    for (const txType of txTypes) {
+      const eip3860ActiveTx = TransactionFactory.fromTxData(
+        { data, type: txType },
+        { common, allowUnlimitedInitcodeSize: true }
+      )
+      const eip3860DeactivedTx = TransactionFactory.fromTxData(
+        { data, type: txType },
+        { common, allowUnlimitedInitcodeSize: false }
+      )
+      st.ok(
+        eip3860ActiveTx.getDataFee() === eip3860DeactivedTx.getDataFee(),
+        'charged initcode analysis gas'
+      )
+    }
+    st.end()
+  })
 })


### PR DESCRIPTION
Closes #2588 

This PR adds the `allowUnlimitedInitcodeSize` option. If EIP 3860 is disabled, this does nothing. If it is active, then this only disables the initcode length check, but it will still charge the initcode data gas cost.

This PR also somewhat refactors tx: in all of the tx types the same initcode size check is added, so it makes sense to move this into `baseTransaction`. (However, due to legacy transaction we do not have access to a common there, so either take this from the options or create the default one)