### PR TITLE
Migrate `fromEthersProvider` to `fromJsonRpcProvider` constructors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14189,16 +14189,16 @@
       "license": "MIT"
     },
     "node_modules/quibble": {
-      "version": "0.6.14",
+      "version": "0.6.17",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.17.tgz",
+      "integrity": "sha512-uybGnGrx1hAhBCmzmVny+ycKaS5F71+q+iWVzbf8x/HyeEMDGeiQFVjWl1zhi4rwfTHa05+/NIExC4L5YRNPjQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
-        "resolve": "^1.20.0"
+        "resolve": "^1.22.1"
       },
       "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
+        "node": ">= 0.14.0"
       }
     },
     "node_modules/quick-format-unescaped": {
@@ -16520,17 +16520,18 @@
       }
     },
     "node_modules/testdouble": {
-      "version": "3.16.6",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.17.2.tgz",
+      "integrity": "sha512-oRrk1DJISNoFr3aaczIqrrhkOUQ26BsXN3SopYT/U0GTvk9hlKPCEbd9R2uxkcufKZgEfo9D1JAB4CJrjHE9cw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "lodash": "^4.17.15",
-        "quibble": "^0.6.7",
+        "lodash": "^4.17.21",
+        "quibble": "^0.6.17",
         "stringify-object-es5": "^2.5.0",
         "theredoc": "^1.0.0"
       },
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/testdouble-timers": {
@@ -17822,12 +17823,12 @@
         "@ethereumjs/trie": "^5.0.4",
         "@ethereumjs/tx": "^4.1.1",
         "@ethereumjs/util": "^8.0.5",
-        "ethereum-cryptography": "^1.1.2",
-        "ethers": "^5.7.1"
+        "ethereum-cryptography": "^1.1.2"
       },
       "devDependencies": {
         "@types/lru-cache": "^5.1.0",
-        "c-kzg": "^2.0.4"
+        "c-kzg": "^2.0.4",
+        "testdouble": "^3.17.2"
       },
       "engines": {
         "node": ">=14"
@@ -18121,7 +18122,6 @@
       "dependencies": {
         "@ethereumjs/common": "^3.1.1",
         "@ethereumjs/util": "^8.0.5",
-        "@ethersproject/providers": "^5.7.1",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^1.1.2",
         "mcl-wasm": "^0.7.1",
@@ -18129,7 +18129,6 @@
       },
       "devDependencies": {
         "@ethereumjs/statemanager": "^1.0.4",
-        "@ethersproject/abi": "^5.0.12",
         "@types/benchmark": "^1.0.33",
         "@types/core-js": "^2.5.0",
         "@types/lru-cache": "^5.1.0",
@@ -18249,14 +18248,14 @@
         "@ethereumjs/common": "^3.1.1",
         "@ethereumjs/rlp": "^4.0.1",
         "@ethereumjs/util": "^8.0.5",
-        "@ethersproject/providers": "^5.7.2",
         "ethereum-cryptography": "^1.1.2"
       },
       "devDependencies": {
         "@types/minimist": "^1.2.0",
         "@types/node-dir": "^0.0.34",
         "minimist": "^1.2.0",
-        "node-dir": "^0.1.16"
+        "node-dir": "^0.1.16",
+        "testdouble": "^3.17.2"
       },
       "engines": {
         "node": ">=14"
@@ -19558,7 +19557,7 @@
         "@types/lru-cache": "^5.1.0",
         "c-kzg": "^2.0.4",
         "ethereum-cryptography": "^1.1.2",
-        "ethers": "^5.7.1"
+        "testdouble": "^3.17.2"
       }
     },
     "@ethereumjs/blockchain": {
@@ -19779,8 +19778,6 @@
         "@ethereumjs/common": "^3.1.1",
         "@ethereumjs/statemanager": "^1.0.4",
         "@ethereumjs/util": "^8.0.5",
-        "@ethersproject/abi": "^5.0.12",
-        "@ethersproject/providers": "^5.7.1",
         "@types/benchmark": "^1.0.33",
         "@types/core-js": "^2.5.0",
         "@types/lru-cache": "^5.1.0",
@@ -19875,12 +19872,12 @@
         "@ethereumjs/common": "^3.1.1",
         "@ethereumjs/rlp": "^4.0.1",
         "@ethereumjs/util": "^8.0.5",
-        "@ethersproject/providers": "^5.7.2",
         "@types/minimist": "^1.2.0",
         "@types/node-dir": "^0.0.34",
         "ethereum-cryptography": "^1.1.2",
         "minimist": "^1.2.0",
-        "node-dir": "^0.1.16"
+        "node-dir": "^0.1.16",
+        "testdouble": "^3.17.2"
       }
     },
     "@ethereumjs/util": {
@@ -28275,11 +28272,13 @@
       "dev": true
     },
     "quibble": {
-      "version": "0.6.14",
+      "version": "0.6.17",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.17.tgz",
+      "integrity": "sha512-uybGnGrx1hAhBCmzmVny+ycKaS5F71+q+iWVzbf8x/HyeEMDGeiQFVjWl1zhi4rwfTHa05+/NIExC4L5YRNPjQ==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.21",
-        "resolve": "^1.20.0"
+        "resolve": "^1.22.1"
       }
     },
     "quick-format-unescaped": {
@@ -29856,11 +29855,13 @@
       }
     },
     "testdouble": {
-      "version": "3.16.6",
+      "version": "3.17.2",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.17.2.tgz",
+      "integrity": "sha512-oRrk1DJISNoFr3aaczIqrrhkOUQ26BsXN3SopYT/U0GTvk9hlKPCEbd9R2uxkcufKZgEfo9D1JAB4CJrjHE9cw==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.15",
-        "quibble": "^0.6.7",
+        "lodash": "^4.17.21",
+        "quibble": "^0.6.17",
         "stringify-object-es5": "^2.5.0",
         "theredoc": "^1.0.0"
       }

