### PR TITLE
client: Extend newPayloadV3 for blob versioned hashes checks

### DIFF
--- a/packages/client/lib/rpc/modules/engine.ts
+++ b/packages/client/lib/rpc/modules/engine.ts
@@ -474,7 +474,7 @@ export class Engine {
       if (versionedHashes === undefined) {
         validationError = `Error verifying versionedHashes: received none`
       } else {
-        // Collect versioned hashes in the flat array `txVersionedHashes` to match with recieved
+        // Collect versioned hashes in the flat array `txVersionedHashes` to match with received
         const txVersionedHashes = []
         for (const tx of block.transactions) {
           if (tx instanceof BlobEIP4844Transaction) {

--- a/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
@@ -66,7 +66,7 @@ tape(`${method}: Cancun validations`, (v1) => {
       },
     ]
     req = params(method, blockDataNoneHashes)
-    expectRes = checkError(t, INVALID_PARAMS, 'Missing versionedHashes')
+    expectRes = checkError(t, INVALID_PARAMS, 'Missing versionedHashes after Cancun is activated')
     await baseRequest(t, server, req, 200, expectRes, false)
 
     const blockDataExtraMissingHashes1 = [

--- a/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
@@ -94,7 +94,7 @@ tape(`${method}: Cancun validations`, (v1) => {
         ...blockData,
         parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
         blockHash: '0x701f665755524486783d70ea3808f6d013ddfcd03972bd87eace1f29a44a83e8',
-        // two blob transactions but mismatching versioned hashes of second
+        // two blob transactions but mismatching versioned hash of second
         transactions: [txString, txString],
       },
       [...txVersionedHashesString, '0x3456'],

--- a/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
@@ -1,0 +1,135 @@
+import { BlockHeader } from '@ethereumjs/block'
+import * as tape from 'tape'
+import * as td from 'testdouble'
+
+import { INVALID_PARAMS } from '../../../lib/rpc/error-code'
+import blocks = require('../../testdata/blocks/beacon.json')
+import genesisJSON = require('../../testdata/geth-genesis/eip4844.json')
+import { baseRequest, params, setupChain } from '../helpers'
+import { checkError } from '../util'
+
+import type { HttpServer } from 'jayson'
+type Test = tape.Test
+
+const method = 'engine_newPayloadV3'
+
+const [blockData] = blocks
+
+const originalValidate = BlockHeader.prototype._consensusFormatValidation
+
+export const batchBlocks = async (t: Test, server: HttpServer) => {
+  for (let i = 0; i < 3; i++) {
+    const req = params(method, [blocks[i], []])
+    const expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'VALID')
+    }
+    await baseRequest(t, server, req, 200, expectRes, false)
+  }
+}
+
+tape(`${method}: Cancun validations`, (v1) => {
+  v1.test(`${method}: versionedHashes`, async (t) => {
+    const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
+
+    const blockDataExtraVersionedHashes = [
+      {
+        ...blockData,
+        parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
+        blockHash: '0x5493df0b38523c8e61cd7dd72ac21b023dc5357a5f297ff8db95a03f8a9c4179',
+      },
+      ['0x3434', '0x2334'],
+    ]
+    let req = params(method, blockDataExtraVersionedHashes)
+    let expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'INVALID')
+      t.equal(
+        res.body.result.validationError,
+        'Error verifying versionedHashes: expected=0 received=2'
+      )
+    }
+
+    await baseRequest(t, server, req, 200, expectRes, false)
+
+    const txString =
+      '0x03f87c01808405f5e1008502540be4008401c9c380808080c001e1a001317228841f747eac2b4987a0225753a4f81688b31b21192ad2d2a3f5d252c580a01146addbda4889ddeaa8e4d74baae37c55f9796ab17030c762260faa797ca33ea0555a673397ea115d81c390a560ab77d3f63e93a59270b1b8d12cd2a1fb8b9b11'
+    const txVersionedHashesString = [
+      '0x01317228841f747eac2b4987a0225753a4f81688b31b21192ad2d2a3f5d252c5',
+    ]
+
+    const blockDataNoneHashes = [
+      {
+        ...blockData,
+        parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
+        blockHash: '0x701f665755524486783d70ea3808f6d013ddfcd03972bd87eace1f29a44a83e8',
+        // two blob transactions but no versioned hashesh
+        transactions: [txString, txString],
+      },
+    ]
+    req = params(method, blockDataNoneHashes)
+    expectRes = checkError(t, INVALID_PARAMS, 'Missing versionedHashes')
+    await baseRequest(t, server, req, 200, expectRes, false)
+
+    const blockDataExtraMissingHashes1 = [
+      {
+        ...blockData,
+        parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
+        blockHash: '0x701f665755524486783d70ea3808f6d013ddfcd03972bd87eace1f29a44a83e8',
+        // two blob transactions but missing versioned hashes of second
+        transactions: [txString, txString],
+      },
+      txVersionedHashesString,
+    ]
+    req = params(method, blockDataExtraMissingHashes1)
+    expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'INVALID')
+      t.equal(
+        res.body.result.validationError,
+        'Error verifying versionedHashes: expected=2 received=1'
+      )
+    }
+    await baseRequest(t, server, req, 200, expectRes, false)
+
+    const blockDataExtraMisMatchingHashes1 = [
+      {
+        ...blockData,
+        parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
+        blockHash: '0x701f665755524486783d70ea3808f6d013ddfcd03972bd87eace1f29a44a83e8',
+        // two blob transactions but mismatching versioned hashes of second
+        transactions: [txString, txString],
+      },
+      [...txVersionedHashesString, '0x3456'],
+    ]
+    req = params(method, blockDataExtraMisMatchingHashes1)
+    expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'INVALID')
+      t.equal(
+        res.body.result.validationError,
+        'Error verifying versionedHashes: mismatch at index=1 expected=0x0131…52c5 received=0x3456…'
+      )
+    }
+    await baseRequest(t, server, req, 200, expectRes, false)
+
+    const blockDataMatchingVersionedHashes = [
+      {
+        ...blockData,
+        parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
+        blockHash: '0x701f665755524486783d70ea3808f6d013ddfcd03972bd87eace1f29a44a83e8',
+        // two blob transactions but mismatching versioned hashes of second
+        transactions: [txString, txString],
+      },
+      [...txVersionedHashesString, ...txVersionedHashesString],
+    ]
+    req = params(method, blockDataMatchingVersionedHashes)
+    expectRes = (res: any) => {
+      t.equal(res.body.result.status, 'ACCEPTED')
+    }
+    await baseRequest(t, server, req, 200, expectRes)
+  })
+
+  v1.test(`reset TD`, (t) => {
+    BlockHeader.prototype._consensusFormatValidation = originalValidate
+    td.reset()
+    t.end()
+  })
+  v1.end()
+})

