### PR TITLE
client: add proofs to blobsbundle

### DIFF
--- a/packages/client/lib/miner/pendingBlock.ts
+++ b/packages/client/lib/miner/pendingBlock.ts
@@ -37,6 +37,7 @@ interface BlobBundle {
   blockHash: string
   blobs: Uint8Array[]
   kzgCommitments: Uint8Array[]
+  proofs: Uint8Array[]
 }
 /**
  * In the future this class should build a pending block by keeping the
@@ -323,10 +324,12 @@ export class PendingBlock {
   ) => {
     let blobs: Uint8Array[] = []
     let kzgCommitments: Uint8Array[] = []
+    let proofs: Uint8Array[] = []
     const bundle = this.blobBundles.get(payloadId)
     if (bundle !== undefined) {
       blobs = bundle.blobs
       kzgCommitments = bundle.kzgCommitments
+      proofs = bundle.proofs
     }
 
     for (let tx of txs) {
@@ -334,12 +337,14 @@ export class PendingBlock {
       if (tx.blobs !== undefined && tx.blobs.length > 0) {
         blobs = blobs.concat(tx.blobs)
         kzgCommitments = kzgCommitments.concat(tx.kzgCommitments!)
+        proofs = proofs.concat(tx.kzgProofs!)
       }
     }
     this.blobBundles.set(payloadId, {
       blockHash: bytesToPrefixedHexString(blockHash),
       blobs,
       kzgCommitments,
+      proofs,
     })
   }
 }

--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -112,6 +112,7 @@ type BlobsBundleV1 = {
   blockHash: string
   kzgs: Bytes48[]
   blobs: Blob[]
+  proofs: Bytes48[]
 }
 
 type ExecutionPayloadBodyV1 = {
@@ -1074,6 +1075,7 @@ export class Engine {
       blockHash: bundle.blockHash,
       kzgs: bundle.kzgCommitments.map(bytesToPrefixedHexString),
       blobs: bundle.blobs.map(bytesToPrefixedHexString),
+      proofs: bundle.proofs.map(bytesToPrefixedHexString),
     }
   }
 


### PR DESCRIPTION
Add proofs to blobsbundle and consequently to getblobsbundle engine api call so that CL doesn't need to compute proof which ideally would be coming packaged in the network wrapper serialized tx

ref:
- https://github.com/ethereum/execution-apis/pull/392