### PR TITLE
common: Fix the block's fromValuesArray common refernces

### DIFF
--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -152,19 +152,20 @@ export class Block {
     if (values.length > 4) {
       throw new Error('invalid block. More values than expected were received')
     }
+
+    // First try to load header so that we can use its common (in case of hardforkByBlockNumber being activated)
+    // to correctly make checks on the hardforks
+    const [headerData, txsData, uhsData, withdrawalBytes] = values
+    const header = BlockHeader.fromValuesArray(headerData, opts)
+
     if (
-      opts?.common !== undefined &&
-      opts?.common?.isActivatedEIP(4895) &&
+      header._common.isActivatedEIP(4895) &&
       (values[3] === undefined || !Array.isArray(values[3]))
     ) {
       throw new Error(
         'Invalid serialized block input: EIP-4895 is active, and no withdrawals were provided as array'
       )
     }
-
-    const [headerData, txsData, uhsData, withdrawalBytes] = values
-
-    const header = BlockHeader.fromValuesArray(headerData, opts)
 
     // parse transactions
     const transactions = []


### PR DESCRIPTION
While running devnet5 ethereumjs started crashing on restarts with the error on genesis init

![image](https://user-images.githubusercontent.com/76567250/233703929-e71ec33e-a7d4-40b8-86d4-e84253204c28.png)


because genesis was not shanghai, but being past shanghai time it, the blockchain's/dbmanager's common was shanghai which was being passed in opts, but along with hardforkByBlock opts which was correctly setting hardfork for the header, but failing for block hf validations as it was not using the new updated and properly set header's hardfork

This PR fixes the bug

pre-devent5 genesis
 - https://github.com/ethpandaops/4844-testnet/blob/skylenet/prep-devnet-5/network-configs/devnet-5/genesis.json#L17


This PR is based off on

- https://github.com/ethereumjs/ethereumjs-monorepo/pull/2655

and hence should be merged after the above merges