--- a/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
@@ -61,7 +61,7 @@ tape(`${method}: Cancun validations`, (v1) => {
         ...blockData,
         parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
         blockHash: '0x701f665755524486783d70ea3808f6d013ddfcd03972bd87eace1f29a44a83e8',
-        // two blob transactions but no versioned hashesh
+        // two blob transactions but no versioned hashes
         transactions: [txString, txString],
       },
     ]
@@ -74,7 +74,7 @@ tape(`${method}: Cancun validations`, (v1) => {
         ...blockData,
         parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
         blockHash: '0x701f665755524486783d70ea3808f6d013ddfcd03972bd87eace1f29a44a83e8',
-        // two blob transactions but missing versioned hashes of second
+        // two blob transactions but missing versioned hash of second
         transactions: [txString, txString],
       },
       txVersionedHashesString,
@@ -114,7 +114,7 @@ tape(`${method}: Cancun validations`, (v1) => {
         ...blockData,
         parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
         blockHash: '0x701f665755524486783d70ea3808f6d013ddfcd03972bd87eace1f29a44a83e8',
-        // two blob transactions but mismatching versioned hashes of second
+        // two blob transactions with matching versioned hashes
         transactions: [txString, txString],
       },
       [...txVersionedHashesString, ...txVersionedHashesString],


### PR DESCRIPTION
Post blob tx conversion to RLP, CL's commitments check via versioned hashes is now passed over to EL with new payloads having the computed CL versioned hashes.

Implements:
- https://github.com/ethereum/execution-apis/pull/407

This PR implements the same

Depends on 
 - https://github.com/ethereumjs/ethereumjs-monorepo/pull/2708

and should be merged (post rebase) after #2708 is merged