### PR TITLE
tx: Fix the deserialization of blob tx and add no empty blobs validation

### DIFF
--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -50,6 +50,10 @@ const validateBlobTransactionNetworkWrapper = (
   if (!(versionedHashes.length === blobs.length && blobs.length === commitments.length)) {
     throw new Error('Number of versionedHashes, blobs, and commitments not all equal')
   }
+  if (versionedHashes.length === 0) {
+    throw new Error('Invalid transaction with empty blobs')
+  }
+
   try {
     kzg.verifyBlobKzgProofBatch(blobs, commitments, kzgProofs)
   } catch (e) {
@@ -265,7 +269,8 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
       const accessListItem: AccessListBytesItem = [listItem.address, listItem.storageKeys]
       accessList.push(accessListItem)
     }
-    const to = tx.to.value === null ? undefined : Address.fromString(bytesToHex(tx.to.value))
+    const to =
+      tx.to.value === null ? undefined : Address.fromString(bytesToPrefixedHexString(tx.to.value))
     const versionedHashes = tx.blobVersionedHashes
     const txData = {
       ...tx,


### PR DESCRIPTION
In the Uint8Array conversion a bug might have gotten  introduced for deserialization. This PR fixes that as well as ban zero blob tx

ref: 
- https://github.com/ethereum/EIPs/pull/6863