### PR TITLE
client: Add 4844 devnet5 blob post utility

### DIFF
--- a/packages/client/test/sim/4844-devnet-5.md
+++ b/packages/client/test/sim/4844-devnet-5.md
@@ -1,0 +1,14 @@
+A blob tx gen utility for seeding devnet5 (or subsequent devnets/testnests with blobs)
+
+how to run:
+
+1. Clone the repo set to branch `develop-v7` and run `npm i` with nodejs `18` installed and latest npm version
+2. Run the blob gen utility (replace PRIVATE_KEY with a funded account private key and RPC_URL with an authenticated rpc url):
+  ```typescript
+    cd packages/client
+    PRIVATE_KEY=ae557af4ceefda559c924516cabf029bedc36b68109bf8d6183fe96e04121f4e RPC_URL=https://rpc.lodestar-ethereumjs-1.srv.4844-devnet-5.ethpandaops.io npm run tape -- test/sim/4844devnet5.spec.ts
+  ```
+
+  It runs with current chainId of `4844001005`, if you want to override pass `CHAIN_ID=` env param in above command
+  currently it posts 2 txs, but that can be modified with another env variable `NUM_TXS`
+  

--- a/packages/client/test/sim/4844-devnet-5.md
+++ b/packages/client/test/sim/4844-devnet-5.md
@@ -11,4 +11,7 @@ how to run:
 
   It runs with current chainId of `4844001005`, if you want to override pass `CHAIN_ID=` env param in above command
   currently it posts 2 txs, but that can be modified with another env variable `NUM_TXS`
-  
+
+  You can manipulate the fees for the txs using env variables in the following way (for e.g. to replace a low fee stuck tx):
+
+  `GAS_LIMIT=0xffffff MAX_FEE=1000000000 MAX_PRIORITY=100000000 MAX_DATAFEE=100000000 RIVATE_KEY=ae557af4ceefda559c924516cabf029bedc36b68109bf8d6183fe96e04121f4e RPC_URL=https://rpc.lodestar-ethereumjs-1.srv.4844-devnet-5.ethpandaops.io npm run tape -- test/sim/4844devnet5.spec.ts`

