### PR TITLE
fix unknown argument error

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,5 +8,5 @@ services:
     volumes:
       - ./datadir:/datadir
     command: >
-      --datadir=/datadir
+      --dataDir=/datadir
     network_mode: host


### PR DESCRIPTION
Running `docker-compose up` was resulting with `Unknown argument: datadir` because `datadir` should be spelled as `dataDir` for `@ethereumjs/client v0.7.1`.