### PR TITLE
Fix Block Hash Calculation When Creating a New Block Object From JSON RPC (Shanghai)

### DIFF
--- a/packages/block/src/from-rpc.ts
+++ b/packages/block/src/from-rpc.ts
@@ -54,5 +54,8 @@ export function blockFromRpc(
 
   const uncleHeaders = uncles.map((uh) => blockHeaderFromRpc(uh, options))
 
-  return Block.fromBlockData({ header, transactions, uncleHeaders }, options)
+  return Block.fromBlockData(
+    { header, transactions, uncleHeaders, withdrawals: blockParams.withdrawals },
+    options
+  )
 }

--- a/packages/block/src/header-from-rpc.ts
+++ b/packages/block/src/header-from-rpc.ts
@@ -27,6 +27,7 @@ export function blockHeaderFromRpc(blockParams: JsonRpcBlock, options?: BlockOpt
     mixHash,
     nonce,
     baseFeePerGas,
+    withdrawalsRoot,
   } = blockParams
 
   const blockHeader = BlockHeader.fromHeaderData(
@@ -47,6 +48,7 @@ export function blockHeaderFromRpc(blockParams: JsonRpcBlock, options?: BlockOpt
       mixHash,
       nonce,
       baseFeePerGas,
+      withdrawalsRoot,
     },
     options
   )

--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -196,5 +196,6 @@ export interface JsonRpcBlock {
   uncles: string[] // Array of uncle hashes
   baseFeePerGas?: string // If EIP-1559 is enabled for this block, returns the base fee per gas
   withdrawals?: Array<JsonRpcWithdrawal> // If EIP-4895 is enabled for this block, array of withdrawals
+  withdrawalsRoot?: string // If EIP-4895 is enabled for this block, the root of the withdrawal trie of the block.
   excessDataGas?: string // If EIP-4844 is enabled for this block, returns the excess data gas for the block
 }


### PR DESCRIPTION
This PR fixes an issue in which the withdrawals root would not be passed to block header creation when creating a block from JSON RPC, which caused the block hash to be computed incorrectly.

The withdrawals are also passed to the `Block` class via `fromBlockData` when creating a block from RPC, which enables `validateWithdrawalsTrie` to function as expected.