### PR TITLE
Fix handling of nested uint8Arrays in JSON in DB

### DIFF
--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -1211,8 +1211,14 @@ export class Blockchain implements BlockchainInterface {
    * @hidden
    */
   private _saveHeadOps(): DBOp[] {
+    // Convert DB heads to hex strings for efficient storage in DB
+    // LevelDB doesn't handle Uint8Arrays properly when they are part
+    // of a JSON object being stored as a value in the DB
+    const hexHeads = Object.fromEntries(
+      Object.entries(this._heads).map((entry) => [entry[0], bytesToHex(entry[1])])
+    )
     return [
-      DBOp.set(DBTarget.Heads, this._heads),
+      DBOp.set(DBTarget.Heads, hexHeads),
       DBOp.set(DBTarget.HeadHeader, this._headHeaderHash!),
       DBOp.set(DBTarget.HeadBlock, this._headBlockHash!),
     ]

--- a/packages/blockchain/src/db/manager.ts
+++ b/packages/blockchain/src/db/manager.ts
@@ -1,6 +1,7 @@
 import { Block, BlockHeader, valuesArrayToHeaderData } from '@ethereumjs/block'
 import { RLP } from '@ethereumjs/rlp'
 import { KECCAK256_RLP, KECCAK256_RLP_ARRAY, bytesToBigInt, equalsBytes } from '@ethereumjs/util'
+import { hexToBytes } from 'ethereum-cryptography/utils'
 
 import { Cache } from './cache'
 import { DBOp, DBTarget } from './operation'
@@ -65,11 +66,10 @@ export class DBManager {
   async getHeads(): Promise<{ [key: string]: Uint8Array }> {
     const heads = await this.get(DBTarget.Heads)
     for (const key of Object.keys(heads)) {
-      // DB incorrectly stores the `uint8Array` representation of each head hash
-      // as a JSON object of key value pairs where the key is the array index
-      // and the value is the uint8 from that index of the original array
-      // so we convert it back to a Uint8Array before storing the heads
-      heads[key] = Uint8Array.from(Object.values(heads[key]))
+      // Heads are stored in DB as hex strings since Level converts Uint8Arrays
+      // to nested JSON objects when they are included in a value being stored
+      // in the DB
+      heads[key] = hexToBytes(heads[key])
     }
     return heads
   }

--- a/packages/blockchain/test/util.ts
+++ b/packages/blockchain/test/util.ts
@@ -3,7 +3,7 @@ import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import { toBytes } from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak'
-import { equalsBytes, hexToBytes, utf8ToBytes } from 'ethereum-cryptography/utils'
+import { bytesToHex, equalsBytes, hexToBytes, utf8ToBytes } from 'ethereum-cryptography/utils'
 import { MemoryLevel } from 'memory-level'
 
 import { Blockchain } from '../src'
@@ -179,7 +179,7 @@ export const createTestDB = async (): Promise<[Level<any, any>, Block]> => {
       type: 'put',
       key: 'heads',
       valueEncoding: 'json',
-      value: { head0: [171, 205] },
+      value: { head0: bytesToHex(Uint8Array.from([171, 205])) },
     },
   ])
   return [db as any, genesis]


### PR DESCRIPTION
Switches the handling of uint8Arrays nested inside JSON objects put in the DB to store as hex strings since LevelDB incorrectly converts these uint8Arrays to nested JSON objects and reassembling the Uint8Array is slower than converting to and from hex strings.