### PR TITLE
Add low overhead blob tx constructor option

### DIFF
--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -137,12 +137,15 @@ const txData = {
   versionedHashes: ['0xabc...'], // Test with empty array on a first run
   kzgCommitments: ['0xdef...'], // Test with empty array on a first run
   blobs: ['0xghi...'], // Test with empty array on a first run
+  proofs: ['0xabcd...'], //
 }
 
 const tx = BlobEIP4844Transaction.fromTxData(txData, { common })
 ```
 
-Note that `versionedHashes` and `kzgCommitments` have a real length of 32 bytes and `blobs` have a real length of `4096` bytes and values are trimmed here for brevity.
+Note that `versionedHashes` and `kzgCommitments` have a real length of 32 bytes, `blobs` have a real length of `4096` bytes and values are trimmed here for brevity.
+
+Alternatively, you can pass a `blobsData` property with an array of strings corresponding to a set of blobs and the `fromTxData` constructor will derive the corresponding `blobs`, `versionedHashes`, `kzgCommitments`, and `kzgProofs` for you.
 
 See the [Blob Transaction Tests](./test/eip4844.spec.ts) for examples of usage in instantiating, serializing, and deserializing these transactions.
 

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -184,7 +184,10 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
         throw new Error('cannot have both raw blobs data and KZG commitments in constructor')
       }
       if (txData.versionedHashes !== undefined) {
-        throw new Error('cannot have both raw blobs data and encoded blobs in constructor')
+        throw new Error('cannot have both raw blobs data and versioned hashes in constructor')
+      }
+      if (txData.kzgProofs !== undefined) {
+        throw new Error('cannot have both raw blobs data and KZG proofs in constructor')
       }
       txData.blobs = getBlobs(txData.blobsData.reduce((acc, cur) => acc + cur))
       txData.kzgCommitments = blobsToCommitments(txData.blobs as Uint8Array[])

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -3,13 +3,17 @@ import {
   MAX_INTEGER,
   bigIntToHex,
   bigIntToUnpaddedBytes,
+  blobsToCommitments,
+  blobsToProofs,
   bytesToBigInt,
   bytesToHex,
   bytesToPrefixedHexString,
+  commitmentsToVersionedHashes,
   computeVersionedHash,
   concatBytes,
   ecrecover,
   equalsBytes,
+  getBlobs,
   hexStringToBytes,
   kzg,
   toBytes,
@@ -172,6 +176,25 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
   }
 
   public static fromTxData(txData: BlobEIP4844TxData, opts?: TxOptions) {
+    if (txData.blobsData !== undefined) {
+      if (txData.blobs !== undefined) {
+        throw new Error('cannot have both raw blobs data and encoded blobs in constructor')
+      }
+      if (txData.kzgCommitments !== undefined) {
+        throw new Error('cannot have both raw blobs data and KZG commitments in constructor')
+      }
+      if (txData.versionedHashes !== undefined) {
+        throw new Error('cannot have both raw blobs data and encoded blobs in constructor')
+      }
+      txData.blobs = getBlobs(txData.blobsData.reduce((acc, cur) => acc + cur))
+      txData.kzgCommitments = blobsToCommitments(txData.blobs as Uint8Array[])
+      txData.versionedHashes = commitmentsToVersionedHashes(txData.kzgCommitments as Uint8Array[])
+      txData.kzgProofs = blobsToProofs(
+        txData.blobs as Uint8Array[],
+        txData.kzgCommitments as Uint8Array[]
+      )
+    }
+
     return new BlobEIP4844Transaction(txData, opts)
   }
 

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -217,6 +217,10 @@ export interface BlobEIP4844TxData extends FeeMarketEIP1559TxData {
    * The KZG proofs associated with the transaction
    */
   kzgProofs?: BytesLike[]
+  /**
+   * An array of arbitrary strings that blobs are to be constructed from
+   */
+  blobsData?: string[]
 }
 
 /**

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -25,7 +25,7 @@ if (isBrowser() === false) {
   try {
     initKZG(kzg, __dirname + '/../../client/src/trustedSetups/devnet4.txt')
     // eslint-disable-next-line
-    } catch {}
+  } catch {}
 }
 
 const gethGenesis = require('../../block/test/testdata/4844-hardfork.json')
@@ -178,7 +178,7 @@ tape('EIP4844 constructor tests - invalid scenarios', (t) => {
   }
 })
 
-tape('Network wrapper tests', async (t) => {
+tape.only('Network wrapper tests', async (t) => {
   if (isBrowser() === true) {
     t.end()
   } else {
@@ -224,6 +224,60 @@ tape('Network wrapper tests', async (t) => {
       'has the same hash as the network wrapper version'
     )
 
+    const simpleBlobTx = BlobEIP4844Transaction.fromTxData(
+      {
+        blobsData: ['hello world'],
+        maxFeePerDataGas: 100000000n,
+        gasLimit: 0xffffffn,
+        to: randomBytes(20),
+      },
+      { common }
+    )
+
+    t.equal(
+      bytesToHex(unsignedTx.versionedHashes[0]),
+      bytesToHex(simpleBlobTx.versionedHashes[0]),
+      'tx versioned hash for simplified blob txData constructor matches fully specified versioned hashes'
+    )
+
+    t.throws(() =>
+      BlobEIP4844Transaction.fromTxData(
+        {
+          blobsData: ['hello world'],
+          blobs: ['hello world'],
+          maxFeePerDataGas: 100000000n,
+          gasLimit: 0xffffffn,
+          to: randomBytes(20),
+        },
+        { common }
+      )
+    )
+
+    t.throws(() =>
+      BlobEIP4844Transaction.fromTxData(
+        {
+          blobsData: ['hello world'],
+          kzgCommitments: ['0xabcd'],
+          maxFeePerDataGas: 100000000n,
+          gasLimit: 0xffffffn,
+          to: randomBytes(20),
+        },
+        { common }
+      )
+    )
+
+    t.throws(() =>
+      BlobEIP4844Transaction.fromTxData(
+        {
+          blobsData: ['hello world'],
+          versionedHashes: ['0x01cd'],
+          maxFeePerDataGas: 100000000n,
+          gasLimit: 0xffffffn,
+          to: randomBytes(20),
+        },
+        { common }
+      )
+    )
     const txWithEmptyBlob = BlobEIP4844Transaction.fromTxData(
       {
         versionedHashes: [],

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -178,7 +178,7 @@ tape('EIP4844 constructor tests - invalid scenarios', (t) => {
   }
 })
 
-tape.only('Network wrapper tests', async (t) => {
+tape('Network wrapper tests', async (t) => {
   if (isBrowser() === true) {
     t.end()
   } else {
@@ -240,44 +240,78 @@ tape.only('Network wrapper tests', async (t) => {
       'tx versioned hash for simplified blob txData constructor matches fully specified versioned hashes'
     )
 
-    t.throws(() =>
-      BlobEIP4844Transaction.fromTxData(
-        {
-          blobsData: ['hello world'],
-          blobs: ['hello world'],
-          maxFeePerDataGas: 100000000n,
-          gasLimit: 0xffffffn,
-          to: randomBytes(20),
-        },
-        { common }
-      )
+    t.throws(
+      () =>
+        BlobEIP4844Transaction.fromTxData(
+          {
+            blobsData: ['hello world'],
+            blobs: ['hello world'],
+            maxFeePerDataGas: 100000000n,
+            gasLimit: 0xffffffn,
+            to: randomBytes(20),
+          },
+          { common }
+        ),
+      (err: any) => {
+        return err.message.includes('encoded blobs')
+      },
+      'throws on blobsData and blobs in txData'
     )
 
-    t.throws(() =>
-      BlobEIP4844Transaction.fromTxData(
-        {
-          blobsData: ['hello world'],
-          kzgCommitments: ['0xabcd'],
-          maxFeePerDataGas: 100000000n,
-          gasLimit: 0xffffffn,
-          to: randomBytes(20),
-        },
-        { common }
-      )
+    t.throws(
+      () =>
+        BlobEIP4844Transaction.fromTxData(
+          {
+            blobsData: ['hello world'],
+            kzgCommitments: ['0xabcd'],
+            maxFeePerDataGas: 100000000n,
+            gasLimit: 0xffffffn,
+            to: randomBytes(20),
+          },
+          { common }
+        ),
+      (err: any) => {
+        return err.message.includes('KZG commitments')
+      },
+      'throws on blobsData and KZG commitments in txData'
     )
 
-    t.throws(() =>
-      BlobEIP4844Transaction.fromTxData(
-        {
-          blobsData: ['hello world'],
-          versionedHashes: ['0x01cd'],
-          maxFeePerDataGas: 100000000n,
-          gasLimit: 0xffffffn,
-          to: randomBytes(20),
-        },
-        { common }
-      )
+    t.throws(
+      () =>
+        BlobEIP4844Transaction.fromTxData(
+          {
+            blobsData: ['hello world'],
+            versionedHashes: ['0x01cd'],
+            maxFeePerDataGas: 100000000n,
+            gasLimit: 0xffffffn,
+            to: randomBytes(20),
+          },
+          { common }
+        ),
+      (err: any) => {
+        return err.message.includes('versioned hashes')
+      },
+      'throws on blobsData and versioned hashes in txData'
     )
+
+    t.throws(
+      () =>
+        BlobEIP4844Transaction.fromTxData(
+          {
+            blobsData: ['hello world'],
+            kzgProofs: ['0x01cd'],
+            maxFeePerDataGas: 100000000n,
+            gasLimit: 0xffffffn,
+            to: randomBytes(20),
+          },
+          { common }
+        ),
+      (err: any) => {
+        return err.message.includes('KZG proofs')
+      },
+      'throws on blobsData and KZG proofs in txData'
+    )
+
     const txWithEmptyBlob = BlobEIP4844Transaction.fromTxData(
       {
         versionedHashes: [],


### PR DESCRIPTION
Adds a new optional `blobsData` property to the `fromTxData` constructor for blob transactions to simplify tx construction