### PR TITLE
client: Fix double runs of the block execution

### DIFF
--- a/packages/blockchain/src/types.ts
+++ b/packages/blockchain/src/types.ts
@@ -63,6 +63,14 @@ export interface BlockchainInterface {
   getIteratorHead?(name?: string): Promise<Block>
 
   /**
+   * Set header hash of a certain `tag`.
+   * When calling the iterator, the iterator will start running the first child block after the header hash currently stored.
+   * @param tag - The tag to save the headHash to
+   * @param headHash - The head hash to save
+   */
+  setIteratorHead(tag: string, headHash: Uint8Array): Promise<void>
+
+  /**
    * Gets total difficulty for a block specified by hash and number
    */
   getTotalDifficulty?(hash: Uint8Array, number?: bigint): Promise<bigint>

--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -269,7 +269,7 @@ export class VMExecution extends Execution {
     this.running = true
 
     // run inside a lock so as to not be entangle with runWithoutSetHead or setHead
-    return await this.runWithLock<number>(async () => {
+    return this.runWithLock<number>(async () => {
       let numExecuted: number | null | undefined = undefined
 
       const { blockchain } = this.vm

--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -153,9 +153,16 @@ export class VMExecution extends Execution {
    */
   async runWithoutSetHead(opts: RunBlockOpts, receipts?: TxReceipt[]): Promise<void> {
     return this.runWithLock<void>(async () => {
-      const { block } = opts
+      const { block, root } = opts
+
       if (receipts === undefined) {
-        const result = await this.vm.runBlock(opts)
+        // Check if we need to pass flag to clear statemanager cache or not
+        const prevVMStateRoot = await this.vm.stateManager.getStateRoot()
+        // If root is not provided its mean to be run on the same set state
+        const parentState = root ?? prevVMStateRoot
+        const clearCache = !equalsBytes(prevVMStateRoot, parentState)
+
+        const result = await this.vm.runBlock({ clearCache, ...opts })
         receipts = result.receipts
       }
       if (receipts !== undefined) {
@@ -260,109 +267,115 @@ export class VMExecution extends Execution {
   async run(loop = true, runOnlybatched = false): Promise<number> {
     if (this.running || !this.started || this.config.shutdown) return 0
     this.running = true
-    let numExecuted: number | null | undefined = undefined
 
-    const { blockchain } = this.vm
-    if (typeof blockchain.getIteratorHead !== 'function') {
-      throw new Error('cannot get iterator head: blockchain has no getIteratorHead function')
-    }
-    let startHeadBlock = await blockchain.getIteratorHead()
-    if (typeof blockchain.getCanonicalHeadBlock !== 'function') {
-      throw new Error('cannot get iterator head: blockchain has no getCanonicalHeadBlock function')
-    }
-    let canonicalHead = await blockchain.getCanonicalHeadBlock()
+    // run inside a lock so as to not be entangle with runWithoutSetHead or setHead
+    return await this.runWithLock<number>(async () => {
+      let numExecuted: number | null | undefined = undefined
 
-    this.config.logger.debug(
-      `Running execution startHeadBlock=${startHeadBlock?.header.number} canonicalHead=${canonicalHead?.header.number} loop=${loop}`
-    )
+      const { blockchain } = this.vm
+      if (typeof blockchain.getIteratorHead !== 'function') {
+        throw new Error('cannot get iterator head: blockchain has no getIteratorHead function')
+      }
+      let startHeadBlock = await blockchain.getIteratorHead()
+      if (typeof blockchain.getCanonicalHeadBlock !== 'function') {
+        throw new Error(
+          'cannot get iterator head: blockchain has no getCanonicalHeadBlock function'
+        )
+      }
+      let canonicalHead = await blockchain.getCanonicalHeadBlock()
 
-    let headBlock: Block | undefined
-    let parentState: Uint8Array | undefined
-    let errorBlock: Block | undefined
+      this.config.logger.debug(
+        `Running execution startHeadBlock=${startHeadBlock?.header.number} canonicalHead=${canonicalHead?.header.number} loop=${loop}`
+      )
 
-    // flag for vm to clear statemanager cache on runBlock
-    //  i) If on start of iterator the last run state is not same as the block's parent
-    //  ii) If reorg happens on the block iterator
-    let clearCache = false
+      let headBlock: Block | undefined
+      let parentState: Uint8Array | undefined
+      let errorBlock: Block | undefined
 
-    while (
-      this.started &&
-      !this.config.shutdown &&
-      (!runOnlybatched ||
-        (runOnlybatched &&
-          canonicalHead.header.number - startHeadBlock.header.number >=
-            BigInt(this.config.numBlocksPerIteration))) &&
-      (numExecuted === undefined || (loop && numExecuted === this.config.numBlocksPerIteration)) &&
-      equalsBytes(startHeadBlock.hash(), canonicalHead.hash()) === false
-    ) {
-      let txCounter = 0
-      headBlock = undefined
-      parentState = undefined
-      errorBlock = undefined
-      this.vmPromise = blockchain
-        .iterator(
-          'vm',
-          async (block: Block, reorg: boolean) => {
-            // determine starting state for block run
-            // if we are just starting or if a chain reorg has happened
-            if (headBlock === undefined || reorg) {
-              const headBlock = await blockchain.getBlock(block.header.parentHash)
-              parentState = headBlock.header.stateRoot
+      // flag for vm to clear statemanager cache on runBlock
+      //  i) If on start of iterator the last run state is not same as the block's parent
+      //  ii) If reorg happens on the block iterator
+      let clearCache = false
 
-              if (reorg) {
-                clearCache = true
-                this.config.logger.info(
-                  `VM run: Chain reorged, setting new head to block number=${headBlock.header.number} clearCache=${clearCache}.`
-                )
+      while (
+        this.started &&
+        !this.config.shutdown &&
+        (!runOnlybatched ||
+          (runOnlybatched &&
+            canonicalHead.header.number - startHeadBlock.header.number >=
+              BigInt(this.config.numBlocksPerIteration))) &&
+        (numExecuted === undefined ||
+          (loop && numExecuted === this.config.numBlocksPerIteration)) &&
+        equalsBytes(startHeadBlock.hash(), canonicalHead.hash()) === false
+      ) {
+        let txCounter = 0
+        headBlock = undefined
+        parentState = undefined
+        errorBlock = undefined
+        this.vmPromise = blockchain
+          .iterator(
+            'vm',
+            async (block: Block, reorg: boolean) => {
+              // determine starting state for block run
+              // if we are just starting or if a chain reorg has happened
+              if (headBlock === undefined || reorg) {
+                const headBlock = await blockchain.getBlock(block.header.parentHash)
+                parentState = headBlock.header.stateRoot
+
+                if (reorg) {
+                  clearCache = true
+                  this.config.logger.info(
+                    `VM run: Chain reorged, setting new head to block number=${headBlock.header.number} clearCache=${clearCache}.`
+                  )
+                } else {
+                  const prevVMStateRoot = await this.vm.stateManager.getStateRoot()
+                  clearCache = !equalsBytes(prevVMStateRoot, parentState)
+                }
               } else {
-                const prevVMStateRoot = await this.vm.stateManager.getStateRoot()
-                clearCache = !equalsBytes(prevVMStateRoot, parentState)
+                // Continuation of last vm run, no need to clearCache
+                clearCache = false
               }
-            } else {
-              // Continuation of last vm run, no need to clearCache
-              clearCache = false
-            }
 
-            // run block, update head if valid
-            try {
-              const { number, timestamp } = block.header
-              if (typeof blockchain.getTotalDifficulty !== 'function') {
-                throw new Error(
-                  'cannot get iterator head: blockchain has no getTotalDifficulty function'
-                )
-              }
-              const td = await blockchain.getTotalDifficulty(block.header.parentHash)
+              // run block, update head if valid
+              try {
+                const { number, timestamp } = block.header
+                if (typeof blockchain.getTotalDifficulty !== 'function') {
+                  throw new Error(
+                    'cannot get iterator head: blockchain has no getTotalDifficulty function'
+                  )
+                }
+                const td = await blockchain.getTotalDifficulty(block.header.parentHash)
 
-              const hardfork = this.config.execCommon.getHardforkByBlockNumber(
-                number,
-                td,
-                timestamp
-              )
-              if (hardfork !== this.hardfork) {
-                const hash = short(block.hash())
-                this.config.logger.info(
-                  `Execution hardfork switch on block number=${number} hash=${hash} old=${this.hardfork} new=${hardfork}`
-                )
-                this.hardfork = this.config.execCommon.setHardforkByBlockNumber(
+                const hardfork = this.config.execCommon.getHardforkByBlockNumber(
                   number,
                   td,
                   timestamp
                 )
-              }
-              let skipBlockValidation = false
-              if (this.config.execCommon.consensusType() === ConsensusType.ProofOfAuthority) {
-                // Block validation is redundant here and leads to consistency problems
-                // on PoA clique along blockchain-including validation checks
-                // (signer states might have moved on when sync is ahead)
-                skipBlockValidation = true
-              }
+                if (hardfork !== this.hardfork) {
+                  const hash = short(block.hash())
+                  this.config.logger.info(
+                    `Execution hardfork switch on block number=${number} hash=${hash} old=${this.hardfork} new=${hardfork}`
+                  )
+                  this.hardfork = this.config.execCommon.setHardforkByBlockNumber(
+                    number,
+                    td,
+                    timestamp
+                  )
+                }
+                let skipBlockValidation = false
+                if (this.config.execCommon.consensusType() === ConsensusType.ProofOfAuthority) {
+                  // Block validation is redundant here and leads to consistency problems
+                  // on PoA clique along blockchain-including validation checks
+                  // (signer states might have moved on when sync is ahead)
+                  skipBlockValidation = true
+                }
 
-              await this.runWithLock<void>(async () => {
                 // we are skipping header validation because the block has been picked from the
                 // blockchain and header should have already been validated while putBlock
                 if (!this.started) {
                   throw Error('Execution stopped')
                 }
+
                 const beforeTS = Date.now()
                 this.stats(this.vm)
                 const result = await this.vm.runBlock({
@@ -385,39 +398,38 @@ export class VMExecution extends Execution {
                 }
 
                 void this.receiptsManager?.saveReceipts(block, result.receipts)
-              })
 
-              txCounter += block.transactions.length
-              // set as new head block
-              headBlock = block
-              parentState = block.header.stateRoot
-            } catch (error: any) {
-              // Store error block and throw which will make iterator stop, exit and save
-              // last successfully executed head as vmHead
-              errorBlock = block
-              throw error
-            }
-          },
-          this.config.numBlocksPerIteration,
-          // release lock on this callback so other blockchain ops can happen while this block is being executed
-          true
-        )
-        // Ensure to catch and not throw as this would lead to unCaughtException with process exit
-        .catch(async (error) => {
-          if (errorBlock !== undefined) {
-            // TODO: determine if there is a way to differentiate between the cases
-            // a) a bad block is served by a bad peer -> delete the block and restart sync
-            //    sync from parent block
-            // b) there is a consensus error in the VM -> stop execution until the
-            //    consensus error is fixed
-            //
-            // For now only option b) is implemented, atm this is a very likely case
-            // and the implemented behavior helps on debugging.
-            // Option a) would likely need some block comparison of the same blocks
-            // received by different peer to decide on bad blocks
-            // (minimal solution: receive block from 3 peers and take block if there is
-            // is equally served from at least 2 peers)
-            /*try {
+                txCounter += block.transactions.length
+                // set as new head block
+                headBlock = block
+                parentState = block.header.stateRoot
+              } catch (error: any) {
+                // Store error block and throw which will make iterator stop, exit and save
+                // last successfully executed head as vmHead
+                errorBlock = block
+                throw error
+              }
+            },
+            this.config.numBlocksPerIteration,
+            // release lock on this callback so other blockchain ops can happen while this block is being executed
+            true
+          )
+          // Ensure to catch and not throw as this would lead to unCaughtException with process exit
+          .catch(async (error) => {
+            if (errorBlock !== undefined) {
+              // TODO: determine if there is a way to differentiate between the cases
+              // a) a bad block is served by a bad peer -> delete the block and restart sync
+              //    sync from parent block
+              // b) there is a consensus error in the VM -> stop execution until the
+              //    consensus error is fixed
+              //
+              // For now only option b) is implemented, atm this is a very likely case
+              // and the implemented behavior helps on debugging.
+              // Option a) would likely need some block comparison of the same blocks
+              // received by different peer to decide on bad blocks
+              // (minimal solution: receive block from 3 peers and take block if there is
+              // is equally served from at least 2 peers)
+              /*try {
             // remove invalid block
               await blockchain!.delBlock(block.header.hash())
             } catch (error: any) {
@@ -436,69 +448,70 @@ export class VMExecution extends Execution {
               )
               this.config.execCommon.setHardforkByBlockNumber(blockNumber, td)
             }*/
-            // Option a): set iterator head to the parent block so that an
-            // error can repeatedly processed for debugging
-            const { number } = errorBlock.header
-            const hash = short(errorBlock.hash())
-            this.config.logger.warn(
-              `Execution of block number=${number} hash=${hash} hardfork=${this.hardfork} failed:\n${error}`
-            )
-            if (this.config.debugCode) {
-              await debugCodeReplayBlock(this, errorBlock)
+              // Option a): set iterator head to the parent block so that an
+              // error can repeatedly processed for debugging
+              const { number } = errorBlock.header
+              const hash = short(errorBlock.hash())
+              this.config.logger.warn(
+                `Execution of block number=${number} hash=${hash} hardfork=${this.hardfork} failed:\n${error}`
+              )
+              if (this.config.debugCode) {
+                await debugCodeReplayBlock(this, errorBlock)
+              }
+              this.config.events.emit(Event.SYNC_EXECUTION_VM_ERROR, error)
+              const actualExecuted = Number(errorBlock.header.number - startHeadBlock.header.number)
+              return actualExecuted
+            } else {
+              this.config.logger.error(`VM execution failed with error`, error)
+              return null
             }
-            this.config.events.emit(Event.SYNC_EXECUTION_VM_ERROR, error)
-            const actualExecuted = Number(errorBlock.header.number - startHeadBlock.header.number)
-            return actualExecuted
+          })
+
+        numExecuted = await this.vmPromise
+        if (numExecuted !== null) {
+          let endHeadBlock
+          if (typeof this.vm.blockchain.getIteratorHead === 'function') {
+            endHeadBlock = await this.vm.blockchain.getIteratorHead('vm')
           } else {
-            this.config.logger.error(`VM execution failed with error`, error)
-            return null
+            throw new Error('cannot get iterator head: blockchain has no getIteratorHead function')
           }
-        })
 
-      numExecuted = await this.vmPromise
-      if (numExecuted !== null) {
-        let endHeadBlock
-        if (typeof this.vm.blockchain.getIteratorHead === 'function') {
-          endHeadBlock = await this.vm.blockchain.getIteratorHead('vm')
-        } else {
-          throw new Error('cannot get iterator head: blockchain has no getIteratorHead function')
+          if (typeof numExecuted === 'number' && numExecuted > 0) {
+            const firstNumber = startHeadBlock.header.number
+            const firstHash = short(startHeadBlock.hash())
+            const lastNumber = endHeadBlock.header.number
+            const lastHash = short(endHeadBlock.hash())
+            const baseFeeAdd =
+              this.config.execCommon.gteHardfork(Hardfork.London) === true
+                ? `baseFee=${endHeadBlock.header.baseFeePerGas} `
+                : ''
+            const tdAdd =
+              this.config.execCommon.gteHardfork(Hardfork.Paris) === true
+                ? ''
+                : `td=${this.chain.blocks.td} `
+            this.config.logger.info(
+              `Executed blocks count=${numExecuted} first=${firstNumber} hash=${firstHash} ${tdAdd}${baseFeeAdd}hardfork=${this.hardfork} last=${lastNumber} hash=${lastHash} txs=${txCounter}`
+            )
+          } else {
+            this.config.logger.debug(
+              `No blocks executed past chain head hash=${short(endHeadBlock.hash())} number=${
+                endHeadBlock.header.number
+              }`
+            )
+          }
+          startHeadBlock = endHeadBlock
+          if (typeof this.vm.blockchain.getCanonicalHeadBlock !== 'function') {
+            throw new Error(
+              'cannot get iterator head: blockchain has no getCanonicalHeadBlock function'
+            )
+          }
+          canonicalHead = await this.vm.blockchain.getCanonicalHeadBlock()
         }
-
-        if (typeof numExecuted === 'number' && numExecuted > 0) {
-          const firstNumber = startHeadBlock.header.number
-          const firstHash = short(startHeadBlock.hash())
-          const lastNumber = endHeadBlock.header.number
-          const lastHash = short(endHeadBlock.hash())
-          const baseFeeAdd =
-            this.config.execCommon.gteHardfork(Hardfork.London) === true
-              ? `baseFee=${endHeadBlock.header.baseFeePerGas} `
-              : ''
-          const tdAdd =
-            this.config.execCommon.gteHardfork(Hardfork.Paris) === true
-              ? ''
-              : `td=${this.chain.blocks.td} `
-          this.config.logger.info(
-            `Executed blocks count=${numExecuted} first=${firstNumber} hash=${firstHash} ${tdAdd}${baseFeeAdd}hardfork=${this.hardfork} last=${lastNumber} hash=${lastHash} txs=${txCounter}`
-          )
-        } else {
-          this.config.logger.debug(
-            `No blocks executed past chain head hash=${short(endHeadBlock.hash())} number=${
-              endHeadBlock.header.number
-            }`
-          )
-        }
-        startHeadBlock = endHeadBlock
-        if (typeof this.vm.blockchain.getCanonicalHeadBlock !== 'function') {
-          throw new Error(
-            'cannot get iterator head: blockchain has no getCanonicalHeadBlock function'
-          )
-        }
-        canonicalHead = await this.vm.blockchain.getCanonicalHeadBlock()
       }
-    }
 
-    this.running = false
-    return numExecuted ?? 0
+      this.running = false
+      return numExecuted ?? 0
+    })
   }
 
   /**

--- a/packages/client/test/execution/vmexecution.spec.ts
+++ b/packages/client/test/execution/vmexecution.spec.ts
@@ -1,14 +1,18 @@
+import { Block } from '@ethereumjs/block'
 import { Blockchain } from '@ethereumjs/blockchain'
 import { Chain as ChainEnum, Common, Hardfork } from '@ethereumjs/common'
+import { bytesToHex } from '@ethereumjs/util'
 import { VM } from '@ethereumjs/vm'
 import * as tape from 'tape'
 
 import { Chain } from '../../src/blockchain'
 import { Config } from '../../src/config'
 import { VMExecution } from '../../src/execution'
+import { closeRPC, setupChain } from '../rpc/helpers'
 import blocksDataGoerli = require('../testdata/blocks/goerli.json')
 import blocksDataMainnet = require('../testdata/blocks/mainnet.json')
 import testnet = require('../testdata/common/testnet.json')
+import shanghaiJSON = require('../testdata/geth-genesis/withdrawals.json')
 
 tape('[VMExecution]', async (t) => {
   t.test('Initialization', async (t) => {
@@ -104,4 +108,94 @@ tape('[VMExecution]', async (t) => {
 
     t.end()
   })
+
+  t.test('Block execution / Hardforks PoA (goerli)', async (t) => {
+    const { server, execution, blockchain } = await setupChain(shanghaiJSON, 'post-merge', {
+      engine: true,
+    })
+
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    const block = await Block.fromExecutionPayload(shanghaiPayload)
+    const oldHead = await blockchain.getIteratorHead()
+
+    const parentStateRoot = oldHead.header.stateRoot
+    await execution.runWithoutSetHead({ block, root: parentStateRoot })
+
+    await blockchain.putBlock(block)
+    await execution.run()
+
+    const newHead = await blockchain.getIteratorHead()
+    t.equal(bytesToHex(block.hash()), bytesToHex(newHead.hash()), 'vm execution head should be on')
+
+    closeRPC(server)
+    t.end()
+  })
 })
+
+const shanghaiPayload = {
+  blockNumber: '0x1',
+  parentHash: '0xfe950635b1bd2a416ff6283b0bbd30176e1b1125ad06fa729da9f3f4c1c61710',
+  feeRecipient: '0xaa00000000000000000000000000000000000000',
+  stateRoot: '0x23eadd91fca55c0e14034e4d63b2b3ed43f2e807b6bf4d276b784ac245e7fa3f',
+  receiptsRoot: '0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421',
+  logsBloom:
+    '0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+  gasLimit: '0x1c9c380',
+  gasUsed: '0x0',
+  timestamp: '0x2f',
+  extraData: '0x',
+  baseFeePerGas: '0x7',
+  blockHash: '0xd30a8c821078a9153a5cbc5ac9a2c5baca7f7885496f1f461dbfcb8dbe1fa0c0',
+  prevRandao: '0xff00000000000000000000000000000000000000000000000000000000000000',
+  transactions: [],
+  withdrawals: [
+    {
+      index: '0x0',
+      validatorIndex: '0xffff',
+      address: '0x0000000000000000000000000000000000000000',
+      amount: '0x0',
+    },
+    {
+      index: '0x1',
+      validatorIndex: '0x10000',
+      address: '0x0100000000000000000000000000000000000000',
+      amount: '0x100000000000000000000000000000000000000000000000000000000000000',
+    },
+    {
+      index: '0x2',
+      validatorIndex: '0x10001',
+      address: '0x0200000000000000000000000000000000000000',
+      amount: '0x200000000000000000000000000000000000000000000000000000000000000',
+    },
+    {
+      index: '0x3',
+      validatorIndex: '0x10002',
+      address: '0x0300000000000000000000000000000000000000',
+      amount: '0x300000000000000000000000000000000000000000000000000000000000000',
+    },
+    {
+      index: '0x4',
+      validatorIndex: '0x10003',
+      address: '0x0400000000000000000000000000000000000000',
+      amount: '0x400000000000000000000000000000000000000000000000000000000000000',
+    },
+    {
+      index: '0x5',
+      validatorIndex: '0x10004',
+      address: '0x0500000000000000000000000000000000000000',
+      amount: '0x500000000000000000000000000000000000000000000000000000000000000',
+    },
+    {
+      index: '0x6',
+      validatorIndex: '0x10005',
+      address: '0x0600000000000000000000000000000000000000',
+      amount: '0x600000000000000000000000000000000000000000000000000000000000000',
+    },
+    {
+      index: '0x7',
+      validatorIndex: '0x10006',
+      address: '0x0700000000000000000000000000000000000000',
+      amount: '0x700000000000000000000000000000000000000000000000000000000000000',
+    },
+  ],
+}

--- a/packages/client/test/execution/vmexecution.spec.ts
+++ b/packages/client/test/execution/vmexecution.spec.ts
@@ -125,7 +125,11 @@ tape('[VMExecution]', async (t) => {
     await execution.run()
 
     const newHead = await blockchain.getIteratorHead()
-    t.equal(bytesToHex(block.hash()), bytesToHex(newHead.hash()), 'vm execution head should be on')
+    t.equal(
+      bytesToHex(block.hash()),
+      bytesToHex(newHead.hash()),
+      'vmHead should be on the latest block'
+    )
 
     closeRPC(server)
     t.end()

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -255,7 +255,7 @@ export async function setupChain(genesisFile: any, chainName = 'dev', clientOpts
   await chain.open()
   await execution?.open()
   await chain.update()
-  return { chain, common, execution: execution!, server, service }
+  return { chain, common, execution: execution!, server, service, blockchain }
 }
 
 /**

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -79,7 +79,7 @@ export async function runBlock(this: VM, opts: RunBlockOpts): Promise<RunBlockRe
   // Set state root if provided
   if (root) {
     if (this.DEBUG) {
-      debug(`Set provided state root ${bytesToHex(root)}`)
+      debug(`Set provided state root ${bytesToHex(root)} clearCache=${clearCache}`)
     }
     await state.setStateRoot(root, clearCache)
   }


### PR DESCRIPTION

On the 4844 devnet5 a weird error was noticed:

1. on new payload the client runs `vmExecution.runWithoutSetBlock` first and 
  ![image](https://github.com/ethereumjs/ethereumjs-monorepo/assets/76567250/c921ce11-e6af-4d21-b5cd-f166a2019b26)
2. then on fcU once the block is part of canonical chain it runs `vmExecution.run` which runs block in an iterator loop
  ![image](https://github.com/ethereumjs/ethereumjs-monorepo/assets/76567250/332c3a59-7547-4619-bbe0-b5fc90f65637)

Run on 1. gives `VALID` execution while 2nd fails with `invalid state root`

This PR aims to solve it:
Synopsis of the issue: the vmExecution's `run` and `runWithoutSetHead` can end up running the same block one after another leading to state manager's incorrect caches

This PR updates `clearCache` flag in runBlock if such a scenario comes up during client execution.




- [x] Add a testcase to repro
- [x] Fix the issue
- [x] Testing
  - [x] sync mainnet
  - [x] sync local post merge devnet
  - [x] beacon sync and stay sync in a devnet 


PS:
the issue is resolved with this diff which might give an idea about where the problem could be i.e. by running the block again in the `vm` copy of vmexecution

```diff
--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -353,7 +353,8 @@ export class VMExecution extends Execution {
                 }
                 const beforeTS = Date.now()
                 this.stats(this.vm)
-                const result = await this.vm.runBlock({
+                const ivm = await this.vm.copy()
+                const result = await ivm.runBlock({
                   block,
                   root: parentState,
                   clearCache: reorg ? true : false,
```