### PR TITLE
RPC method eth_feeHistory implementation

### DIFF
--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -240,7 +240,7 @@ const getBlockByOption = async (blockOpt: string, chain: Chain) => {
 const calculateRewards = async (
   block: Block,
   receiptsManager: ReceiptsManager,
-  priorityFeePercentiles: number[]
+  priorityFeePercentiles: bigint[]
 ) => {
   const blockRewards: bigint[] = []
   const txGasUsed: bigint[] = []
@@ -1205,7 +1205,7 @@ export class Eth {
     return bigIntToHex(gasPrice)
   }
 
-  async feeHistory(params: [string | number | bigint, string, Array<number>?]) {
+  async feeHistory(params: [string | number | bigint, string, [bigint]?]) {
     let [blockCount] = params
     const [, lastBlockRequested, priorityFeePercentiles] = params
 

--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -284,34 +284,34 @@ const calculateRewards = async (
   return blockRewards
 }
 
-const calculateNextBaseFee = (parentBlock: Block, londonHardforkNumber: bigint | null) => {
-  const { header: parentBlockHeader } = parentBlock
-  const {
-    gasUsed: parentBlockGasUsed,
-    gasLimit: parentBlockGasLimit,
-    baseFeePerGas: parentBlockBaseFee,
-  } = parentBlockHeader
+// const calculateNextBaseFee = (parentBlock: Block, londonHardforkNumber: bigint | null) => {
+//   const { header: parentBlockHeader } = parentBlock
+//   const {
+//     gasUsed: parentBlockGasUsed,
+//     gasLimit: parentBlockGasLimit,
+//     baseFeePerGas: parentBlockBaseFee,
+//   } = parentBlockHeader
 
-  const nextBlockNumber = parentBlockHeader.number + 1n
-  if (nextBlockNumber === londonHardforkNumber) {
-    return BigInt(1000000000)
-  }
+//   const nextBlockNumber = parentBlockHeader.number + 1n
+//   if (nextBlockNumber === londonHardforkNumber) {
+//     return BigInt(1000000000)
+//   }
 
-  const targetGasUsed = parentBlockGasLimit / 2n
+//   const targetGasUsed = parentBlockGasLimit / 2n
 
-  if (targetGasUsed === parentBlockGasUsed) {
-    return parentBlockBaseFee!
-  } else if (parentBlockGasUsed > targetGasUsed) {
-    const gasDelta = parentBlockGasUsed - targetGasUsed
-    return bigIntMax(
-      parentBlockBaseFee! + (gasDelta * parentBlockBaseFee!) / (targetGasUsed * 8n),
-      1n
-    )
-  } else {
-    const gasDelta = targetGasUsed - parentBlockGasUsed
-    return parentBlockBaseFee! - (gasDelta * parentBlockBaseFee!) / (targetGasUsed * 8n)
-  }
-}
+//   if (targetGasUsed === parentBlockGasUsed) {
+//     return parentBlockBaseFee!
+//   } else if (parentBlockGasUsed > targetGasUsed) {
+//     const gasDelta = parentBlockGasUsed - targetGasUsed
+//     return bigIntMax(
+//       parentBlockBaseFee! + (gasDelta * parentBlockBaseFee!) / (targetGasUsed * 8n),
+//       1n
+//     )
+//   } else {
+//     const gasDelta = targetGasUsed - parentBlockGasUsed
+//     return parentBlockBaseFee! - (gasDelta * parentBlockBaseFee!) / (targetGasUsed * 8n)
+//   }
+// }
 
 /**
  * eth_* RPC module
@@ -1249,10 +1249,7 @@ export class Eth {
     const londonHardforkBlockNumber = this._chain.blockchain._common.hardforkBlock(Hardfork.London)!
     const nextBaseFee =
       lastRequestedBlockNumber - londonHardforkBlockNumber >= -1n
-        ? calculateNextBaseFee(
-            requestedBlocks[requestedBlocks.length - 1],
-            londonHardforkBlockNumber
-          )
+        ? requestedBlocks[requestedBlocks.length - 1].header.calcNextBaseFee()
         : BigInt(0)
     baseFees.push(nextBaseFee)
 

--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -453,7 +453,7 @@ export class Eth {
     this.feeHistory = middleware(this.feeHistory.bind(this), 2, [
       [validators.either(validators.hex, validators.uint256)],
       [validators.blockOption],
-      [validators.array(validators.hex)],
+      [validators.array(validators.integer)],
     ])
   }
 

--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -284,35 +284,6 @@ const calculateRewards = async (
   return blockRewards
 }
 
-// const calculateNextBaseFee = (parentBlock: Block, londonHardforkNumber: bigint | null) => {
-//   const { header: parentBlockHeader } = parentBlock
-//   const {
-//     gasUsed: parentBlockGasUsed,
-//     gasLimit: parentBlockGasLimit,
-//     baseFeePerGas: parentBlockBaseFee,
-//   } = parentBlockHeader
-
-//   const nextBlockNumber = parentBlockHeader.number + 1n
-//   if (nextBlockNumber === londonHardforkNumber) {
-//     return BigInt(1000000000)
-//   }
-
-//   const targetGasUsed = parentBlockGasLimit / 2n
-
-//   if (targetGasUsed === parentBlockGasUsed) {
-//     return parentBlockBaseFee!
-//   } else if (parentBlockGasUsed > targetGasUsed) {
-//     const gasDelta = parentBlockGasUsed - targetGasUsed
-//     return bigIntMax(
-//       parentBlockBaseFee! + (gasDelta * parentBlockBaseFee!) / (targetGasUsed * 8n),
-//       1n
-//     )
-//   } else {
-//     const gasDelta = targetGasUsed - parentBlockGasUsed
-//     return parentBlockBaseFee! - (gasDelta * parentBlockBaseFee!) / (targetGasUsed * 8n)
-//   }
-// }
-
 /**
  * eth_* RPC module
  * @memberof module:rpc/modules

--- a/packages/client/src/rpc/validation.ts
+++ b/packages/client/src/rpc/validation.ts
@@ -272,6 +272,22 @@ export const validators = {
   },
 
   /**
+   * number validator to check if type is integer
+   * @param params parameters of method
+   * @param index index of parameter
+   */
+  get integer() {
+    return (params: any[], index: number) => {
+      if (typeof params[index] !== 'number') {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument is not a number`,
+        }
+      }
+    }
+  },
+
+  /**
    * validator to ensure required transaction fields are present, and checks for valid address and hex values.
    * @param requiredFields array of required fields
    * @returns validator function with params:

--- a/packages/client/test/rpc/eth/getFeeHistory.spec.ts
+++ b/packages/client/test/rpc/eth/getFeeHistory.spec.ts
@@ -1,0 +1,58 @@
+import { bytesToBigInt } from '@ethereumjs/util'
+import { hexToBytes } from 'ethereum-cryptography/utils'
+import * as tape from 'tape'
+
+import { baseRequest, gethGenesisStartLondon, params, setupChain } from '../helpers'
+
+import pow = require('./../../testdata/geth-genesis/pow.json')
+
+import type { Chain } from '../../../src/blockchain'
+import type { VMExecution } from '../../../src/execution'
+
+const method = 'eth_feeHistory'
+
+const produceFakeBlock = async (execution: VMExecution, chain: Chain, gasUsed: string) => {
+  const { vm } = execution
+  const parentBlock = await chain.getCanonicalHeadBlock()
+  const vmCopy = await vm.copy()
+  // Set block's gas used to max
+  const blockBuilder = await vmCopy.buildBlock({
+    parentBlock,
+    headerData: {
+      timestamp: parentBlock.header.timestamp + BigInt(1),
+      gasUsed,
+    },
+    blockOpts: {
+      calcDifficultyFromHeader: parentBlock.header,
+      putBlockIntoBlockchain: false,
+    },
+  })
+  const block = await blockBuilder.build()
+  await chain.putBlocks([block], false)
+  await execution.run()
+}
+
+tape.only(
+  `${method}: should return 12.5% increased baseFee if parent block is 100% full`,
+  async (t) => {
+    const { chain, server, execution } = await setupChain(gethGenesisStartLondon(pow), 'powLondon')
+    const gasLimit = pow.gasLimit
+
+    await produceFakeBlock(execution, chain, gasLimit)
+    const req = params(method, ['0x1', 'latest', [20, 30]])
+
+    const expectRes = (res: any) => {
+      const [previousBaseFee, nextBaseFee] = res.body.result.baseFeePerGas as [string, string]
+      const increase =
+        Number(
+          (1000n *
+            (bytesToBigInt(hexToBytes(nextBaseFee)) - bytesToBigInt(hexToBytes(previousBaseFee)))) /
+            bytesToBigInt(hexToBytes(previousBaseFee))
+        ) / 1000
+
+      t.equal(increase, 0.125)
+    }
+
+    await baseRequest(t, server, req, 200, expectRes)
+  }
+)

--- a/packages/client/test/rpc/eth/getFeeHistory.spec.ts
+++ b/packages/client/test/rpc/eth/getFeeHistory.spec.ts
@@ -1,4 +1,4 @@
-import { bytesToBigInt } from '@ethereumjs/util'
+import { bigIntToHex, bytesToBigInt } from '@ethereumjs/util'
 import { hexToBytes } from 'ethereum-cryptography/utils'
 import * as tape from 'tape'
 
@@ -11,7 +11,7 @@ import type { VMExecution } from '../../../src/execution'
 
 const method = 'eth_feeHistory'
 
-const produceFakeBlock = async (execution: VMExecution, chain: Chain, gasUsed: string) => {
+const produceFakeGasUsedBlock = async (execution: VMExecution, chain: Chain, gasUsed: bigint) => {
   const { vm } = execution
   const parentBlock = await chain.getCanonicalHeadBlock()
   const vmCopy = await vm.copy()
@@ -20,39 +20,142 @@ const produceFakeBlock = async (execution: VMExecution, chain: Chain, gasUsed: s
     parentBlock,
     headerData: {
       timestamp: parentBlock.header.timestamp + BigInt(1),
-      gasUsed,
+      gasUsed: bigIntToHex(gasUsed),
     },
     blockOpts: {
       calcDifficultyFromHeader: parentBlock.header,
       putBlockIntoBlockchain: false,
     },
   })
+  blockBuilder.gasUsed = gasUsed
+
   const block = await blockBuilder.build()
   await chain.putBlocks([block], false)
   await execution.run()
 }
 
-tape.only(
-  `${method}: should return 12.5% increased baseFee if parent block is 100% full`,
-  async (t) => {
-    const { chain, server, execution } = await setupChain(gethGenesisStartLondon(pow), 'powLondon')
-    const gasLimit = pow.gasLimit
+tape(`${method}: should return 12.5% increased baseFee if parent block is full`, async (t) => {
+  const { chain, server, execution } = await setupChain(gethGenesisStartLondon(pow), 'powLondon')
+  const gasUsed = bytesToBigInt(hexToBytes(pow.gasLimit))
 
-    await produceFakeBlock(execution, chain, gasLimit)
-    const req = params(method, ['0x1', 'latest', [20, 30]])
+  await produceFakeGasUsedBlock(execution, chain, gasUsed)
+  const req = params(method, ['0x2', 'latest', []])
+
+  const expectRes = (res: any) => {
+    const [, previousBaseFee, nextBaseFee] = res.body.result.baseFeePerGas as [
+      string,
+      string,
+      string
+    ]
+    const increase =
+      Number(
+        (1000n *
+          (bytesToBigInt(hexToBytes(nextBaseFee)) - bytesToBigInt(hexToBytes(previousBaseFee)))) /
+          bytesToBigInt(hexToBytes(previousBaseFee))
+      ) / 1000
+
+    t.equal(increase, 0.125)
+  }
+
+  await baseRequest(t, server, req, 200, expectRes)
+})
+
+tape(`${method}: should return 12.5% decreased base fee if the block is empty`, async (t) => {
+  const { chain, server, execution } = await setupChain(gethGenesisStartLondon(pow), 'powLondon')
+  const gasUsed = BigInt(0)
+
+  await produceFakeGasUsedBlock(execution, chain, gasUsed)
+  const req = params(method, ['0x2', 'latest', []])
+
+  const expectRes = (res: any) => {
+    const [, previousBaseFee, nextBaseFee] = res.body.result.baseFeePerGas as [
+      string,
+      string,
+      string
+    ]
+    const increase =
+      Number(
+        (1000n *
+          (bytesToBigInt(hexToBytes(nextBaseFee)) - bytesToBigInt(hexToBytes(previousBaseFee)))) /
+          bytesToBigInt(hexToBytes(previousBaseFee))
+      ) / 1000
+
+    t.equal(increase, -0.125)
+  }
+
+  await baseRequest(t, server, req, 200, expectRes)
+})
+
+tape(
+  `${method}: should return initial base fee if the block number is london hard fork`,
+  async (t) => {
+    const initialBaseFee = 1000000000n
+    const { server } = await setupChain(gethGenesisStartLondon(pow), 'powLondon')
+
+    const req = params(method, ['0x1', 'latest', []])
 
     const expectRes = (res: any) => {
-      const [previousBaseFee, nextBaseFee] = res.body.result.baseFeePerGas as [string, string]
-      const increase =
-        Number(
-          (1000n *
-            (bytesToBigInt(hexToBytes(nextBaseFee)) - bytesToBigInt(hexToBytes(previousBaseFee)))) /
-            bytesToBigInt(hexToBytes(previousBaseFee))
-        ) / 1000
+      const [baseFee] = res.body.result.baseFeePerGas as [string]
 
-      t.equal(increase, 0.125)
+      t.equal(bytesToBigInt(hexToBytes(baseFee)), initialBaseFee)
     }
 
     await baseRequest(t, server, req, 200, expectRes)
   }
 )
+
+tape(`${method}: should return 0x0 for base fees requested before eip-1559`, async (t) => {
+  const { chain, execution, server } = await setupChain(pow, 'pow')
+  const gasUsed = BigInt(0)
+
+  await produceFakeGasUsedBlock(execution, chain, gasUsed)
+  const req = params(method, ['0x1', 'latest', []])
+
+  const expectRes = (res: any) => {
+    const [previousBaseFee, nextBaseFee] = res.body.result.baseFeePerGas as [string, string]
+
+    t.equal(previousBaseFee, '0x0')
+    t.equal(nextBaseFee, '0x0')
+  }
+
+  await baseRequest(t, server, req, 200, expectRes)
+})
+
+tape(`${method}: should return correct gas used ratios`, async (t) => {
+  const { chain, server, execution } = await setupChain(gethGenesisStartLondon(pow), 'powLondon')
+  const gasUsed = bytesToBigInt(hexToBytes(pow.gasLimit)) / 2n
+
+  await produceFakeGasUsedBlock(execution, chain, gasUsed)
+  const req = params(method, ['0x2', 'latest', []])
+
+  const expectRes = (res: any) => {
+    const [genesisGasUsedRatio, nextGasUsedRatio] = res.body.result.gasUsedRatio as [number, number]
+
+    t.equal(genesisGasUsedRatio, 0)
+    t.equal(nextGasUsedRatio, 0.5)
+  }
+
+  await baseRequest(t, server, req, 200, expectRes)
+})
+
+tape(`${method}: should throw error if block count is below 1`, async (t) => {
+  const { server } = await setupChain(gethGenesisStartLondon(pow), 'powLondon')
+
+  const req = params(method, ['0x0', 'latest', []])
+  const expectRes = (res: any) => {
+    t.assert('error' in res.body)
+  }
+
+  await baseRequest(t, server, req, 200, expectRes)
+})
+
+tape(`${method}: should throw error if block count is above 1024`, async (t) => {
+  const { server } = await setupChain(gethGenesisStartLondon(pow), 'powLondon')
+
+  const req = params(method, ['0x401', 'latest', []])
+  const expectRes = (res: any) => {
+    t.assert('error' in res.body)
+  }
+
+  await baseRequest(t, server, req, 200, expectRes)
+})

--- a/packages/client/test/rpc/eth/getFeeHistory.spec.ts
+++ b/packages/client/test/rpc/eth/getFeeHistory.spec.ts
@@ -1,3 +1,4 @@
+import { Common, Chain as CommonChain, Hardfork } from '@ethereumjs/common'
 import { bigIntToHex, bytesToBigInt } from '@ethereumjs/util'
 import { hexToBytes } from 'ethereum-cryptography/utils'
 import * as tape from 'tape'
@@ -89,7 +90,13 @@ tape(`${method}: should return 12.5% decreased base fee if the block is empty`, 
 tape(
   `${method}: should return initial base fee if the block number is london hard fork`,
   async (t) => {
-    const initialBaseFee = 1000000000n
+    const common = new Common({
+      eips: [1559],
+      chain: CommonChain.Mainnet,
+      hardfork: Hardfork.London,
+    })
+
+    const initialBaseFee = common.param('gasConfig', 'initialBaseFee')
     const { server } = await setupChain(gethGenesisStartLondon(pow), 'powLondon')
 
     const req = params(method, ['0x1', 'latest', []])

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -240,6 +240,8 @@ export abstract class BaseTransaction<TransactionObject> {
     return cost
   }
 
+  abstract getEffectivePriorityFee(baseFee: bigint | undefined): bigint
+
   /**
    * The up front amount that an account must have for this transaction to be valid
    */

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -222,6 +222,21 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<FeeMarketEIP155
   }
 
   /**
+   * Returns the minimum of calculated priority fee (from maxFeePerGas and baseFee) and maxPriorityFeePerGas
+   *
+   * * @param baseFee Base fee retrieved from block
+   */
+  getEffectivePriorityFee(baseFee: bigint | undefined): bigint {
+    if (baseFee === undefined || baseFee >= this.maxFeePerGas) {
+      return 0n
+    }
+
+    const priorityFee = this.maxFeePerGas - baseFee
+
+    return this.maxPriorityFeePerGas < priorityFee ? this.maxPriorityFeePerGas : priorityFee
+  }
+
+  /**
    * The up front amount that an account must have for this transaction to be valid
    * @param baseFee The base fee of the block (will be set to 0 if not provided)
    */

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -181,6 +181,19 @@ export class AccessListEIP2930Transaction extends BaseTransaction<AccessListEIP2
   }
 
   /**
+   * Returns the minimum of calculated priority fee (from maxFeePerGas and baseFee) and maxPriorityFeePerGas
+   *
+   * * @param baseFee Base fee retrieved from block
+   */
+  getEffectivePriorityFee(baseFee: bigint | undefined): bigint {
+    if (baseFee === undefined || baseFee >= this.gasPrice) {
+      return 0n
+    }
+
+    return this.gasPrice - baseFee
+  }
+
+  /**
    * The amount of gas paid for the data in this tx
    */
   getDataFee(): bigint {

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -176,6 +176,21 @@ export class BlobEIP4844Transaction extends BaseTransaction<BlobEIP4844Transacti
   }
 
   /**
+   * Returns the minimum of calculated priority fee (from maxFeePerGas and baseFee) and maxPriorityFeePerGas
+   *
+   * * @param baseFee Base fee retrieved from block
+   */
+  getEffectivePriorityFee(baseFee: bigint | undefined): bigint {
+    if (baseFee === undefined || baseFee >= this.maxFeePerGas) {
+      return 0n
+    }
+
+    const priorityFee = this.maxFeePerGas - baseFee
+
+    return this.maxPriorityFeePerGas < priorityFee ? this.maxPriorityFeePerGas : priorityFee
+  }
+
+  /**
    * Creates the minimal representation of a blob transaction from the network wrapper version.
    * The minimal representation is used when adding transactions to an execution payload/block
    * @param txData a {@link BlobEIP4844Transaction} containing optional blobs/kzg commitments

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -137,6 +137,14 @@ export class Transaction extends BaseTransaction<Transaction> {
     }
   }
 
+  getEffectivePriorityFee(baseFee: bigint | undefined): bigint {
+    if (baseFee === undefined || baseFee >= this.gasPrice) {
+      return 0n
+    }
+
+    return this.gasPrice - baseFee
+  }
+
   /**
    * Returns a Uint8Array Array of the raw Bytes of the legacy transaction, in order.
    *

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -351,6 +351,18 @@ export const bigIntToHex = (num: bigint) => {
 }
 
 /**
+ * Calculates max bigint from an array of bigints
+ * @param args array of bigints
+ */
+export const bigIntMax = (...args: bigint[]) => args.reduce((m, e) => (e > m ? e : m))
+
+/**
+ * Calculates min BigInt from an array of BigInts
+ * @param args array of bigints
+ */
+export const bigIntMin = (...args: bigint[]) => args.reduce((m, e) => (e < m ? e : m))
+
+/**
  * Convert value from bigint to an unpadded Uint8Array
  * (useful for RLP transport)
  * @param value value to convert

--- a/packages/wallet/src/util/bytes.ts
+++ b/packages/wallet/src/util/bytes.ts
@@ -380,6 +380,18 @@ export const bigIntToHex = (num: bigint) => {
 }
 
 /**
+ * Calculates max bigint from an array of bigints
+ * @param args array of bigints
+ */
+export const bigIntMax = (...args: bigint[]) => args.reduce((m, e) => (e > m ? e : m))
+
+/**
+ * Calculates min BigInt from an array of BigInts
+ * @param args array of bigints
+ */
+export const bigIntMin = (...args: bigint[]) => args.reduce((m, e) => (e < m ? e : m))
+
+/**
  * Convert value from bigint to an unpadded Buffer
  * (useful for RLP transport)
  * @param value value to convert

--- a/packages/wallet/src/util/bytes.ts
+++ b/packages/wallet/src/util/bytes.ts
@@ -380,12 +380,6 @@ export const bigIntToHex = (num: bigint) => {
 }
 
 /**
- * Calculates max bigint from an array of bigints
- * @param args array of bigints
- */
-export const bigIntMax = (...args: bigint[]) => args.reduce((m, e) => (e > m ? e : m))
-
-/**
  * Calculates min BigInt from an array of BigInts
  * @param args array of bigints
  */


### PR DESCRIPTION
Implements: `eth_feeHistory` method for tracking historical gas information

Method is used as described in: https://docs.infura.io/networks/ethereum/json-rpc-methods/eth_feehistory