### PR TITLE
tx: Fix EIP-155 transaction encoding on chain ID 0.

### DIFF
--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -190,7 +190,7 @@ export class Transaction extends BaseTransaction<Transaction> {
     ]
 
     if (this.supports(Capability.EIP155ReplayProtection)) {
-      values.push(toBuffer(this.common.chainId()))
+      values.push(bigIntToUnpaddedBuffer(this.common.chainId()))
       values.push(unpadBuffer(toBuffer(0)))
       values.push(unpadBuffer(toBuffer(0)))
     }


### PR DESCRIPTION
When preparing Ethereum data for RLP encoding, you must convert all values to either byte arrays or lists.  Scalar values (positive integers) are converted to byte arrays by using the fewest bytes possible to represent the value in big endian format.  The canonical form of any scalar value prepped for RLP encoding is that any leading `0` bytes stripped.  In the case of `0`, this means that the only byte (`0x00`) is stripped and you are left with an empty array.

Most of the values in this code are properly 0-stripped using `bigIntToUnpaddedBuffer`.  Unfortunately, it appears that the `chainId` was added without stripping leading zeros.  In most cases this doesn't matter, but if someone is running a chainId 0 blockchain and they want to EIP-155 encode their transaction, the previous code would result in an invalid transaction because only the canonical form is allowed.

This change fixes this bug and correctly prepares the chainId in EIP-155 transactions for RLP encoding.