### PR TITLE
block: add missing tx type

### DIFF
--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -2,6 +2,7 @@ import type { BlockHeader } from './header'
 import type { Common } from '@ethereumjs/common'
 import type {
   AccessListEIP2930TxData,
+  BlobEIP4844TxData,
   FeeMarketEIP1559TxData,
   JsonRpcTx,
   JsonTx,
@@ -116,7 +117,9 @@ export interface BlockData {
    * Header data for the block
    */
   header?: HeaderData
-  transactions?: Array<TxData | AccessListEIP2930TxData | FeeMarketEIP1559TxData>
+  transactions?: Array<
+    TxData | AccessListEIP2930TxData | FeeMarketEIP1559TxData | BlobEIP4844TxData
+  >
   uncleHeaders?: Array<HeaderData>
   withdrawals?: Array<WithdrawalData>
 }


### PR DESCRIPTION
This adds a missing 4844 txData type to the block `transactions` type 