### PR TITLE
Client: Fix PeerPool Memory Leak

### DIFF
--- a/packages/client/src/net/peer/peer.ts
+++ b/packages/client/src/net/peer/peer.ts
@@ -94,6 +94,8 @@ export class Peer extends events.EventEmitter {
     this._idle = value
   }
 
+  async connect(): Promise<void> {}
+
   /**
    * Adds a protocol to this peer given a sender instance. Protocol methods
    * will be accessible via a field with the same name as protocol. New methods

--- a/packages/client/src/net/peerpool.ts
+++ b/packages/client/src/net/peerpool.ts
@@ -191,7 +191,7 @@ export class PeerPool {
     // Reconnect to peer after ban period if pool is empty
     this._reconnectTimeout = setTimeout(async () => {
       if (this.running && this.size === 0) {
-        await peer.server?.connect(peer.id)
+        await peer.connect()
         this.connected(peer)
       }
     }, maxAge + 1000)

--- a/packages/client/src/net/protocol/boundprotocol.ts
+++ b/packages/client/src/net/protocol/boundprotocol.ts
@@ -55,6 +55,12 @@ export class BoundProtocol {
           this.handle(message)
         } else {
           this.messageQueue.push(message)
+          // Expected message queue growth is in the single digits
+          // so this adds a guard here if something goes wrong
+          if (this.messageQueue.length >= 50) {
+            const error = new Error('unexpected message queue growth for peer')
+            this.config.events.emit(Event.PROTOCOL_ERROR, error, this.peer)
+          }
         }
       } catch (error: any) {
         this.config.events.emit(Event.PROTOCOL_ERROR, error, this.peer)

--- a/packages/client/src/net/server/rlpxserver.ts
+++ b/packages/client/src/net/server/rlpxserver.ts
@@ -1,5 +1,5 @@
 import { DPT as Devp2pDPT, RLPx as Devp2pRLPx } from '@ethereumjs/devp2p'
-import { bytesToHex, utf8ToBytes } from 'ethereum-cryptography/utils'
+import { bytesToHex, hexToBytes, utf8ToBytes } from 'ethereum-cryptography/utils'
 
 import { Event } from '../../types'
 import { getClientVersion } from '../../util'
@@ -188,6 +188,7 @@ export class RlpxServer extends Server {
       return false
     }
     this.dpt!.banPeer(peerId, maxAge)
+    this.rlpx!.disconnect(hexToBytes(peerId))
     return true
   }
 

--- a/packages/client/src/service/ethereumservice.ts
+++ b/packages/client/src/service/ethereumservice.ts
@@ -52,7 +52,7 @@ export class EthereumService extends Service {
    * Shutdown the client when memory threshold is reached (in percent)
    *
    */
-  private MEMORY_SHUTDOWN_THRESHOLD = 95
+  private MEMORY_SHUTDOWN_THRESHOLD = 92
 
   private _statsInterval: NodeJS.Timeout | undefined /* global NodeJS */
 

--- a/packages/client/test/net/server/rlpxserver.spec.ts
+++ b/packages/client/test/net/server/rlpxserver.spec.ts
@@ -221,8 +221,9 @@ tape('[RlpxServer]', async (t) => {
     t.notOk(server.ban('123'), 'not started')
     server.started = true
     server.dpt = td.object()
-    server.ban('peer0', 1234)
-    td.verify(server.dpt!.banPeer('peer0', 1234))
+    server.rlpx = td.object()
+    server.ban('112233', 1234)
+    td.verify(server.dpt!.banPeer('112233', 1234))
     t.end()
   })
 

--- a/packages/client/tsconfig.prod.cjs.json
+++ b/packages/client/tsconfig.prod.cjs.json
@@ -1,6 +1,6 @@
 {
   "extends": "../../config/tsconfig.prod.cjs.json",
-  "include": ["bin", "lib"],
+  "include": ["bin", "src"],
   "compilerOptions": {
     "outDir": "dist",
     "typeRoots": ["node_modules/@types", "src/@types"]

--- a/packages/devp2p/src/rlpx/rlpx.ts
+++ b/packages/devp2p/src/rlpx/rlpx.ts
@@ -174,7 +174,9 @@ export class RLPx extends EventEmitter {
 
   disconnect(id: Uint8Array) {
     const peer = this._peers.get(bytesToHex(id))
-    if (peer instanceof Peer) peer.disconnect(DISCONNECT_REASONS.CLIENT_QUITTING)
+    if (peer instanceof Peer) {
+      peer.disconnect(DISCONNECT_REASONS.CLIENT_QUITTING)
+    }
   }
 
   _isAlive() {


### PR DESCRIPTION
This fixes a memory leak in the client being triggered when a peer is banned who is then sending continued messages to our client. These messages are the not answered but added to the `messageQueue` in `BoundProtocol`. If the other client is staying connected and continues to send messages (which happens in practice) `messageQueue` is growing indefinitely.

![Bildschirmfoto 2023-06-05 um 14 14 53](https://github.com/ethereumjs/ethereumjs-monorepo/assets/931137/4f110991-696d-4e05-bea5-688bb2480686)

I have tested that the functionality both triggers and is not breaking anything by adding `console.log()` output to both the `server.ban()` method in the client and the then executed `rlpx.disconnect()` method in devp2p, see screenshot above, and then waiting for a respective event to trigger during client run.

I have also added a general reasonable guard for `messageQueue` to generally avoid this list to grow without bounds.

Ready for review. 🙂 