### PR TITLE
Updated  ethereum-cryptography to ^2.0.0

### DIFF
--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@ethereumjs/util": "^8.0.6",
     "@scure/base": "1.1.1",
-    "ethereum-cryptography": "1.2.0",
+    "ethereum-cryptography": "^2.0.0",
     "js-md5": "0.7.3",
     "uuid": "8.3.2"
   },


### PR DESCRIPTION
Solves https://github.com/ethereumjs/ethereumjs-monorepo/issues/2731 Updated dependencies of ethereum-cryptography to v2.0.0

- [x] Update `ethereum-cryptography` dep to v2.0.0