### PR TITLE
common: Rename shardingForkTime to cancunTime

### DIFF
--- a/packages/block/test/testdata/4844-hardfork.json
+++ b/packages/block/test/testdata/4844-hardfork.json
@@ -14,7 +14,7 @@
     "berlinBlock": 0,
     "londonBlock": 0,
     "shanghaiTime": 0,
-    "shardingForkTime": 0,
+    "cancunTime": 0,
     "clique": {
       "period": 5,
       "epoch": 30000

--- a/packages/client/devnets/4844-interop/config/genesis.json
+++ b/packages/client/devnets/4844-interop/config/genesis.json
@@ -20,7 +20,7 @@
 		"arrowGlacierBlock": 0,
 		"grayGlacierBlock": 0,
         "shanghaiTime": 1673487257,
-        "shardingForkTime": 1673487293,
+        "cancunTime": 1673487293,
 		"ethash": {
 		},
 		"terminalTotalDifficulty": 50

--- a/packages/client/devnets/4844-interop/lighthouse/genesis.json
+++ b/packages/client/devnets/4844-interop/lighthouse/genesis.json
@@ -13,7 +13,7 @@
     "londonBlock": 0,
     "mergeNetsplitBlock": 0,
     "shanghaiTime": 1674244123,
-    "shardingForkTime": 1674244219,
+    "cancunTime": 1674244219,
     "terminalTotalDifficulty": 80
   },
   "alloc": {

--- a/packages/client/devnets/4844-interop/lighthouse/setup.sh
+++ b/packages/client/devnets/4844-interop/lighthouse/setup.sh
@@ -56,5 +56,5 @@ CAPELLA_TIME=$((GENESIS_TIME + (CAPELLA_FORK_EPOCH * 32 * SECONDS_PER_SLOT)))
 EIP4844_TIME=$((GENESIS_TIME + (EIP4844_FORK_EPOCH * 32 * SECONDS_PER_SLOT)))
 
 sed -i 's/"shanghaiTime".*$/"shanghaiTime": '"$CAPELLA_TIME"',/g' $DATADIR/genesis.json
-sed -i 's/"shardingForkTime".*$/"shardingForkTime": '"$EIP4844_TIME"',/g' $DATADIR/genesis.json
+sed -i 's/"cancunTime".*$/"cancunTime": '"$EIP4844_TIME"',/g' $DATADIR/genesis.json
 cp $DATADIR/genesis.json $TESTNET_DIR/genesis.json

--- a/packages/client/devnets/4844-interop/prysm/genesisGEN.json
+++ b/packages/client/devnets/4844-interop/prysm/genesisGEN.json
@@ -20,7 +20,7 @@
     "arrowGlacierBlock": 0,
     "grayGlacierBlock": 0,
     "shanghaiTime": 1674239093,
-    "shardingForkTime": 1674239129,
+    "cancunTime": 1674239129,
     "ethash": {},
     "terminalTotalDifficulty": 50
   },

--- a/packages/client/devnets/4844-interop/prysm/prysm.json
+++ b/packages/client/devnets/4844-interop/prysm/prysm.json
@@ -20,7 +20,7 @@
 		"arrowGlacierBlock": 0,
 		"grayGlacierBlock": 0,
         "shanghaiTime": XXX,
-        "shardingForkTime": YYY,
+        "cancunTime": YYY,
 		"ethash": {
 		},
 		"terminalTotalDifficulty": 50

--- a/packages/client/test/sim/configs/sharding.json
+++ b/packages/client/test/sim/configs/sharding.json
@@ -15,7 +15,7 @@
     "berlinBlock": 0,
     "londonBlock": 0,
     "shanghaiTime": 0,
-    "shardingForkTime": 0,
+    "cancunTime": 0,
     "clique": {
       "period": 5,
       "epoch": 30000

--- a/packages/client/test/testdata/geth-genesis/eip4844.json
+++ b/packages/client/test/testdata/geth-genesis/eip4844.json
@@ -13,7 +13,7 @@
     "berlinBlock": 0,
     "londonBlock": 0,
     "shanghaiTime": 0,
-    "shardingForkTime": 0,
+    "cancunTime": 0,
     "clique": {
       "blockperiodseconds": 5,
       "epochlength": 30000

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -123,7 +123,7 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
     [Hardfork.London]: { name: 'londonBlock' },
     [Hardfork.MergeForkIdTransition]: { name: 'mergeForkBlock', postMerge: mergeForkIdPostMerge },
     [Hardfork.Shanghai]: { name: 'shanghaiTime', postMerge: true, isTimestamp: true },
-    [Hardfork.ShardingForkDev]: { name: 'shardingForkTime', postMerge: true, isTimestamp: true },
+    [Hardfork.ShardingForkDev]: { name: 'cancunTime', postMerge: true, isTimestamp: true },
   }
 
   // forkMapRev is the map from config field name to Hardfork

--- a/packages/common/test/timestamp.spec.ts
+++ b/packages/common/test/timestamp.spec.ts
@@ -30,7 +30,7 @@ tape('[Common]: Timestamp Hardfork logic', function (t: tape.Test) {
 
   t.test('schedule sharding on shanghai-time', function (st: tape.Test) {
     const config = Object.assign({}, timestampJson.config, {
-      shardingForkTime: timestampJson.config.shanghaiTime,
+      cancunTime: timestampJson.config.shanghaiTime,
     })
     const modifiedJson = Object.assign({}, timestampJson, { config })
     const c = Common.fromGethGenesis(modifiedJson, {
@@ -52,7 +52,7 @@ tape('[Common]: Timestamp Hardfork logic', function (t: tape.Test) {
 
   t.test('schedule sharding post shanghai-time', function (st: tape.Test) {
     const config = Object.assign({}, timestampJson.config, {
-      shardingForkTime: timestampJson.config.shanghaiTime + 1000,
+      cancunTime: timestampJson.config.shanghaiTime + 1000,
     })
     const modifiedJson = Object.assign({}, timestampJson, { config })
     const c = Common.fromGethGenesis(modifiedJson, {


### PR DESCRIPTION
from devnet5 onwards the `shardingForkTime` is renamed to `cancunTime` in genesis.json

This PR is build on
- https://github.com/ethereumjs/ethereumjs-monorepo/pull/2657

pls rebase and merge when #2657 is merged!

devnet 5 genesi: 
- https://github.com/ethpandaops/4844-testnet/blob/skylenet/prep-devnet-5/network-configs/devnet-5/genesis.json#L17