### PR TITLE
Use `storageCache` in `ethersStateManager`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17838,7 +17838,7 @@
         "testdouble": "^3.17.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "packages/blockchain": {
@@ -17865,7 +17865,7 @@
         "@types/level-errors": "^3.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "packages/client": {
@@ -17942,7 +17942,7 @@
         "webpack-cli": "^4.8.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "packages/client/node_modules/cliui": {
@@ -18043,7 +18043,7 @@
         "testdouble": "^3.8.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "packages/devp2p/node_modules/ansi-styles": {
@@ -18119,7 +18119,7 @@
         "memory-level": "^1.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "packages/evm": {
@@ -18128,7 +18128,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/common": "^3.1.1",
-        "@ethereumjs/tx": "^4.1.1",
+        "@ethereumjs/statemanager": "^1.0.4",
         "@ethereumjs/util": "^8.0.5",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^1.1.2",
@@ -18137,6 +18137,7 @@
       },
       "devDependencies": {
         "@ethereumjs/statemanager": "^1.0.4",
+        "@ethersproject/abi": "^5.0.12",
         "@types/benchmark": "^1.0.33",
         "@types/core-js": "^2.5.0",
         "@types/minimist": "^1.2.2",
@@ -18150,7 +18151,7 @@
         "solc": "^0.8.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "packages/rlp": {
@@ -18161,7 +18162,7 @@
         "rlp": "bin/rlp"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "packages/statemanager": {
@@ -18224,7 +18225,7 @@
         "micro-bmark": "0.2.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "packages/trie/node_modules/readable-stream": {
@@ -18258,7 +18259,7 @@
         "testdouble": "^3.17.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "peerDependencies": {
         "c-kzg": "^2.0.4"
@@ -18283,7 +18284,7 @@
         "@types/secp256k1": "^4.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "peerDependencies": {
         "c-kzg": "^2.0.4"
@@ -18335,7 +18336,7 @@
         "typescript": "^4.4.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "packages/vm/node_modules/brace-expansion": {
@@ -19777,6 +19778,7 @@
         "@ethereumjs/common": "^3.1.1",
         "@ethereumjs/statemanager": "^1.0.4",
         "@ethereumjs/util": "^8.0.5",
+        "@ethersproject/abi": "^5.0.12",
         "@types/benchmark": "^1.0.33",
         "@types/core-js": "^2.5.0",
         "@types/minimist": "^1.2.2",

--- a/packages/statemanager/src/ethersStateManager.ts
+++ b/packages/statemanager/src/ethersStateManager.ts
@@ -46,7 +46,7 @@ export class EthersStateManager implements StateManagerInterface {
       blockTag: BigInt(this.blockTag),
     })
     ;(newState as any).contractCache = new Map(this.contractCache)
-    ;(newState as any).storageCache = this.storageCache
+    ;(newState as any).storageCache = new StorageCache({ size: 10000, type: CacheType.LRU })
     ;(newState as any)._accountCache = this._accountCache
     return newState
   }

--- a/packages/statemanager/src/ethersStateManager.ts
+++ b/packages/statemanager/src/ethersStateManager.ts
@@ -1,4 +1,3 @@
-import { RLP } from '@ethereumjs/rlp'
 import { Trie } from '@ethereumjs/trie'
 import { Account, bigIntToHex, bytesToBigInt, bytesToHex, toBytes } from '@ethereumjs/util'
 import { debug } from 'debug'


### PR DESCRIPTION
Updates the `ethersStateManager` to use the newly implemented `storageCache` instead of the custom JS Map we were using before.