### PR TITLE
evm: Fix the gasCost logs in op code trace

### DIFF
--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -1,12 +1,5 @@
 import { ConsensusAlgorithm } from '@ethereumjs/common'
-import {
-  Account,
-  MAX_UINT64,
-  bigIntToHex,
-  bytesToBigInt,
-  bytesToHex,
-  intToHex,
-} from '@ethereumjs/util'
+import { Account, MAX_UINT64, bigIntToHex, bytesToBigInt, bytesToHex } from '@ethereumjs/util'
 import { debug as createDebugLogger } from 'debug'
 
 import { EOF } from './eof'
@@ -331,7 +324,7 @@ export class Interpreter {
         pc: eventObj.pc,
         op: name,
         gas: bigIntToHex(eventObj.gasLeft),
-        gasCost: intToHex(eventObj.opcode.fee),
+        gasCost: bigIntToHex(dynamicFee),
         stack: hexStack,
         depth: eventObj.depth,
       }


### PR DESCRIPTION
While matching op code trace of ethereumjs with the geth it was observed that ethereumjs's gasCost logs were incorrect w.r.t the actual gas used by the opcode.

This was happening because the dynamicFee should be the one to be logged which is the actual gas consumed by the opcode 


Post this the gasCost mismatch diff with geth greatly reduced and the `0` gasCost entries disappeared from the trace