### PR TITLE
Bump `@chainsafe/ssz` to `0.11.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1800,9 +1800,9 @@
       "dev": true
     },
     "node_modules/@chainsafe/as-sha256": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.4.0.tgz",
-      "integrity": "sha512-2bFmA0JLDAXZqrmOQqrri0aeAgfdpk/kPays862raEG80nr45gyDM1BfI+HeaAvQMWgBDGoqAdFJTSb6+/DdeQ=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.4.1.tgz",
+      "integrity": "sha512-IqeeGwQihK6Y2EYLFofqs2eY2ep1I2MvQXHzOAI+5iQN51OZlUkrLgyAugu2x86xZewDk5xas7lNczkzFzF62w=="
     },
     "node_modules/@chainsafe/libp2p-noise": {
       "version": "4.1.2",
@@ -1871,21 +1871,21 @@
       }
     },
     "node_modules/@chainsafe/persistent-merkle-tree": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.6.0.tgz",
-      "integrity": "sha512-OHDu/ZyjbsSHBTr2fbkeZG2qWfBvLrSJweCNwPsTcngi62Z7xaI0bLtBH69Q1QuvOYzJd2eNqseq5a58SZE1Xw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.6.1.tgz",
+      "integrity": "sha512-gcENLemRR13+1MED2NeZBMA7FRS0xQPM7L2vhMqvKkjqtFT4YfjSVADq5U0iLuQLhFUJEMVuA8fbv5v+TN6O9A==",
       "dependencies": {
-        "@chainsafe/as-sha256": "^0.4.0",
+        "@chainsafe/as-sha256": "^0.4.1",
         "@noble/hashes": "^1.3.0"
       }
     },
     "node_modules/@chainsafe/ssz": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.11.0.tgz",
-      "integrity": "sha512-osjFURtWTk3QH73bEoU9E7XTQmYHmX+dm24btUEoaTMyaKEhaMhI0Q98BYe8M/wTdxarUV7+f2A05Im5gHlk0w==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.11.1.tgz",
+      "integrity": "sha512-cB8dBkgGN6ZoeOKuk+rIRHKN0L5i9JLGeC0Lui71QX0TuLcQKwgbfkUexpyJxnGFatWf8yeJxlOjozMn/OTP0g==",
       "dependencies": {
-        "@chainsafe/as-sha256": "^0.4.0",
-        "@chainsafe/persistent-merkle-tree": "^0.6.0"
+        "@chainsafe/as-sha256": "^0.4.1",
+        "@chainsafe/persistent-merkle-tree": "^0.6.1"
       }
     },
     "node_modules/@colors/colors": {
@@ -20078,7 +20078,7 @@
       "version": "4.1.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "@chainsafe/ssz": "^0.11.0",
+        "@chainsafe/ssz": "^0.11.1",
         "@ethereumjs/common": "^3.1.1",
         "@ethereumjs/rlp": "^4.0.1",
         "@ethereumjs/util": "^8.0.5",
@@ -20108,7 +20108,7 @@
       "version": "8.0.5",
       "license": "MPL-2.0",
       "dependencies": {
-        "@chainsafe/ssz": "^0.11.0",
+        "@chainsafe/ssz": "^0.11.1",
         "@ethereumjs/rlp": "^4.0.1",
         "ethereum-cryptography": "^2.0.0",
         "micro-ftch": "^0.3.1"
@@ -21477,9 +21477,9 @@
       "dev": true
     },
     "@chainsafe/as-sha256": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.4.0.tgz",
-      "integrity": "sha512-2bFmA0JLDAXZqrmOQqrri0aeAgfdpk/kPays862raEG80nr45gyDM1BfI+HeaAvQMWgBDGoqAdFJTSb6+/DdeQ=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-0.4.1.tgz",
+      "integrity": "sha512-IqeeGwQihK6Y2EYLFofqs2eY2ep1I2MvQXHzOAI+5iQN51OZlUkrLgyAugu2x86xZewDk5xas7lNczkzFzF62w=="
     },
     "@chainsafe/libp2p-noise": {
       "version": "4.1.2",
@@ -21543,21 +21543,21 @@
       }
     },
     "@chainsafe/persistent-merkle-tree": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.6.0.tgz",
-      "integrity": "sha512-OHDu/ZyjbsSHBTr2fbkeZG2qWfBvLrSJweCNwPsTcngi62Z7xaI0bLtBH69Q1QuvOYzJd2eNqseq5a58SZE1Xw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.6.1.tgz",
+      "integrity": "sha512-gcENLemRR13+1MED2NeZBMA7FRS0xQPM7L2vhMqvKkjqtFT4YfjSVADq5U0iLuQLhFUJEMVuA8fbv5v+TN6O9A==",
       "requires": {
-        "@chainsafe/as-sha256": "^0.4.0",
+        "@chainsafe/as-sha256": "^0.4.1",
         "@noble/hashes": "^1.3.0"
       }
     },
     "@chainsafe/ssz": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.11.0.tgz",
-      "integrity": "sha512-osjFURtWTk3QH73bEoU9E7XTQmYHmX+dm24btUEoaTMyaKEhaMhI0Q98BYe8M/wTdxarUV7+f2A05Im5gHlk0w==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/ssz/-/ssz-0.11.1.tgz",
+      "integrity": "sha512-cB8dBkgGN6ZoeOKuk+rIRHKN0L5i9JLGeC0Lui71QX0TuLcQKwgbfkUexpyJxnGFatWf8yeJxlOjozMn/OTP0g==",
       "requires": {
-        "@chainsafe/as-sha256": "^0.4.0",
-        "@chainsafe/persistent-merkle-tree": "^0.6.0"
+        "@chainsafe/as-sha256": "^0.4.1",
+        "@chainsafe/persistent-merkle-tree": "^0.6.1"
       }
     },
     "@colors/colors": {
@@ -21965,7 +21965,7 @@
     "@ethereumjs/tx": {
       "version": "file:packages/tx",
       "requires": {
-        "@chainsafe/ssz": "^0.11.0",
+        "@chainsafe/ssz": "^0.11.1",
         "@ethereumjs/common": "^3.1.1",
         "@ethereumjs/rlp": "^4.0.1",
         "@ethereumjs/util": "^8.0.5",
@@ -21980,7 +21980,7 @@
     "@ethereumjs/util": {
       "version": "file:packages/util",
       "requires": {
-        "@chainsafe/ssz": "^0.11.0",
+        "@chainsafe/ssz": "^0.11.1",
         "@ethereumjs/rlp": "^4.0.1",
         "@types/bn.js": "^5.1.0",
         "@types/secp256k1": "^4.0.1",

--- a/packages/block/karma.conf.js
+++ b/packages/block/karma.conf.js
@@ -13,14 +13,6 @@ module.exports = function (config) {
         acornOptions: {
           ecmaVersion: 12,
         },
-        resolve: {
-          alias: {
-            '@chainsafe/persistent-merkle-tree/hasher':
-              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
-            '@chainsafe/as-sha256/hashObject':
-              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
-          },
-        },
       },
     },
     concurrency: 1,

--- a/packages/blockchain/karma.conf.js
+++ b/packages/blockchain/karma.conf.js
@@ -16,10 +16,6 @@ module.exports = function (config) {
         resolve: {
           alias: {
             'bigint-crypto-utils': '../../node_modules/bigint-crypto-utils/dist/bundle.umd.js',
-            '@chainsafe/persistent-merkle-tree/hasher':
-              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
-            '@chainsafe/as-sha256/hashObject':
-              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
           },
         },
       },

--- a/packages/client/karma.conf.js
+++ b/packages/client/karma.conf.js
@@ -26,10 +26,6 @@ module.exports = function (config) {
               '../../node_modules/multiformats/cjs/src/hashes/identity.js',
             'multiformats/hashes/sha2':
               '../../node_modules/multiformats/cjs/src/hashes/sha2-browser.js',
-            '@chainsafe/persistent-merkle-tree/hasher':
-              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
-            '@chainsafe/as-sha256/hashObject':
-              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
           },
         },
 

--- a/packages/common/karma.conf.js
+++ b/packages/common/karma.conf.js
@@ -13,14 +13,6 @@ module.exports = function (config) {
         acornOptions: {
           ecmaVersion: 12,
         },
-        resolve: {
-          alias: {
-            '@chainsafe/persistent-merkle-tree/hasher':
-              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
-            '@chainsafe/as-sha256/hashObject':
-              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
-          },
-        },
       },
     },
     concurrency: 1,

--- a/packages/evm/karma.conf.js
+++ b/packages/evm/karma.conf.js
@@ -29,10 +29,6 @@ module.exports = function (config) {
         resolve: {
           alias: {
             'bigint-crypto-utils': '../../node_modules/bigint-crypto-utils/dist/bundle.umd.js',
-            '@chainsafe/persistent-merkle-tree/hasher':
-              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
-            '@chainsafe/as-sha256/hashObject':
-              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
           },
         },
       },

--- a/packages/statemanager/karma.conf.js
+++ b/packages/statemanager/karma.conf.js
@@ -24,10 +24,6 @@ module.exports = function (config) {
         resolve: {
           alias: {
             'bigint-crypto-utils': '../../node_modules/bigint-crypto-utils/dist/bundle.umd.js',
-            '@chainsafe/persistent-merkle-tree/hasher':
-              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
-            '@chainsafe/as-sha256/hashObject':
-              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
           },
         },
       },

--- a/packages/trie/karma.conf.js
+++ b/packages/trie/karma.conf.js
@@ -16,10 +16,6 @@ module.exports = function (config) {
         resolve: {
           alias: {
             'bigint-crypto-utils': '../../node_modules/bigint-crypto-utils/dist/bundle.umd.js',
-            '@chainsafe/persistent-merkle-tree/hasher':
-              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
-            '@chainsafe/as-sha256/hashObject':
-              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
           },
         },
       },

--- a/packages/tx/karma.conf.js
+++ b/packages/tx/karma.conf.js
@@ -15,14 +15,6 @@ module.exports = function (config) {
         acornOptions: {
           ecmaVersion: 12,
         },
-        resolve: {
-          alias: {
-            '@chainsafe/persistent-merkle-tree/hasher':
-              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
-            '@chainsafe/as-sha256/hashObject':
-              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
-          },
-        },
       },
     },
     browsers: ['FirefoxHeadless', 'ChromeHeadless'],

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -51,7 +51,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^0.11.0",
+    "@chainsafe/ssz": "^0.11.1",
     "@ethereumjs/common": "^3.1.1",
     "@ethereumjs/rlp": "^4.0.1",
     "@ethereumjs/util": "^8.0.5",

--- a/packages/util/karma.conf.js
+++ b/packages/util/karma.conf.js
@@ -11,14 +11,6 @@ module.exports = function (config) {
         acornOptions: {
           ecmaVersion: 12,
         },
-        resolve: {
-          alias: {
-            '@chainsafe/persistent-merkle-tree/hasher':
-              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
-            '@chainsafe/as-sha256/hashObject':
-              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
-          },
-        },
       },
       tsconfig: './tsconfig.json',
     },

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -83,7 +83,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@chainsafe/ssz": "^0.11.0",
+    "@chainsafe/ssz": "^0.11.1",
     "@ethereumjs/rlp": "^4.0.1",
     "ethereum-cryptography": "^2.0.0",
     "micro-ftch": "^0.3.1"

--- a/packages/vm/karma.conf.js
+++ b/packages/vm/karma.conf.js
@@ -29,10 +29,6 @@ module.exports = function (config) {
         resolve: {
           alias: {
             'bigint-crypto-utils': '../../node_modules/bigint-crypto-utils/dist/bundle.umd.js',
-            '@chainsafe/persistent-merkle-tree/hasher':
-              '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble.js',
-            '@chainsafe/as-sha256/hashObject':
-              '../../node_modules/@chainsafe/as-sha256/lib/hashObject.js',
           },
         },
       },


### PR DESCRIPTION
Bump `@chainsafe/ssz` to `0.11.1`.

This allows for removal of `karma` aliasing needed with the previous version of the package. See https://github.com/ChainSafe/ssz/pull/318