### PR TITLE
monorepo: remove instances of `any` typecasting 

### DIFF
--- a/packages/blockchain/src/consensus/clique.ts
+++ b/packages/blockchain/src/consensus/clique.ts
@@ -566,7 +566,7 @@ export class CliqueConsensus implements Consensus {
     const signers = RLP.decode(blockSigners as Uint8Array) as [Uint8Array, Uint8Array][]
     return signers.map((s) => {
       const blockNum = bytesToBigInt(s[0] as Uint8Array)
-      const signer = new Address(s[1] as any)
+      const signer = new Address(s[1])
       return [blockNum, signer]
     }) as CliqueLatestBlockSigners
   }

--- a/packages/blockchain/src/consensus/ethash.ts
+++ b/packages/blockchain/src/consensus/ethash.ts
@@ -44,7 +44,7 @@ export class EthashConsensus implements Consensus {
   public async genesisInit(): Promise<void> {}
   public async setup({ blockchain }: ConsensusOptions): Promise<void> {
     this.blockchain = blockchain
-    this._ethash = new Ethash(this.blockchain.db as any)
+    this._ethash = new Ethash(this.blockchain.db)
   }
   public async newBlock(): Promise<void> {}
 }

--- a/packages/blockchain/src/consensus/ethash.ts
+++ b/packages/blockchain/src/consensus/ethash.ts
@@ -44,7 +44,7 @@ export class EthashConsensus implements Consensus {
   public async genesisInit(): Promise<void> {}
   public async setup({ blockchain }: ConsensusOptions): Promise<void> {
     this.blockchain = blockchain
-    this._ethash = new Ethash(this.blockchain.db)
+    this._ethash = new Ethash(this.blockchain.db as any)
   }
   public async newBlock(): Promise<void> {}
 }

--- a/packages/blockchain/src/utils.ts
+++ b/packages/blockchain/src/utils.ts
@@ -15,7 +15,7 @@ export function parseGethGenesisState(json: any) {
     code = code !== undefined ? addHexPrefix(code) : undefined
     storage = storage !== undefined ? Object.entries(storage) : undefined
     nonce = nonce !== undefined ? addHexPrefix(nonce) : undefined
-    state[address] = [balance, code, storage, nonce] as any
+    state[address] = [balance, code, storage, nonce]
   }
   return state
 }

--- a/packages/blockchain/test/util.ts
+++ b/packages/blockchain/test/util.ts
@@ -169,7 +169,7 @@ export const createTestDB = async (): Promise<
       value: { head0: bytesToHex(Uint8Array.from([171, 205])) },
     },
   ])
