### PR TITLE
trie: update references to old deleteFromDB constructor arg

### DIFF
--- a/packages/trie/README.md
+++ b/packages/trie/README.md
@@ -91,7 +91,7 @@ const trie = new Trie({ db: new LevelDB(new Level('MY_TRIE_DB_LOCATION')) })
 
 #### Node Deletion (Pruning)
 
-By default, the deletion of trie nodes from the underlying database does not occur in order to avoid corrupting older trie states (as of `v4.2.0`). Should you only wish to work with the latest state of a trie, you can switch to a delete behavior (for example, if you wish to save disk space) by using the `deleteFromDB` constructor option (see related release notes in the changelog for further details).
+By default, the deletion of trie nodes from the underlying database does not occur in order to avoid corrupting older trie states (as of `v4.2.0`). Should you only wish to work with the latest state of a trie, you can switch to a delete behavior (for example, if you wish to save disk space) by using the `useNodePruning` constructor option (see related release notes in the changelog for further details).
 
 #### Root Persistence
 

--- a/packages/trie/docs/classes/Trie.md
+++ b/packages/trie/docs/classes/Trie.md
@@ -78,7 +78,7 @@ The root for an empty trie
 ▸ **batch**(`ops`): `Promise`<`void`\>
 
 The given hash of operations (key additions or deletions) are executed on the trie
-(delete operations are only executed on DB with `deleteFromDB` set to `true`)
+(delete operations are only executed on DB with `useNodePruning` set to `true`)
 
 **`Example`**
 
@@ -256,7 +256,7 @@ ___
 ▸ **del**(`key`): `Promise`<`void`\>
 
 Deletes a value given a `key` from the trie
-(delete operations are only executed on DB with `deleteFromDB` set to `true`)
+(delete operations are only executed on DB with `useNodePruning` set to `true`)
 
 #### Parameters
 
@@ -422,7 +422,7 @@ ___
 ▸ **put**(`key`, `value`): `Promise`<`void`\>
 
 Stores a given `value` at the given `key` or do a delete if `value` is empty
-(delete operations are only executed on DB with `deleteFromDB` set to `true`)
+(delete operations are only executed on DB with `useNodePruning` set to `true`)
 
 #### Parameters
 

--- a/packages/trie/test/index.spec.ts
+++ b/packages/trie/test/index.spec.ts
@@ -290,7 +290,7 @@ tape('it should create the genesis state root from ethereum', function (tester) 
   })
 })
 
-tape('setting back state root (deleteFromDB)', async (t) => {
+tape('setting back state root (useNodePruning)', async (t) => {
   const k1 = Buffer.from('1')
   /* Testing with longer value due to `rlpNode.length >= 32` check in `_formatNode()`
    * Reasoning from https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/:
@@ -309,7 +309,7 @@ tape('setting back state root (deleteFromDB)', async (t) => {
   const trieSetup = {
     trie: new Trie(),
     expected: v1,
-    msg: 'should return v1 when setting back the state root when deleteFromDB=false',
+    msg: 'should return v1 when setting back the state root when useNodePruning=false',
   }
 
   await trieSetup.trie.put(k1, v1)
@@ -318,7 +318,7 @@ tape('setting back state root (deleteFromDB)', async (t) => {
   t.equal(
     await trieSetup.trie.get(k1),
     null,
-    'should return null on latest state root independently from deleteFromDB setting'
+    'should return null on latest state root independently from useNodePruning setting'
   )
 
   trieSetup.trie.root(rootAfterK1)


### PR DESCRIPTION
This PR updates old references to the deleteFromDB trie constructor arg, which was replaced in favour of `useNodePruning` in #2203