### PR TITLE
Abstract "keys" method

### DIFF
--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -800,7 +800,7 @@ export class Trie {
   // If this method returns `true`, the Trie is correctly pruned and all keys are reachable
   async verifyPrunedIntegrity(): Promise<boolean> {
     const roots = [this.root().toString('hex'), this.appliedKey(ROOT_DB_KEY).toString('hex')]
-    for (const dbkey of (<any>this)._db.db._database.keys()) {
+    for (const dbkey of await (<any>this)._db.db.keys()) {
       if (roots.includes(dbkey)) {
         // The root key can never be found from the trie, otherwise this would
         // convert the tree from a directed acyclic graph to a directed cycling graph


### PR DESCRIPTION
- the ethereumjs trie now uses these db adapters
- e.g. I'm using the same lmdb adapter that is used here: https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/trie/recipes
- and e.g. lmdb doesn't implement a "keys" function: https://github.com/kriszyp/lmdbx-js#dbgetkeysoptions-rangeoptions-iterableany it's called "getKeys" and it's also a promise
- However, before merging this PR, I think we should source the respective "keys" methods for all exemplified db adapters