### PR TITLE
tx: Normalize toJson for different tx types

### DIFF
--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -4,8 +4,10 @@ import {
   MAX_INTEGER,
   MAX_UINT64,
   SECP256K1_ORDER_DIV_2,
+  bigIntToHex,
   bytesToBigInt,
   bytesToHex,
+  bytesToPrefixedHexString,
   ecsign,
   publicToAddress,
   toBytes,
@@ -354,7 +356,19 @@ export abstract class BaseTransaction<TransactionObject> {
   /**
    * Returns an object with the JSON representation of the transaction
    */
-  abstract toJSON(): JsonTx
+  toJSON(): JsonTx {
+    return {
+      type: bigIntToHex(BigInt(this.type)),
+      nonce: bigIntToHex(this.nonce),
+      gasLimit: bigIntToHex(this.gasLimit),
+      to: this.to !== undefined ? this.to.toString() : undefined,
+      value: bigIntToHex(this.value),
+      data: bytesToPrefixedHexString(this.data),
+      v: this.v !== undefined ? bigIntToHex(this.v) : undefined,
+      r: this.r !== undefined ? bigIntToHex(this.r) : undefined,
+      s: this.s !== undefined ? bigIntToHex(this.s) : undefined,
+    }
+  }
 
   // Accept the v,r,s values from the `sign` method, and convert this into a TransactionObject
   protected abstract _processSignature(v: bigint, r: Uint8Array, s: Uint8Array): TransactionObject

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -5,7 +5,6 @@ import {
   bigIntToUnpaddedBytes,
   bytesToBigInt,
   bytesToHex,
-  bytesToPrefixedHexString,
   concatBytes,
   ecrecover,
   equalsBytes,
@@ -385,20 +384,14 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMarketEIP155
    */
   toJSON(): JsonTx {
     const accessListJSON = AccessLists.getAccessListJSON(this.accessList)
+    const baseJson = super.toJSON()
 
     return {
+      ...baseJson,
       chainId: bigIntToHex(this.chainId),
-      nonce: bigIntToHex(this.nonce),
       maxPriorityFeePerGas: bigIntToHex(this.maxPriorityFeePerGas),
       maxFeePerGas: bigIntToHex(this.maxFeePerGas),
-      gasLimit: bigIntToHex(this.gasLimit),
-      to: this.to !== undefined ? this.to.toString() : undefined,
-      value: bigIntToHex(this.value),
-      data: bytesToPrefixedHexString(this.data),
       accessList: accessListJSON,
-      v: this.v !== undefined ? bigIntToHex(this.v) : undefined,
-      r: this.r !== undefined ? bigIntToHex(this.r) : undefined,
-      s: this.s !== undefined ? bigIntToHex(this.s) : undefined,
     }
   }
 

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -5,7 +5,6 @@ import {
   bigIntToUnpaddedBytes,
   bytesToBigInt,
   bytesToHex,
-  bytesToPrefixedHexString,
   concatBytes,
   ecrecover,
   equalsBytes,
@@ -354,19 +353,13 @@ export class AccessListEIP2930Transaction extends BaseTransaction<AccessListEIP2
    */
   toJSON(): JsonTx {
     const accessListJSON = AccessLists.getAccessListJSON(this.accessList)
+    const baseJson = super.toJSON()
 
     return {
+      ...baseJson,
       chainId: bigIntToHex(this.chainId),
-      nonce: bigIntToHex(this.nonce),
       gasPrice: bigIntToHex(this.gasPrice),
-      gasLimit: bigIntToHex(this.gasLimit),
-      to: this.to !== undefined ? this.to.toString() : undefined,
-      value: bigIntToHex(this.value),
-      data: bytesToPrefixedHexString(this.data),
       accessList: accessListJSON,
-      v: this.v !== undefined ? bigIntToHex(this.v) : undefined,
-      r: this.r !== undefined ? bigIntToHex(this.r) : undefined,
-      s: this.s !== undefined ? bigIntToHex(this.s) : undefined,
     }
   }
 

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -5,7 +5,6 @@ import {
   bigIntToHex,
   bigIntToUnpaddedBytes,
   bytesToBigInt,
-  bytesToHex,
   bytesToPrefixedHexString,
   computeVersionedHash,
   concatBytes,
@@ -425,21 +424,16 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
 
   toJSON(): JsonTx {
     const accessListJSON = AccessLists.getAccessListJSON(this.accessList)
+    const baseJson = super.toJSON()
+
     return {
+      ...baseJson,
       chainId: bigIntToHex(this.chainId),
-      nonce: bigIntToHex(this.nonce),
       maxPriorityFeePerGas: bigIntToHex(this.maxPriorityFeePerGas),
       maxFeePerGas: bigIntToHex(this.maxFeePerGas),
-      gasLimit: bigIntToHex(this.gasLimit),
-      to: this.to !== undefined ? this.to.toString() : undefined,
-      value: bigIntToHex(this.value),
-      data: bytesToPrefixedHexString(this.data),
       accessList: accessListJSON,
-      v: this.v !== undefined ? bigIntToHex(this.v) : undefined,
-      r: this.r !== undefined ? bigIntToHex(this.r) : undefined,
-      s: this.s !== undefined ? bigIntToHex(this.s) : undefined,
       maxFeePerDataGas: bigIntToHex(this.maxFeePerDataGas),
-      versionedHashes: this.versionedHashes.map((hash) => bytesToHex(hash)),
+      versionedHashes: this.versionedHashes.map((hash) => bytesToPrefixedHexString(hash)),
     }
   }
 

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -336,16 +336,10 @@ export class Transaction extends BaseTransaction<Transaction> {
    * Returns an object with the JSON representation of the transaction.
    */
   toJSON(): JsonTx {
+    const baseJson = super.toJSON()
     return {
-      nonce: bigIntToHex(this.nonce),
+      ...baseJson,
       gasPrice: bigIntToHex(this.gasPrice),
-      gasLimit: bigIntToHex(this.gasLimit),
-      to: this.to !== undefined ? this.to.toString() : undefined,
-      value: bigIntToHex(this.value),
-      data: bytesToPrefixedHexString(this.data),
-      v: this.v !== undefined ? bigIntToHex(this.v) : undefined,
-      r: this.r !== undefined ? bigIntToHex(this.r) : undefined,
-      s: this.s !== undefined ? bigIntToHex(this.s) : undefined,
     }
   }
 

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -4,7 +4,6 @@ import {
   bigIntToHex,
   bigIntToUnpaddedBytes,
   bytesToBigInt,
-  bytesToPrefixedHexString,
   ecrecover,
   toBytes,
   unpadBytes,

--- a/packages/tx/test/eip1559.spec.ts
+++ b/packages/tx/test/eip1559.spec.ts
@@ -183,6 +183,7 @@ tape('[FeeMarketEIP1559Transaction]', function (t) {
 
     const json = signed.toJSON()
     const expectedJSON = {
+      type: '0x2',
       chainId: '0x4',
       nonce: '0x333',
       maxPriorityFeePerGas: '0x1284d',

--- a/packages/tx/test/typedTxsAndEIP2930.spec.ts
+++ b/packages/tx/test/typedTxsAndEIP2930.spec.ts
@@ -556,6 +556,7 @@ tape('[AccessListEIP2930Transaction] -> Class Specific Tests', function (t) {
     t.ok(equalsBytes(expectedHash, signed.hash()), 'hash correct')
 
     const expectedJSON = {
+      type: '0x1',
       chainId: '0x796f6c6f763378',
       nonce: '0x0',
       gasPrice: '0x3b9aca00',


### PR DESCRIPTION
While sharing a block via json with @acolytec3 it was noticed that jsons didnt have type info in many instances, althrough one could interpret the json type via other fields, but a more verbose `type` can certainly help in easy identification. 

This PR aims to add normalized base transaction json fields in every toJson as well as removes some serialization redundancy of these common fields

Also fixes `versionedHashes` serialization which didn't have prefixed 0x