### PR TITLE
Bump `@chainsafe/ssz` to `0.11.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1695,9 +1695,9 @@
       "license": "MIT"
     },
     "node_modules/@chainsafe/as-sha256": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz",
-      "integrity": "sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.4.0.tgz",
+      "integrity": "sha512-2bFmA0JLDAXZqrmOQqrri0aeAgfdpk/kPays862raEG80nr45gyDM1BfI+HeaAvQMWgBDGoqAdFJTSb6+/DdeQ=="
     },
     "node_modules/@chainsafe/libp2p-noise": {
       "version": "4.1.2",
@@ -1762,20 +1762,32 @@
       }
     },
     "node_modules/@chainsafe/persistent-merkle-tree": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.5.0.tgz",
-      "integrity": "sha512-l0V1b5clxA3iwQLXP40zYjyZYospQLZXzBVIhhr9kDg/1qHZfzzHw0jj4VPBijfYCArZDlPkRi1wZaV2POKeuw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.6.0.tgz",
+      "integrity": "sha512-OHDu/ZyjbsSHBTr2fbkeZG2qWfBvLrSJweCNwPsTcngi62Z7xaI0bLtBH69Q1QuvOYzJd2eNqseq5a58SZE1Xw==",
       "dependencies": {
-        "@chainsafe/as-sha256": "^0.3.1"
+        "@chainsafe/as-sha256": "^0.4.0",
+        "@noble/hashes": "^1.3.0"
       }
     },
+    "node_modules/@chainsafe/persistent-merkle-tree/node_modules/@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@chainsafe/ssz": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.10.2.tgz",
-      "integrity": "sha512-/NL3Lh8K+0q7A3LsiFq09YXS9fPE+ead2rr7vM2QK8PLzrNsw3uqrif9bpRX5UxgeRjM+vYi+boCM3+GM4ovXg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.11.0.tgz",
+      "integrity": "sha512-osjFURtWTk3QH73bEoU9E7XTQmYHmX+dm24btUEoaTMyaKEhaMhI0Q98BYe8M/wTdxarUV7+f2A05Im5gHlk0w==",
       "dependencies": {
-        "@chainsafe/as-sha256": "^0.3.1",
-        "@chainsafe/persistent-merkle-tree": "^0.5.0"
+        "@chainsafe/as-sha256": "^0.4.0",
+        "@chainsafe/persistent-merkle-tree": "^0.6.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -18225,7 +18237,7 @@
       "version": "4.1.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "@chainsafe/ssz": "^0.10.2",
+        "@chainsafe/ssz": "^0.11.0",
         "@ethereumjs/common": "^3.1.1",
         "@ethereumjs/rlp": "^4.0.1",
         "@ethereumjs/util": "^8.0.5",
@@ -18255,7 +18267,7 @@
       "version": "8.0.5",
       "license": "MPL-2.0",
       "dependencies": {
-        "@chainsafe/ssz": "^0.10.2",
+        "@chainsafe/ssz": "^0.11.0",
         "@ethereumjs/rlp": "^4.0.1",
         "ethereum-cryptography": "^1.1.2"
       },
@@ -19389,9 +19401,9 @@
       "dev": true
     },
     "@chainsafe/as-sha256": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.3.1.tgz",
-      "integrity": "sha512-hldFFYuf49ed7DAakWVXSJODuq3pzJEguD8tQ7h+sGkM18vja+OFoJI9krnGmgzyuZC2ETX0NOIcCTy31v2Mtg=="
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.4.0.tgz",
+      "integrity": "sha512-2bFmA0JLDAXZqrmOQqrri0aeAgfdpk/kPays862raEG80nr45gyDM1BfI+HeaAvQMWgBDGoqAdFJTSb6+/DdeQ=="
     },
     "@chainsafe/libp2p-noise": {
       "version": "4.1.2",
@@ -19447,20 +19459,28 @@
       }
     },
     "@chainsafe/persistent-merkle-tree": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.5.0.tgz",
-      "integrity": "sha512-l0V1b5clxA3iwQLXP40zYjyZYospQLZXzBVIhhr9kDg/1qHZfzzHw0jj4VPBijfYCArZDlPkRi1wZaV2POKeuw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.6.0.tgz",
+      "integrity": "sha512-OHDu/ZyjbsSHBTr2fbkeZG2qWfBvLrSJweCNwPsTcngi62Z7xaI0bLtBH69Q1QuvOYzJd2eNqseq5a58SZE1Xw==",
       "requires": {
-        "@chainsafe/as-sha256": "^0.3.1"
+        "@chainsafe/as-sha256": "^0.4.0",
+        "@noble/hashes": "^1.3.0"
+      },
+      "dependencies": {
+        "@noble/hashes": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+          "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg=="
+        }
       }
     },
     "@chainsafe/ssz": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.10.2.tgz",
-      "integrity": "sha512-/NL3Lh8K+0q7A3LsiFq09YXS9fPE+ead2rr7vM2QK8PLzrNsw3uqrif9bpRX5UxgeRjM+vYi+boCM3+GM4ovXg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.11.0.tgz",
+      "integrity": "sha512-osjFURtWTk3QH73bEoU9E7XTQmYHmX+dm24btUEoaTMyaKEhaMhI0Q98BYe8M/wTdxarUV7+f2A05Im5gHlk0w==",
       "requires": {
-        "@chainsafe/as-sha256": "^0.3.1",
-        "@chainsafe/persistent-merkle-tree": "^0.5.0"
+        "@chainsafe/as-sha256": "^0.4.0",
+        "@chainsafe/persistent-merkle-tree": "^0.6.0"
       }
     },
     "@colors/colors": {
@@ -19830,7 +19850,7 @@
     "@ethereumjs/tx": {
       "version": "file:packages/tx",
       "requires": {
-        "@chainsafe/ssz": "^0.10.2",
+        "@chainsafe/ssz": "^0.11.0",
         "@ethereumjs/common": "^3.1.1",
         "@ethereumjs/rlp": "^4.0.1",
         "@ethereumjs/util": "^8.0.5",
@@ -19845,7 +19865,7 @@
     "@ethereumjs/util": {
       "version": "file:packages/util",
       "requires": {
-        "@chainsafe/ssz": "^0.10.2",
+        "@chainsafe/ssz": "^0.11.0",
         "@ethereumjs/rlp": "^4.0.1",
         "@types/bn.js": "^5.1.0",
         "@types/secp256k1": "^4.0.1",

--- a/packages/block/karma.conf.js
+++ b/packages/block/karma.conf.js
@@ -13,6 +13,14 @@ module.exports = function (config) {
         acornOptions: {
           ecmaVersion: 12,
         },
+        resolve: {
+          alias: {
+            '@chainsafe/persistent-merkle-tree/hasher':
+              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
+            '@chainsafe/as-sha256/hashObject':
+              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
+          },
+        },
       },
     },
     concurrency: 1,

--- a/packages/blockchain/karma.conf.js
+++ b/packages/blockchain/karma.conf.js
@@ -16,6 +16,10 @@ module.exports = function (config) {
         resolve: {
           alias: {
             'bigint-crypto-utils': '../../node_modules/bigint-crypto-utils/dist/bundles/umd.js',
+            '@chainsafe/persistent-merkle-tree/hasher':
+              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
+            '@chainsafe/as-sha256/hashObject':
+              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
           },
         },
       },

--- a/packages/client/karma.conf.js
+++ b/packages/client/karma.conf.js
@@ -26,8 +26,13 @@ module.exports = function (config) {
               '../../node_modules/multiformats/cjs/src/hashes/identity.js',
             'multiformats/hashes/sha2':
               '../../node_modules/multiformats/cjs/src/hashes/sha2-browser.js',
+            '@chainsafe/persistent-merkle-tree/hasher':
+              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
+            '@chainsafe/as-sha256/hashObject':
+              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
           },
         },
+
         transforms: [
           require('karma-typescript-es6-transform')({
             presets: [['@babel/preset-env', { targets: { chrome: '74' } }]],

--- a/packages/common/karma.conf.js
+++ b/packages/common/karma.conf.js
@@ -13,6 +13,14 @@ module.exports = function (config) {
         acornOptions: {
           ecmaVersion: 12,
         },
+        resolve: {
+          alias: {
+            '@chainsafe/persistent-merkle-tree/hasher':
+              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
+            '@chainsafe/as-sha256/hashObject':
+              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
+          },
+        },
       },
     },
     concurrency: 1,

--- a/packages/evm/karma.conf.js
+++ b/packages/evm/karma.conf.js
@@ -29,6 +29,10 @@ module.exports = function (config) {
         resolve: {
           alias: {
             'bigint-crypto-utils': '../../node_modules/bigint-crypto-utils/dist/bundles/umd.js',
+            '@chainsafe/persistent-merkle-tree/hasher':
+              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
+            '@chainsafe/as-sha256/hashObject':
+              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
           },
         },
       },

--- a/packages/statemanager/karma.conf.js
+++ b/packages/statemanager/karma.conf.js
@@ -24,6 +24,10 @@ module.exports = function (config) {
         resolve: {
           alias: {
             'bigint-crypto-utils': '../../node_modules/bigint-crypto-utils/dist/bundles/umd.js',
+            '@chainsafe/persistent-merkle-tree/hasher':
+              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
+            '@chainsafe/as-sha256/hashObject':
+              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
           },
         },
       },

--- a/packages/trie/karma.conf.js
+++ b/packages/trie/karma.conf.js
@@ -13,6 +13,15 @@ module.exports = function (config) {
         acornOptions: {
           ecmaVersion: 12,
         },
+        resolve: {
+          alias: {
+            'bigint-crypto-utils': '../../node_modules/bigint-crypto-utils/dist/bundles/umd.js',
+            '@chainsafe/persistent-merkle-tree/hasher':
+              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
+            '@chainsafe/as-sha256/hashObject':
+              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
+          },
+        },
       },
     },
     colors: true,

--- a/packages/tx/karma.conf.js
+++ b/packages/tx/karma.conf.js
@@ -15,6 +15,14 @@ module.exports = function (config) {
         acornOptions: {
           ecmaVersion: 12,
         },
+        resolve: {
+          alias: {
+            '@chainsafe/persistent-merkle-tree/hasher':
+              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
+            '@chainsafe/as-sha256/hashObject':
+              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
+          },
+        },
       },
     },
     browsers: ['FirefoxHeadless', 'ChromeHeadless'],

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -51,7 +51,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^0.10.2",
+    "@chainsafe/ssz": "^0.11.0",
     "@ethereumjs/common": "^3.1.1",
     "@ethereumjs/rlp": "^4.0.1",
     "@ethereumjs/util": "^8.0.5",

--- a/packages/util/karma.conf.js
+++ b/packages/util/karma.conf.js
@@ -11,6 +11,14 @@ module.exports = function (config) {
         acornOptions: {
           ecmaVersion: 12,
         },
+        resolve: {
+          alias: {
+            '@chainsafe/persistent-merkle-tree/hasher':
+              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
+            '@chainsafe/as-sha256/hashObject':
+              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
+          },
+        },
       },
       tsconfig: './tsconfig.json',
     },

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -83,7 +83,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^0.10.2",
+    "@chainsafe/ssz": "^0.11.0",
     "@ethereumjs/rlp": "^4.0.1",
     "ethereum-cryptography": "^1.1.2"
   },

--- a/packages/vm/karma.conf.js
+++ b/packages/vm/karma.conf.js
@@ -29,6 +29,10 @@ module.exports = function (config) {
         resolve: {
           alias: {
             'bigint-crypto-utils': '../../node_modules/bigint-crypto-utils/dist/bundles/umd.js',
+            '@chainsafe/persistent-merkle-tree/hasher':
+              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
+            '@chainsafe/as-sha256/hashObject':
+              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
           },
         },
       },


### PR DESCRIPTION
Bumps `@chainsafe/ssz` to `0.11.0`. 

The current version of `@chainsafe/ssz` uses an AssemblyScript based SHA-256 implementation that causes issues on some platforms since it requires `WebAssembly` for execution (e.g. in sites or extensions with strict CSPs). 

This new version uses a pure JS implementation (`@noble/hashes`) as the default hasher for SHA-256 and should fix some of these aforementioned incompatibility issues.

For more context see: https://github.com/ChainSafe/ssz/issues/313