### PR TITLE
vm: Discard blob txs with missing blobs for block building

### DIFF
--- a/packages/client/src/miner/miner.ts
+++ b/packages/client/src/miner/miner.ts
@@ -2,7 +2,7 @@ import { BlockHeader } from '@ethereumjs/block'
 import { ConsensusType, Hardfork } from '@ethereumjs/common'
 import { Ethash } from '@ethereumjs/ethash'
 import { bytesToPrefixedHexString } from '@ethereumjs/util'
-import { bytesToHex, equalsBytes } from 'ethereum-cryptography/utils'
+import { equalsBytes } from 'ethereum-cryptography/utils'
 import { MemoryLevel } from 'memory-level'
 
 import { LevelDB } from '../execution/level'
@@ -325,18 +325,6 @@ export class Miner {
               `Miner: Assembled block full (gasLeft: ${gasLimit - blockBuilder.gasUsed})`
             )
           }
-        } else if ((error as Error).message.includes('tx has a different hardfork than the vm')) {
-          // We can here decide to keep a tx in pool if it belongs to future hf
-          // but for simplicity just remove the tx as the sender can always retransmit
-          // the tx
-          this.service.txPool.removeByHash(bytesToHex(txs[index].hash()))
-          this.config.logger.error(
-            `Pending: Removed from txPool tx ${bytesToPrefixedHexString(
-              txs[index].hash()
-            )} having different hf=${txs[index].common.hardfork()} than block vm hf=${blockBuilder[
-              'vm'
-            ]._common.hardfork()}`
-          )
         } else {
           // If there is an error adding a tx, it will be skipped
           const hash = bytesToPrefixedHexString(txs[index].hash())

--- a/packages/client/src/miner/pendingBlock.ts
+++ b/packages/client/src/miner/pendingBlock.ts
@@ -47,6 +47,14 @@ export interface BlobsBundle {
 // Max two payload to be cached
 const MAX_PAYLOAD_CACHE = 2
 
+enum AddTxResult {
+  Success,
+  BlockFull,
+  SkippedByGasLimit,
+  SkippedByErrors,
+  RemovedByErrors,
+}
+
 export class PendingBlock {
   config: Config
   txPool: TxPool
@@ -166,39 +174,34 @@ export class PendingBlock {
     )
     let index = 0
     let blockFull = false
+    let skippedByAddErrors = 0
     const blobTxs = []
     while (index < txs.length && !blockFull) {
-      try {
-        const tx = txs[index]
-        await builder.addTransaction(tx, {
-          skipHardForkValidation: this.skipHardForkValidation,
-        })
+      const tx = txs[index]
+      const addTxResult = await this.addTransaction(builder, tx)
 
-        // Push the tx in blobTxs only after successful addTransaction
-        if (tx instanceof BlobEIP4844Transaction) blobTxs.push(tx)
-      } catch (error) {
-        if (
-          (error as Error).message ===
-          'tx has a higher gas limit than the remaining gas in the block'
-        ) {
-          if (builder.gasUsed > gasLimit - BigInt(21000)) {
-            // If block has less than 21000 gas remaining, consider it full
-            blockFull = true
-            this.config.logger.info(
-              `Pending: Assembled block full (gasLeft: ${gasLimit - builder.gasUsed})`
-            )
-          }
-        } else {
-          // If there is an error adding a tx, it will be skipped
-          this.config.logger.debug(
-            `Pending: Skipping tx ${bytesToPrefixedHexString(
-              txs[index].hash()
-            )}, error encountered when trying to add tx:\n${error}`
-          )
-        }
+      switch (addTxResult) {
+        case AddTxResult.Success:
+          // Push the tx in blobTxs only after successful addTransaction
+          if (tx instanceof BlobEIP4844Transaction) blobTxs.push(tx)
+          break
+
+        case AddTxResult.BlockFull:
+          blockFull = true
+        // Falls through
+        default:
+          skippedByAddErrors++
       }
+
+      // TODO: if addTxResult is not successfull also remove any other txs from this account
       index++
     }
+
+    this.config.logger.info(
+      `Pending: Added txs=${
+        txs.length - skippedByAddErrors
+      } skippedByAddErrors=${skippedByAddErrors}} total=${txs.length} candidates`
+    )
 
     // Construct initial blobs bundle when payload is constructed
     if (vm._common.isActivatedEIP(4844)) {
@@ -263,50 +266,28 @@ export class PendingBlock {
           equalsBytes(t.hash(), tx.hash())
         ) === false
     )
+
     this.config.logger.info(`Pending: Adding ${txs.length} additional eligible txs`)
     let index = 0
     let blockFull = false
     let skippedByAddErrors = 0
     const blobTxs = []
-    while (index < txs.length && !blockFull) {
-      try {
-        const tx = txs[index]
-        await builder.addTransaction(tx, {
-          skipHardForkValidation: this.skipHardForkValidation,
-        })
 
-        // Push tx in blobTxs only after successful inclusion in the builder addTransaction
-        if (tx instanceof BlobEIP4844Transaction) {
-          blobTxs.push(tx)
-        }
-      } catch (error: any) {
-        if (error.message === 'tx has a higher gas limit than the remaining gas in the block') {
-          if (builder.gasUsed > (builder as any).headerData.gasLimit - BigInt(21000)) {
-            // If block has less than 21000 gas remaining, consider it full
-            blockFull = true
-            this.config.logger.info(`Pending: Assembled block full`)
-          }
-        } else if ((error as Error).message.includes('tx has a different hardfork than the vm')) {
-          // We can here decide to keep a tx in pool if it belongs to future hf
-          // but for simplicity just remove the tx as the sender can always retransmit
-          // the tx
-          this.txPool.removeByHash(bytesToHex(txs[index].hash()))
-          this.config.logger.error(
-            `Pending: Removed from txPool tx ${bytesToPrefixedHexString(
-              txs[index].hash()
-            )} having different hf=${txs[
-              index
-            ].common.hardfork()} than block vm hf=${vm._common.hardfork()}`
-          )
-        } else {
+    while (index < txs.length && !blockFull) {
+      const tx = txs[index]
+      const addTxResult = await this.addTransaction(builder, tx)
+
+      switch (addTxResult) {
+        case AddTxResult.Success:
+          // Push the tx in blobTxs only after successful addTransaction
+          if (tx instanceof BlobEIP4844Transaction) blobTxs.push(tx)
+          break
+
+        case AddTxResult.BlockFull:
+          blockFull = true
+        // Falls through
+        default:
           skippedByAddErrors++
-          // If there is an error adding a tx, it will be skipped
-          this.config.logger.debug(
-            `Pending: Skipping tx ${bytesToPrefixedHexString(
-              txs[index].hash()
-            )}, error encountered when trying to add tx:\n${error}`
-          )
-        }
       }
       index++
     }
@@ -329,6 +310,58 @@ export class PendingBlock {
     )
 
     return [block, builder.transactionReceipts, builder.minerValue, blobs]
+  }
+
+  private async addTransaction(builder: BlockBuilder, tx: TypedTransaction) {
+    let addTxResult: AddTxResult
+
+    try {
+      await builder.addTransaction(tx, {
+        skipHardForkValidation: this.skipHardForkValidation,
+      })
+      addTxResult = AddTxResult.Success
+    } catch (error: any) {
+      if (error.message === 'tx has a higher gas limit than the remaining gas in the block') {
+        if (builder.gasUsed > (builder as any).headerData.gasLimit - BigInt(21000)) {
+          // If block has less than 21000 gas remaining, consider it full
+          this.config.logger.info(`Pending: Assembled block full`)
+          addTxResult = AddTxResult.BlockFull
+        } else {
+          addTxResult = AddTxResult.SkippedByGasLimit
+        }
+      } else if ((error as Error).message.includes('tx has a different hardfork than the vm')) {
+        // We can here decide to keep a tx in pool if it belongs to future hf
+        // but for simplicity just remove the tx as the sender can always retransmit
+        // the tx
+        this.txPool.removeByHash(bytesToHex(tx.hash()))
+        this.config.logger.error(
+          `Pending: Removed from txPool tx ${bytesToPrefixedHexString(
+            tx.hash()
+          )} having different hf=${tx.common.hardfork()} than block vm hf=${builder[
+            'vm'
+          ]._common.hardfork()}`
+        )
+        addTxResult = AddTxResult.RemovedByErrors
+      } else if ((error as Error).message.includes('blobs missing')) {
+        // Remove the blob tx which doesn't has blobs bundled
+        this.txPool.removeByHash(bytesToHex(tx.hash()))
+        this.config.logger.error(
+          `Pending: Removed from txPool a blob tx ${bytesToPrefixedHexString(
+            tx.hash()
+          )} with missing blobs`
+        )
+        addTxResult = AddTxResult.RemovedByErrors
+      } else {
+        // If there is an error adding a tx, it will be skipped
+        this.config.logger.debug(
+          `Pending: Skipping tx ${bytesToPrefixedHexString(
+            tx.hash()
+          )}, error encountered when trying to add tx:\n${error}`
+        )
+        addTxResult = AddTxResult.SkippedByErrors
+      }
+    }
+    return addTxResult
   }
 
   /**

--- a/packages/client/src/miner/pendingBlock.ts
+++ b/packages/client/src/miner/pendingBlock.ts
@@ -314,19 +314,6 @@ export class PendingBlock {
         } else {
           addTxResult = AddTxResult.SkippedByGasLimit
         }
-      } else if ((error as Error).message.includes('tx has a different hardfork than the vm')) {
-        // We can here decide to keep a tx in pool if it belongs to future hf
-        // but for simplicity just remove the tx as the sender can always retransmit
-        // the tx
-        this.txPool.removeByHash(bytesToHex(tx.hash()))
-        this.config.logger.error(
-          `Pending: Removed from txPool tx ${bytesToPrefixedHexString(
-            tx.hash()
-          )} having different hf=${tx.common.hardfork()} than block vm hf=${builder[
-            'vm'
-          ]._common.hardfork()}`
-        )
-        addTxResult = AddTxResult.RemovedByErrors
       } else if ((error as Error).message.includes('blobs missing')) {
         // Remove the blob tx which doesn't has blobs bundled
         this.txPool.removeByHash(bytesToHex(tx.hash()))

--- a/packages/client/src/net/protocol/ethprotocol.ts
+++ b/packages/client/src/net/protocol/ethprotocol.ts
@@ -223,7 +223,7 @@ export class EthProtocol extends Protocol {
             case 0:
               serializedTxs.push(tx.raw())
               break
-            case 5:
+            case 3:
               serializedTxs.push((tx as BlobEIP4844Transaction).serializeNetworkWrapper())
               break
             default:
@@ -247,7 +247,7 @@ export class EthProtocol extends Protocol {
           bytesToBigInt(reqId),
           txs.map((txData) => {
             // Blob transactions are deserialized with network wrapper
-            if (txData[0] === 5) {
+            if (txData[0] === 3) {
               return BlobEIP4844Transaction.fromSerializedBlobTxNetworkWrapper(txData, { common })
             } else {
               return TransactionFactory.fromBlockBodyData(txData, { common })

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -195,6 +195,11 @@ export class BlockBuilder {
       }
       const blobTx = tx as BlobEIP4844Transaction
 
+      // Guard against the case if a tx came into the pool without blobs i.e. network wrapper payload
+      if (blobTx.blobs === undefined) {
+        throw new Error('blobs missing for 4844 transaction')
+      }
+
       if (this.dataGasUsed + BigInt(blobTx.numBlobs()) * dataGasPerBlob > dataGasLimit) {
         throw new Error('block data gas limit reached')
       }


### PR DESCRIPTION
makes sure that a block is not build with missing blobs (i.e. from non network wrapper tx)

TODO:
- [x] reject tx with missing blob in build block
~~- [ ] ensure same in gossip~~ TO be dealt in a different PR after discussion
- [x] recheck in rpc submission
- [x] enhance coverage