### PR TITLE
Update `rustbn.js` to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19943,7 +19943,7 @@
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.0.0",
         "mcl-wasm": "^0.7.1",
-        "rustbn.js": "~0.2.0"
+        "rustbn.js": "^0.3.0"
       },
       "devDependencies": {
         "@ethereumjs/statemanager": "^1.0.5",
@@ -19963,6 +19963,11 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "packages/evm/node_modules/rustbn.js": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.3.0.tgz",
+      "integrity": "sha512-RXLW0TSDBFlujBgq/ZdWa6ADGKiEFZgSqRdCcSXy8XiPqLPApKwaJjf14ImspysQm2mI8hA3EBWN+IOQReqwtA=="
     },
     "packages/rlp": {
       "name": "@ethereumjs/rlp",
@@ -21865,8 +21870,15 @@
         "memory-level": "^1.0.0",
         "minimist": "^1.2.5",
         "node-dir": "^0.1.17",
-        "rustbn.js": "~0.2.0",
+        "rustbn.js": "^0.3.0",
         "solc": "^0.8.1"
+      },
+      "dependencies": {
+        "rustbn.js": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.3.0.tgz",
+          "integrity": "sha512-RXLW0TSDBFlujBgq/ZdWa6ADGKiEFZgSqRdCcSXy8XiPqLPApKwaJjf14ImspysQm2mI8hA3EBWN+IOQReqwtA=="
+        }
       }
     },
     "@ethereumjs/rlp": {

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -34,8 +34,7 @@
     "src"
   ],
   "scripts": {
-    "rustbnHotFix": "sed -i -e \"s/.toString('hex')), 'hex'//g\" ../../node_modules/rustbn.js/index.js && sed -i -e \"s/Buffer.from(//g\" ../../node_modules/rustbn.js/index.js",
-    "build": "npm run rustbnHotFix && ../../config/cli/ts-build.sh",
+    "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
     "coverage": "c8 --all --reporter=lcov --reporter=text npm run coverage:test",
     "coverage:test": "npm run test && cd ../vm && npm run tester -- --state",
@@ -59,7 +58,7 @@
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.0.0",
     "mcl-wasm": "^0.7.1",
-    "rustbn.js": "~0.2.0"
+    "rustbn.js": "^0.3.0"
   },
   "devDependencies": {
     "@ethereumjs/statemanager": "^1.0.5",


### PR DESCRIPTION
Updates `rustbn.js` to v0.3.0 and removes a hack in `node_modules` required to pass in hex strings.