### PR TITLE
blockchain: Save iterator head to last successfuly executed even on errors

### DIFF
--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -1016,7 +1016,7 @@ export class Blockchain implements BlockchainInterface {
               }
             }
 
-            // if there was no reorg, updated head
+            // if there was no reorg, update head
             if (!reorgWhileOnBlock) {
               this._heads[name] = nextBlock.hash()
               lastBlock = nextBlock

--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -398,6 +398,7 @@ export class VMExecution extends Execution {
           // release lock on this callback so other blockchain ops can happen while this block is being executed
           true
         )
+        // Ensure to catch and not throw as this would lead to unCaughtException with process exit
         .catch(async (error) => {
           if (errorBlock !== undefined) {
             // TODO: determine if there is a way to differentiate between the cases
@@ -450,7 +451,6 @@ export class VMExecution extends Execution {
           }
         })
 
-      // Promise never errors as its catch and handled so that it cannot interrupt and end the process
       numExecuted = await this.vmPromise
       if (numExecuted !== null) {
         let endHeadBlock

--- a/packages/client/lib/execution/vmexecution.ts
+++ b/packages/client/lib/execution/vmexecution.ts
@@ -34,7 +34,7 @@ export class VMExecution extends Execution {
 
   public receiptsManager?: ReceiptsManager
   private pendingReceipts?: Map<string, TxReceipt[]>
-  private vmPromise?: Promise<number>
+  private vmPromise?: Promise<number | null>
 
   /** Maximally tolerated block time before giving a warning on console */
   private MAX_TOLERATED_BLOCK_TIME = 12
@@ -268,7 +268,7 @@ export class VMExecution extends Execution {
   async run(loop = true, runOnlybatched = false): Promise<number> {
     if (this.running || !this.started || this.shutdown) return 0
     this.running = true
-    let numExecuted: number | undefined
+    let numExecuted: number | null | undefined = undefined
 
     const { blockchain } = this.vm
     if (typeof blockchain.getIteratorHead !== 'function') {
@@ -302,82 +302,104 @@ export class VMExecution extends Execution {
       headBlock = undefined
       parentState = undefined
       errorBlock = undefined
-      this.vmPromise = blockchain.iterator(
-        'vm',
-        async (block: Block, reorg: boolean) => {
-          if (errorBlock !== undefined) return
-          // determine starting state for block run
-          // if we are just starting or if a chain reorg has happened
-          if (headBlock === undefined || reorg) {
-            const headBlock = await blockchain.getBlock(block.header.parentHash)
-            parentState = headBlock.header.stateRoot
+      this.vmPromise = blockchain
+        .iterator(
+          'vm',
+          async (block: Block, reorg: boolean) => {
+            // determine starting state for block run
+            // if we are just starting or if a chain reorg has happened
+            if (headBlock === undefined || reorg) {
+              const headBlock = await blockchain.getBlock(block.header.parentHash)
+              parentState = headBlock.header.stateRoot
 
-            if (reorg) {
-              this.config.logger.info(
-                `Chain reorg happened, set new head to block number=${headBlock.header.number}, clearing state cache for VM execution.`
-              )
-            }
-          }
-          // run block, update head if valid
-          try {
-            const { number, timestamp } = block.header
-            if (typeof blockchain.getTotalDifficulty !== 'function') {
-              throw new Error(
-                'cannot get iterator head: blockchain has no getTotalDifficulty function'
-              )
-            }
-            const td = await blockchain.getTotalDifficulty(block.header.parentHash)
-
-            const hardfork = this.config.execCommon.getHardforkByBlockNumber(number, td, timestamp)
-            if (hardfork !== this.hardfork) {
-              const hash = short(block.hash())
-              this.config.logger.info(
-                `Execution hardfork switch on block number=${number} hash=${hash} old=${this.hardfork} new=${hardfork}`
-              )
-              this.hardfork = this.config.execCommon.setHardforkByBlockNumber(number, td, timestamp)
-            }
-            let skipBlockValidation = false
-            if (this.config.execCommon.consensusType() === ConsensusType.ProofOfAuthority) {
-              // Block validation is redundant here and leads to consistency problems
-              // on PoA clique along blockchain-including validation checks
-              // (signer states might have moved on when sync is ahead)
-              skipBlockValidation = true
-            }
-
-            await this.runWithLock<void>(async () => {
-              // we are skipping header validation because the block has been picked from the
-              // blockchain and header should have already been validated while putBlock
-              if (!this.started) {
-                throw Error('Execution stopped')
+              if (reorg) {
+                this.config.logger.info(
+                  `Chain reorg happened, set new head to block number=${headBlock.header.number}, clearing state cache for VM execution.`
+                )
               }
-              const beforeTS = Date.now()
-              this.stats(this.vm)
-              const result = await this.vm.runBlock({
-                block,
-                root: parentState,
-                clearCache: reorg ? true : false,
-                skipBlockValidation,
-                skipHeaderValidation: true,
+            }
+
+            // run block, update head if valid
+            try {
+              const { number, timestamp } = block.header
+              if (typeof blockchain.getTotalDifficulty !== 'function') {
+                throw new Error(
+                  'cannot get iterator head: blockchain has no getTotalDifficulty function'
+                )
+              }
+              const td = await blockchain.getTotalDifficulty(block.header.parentHash)
+
+              const hardfork = this.config.execCommon.getHardforkByBlockNumber(
+                number,
+                td,
+                timestamp
+              )
+              if (hardfork !== this.hardfork) {
+                const hash = short(block.hash())
+                this.config.logger.info(
+                  `Execution hardfork switch on block number=${number} hash=${hash} old=${this.hardfork} new=${hardfork}`
+                )
+                this.hardfork = this.config.execCommon.setHardforkByBlockNumber(
+                  number,
+                  td,
+                  timestamp
+                )
+              }
+              let skipBlockValidation = false
+              if (this.config.execCommon.consensusType() === ConsensusType.ProofOfAuthority) {
+                // Block validation is redundant here and leads to consistency problems
+                // on PoA clique along blockchain-including validation checks
+                // (signer states might have moved on when sync is ahead)
+                skipBlockValidation = true
+              }
+
+              await this.runWithLock<void>(async () => {
+                // we are skipping header validation because the block has been picked from the
+                // blockchain and header should have already been validated while putBlock
+                if (!this.started) {
+                  throw Error('Execution stopped')
+                }
+                const beforeTS = Date.now()
+                this.stats(this.vm)
+                const result = await this.vm.runBlock({
+                  block,
+                  root: parentState,
+                  clearCache: reorg ? true : false,
+                  skipBlockValidation,
+                  skipHeaderValidation: true,
+                })
+                const afterTS = Date.now()
+                const diffSec = Math.round((afterTS - beforeTS) / 1000)
+
+                if (diffSec > this.MAX_TOLERATED_BLOCK_TIME) {
+                  const msg = `Slow block execution for block num=${
+                    block.header.number
+                  } hash=0x${bytesToHex(block.hash())} txs=${block.transactions.length} gasUsed=${
+                    result.gasUsed
+                  } time=${diffSec}secs`
+                  this.config.logger.warn(msg)
+                }
+
+                void this.receiptsManager?.saveReceipts(block, result.receipts)
               })
-              const afterTS = Date.now()
-              const diffSec = Math.round((afterTS - beforeTS) / 1000)
 
-              if (diffSec > this.MAX_TOLERATED_BLOCK_TIME) {
-                const msg = `Slow block execution for block num=${
-                  block.header.number
-                } hash=0x${bytesToHex(block.hash())} txs=${block.transactions.length} gasUsed=${
-                  result.gasUsed
-                } time=${diffSec}secs`
-                this.config.logger.warn(msg)
-              }
-
-              void this.receiptsManager?.saveReceipts(block, result.receipts)
-            })
-            txCounter += block.transactions.length
-            // set as new head block
-            headBlock = block
-            parentState = block.header.stateRoot
-          } catch (error: any) {
+              txCounter += block.transactions.length
+              // set as new head block
+              headBlock = block
+              parentState = block.header.stateRoot
+            } catch (error: any) {
+              // Store error block and throw which will make iterator stop, exit and save
+              // last successfully executed head as vmHead
+              errorBlock = block
+              throw error
+            }
+          },
+          this.config.numBlocksPerIteration,
+          // release lock on this callback so other blockchain ops can happen while this block is being executed
+          true
+        )
+        .catch(async (error) => {
+          if (errorBlock !== undefined) {
             // TODO: determine if there is a way to differentiate between the cases
             // a) a bad block is served by a bad peer -> delete the block and restart sync
             //    sync from parent block
@@ -411,71 +433,66 @@ export class VMExecution extends Execution {
             }*/
             // Option a): set iterator head to the parent block so that an
             // error can repeatedly processed for debugging
-            const { number } = block.header
-            const hash = short(block.hash())
+            const { number } = errorBlock.header
+            const hash = short(errorBlock.hash())
             this.config.logger.warn(
               `Execution of block number=${number} hash=${hash} hardfork=${this.hardfork} failed:\n${error}`
             )
             if (this.config.debugCode) {
-              await debugCodeReplayBlock(this, block)
+              await debugCodeReplayBlock(this, errorBlock)
             }
             this.config.events.emit(Event.SYNC_EXECUTION_VM_ERROR, error)
-            errorBlock = block
+            const actualExecuted = Number(errorBlock.header.number - startHeadBlock.header.number)
+            return actualExecuted
+          } else {
+            this.config.logger.error(`VM execution failed with error`, error)
+            return null
           }
-        },
-        this.config.numBlocksPerIteration,
-        // release lock on this callback so other blockchain ops can happen while this block is being executed
-        true
-      )
+        })
+
+      // Promise never errors as its catch and handled so that it cannot interrupt and end the process
       numExecuted = await this.vmPromise
+      if (numExecuted !== null) {
+        let endHeadBlock
+        if (typeof this.vm.blockchain.getIteratorHead === 'function') {
+          endHeadBlock = await this.vm.blockchain.getIteratorHead('vm')
+        } else {
+          throw new Error('cannot get iterator head: blockchain has no getIteratorHead function')
+        }
 
-      // TODO: one should update the iterator head later as this is dangerous for the blockchain and can cause
-      // problems in concurrent execution
-      if (errorBlock !== undefined) {
-        await this.chain.blockchain.setIteratorHead(
-          'vm',
-          (errorBlock as unknown as Block).header.parentHash
-        )
-        return 0
+        if (typeof numExecuted === 'number' && numExecuted > 0) {
+          const firstNumber = startHeadBlock.header.number
+          const firstHash = short(startHeadBlock.hash())
+          const lastNumber = endHeadBlock.header.number
+          const lastHash = short(endHeadBlock.hash())
+          const baseFeeAdd =
+            this.config.execCommon.gteHardfork(Hardfork.London) === true
+              ? `baseFee=${endHeadBlock.header.baseFeePerGas} `
+              : ''
+          const tdAdd =
+            this.config.execCommon.gteHardfork(Hardfork.Paris) === true
+              ? ''
+              : `td=${this.chain.blocks.td} `
+          this.config.logger.info(
+            `Executed blocks count=${numExecuted} first=${firstNumber} hash=${firstHash} ${tdAdd}${baseFeeAdd}hardfork=${this.hardfork} last=${lastNumber} hash=${lastHash} txs=${txCounter}`
+          )
+        } else {
+          this.config.logger.debug(
+            `No blocks executed past chain head hash=${short(endHeadBlock.hash())} number=${
+              endHeadBlock.header.number
+            }`
+          )
+        }
+        startHeadBlock = endHeadBlock
+        if (typeof this.vm.blockchain.getCanonicalHeadBlock !== 'function') {
+          throw new Error(
+            'cannot get iterator head: blockchain has no getCanonicalHeadBlock function'
+          )
+        }
+        canonicalHead = await this.vm.blockchain.getCanonicalHeadBlock()
       }
-      let endHeadBlock
-      if (typeof this.vm.blockchain.getIteratorHead === 'function') {
-        endHeadBlock = await this.vm.blockchain.getIteratorHead('vm')
-      } else {
-        throw new Error('cannot get iterator head: blockchain has no getIteratorHead function')
-      }
-
-      if (typeof numExecuted === 'number' && numExecuted > 0) {
-        const firstNumber = startHeadBlock.header.number
-        const firstHash = short(startHeadBlock.hash())
-        const lastNumber = endHeadBlock.header.number
-        const lastHash = short(endHeadBlock.hash())
-        const baseFeeAdd =
-          this.config.execCommon.gteHardfork(Hardfork.London) === true
-            ? `baseFee=${endHeadBlock.header.baseFeePerGas} `
-            : ''
-        const tdAdd =
-          this.config.execCommon.gteHardfork(Hardfork.Paris) === true
-            ? ''
-            : `td=${this.chain.blocks.td} `
-        this.config.logger.info(
-          `Executed blocks count=${numExecuted} first=${firstNumber} hash=${firstHash} ${tdAdd}${baseFeeAdd}hardfork=${this.hardfork} last=${lastNumber} hash=${lastHash} txs=${txCounter}`
-        )
-      } else {
-        this.config.logger.debug(
-          `No blocks executed past chain head hash=${short(endHeadBlock.hash())} number=${
-            endHeadBlock.header.number
-          }`
-        )
-      }
-      startHeadBlock = endHeadBlock
-      if (typeof this.vm.blockchain.getCanonicalHeadBlock !== 'function') {
-        throw new Error(
-          'cannot get iterator head: blockchain has no getCanonicalHeadBlock function'
-        )
-      }
-      canonicalHead = await this.vm.blockchain.getCanonicalHeadBlock()
     }
+
     this.running = false
     return numExecuted ?? 0
   }

--- a/packages/client/lib/util/debug.ts
+++ b/packages/client/lib/util/debug.ts
@@ -6,7 +6,7 @@ import type { VMExecution } from '../execution'
 import type { Block } from '@ethereumjs/block'
 
 /**
- * Generates a code snippet which can be used to replay an erraneous block
+ * Generates a code snippet which can be used to replay an erroneous block
  * locally in the VM
  *
  * @param block


### PR DESCRIPTION
On further debugging and testing another case of `vmHead` corruption was observed:

1. client was executing 749796-749896 range but got an interrup signal and 749890 failed

2. next time client started vmHead was already updated to 749896 and execution started from block 749897 which obviously would fail
![image](https://user-images.githubusercontent.com/76567250/236462370-bb6bddff-fef0-4a89-835a-5e71e2571b10.png)


The synopsis of the issue:

In vmExecution  iterator, block error was being ignored leading to incorrect vmHead forward movement. So the right thing to do was to throw error. 
However in blockchain,  iterator head was not being properly saved to last successfully executed if `onBlock` callbacks errored. 

This PR addressed both the issues and also moves out iterator error handling out side of the vm iterator callback for further simplicity.