--- a/packages/client/test/sim/4844.md
+++ b/packages/client/test/sim/4844.md
@@ -5,10 +5,10 @@ Note: All commands should be run from the `client` package directory root (so so
 ## Running a local devnet
 
 Step 1. To run a single EthereumJS client <> Lodestar CL client for testing, run the following command:
-`NETWORK=sharding EXTRA_CL_PARAMS="--params.CAPELLA_FORK_EPOCH 0 --params.DENEB_FORK_EPOCH 0" LODE_IMAGE=g11tech/lodestar:decoupled DATADIR=path/to/your/data/directory test/sim/./single-run.sh`
+`NETWORK=sharding EXTRA_CL_PARAMS="--params.CAPELLA_FORK_EPOCH 0 --params.DENEB_FORK_EPOCH 0" LODE_IMAGE=g11tech/lodestar:blobs-2467 DATADIR=path/to/your/data/directory test/sim/./single-run.sh`
 
 Step 2. (Optional) To run a second EthereumJS <> Lodestar pair, use this command:
-`MULTIPEER=syncpeer NETWORK=sharding EXTRA_CL_PARAMS="--params.CAPELLA_FORK_EPOCH 0 --params.DENEB_FORK_EPOCH 0" LODE_IMAGE=g11tech/lodestar:decoupled DATADIR=path/to/your/data/directory test/sim/./single-run.sh`
+`MULTIPEER=syncpeer NETWORK=sharding EXTRA_CL_PARAMS="--params.CAPELLA_FORK_EPOCH 0 --params.DENEB_FORK_EPOCH 0" LODE_IMAGE=g11tech/lodestar:blobs-2467 DATADIR=path/to/your/data/directory test/sim/./single-run.sh`
 
 Step 3. To send a single blob transaction to the network, you may just run spec test:
 `EXTERNAL_RUN=true npm run tape -- test/sim/sharding.spec.ts`
@@ -25,10 +25,10 @@ You don't need to externally start the nodes, the sim tests will do all that for
 
 Run Step 1 & 3 together:
 
-`LODE_IMAGE=g11tech/lodestar:decoupled DATADIR=path/to/your/data/directory npm run tape -- test/sim/sharding.spec.ts`
+`LODE_IMAGE=g11tech/lodestar:blobs-2467 DATADIR=path/to/your/data/directory npm run tape -- test/sim/sharding.spec.ts`
 
 ### Run Step 1, 2 & 3 together
 
-`WITH_PEER=syncpeer LODE_IMAGE=g11tech/lodestar:decoupled DATADIR=path/to/your/data/directory npm run tape -- test/sim/sharding.spec.ts`
+`WITH_PEER=syncpeer LODE_IMAGE=g11tech/lodestar:blobs-2467 DATADIR=path/to/your/data/directory npm run tape -- test/sim/sharding.spec.ts`
 
 Note, these tests are adapted from the specification tests contained in the [EIP-4844 Interop repo](https://github.com/Inphi/eip4844-interop)

--- a/packages/client/test/sim/4844devnet5.spec.ts
+++ b/packages/client/test/sim/4844devnet5.spec.ts
@@ -69,7 +69,7 @@ tape(`running txes on ${rpcUrl}`, async (t) => {
     st.pass(`fetched ${sender}'s  nonce=${nonce} for blob txs`)
 
     const txns = await createBlobTxs(
-      numTxs,
+      numTxs - 1,
       4096,
       pkey,
       nonce,

--- a/packages/client/test/sim/4844devnet5.spec.ts
+++ b/packages/client/test/sim/4844devnet5.spec.ts
@@ -79,6 +79,11 @@ tape(`running txes on ${rpcUrl}`, async (t) => {
     const txHashes = []
     for (const txn of txns) {
       const res = await client.request('eth_sendRawTransaction', [txn], 2.0)
+      if(res.result===undefined){
+        console.log("eth_sendRawTransaction returned invalid response",res);
+        st.fail(`Unable to post all txs`);
+        break;
+      }
       st.pass(`posted tx with hash=${res.result}`)
       txHashes.push(res.result)
     }

--- a/packages/client/test/sim/4844devnet5.spec.ts
+++ b/packages/client/test/sim/4844devnet5.spec.ts
@@ -1,0 +1,115 @@
+import { Common } from '@ethereumjs/common'
+import { bytesToPrefixedHexString, hexStringToBytes, privateToAddress } from '@ethereumjs/util'
+import { Client } from 'jayson/promise'
+import { randomBytes } from 'node:crypto'
+import * as tape from 'tape'
+
+import {
+  createBlobTxs,
+  filterKeywords,
+  filterOutWords,
+  runTxHelper,
+  startNetwork,
+  waitForELStart,
+} from './simutils'
+
+const pkey = hexStringToBytes(
+  process.env.PRIVATE_KEY ?? 'ae557af4ceefda559c924516cabf029bedc36b68109bf8d6183fe96e04121f4e'
+)
+const sender = bytesToPrefixedHexString(privateToAddress(pkey))
+const rpcUrl =
+  process.env.RPC_URL ?? 'https://rpc.lodestar-ethereumjs-1.srv.4844-devnet-5.ethpandaops.io'
+if (rpcUrl === undefined) {
+  throw Error('Need a valid RPC url to connect to EL client')
+}
+
+const client = Client.https(rpcUrl as any)
+// pick sharding spec which has cancun hf instantiated from genesis itself
+// only override the chainid if provided
+const chainId = Number(process.env.CHAIN_ID ?? 4844001005)
+const numTxs = Number(process.env.NUM_TXS ?? 1)
+console.log({ sender, rpcUrl, chainId, numTxs })
+
+const network = 'sharding'
+const shardingJson = require(`./configs/${network}.json`)
+
+// safely change chainId without modifying undelying json
+const commonJson = { ...shardingJson }
+commonJson.config = { ...commonJson.config, chainId }
+const common = Common.fromGethGenesis(commonJson, { chain: network })
+
+export async function runTx(data: string, to?: string, value?: bigint) {
+  return runTxHelper({ client, common, sender, pkey }, data, to, value)
+}
+
+tape(`running txes on ${rpcUrl}`, async (t) => {
+  const { teardownCallBack, result } = await startNetwork(network, client, {
+    filterKeywords,
+    filterOutWords,
+    externalRun: 'true',
+  })
+  t.pass(`connected to client ${result}`)
+
+  console.log(`Checking for network running...`)
+  try {
+    await waitForELStart(client)
+    t.pass(`${result} confirmed running`)
+  } catch (e) {
+    t.fail(`failed to confirm ${result} running`)
+    throw e
+  }
+
+  t.test('run blob transactions', async (st) => {
+    const nonceFetch = await client.request(
+      'eth_getTransactionCount',
+      [sender.toString(), 'latest'],
+      2.0
+    )
+    const nonce = Number(nonceFetch.result)
+    st.pass(`fetched ${sender}'s  nonce=${nonce} for blob txs`)
+
+    const txns = await createBlobTxs(
+      numTxs,
+      4096,
+      pkey,
+      nonce,
+      { to: bytesToPrefixedHexString(randomBytes(20)), chainId },
+      { common }
+    )
+    const txHashes = []
+    for (const txn of txns) {
+      const res = await client.request('eth_sendRawTransaction', [txn], 2.0)
+      st.pass(`posted tx with hash=${res.result}`)
+      txHashes.push(res.result)
+    }
+    st.pass(`posted txs=${txHashes.length}`)
+
+    // let done = false
+    // let txReceipt
+    // while (!done) {
+    //   txReceipt = await client.request('eth_getTransactionReceipt', [txHashes[0]], 2.0)
+    //   if (txReceipt.result !== null) {
+    //     done = true
+    //   }
+    //   await sleep(2000)
+    // }
+    // const block1 = await client.request(
+    //   'eth_getBlockByHash',
+    //   [txReceipt.result.blockHash, false],
+    //   2.0
+    // )
+    // st.ok(BigInt(block1.result.excessDataGas) > 0n, 'block1 has excess data gas > 0')
+  })
+
+  t.test('cleanup', async (st) => {
+    try {
+      await teardownCallBack()
+      st.pass('script terminated')
+    } catch (e) {
+      st.fail('could not terminate properly')
+    }
+    st.end()
+  })
+
+  t.end()
+})

--- a/packages/client/test/sim/4844devnet5.spec.ts
+++ b/packages/client/test/sim/4844devnet5.spec.ts
@@ -79,10 +79,10 @@ tape(`running txes on ${rpcUrl}`, async (t) => {
     const txHashes = []
     for (const txn of txns) {
       const res = await client.request('eth_sendRawTransaction', [txn], 2.0)
-      if(res.result===undefined){
-        console.log("eth_sendRawTransaction returned invalid response",res);
-        st.fail(`Unable to post all txs`);
-        break;
+      if (res.result === undefined) {
+        console.log('eth_sendRawTransaction returned invalid response', res)
+        st.fail(`Unable to post all txs`)
+        break
       }
       st.pass(`posted tx with hash=${res.result}`)
       txHashes.push(res.result)

--- a/packages/client/test/sim/4844devnet5.spec.ts
+++ b/packages/client/test/sim/4844devnet5.spec.ts
@@ -73,7 +73,14 @@ tape(`running txes on ${rpcUrl}`, async (t) => {
       4096,
       pkey,
       nonce,
-      { to: bytesToPrefixedHexString(randomBytes(20)), chainId },
+      {
+        to: bytesToPrefixedHexString(randomBytes(20)),
+        chainId,
+        maxFeePerDataGas: BigInt(process.env.MAX_DATAFEE ?? 100000000n),
+        maxPriorityFeePerGas: BigInt(process.env.MAX_PRIORITY ?? 100000000n),
+        maxFeePerGas: BigInt(process.env.MAX_FEE ?? 1000000000n),
+        gasLimit: BigInt(process.env.GAS_LIMIT ?? 0xffffffn),
+      },
       { common }
     )
     const txHashes = []

--- a/packages/client/test/sim/4844devnet5.spec.ts
+++ b/packages/client/test/sim/4844devnet5.spec.ts
@@ -95,22 +95,6 @@ tape(`running txes on ${rpcUrl}`, async (t) => {
       txHashes.push(res.result)
     }
     st.pass(`posted txs=${txHashes.length}`)
-
-    // let done = false
-    // let txReceipt
-    // while (!done) {
-    //   txReceipt = await client.request('eth_getTransactionReceipt', [txHashes[0]], 2.0)
-    //   if (txReceipt.result !== null) {
-    //     done = true
-    //   }
-    //   await sleep(2000)
-    // }
-    // const block1 = await client.request(
-    //   'eth_getBlockByHash',
-    //   [txReceipt.result.blockHash, false],
-    //   2.0
-    // )
-    // st.ok(BigInt(block1.result.excessDataGas) > 0n, 'block1 has excess data gas > 0')
   })
 
   t.test('cleanup', async (st) => {

--- a/packages/client/test/sim/sharding.spec.ts
+++ b/packages/client/test/sim/sharding.spec.ts
@@ -108,7 +108,14 @@ tape('sharding/eip4844 hardfork tests', async (t) => {
       pkey,
       // Start with nonce of 1 since a tx previous has already been posted
       1,
-      { to: bytesToPrefixedHexString(randomBytes(20)), chainId: 1 },
+      {
+        to: bytesToPrefixedHexString(randomBytes(20)),
+        chainId: 1,
+        maxFeePerDataGas: BigInt(1000) as any,
+        maxPriorityFeePerGas: BigInt(1) as any,
+        maxFeePerGas: '0xff' as any,
+        gasLimit: BigInt(1000000) as any,
+      },
       { common }
     )
     const txHashes = []

--- a/packages/client/test/sim/sharding.spec.ts
+++ b/packages/client/test/sim/sharding.spec.ts
@@ -106,8 +106,9 @@ tape('sharding/eip4844 hardfork tests', async (t) => {
       4,
       4096,
       pkey,
-      bytesToPrefixedHexString(randomBytes(20)),
-      undefined,
+      // Start with nonce of 1 since a tx previous has already been posted
+      1,
+      { to: bytesToPrefixedHexString(randomBytes(20)), chainId: 1 },
       { common }
     )
     const txHashes = []

--- a/packages/client/test/sim/simutils.ts
+++ b/packages/client/test/sim/simutils.ts
@@ -363,7 +363,15 @@ export const createBlobTxs = async (
   blobSize = 2 ** 17 - 1,
   pkey: Uint8Array,
   startNonce: number = 0,
-  txMeta: { to?: string; value?: bigint; chainId?: number } = {},
+  txMeta: {
+    to?: string
+    value?: bigint
+    chainId?: number
+    maxFeePerDataGas: bigint
+    maxPriorityFeePerGas: bigint
+    maxFeePerGas: bigint
+    gasLimit: bigint
+  },
   opts?: TxOptions
 ) => {
   const txHashes: string[] = []
@@ -383,12 +391,8 @@ export const createBlobTxs = async (
       kzgCommitments: commitments,
       kzgProofs: proofs,
       versionedHashes: hashes,
-      gas: undefined,
-      maxFeePerDataGas: BigInt(1000) as any,
-      maxPriorityFeePerGas: BigInt(1) as any,
-      maxFeePerGas: '0xff' as any,
       nonce: BigInt(x),
-      gasLimit: BigInt(1000000) as any,
+      gas: undefined,
     }
 
     const blobTx = BlobEIP4844Transaction.fromTxData(txData, opts).sign(pkey)

--- a/packages/client/test/sim/simutils.ts
+++ b/packages/client/test/sim/simutils.ts
@@ -362,8 +362,8 @@ export const createBlobTxs = async (
   numTxs: number,
   blobSize = 2 ** 17 - 1,
   pkey: Uint8Array,
-  to?: string,
-  value?: bigint,
+  startNonce: number = 0,
+  txMeta: { to?: string; value?: bigint; chainId?: number } = {},
   opts?: TxOptions
 ) => {
   const txHashes: string[] = []
@@ -372,39 +372,33 @@ export const createBlobTxs = async (
   const commitments = blobsToCommitments(blobs)
   const proofs = blobsToProofs(blobs, commitments)
   const hashes = commitmentsToVersionedHashes(commitments)
+  const txns = []
 
-  for (let x = 1; x <= numTxs; x++) {
+  for (let x = startNonce; x <= startNonce + numTxs; x++) {
     const sender = Address.fromPrivateKey(pkey)
     const txData = {
       from: sender.toString(),
-      to,
-      data: '0x',
-      chainId: '0x1',
+      ...txMeta,
       blobs,
       kzgCommitments: commitments,
       kzgProofs: proofs,
       versionedHashes: hashes,
       gas: undefined,
-      maxFeePerDataGas: undefined,
-      maxPriorityFeePerGas: undefined,
-      maxFeePerGas: undefined,
+      maxFeePerDataGas: BigInt(1000) as any,
+      maxPriorityFeePerGas: BigInt(1) as any,
+      maxFeePerGas: '0xff' as any,
       nonce: BigInt(x),
-      gasLimit: undefined,
-      value,
+      gasLimit: BigInt(1000000) as any,
     }
-
-    txData['maxFeePerGas'] = '0xff' as any
-    txData['maxPriorityFeePerGas'] = BigInt(1) as any
-    txData['maxFeePerDataGas'] = BigInt(1000) as any
-    txData['gasLimit'] = BigInt(1000000) as any
 
     const blobTx = BlobEIP4844Transaction.fromTxData(txData, opts).sign(pkey)
 
     const serializedWrapper = blobTx.serializeNetworkWrapper()
     await fs.appendFile('./blobs.txt', bytesToPrefixedHexString(serializedWrapper) + '\n')
+    txns.push(bytesToPrefixedHexString(serializedWrapper))
     txHashes.push(bytesToPrefixedHexString(blobTx.hash()))
   }
-  return txHashes
+  return txns
 }
 
 export const runBlobTxsFromFile = async (client: Client, path: string) => {

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -104,7 +104,7 @@ export abstract class BaseTransaction<TransactionObject> {
     this.gasLimit = bytesToBigInt(toBytes(gasLimit === '' ? '0x' : gasLimit))
     this.to = toB.length > 0 ? new Address(toB) : undefined
     this.value = bytesToBigInt(toBytes(value === '' ? '0x' : value))
-    this.data = toBytes(data === '' ? '0x' : data)
+    this.data = toBytes((data ?? '') === '' ? '0x' : data)
 
     this.v = vB.length > 0 ? bytesToBigInt(vB) : undefined
     this.r = rB.length > 0 ? bytesToBigInt(rB) : undefined

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -104,7 +104,7 @@ export abstract class BaseTransaction<TransactionObject> {
     this.gasLimit = bytesToBigInt(toBytes(gasLimit === '' ? '0x' : gasLimit))
     this.to = toB.length > 0 ? new Address(toB) : undefined
     this.value = bytesToBigInt(toBytes(value === '' ? '0x' : value))
-    this.data = toBytes((data ?? '') === '' ? '0x' : data)
+    this.data = toBytes(data === '' ? '0x' : data)
 
     this.v = vB.length > 0 ? bytesToBigInt(vB) : undefined
     this.r = rB.length > 0 ? bytesToBigInt(rB) : undefined


### PR DESCRIPTION
A blob tx gen utility for seeding devnet5 (or subsequent devnets/testnests with blobs)

how to run:

1. Clone the repo set to branch `develop-v7` and run `npm i` with nodejs `18` installed and latest npm version
2. Run the blob gen utility (replace PRIVATE_KEY with a funded account private key and RPC_URL with an authenticated rpc url):
  ```typescript
    cd packages/client
    PRIVATE_KEY=ae557af4ceefda559c924516cabf029bedc36b68109bf8d6183fe96e04121f4e RPC_URL=https://rpc.lodestar-ethereumjs-1.srv.4844-devnet-5.ethpandaops.io npm run tape -- test/sim/4844devnet5.spec.ts
  ```

  It runs with current chainId of `4844001005`, if you want to override pass `CHAIN_ID=` env param in above command
  currently it posts 2 txs, but that can be modified with another env variable `NUM_TXS`

  You can manipulate the fees for the txs using env variables in the following way (for e.g. to replace a low fee stuck tx):

  `GAS_LIMIT=0xffffff MAX_FEE=1000000000 MAX_PRIORITY=100000000 MAX_DATAFEE=100000000 RIVATE_KEY=ae557af4ceefda559c924516cabf029bedc36b68109bf8d6183fe96e04121f4e RPC_URL=https://rpc.lodestar-ethereumjs-1.srv.4844-devnet-5.ethpandaops.io npm run tape -- test/sim/4844devnet5.spec.ts`
