### PR TITLE
eslint: add eslint package.json

### DIFF
--- a/eslint/package.json
+++ b/eslint/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "eslint-plugin-ethereumjs",
+  "version": "0.1.0",
+  "files": [
+    "index.js",
+    "noBuffer.js"
+  ],
+  "main": "index.js"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,8 @@
       }
     },
     "eslint": {
+      "name": "eslint-plugin-ethereumjs",
+      "version": "0.1.0",
       "dev": true
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
This PR provides a tentative fix for the issue below that a user has run into.

```
npm ERR! code ENOENT
npm ERR! syscall open
npm ERR! path D:\Workspace\ethereumjs-monorepo\eslint/package.json
npm ERR! errno -4058
npm ERR! enoent ENOENT: no such file or directory, open 'D:\Workspace\ethereumjs-monorepo\eslint\package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent
```