### PR TITLE
Client short-term "Execution Mode" Mitigations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3360,6 +3360,21 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/yargs": {
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
+      "dev": true,
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
+      "dev": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.33.1",
       "dev": true,
@@ -17906,7 +17921,7 @@
         "qheap": "^1.4.0",
         "winston": "^3.3.3",
         "winston-daily-rotate-file": "^4.5.5",
-        "yargs": "^17.2.1"
+        "yargs": "^17.7.1"
       },
       "bin": {
         "ethereumjs": "dist/bin/cli.js"
@@ -17916,6 +17931,7 @@
         "@types/connect": "^3.4.35",
         "@types/fs-extra": "^9.0.13",
         "@types/jwt-simple": "^0.5.33",
+        "@types/yargs": "^17.0.24",
         "constants-browserify": "^1.0.0",
         "crypto-browserify": "^3.12.0",
         "file-replace-loader": "^1.2.0",
@@ -17973,8 +17989,9 @@
       }
     },
     "packages/client/node_modules/yargs": {
-      "version": "17.6.0",
-      "license": "MIT",
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -17982,7 +17999,7 @@
         "require-directory": "^2.1.1",
         "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^21.0.0"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
         "node": ">=12"
@@ -19603,6 +19620,7 @@
         "@types/connect": "^3.4.35",
         "@types/fs-extra": "^9.0.13",
         "@types/jwt-simple": "^0.5.33",
+        "@types/yargs": "^17.0.24",
         "abstract-level": "^1.0.3",
         "body-parser": "^1.19.2",
         "c-kzg": "^2.0.4",
@@ -19645,7 +19663,7 @@
         "webpack-cli": "^4.8.0",
         "winston": "^3.3.3",
         "winston-daily-rotate-file": "^4.5.5",
-        "yargs": "^17.2.1"
+        "yargs": "^17.7.1"
       },
       "dependencies": {
         "cliui": {
@@ -19671,7 +19689,9 @@
           }
         },
         "yargs": {
-          "version": "17.6.0",
+          "version": "17.7.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+          "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
           "requires": {
             "cliui": "^8.0.1",
             "escalade": "^3.1.1",
@@ -19679,7 +19699,7 @@
             "require-directory": "^2.1.1",
             "string-width": "^4.2.3",
             "y18n": "^5.0.5",
-            "yargs-parser": "^21.0.0"
+            "yargs-parser": "^21.1.1"
           }
         },
         "yargs-parser": {
@@ -20867,6 +20887,21 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/yargs": {
+      "version": "17.0.24",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.24.tgz",
+      "integrity": "sha512-6i0aC7jV6QzQB8ne1joVZ0eSFIstHsCrobmOtghM11yGlH0j43FKL2UhWdELkyps0zuf7qVTUVCCR+tgSlyLLw==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
+      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.33.1",

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -58,7 +58,7 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     choices: networks.map((n) => parseInt(n[0])),
     default: undefined,
   })
