### PR TITLE
Statemanager: Expand Checkpointing Tests

### DIFF
--- a/packages/statemanager/test/checkpointing.account.spec.ts
+++ b/packages/statemanager/test/checkpointing.account.spec.ts
@@ -3,308 +3,401 @@ import * as tape from 'tape'
 
 import { DefaultStateManager } from '../src'
 
+/**
+ * Compares account read to none or undefined
+ */
+const accountEval = async (
+  sm: DefaultStateManager,
+  address: Address,
+  compare: bigint | undefined
+) => {
+  const account = await sm.getAccount(address)
+  if (compare === undefined) {
+    return account === undefined
+  } else {
+    if (account === undefined) {
+      return false
+    } else {
+      return account.nonce === compare
+    }
+  }
+}
+
+type CompareList = [Account | undefined, bigint | undefined]
+
 tape('StateManager -> Account Checkpointing', (t) => {
   const address = new Address(hexStringToBytes('11'.repeat(20)))
-  const account = Account.fromAccountData({
-    nonce: 1,
-  })
-  const account2 = Account.fromAccountData({
-    nonce: 2,
-  })
-  const account3 = Account.fromAccountData({
-    nonce: 3,
-  })
-  const account4 = Account.fromAccountData({
-    nonce: 4,
-  })
-  const account5 = Account.fromAccountData({
-    nonce: 5,
-  })
 
-  t.test('No CP -> A1 -> Flush() (-> A1)', async (st) => {
-    const sm = new DefaultStateManager()
+  const accountN1: CompareList = [
+    Account.fromAccountData({
+      nonce: 1,
+    }),
+    1n,
+  ]
+  const accountN2: CompareList = [
+    Account.fromAccountData({
+      nonce: 2,
+    }),
+    2n,
+  ]
+  const accountN3: CompareList = [
+    Account.fromAccountData({
+      nonce: 3,
+    }),
+    3n,
+  ]
+  const accountN4: CompareList = [
+    Account.fromAccountData({
+      nonce: 4,
+    }),
+    4n,
+  ]
+  const accountN5: CompareList = [
+    Account.fromAccountData({
+      nonce: 5,
+    }),
+    5n,
+  ]
+  const accountUndefined: CompareList = [undefined, undefined]
 
-    await sm.putAccount(address, account)
-    await sm.flush()
-    st.equal((await sm.getAccount(address))!.nonce, 1n)
+  const accountSets = [
+    {
+      a1: accountN1,
+      a2: accountN2,
+      a3: accountN3,
+      a4: accountN4,
+      a5: accountN5,
+    },
+    {
+      a1: accountUndefined,
+      a2: accountN2,
+      a3: accountN3,
+      a4: accountN4,
+      a5: accountN5,
+    },
+    {
+      a1: accountUndefined,
+      a2: accountN2,
+      a3: accountUndefined,
+      a4: accountN4,
+      a5: accountN5,
+    },
+    {
+      a1: accountUndefined,
+      a2: accountN2,
+      a3: accountN3,
+      a4: accountUndefined,
+      a5: accountN5,
+    },
+    {
+      a1: accountN1,
+      a2: accountUndefined,
+      a3: accountN3,
+      a4: accountUndefined,
+      a5: accountN5,
+    },
+    {
+      a1: accountN1,
+      a2: accountUndefined,
+      a3: accountN3,
+      a4: accountN4,
+      a5: accountUndefined,
+    },
+    {
+      a1: accountN1,
+      a2: accountN2,
+      a3: accountUndefined,
+      a4: accountN4,
+      a5: accountUndefined,
+    },
+  ]
 
-    sm.clearCaches()
-    st.equal((await sm.getAccount(address))!.nonce, 1n)
-
-    st.end()
-  })
-
-  t.test('CP -> A1.1 -> Commit -> Flush() (-> A1.1)', async (st) => {
-    const sm = new DefaultStateManager()
-
-    await sm.checkpoint()
-    await sm.putAccount(address, account)
-    await sm.commit()
-    await sm.flush()
-    st.equal((await sm.getAccount(address))!.nonce, 1n)
-
-    sm.clearCaches()
-    st.equal((await sm.getAccount(address))!.nonce, 1n)
-
-    st.end()
-  })
-
-  t.test('CP -> A1.1 -> Revert -> Flush() (-> Undefined)', async (st) => {
-    const sm = new DefaultStateManager()
-
-    await sm.checkpoint()
-    await sm.putAccount(address, account)
-    await sm.revert()
-    await sm.flush()
-    st.equal(await sm.getAccount(address), undefined)
-
-    sm.clearCaches()
-    st.equal(await sm.getAccount(address), undefined)
-
-    st.end()
-  })
-
-  t.test('A1.1 -> CP -> Commit -> Flush() (-> A1.1)', async (st) => {
-    const sm = new DefaultStateManager()
-
-    await sm.putAccount(address, account)
-    await sm.checkpoint()
-    await sm.commit()
-    await sm.flush()
-    st.equal((await sm.getAccount(address))!.nonce, 1n)
-
-    sm.clearCaches()
-    st.equal((await sm.getAccount(address))!.nonce, 1n)
-
-    st.end()
-  })
-
-  t.test('A1.1 -> CP -> Revert -> Flush() (-> A1.1)', async (st) => {
-    const sm = new DefaultStateManager()
-
-    await sm.putAccount(address, account)
-    await sm.checkpoint()
-    await sm.revert()
-    await sm.flush()
-    st.equal((await sm.getAccount(address))!.nonce, 1n)
-
-    sm.clearCaches()
-    st.equal((await sm.getAccount(address))!.nonce, 1n)
-
-    st.end()
-  })
-
-  t.test('A1.1 -> CP -> A1.2 -> Commit -> Flush() (-> A1.2)', async (st) => {
-    const sm = new DefaultStateManager()
-
-    await sm.putAccount(address, account)
-    await sm.checkpoint()
-    await sm.putAccount(address, account2)
-    await sm.commit()
-    await sm.flush()
-    st.equal((await sm.getAccount(address))!.nonce, 2n)
-
-    sm.clearCaches()
-    st.equal((await sm.getAccount(address))!.nonce, 2n)
-
-    st.end()
-  })
-
-  t.test('A1.1 -> CP -> A1.2 -> Commit -> A1.3 -> Flush() (-> A1.3)', async (st) => {
-    const sm = new DefaultStateManager()
-
-    await sm.putAccount(address, account)
-    await sm.checkpoint()
-    await sm.putAccount(address, account2)
-    await sm.commit()
-    await sm.putAccount(address, account3)
-    await sm.flush()
-    st.equal((await sm.getAccount(address))!.nonce, 3n)
-
-    sm.clearCaches()
-    st.equal((await sm.getAccount(address))!.nonce, 3n)
-
-    st.end()
-  })
-
-  t.test('A1.1 -> CP -> A1.2 -> A1.3 -> Commit -> Flush() (-> A1.3)', async (st) => {
-    const sm = new DefaultStateManager()
-
-    await sm.putAccount(address, account)
-    await sm.checkpoint()
-    await sm.putAccount(address, account2)
-    await sm.putAccount(address, account3)
-    await sm.commit()
-    await sm.flush()
-    st.equal((await sm.getAccount(address))!.nonce, 3n)
-
-    sm.clearCaches()
-    st.equal((await sm.getAccount(address))!.nonce, 3n)
-
-    st.end()
-  })
-
-  t.test('CP -> A1.1 -> A1.2 -> Commit -> Flush() (-> A1.2)', async (st) => {
-    const sm = new DefaultStateManager()
-
-    await sm.checkpoint()
-    await sm.putAccount(address, account)
-    await sm.putAccount(address, account2)
-    await sm.commit()
-    await sm.flush()
-    st.equal((await sm.getAccount(address))!.nonce, 2n)
-
-    sm.clearCaches()
-    st.equal((await sm.getAccount(address))!.nonce, 2n)
-
-    st.end()
-  })
-
-  t.test('CP -> A1.1 -> A1.2 -> Revert -> Flush() (-> Undefined)', async (st) => {
-    const sm = new DefaultStateManager()
-
-    await sm.checkpoint()
-    await sm.putAccount(address, account)
-
-    await sm.putAccount(address, account2)
-    await sm.revert()
-    await sm.flush()
-    st.equal(await sm.getAccount(address), undefined)
-
-    sm.clearCaches()
-    st.equal(await sm.getAccount(address), undefined)
-
-    st.end()
-  })
-
-  t.test('A1.1 -> CP -> A1.2 -> Revert -> Flush() (-> A1.1)', async (st) => {
-    const sm = new DefaultStateManager()
-
-    await sm.putAccount(address, account)
-    await sm.checkpoint()
-    await sm.putAccount(address, account2)
-    await sm.revert()
-    await sm.flush()
-    st.equal((await sm.getAccount(address))!.nonce, 1n)
-
-    sm.clearCaches()
-    st.equal((await sm.getAccount(address))!.nonce, 1n)
-
-    st.end()
-  })
-
-  t.test(
-    'A1.1 -> CP -> A1.2 -> CP -> A1.3 -> Commit -> Commit -> Flush() (-> A1.3)',
-    async (st) => {
+  for (const as of accountSets) {
+    t.test('No CP -> A1 -> Flush() (-> A1)', async (st) => {
       const sm = new DefaultStateManager()
 
-      await sm.putAccount(address, account)
-      await sm.checkpoint()
-      await sm.putAccount(address, account2)
-      await sm.checkpoint()
-      await sm.putAccount(address, account3)
-      await sm.commit()
-      await sm.commit()
+      await sm.putAccount(address, as.a1[0])
       await sm.flush()
-      st.equal((await sm.getAccount(address))!.nonce, 3n)
+      st.ok(accountEval(sm, address, as.a1[1]))
 
       sm.clearCaches()
-      st.equal((await sm.getAccount(address))!.nonce, 3n)
+      st.ok(accountEval(sm, address, as.a1[1]))
 
       st.end()
-    }
-  )
+    })
 
-  t.test(
-    'A1.1 -> CP -> A1.2 -> CP -> A1.3 -> Commit -> Revert -> Flush() (-> A1.1)',
-    async (st) => {
+    t.test('CP -> A1.1 -> Commit -> Flush() (-> A1.1)', async (st) => {
       const sm = new DefaultStateManager()
 
-      await sm.putAccount(address, account)
       await sm.checkpoint()
-      await sm.putAccount(address, account2)
-      await sm.checkpoint()
-      await sm.putAccount(address, account3)
+      await sm.putAccount(address, as.a1[0])
       await sm.commit()
+      await sm.flush()
+      st.ok(accountEval(sm, address, as.a1[1]))
+
+      sm.clearCaches()
+      st.ok(accountEval(sm, address, as.a1[1]))
+
+      st.end()
+    })
+
+    t.test('CP -> A1.1 -> Revert -> Flush() (-> Undefined)', async (st) => {
+      const sm = new DefaultStateManager()
+
+      await sm.checkpoint()
+      await sm.putAccount(address, as.a1[0])
       await sm.revert()
       await sm.flush()
-      st.equal((await sm.getAccount(address))!.nonce, 1n)
+      st.ok(accountEval(sm, address, undefined))
 
       sm.clearCaches()
-      st.equal((await sm.getAccount(address))!.nonce, 1n)
+      st.ok(accountEval(sm, address, undefined))
 
       st.end()
-    }
-  )
+    })
 
-  t.test(
-    'A1.1 -> CP -> A1.2 -> CP -> A1.3 -> Revert -> Commit -> Flush() (-> A1.2)',
-    async (st) => {
+    t.test('A1.1 -> CP -> Commit -> Flush() (-> A1.1)', async (st) => {
       const sm = new DefaultStateManager()
 
-      await sm.putAccount(address, account)
+      await sm.putAccount(address, as.a1[0])
       await sm.checkpoint()
-      await sm.putAccount(address, account2)
-      await sm.checkpoint()
-      await sm.putAccount(address, account3)
-      await sm.revert()
       await sm.commit()
       await sm.flush()
-      st.equal((await sm.getAccount(address))!.nonce, 2n)
+      st.ok(accountEval(sm, address, as.a1[1]))
 
       sm.clearCaches()
-      st.equal((await sm.getAccount(address))!.nonce, 2n)
+      st.ok(accountEval(sm, address, as.a1[1]))
 
       st.end()
-    }
-  )
+    })
 
-  t.test(
-    'A1.1 -> CP -> A1.2 -> CP -> A1.3 -> Revert -> A1.4 -> Commit -> Flush() (-> A1.4)',
-    async (st) => {
+    t.test('A1.1 -> CP -> Revert -> Flush() (-> A1.1)', async (st) => {
       const sm = new DefaultStateManager()
 
-      await sm.putAccount(address, account)
+      await sm.putAccount(address, as.a1[0])
       await sm.checkpoint()
-      await sm.putAccount(address, account2)
-      await sm.checkpoint()
-      await sm.putAccount(address, account3)
       await sm.revert()
-      await sm.putAccount(address, account4)
-      await sm.commit()
       await sm.flush()
-      st.equal((await sm.getAccount(address))!.nonce, 4n)
+      st.ok(accountEval(sm, address, as.a1[1]))
 
       sm.clearCaches()
-      st.equal((await sm.getAccount(address))!.nonce, 4n)
+      st.ok(accountEval(sm, address, as.a1[1]))
 
       st.end()
-    }
-  )
+    })
 
-  t.test(
-    'A1.1 -> CP -> A1.2 -> CP -> A1.3 -> Revert -> A1.4 -> CP -> A1.5 -> Commit -> Commit -> Flush() (-> A1.5)',
-    async (st) => {
+    t.test('A1.1 -> CP -> A1.2 -> Commit -> Flush() (-> A1.2)', async (st) => {
       const sm = new DefaultStateManager()
 
-      await sm.putAccount(address, account)
+      await sm.putAccount(address, as.a1[0])
       await sm.checkpoint()
-      await sm.putAccount(address, account2)
-      await sm.checkpoint()
-      await sm.putAccount(address, account3)
-      await sm.revert()
-      await sm.putAccount(address, account4)
-      await sm.checkpoint()
-      await sm.putAccount(address, account5)
-      await sm.commit()
+      await sm.putAccount(address, as.a2[0])
       await sm.commit()
       await sm.flush()
-      st.equal((await sm.getAccount(address))!.nonce, 5n)
+      st.ok(accountEval(sm, address, as.a2[1]))
 
       sm.clearCaches()
-      st.equal((await sm.getAccount(address))!.nonce, 5n)
+      st.ok(accountEval(sm, address, as.a2[1]))
 
       st.end()
-    }
-  )
+    })
+
+    t.test('A1.1 -> CP -> A1.2 -> Commit -> A1.3 -> Flush() (-> A1.3)', async (st) => {
+      const sm = new DefaultStateManager()
+
+      await sm.putAccount(address, as.a1[0])
+      await sm.checkpoint()
+      await sm.putAccount(address, as.a2[0])
+      await sm.commit()
+      await sm.putAccount(address, as.a3[0])
+      await sm.flush()
+      st.ok(accountEval(sm, address, as.a3[1]))
+
+      sm.clearCaches()
+      st.ok(accountEval(sm, address, as.a3[1]))
+
+      st.end()
+    })
+
+    t.test('A1.1 -> CP -> A1.2 -> A1.3 -> Commit -> Flush() (-> A1.3)', async (st) => {
+      const sm = new DefaultStateManager()
+
+      await sm.putAccount(address, as.a1[0])
+      await sm.checkpoint()
+      await sm.putAccount(address, as.a2[0])
+      await sm.putAccount(address, as.a3[0])
+      await sm.commit()
+      await sm.flush()
+      st.ok(accountEval(sm, address, as.a3[1]))
+
+      sm.clearCaches()
+      st.ok(accountEval(sm, address, as.a3[1]))
+
+      st.end()
+    })
+
+    t.test('CP -> A1.1 -> A1.2 -> Commit -> Flush() (-> A1.2)', async (st) => {
+      const sm = new DefaultStateManager()
+
+      await sm.checkpoint()
+      await sm.putAccount(address, as.a1[0])
+      await sm.putAccount(address, as.a2[0])
+      await sm.commit()
+      await sm.flush()
+      st.ok(accountEval(sm, address, as.a2[1]))
+
+      sm.clearCaches()
+      st.ok(accountEval(sm, address, as.a2[1]))
+
+      st.end()
+    })
+
+    t.test('CP -> A1.1 -> A1.2 -> Revert -> Flush() (-> Undefined)', async (st) => {
+      const sm = new DefaultStateManager()
+
+      await sm.checkpoint()
+      await sm.putAccount(address, as.a1[0])
+
+      await sm.putAccount(address, as.a2[0])
+      await sm.revert()
+      await sm.flush()
+      st.ok(accountEval(sm, address, undefined))
+
+      sm.clearCaches()
+      st.ok(accountEval(sm, address, undefined))
+
+      st.end()
+    })
+
+    t.test('A1.1 -> CP -> A1.2 -> Revert -> Flush() (-> A1.1)', async (st) => {
+      const sm = new DefaultStateManager()
+
+      await sm.putAccount(address, as.a1[0])
+      await sm.checkpoint()
+      await sm.putAccount(address, as.a2[0])
+      await sm.revert()
+      await sm.flush()
+      st.ok(accountEval(sm, address, as.a1[1]))
+
+      sm.clearCaches()
+      st.ok(accountEval(sm, address, as.a1[1]))
+
+      st.end()
+    })
+
+    t.test(
+      'A1.1 -> CP -> A1.2 -> CP -> A1.3 -> Commit -> Commit -> Flush() (-> A1.3)',
+      async (st) => {
+        const sm = new DefaultStateManager()
+
+        await sm.putAccount(address, as.a1[0])
+        await sm.checkpoint()
+        await sm.putAccount(address, as.a2[0])
+        await sm.checkpoint()
+        await sm.putAccount(address, as.a3[0])
+        await sm.commit()
+        await sm.commit()
+        await sm.flush()
+        st.ok(accountEval(sm, address, as.a3[1]))
+
+        sm.clearCaches()
+        st.ok(accountEval(sm, address, as.a3[1]))
+
+        st.end()
+      }
+    )
+
+    t.test(
+      'A1.1 -> CP -> A1.2 -> CP -> A1.3 -> Commit -> Revert -> Flush() (-> A1.1)',
+      async (st) => {
+        const sm = new DefaultStateManager()
+
+        await sm.putAccount(address, as.a1[0])
+        await sm.checkpoint()
+        await sm.putAccount(address, as.a2[0])
+        await sm.checkpoint()
+        await sm.putAccount(address, as.a3[0])
+        await sm.commit()
+        await sm.revert()
+        await sm.flush()
+        st.ok(accountEval(sm, address, as.a1[1]))
+
+        sm.clearCaches()
+        st.ok(accountEval(sm, address, as.a1[1]))
+
+        st.end()
+      }
+    )
+
+    t.test(
+      'A1.1 -> CP -> A1.2 -> CP -> A1.3 -> Revert -> Commit -> Flush() (-> A1.2)',
+      async (st) => {
+        const sm = new DefaultStateManager()
+
+        await sm.putAccount(address, as.a1[0])
+        await sm.checkpoint()
+        await sm.putAccount(address, as.a2[0])
+        await sm.checkpoint()
+        await sm.putAccount(address, as.a3[0])
+        await sm.revert()
+        await sm.commit()
+        await sm.flush()
+        st.ok(accountEval(sm, address, as.a2[1]))
+
+        sm.clearCaches()
+        st.ok(accountEval(sm, address, as.a2[1]))
+
+        st.end()
+      }
+    )
+
+    t.test(
+      'A1.1 -> CP -> A1.2 -> CP -> A1.3 -> Revert -> A1.4 -> Commit -> Flush() (-> A1.4)',
+      async (st) => {
+        const sm = new DefaultStateManager()
+
+        await sm.putAccount(address, as.a1[0])
+        await sm.checkpoint()
+        await sm.putAccount(address, as.a2[0])
+        await sm.checkpoint()
+        await sm.putAccount(address, as.a3[0])
+        await sm.revert()
+        await sm.putAccount(address, as.a4[0])
+        await sm.commit()
+        await sm.flush()
+        st.ok(accountEval(sm, address, as.a4[1]))
+
+        sm.clearCaches()
+        st.ok(accountEval(sm, address, as.a4[1]))
+
+        st.end()
+      }
+    )
+
+    t.test(
+      'A1.1 -> CP -> A1.2 -> CP -> A1.3 -> Revert -> A1.4 -> CP -> A1.5 -> Commit -> Commit -> Flush() (-> A1.5)',
+      async (st) => {
+        const sm = new DefaultStateManager()
+
+        await sm.putAccount(address, as.a1[0])
+        await sm.checkpoint()
+        await sm.putAccount(address, as.a2[0])
+        await sm.checkpoint()
+        await sm.putAccount(address, as.a3[0])
+        await sm.revert()
+        await sm.putAccount(address, as.a4[0])
+        await sm.checkpoint()
+        await sm.putAccount(address, as.a5[0])
+        await sm.commit()
+        await sm.commit()
+        await sm.flush()
+        st.ok(accountEval(sm, address, as.a5[1]))
+
+        sm.clearCaches()
+        st.ok(accountEval(sm, address, as.a5[1]))
+
+        st.end()
+      }
+    )
+  }
 })

