### PR TITLE
tx: remove default hardfork from tx classes

### DIFF
--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -1,4 +1,4 @@
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common } from '@ethereumjs/common'
 import {
   Address,
   MAX_INTEGER,
@@ -25,6 +25,7 @@ import type {
   TxOptions,
   TxValuesArray,
 } from './types'
+import type { Hardfork } from '@ethereumjs/common'
 import type { BigIntLike } from '@ethereumjs/util'
 
 interface TransactionCache {
@@ -82,14 +83,6 @@ export abstract class BaseTransaction<T extends TransactionType>
    * @hidden
    */
   protected DEFAULT_CHAIN = Chain.Mainnet
-
-  /**
-   * The default HF if the tx type is active on that HF
-   * or the first greater HF where the tx is active.
-   *
-   * @hidden
-   */
-  protected DEFAULT_HARDFORK: string | Hardfork = Hardfork.Shanghai
 
   constructor(txData: TxData[T], opts: TxOptions) {
     const { nonce, gasLimit, to, value, data, v, r, s, type } = txData
@@ -397,7 +390,7 @@ export abstract class BaseTransaction<T extends TransactionType>
         if (Common.isSupportedChainId(chainIdBigInt)) {
           // No Common, chain ID supported by Common
           // -> Instantiate Common with chain ID
-          return new Common({ chain: chainIdBigInt, hardfork: this.DEFAULT_HARDFORK })
+          return new Common({ chain: chainIdBigInt })
         } else {
           // No Common, chain ID not supported by Common
           // -> Instantiate custom Common derived from DEFAULT_CHAIN
@@ -407,16 +400,14 @@ export abstract class BaseTransaction<T extends TransactionType>
               networkId: chainIdBigInt,
               chainId: chainIdBigInt,
             },
-            { baseChain: this.DEFAULT_CHAIN, hardfork: this.DEFAULT_HARDFORK }
+            { baseChain: this.DEFAULT_CHAIN }
           )
         }
       }
     } else {
       // No chain ID provided
       // -> return Common provided or create new default Common
-      return (
-        common?.copy() ?? new Common({ chain: this.DEFAULT_CHAIN, hardfork: this.DEFAULT_HARDFORK })
-      )
+      return common?.copy() ?? new Common({ chain: this.DEFAULT_CHAIN })
     }
   }
 

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -1,4 +1,3 @@
-import { Hardfork } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import {
   MAX_INTEGER,
@@ -50,14 +49,6 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<TransactionType
   public readonly maxFeePerGas: bigint
 
   public readonly common: Common
-
-  /**
-   * The default HF if the tx type is active on that HF
-   * or the first greater HF where the tx is active.
-   *
-   * @hidden
-   */
-  protected DEFAULT_HARDFORK = Hardfork.London
 
   /**
    * Instantiate a transaction from a data dictionary.

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -50,14 +50,6 @@ export class AccessListEIP2930Transaction extends BaseTransaction<TransactionTyp
   public readonly common: Common
 
   /**
-   * The default HF if the tx type is active on that HF
-   * or the first greater HF where the tx is active.
-   *
-   * @hidden
-   */
-  protected DEFAULT_HARDFORK = 'berlin'
-
-  /**
    * Instantiate a transaction from a data dictionary.
    *
    * Format: { chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -79,7 +79,7 @@ const validateBlobTransactionNetworkWrapper = (
 /**
  * Typed transaction with a new gas fee market mechanism for transactions that include "blobs" of data
  *
- * - TransactionType: 5
+ * - TransactionType: 3
  * - EIP: [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844)
  */
 export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.BlobEIP4844> {


### PR DESCRIPTION
Addresses the issue that was brought up in this comment: https://github.com/ethereumjs/ethereumjs-monorepo/pull/2767#discussion_r1226359471 