### PR TITLE
Implement EIP6780

### DIFF
--- a/packages/common/src/eips/6780.json
+++ b/packages/common/src/eips/6780.json
@@ -1,0 +1,12 @@
+{
+  "name": "EIP-6780",
+  "number": 6780,
+  "comment": "SELFDESTRUCT only in same transaction",
+  "url": "https://eips.ethereum.org/EIPS/eip-6780",
+  "status": "Draft",
+  "minimumHardfork": "london",
+  "gasConfig": {},
+  "gasPrices": {},
+  "vm": {},
+  "pow": {}
+}

--- a/packages/common/src/eips/index.ts
+++ b/packages/common/src/eips/index.ts
@@ -24,4 +24,5 @@ export const EIPs: { [key: number]: any } = {
   4844: require('./4844.json'),
   4895: require('./4895.json'),
   5133: require('./5133.json'),
+  6780: require('./6780.json'),
 }

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -266,7 +266,7 @@ export class EVM implements EVMInterface {
     // Supported EIPs
     const supportedEIPs = [
       1153, 1559, 2315, 2537, 2565, 2718, 2929, 2930, 3074, 3198, 3529, 3540, 3541, 3607, 3651,
-      3670, 3855, 3860, 4399, 4895, 4844, 5133,
+      3670, 3855, 3860, 4399, 4895, 4844, 5133, 6780,
     ]
 
     for (const eip of this._common.eips()) {
@@ -441,6 +441,11 @@ export class EVM implements EVMInterface {
     message.code = message.data
     message.data = Buffer.alloc(0)
     message.to = await this._generateAddress(message)
+
+    if (this._common.isActivatedEIP(6780)) {
+      message.createdAddresses![message.to.toString()] = true
+    }
+
     if (this.DEBUG) {
       debug(`Generated CREATE contract address ${message.to}`)
     }
@@ -656,6 +661,9 @@ export class EVM implements EVMInterface {
     if (message.selfdestruct) {
       interpreter._result.selfdestruct = message.selfdestruct as { [key: string]: Buffer }
     }
+    if (message.createdAddresses) {
+      interpreter._result.createdAddresses = message.createdAddresses
+    }
 
     const interpreterRes = await interpreter.run(message.code as Buffer, opts)
 
@@ -674,6 +682,7 @@ export class EVM implements EVMInterface {
         ...result,
         logs: [],
         selfdestruct: {},
+        createdAddresses: {},
       }
     }
 
@@ -730,6 +739,7 @@ export class EVM implements EVMInterface {
         isStatic: opts.isStatic,
         salt: opts.salt,
         selfdestruct: opts.selfdestruct ?? {},
+        createdAddresses: opts.createdAddresses ?? {},
         delegatecall: opts.delegatecall,
         versionedHashes: opts.versionedHashes,
       })
@@ -796,6 +806,7 @@ export class EVM implements EVMInterface {
     // then the error is dismissed
     if (err && err.error !== ERROR.CODESTORE_OUT_OF_GAS) {
       result.execResult.selfdestruct = {}
+      result.execResult.createdAddresses = {}
       result.execResult.gasRefund = BigInt(0)
     }
     if (
@@ -1004,6 +1015,10 @@ export interface ExecResult {
    * A map from the accounts that have self-destructed to the addresses to send their funds to
    */
   selfdestruct?: { [k: string]: Buffer }
+  /**
+   * Map of addresses which were created (used in EIP 6780)
+   */
+  createdAddresses?: { [k: string]: boolean }
   /**
    * The gas refund counter
    */

--- a/packages/evm/src/message.ts
+++ b/packages/evm/src/message.ts
@@ -29,6 +29,10 @@ interface MessageOpts {
    * A map of addresses to selfdestruct, see {@link Message.selfdestruct}
    */
   selfdestruct?: { [key: string]: boolean } | { [key: string]: Buffer }
+  /**
+   * Map of addresses which were created (used in EIP 6780)
+   */
+  createdAddresses?: { [key: string]: boolean }
   delegatecall?: boolean
   authcallOrigin?: Address
   gasRefund?: bigint
@@ -53,6 +57,10 @@ export class Message {
    * Value is a boolean when marked for destruction and replaced with a Buffer containing the address where the remaining funds are sent.
    */
   selfdestruct?: { [key: string]: boolean } | { [key: string]: Buffer }
+  /**
+   * Map of addresses which were created (used in EIP 6780)
+   */
+  createdAddresses?: { [key: string]: boolean }
   delegatecall: boolean
   /**
    * This is used to store the origin of the AUTHCALL,
@@ -78,6 +86,7 @@ export class Message {
     this.isCompiled = opts.isCompiled ?? defaults.isCompiled
     this.salt = opts.salt
     this.selfdestruct = opts.selfdestruct
+    this.createdAddresses = opts.createdAddresses
     this.delegatecall = opts.delegatecall ?? defaults.delegatecall
     this.authcallOrigin = opts.authcallOrigin
     this.gasRefund = opts.gasRefund ?? defaults.gasRefund

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -127,6 +127,10 @@ export interface EVMRunCallOpts {
    */
   selfdestruct?: { [k: string]: boolean }
   /**
+   * Created addresses in current context. Used in EIP 6780
+   */
+  createdAddresses?: { [k: string]: boolean }
+  /**
    * Skip balance checks if true. If caller balance is less than message value,
    * sets balance to message value to ensure execution doesn't fail.
    */

--- a/packages/statemanager/src/stateManager.ts
+++ b/packages/statemanager/src/stateManager.ts
@@ -122,6 +122,11 @@ export class DefaultStateManager extends BaseStateManager implements StateManage
     })
   }
 
+  async deleteAccount(address: Address) {
+    delete this._storageTries[address.buf.toString('hex')]
+    await super.deleteAccount(address)
+  }
+
   /**
    * Adds `value` to the state trie as code, and sets `codeHash` on the account
    * corresponding to `address` to reference this.

--- a/packages/statemanager/test/stateManager.spec.ts
+++ b/packages/statemanager/test/stateManager.spec.ts
@@ -445,6 +445,17 @@ tape('StateManager - Contract code', (tester) => {
 tape('StateManager - Contract storage', (tester) => {
   const it = tester.test
 
+  it('should delete the storage tries cache if the account is deleted', async (t) => {
+    const stateManager = new DefaultStateManager()
+    const address = Address.zero()
+    const key = zeros(32)
+    const value = Buffer.from('aa'.repeat(32), 'hex')
+    await stateManager.putContractStorage(address, key, value)
+    await stateManager.deleteAccount(address)
+    const storage = await stateManager.getContractStorage(address, key)
+    t.ok(storage.equals(Buffer.from('')))
+  })
+
   it('should throw on storage values larger than 32 bytes', async (t) => {
     t.plan(1)
     const stateManager = new DefaultStateManager()

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -519,6 +519,11 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
     const keys = Object.keys(results.execResult.selfdestruct)
     for (const k of keys) {
       const address = new Address(Buffer.from(k, 'hex'))
+      if (this._common.isActivatedEIP(6780)) {
+        if (!results.execResult.createdAddresses![address.toString()]) {
+          continue
+        }
+      }
       await state.deleteAccount(address)
       if (this.DEBUG) {
         debug(`tx selfdestruct on address=${address}`)

--- a/packages/vm/test/api/EIPs/eip-6780-selfdestruct-same-tx.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-6780-selfdestruct-same-tx.spec.ts
@@ -1,0 +1,105 @@
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Transaction } from '@ethereumjs/tx'
+import { Address, privateToAddress } from '@ethereumjs/util'
+import * as tape from 'tape'
+
+import { VM } from '../../../src/vm'
+const pkey = Buffer.from('20'.repeat(32), 'hex')
+const GWEI = BigInt(1000000000)
+const sender = new Address(privateToAddress(pkey))
+
+const common = new Common({
+  chain: Chain.Mainnet,
+  hardfork: Hardfork.London,
+  eips: [6780],
+})
+
+const payload = Buffer.from('60016001556001FF', 'hex')
+
+async function getVM(common: Common) {
+  const vm = await VM.create({ common })
+  const account = await vm.stateManager.getAccount(sender)
+  const balance = GWEI * BigInt(21000) * BigInt(10000000)
+  account.balance = balance
+  await vm.stateManager.putAccount(sender, account)
+
+  return vm
+}
+
+tape('EIP 6780 tests', (t) => {
+  t.test('should destroy contract if selfdestructed in same tx as it was created', async (st) => {
+    const vm = await getVM(common)
+
+    const value = 1
+    const tx = Transaction.fromTxData({
+      value,
+      gasLimit: 1000000,
+      gasPrice: 10,
+      data: payload,
+    }).sign(pkey)
+
+    const result = await vm.runTx({ tx })
+    const createdAddress = result.createdAddress!
+
+    const contract = await vm.stateManager.getAccount(createdAddress)
+    st.equals(contract.balance, BigInt(0), 'value sent')
+    st.equals(contract.nonce, BigInt(0), 'contract nonce 0')
+    st.ok(
+      (
+        await vm.evm.eei.getContractStorage(
+          createdAddress,
+          Buffer.from('00'.repeat(31) + '01', 'hex')
+        )
+      ).equals(Buffer.from('', 'hex')),
+      'storage cleared'
+    )
+    st.equals(
+      (await vm.stateManager.getAccount(Address.fromString('0x' + '00'.repeat(19) + '01'))).balance,
+      BigInt(value),
+      'balance sent to target'
+    )
+  })
+
+  t.test(
+    'should not destroy contract if selfdestructed in a tx after creating the contract',
+    async (st) => {
+      const vm = await getVM(common)
+
+      const target = Address.fromString('0x' + 'ff'.repeat(20))
+
+      await vm.stateManager.putContractCode(target, payload)
+      const targetContract = await vm.stateManager.getAccount(target)
+      targetContract.nonce = BigInt(1)
+      await vm.stateManager.putAccount(target, targetContract)
+
+      const value = 1
+      const tx = Transaction.fromTxData({
+        value,
+        gasLimit: 1000000,
+        gasPrice: 10,
+        to: target,
+      }).sign(pkey)
+
+      await vm.runTx({ tx })
+
+      const contract = await vm.stateManager.getAccount(target)
+      st.equals(contract.balance, BigInt(0), 'value sent')
+      st.equals(contract.nonce, BigInt(1), 'nonce 1')
+      st.ok(
+        (
+          await vm.stateManager.getContractStorage(
+            target,
+            Buffer.from('00'.repeat(31) + '01', 'hex')
+          )
+        ).equals(Buffer.from('01', 'hex')),
+        'storage not cleared'
+      )
+      st.equals(
+        (await vm.stateManager.getAccount(Address.fromString('0x' + '00'.repeat(19) + '01')))
+          .balance,
+        BigInt(value),
+        'balance sent to target'
+      )
+    }
+  )
+})


### PR DESCRIPTION
Implements [EIP6780](https://eips.ethereum.org/EIPS/eip-6780). This is considered for inclusion by ACD.

Test currently fails, and I have no idea why, the storage root of the contract is the empty storage root, but somehow the contract still returns that the slot is non-empty.