### PR TITLE
Trie/Client: Add permanent Trie Node Cache + Client Integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18210,6 +18210,7 @@
         "@ethereumjs/util": "^8.0.5",
         "@types/readable-stream": "^2.3.13",
         "ethereum-cryptography": "^1.1.2",
+        "lru-cache": "^5.1.1",
         "readable-stream": "^3.6.0"
       },
       "devDependencies": {
@@ -19853,6 +19854,7 @@
         "level-mem": "^6.0.1",
         "levelup": "^5.1.1",
         "lmdb": "^2.5.3",
+        "lru-cache": "^5.1.1",
         "memory-level": "^1.0.0",
         "micro-bmark": "0.2.0",
         "readable-stream": "^3.6.0"

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -253,6 +253,11 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     number: true,
     default: Config.STORAGE_CACHE,
   })
+  .option('trieCache', {
+    describe: 'Size for the trie cache (max number of trie nodes)',
+    number: true,
+    default: Config.TRIE_CACHE,
+  })
   .option('debugCode', {
     describe: 'Generate code for local debugging (internal usage mostly)',
     boolean: true,
@@ -733,6 +738,7 @@ async function run() {
     numBlocksPerIteration: args.numBlocksPerIteration,
     accountCache: args.accountCache,
     storageCache: args.storageCache,
+    trieCache: args.trieCache,
     dnsNetworks: args.dnsNetworks,
     extIP: args.extIP,
     key,

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -204,6 +204,11 @@ export interface ConfigOptions {
   storageCache?: number
 
   /**
+   * Size for the trie cache (max number of trie nodes)
+   */
+  trieCache?: number
+
+  /**
    * Generate code for local debugging, currently providing a
    * code snippet which can be used to run blocks on the
    * EthereumJS VM on execution errors
@@ -307,6 +312,7 @@ export class Config {
   public static readonly NUM_BLOCKS_PER_ITERATION = 50
   public static readonly ACCOUNT_CACHE = 1000000
   public static readonly STORAGE_CACHE = 200000
+  public static readonly TRIE_CACHE = 500000
   public static readonly DEBUGCODE_DEFAULT = false
   public static readonly SAFE_REORG_DISTANCE = 100
   public static readonly SKELETON_FILL_CANONICAL_BACKSTEP = 100
@@ -341,6 +347,7 @@ export class Config {
   public readonly numBlocksPerIteration: number
   public readonly accountCache: number
   public readonly storageCache: number
+  public readonly trieCache: number
   public readonly debugCode: boolean
   public readonly discDns: boolean
   public readonly discV4: boolean
@@ -397,6 +404,7 @@ export class Config {
     this.numBlocksPerIteration = options.numBlocksPerIteration ?? Config.NUM_BLOCKS_PER_ITERATION
     this.accountCache = options.accountCache ?? Config.ACCOUNT_CACHE
     this.storageCache = options.storageCache ?? Config.STORAGE_CACHE
+    this.trieCache = options.trieCache ?? Config.TRIE_CACHE
     this.debugCode = options.debugCode ?? Config.DEBUGCODE_DEFAULT
     this.mine = options.mine ?? false
     this.isSingleNode = options.isSingleNode ?? false

--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -51,10 +51,12 @@ export class VMExecution extends Execution {
       const trie = new Trie({
         db: new LevelDB(this.stateDB),
         useKeyHashing: true,
+        cacheSize: this.config.trieCache,
       })
 
       this.config.logger.info(`Initializing account cache size=${this.config.accountCache}`)
       this.config.logger.info(`Initializing storage cache size=${this.config.storageCache}`)
+      this.config.logger.info(`Initializing trie cache size=${this.config.trieCache}`)
       const stateManager = new DefaultStateManager({
         trie,
         accountCacheOpts: {

--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -576,6 +576,11 @@ export class VMExecution extends Execution {
       this.config.logger.info(
         `Storage cache stats size=${stats.size} reads=${stats.reads} hits=${stats.hits} writes=${stats.writes}`
       )
+      const tStats = ((vm.stateManager as any)._trie as Trie).database().stats()
+      this.config.logger.info(
+        `Trie cache stats size=${tStats.size} reads=${tStats.cache.reads} hits=${tStats.cache.hits} ` +
+          `writes=${tStats.cache.writes} readsDB=${tStats.db.reads} hitsDB=${tStats.db.hits} writesDB=${tStats.db.writes}`
+      )
       this.cacheStatsCount = 0
     }
   }

--- a/packages/client/lib/types.ts
+++ b/packages/client/lib/types.ts
@@ -146,6 +146,7 @@ export interface ClientOpts {
   numBlocksPerIteration?: number
   accountCache?: number
   storageCache?: number
+  trieCache?: number
   dnsNetworks?: string[]
   executeBlocks?: string
   debugCode?: boolean

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -49,6 +49,7 @@
     "@ethereumjs/util": "^8.0.5",
     "@types/readable-stream": "^2.3.13",
     "ethereum-cryptography": "^1.1.2",
+    "lru-cache": "^5.1.1",
     "readable-stream": "^3.6.0"
   },
   "devDependencies": {

--- a/packages/trie/src/db/checkpoint.ts
+++ b/packages/trie/src/db/checkpoint.ts
@@ -30,7 +30,7 @@ export class CheckpointDB implements DB {
     this.checkpoints = []
 
     this._cache = new LRU({
-      max: 1000000,
+      max: 500000,
       updateAgeOnGet: true,
     })
   }
@@ -88,8 +88,8 @@ export class CheckpointDB implements DB {
         }
       }
       await this.batch(batchOp)
-      console.log(this._cache.length)
-      console.log(`LRU:${this._cnt.LRU} CP:${this._cnt.CP} DB:${this._cnt.DB}`)
+      //console.log(this._cache.length)
+      //console.log(`LRU:${this._cnt.LRU} CP:${this._cnt.CP} DB:${this._cnt.DB}`)
       this._cnt = {
         LRU: 0,
         CP: 0,

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -39,6 +39,7 @@ export class Trie {
     useKeyHashingFunction: keccak256,
     useRootPersistence: false,
     useNodePruning: false,
+    cacheSize: 1000,
   }
 
   /** The root for an empty trie */
@@ -96,7 +97,7 @@ export class Trie {
         throw new Error('Cannot pass in an instance of CheckpointDB')
       }
 
-      this._db = new CheckpointDB(db)
+      this._db = new CheckpointDB({ db, cacheSize: this._opts.cacheSize })
     }
 
     return this._db

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -39,7 +39,7 @@ export class Trie {
     useKeyHashingFunction: keccak256,
     useRootPersistence: false,
     useNodePruning: false,
-    cacheSize: 1000,
+    cacheSize: 0,
   }
 
   /** The root for an empty trie */

--- a/packages/trie/src/types.ts
+++ b/packages/trie/src/types.ts
@@ -62,6 +62,14 @@ export interface TrieOpts {
    * unreachable nodes will be pruned (deleted) from the trie
    */
   useNodePruning?: boolean
+
+  /**
+   * The trie library uses a permanent LRU cache to store nodes for faster
+   * retrieval. Set to 0 to deactivate LRU cache completely.
+   *
+   * Default: 1000
+   */
+  cacheSize?: number
 }
 
 export type TrieOptsWithDefaults = TrieOpts & {
@@ -69,6 +77,19 @@ export type TrieOptsWithDefaults = TrieOpts & {
   useKeyHashingFunction: HashKeysFunction
   useRootPersistence: boolean
   useNodePruning: boolean
+  cacheSize: number
+}
+
+export interface CheckpointDBOpts {
+  /**
+   * A database instance.
+   */
+  db: DB
+
+  /**
+   * Cache size (default: 0)
+   */
+  cacheSize?: number
 }
 
 export type BatchDBOp = PutBatch | DelBatch

--- a/packages/trie/src/types.ts
+++ b/packages/trie/src/types.ts
@@ -64,10 +64,9 @@ export interface TrieOpts {
   useNodePruning?: boolean
 
   /**
-   * The trie library uses a permanent LRU cache to store nodes for faster
-   * retrieval. Set to 0 to deactivate LRU cache completely.
+   * LRU cache for trie nodes to allow for faster node retrieval.
    *
-   * Default: 1000
+   * Default: 0 (deactivated)
    */
   cacheSize?: number
 }

--- a/packages/trie/test/db/checkpoint.spec.ts
+++ b/packages/trie/test/db/checkpoint.spec.ts
@@ -12,7 +12,7 @@ tape('DB tests', (t) => {
   const v3 = utf8ToBytes('v3')
 
   t.test('Checkpointing: revert -> put (add)', async (st) => {
-    const db = new CheckpointDB(new MapDB())
+    const db = new CheckpointDB({ db: new MapDB() })
     db.checkpoint(hexStringToBytes('01'))
     await db.put(k, v)
     st.deepEqual(await db.get(k), v, 'before revert: v1')
@@ -22,7 +22,7 @@ tape('DB tests', (t) => {
   })
 
   t.test('Checkpointing: revert -> put (update)', async (st) => {
-    const db = new CheckpointDB(new MapDB())
+    const db = new CheckpointDB({ db: new MapDB() })
     await db.put(k, v)
     st.deepEqual(await db.get(k), v, 'before CP: v1')
     db.checkpoint(hexStringToBytes('01'))
@@ -34,7 +34,7 @@ tape('DB tests', (t) => {
   })
 
   t.test('Checkpointing: revert -> put (update) batched', async (st) => {
-    const db = new CheckpointDB(new MapDB())
+    const db = new CheckpointDB({ db: new MapDB() })
     await db.put(k, v)
     st.deepEqual(await db.get(k), v, 'before CP: v1')
     db.checkpoint(hexStringToBytes('01'))
@@ -49,7 +49,7 @@ tape('DB tests', (t) => {
   })
 
   t.test('Checkpointing: revert -> del', async (st) => {
-    const db = new CheckpointDB(new MapDB())
+    const db = new CheckpointDB({ db: new MapDB() })
     await db.put(k, v)
     st.deepEqual(await db.get(k), v, 'before CP: v1')
     db.checkpoint(hexStringToBytes('01'))
@@ -61,7 +61,7 @@ tape('DB tests', (t) => {
   })
 
   t.test('Checkpointing: nested checkpoints -> commit -> revert', async (st) => {
-    const db = new CheckpointDB(new MapDB())
+    const db = new CheckpointDB({ db: new MapDB() })
     await db.put(k, v)
 
     st.deepEqual(await db.get(k), v, 'before CP: v1')

--- a/packages/trie/test/index.spec.ts
+++ b/packages/trie/test/index.spec.ts
@@ -16,355 +16,366 @@ import { bytesToNibbles } from '../src/util/nibbles'
 
 import type { HashKeysFunction } from '../src'
 
-tape('simple save and retrieve', function (tester) {
-  const it = tester.test
-
-  it('should not crash if given a non-existent root', async function (t) {
-    const root = hexStringToBytes(
-      '3f4399b08efe68945c1cf90ffe85bbe3ce978959da753f9e649f034015b8817d'
-    )
-
-    const trie = new Trie({ root })
-    const value = await trie.get(utf8ToBytes('test'))
-    t.equal(value, null)
-    t.end()
-  })
-
-  const trie = new Trie()
-
-  it('save a value', async function (t) {
-    await trie.put(utf8ToBytes('test'), utf8ToBytes('one'))
-    t.end()
-  })
-
-  it('should get a value', async function (t) {
-    const value = await trie.get(utf8ToBytes('test'))
-    t.equal(bytesToUtf8(value!), 'one')
-    t.end()
-  })
-
-  it('should update a value', async function (t) {
-    await trie.put(utf8ToBytes('test'), utf8ToBytes('two'))
-    const value = await trie.get(utf8ToBytes('test'))
-
-    t.equal(bytesToUtf8(value!), 'two')
-    t.end()
-  })
-
-  it('should delete a value', async function (t) {
-    await trie.del(utf8ToBytes('test'))
-    const value = await trie.get(utf8ToBytes('test'))
-    t.notok(value)
-    t.end()
-  })
-
-  it('should recreate a value', async function (t) {
-    await trie.put(utf8ToBytes('test'), utf8ToBytes('one'))
-    t.end()
-  })
-
-  it('should get updated a value', async function (t) {
-    const value = await trie.get(utf8ToBytes('test'))
-    t.equal(bytesToUtf8(value!), 'one')
-    t.end()
-  })
-
-  it('should create a branch here', async function (t) {
-    await trie.put(utf8ToBytes('doge'), utf8ToBytes('coin'))
-    t.equal(
-      'de8a34a8c1d558682eae1528b47523a483dd8685d6db14b291451a66066bf0fc',
-      bytesToHex(trie.root())
-    )
-    t.end()
-  })
-
-  it('should get a value that is in a branch', async function (t) {
-    const value = await trie.get(utf8ToBytes('doge'))
-    t.equal(bytesToUtf8(value!), 'coin')
-    t.end()
-  })
-
-  it('should delete from a branch', async function (t) {
-    await trie.del(utf8ToBytes('doge'))
-    const value = await trie.get(utf8ToBytes('doge'))
-    t.equal(value, null)
-    t.end()
-  })
-
-  tape('storing longer values', async function (tester) {
+for (const cacheSize of [0, 100]) {
+  tape('simple save and retrieve', function (tester) {
     const it = tester.test
-    const trie = new Trie()
-    const longString = 'this will be a really really really long value'
-    const longStringRoot = 'b173e2db29e79c78963cff5196f8a983fbe0171388972106b114ef7f5c24dfa3'
 
-    it('should store a longer string', async function (t) {
-      await trie.put(utf8ToBytes('done'), utf8ToBytes(longString))
+    it('should not crash if given a non-existent root', async function (t) {
+      const root = hexStringToBytes(
+        '3f4399b08efe68945c1cf90ffe85bbe3ce978959da753f9e649f034015b8817d'
+      )
+
+      const trie = new Trie({ root })
+      const value = await trie.get(utf8ToBytes('test'))
+      t.equal(value, null)
+      t.end()
+    })
+
+    const trie = new Trie({ cacheSize })
+
+    it('save a value', async function (t) {
+      await trie.put(utf8ToBytes('test'), utf8ToBytes('one'))
+      t.end()
+    })
+
+    it('should get a value', async function (t) {
+      const value = await trie.get(utf8ToBytes('test'))
+      t.equal(bytesToUtf8(value!), 'one')
+      t.end()
+    })
+
+    it('should update a value', async function (t) {
+      await trie.put(utf8ToBytes('test'), utf8ToBytes('two'))
+      const value = await trie.get(utf8ToBytes('test'))
+
+      t.equal(bytesToUtf8(value!), 'two')
+      t.end()
+    })
+
+    it('should delete a value', async function (t) {
+      await trie.del(utf8ToBytes('test'))
+      const value = await trie.get(utf8ToBytes('test'))
+      t.notok(value)
+      t.end()
+    })
+
+    it('should recreate a value', async function (t) {
+      await trie.put(utf8ToBytes('test'), utf8ToBytes('one'))
+      t.end()
+    })
+
+    it('should get updated a value', async function (t) {
+      const value = await trie.get(utf8ToBytes('test'))
+      t.equal(bytesToUtf8(value!), 'one')
+      t.end()
+    })
+
+    it('should create a branch here', async function (t) {
       await trie.put(utf8ToBytes('doge'), utf8ToBytes('coin'))
-      t.equal(longStringRoot, bytesToHex(trie.root()))
-      t.end()
-    })
-
-    it('should retrieve a longer value', async function (t) {
-      const value = await trie.get(utf8ToBytes('done'))
-      t.equal(bytesToUtf8(value!), longString)
-      t.end()
-    })
-
-    it('should when being modified delete the old value', async function (t) {
-      await trie.put(utf8ToBytes('done'), utf8ToBytes('test'))
-      t.end()
-    })
-  })
-
-  tape('testing extensions and branches', function (tester) {
-    const it = tester.test
-    const trie = new Trie()
-
-    it('should store a value', async function (t) {
-      await trie.put(utf8ToBytes('doge'), utf8ToBytes('coin'))
-      t.end()
-    })
-
-    it('should create extension to store this value', async function (t) {
-      await trie.put(utf8ToBytes('do'), utf8ToBytes('verb'))
       t.equal(
-        'f803dfcb7e8f1afd45e88eedb4699a7138d6c07b71243d9ae9bff720c99925f9',
+        'de8a34a8c1d558682eae1528b47523a483dd8685d6db14b291451a66066bf0fc',
         bytesToHex(trie.root())
       )
       t.end()
     })
 
-    it('should store this value under the extension', async function (t) {
-      await trie.put(utf8ToBytes('done'), utf8ToBytes('finished'))
-      t.equal(
-        '409cff4d820b394ed3fb1cd4497bdd19ffa68d30ae34157337a7043c94a3e8cb',
-        bytesToHex(trie.root())
-      )
+    it('should get a value that is in a branch', async function (t) {
+      const value = await trie.get(utf8ToBytes('doge'))
+      t.equal(bytesToUtf8(value!), 'coin')
       t.end()
+    })
+
+    it('should delete from a branch', async function (t) {
+      await trie.del(utf8ToBytes('doge'))
+      const value = await trie.get(utf8ToBytes('doge'))
+      t.equal(value, null)
+      t.end()
+    })
+
+    tape('storing longer values', async function (tester) {
+      const it = tester.test
+      const trie = new Trie({ cacheSize })
+      const longString = 'this will be a really really really long value'
+      const longStringRoot = 'b173e2db29e79c78963cff5196f8a983fbe0171388972106b114ef7f5c24dfa3'
+
+      it('should store a longer string', async function (t) {
+        await trie.put(utf8ToBytes('done'), utf8ToBytes(longString))
+        await trie.put(utf8ToBytes('doge'), utf8ToBytes('coin'))
+        t.equal(longStringRoot, bytesToHex(trie.root()))
+        t.end()
+      })
+
+      it('should retrieve a longer value', async function (t) {
+        const value = await trie.get(utf8ToBytes('done'))
+        t.equal(bytesToUtf8(value!), longString)
+        t.end()
+      })
+
+      it('should when being modified delete the old value', async function (t) {
+        await trie.put(utf8ToBytes('done'), utf8ToBytes('test'))
+        t.end()
+      })
+    })
+
+    tape('testing extensions and branches', function (tester) {
+      const it = tester.test
+      const trie = new Trie({ cacheSize })
+
+      it('should store a value', async function (t) {
+        await trie.put(utf8ToBytes('doge'), utf8ToBytes('coin'))
+        t.end()
+      })
+
+      it('should create extension to store this value', async function (t) {
+        await trie.put(utf8ToBytes('do'), utf8ToBytes('verb'))
+        t.equal(
+          'f803dfcb7e8f1afd45e88eedb4699a7138d6c07b71243d9ae9bff720c99925f9',
+          bytesToHex(trie.root())
+        )
+        t.end()
+      })
+
+      it('should store this value under the extension', async function (t) {
+        await trie.put(utf8ToBytes('done'), utf8ToBytes('finished'))
+        t.equal(
+          '409cff4d820b394ed3fb1cd4497bdd19ffa68d30ae34157337a7043c94a3e8cb',
+          bytesToHex(trie.root())
+        )
+        t.end()
+      })
+    })
+
+    tape('testing extensions and branches - reverse', function (tester) {
+      const it = tester.test
+      const trie = new Trie({ cacheSize })
+
+      it('should create extension to store this value', async function (t) {
+        await trie.put(utf8ToBytes('do'), utf8ToBytes('verb'))
+        t.end()
+      })
+
+      it('should store a value', async function (t) {
+        await trie.put(utf8ToBytes('doge'), utf8ToBytes('coin'))
+        t.end()
+      })
+
+      it('should store this value under the extension', async function (t) {
+        await trie.put(utf8ToBytes('done'), utf8ToBytes('finished'))
+        t.equal(
+          '409cff4d820b394ed3fb1cd4497bdd19ffa68d30ae34157337a7043c94a3e8cb',
+          bytesToHex(trie.root())
+        )
+        t.end()
+      })
     })
   })
 
-  tape('testing extensions and branches - reverse', function (tester) {
+  tape('testing deletion cases', function (tester) {
     const it = tester.test
-    const trie = new Trie()
-
-    it('should create extension to store this value', async function (t) {
-      await trie.put(utf8ToBytes('do'), utf8ToBytes('verb'))
-      t.end()
-    })
-
-    it('should store a value', async function (t) {
-      await trie.put(utf8ToBytes('doge'), utf8ToBytes('coin'))
-      t.end()
-    })
-
-    it('should store this value under the extension', async function (t) {
-      await trie.put(utf8ToBytes('done'), utf8ToBytes('finished'))
-      t.equal(
-        '409cff4d820b394ed3fb1cd4497bdd19ffa68d30ae34157337a7043c94a3e8cb',
-        bytesToHex(trie.root())
-      )
-      t.end()
-    })
-  })
-})
-
-tape('testing deletion cases', function (tester) {
-  const it = tester.test
-  const trieSetup = {
-    trie: new Trie(),
-    msg: 'without DB delete',
-  }
-
-  it('should delete from a branch->branch-branch', async function (t) {
-    await trieSetup.trie.put(new Uint8Array([11, 11, 11]), utf8ToBytes('first'))
-    await trieSetup.trie.put(new Uint8Array([12, 22, 22]), utf8ToBytes('create the first branch'))
-    await trieSetup.trie.put(new Uint8Array([12, 34, 44]), utf8ToBytes('create the last branch'))
-
-    await trieSetup.trie.del(new Uint8Array([12, 22, 22]))
-    const val = await trieSetup.trie.get(new Uint8Array([12, 22, 22]))
-    t.equal(null, val, trieSetup.msg)
-    t.end()
-  })
-
-  it('should delete from a branch->branch-extension', async function (t) {
-    await trieSetup.trie.put(new Uint8Array([11, 11, 11]), utf8ToBytes('first'))
-    await trieSetup.trie.put(new Uint8Array([12, 22, 22]), utf8ToBytes('create the first branch'))
-    await trieSetup.trie.put(new Uint8Array([12, 33, 33]), utf8ToBytes('create the middle branch'))
-    await trieSetup.trie.put(new Uint8Array([12, 34, 44]), utf8ToBytes('create the last branch'))
-
-    await trieSetup.trie.del(new Uint8Array([12, 22, 22]))
-    const val = await trieSetup.trie.get(new Uint8Array([12, 22, 22]))
-    t.equal(null, val, trieSetup.msg)
-
-    t.end()
-  })
-
-  it('should delete from a extension->branch-extension', async function (t) {
-    await trieSetup.trie.put(new Uint8Array([11, 11, 11]), utf8ToBytes('first'))
-    await trieSetup.trie.put(new Uint8Array([12, 22, 22]), utf8ToBytes('create the first branch'))
-    await trieSetup.trie.put(new Uint8Array([12, 33, 33]), utf8ToBytes('create the middle branch'))
-    await trieSetup.trie.put(new Uint8Array([12, 34, 44]), utf8ToBytes('create the last branch'))
-
-    // delete the middle branch
-    await trieSetup.trie.del(new Uint8Array([11, 11, 11]))
-    const val = await trieSetup.trie.get(new Uint8Array([11, 11, 11]))
-    t.equal(null, val, trieSetup.msg)
-
-    t.end()
-  })
-
-  it('should delete from a extension->branch-branch', async function (t) {
-    await trieSetup.trie.put(new Uint8Array([11, 11, 11]), utf8ToBytes('first'))
-    await trieSetup.trie.put(new Uint8Array([12, 22, 22]), utf8ToBytes('create the first branch'))
-    await trieSetup.trie.put(new Uint8Array([12, 33, 33]), utf8ToBytes('create the middle branch'))
-    await trieSetup.trie.put(new Uint8Array([12, 34, 44]), utf8ToBytes('create the last branch'))
-    // delete the middle branch
-    await trieSetup.trie.del(new Uint8Array([11, 11, 11]))
-    const val = await trieSetup.trie.get(new Uint8Array([11, 11, 11]))
-    t.equal(null, val, trieSetup.msg)
-
-    t.end()
-  })
-})
-
-tape('shall handle the case of node not found correctly', async (t) => {
-  const trie = new Trie()
-  await trie.put(utf8ToBytes('a'), utf8ToBytes('value1'))
-  await trie.put(utf8ToBytes('aa'), utf8ToBytes('value2'))
-  await trie.put(utf8ToBytes('aaa'), utf8ToBytes('value3'))
-
-  /* Setups a trie which consists of
-    ExtensionNode ->
-    BranchNode -> value1
-    ExtensionNode ->
-    BranchNode -> value2
-    LeafNode -> value3
-  */
-
-  let path = await trie.findPath(utf8ToBytes('aaa'))
-
-  t.ok(path.node !== null, 'findPath should find a node')
-
-  const { stack } = await trie.findPath(utf8ToBytes('aaa'))
-  // @ts-expect-error
-  await trie._db.del(keccak256(stack[1].serialize())) // delete the BranchNode -> value1 from the DB
-
-  path = await trie.findPath(utf8ToBytes('aaa'))
-
-  t.ok(path.node === null, 'findPath should not return a node now')
-  t.ok(
-    path.stack.length === 1,
-    'findPath should find the first extension node which is still in the DB'
-  )
-
-  t.end()
-})
-
-tape('it should create the genesis state root from ethereum', function (tester) {
-  const it = tester.test
-  const trie4 = new Trie()
-
-  const g = hexStringToBytes('8a40bfaa73256b60764c1bf40675a99083efb075')
-  const j = hexStringToBytes('e6716f9544a56c530d868e4bfbacb172315bdead')
-  const v = hexStringToBytes('1e12515ce3e0f817a4ddef9ca55788a1d66bd2df')
-  const a = hexStringToBytes('1a26338f0d905e295fccb71fa9ea849ffa12aaf4')
-
-  const storageRoot = new Uint8Array(32)
-  storageRoot.fill(0)
-
-  const startAmount = new Uint8Array(26)
-  startAmount.fill(0)
-  startAmount[0] = 1
-
-  const account = [startAmount, 0, storageRoot, KECCAK256_NULL]
-  const rlpAccount = RLP.encode(account)
-  const cppRlp =
-    'f85e9a010000000000000000000000000000000000000000000000000080a00000000000000000000000000000000000000000000000000000000000000000a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
-
-  const genesisStateRoot = '2f4399b08efe68945c1cf90ffe85bbe3ce978959da753f9e649f034015b8817d'
-  tester.equal(cppRlp, bytesToHex(rlpAccount))
-
-  it('shall match the root', async function (t) {
-    await trie4.put(g, rlpAccount)
-    await trie4.put(j, rlpAccount)
-    await trie4.put(v, rlpAccount)
-    await trie4.put(a, rlpAccount)
-    t.equal(bytesToHex(trie4.root()), genesisStateRoot)
-    t.end()
-  })
-})
-
-tape('setting back state root (deleteFromDB)', async (t) => {
-  const k1 = utf8ToBytes('1')
-  /* Testing with longer value due to `rlpNode.length >= 32` check in `_formatNode()`
-   * Reasoning from https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/:
-   * "When one node is referenced inside another node, what is included is `H(rlp.encode(x))`,
-   * where `H(x) = sha3(x) if len(x) >= 32 else x`"
-   */
-  const v1 = utf8ToBytes('this-is-some-longer-value-to-test-the-delete-operation-value1')
-  const k2 = utf8ToBytes('2')
-  const v2 = utf8ToBytes('this-is-some-longer-value-to-test-the-delete-operation-value2')
-
-  const rootAfterK1 = hexStringToBytes(
-    '809e75931f394603657e113eb7244794f35b8d326cff99407111d600722e9425'
-  )
-
-  const trieSetup = {
-    trie: new Trie(),
-    expected: v1,
-    msg: 'should return v1 when setting back the state root when deleteFromDB=false',
-  }
-
-  await trieSetup.trie.put(k1, v1)
-  await trieSetup.trie.put(k2, v2)
-  await trieSetup.trie.del(k1)
-  t.equal(
-    await trieSetup.trie.get(k1),
-    null,
-    'should return null on latest state root independently from deleteFromDB setting'
-  )
-
-  trieSetup.trie.root(rootAfterK1)
-  t.deepEqual(await trieSetup.trie.get(k1), trieSetup.expected, trieSetup.msg)
-
-  t.end()
-})
-
-tape('dummy hash', async (t) => {
-  const useKeyHashingFunction: HashKeysFunction = (msg) => {
-    const hashLen = 32
-    if (msg.length <= hashLen - 5) {
-      return concatBytes(utf8ToBytes('hash_'), new Uint8Array(hashLen - msg.length).fill(0), msg)
-    } else {
-      return concatBytes(utf8ToBytes('hash_'), msg.slice(0, hashLen - 5))
+    const trieSetup = {
+      trie: new Trie({ cacheSize }),
+      msg: 'without DB delete',
     }
-  }
 
-  const [k, v] = [utf8ToBytes('foo'), utf8ToBytes('bar')]
-  const expectedRoot = useKeyHashingFunction(new LeafNode(bytesToNibbles(k), v).serialize())
+    it('should delete from a branch->branch-branch', async function (t) {
+      await trieSetup.trie.put(new Uint8Array([11, 11, 11]), utf8ToBytes('first'))
+      await trieSetup.trie.put(new Uint8Array([12, 22, 22]), utf8ToBytes('create the first branch'))
+      await trieSetup.trie.put(new Uint8Array([12, 34, 44]), utf8ToBytes('create the last branch'))
 
-  const trie = new Trie({ useKeyHashingFunction })
-  await trie.put(k, v)
-  t.equal(bytesToHex(trie.root()), bytesToHex(expectedRoot))
+      await trieSetup.trie.del(new Uint8Array([12, 22, 22]))
+      const val = await trieSetup.trie.get(new Uint8Array([12, 22, 22]))
+      t.equal(null, val, trieSetup.msg)
+      t.end()
+    })
 
-  t.end()
-})
+    it('should delete from a branch->branch-extension', async function (t) {
+      await trieSetup.trie.put(new Uint8Array([11, 11, 11]), utf8ToBytes('first'))
+      await trieSetup.trie.put(new Uint8Array([12, 22, 22]), utf8ToBytes('create the first branch'))
+      await trieSetup.trie.put(
+        new Uint8Array([12, 33, 33]),
+        utf8ToBytes('create the middle branch')
+      )
+      await trieSetup.trie.put(new Uint8Array([12, 34, 44]), utf8ToBytes('create the last branch'))
 
-tape('blake2b256 trie root', async (t) => {
-  const trie = new Trie({ useKeyHashingFunction: (msg) => blake2b(msg, 32) })
-  await trie.put(utf8ToBytes('foo'), utf8ToBytes('bar'))
+      await trieSetup.trie.del(new Uint8Array([12, 22, 22]))
+      const val = await trieSetup.trie.get(new Uint8Array([12, 22, 22]))
+      t.equal(null, val, trieSetup.msg)
 
-  t.equal(
-    bytesToHex(trie.root()),
-    'e118db4e01512253df38daafa16fc1d69e03e755595b5847d275d7404ebdc74a'
-  )
-  t.end()
-})
+      t.end()
+    })
 
-tape('empty root', async (t) => {
-  const trie = new Trie()
+    it('should delete from a extension->branch-extension', async function (t) {
+      await trieSetup.trie.put(new Uint8Array([11, 11, 11]), utf8ToBytes('first'))
+      await trieSetup.trie.put(new Uint8Array([12, 22, 22]), utf8ToBytes('create the first branch'))
+      await trieSetup.trie.put(
+        new Uint8Array([12, 33, 33]),
+        utf8ToBytes('create the middle branch')
+      )
+      await trieSetup.trie.put(new Uint8Array([12, 34, 44]), utf8ToBytes('create the last branch'))
 
-  t.equal(bytesToHex(trie.root()), KECCAK256_RLP_S)
-  t.end()
-})
+      // delete the middle branch
+      await trieSetup.trie.del(new Uint8Array([11, 11, 11]))
+      const val = await trieSetup.trie.get(new Uint8Array([11, 11, 11]))
+      t.equal(null, val, trieSetup.msg)
+
+      t.end()
+    })
+
+    it('should delete from a extension->branch-branch', async function (t) {
+      await trieSetup.trie.put(new Uint8Array([11, 11, 11]), utf8ToBytes('first'))
+      await trieSetup.trie.put(new Uint8Array([12, 22, 22]), utf8ToBytes('create the first branch'))
+      await trieSetup.trie.put(
+        new Uint8Array([12, 33, 33]),
+        utf8ToBytes('create the middle branch')
+      )
+      await trieSetup.trie.put(new Uint8Array([12, 34, 44]), utf8ToBytes('create the last branch'))
+      // delete the middle branch
+      await trieSetup.trie.del(new Uint8Array([11, 11, 11]))
+      const val = await trieSetup.trie.get(new Uint8Array([11, 11, 11]))
+      t.equal(null, val, trieSetup.msg)
+
+      t.end()
+    })
+  })
+
+  tape('shall handle the case of node not found correctly', async (t) => {
+    const trie = new Trie({ cacheSize })
+    await trie.put(utf8ToBytes('a'), utf8ToBytes('value1'))
+    await trie.put(utf8ToBytes('aa'), utf8ToBytes('value2'))
+    await trie.put(utf8ToBytes('aaa'), utf8ToBytes('value3'))
+
+    /* Setups a trie which consists of
+      ExtensionNode ->
+      BranchNode -> value1
+      ExtensionNode ->
+      BranchNode -> value2
+      LeafNode -> value3
+    */
+
+    let path = await trie.findPath(utf8ToBytes('aaa'))
+
+    t.ok(path.node !== null, 'findPath should find a node')
+
+    const { stack } = await trie.findPath(utf8ToBytes('aaa'))
+    // @ts-expect-error
+    await trie._db.del(keccak256(stack[1].serialize())) // delete the BranchNode -> value1 from the DB
+
+    path = await trie.findPath(utf8ToBytes('aaa'))
+
+    t.ok(path.node === null, 'findPath should not return a node now')
+    t.ok(
+      path.stack.length === 1,
+      'findPath should find the first extension node which is still in the DB'
+    )
+
+    t.end()
+  })
+
+  tape('it should create the genesis state root from ethereum', function (tester) {
+    const it = tester.test
+    const trie4 = new Trie({ cacheSize })
+
+    const g = hexStringToBytes('8a40bfaa73256b60764c1bf40675a99083efb075')
+    const j = hexStringToBytes('e6716f9544a56c530d868e4bfbacb172315bdead')
+    const v = hexStringToBytes('1e12515ce3e0f817a4ddef9ca55788a1d66bd2df')
+    const a = hexStringToBytes('1a26338f0d905e295fccb71fa9ea849ffa12aaf4')
+
+    const storageRoot = new Uint8Array(32)
+    storageRoot.fill(0)
+
+    const startAmount = new Uint8Array(26)
+    startAmount.fill(0)
+    startAmount[0] = 1
+
+    const account = [startAmount, 0, storageRoot, KECCAK256_NULL]
+    const rlpAccount = RLP.encode(account)
+    const cppRlp =
+      'f85e9a010000000000000000000000000000000000000000000000000080a00000000000000000000000000000000000000000000000000000000000000000a0c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470'
+
+    const genesisStateRoot = '2f4399b08efe68945c1cf90ffe85bbe3ce978959da753f9e649f034015b8817d'
+    tester.equal(cppRlp, bytesToHex(rlpAccount))
+
+    it('shall match the root', async function (t) {
+      await trie4.put(g, rlpAccount)
+      await trie4.put(j, rlpAccount)
+      await trie4.put(v, rlpAccount)
+      await trie4.put(a, rlpAccount)
+      t.equal(bytesToHex(trie4.root()), genesisStateRoot)
+      t.end()
+    })
+  })
+
+  tape('setting back state root (deleteFromDB)', async (t) => {
+    const k1 = utf8ToBytes('1')
+    /* Testing with longer value due to `rlpNode.length >= 32` check in `_formatNode()`
+     * Reasoning from https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/:
+     * "When one node is referenced inside another node, what is included is `H(rlp.encode(x))`,
+     * where `H(x) = sha3(x) if len(x) >= 32 else x`"
+     */
+    const v1 = utf8ToBytes('this-is-some-longer-value-to-test-the-delete-operation-value1')
+    const k2 = utf8ToBytes('2')
+    const v2 = utf8ToBytes('this-is-some-longer-value-to-test-the-delete-operation-value2')
+
+    const rootAfterK1 = hexStringToBytes(
+      '809e75931f394603657e113eb7244794f35b8d326cff99407111d600722e9425'
+    )
+
+    const trieSetup = {
+      trie: new Trie({ cacheSize }),
+      expected: v1,
+      msg: 'should return v1 when setting back the state root when deleteFromDB=false',
+    }
+
+    await trieSetup.trie.put(k1, v1)
+    await trieSetup.trie.put(k2, v2)
+    await trieSetup.trie.del(k1)
+    t.equal(
+      await trieSetup.trie.get(k1),
+      null,
+      'should return null on latest state root independently from deleteFromDB setting'
+    )
+
+    trieSetup.trie.root(rootAfterK1)
+    t.deepEqual(await trieSetup.trie.get(k1), trieSetup.expected, trieSetup.msg)
+
+    t.end()
+  })
+
+  tape('dummy hash', async (t) => {
+    const useKeyHashingFunction: HashKeysFunction = (msg) => {
+      const hashLen = 32
+      if (msg.length <= hashLen - 5) {
+        return concatBytes(utf8ToBytes('hash_'), new Uint8Array(hashLen - msg.length).fill(0), msg)
+      } else {
+        return concatBytes(utf8ToBytes('hash_'), msg.slice(0, hashLen - 5))
+      }
+    }
+
+    const [k, v] = [utf8ToBytes('foo'), utf8ToBytes('bar')]
+    const expectedRoot = useKeyHashingFunction(new LeafNode(bytesToNibbles(k), v).serialize())
+
+    const trie = new Trie({ useKeyHashingFunction, cacheSize })
+    await trie.put(k, v)
+    t.equal(bytesToHex(trie.root()), bytesToHex(expectedRoot))
+
+    t.end()
+  })
+
+  tape('blake2b256 trie root', async (t) => {
+    const trie = new Trie({ useKeyHashingFunction: (msg) => blake2b(msg, 32), cacheSize })
+    await trie.put(utf8ToBytes('foo'), utf8ToBytes('bar'))
+
+    t.equal(
+      bytesToHex(trie.root()),
+      'e118db4e01512253df38daafa16fc1d69e03e755595b5847d275d7404ebdc74a'
+    )
+    t.end()
+  })
+
+  tape('empty root', async (t) => {
+    const trie = new Trie({ cacheSize })
+
+    t.equal(bytesToHex(trie.root()), KECCAK256_RLP_S)
+    t.end()
+  })
+}


### PR DESCRIPTION
This PR adds a permanent Node cache to the Trie checkpoint DB class which increases client block execution in particular and repetitive trie reads in general.

Cache design is extremely simple since trie node keys are unique, so there is no need for this back-and-forth related to checkpointing, since there is no risk to overwrite and old entry and therefore accidentally introduce a wrong key. I tested this with longer client sync ranges and there were no problems.

It is also "by design" that reverted node entries are kept in the cache, since this might help to mitigate repeated revert-attacks with the same attack setup, always re-reading the same accounts/slots e.g. and then revert.

I in-between planned to activate this LRU cache by default, since in most cases there should be no downsides. I then discovered several ad-hoc Trie instantiations in our own code base (mostly related to proofs), so I restrained since there might be side effects if regarding too frequent instantiations.

(Side question: do these Proof methods need any Trie object state or might it generally be an option (respectively occasion now during breaking period) to make these methods static?)

Another note: I first added an active cache to the Trie checkpointing tests and these were actually failing. I then had a closer look and realized that these were just creating "un-realistic" trie scenarios - by directly operating on the db and then adding a key and updating the same key with a different value. This scenario can - by Merkle Patricia Tree design - just not happen, since keys are always unique (in relation to the content/subtree they refer to). I already thought if these tests should generally be deleted, but refrained since they do test the general DB functionality nevertheless. All other tests (which I ran in between with the Trie-cache-active-by-default work state) are passing with the cache though.

Open for review and merge.