-  return [db as any, genesis]
+  return [db, genesis]
 }
 
 /**

--- a/packages/client/src/blockchain/chain.ts
+++ b/packages/client/src/blockchain/chain.ts
@@ -398,7 +398,7 @@ export class Chain {
 
       const td = await this.blockchain.getParentTD(b.header)
       if (b.header.number <= this.headers.height) {
-        ;(this.blockchain as any).checkAndTransitionHardForkByNumber(b.header.number, td)
+        await this.blockchain.checkAndTransitionHardForkByNumber(b.header.number, td)
         await this.blockchain.consensus.setup({ blockchain: this.blockchain })
       }
 

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -8,7 +8,7 @@ import { Event, EventBus } from './types'
 import { parseTransports, short } from './util'
 
 import type { Logger } from './logging'
-import type { EventBusType } from './types'
+import type { EventBusType, MultiaddrLike } from './types'
 import type { BlockHeader } from '@ethereumjs/block'
 import type { Address } from '@ethereumjs/util'
 import type { VM } from '@ethereumjs/vm'
@@ -462,7 +462,8 @@ export class Config {
       // Otherwise parse transports from transports option
       this.servers = parseTransports(this.transports).map((t) => {
         if (t.name === 'rlpx') {
-          const bootnodes = this.bootnodes ?? (this.chainCommon.bootstrapNodes() as any)
+          const bootnodes: MultiaddrLike =
+            this.bootnodes ?? (this.chainCommon.bootstrapNodes() as any)
           const dnsNetworks = options.dnsNetworks ?? this.chainCommon.dnsNetworks()
           return new RlpxServer({ config: this, bootnodes, dnsNetworks })
         } else if (t.name === 'libp2p') {

--- a/packages/client/src/sync/fetcher/accountfetcher.ts
+++ b/packages/client/src/sync/fetcher/accountfetcher.ts
@@ -274,7 +274,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
       if (rangeResult.proof.length > 0) {
         this.debug(`Data for last range has been received`)
         // response contains empty object so that task can be terminated in store phase and not reenqueued
-        return Object.assign([], [Object.create(null) as any], { completed: true })
+        return Object.assign([], [Object.create(null)], { completed: true })
       }
     }
 

--- a/packages/client/src/sync/fetcher/blockfetcherbase.ts
+++ b/packages/client/src/sync/fetcher/blockfetcherbase.ts
@@ -241,7 +241,7 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
     }
     str += `first=${first} count=${count}${partialResult}`
     if ('reverse' in this) {
-      str += ` reverse=${(this as any).reverse}`
+      str += ` reverse=${this.reverse}`
     }
     return str
   }

--- a/packages/client/src/sync/fetcher/bytecodefetcher.ts
+++ b/packages/client/src/sync/fetcher/bytecodefetcher.ts
@@ -216,9 +216,7 @@ export class ByteCodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
         for (const task of tasks) {
           this.enqueueTask(task, true)
         }
-        this.debug(
-          `Fetcher pending with ${(fullJob as any)!.task.hashes.length} code hashes requested`
-        )
+        this.debug(`Fetcher pending with ${fullJob!.task.hashes.length} code hashes requested`)
       }
     } catch (err) {
       this.debug(err)

--- a/packages/client/src/util/parse.ts
+++ b/packages/client/src/util/parse.ts
@@ -39,7 +39,7 @@ export function parseMultiaddrs(input: MultiaddrLike): Multiaddr[] {
       }
       // parse as object
       if (typeof s === 'object') {
-        const { ip, port } = s as any
+        const { ip, port } = s
         if (ip !== undefined && port !== undefined) {
           return multiaddr(`/ip4/${ip}/tcp/${port}`)
         }
@@ -54,7 +54,7 @@ export function parseMultiaddrs(input: MultiaddrLike): Multiaddr[] {
       const ipv6WithPort = new RegExp('\\[(?<ip6>' + ip6RegExp.source + ')\\]:(?<port>[0-9]+)$')
       const matchip6 = s.match(ipv6WithPort)
       if (matchip6) {
-        const { ip6, port } = matchip6.groups as any
+        const { ip6, port } = matchip6.groups!
         return multiaddr(`/ip6/${ip6}/tcp/${port}`)
       }
       // parse using WHATWG URL API

--- a/packages/client/src/util/rpc.ts
+++ b/packages/client/src/util/rpc.ts
@@ -48,7 +48,7 @@ export function inspectParams(params: any, shorten?: number) {
   let inspected = inspect(params, {
     colors: true,
     maxStringLength: 100,
-  } as any)
+  })
   if (typeof shorten === 'number') {
     inspected = inspected.replace(/\n/g, '').replace(/ {2}/g, ' ')
     if (inspected.length > shorten) {
@@ -217,6 +217,7 @@ export function createWsRPCServerListener(opts: CreateWSServerOpts): HttpServer 
         socket.destroy()
       }
     }
+
     ;(wss as any).handleUpgrade(req, socket, head, (ws: any) => {
       ;(wss as any).emit('connection', ws, req)
     })

--- a/packages/client/test/integration/util.ts
+++ b/packages/client/test/integration/util.ts
@@ -70,7 +70,7 @@ export async function setup(
   } else {
     service = new FullEthereumService({
       ...serviceOpts,
-      metaDB: new MemoryLevel() as any,
+      metaDB: new MemoryLevel(),
       lightserv: true,
     })
   }

--- a/packages/statemanager/src/ethersStateManager.ts
+++ b/packages/statemanager/src/ethersStateManager.ts
@@ -52,12 +52,12 @@ export class EthersStateManager implements EVMStateManagerInterface {
       provider: this.provider,
       blockTag: BigInt(this.blockTag),
     })
-    ;(newState as any).contractCache = new Map(this.contractCache)
-    ;(newState as any).storageCache = new StorageCache({
+    newState.contractCache = new Map(this.contractCache)
+    newState.storageCache = new StorageCache({
       size: 100000,
       type: CacheType.ORDERED_MAP,
     })
-    ;(newState as any)._accountCache = new AccountCache({
+    newState._accountCache = new AccountCache({
       size: 100000,
       type: CacheType.ORDERED_MAP,
     })

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -88,7 +88,7 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMarketEIP155
       throw new Error('Invalid serialized tx input: must be array')
     }
 
-    return FeeMarketEIP1559Transaction.fromValuesArray(values as any, opts)
+    return FeeMarketEIP1559Transaction.fromValuesArray(values as FeeMarketEIP1559ValuesArray, opts)
   }
 
   /**

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -244,7 +244,7 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
       throw new Error('Invalid serialized tx input: must be array')
     }
 
-    return BlobEIP4844Transaction.fromValuesArray(values as any, opts)
+    return BlobEIP4844Transaction.fromValuesArray(values as BlobEIP4844ValuesArray, opts)
   }
 
   /**


### PR DESCRIPTION
This PR removes ~15 instances of `any` typecasting when unnecessary, by either replacing them with more precise typecasting or removing them completely.