-  .option('syncMode', {
+  .option('sync', {
     describe: 'Blockchain sync mode (light sync experimental)',
     choices: Object.values(SyncMode),
     default: Config.SYNCMODE_DEFAULT,
@@ -754,7 +754,7 @@ async function run() {
     multiaddrs,
     port: args.port,
     saveReceipts: args.saveReceipts,
-    syncmode: args.syncMode,
+    syncmode: args.sync,
     disableBeaconSync: args.disableBeaconSync,
     forceSnapSync: args.forceSnapSync,
     transports: args.transports,

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -21,6 +21,8 @@ import { Level } from 'level'
 import { homedir } from 'os'
 import * as path from 'path'
 import * as readline from 'readline'
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
 
 import { EthereumClient } from '../lib/client'
 import { Config, DataDirectory, SyncMode } from '../lib/config'
@@ -38,15 +40,13 @@ import type { BlockBytes } from '@ethereumjs/block'
 import type { GenesisState } from '@ethereumjs/blockchain/dist/genesisStates'
 import type { AbstractLevel } from 'abstract-level'
 
-const { hideBin } = require('yargs/helpers')
-const yargs = require('yargs/yargs')
-
 type Account = [address: Address, privateKey: Uint8Array]
 
 const networks = Object.entries(Common._getInitializedChains().names)
 
 let logger: Logger
 
+// @ts-ignore
 const args: ClientOpts = yargs(hideBin(process.argv))
   .option('network', {
     describe: 'Network',

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -48,6 +48,9 @@ let logger: Logger
 
 // @ts-ignore
 const args: ClientOpts = yargs(hideBin(process.argv))
+  .parserConfiguration({
+    'dot-notation': false,
+  })
   .option('network', {
     describe: 'Network',
     choices: networks.map((n) => n[1]),

--- a/packages/client/lib/client.ts
+++ b/packages/client/lib/client.ts
@@ -59,7 +59,7 @@ export interface EthereumClientOptions {
 export class EthereumClient {
   public config: Config
   public chain: Chain
-  public services: (FullEthereumService | LightEthereumService)[]
+  public services: (FullEthereumService | LightEthereumService)[] = []
 
   public opened: boolean
   public started: boolean
@@ -82,7 +82,7 @@ export class EthereumClient {
     this.config = options.config
     this.chain = chain
 
-    if (this.config.syncmode === SyncMode.Full) {
+    if (this.config.syncmode === SyncMode.Full || this.config.syncmode === SyncMode.None) {
       this.services = [
         new FullEthereumService({
           config: this.config,
@@ -92,7 +92,8 @@ export class EthereumClient {
           chain,
         }),
       ]
-    } else {
+    }
+    if (this.config.syncmode === SyncMode.Light) {
       this.services = [
         new LightEthereumService({
           config: this.config,

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -147,7 +147,7 @@ export interface ConfigOptions {
   /**
    * Max items per block or header request
    *
-   * Default: `50``
+   * Default: `100`
    */
   maxPerRequest?: number
 
@@ -304,13 +304,13 @@ export class Config {
   public static readonly DATADIR_DEFAULT = `./datadir`
   public static readonly TRANSPORTS_DEFAULT = ['rlpx']
   public static readonly PORT_DEFAULT = 30303
-  public static readonly MAXPERREQUEST_DEFAULT = 50
+  public static readonly MAXPERREQUEST_DEFAULT = 100
   public static readonly MAXFETCHERJOBS_DEFAULT = 100
   public static readonly MAXFETCHERREQUESTS_DEFAULT = 5
   public static readonly MINPEERS_DEFAULT = 1
   public static readonly MAXPEERS_DEFAULT = 25
   public static readonly DNSADDR_DEFAULT = '8.8.8.8'
-  public static readonly NUM_BLOCKS_PER_ITERATION = 50
+  public static readonly NUM_BLOCKS_PER_ITERATION = 100
   public static readonly ACCOUNT_CACHE = 1000000
   public static readonly STORAGE_CACHE = 200000
   public static readonly TRIE_CACHE = 500000

--- a/packages/client/lib/config.ts
+++ b/packages/client/lib/config.ts
@@ -23,6 +23,7 @@ export enum DataDirectory {
 export enum SyncMode {
   Full = 'full',
   Light = 'light',
+  None = 'none',
 }
 
 export interface ConfigOptions {

--- a/packages/client/lib/execution/execution.ts
+++ b/packages/client/lib/execution/execution.ts
@@ -1,3 +1,5 @@
+import { Event } from '../types'
+
 import type { Chain } from '../blockchain'
 import type { Config } from '../config'
 import type { AbstractLevel } from 'abstract-level'
@@ -25,6 +27,7 @@ export abstract class Execution {
 
   public running: boolean = false
   public started: boolean = false
+  public shutdown: boolean = false
 
   /**
    * Create new execution module
@@ -35,6 +38,10 @@ export abstract class Execution {
     this.chain = options.chain
     this.stateDB = options.stateDB
     this.metaDB = options.metaDB
+
+    this.config.events.once(Event.CLIENT_SHUTDOWN, () => {
+      this.shutdown = true
+    })
   }
 
   /**

--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -257,7 +257,7 @@ export class VMExecution extends Execution {
    * @returns number of blocks executed
    */
   async run(loop = true, runOnlybatched = false): Promise<number> {
-    if (this.running || !this.started) return 0
+    if (this.running || !this.started || this.shutdown) return 0
     this.running = true
     let numExecuted: number | undefined
 
@@ -281,6 +281,7 @@ export class VMExecution extends Execution {
 
     while (
       this.started &&
+      !this.shutdown &&
       (!runOnlybatched ||
         (runOnlybatched &&
           canonicalHead.header.number - startHeadBlock.header.number >=

--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -1028,6 +1028,9 @@ export class Eth {
     const currentBlock = bigIntToHex(currentBlockHeader.number)
 
     const synchronizer = this.client.services[0].synchronizer
+    if (!synchronizer) {
+      return false
+    }
     const { syncTargetHeight } = this.client.config
     const startingBlock = bigIntToHex(synchronizer.startingBlock)
 

--- a/packages/client/lib/service/ethereumservice.ts
+++ b/packages/client/lib/service/ethereumservice.ts
@@ -36,7 +36,7 @@ export class EthereumService extends Service {
   public chain: Chain
   public interval: number
   public timeout: number
-  public synchronizer!: Synchronizer
+  public synchronizer?: Synchronizer
 
   /**
    * Create new ETH service
@@ -67,7 +67,7 @@ export class EthereumService extends Service {
     }
     await super.open()
     await this.chain.open()
-    await this.synchronizer.open()
+    await this.synchronizer?.open()
     return true
   }
 
@@ -79,7 +79,7 @@ export class EthereumService extends Service {
       return false
     }
     await super.start()
-    void this.synchronizer.start()
+    void this.synchronizer?.start()
     return true
   }
 
@@ -90,7 +90,7 @@ export class EthereumService extends Service {
     if (!this.running) {
       return false
     }
-    await this.synchronizer.stop()
+    await this.synchronizer?.stop()
     await super.stop()
     return true
   }
@@ -100,7 +100,7 @@ export class EthereumService extends Service {
    */
   async close() {
     if (this.opened) {
-      await this.synchronizer.close()
+      await this.synchronizer?.close()
     }
     await super.close()
   }

--- a/packages/client/lib/service/fullethereumservice.ts
+++ b/packages/client/lib/service/fullethereumservice.ts
@@ -2,6 +2,7 @@ import { Hardfork } from '@ethereumjs/common'
 import { encodeReceipt } from '@ethereumjs/vm/dist/runBlock'
 import { concatBytes } from 'ethereum-cryptography/utils'
 
+import { SyncMode } from '../config'
 import { VMExecution } from '../execution'
 import { Miner } from '../miner'
 import { EthProtocol } from '../net/protocol/ethprotocol'
@@ -28,7 +29,7 @@ interface FullEthereumServiceOptions extends EthereumServiceOptions {
  * @memberof module:service
  */
 export class FullEthereumService extends EthereumService {
-  public synchronizer!: BeaconSynchronizer | FullSynchronizer | SnapSynchronizer
+  public synchronizer?: BeaconSynchronizer | FullSynchronizer | SnapSynchronizer
   public lightserv: boolean
   public miner: Miner | undefined
   public execution: VMExecution
@@ -73,14 +74,16 @@ export class FullEthereumService extends EthereumService {
         }
         this.config.logger.info(`Post-merge 🐼 client mode: run with CL client.`)
       } else {
-        this.synchronizer = new FullSynchronizer({
-          config: this.config,
-          pool: this.pool,
-          chain: this.chain,
-          txPool: this.txPool,
-          execution: this.execution,
-          interval: this.interval,
-        })
+        if (this.config.syncmode === SyncMode.Full) {
+          this.synchronizer = new FullSynchronizer({
+            config: this.config,
+            pool: this.pool,
+            chain: this.chain,
+            txPool: this.txPool,
+            execution: this.execution,
+            interval: this.interval,
+          })
+        }
       }
     }
 
@@ -129,11 +132,17 @@ export class FullEthereumService extends EthereumService {
   }
 
   async open() {
-    this.config.logger.info(
-      `Preparing for sync using FullEthereumService with ${
-        this.synchronizer instanceof BeaconSynchronizer ? 'BeaconSynchronizer' : 'FullSynchronizer'
-      }.`
-    )
+    if (this.synchronizer !== undefined) {
+      this.config.logger.info(
+        `Preparing for sync using FullEthereumService with ${
+          this.synchronizer instanceof BeaconSynchronizer
+            ? 'BeaconSynchronizer'
+            : 'FullSynchronizer'
+        }.`
+      )
+    } else {
+      this.config.logger.info('Starting FullEthereumService with no syncing.')
+    }
     await super.open()
     await this.execution.open()
     this.txPool.open()
@@ -168,7 +177,7 @@ export class FullEthereumService extends EthereumService {
     }
     this.txPool.stop()
     this.miner?.stop()
-    await this.synchronizer.stop()
+    await this.synchronizer?.stop()
     await this.execution.stop()
     await super.stop()
     return true

--- a/packages/client/lib/types.ts
+++ b/packages/client/lib/types.ts
@@ -105,7 +105,7 @@ export type Libp2pMuxedStream = MuxedStream
 export interface ClientOpts {
   network?: string
   networkId?: number
-  syncMode?: SyncMode
+  sync?: SyncMode
   lightServe?: boolean
   dataDir?: string
   customChain?: string

--- a/packages/client/lib/types.ts
+++ b/packages/client/lib/types.ts
@@ -162,6 +162,5 @@ export interface ClientOpts {
   txLookupLimit?: number
   startBlock?: number
   isSingleNode?: boolean
-  opened: boolean
   loadBlocksFromRlp?: string
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -94,13 +94,14 @@
     "qheap": "^1.4.0",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.5.5",
-    "yargs": "^17.2.1"
+    "yargs": "^17.7.1"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.2",
     "@types/connect": "^3.4.35",
     "@types/fs-extra": "^9.0.13",
     "@types/jwt-simple": "^0.5.33",
+    "@types/yargs": "^17.0.24",
     "constants-browserify": "^1.0.0",
     "crypto-browserify": "^3.12.0",
     "file-replace-loader": "^1.2.0",

--- a/packages/client/test/cli/cli-libp2p.spec.ts
+++ b/packages/client/test/cli/cli-libp2p.spec.ts
@@ -47,7 +47,7 @@ tape('[CLI] rpc', (t) => {
             '--mine=false',
             '--dev',
             '--multiaddrs=/ip4/0.0.0.0/tcp/50506',
-            '--syncMode=light',
+            '--sync=light',
             '--logLevel=debug',
           ],
         ])

--- a/packages/client/test/cli/cli-sync.spec.ts
+++ b/packages/client/test/cli/cli-sync.spec.ts
@@ -3,7 +3,7 @@ import * as tape from 'tape'
 
 // get args for --network and --syncmode
 const cliArgs = process.argv.filter(
-  (arg) => arg.startsWith('--network') || arg.startsWith('--syncMode')
+  (arg) => arg.startsWith('--network') || arg.startsWith('--sync')
 )
 
 tape('[CLI] sync', (t) => {

--- a/packages/client/test/integration/beaconsync.spec.ts
+++ b/packages/client/test/integration/beaconsync.spec.ts
@@ -28,14 +28,14 @@ tape('[Integration:BeaconSync]', async (t) => {
         next: next.hash(),
       },
     ]
-    await localService.synchronizer.stop()
+    await localService.synchronizer!.stop()
     await localServer.discover('remotePeer1', '127.0.0.2')
     localService.config.events.on(Event.SYNC_SYNCHRONIZED, async () => {
       t.equals(localService.chain.blocks.height, BigInt(20), 'synced')
       await destroy(localServer, localService)
       await destroy(remoteServer, remoteService)
     })
-    await localService.synchronizer.start()
+    await localService.synchronizer!.start()
   })
 
   t.test('should not sync with stale peers', async (t) => {
@@ -76,7 +76,7 @@ tape('[Integration:BeaconSync]', async (t) => {
       },
     ]
     localService.interval = 1000
-    await localService.synchronizer.stop()
+    await localService.synchronizer!.stop()
     await localServer.discover('remotePeer1', '127.0.0.2')
     await localServer.discover('remotePeer2', '127.0.0.3')
 
@@ -88,7 +88,7 @@ tape('[Integration:BeaconSync]', async (t) => {
         await destroy(remoteServer2, remoteService2)
       }
     })
-    await localService.synchronizer.start()
+    await localService.synchronizer!.start()
   })
 })
 

--- a/packages/client/test/integration/fullsync.spec.ts
+++ b/packages/client/test/integration/fullsync.spec.ts
@@ -8,7 +8,7 @@ tape('[Integration:FullSync]', async (t) => {
   t.test('should sync blocks', async (t) => {
     const [remoteServer, remoteService] = await setup({ location: '127.0.0.2', height: 20 })
     const [localServer, localService] = await setup({ location: '127.0.0.1', height: 0 })
-    await localService.synchronizer.stop()
+    await localService.synchronizer!.stop()
     await localServer.discover('remotePeer1', '127.0.0.2')
     // await localService.synchronizer.sync()
     localService.config.events.on(Event.SYNC_SYNCHRONIZED, async () => {
@@ -16,7 +16,7 @@ tape('[Integration:FullSync]', async (t) => {
       await destroy(localServer, localService)
       await destroy(remoteServer, remoteService)
     })
-    await localService.synchronizer.start()
+    await localService.synchronizer!.start()
   })
 
   t.test('should not sync with stale peers', async (t) => {
@@ -40,7 +40,7 @@ tape('[Integration:FullSync]', async (t) => {
       height: 0,
       minPeers: 2,
     })
-    await localService.synchronizer.stop()
+    await localService.synchronizer!.stop()
     await localServer.discover('remotePeer1', '127.0.0.2')
     await localServer.discover('remotePeer2', '127.0.0.3')
 
@@ -52,6 +52,6 @@ tape('[Integration:FullSync]', async (t) => {
         await destroy(remoteServer2, remoteService2)
       }
     })
-    await localService.synchronizer.start()
+    await localService.synchronizer!.start()
   })
 })

--- a/packages/client/test/integration/lightsync.spec.ts
+++ b/packages/client/test/integration/lightsync.spec.ts
@@ -17,14 +17,14 @@ tape('[Integration:LightSync]', async (t) => {
       height: 0,
       syncmode: SyncMode.Light,
     })
-    await localService.synchronizer.stop()
+    await localService.synchronizer!.stop()
     await localServer.discover('remotePeer1', '127.0.0.2')
     localService.config.events.on(Event.SYNC_SYNCHRONIZED, async () => {
       t.equals(localService.chain.headers.height, BigInt(20), 'synced')
       await destroy(localServer, localService)
       await destroy(remoteServer, remoteService)
     })
-    await localService.synchronizer.start()
+    await localService.synchronizer!.start()
   })
 
   t.test('should not sync with stale peers', async (t) => {
@@ -64,7 +64,7 @@ tape('[Integration:LightSync]', async (t) => {
       height: 0,
       syncmode: SyncMode.Light,
     })
-    await localService.synchronizer.stop()
+    await localService.synchronizer!.stop()
     await localServer.discover('remotePeer1', '127.0.0.2')
     await localServer.discover('remotePeer2', '127.0.0.3')
     localService.config.events.on(Event.SYNC_SYNCHRONIZED, async () => {
@@ -75,6 +75,6 @@ tape('[Integration:LightSync]', async (t) => {
         await destroy(remoteServer2, remoteService2)
       }
     })
-    await localService.synchronizer.start()
+    await localService.synchronizer!.start()
   })
 })

--- a/packages/client/test/integration/merge.spec.ts
+++ b/packages/client/test/integration/merge.spec.ts
@@ -130,7 +130,7 @@ tape('[Integration:Merge]', async (t) => {
         t.fail('chain should not exceed merge TTD')
       }
     })
-    await remoteService.synchronizer.start()
+    await remoteService.synchronizer!.start()
     await new Promise(() => {}) // resolves once t.end() is called
   })
 
@@ -169,7 +169,7 @@ tape('[Integration:Merge]', async (t) => {
         t.fail('chain should not exceed merge terminal block')
       }
     })
-    await remoteService.synchronizer.start()
+    await remoteService.synchronizer!.start()
     await new Promise(() => {}) // resolves once t.end() is called
   })
 })

--- a/packages/client/test/integration/miner.spec.ts
+++ b/packages/client/test/integration/miner.spec.ts
@@ -102,7 +102,7 @@ tape('[Integration:Miner]', async (t) => {
           t.end()
         }
       })
-      await remoteService.synchronizer.start()
+      await remoteService.synchronizer!.start()
       await new Promise(() => {}) // resolves once t.end() is called
     }
   )

--- a/packages/client/test/rpc/eth/getTransactionByHash.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionByHash.spec.ts
@@ -32,7 +32,7 @@ tape(`${method}: call with legacy tx`, async (t) => {
     const msg = 'should return the correct tx'
     t.equal(res.body.result.hash, bytesToPrefixedHexString(tx.hash()), msg)
   }
-  await baseRequest(t, server, req, 200, expectRes, false)
+  await baseRequest(t, server, req, 200, expectRes, false, false)
 
   // run a block to ensure tx hash index is cleaned up when txLookupLimit=1
   await runBlockWithTxs(chain, execution, [])

--- a/packages/client/test/rpc/eth/syncing.spec.ts
+++ b/packages/client/test/rpc/eth/syncing.spec.ts
@@ -46,7 +46,7 @@ tape(`${method}: should return highest block header unavailable error`, async (t
   const manager = createManager(client)
   const rpcServer = startRPC(manager.getMethods())
 
-  const synchronizer = client.services[0].synchronizer
+  const synchronizer = client.services[0].synchronizer!
   synchronizer.best = td.func<typeof synchronizer['best']>()
   td.when(synchronizer.best()).thenResolve('peer')
 

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -193,7 +193,8 @@ export async function baseRequest(
   req: Object,
   expect: number,
   expectRes: Function,
-  endOnFinish = true
+  endOnFinish = true,
+  doCloseRPCOnSuccess = true
 ) {
   try {
     await request(server)
@@ -202,7 +203,9 @@ export async function baseRequest(
       .send(req)
       .expect(expect)
       .expect(expectRes)
-    closeRPC(server)
+    if (doCloseRPCOnSuccess) {
+      closeRPC(server)
+    }
     if (endOnFinish) {
       t.end()
     }

--- a/packages/client/test/service/fullethereumservice.spec.ts
+++ b/packages/client/test/service/fullethereumservice.spec.ts
@@ -100,7 +100,7 @@ tape('[FullEthereumService]', async (t) => {
     const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     await service.open()
-    td.verify(service.synchronizer.open())
+    td.verify(service.synchronizer!.open())
     td.verify(server.addProtocols(td.matchers.anything()))
     service.config.events.on(Event.SYNC_SYNCHRONIZED, () => t.pass('synchronized'))
     service.config.events.on(Event.SYNC_ERROR, (err) => {
@@ -122,10 +122,10 @@ tape('[FullEthereumService]', async (t) => {
     const service = new FullEthereumService({ config, chain })
 
     await service.start()
-    td.verify(service.synchronizer.start())
+    td.verify(service.synchronizer!.start())
     t.notOk(await service.start(), 'already started')
     await service.stop()
-    td.verify(service.synchronizer.stop())
+    td.verify(service.synchronizer!.stop())
     t.notOk(await service.stop(), 'already stopped')
     t.end()
   })


### PR DESCRIPTION
Ok, this PR now starts with some low-level things to ease respectively improve (aka: speed up) "execution mode", so to catch up with execution if things are behind.

It does so by:

- Allowing to disable transports (actually by updating the Yargs version, `--transports` didn't work as expected before)
- Allowing to completely disable sync (`syncMode` option also renamed to `sync` since easier to write, new option `none`, so now: `--sync=full` (normally not used), `sync=none`)

So this allow to run the client with:

```shell
npm run client:start -- --transports --sync=none
```

Haven't explicitly tested execution speed-up, since at the end it doesn't really matter for this PR, think it's generally good to have at least these possibilities from above, independtly from the purpose. Should help for execution too though.

PR also cautiously sets up the block per request and execution iteration from 50 to 100 following Jochems suggestion respectively mentioning. We can see how this goes, generally one can already see that this better reflects execution/download speed now.

Open for review and merge.