--- a/packages/statemanager/test/checkpointing.storage.spec.ts
+++ b/packages/statemanager/test/checkpointing.storage.spec.ts
@@ -64,6 +64,34 @@ tape('StateManager -> Storage Checkpointing', (t) => {
       s4: { value: value4, root: root4 },
       s5: { value: value5, root: root5 },
     },
+    {
+      s1: { value: valueEmpty, root: rootEmpty },
+      s2: { value: value2, root: root2 },
+      s3: { value: value3, root: root3 },
+      s4: { value: valueEmpty, root: rootEmpty },
+      s5: { value: value5, root: root5 },
+    },
+    {
+      s1: { value, root },
+      s2: { value: valueEmpty, root: rootEmpty },
+      s3: { value: value3, root: root3 },
+      s4: { value: valueEmpty, root: rootEmpty },
+      s5: { value: value5, root: root5 },
+    },
+    {
+      s1: { value, root },
+      s2: { value: valueEmpty, root: rootEmpty },
+      s3: { value: value3, root: root3 },
+      s4: { value: value4, root: root4 },
+      s5: { value: valueEmpty, root: rootEmpty },
+    },
+    {
+      s1: { value, root },
+      s2: { value: value2, root: root2 },
+      s3: { value: valueEmpty, root: rootEmpty },
+      s4: { value: value4, root: root4 },
+      s5: { value: valueEmpty, root: rootEmpty },
+    },
   ]
 
   for (const s of storageSets) {
@@ -76,7 +104,7 @@ tape('StateManager -> Storage Checkpointing', (t) => {
       await storageEval(st, sm, address, key, s.s1.value, s.s1.root)
 
       sm.clearCaches()
-      st.deepEqual(await sm.getContractStorage(address, key), value)
+      st.deepEqual(await sm.getContractStorage(address, key), s.s1.value)
       await storageEval(st, sm, address, key, s.s1.value, s.s1.root)
 
       st.end()
@@ -104,7 +132,6 @@ tape('StateManager -> Storage Checkpointing', (t) => {
 
       await sm.checkpoint()
       await sm.putContractStorage(address, key, s.s1.value)
-      await storageEval(st, sm, address, key, s.s1.value, s.s1.root)
 
       await sm.revert()
       await sm.flush()


### PR DESCRIPTION
This PR expands the StateManager checkpointing test suites, both for account and for storage checkpointing, with some stronger emphasis on the storage tests.

Two test cases failing at the moment (one is a double failure due to 2 consecutive runs), one failure with directly reading a storage slot saved to cache, one other involving an empty/non-empty storage slot write.

Still needs investigation and fixes.