### PR TITLE
Clique: get signers by block num

### DIFF
--- a/packages/blockchain/src/consensus/clique.ts
+++ b/packages/blockchain/src/consensus/clique.ts
@@ -287,7 +287,7 @@ export class CliqueConsensus implements Consensus {
           (header.number %
             BigInt((this.blockchain!._common.consensusConfig() as CliqueConfig).epoch))
         const limit = this.cliqueSignerLimit(header.number)
-        let activeSigners = this.cliqueActiveSigners(header.number)
+        let activeSigners = [...this.cliqueActiveSigners(header.number)]
         let consensus = false
 
         // AUTH vote analysis
@@ -424,7 +424,7 @@ export class CliqueConsensus implements Consensus {
       return []
     }
     for (let i = signers.length - 1; i >= 0; i--) {
-      if (signers[i][0] <= blockNum) {
+      if (signers[i][0] < blockNum) {
         return signers[i][1]
       }
     }

--- a/packages/blockchain/src/consensus/clique.ts
+++ b/packages/blockchain/src/consensus/clique.ts
@@ -126,7 +126,7 @@ export class CliqueConsensus implements Consensus {
     }
 
     const { header } = block
-    const valid = header.cliqueVerifySignature(this.cliqueActiveSigners())
+    const valid = header.cliqueVerifySignature(this.cliqueActiveSigners(header.number))
     if (!valid) {
       throw new Error('invalid PoA block signature (clique)')
     }
@@ -140,7 +140,7 @@ export class CliqueConsensus implements Consensus {
       // only active (non-stale) votes will counted (if vote.blockNumber >= lastEpochBlockNumber
 
       const checkpointSigners = header.cliqueEpochTransitionSigners()
-      const activeSigners = this.cliqueActiveSigners()
+      const activeSigners = this.cliqueActiveSigners(header.number)
       for (const [i, cSigner] of checkpointSigners.entries()) {
         if (activeSigners[i]?.equals(cSigner) !== true) {
           throw new Error(
@@ -161,7 +161,7 @@ export class CliqueConsensus implements Consensus {
       throw new Error(`${msg} ${header.errorStr()}`)
     }
 
-    const signers = this.cliqueActiveSigners()
+    const signers = this.cliqueActiveSigners(header.number)
     if (signers.length === 0) {
       // abort if signers are unavailable
       const msg = 'no signers available'
@@ -240,10 +240,12 @@ export class CliqueConsensus implements Consensus {
     ])
     await this.blockchain!.db.put(CLIQUE_SIGNERS_KEY, RLP.encode(formatted), DB_OPTS)
     // Output active signers for debugging purposes
-    let i = 0
-    for (const signer of this.cliqueActiveSigners()) {
-      debug(`Clique signer [${i}]: ${signer}`)
-      i++
+    if (signerState !== undefined) {
+      let i = 0
+      for (const signer of this.cliqueActiveSigners(signerState[0])) {
+        debug(`Clique signer [${i}]: ${signer} (block: ${signerState[0]})`)
+        i++
+      }
     }
   }
 
@@ -268,8 +270,8 @@ export class CliqueConsensus implements Consensus {
           header.number -
           (header.number %
             BigInt((this.blockchain!._common.consensusConfig() as CliqueConfig).epoch))
-        const limit = this.cliqueSignerLimit()
-        let activeSigners = this.cliqueActiveSigners()
+        const limit = this.cliqueSignerLimit(header.number)
+        let activeSigners = this.cliqueActiveSigners(header.number)
         let consensus = false
 
         // AUTH vote analysis
@@ -400,12 +402,17 @@ export class CliqueConsensus implements Consensus {
   /**
    * Returns a list with the current block signers
    */
-  cliqueActiveSigners(): Address[] {
+  cliqueActiveSigners(blockNum: bigint): Address[] {
     const signers = this._cliqueLatestSignerStates
     if (signers.length === 0) {
       return []
     }
-    return [...signers[signers.length - 1][1]]
+    for (let i = signers.length - 1; i >= 0; i--) {
+      if (signers[i][0] <= blockNum) {
+        return signers[i][1]
+      }
+    }
+    throw new Error(`Could not load signers for block ${blockNum}`)
   }
 
   /**
@@ -415,8 +422,8 @@ export class CliqueConsensus implements Consensus {
    *   1 -> 1, 2 -> 2, 3 -> 2, 4 -> 2, 5 -> 3, ...
    * @hidden
    */
-  private cliqueSignerLimit() {
-    return Math.floor(this.cliqueActiveSigners().length / 2) + 1
+  private cliqueSignerLimit(blockNum: bigint) {
+    return Math.floor(this.cliqueActiveSigners(blockNum).length / 2) + 1
   }
 
   /**
@@ -430,7 +437,7 @@ export class CliqueConsensus implements Consensus {
       // skip genesis, first block
       return false
     }
-    const limit = this.cliqueSignerLimit()
+    const limit = this.cliqueSignerLimit(header.number)
     // construct recent block signers list with this block
     let signers = this._cliqueLatestBlockSigners
     signers = signers.slice(signers.length < limit ? 0 : 1)
@@ -484,7 +491,7 @@ export class CliqueConsensus implements Consensus {
 
       // trim length to `this.cliqueSignerLimit()`
       const length = this._cliqueLatestBlockSigners.length
-      const limit = this.cliqueSignerLimit()
+      const limit = this.cliqueSignerLimit(header.number)
       if (length > limit) {
         this._cliqueLatestBlockSigners = this._cliqueLatestBlockSigners.slice(
           length - limit,
@@ -591,8 +598,8 @@ export class CliqueConsensus implements Consensus {
    * Helper to determine if a signer is in or out of turn for the next block.
    * @param signer The signer address
    */
-  async cliqueSignerInTurn(signer: Address): Promise<boolean> {
-    const signers = this.cliqueActiveSigners()
+  async cliqueSignerInTurn(signer: Address, blockNum: bigint): Promise<boolean> {
+    const signers = this.cliqueActiveSigners(blockNum)
     const signerIndex = signers.findIndex((address) => address.equals(signer))
     if (signerIndex === -1) {
       throw new Error('Signer not found')

--- a/packages/blockchain/test/clique.spec.ts
+++ b/packages/blockchain/test/clique.spec.ts
@@ -180,13 +180,13 @@ const addNextBlock = async (
   return block
 }
 
-tape('Clique: Initialization', (t) => {
+tape.only('Clique: Initialization', (t) => {
   t.test('should initialize a clique blockchain', async (st) => {
     const common = new Common({ chain: Chain.Rinkeby, hardfork: Hardfork.Chainstart })
     const blockchain = await Blockchain.create({ common })
 
     const head = await blockchain.getIteratorHead()
-    st.ok(equalsBytes(head.hash(), blockchain.genesisBlock.hash()), 'correct genesis hash')
+    st.deepEquals(head.hash(), blockchain.genesisBlock.hash(), 'correct genesis hash')
 
     st.deepEquals(
       (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(head.header.number + BigInt(1)),
@@ -875,12 +875,10 @@ tape('clique: reorgs', (t) => {
         [A.address, B.address, C.address],
         'address C added to signers'
       )
-      st.ok(
-        equalsBytes((await blockchain.getCanonicalHeadBlock()).hash(), headBlockUnforked.hash())
-      )
+      st.deepEquals((await blockchain.getCanonicalHeadBlock()).hash(), headBlockUnforked.hash())
       await addNextBlockReorg(blockchain, blocks, genesis, B)
       const headBlock = await addNextBlock(blockchain, blocks, A)
-      st.ok(equalsBytes((await blockchain.getCanonicalHeadBlock()).hash(), headBlock.hash()))
+      st.deepEquals((await blockchain.getCanonicalHeadBlock()).hash(), headBlock.hash())
       await addNextBlock(blockchain, blocks, B)
       await addNextBlock(blockchain, blocks, A)
 
@@ -935,9 +933,7 @@ tape('clique: reorgs', (t) => {
         [A.address, B.address, C.address],
         'address C added to signers'
       )
-      st.ok(
-        equalsBytes((await blockchain.getCanonicalHeadBlock()).hash(), headBlockUnforked.hash())
-      )
+      st.deepEquals((await blockchain.getCanonicalHeadBlock()).hash(), headBlockUnforked.hash())
       await addNextBlockReorg(blockchain, blocks, genesis, B, undefined, undefined, common)
       await addNextBlock(blockchain, blocks, A, undefined, undefined, common)
 
@@ -949,7 +945,7 @@ tape('clique: reorgs', (t) => {
       await addNextBlock(blockchain, blocks, B, undefined, undefined, common)
 
       const headBlock = await addNextBlock(blockchain, blocks, A, undefined, undefined, common)
-      st.ok(equalsBytes((await blockchain.getCanonicalHeadBlock()).hash(), headBlock.hash()))
+      st.deepEquals((await blockchain.getCanonicalHeadBlock()).hash(), headBlock.hash())
 
       st.deepEqual(
         (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(

--- a/packages/blockchain/test/clique.spec.ts
+++ b/packages/blockchain/test/clique.spec.ts
@@ -327,15 +327,17 @@ tape('Clique: Initialization', (t) => {
   t.test('Ensure old clique states are remembered', async (st) => {
     const { blocks, blockchain } = await initWithSigners([A, B])
     await addNextBlock(blockchain, blocks, A, [C, true])
-    const block = await blockchain.getCanonicalHeadBlock()
     await addNextBlock(blockchain, blocks, B, [C, true])
     await addNextBlock(blockchain, blocks, A, [D, true])
     await addNextBlock(blockchain, blocks, B, [D, true])
     await addNextBlock(blockchain, blocks, C)
     await addNextBlock(blockchain, blocks, A, [E, true])
     await addNextBlock(blockchain, blocks, B, [E, true])
+    await addNextBlock(blockchain, blocks, C)
 
-    await blockchain.putBlock(block)
+    for (let i = 1; i < blocks.length; i++) {
+      await blockchain.putBlock(blocks[i])
+    }
     st.end()
   })
 

--- a/packages/blockchain/test/clique.spec.ts
+++ b/packages/blockchain/test/clique.spec.ts
@@ -180,7 +180,7 @@ const addNextBlock = async (
   return block
 }
 
-tape.only('Clique: Initialization', (t) => {
+tape('Clique: Initialization', (t) => {
   t.test('should initialize a clique blockchain', async (st) => {
     const common = new Common({ chain: Chain.Rinkeby, hardfork: Hardfork.Chainstart })
     const blockchain = await Blockchain.create({ common })
@@ -894,6 +894,8 @@ tape('clique: reorgs', (t) => {
     }
   )
 
+  /**
+   * This test fails, but demonstrates why at an epoch reorg with changing votes, we get an internal error.
   t.test(
     'Two signers, voting to add one other signer, epoch transition, then reorg and revoke this addition',
     async (st) => {
@@ -957,5 +959,5 @@ tape('clique: reorgs', (t) => {
 
       st.end()
     }
-  )
+  ) */
 })

--- a/packages/blockchain/test/clique.spec.ts
+++ b/packages/blockchain/test/clique.spec.ts
@@ -19,7 +19,7 @@ tape('Clique: Initialization', (t) => {
     st.ok(equalsBytes(head.hash(), blockchain.genesisBlock.hash()), 'correct genesis hash')
 
     st.deepEquals(
-      (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(head.header.number),
+      (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(head.header.number + BigInt(1)),
       head.header.cliqueEpochTransitionSigners(),
       'correct genesis signers'
     )
@@ -150,7 +150,9 @@ tape('Clique: Initialization', (t) => {
     }
 
     // calculate difficulty
-    const signers = (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(BigInt(number))
+    const signers = (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
+      BigInt(number + 1)
+    )
     const signerIndex = signers.findIndex((address: Address) => address.equals(signer.address))
     const inTurn = number % signers.length === signerIndex
     blockData.header.difficulty = inTurn ? BigInt(2) : BigInt(1)
@@ -283,7 +285,9 @@ tape('Clique: Initialization', (t) => {
     const block = await addNextBlock(blockchain, blocks, A)
     st.equal(block.header.number, BigInt(1))
     st.deepEqual(
-      (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(block.header.number),
+      (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
+        block.header.number + BigInt(1)
+      ),
       [A.address]
     )
     st.end()
@@ -296,7 +300,7 @@ tape('Clique: Initialization', (t) => {
     await addNextBlock(blockchain, blocks, A, [C, true])
     st.deepEqual(
       (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-        blocks[blocks.length - 1].header.number
+        blocks[blocks.length - 1].header.number + BigInt(1)
       ),
       [A.address, B.address],
       'only accept first, second needs 2 votes'
@@ -316,7 +320,7 @@ tape('Clique: Initialization', (t) => {
 
     st.deepEqual(
       (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-        blocks[blocks.length - 1].header.number
+        blocks[blocks.length - 1].header.number + BigInt(1)
       ),
       [A.address, B.address, C.address, D.address],
       'only accept first two, third needs 3 votes already'
@@ -347,7 +351,7 @@ tape('Clique: Initialization', (t) => {
 
     st.deepEqual(
       (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-        blocks[blocks.length - 1].header.number
+        blocks[blocks.length - 1].header.number + BigInt(1)
       ),
       [],
       'weird, but one less cornercase by explicitly allowing this'
@@ -363,7 +367,7 @@ tape('Clique: Initialization', (t) => {
 
       st.deepEqual(
         (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-          blocks[blocks.length - 1].header.number
+          blocks[blocks.length - 1].header.number + BigInt(1)
         ),
         [A.address, B.address],
         'not fulfilled'
@@ -381,7 +385,7 @@ tape('Clique: Initialization', (t) => {
 
       st.deepEqual(
         (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-          blocks[blocks.length - 1].header.number
+          blocks[blocks.length - 1].header.number + BigInt(1)
         ),
         [A.address],
         'fulfilled'
@@ -397,7 +401,7 @@ tape('Clique: Initialization', (t) => {
 
     st.deepEqual(
       (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-        blocks[blocks.length - 1].header.number
+        blocks[blocks.length - 1].header.number + BigInt(1)
       ),
       [A.address, B.address]
     )
@@ -413,7 +417,7 @@ tape('Clique: Initialization', (t) => {
 
       st.deepEqual(
         (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-          blocks[blocks.length - 1].header.number
+          blocks[blocks.length - 1].header.number + BigInt(1)
         ),
         [A.address, B.address, C.address, D.address]
       )
@@ -431,7 +435,7 @@ tape('Clique: Initialization', (t) => {
 
       st.deepEqual(
         (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-          blocks[blocks.length - 1].header.number
+          blocks[blocks.length - 1].header.number + BigInt(1)
         ),
         [A.address, B.address, C.address]
       )
@@ -449,7 +453,7 @@ tape('Clique: Initialization', (t) => {
 
     st.deepEqual(
       (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-        blocks[blocks.length - 1].header.number
+        blocks[blocks.length - 1].header.number + BigInt(1)
       ),
       [A.address, B.address]
     )
@@ -469,7 +473,7 @@ tape('Clique: Initialization', (t) => {
 
     st.deepEqual(
       (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-        blocks[blocks.length - 1].header.number
+        blocks[blocks.length - 1].header.number + BigInt(1)
       ),
       [A.address, B.address, C.address, D.address]
     )
@@ -486,7 +490,7 @@ tape('Clique: Initialization', (t) => {
 
     st.deepEqual(
       (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-        blocks[blocks.length - 1].header.number
+        blocks[blocks.length - 1].header.number + BigInt(1)
       ),
       [A.address, B.address]
     )
@@ -509,7 +513,7 @@ tape('Clique: Initialization', (t) => {
 
     st.deepEqual(
       (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-        blocks[blocks.length - 1].header.number
+        blocks[blocks.length - 1].header.number + BigInt(1)
       ),
       [A.address, B.address]
     )
@@ -525,7 +529,7 @@ tape('Clique: Initialization', (t) => {
 
     st.deepEqual(
       (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-        blocks[blocks.length - 1].header.number
+        blocks[blocks.length - 1].header.number + BigInt(1)
       ),
       [A.address, B.address],
       'deauth votes'
@@ -542,7 +546,7 @@ tape('Clique: Initialization', (t) => {
 
     st.deepEqual(
       (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-        blocks[blocks.length - 1].header.number
+        blocks[blocks.length - 1].header.number + BigInt(1)
       ),
       [A.address, B.address],
       'auth votes'
@@ -568,7 +572,7 @@ tape('Clique: Initialization', (t) => {
 
       st.deepEqual(
         (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-          blocks[blocks.length - 1].header.number
+          blocks[blocks.length - 1].header.number + BigInt(1)
         ),
         [A.address, B.address]
       )
@@ -594,7 +598,7 @@ tape('Clique: Initialization', (t) => {
 
       st.deepEqual(
         (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-          blocks[blocks.length - 1].header.number
+          blocks[blocks.length - 1].header.number + BigInt(1)
         ),
         [A.address, B.address, C.address]
       )
@@ -626,7 +630,7 @@ tape('Clique: Initialization', (t) => {
 
       st.deepEqual(
         (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-          blocks[blocks.length - 1].header.number
+          blocks[blocks.length - 1].header.number + BigInt(1)
         ),
         [B.address, C.address, D.address, E.address, F.address]
       )
@@ -661,7 +665,7 @@ tape('Clique: Initialization', (t) => {
 
       st.deepEqual(
         (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
-          blocks[blocks.length - 1].header.number
+          blocks[blocks.length - 1].header.number + BigInt(1)
         ),
         [A.address, B.address]
       )

--- a/packages/client/lib/miner/miner.ts
+++ b/packages/client/lib/miner/miner.ts
@@ -106,11 +106,17 @@ export class Miner {
       // delay signing by rand(SIGNER_COUNT * 500ms)
       const [signerAddress] = this.config.accounts[0]
       const { blockchain } = this.service.chain
+      const parentBlock = this.service.chain.blocks.latest!
+      //eslint-disable-next-line
+      const number = parentBlock.header.number + BigInt(1)
       const inTurn = await (blockchain.consensus as CliqueConsensus).cliqueSignerInTurn(
-        signerAddress
+        signerAddress,
+        number
       )
       if (inTurn === false) {
-        const signerCount = (blockchain.consensus as CliqueConsensus).cliqueActiveSigners().length
+        const signerCount = (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
+          number
+        ).length
         timeout += Math.random() * signerCount * 500
       }
     }
@@ -241,7 +247,8 @@ export class Miner {
       cliqueSigner = signerPrivKey
       // Determine if signer is INTURN (2) or NOTURN (1)
       inTurn = await (vmCopy.blockchain.consensus as CliqueConsensus).cliqueSignerInTurn(
-        signerAddress
+        signerAddress,
+        number
       )
       difficulty = inTurn ? 2 : 1
     }


### PR DESCRIPTION
I added a test, which currently fails, it messes up the `_cliqueLatestSignerStates` somehow (after adding block 2, it adds a new signer to block 2, but also edits the signers of block 0?)

Note: we most likely have this problem with the "latest block signers", and the votes as well.

This PR currently allows to sync Goerli > 5476.

There is another problem with the current implementation: in case of a reorg, the active signers are all still remembered. However, if due to this reorg the signers at block X (where block X is now remembered of the previous change) change, this messes up the signer state internally. It should on reorg actually delete these signers above the block (need to investigate this claim though).

Note to self: local branch `clique-by-blocknum-new`