--- a/packages/block/README.md
+++ b/packages/block/README.md
@@ -31,7 +31,7 @@ There are five static factories to instantiate a `Block`:
 - `Block.fromRLPSerializedBlock(serialized: Buffer, opts?: BlockOptions)`
 - `Block.fromValuesArray(values: BlockBuffer, opts?: BlockOptions)`
 - `Block.fromRPC(blockData: JsonRpcBlock, uncles?: any[], opts?: BlockOptions)`
-- `Block.fromEthersProvider(provider: ethers.providers.JsonRpcProvider | string, blockTag: string | bigint, opts: BlockOptions)`
+- `Block.fromJsonRpcProvider(provider: ethers.providers.JsonRpcProvider | string, blockTag: string | bigint, opts: BlockOptions)`
 
 For `BlockHeader` instantiation analog factory methods exists, see API docs linked below.
 

--- a/packages/block/README.md
+++ b/packages/block/README.md
@@ -31,7 +31,7 @@ There are five static factories to instantiate a `Block`:
 - `Block.fromRLPSerializedBlock(serialized: Buffer, opts?: BlockOptions)`
 - `Block.fromValuesArray(values: BlockBuffer, opts?: BlockOptions)`
 - `Block.fromRPC(blockData: JsonRpcBlock, uncles?: any[], opts?: BlockOptions)`
-- `Block.fromJsonRpcProvider(provider: ethers.providers.JsonRpcProvider | string, blockTag: string | bigint, opts: BlockOptions)`
+- `Block.fromJsonRpcProvider(provider: string | EthersProvider, blockTag: string | bigint, opts: BlockOptions)`
 
 For `BlockHeader` instantiation analog factory methods exists, see API docs linked below.
 

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -43,12 +43,12 @@
     "@ethereumjs/trie": "^5.0.4",
     "@ethereumjs/tx": "^4.1.1",
     "@ethereumjs/util": "^8.0.5",
