### PR TITLE
Use JS maps in cache

### DIFF
--- a/packages/statemanager/src/cache/account.ts
+++ b/packages/statemanager/src/cache/account.ts
@@ -198,11 +198,10 @@ export class AccountCache extends Cache {
       this._debug(`Commit to checkpoint ${this._checkpoints}`)
     }
     const diffMap = this._diffCache.pop()!
-
     for (const entry of diffMap.entries()) {
       const addressHex = entry[0]
       const oldEntry = this._diffCache[this._checkpoints].has(addressHex)
-      if (oldEntry === undefined) {
+      if (!oldEntry) {
         const elem = entry[1]
         this._diffCache[this._checkpoints].set(addressHex, elem)
       }


### PR DESCRIPTION
Replace `OrderedMaps` in account and storage `diffCache` with pure JS maps.  Appears to have a small performance gain (as well as readability improvements).

Can use a script like this to validate performance:
```
import { Address } from '@ethereumjs/util'
import { randomBytes } from 'crypto'

import { createAccount } from '../../test/util'

import { AccountCache } from './account'
import { CacheType } from './types'

const samples = 10000
const accountCache = () => {
  const cache = new AccountCache({ type: CacheType.LRU, size: 10000 })
  for (let x = 0; x < samples; x++) {
    const address = Address.fromPrivateKey(randomBytes(32))
    const account = createAccount(undefined, 1n)
    cache.get(address)
    cache.put(address, account)
    if ((x ^ 10) === 0) {
      cache.checkpoint()
    }
    if ((x ^ 20) === 0) {
      cache.commit()
    }
  }
}

for (let x = 0; x < 10; x++) {
  console.time('accountcache')
  accountCache()
  console.timeEnd('accountcache')
}
```
