### PR TITLE
client: Enable default debug logging to file

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -734,7 +734,7 @@ async function run() {
   ensureDirSync(configDirectory)
   const key = await Config.getClientKey(datadir, common)
 
-  // logFile is either filename or string "true"
+  // logFile is either filename or boolean true or false to enable (with default) or disable
   if (typeof args.logFile === 'boolean') {
     args.logFile = args.logFile ? `${networkDir}/ethereumjs.log` : undefined
   }

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -182,12 +182,14 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     default: 'info',
   })
   .option('logFile', {
-    describe: 'File to save log file (pass true for `ethereumjs.log`)',
+    describe:
+      'File to save log file (default logs to `$dataDir/ethereumjs.log`, pass false to disable)',
+    default: true,
   })
   .option('logLevelFile', {
     describe: 'Log level for logFile',
     choices: ['error', 'warn', 'info', 'debug'],
-    default: 'info',
+    default: 'debug',
   })
   .option('logRotate', {
     describe: 'Rotate log file daily',
@@ -727,9 +729,16 @@ async function run() {
   }
 
   const datadir = args.dataDir ?? Config.DATADIR_DEFAULT
-  const configDirectory = `${datadir}/${common.chainName()}/config`
+  const networkDir = `${datadir}/${common.chainName()}`
+  const configDirectory = `${networkDir}/config`
   ensureDirSync(configDirectory)
   const key = await Config.getClientKey(datadir, common)
+
+  // logFile is either filename or string "true"
+  if (typeof args.logFile === 'boolean') {
+    args.logFile = args.logFile ? `${networkDir}/ethereumjs.log` : undefined
+  }
+
   logger = getLogger(args)
   const bootnodes = args.bootnodes !== undefined ? parseMultiaddrs(args.bootnodes) : undefined
   const multiaddrs = args.multiaddrs !== undefined ? parseMultiaddrs(args.multiaddrs) : undefined

--- a/packages/client/lib/logging.ts
+++ b/packages/client/lib/logging.ts
@@ -6,6 +6,10 @@ import type { Logger as WinstonLogger } from 'winston'
 const DailyRotateFile = require('winston-daily-rotate-file')
 
 export type Logger = WinstonLogger
+type LoggerArgs = { logFile: string; logLevelFile: 'error' | 'warn' | 'info' | 'debug' } & {
+  logRotate?: Boolean
+  logMaxFiles?: number
+}
 
 const { combine, timestamp, label, printf } = format
 
@@ -102,8 +106,8 @@ function formatConfig(colors = false) {
 /**
  * Returns a transport with log file saving (rotates if args.logRotate is true)
  */
-function logFileTransport(args: any) {
-  let filename = args.logFile === true ? 'ethereumjs.log' : args.logFile
+function logFileTransport(args: LoggerArgs) {
+  let filename = args.logFile
   const opts = {
     level: args.logLevelFile,
     format: formatConfig(),
@@ -137,7 +141,7 @@ export function getLogger(args: { [key: string]: any } = { logLevel: 'info' }) {
     }),
   ]
   if (typeof args.logFile === 'string') {
-    transports.push(logFileTransport(args))
+    transports.push(logFileTransport(args as LoggerArgs))
   }
   const logger = createLogger({
     transports,

--- a/packages/client/lib/types.ts
+++ b/packages/client/lib/types.ts
@@ -132,7 +132,7 @@ export interface ClientOpts {
   jwtSecret?: string
   helpRpc?: boolean
   logLevel?: string
-  logFile?: boolean
+  logFile?: boolean | string
   logLevelFile?: string
   logRotate?: boolean
   logMaxFiles?: number

--- a/packages/client/test/logging.spec.ts
+++ b/packages/client/test/logging.spec.ts
@@ -3,8 +3,20 @@ import * as tape from 'tape'
 import { getLogger } from '../lib/logging'
 
 tape('[Logging]', (t) => {
-  const logger = getLogger()
+  const logger = getLogger({ logLevel: 'info', logFile: 'ethereumjs.log', logLevelFile: 'info' })
   const format = logger.transports.find((t: any) => t.name === 'console')!.format!
+
+  t.test('should have correct transports', (st) => {
+    st.ok(
+      logger.transports.find((t: any) => t.name === 'console') !== undefined,
+      'should have stdout transport'
+    )
+    st.ok(
+      logger.transports.find((t: any) => t.name === 'file') !== undefined,
+      'should have file transport'
+    )
+    st.end()
+  })
 
   t.test('should log error stacks properly', (st) => {
     try {


### PR DESCRIPTION
Most if not all clients have this as default policy:
 - info logs on stdout
 - debug logs on file with filerotate

The default enabling of debug logs help in retrospective debugging even if the user forgets to enable logging. This PR enables the same and fixes a previous issue of `--logFile true` not working which according to help should have logged to `ethereumjs.log`
