### PR TITLE
vm/tests: ensure tests with aliases run with eip configs

### DIFF
--- a/packages/vm/test/tester/config.ts
+++ b/packages/vm/test/tester/config.ts
@@ -129,32 +129,34 @@ export const SKIP_SLOW = [
  * @returns {String} Either an alias of the forkConfig param, or the forkConfig param itself
  */
 export function getRequiredForkConfigAlias(forkConfig: string) {
+  const indexOfPlus = forkConfig.indexOf('+')
+  const remainder = indexOfPlus !== -1 ? forkConfig.substring(indexOfPlus) : ''
   // Chainstart is also called Frontier and is called as such in the tests
   if (String(forkConfig).match(/^chainstart$/i)) {
-    return 'Frontier'
+    return 'Frontier' + remainder
   }
   // TangerineWhistle is named EIP150 (attention: misleading name)
   // in the client-independent consensus test suite
   if (String(forkConfig).match(/^tangerineWhistle$/i)) {
-    return 'EIP150'
+    return 'EIP150' + remainder
   }
   // SpuriousDragon is named EIP158 (attention: misleading name)
   // in the client-independent consensus test suite
   if (String(forkConfig).match(/^spuriousDragon$/i)) {
-    return 'EIP158'
+    return 'EIP158' + remainder
   }
   // Run the Istanbul tests for MuirGlacier since there are no dedicated tests
   if (String(forkConfig).match(/^muirGlacier/i)) {
-    return 'Istanbul'
+    return 'Istanbul' + remainder
   }
   // Petersburg is named ConstantinopleFix
   // in the client-independent consensus test suite
   if (String(forkConfig).match(/^petersburg$/i)) {
-    return 'ConstantinopleFix'
+    return 'ConstantinopleFix' + remainder
   }
   // Paris is named Merge
   if (String(forkConfig).match(/^paris/i)) {
-    return 'Merge'
+    return 'Merge' + remainder
   }
   return forkConfig
 }

--- a/packages/vm/test/util.ts
+++ b/packages/vm/test/util.ts
@@ -370,23 +370,6 @@ export async function setupPreConditions(state: EVMStateManagerInterface, testDa
 }
 
 /**
- * Returns an alias for specified hardforks to meet test dependencies requirements/assumptions.
- * @param forkConfig - the name of the hardfork for which an alias should be returned
- * @returns Either an alias of the forkConfig param, or the forkConfig param itself
- */
-export function getRequiredForkConfigAlias(forkConfig: string): string {
-  // Run the Istanbul tests for MuirGlacier since there are no dedicated tests
-  if (String(forkConfig).match(/^muirGlacier/i)) {
-    return 'Istanbul'
-  }
-  // Petersburg is named ConstantinopleFix in the client-independent consensus test suite
-  if (String(forkConfig).match(/^petersburg$/i)) {
-    return 'ConstantinopleFix'
-  }
-  return forkConfig
-}
-
-/**
  * Checks if in a karma test runner.
  * @returns boolean whether running in karma
  */


### PR DESCRIPTION
This small update ensures we can run tests which have an alias, plus EIP numbers, in our test runner.

Example to run the TSTORE tests:

```
cd ./packages/vm
npm run test:blockchain -- --fork=Paris+1153 --dir=../EIPTests
```

Without this PR you are unable to run the tests, since test runner converted `Paris+1153` to `Merge` before and will thus run the Merge tests, and not the `Merge+1153` tests which are the TSTORE tests.