### PR TITLE
Add London+ hardfork support for Retesteth, fix EIP150 tests

### DIFF
--- a/packages/vm/test/retesteth/clients/ethereumjs/config
+++ b/packages/vm/test/retesteth/clients/ethereumjs/config
@@ -13,7 +13,8 @@
        "Istanbul",
        "Berlin",
        "London",
-       "Merge"
+       "Merge",
+       "Shanghai"
     ],
     "additionalForks":[
        "FrontierToHomesteadAt5",

--- a/packages/vm/test/retesteth/clients/ethereumjs/genesis/Shanghai.json
+++ b/packages/vm/test/retesteth/clients/ethereumjs/genesis/Shanghai.json
@@ -1,0 +1,10 @@
+{
+  "params": {
+    "fork": "Shanghai",
+    "terminalTotalDifficulty": "0x00",
+    "constantinopleForkBlock": "0x00",
+    "byzantiumForkBlock": "0x00",
+    "homesteadForkBlock": "0x00"
+  },
+  "accounts": {}
+}

--- a/packages/vm/test/retesteth/clients/ethereumjs/genesis/correctMiningReward.json
+++ b/packages/vm/test/retesteth/clients/ethereumjs/genesis/correctMiningReward.json
@@ -12,6 +12,7 @@
   "London": "2000000000000000000",
   "Merge": "2000000000000000000",
   "Merged": "2000000000000000000",
+  "Shanghai": "2000000000000000000",
 
   "//comment": "Retesteth calculate rewards on behalf of the tool when filling state tests",
   "YOLOv1": "2000000000000000000",

--- a/packages/vm/test/retesteth/clients/version
+++ b/packages/vm/test/retesteth/clients/version
@@ -1,1 +1,1 @@
-0.2.2-merge
+0.3.0-shanghai

--- a/packages/vm/test/retesteth/transition-child.ts
+++ b/packages/vm/test/retesteth/transition-child.ts
@@ -63,6 +63,9 @@ async function runTransition(argsIn: any) {
 
   const block = makeBlockFromEnv(inputEnv, { common })
 
+  const acc = await vm.stateManager.getAccount(block.header.coinbase)
+  await vm.stateManager.putAccount(block.header.coinbase, acc)
+
   const txsData = arrToBufArr(RLP.decode(Buffer.from(rlpTxs.slice(2), 'hex')))
 
   const headerData = block.header.toJSON()
@@ -121,6 +124,8 @@ async function runTransition(argsIn: any) {
   const logsBloom = builder.logsBloom()
   const logsHash = Buffer.from(keccak256(logsBloom))
 
+  await vm.eei.cleanupTouchedAccounts()
+
   const output = {
     stateRoot: '0x' + (await vm.eei.getStateRoot()).toString('hex'),
     txRoot: '0x' + (await builder.transactionsTrie()).toString('hex'),
@@ -158,6 +163,7 @@ process.on('message', async (message) => {
       await runTransition(message)
       // eslint-disable-next-line no-empty
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.log(e)
     }
 

--- a/packages/vm/test/retesteth/transition-cluster.ts
+++ b/packages/vm/test/retesteth/transition-cluster.ts
@@ -22,6 +22,7 @@ function getChild() {
   }
   if (index === -1) {
     const child = fork(program, parameters, options)
+    // eslint-disable-next-line no-console
     child.on('error', console.log)
     const newChild = {
       active: false,
@@ -62,4 +63,5 @@ const server = http.createServer((request: any, result: any) => {
   }
 })
 server.listen(3000)
+// eslint-disable-next-line no-console
 console.log('Transition cluster ready')

--- a/packages/vm/test/util.ts
+++ b/packages/vm/test/util.ts
@@ -281,6 +281,9 @@ export function makeBlockHeader(data: any, opts?: BlockOptions) {
     currentNumber,
     currentBaseFee,
     currentRandom,
+    parentGasLimit,
+    parentGasUsed,
+    parentBaseFee,
   } = data
   const headerData: any = {
     number: currentNumber,
@@ -292,6 +295,17 @@ export function makeBlockHeader(data: any, opts?: BlockOptions) {
   }
   if (opts?.common && opts.common.gteHardfork('london')) {
     headerData['baseFeePerGas'] = currentBaseFee
+    if (currentBaseFee === undefined) {
+      const parentBlockHeader = BlockHeader.fromHeaderData(
+        {
+          gasLimit: parentGasLimit,
+          gasUsed: parentGasUsed,
+          baseFeePerGas: parentBaseFee,
+        },
+        { common: opts.common }
+      )
+      headerData['baseFeePerGas'] = parentBlockHeader.calcNextBaseFee()
+    }
   }
   if (opts?.common && opts.common.gteHardfork('merge')) {
     headerData['mixHash'] = currentRandom


### PR DESCRIPTION
This PR:

- Ensures we run correctly on London+ hardforks. We always defaulted to base fee 7, while most tests have different base fee.
- Fixes EIP150 tests by ensuring if tx fails, coinbase account is still touched and cleaned up if necessary.