-    "ethereum-cryptography": "^1.1.2",
-    "ethers": "^5.7.1"
+    "ethereum-cryptography": "^1.1.2"
   },
   "devDependencies": {
     "@types/lru-cache": "^5.1.0",
-    "c-kzg": "^2.0.4"
+    "c-kzg": "^2.0.4",
+    "testdouble": "^3.17.2"
   },
   "engines": {
     "node": ">=14"

--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -8,12 +8,13 @@ import {
   bigIntToHex,
   bytesToHex,
   equalsBytes,
+  fetchFromProvider,
+  getProvider,
   intToHex,
   isHexPrefixed,
   ssz,
 } from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak'
-import { ethers } from 'ethers'
 
 import { blockFromRpc } from './from-rpc'
 import { BlockHeader } from './header'
@@ -223,44 +224,57 @@ export class Block {
   }
 
   /**
-   *  Method to retrieve a block from the provider and format as a {@link Block}
-   * @param provider an Ethers JsonRPCProvider
+   *  Method to retrieve a block from a JSON-RPC provider and format as a {@link Block}
+   * @param provider either a url for a remote provider or an Ethers JsonRpcProvider object
    * @param blockTag block hash or block number to be run
    * @param opts {@link BlockOptions}
    * @returns the block specified by `blockTag`
    */
-  public static fromEthersProvider = async (
-    provider: ethers.providers.JsonRpcProvider | string,
+  public static fromJsonRpcProvider = async (
+    provider: any,
     blockTag: string | bigint,
     opts: BlockOptions
   ) => {
     let blockData
-    const prov =
-      typeof provider === 'string' ? new ethers.providers.JsonRpcProvider(provider) : provider
+    const providerUrl = getProvider(provider)
+
     if (typeof blockTag === 'string' && blockTag.length === 66) {
-      blockData = await prov.send('eth_getBlockByHash', [blockTag, true])
+      blockData = await fetchFromProvider(providerUrl, {
+        method: 'eth_getBlockByHash',
+        params: [blockTag, true],
+      })
     } else if (typeof blockTag === 'bigint') {
-      blockData = await prov.send('eth_getBlockByNumber', [bigIntToHex(blockTag), true])
+      blockData = await fetchFromProvider(providerUrl, {
+        method: 'eth_getBlockByNumber',
+        params: [bigIntToHex(blockTag), true],
+      })
     } else if (
       isHexPrefixed(blockTag) ||
       blockTag === 'latest' ||
       blockTag === 'earliest' ||
       blockTag === 'pending'
     ) {
-      blockData = await prov.send('eth_getBlockByNumber', [blockTag, true])
+      blockData = await fetchFromProvider(providerUrl, {
+        method: 'eth_getBlockByNumber',
+        params: [blockTag, true],
+      })
     } else {
       throw new Error(
         `expected blockTag to be block hash, bigint, hex prefixed string, or earliest/latest/pending; got ${blockTag}`
       )
     }
 
+    if (blockData === null) {
+      throw new Error('No block data returned from provider')
+    }
+
     const uncleHeaders = []
     if (blockData.uncles.length > 0) {
       for (let x = 0; x < blockData.uncles.length; x++) {
-        const headerData = await prov.send('eth_getUncleByBlockHashAndIndex', [
-          blockData.hash,
-          intToHex(x),
-        ])
+        const headerData = await fetchFromProvider(providerUrl, {
+          method: 'eth_getUncleByBlockHashAndIndex',
+          params: [blockData.hash, intToHex(x)],
+        })
         uncleHeaders.push(headerData)
       }
     }

--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -28,7 +28,7 @@ import type {
   TxOptions,
   TypedTransaction,
 } from '@ethereumjs/tx'
-import type { WithdrawalBytes } from '@ethereumjs/util'
+import type { EthersProvider, WithdrawalBytes } from '@ethereumjs/util'
 
 /**
  * An object that represents the block.
@@ -231,7 +231,7 @@ export class Block {
    * @returns the block specified by `blockTag`
    */
   public static fromJsonRpcProvider = async (
-    provider: any,
+    provider: string | EthersProvider,
     blockTag: string | bigint,
     opts: BlockOptions
   ) => {

--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -252,7 +252,9 @@ export class Block {
       isHexPrefixed(blockTag) ||
       blockTag === 'latest' ||
       blockTag === 'earliest' ||
-      blockTag === 'pending'
+      blockTag === 'pending' ||
+      blockTag === 'finalized' ||
+      blockTag === 'safe'
     ) {
       blockData = await fetchFromProvider(providerUrl, {
         method: 'eth_getBlockByNumber',

--- a/packages/block/test/from-rpc.spec.ts
+++ b/packages/block/test/from-rpc.spec.ts
@@ -8,7 +8,6 @@ import { blockFromRpc } from '../src/from-rpc'
 import { blockHeaderFromRpc } from '../src/header-from-rpc'
 import { Block } from '../src/index'
 
-import { MockProvider } from './mockProvider'
 import * as alchemy14151203 from './testdata/alchemy14151203.json'
 import * as infura15571241woTxs from './testdata/infura15571241.json'
 import * as infura15571241wTxs from './testdata/infura15571241wtxns.json'
@@ -188,7 +187,7 @@ tape('[fromRPC] - Alchemy/Infura API block responses', (t) => {
 
 tape('[fromJsonRpcProvider]', async (t) => {
   const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
-  const provider = new MockProvider() // mimics some properties of an Ethers JsonRPCProvider
+  const provider = 'https://my.json.rpc.provider.com:8545'
 
   const fakeFetch = async (_url: string, req: any) => {
     if (

--- a/packages/block/test/from-rpc.spec.ts
+++ b/packages/block/test/from-rpc.spec.ts
@@ -1,7 +1,8 @@
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
-import { bytesToPrefixedHexString, hexStringToBytes } from '@ethereumjs/util'
+import { bytesToPrefixedHexString, hexStringToBytes, randomBytes } from '@ethereumjs/util'
 import { bytesToHex, equalsBytes } from 'ethereum-cryptography/utils'
 import * as tape from 'tape'
+import * as td from 'testdouble'
 
 import { blockFromRpc } from '../src/from-rpc'
 import { blockHeaderFromRpc } from '../src/header-from-rpc'
@@ -185,15 +186,41 @@ tape('[fromRPC] - Alchemy/Infura API block responses', (t) => {
   t.end()
 })
 
-tape('[fromEthersProvider]', async (t) => {
+tape('[fromJsonRpcProvider]', async (t) => {
   const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
-  const provider = new MockProvider()
+  const provider = new MockProvider() // mimics some properties of an Ethers JsonRPCProvider
+
+  const fakeFetch = async (_url: string, req: any) => {
+    if (
+      req.method === 'eth_getBlockByHash' &&
+      req.params[0] === '0x1850b014065b23d804ecf71a8a4691d076ca87c2e6fb8fe81ee20a4d8e884c24'
+    ) {
+      const block = await import(`./testdata/infura15571241wtxns.json`)
+      return block
+    } else {
+      return null // Infura returns null if no block is found
+    }
+  }
+
+  const providerUtils = require('@ethereumjs/util/dist/provider')
+  td.replace<any>(providerUtils, 'fetchFromProvider', fakeFetch)
+
   const blockHash = '0x1850b014065b23d804ecf71a8a4691d076ca87c2e6fb8fe81ee20a4d8e884c24'
-  const block = await Block.fromEthersProvider(provider, blockHash, { common })
+  const block = await Block.fromJsonRpcProvider(provider, blockHash, { common })
   t.equal(
     bytesToPrefixedHexString(block.hash()),
     blockHash,
     'assembled a block from blockdata from a provider'
   )
+  try {
+    await Block.fromJsonRpcProvider(provider, bytesToPrefixedHexString(randomBytes(32)), {})
+    t.fail('should throw')
+  } catch (err: any) {
+    t.ok(
+      err.message.includes('No block data returned from provider'),
+      'returned correct error message'
+    )
+  }
+  td.reset()
   t.end()
 })

--- a/packages/block/test/mockProvider.ts
+++ b/packages/block/test/mockProvider.ts
@@ -1,19 +1,5 @@
-import { ethers } from 'ethers'
-
-export class MockProvider extends ethers.providers.JsonRpcProvider {
-  send = async (method: string, params: Array<any>) => {
-    switch (method) {
-      case 'eth_getBlockByHash':
-        return this.getBlockValues(params as any)
-      case 'eth_chainId': // Always pretends to be mainnet
-        return 1
-      default:
-        throw new Error(`method ${method} not implemented`)
-    }
-  }
-
-  private getBlockValues = async (_params: any) => {
-    const block = await import(`./testdata/infura15571241wtxns.json`)
-    return block
+export class MockProvider {
+  connection = {
+    url: 'http://localhost',
   }
 }

--- a/packages/block/test/mockProvider.ts
+++ b/packages/block/test/mockProvider.ts
@@ -1,5 +1,0 @@
-export class MockProvider {
-  connection = {
-    url: 'http://localhost',
-  }
-}

--- a/packages/client/test/net/peer/libp2pnode.spec.ts
+++ b/packages/client/test/net/peer/libp2pnode.spec.ts
@@ -2,7 +2,7 @@ import * as tape from 'tape'
 import * as td from 'testdouble'
 
 tape('[Libp2pNode]', async (t) => {
-  const _libp2p = td.replace('libp2p')
+  td.replace('libp2p')
   const { Libp2pNode } = await import('../../../lib/net/peer/libp2pnode')
 
   t.test('should be a libp2p bundle', (t) => {

--- a/packages/client/test/net/peer/libp2ppeer.spec.ts
+++ b/packages/client/test/net/peer/libp2ppeer.spec.ts
@@ -9,11 +9,11 @@ import type { Libp2pPeer } from '../../../lib/net/peer'
 import type { Protocol } from '../../../lib/net/protocol'
 
 tape('[Libp2pPeer]', async (t) => {
-  const _PeerId = td.replace('peer-id')
+  td.replace('peer-id')
 
   const Libp2pNode = td.constructor(['start', 'stop', 'dial', 'dialProtocol'] as any)
   td.replace('../../../lib/net/peer/libp2pnode', { Libp2pNode })
-  const Libp2pSender = td.replace('../../../lib/net/protocol/libp2psender')
+  const Libp2pSender = td.replace<any>('../../../lib/net/protocol/libp2psender')
 
   td.when(Libp2pNode.prototype.start()).thenResolve(null)
   td.when(Libp2pNode.prototype.dial(td.matchers.anything())).thenResolve(null)

--- a/packages/client/test/net/peerpool.spec.ts
+++ b/packages/client/test/net/peerpool.spec.ts
@@ -9,7 +9,7 @@ import { MockPeer } from '../integration/mocks/mockpeer'
 import type { RlpxServer } from '../../lib/net/server'
 
 tape('[PeerPool]', async (t) => {
-  const Peer = td.replace('../../lib/net/peer/peer', function (this: any, id: string) {
+  const Peer = td.replace<any>('../../lib/net/peer/peer', function (this: any, id: string) {
     this.id = id // eslint-disable-line no-invalid-this
   })
   const { PeerPool } = await import('../../lib/net/peerpool')

--- a/packages/client/test/net/server/libp2pserver.spec.ts
+++ b/packages/client/test/net/server/libp2pserver.spec.ts
@@ -10,7 +10,7 @@ import { Event } from '../../../lib/types'
 import { wait } from '../../integration/util'
 
 tape('[Libp2pServer]', async (t) => {
-  const Libp2pPeer = td.replace('../../../lib/net/peer/libp2ppeer')
+  const Libp2pPeer = td.replace<any>('../../../lib/net/peer/libp2ppeer')
   Libp2pPeer.id = 'id0'
 
   class Libp2pNode extends EventEmitter {

--- a/packages/devp2p/test/dns.spec.ts
+++ b/packages/devp2p/test/dns.spec.ts
@@ -7,7 +7,7 @@ import * as testdata from './testdata.json'
 
 tape('DNS', async (t) => {
   const mockData = testdata.dns
-  const mockDns = td.replace('dns')
+  const mockDns = td.replace<any>('dns')
 
   let dns: DNS
   function initializeDns() {

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "@ethereumjs/common": "^3.1.1",
     "@ethereumjs/util": "^8.0.5",
-    "@ethersproject/providers": "^5.7.1",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^1.1.2",
     "mcl-wasm": "^0.7.1",
@@ -57,7 +56,6 @@
   },
   "devDependencies": {
     "@ethereumjs/statemanager": "^1.0.4",
-    "@ethersproject/abi": "^5.0.12",
     "@types/benchmark": "^1.0.33",
     "@types/core-js": "^2.5.0",
     "@types/lru-cache": "^5.1.0",

--- a/packages/statemanager/test/ethersStateManager.spec.ts
+++ b/packages/statemanager/test/ethersStateManager.spec.ts
@@ -145,7 +145,7 @@ tape('Ethers State Manager API tests', async (t) => {
     t.ok(await state.accountExists(vitalikDotEth), 'account should not exist after being deleted')
 
     try {
-      await Block.fromEthersProvider(provider, 'fakeBlockTag', {} as any)
+      await Block.fromJsonRpcProvider(provider, 'fakeBlockTag', {} as any)
       t.fail('should have thrown')
     } catch (err: any) {
       t.ok(
@@ -225,7 +225,7 @@ tape('runTx test: replay mainnet transactions', async (t) => {
     const blockTag = 15496077n
     common.setHardforkByBlockNumber(blockTag)
     const txHash = '0xed1960aa7d0d7b567c946d94331dddb37a1c67f51f30bf51f256ea40db88cfb0'
-    const tx = await TransactionFactory.fromEthersProvider(provider, txHash, { common })
+    const tx = await TransactionFactory.fromJsonRpcProvider(provider, txHash, { common })
     const state = new EthersStateManager({
       provider,
       // Set the state manager to look at the state of the chain before the block has been executed
@@ -260,7 +260,7 @@ tape('runBlock test', async (t) => {
     common.setHardforkByBlockNumber(blockTag - 1n)
 
     const vm = await VM.create({ common, stateManager: state })
-    const block = await Block.fromEthersProvider(provider, blockTag, { common })
+    const block = await Block.fromJsonRpcProvider(provider, blockTag, { common })
     try {
       const res = await vm.runBlock({
         block,

--- a/packages/statemanager/test/ethersStateManager.spec.ts
+++ b/packages/statemanager/test/ethersStateManager.spec.ts
@@ -36,9 +36,8 @@ tape('Ethers State Manager initialization tests', (t) => {
   state = new EthersStateManager({ provider, blockTag: 1n })
   t.equal((state as any).blockTag, '0x1', 'State Manager instantiated with predefined blocktag')
 
-  state = new EthersStateManager({ provider: 'http://localhost:8545', blockTag: 1n })
+  state = new EthersStateManager({ provider: 'https://google.com', blockTag: 1n })
   t.ok(state instanceof EthersStateManager, 'was able to instantiate state manager with valid url')
-
   const invalidProvider = new BaseProvider('mainnet')
   t.throws(
     () => new EthersStateManager({ provider: invalidProvider as any, blockTag: 1n }),
@@ -224,8 +223,8 @@ tape('runTx test: replay mainnet transactions', async (t) => {
 
     const blockTag = 15496077n
     common.setHardforkByBlockNumber(blockTag)
-    const txHash = '0xed1960aa7d0d7b567c946d94331dddb37a1c67f51f30bf51f256ea40db88cfb0'
-    const tx = await TransactionFactory.fromJsonRpcProvider(provider, txHash, { common })
+    const txData = require('./testdata/providerData/transactions/0xed1960aa7d0d7b567c946d94331dddb37a1c67f51f30bf51f256ea40db88cfb0.json')
+    const tx = await TransactionFactory.fromRPCTx(txData, { common })
     const state = new EthersStateManager({
       provider,
       // Set the state manager to look at the state of the chain before the block has been executed
@@ -260,7 +259,8 @@ tape('runBlock test', async (t) => {
     common.setHardforkByBlockNumber(blockTag - 1n)
 
     const vm = await VM.create({ common, stateManager: state })
-    const block = await Block.fromJsonRpcProvider(provider, blockTag, { common })
+    const blockData = require('./testdata/providerData/blocks/block0x7a120.json')
+    const block = Block.fromRPC(blockData, [], { common })
     try {
       const res = await vm.runBlock({
         block,

--- a/packages/statemanager/test/ethersStateManager.spec.ts
+++ b/packages/statemanager/test/ethersStateManager.spec.ts
@@ -38,6 +38,7 @@ tape('Ethers State Manager initialization tests', (t) => {
 
   state = new EthersStateManager({ provider: 'https://google.com', blockTag: 1n })
   t.ok(state instanceof EthersStateManager, 'was able to instantiate state manager with valid url')
+
   const invalidProvider = new BaseProvider('mainnet')
   t.throws(
     () => new EthersStateManager({ provider: invalidProvider as any, blockTag: 1n }),

--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -282,7 +282,7 @@ The correct tx type class for instantiation will then be chosen on runtime based
 - `public static fromTxData(txData: TxData | AccessListEIP2930TxData, txOptions: TxOptions = {}): TypedTransaction`
 - `public static fromSerializedData(data: Buffer, txOptions: TxOptions = {}): TypedTransaction`
 - `public static fromBlockBodyData(data: Buffer | Buffer[], txOptions: TxOptions = {})`
-- `public static async fromJsonRpcProvider(provider: string | ethers.providers.JsonRpcProvider, txHash: string, txOptions?: TxOptions)`
+- `public static async fromJsonRpcProvider(provider: string | EthersProvider, txHash: string, txOptions?: TxOptions)`
 
 ### Sending a Transaction
 

--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -282,7 +282,7 @@ The correct tx type class for instantiation will then be chosen on runtime based
 - `public static fromTxData(txData: TxData | AccessListEIP2930TxData, txOptions: TxOptions = {}): TypedTransaction`
 - `public static fromSerializedData(data: Buffer, txOptions: TxOptions = {}): TypedTransaction`
 - `public static fromBlockBodyData(data: Buffer | Buffer[], txOptions: TxOptions = {})`
-- `public static async fromEthersProvider(provider: string | ethers.providers.JsonRpcProvider, txHash: string, txOptions?: TxOptions)`
+- `public static async fromJsonRpcProvider(provider: string | ethers.providers.JsonRpcProvider, txHash: string, txOptions?: TxOptions)`
 
 ### Sending a Transaction
 

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -55,8 +55,7 @@
     "@ethereumjs/common": "^3.1.1",
     "@ethereumjs/rlp": "^4.0.1",
     "@ethereumjs/util": "^8.0.5",
-    "ethereum-cryptography": "^1.1.2",
-    "@ethersproject/providers": "^5.7.2"
+    "ethereum-cryptography": "^1.1.2"
   },
   "peerDependencies": {
     "c-kzg": "^2.0.4"
@@ -70,7 +69,8 @@
     "@types/minimist": "^1.2.0",
     "@types/node-dir": "^0.0.34",
     "minimist": "^1.2.0",
-    "node-dir": "^0.1.16"
+    "node-dir": "^0.1.16",
+    "testdouble": "^3.17.2"
   },
   "engines": {
     "node": ">=14"

--- a/packages/tx/src/transactionFactory.ts
+++ b/packages/tx/src/transactionFactory.ts
@@ -1,5 +1,4 @@
-import { bytesToBigInt, toBytes } from '@ethereumjs/util'
-import { JsonRpcProvider } from '@ethersproject/providers'
+import { bytesToBigInt, fetchFromProvider, getProvider, toBytes } from '@ethereumjs/util'
 
 import { FeeMarketEIP1559Transaction } from './eip1559Transaction'
 import { AccessListEIP2930Transaction } from './eip2930Transaction'
@@ -95,18 +94,24 @@ export class TransactionFactory {
 
   /**
    *  Method to retrieve a transaction from the provider
-   * @param provider - An Ethers JsonRPCProvider
+   * @param provider - a url string for a JSON-RPC provider or an Ethers JsonRPCProvider object
    * @param txHash - Transaction hash
    * @param txOptions - The transaction options
    * @returns the transaction specified by `txHash`
    */
-  public static async fromEthersProvider(
-    provider: string | JsonRpcProvider,
+  public static async fromJsonRpcProvider(
+    provider: string | any,
     txHash: string,
     txOptions?: TxOptions
   ) {
-    const prov = typeof provider === 'string' ? new JsonRpcProvider(provider) : provider
-    const txData = await prov.send('eth_getTransactionByHash', [txHash])
+    const prov = getProvider(provider)
+    const txData = await fetchFromProvider(prov, {
+      method: 'eth_getTransactionByHash',
+      params: [txHash],
+    })
+    if (txData === null) {
+      throw new Error('No data returned from provider')
+    }
     return TransactionFactory.fromRPCTx(txData, txOptions)
   }
 

--- a/packages/tx/src/transactionFactory.ts
+++ b/packages/tx/src/transactionFactory.ts
@@ -14,6 +14,7 @@ import type {
   TxOptions,
   TypedTransaction,
 } from './types'
+import type { EthersProvider } from '@ethereumjs/util'
 
 export class TransactionFactory {
   // It is not possible to instantiate a TransactionFactory object.
@@ -100,7 +101,7 @@ export class TransactionFactory {
    * @returns the transaction specified by `txHash`
    */
   public static async fromJsonRpcProvider(
-    provider: string | any,
+    provider: string | EthersProvider,
     txHash: string,
     txOptions?: TxOptions
   ) {

--- a/packages/tx/test/fromRpc.spec.ts
+++ b/packages/tx/test/fromRpc.spec.ts
@@ -6,8 +6,6 @@ import * as td from 'testdouble'
 import { TransactionFactory } from '../src'
 import { normalizeTxParams } from '../src/fromRpc'
 
-import { MockProvider } from './mockProvider'
-
 const optimismTx = require('./json/optimismTx.json')
 
 const txTypes = [0, 1, 2]
@@ -26,7 +24,7 @@ tape('[fromJsonRpcProvider]', async (t) => {
   }
 
   const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
-  const provider = new MockProvider()
+  const provider = 'https://my.json.rpc.provider.com:8545'
   const providerUtils = require('@ethereumjs/util/dist/provider')
   td.replace<any>(providerUtils, 'fetchFromProvider', fakeFetch)
   const txHash = '0xed1960aa7d0d7b567c946d94331dddb37a1c67f51f30bf51f256ea40db88cfb0'

--- a/packages/tx/test/fromRpc.spec.ts
+++ b/packages/tx/test/fromRpc.spec.ts
@@ -1,6 +1,7 @@
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
-import { bytesToHex, bytesToPrefixedHexString } from '@ethereumjs/util'
+import { bytesToHex, bytesToPrefixedHexString, randomBytes } from '@ethereumjs/util'
 import * as tape from 'tape'
+import * as td from 'testdouble'
 
 import { TransactionFactory } from '../src'
 import { normalizeTxParams } from '../src/fromRpc'
@@ -12,15 +13,43 @@ const optimismTx = require('./json/optimismTx.json')
 const txTypes = [0, 1, 2]
 
 tape('[fromEthersProvider]', async (t) => {
+  const fakeFetch = async (_url: string, req: any) => {
+    if (
+      req.method === 'eth_getTransactionByHash' &&
+      req.params[0] === '0xed1960aa7d0d7b567c946d94331dddb37a1c67f51f30bf51f256ea40db88cfb0'
+    ) {
+      const txData = await import(`./json/rpcTx.json`)
+      return txData
+    } else {
+      return null // This is the value Infura returns if no transaction is found matching the provided hash
+    }
+  }
+
   const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
   const provider = new MockProvider()
+  const providerUtils = require('@ethereumjs/util/dist/provider')
+  td.replace<any>(providerUtils, 'fetchFromProvider', fakeFetch)
   const txHash = '0xed1960aa7d0d7b567c946d94331dddb37a1c67f51f30bf51f256ea40db88cfb0'
-  const tx = await TransactionFactory.fromEthersProvider(provider, txHash, { common })
+  const tx = await TransactionFactory.fromJsonRpcProvider(provider, txHash, { common })
   t.equal(
     bytesToPrefixedHexString(tx.hash()),
     txHash,
     'generated correct tx from transaction RPC data'
   )
+  try {
+    await TransactionFactory.fromJsonRpcProvider(
+      provider,
+      bytesToPrefixedHexString(randomBytes(32)),
+      {}
+    )
+    t.fail('should throw')
+  } catch (err: any) {
+    t.ok(
+      err.message.includes('No data returned from provider'),
+      'throws correct error when no tx returned'
+    )
+  }
+  td.reset()
   t.end()
 })
 

--- a/packages/tx/test/fromRpc.spec.ts
+++ b/packages/tx/test/fromRpc.spec.ts
@@ -12,7 +12,7 @@ const optimismTx = require('./json/optimismTx.json')
 
 const txTypes = [0, 1, 2]
 
-tape('[fromEthersProvider]', async (t) => {
+tape('[fromJsonRpcProvider]', async (t) => {
   const fakeFetch = async (_url: string, req: any) => {
     if (
       req.method === 'eth_getTransactionByHash' &&

--- a/packages/tx/test/mockProvider.ts
+++ b/packages/tx/test/mockProvider.ts
@@ -1,19 +1,5 @@
-import { JsonRpcProvider } from '@ethersproject/providers'
-
-export class MockProvider extends JsonRpcProvider {
-  send = async (method: string, params: Array<any>) => {
-    switch (method) {
-      case 'eth_chainId': // Always pretends to be mainnet
-        return 1
-      case 'eth_getTransactionByHash':
-        return this.getTransactionData(params as any)
-      default:
-        throw new Error(`method ${method} not implemented`)
-    }
-  }
-
-  private getTransactionData = async (_params: [txHash: string]) => {
-    const txData = await import(`./json/rpcTx.json`)
-    return txData
+export class MockProvider {
+  connection = {
+    url: 'https://localhost',
   }
 }

--- a/packages/tx/test/mockProvider.ts
+++ b/packages/tx/test/mockProvider.ts
@@ -1,5 +1,0 @@
-export class MockProvider {
-  connection = {
-    url: 'https://localhost',
-  }
-}

--- a/packages/util/src/index.ts
+++ b/packages/util/src/index.ts
@@ -67,3 +67,4 @@ export {
 } from './internal'
 export * from './kzg'
 export * from './lock'
+export * from './provider'

--- a/packages/util/src/provider.ts
+++ b/packages/util/src/provider.ts
@@ -31,6 +31,15 @@ const nodeFetch = async (url: string, data: string) =>
     req.end(data)
   })
 
+/**
+ * Makes a simple RPC call to a remote Ethereum JSON-RPC provider and passes through the response.
+ * No parameter or response validation is done.
+ *
+ * @param url the URL for the JSON RPC provider
+ * @param params the parameters for the JSON-RPC method - refer to
+ * https://ethereum.org/en/developers/docs/apis/json-rpc/ for details on RPC methods
+ * @returns the `result` field from the JSON-RPC response
+ */
 export const fetchFromProvider = async (url: string, params: rpcParams) => {
   const data = JSON.stringify({
     method: params.method,
@@ -54,12 +63,28 @@ export const fetchFromProvider = async (url: string, params: rpcParams) => {
   }
 }
 
-export const getProvider = (provider: string | any) => {
+/**
+ *
+ * @param provider a URL string or {@link EthersProvider}
+ * @returns the extracted URL string for the JSON-RPC Provider
+ */
+export const getProvider = (provider: string | EthersProvider) => {
   if (typeof provider === 'string') {
     return provider
-  } else if (provider?.connection?.url !== undefined) {
+  } else if (provider.connection.url !== undefined) {
     return provider.connection.url
   } else {
     throw new Error('Must provide valid provider URL or Web3Provider')
+  }
+}
+
+/**
+ * A partial interface for an `ethers` `JsonRpcProvider`
+ * We only use the url string since we do raw `fetch` or `http` calls to
+ * retrieve the necessary data
+ */
+export interface EthersProvider {
+  connection: {
+    url: string
   }
 }

--- a/packages/util/src/provider.ts
+++ b/packages/util/src/provider.ts
@@ -1,0 +1,65 @@
+import * as https from 'https'
+
+type rpcParams = {
+  method: string
+  params: (string | boolean | number)[]
+}
+
+const nodeFetch = async (url: string, data: string) =>
+  new Promise((resolve, reject) => {
+    const options = {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+    }
+
+    const req = https
+      .request(url, options, (resp) => {
+        let data = ''
+        resp.on('data', (chunk) => {
+          data += chunk
+        })
+        resp.on('end', () => {
+          const res = JSON.parse(data)
+          resolve(res)
+        })
+      })
+      .on('error', (err) => {
+        reject(err.message)
+      })
+    req.end(data)
+  })
+
+export const fetchFromProvider = async (url: string, params: rpcParams) => {
+  const data = JSON.stringify({
+    method: params.method,
+    params: params.params,
+    jsonrpc: '2.0',
+    id: 1,
+  })
+  if (global.fetch !== undefined) {
+    const res = await fetch(url, {
+      headers: {
+        'content-type': 'application/json',
+      },
+      method: 'POST',
+      body: data,
+    })
+    const json = await res.json()
+    return json.result
+  } else {
+    const res: any = await nodeFetch(url, data)
+    return res.result
+  }
+}
+
+export const getProvider = (provider: string | any) => {
+  if (typeof provider === 'string') {
+    return provider
+  } else if (provider?.connection?.url !== undefined) {
+    return provider.connection.url
+  } else {
+    throw new Error('Must provide valid provider URL or Web3Provider')
+  }
+}

--- a/packages/util/src/provider.ts
+++ b/packages/util/src/provider.ts
@@ -71,7 +71,7 @@ export const fetchFromProvider = async (url: string, params: rpcParams) => {
 export const getProvider = (provider: string | EthersProvider) => {
   if (typeof provider === 'string') {
     return provider
-  } else if (provider.connection.url !== undefined) {
+  } else if (typeof provider === 'object' && provider.connection.url !== undefined) {
     return provider.connection.url
   } else {
     throw new Error('Must provide valid provider URL or Web3Provider')

--- a/packages/util/test/provider.spec.ts
+++ b/packages/util/test/provider.spec.ts
@@ -16,7 +16,7 @@ tape('getProvider', (t) => {
     'returned correct provider url string'
   )
   t.throws(
-    () => getProvider(1),
+    () => getProvider(<any>1),
     (err: any) => err.message.includes('Must provide valid provider URL or Web3Provider'),
     'throws correct error'
   )

--- a/packages/util/test/provider.spec.ts
+++ b/packages/util/test/provider.spec.ts
@@ -24,12 +24,6 @@ tape('getProvider', (t) => {
 })
 
 tape('fetchFromProvider', async (t) => {
-  // Hack to detect if running in browser or not
-  const isBrowser = new Function('try {return this===window;}catch(e){ return false;}')
-
-  // This test verifies that the fetch is attempted made to the correct provider URL in
-  // the nodejs test branch since trying to stub out `cross-fetch` seems to be impossible
-  // without introducing a new testing tool not used in the monorepo currently (e.g. jest)
   try {
     await fetchFromProvider(providerUrl, {
       method: 'eth_getBalance',
@@ -37,11 +31,11 @@ tape('fetchFromProvider', async (t) => {
     })
     t.fail('should throw')
   } catch (err: any) {
-    if (isBrowser() === true) {
-      t.pass('tries to fetch')
+    if (global.fetch !== undefined) {
+      t.ok(err.message.includes('fetch'), 'tried to fetch and failed')
     } else {
       t.ok(
-        err.message.includes(providerUrl.split('//')[1]),
+        err.toString().includes(providerUrl.split('//')[1]),
         'tries to fetch from specified provider url'
       )
     }

--- a/packages/util/test/provider.spec.ts
+++ b/packages/util/test/provider.spec.ts
@@ -1,0 +1,49 @@
+import * as tape from 'tape'
+
+import { fetchFromProvider, getProvider } from '../src'
+
+const providerUrl = 'https://myfakeprovider.com'
+const fakeEthersProvider = {
+  connection: {
+    url: 'https://myfakeethersprovider.com/rpc',
+  },
+}
+tape('getProvider', (t) => {
+  t.equal(getProvider(providerUrl), providerUrl, 'returned correct provider url string')
+  t.equal(
+    getProvider(fakeEthersProvider),
+    fakeEthersProvider.connection.url,
+    'returned correct provider url string'
+  )
+  t.throws(
+    () => getProvider(1),
+    (err: any) => err.message.includes('Must provide valid provider URL or Web3Provider'),
+    'throws correct error'
+  )
+  t.end()
+})
+
+tape('fetchFromProvider', async (t) => {
+  // Hack to detect if running in browser or not
+  const isBrowser = new Function('try {return this===window;}catch(e){ return false;}')
+
+  // This test verifies that the fetch is attempted made to the correct provider URL in
+  // the nodejs test branch since trying to stub out `cross-fetch` seems to be impossible
+  // without introducing a new testing tool not used in the monorepo currently (e.g. jest)
+  try {
+    await fetchFromProvider(providerUrl, {
+      method: 'eth_getBalance',
+      params: ['0xabcd'],
+    })
+    t.fail('should throw')
+  } catch (err: any) {
+    if (isBrowser() === true) {
+      t.pass('tries to fetch')
+    } else {
+      t.ok(
+        err.message.includes(providerUrl.split('//')[1]),
+        'tries to fetch from specified provider url'
+      )
+    }
+  }
+})


### PR DESCRIPTION
This PR, when complete, will replace the `fromEthersProvider` static constructors in `block` and `tx` with a more generalized `fromJsonRpcProvider` constructor that will take the URL string for a JSON-RPC provider and then fetch the corresponding block or tx from the provider using native `fetch` or `http` request and will also remove the` micro-ftch` dependency which requires several polyfills in a browser/webpack context (i.e. `zlib-browserify`,`https-browserify`, and `stream-http`).

- [x] Rewrite `fetchFromProvider` to use native `fetch` or `http` calls instead of `micro-ftch`
- [x] Replace `fromEthersProvider` with `fromJsonRpcProvider` in `block` and `tx`
- [x] Clean up various `testdouble` typing items across tests