### PR TITLE
vm: fix the dataGasPrice calculation in running the tx

### DIFF
--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -299,8 +299,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
       )
       throw new Error(msg)
     }
-    const parentBlock = await this.blockchain.getBlock(opts.block?.header.parentHash)
-    dataGasPrice = parentBlock.header.getDataGasPrice()
+    dataGasPrice = opts.block.header.getDataGasPrice()
     if (castTx.maxFeePerDataGas < dataGasPrice) {
       const msg = _errorMsg(
         `Transaction's maxFeePerDataGas ${castTx.maxFeePerDataGas}) is less than block dataGasPrice (${dataGasPrice}).`,


### PR DESCRIPTION
fix the bug in vm runTx where the dataGasPrice calc was still being based on the block's parent from ssz times.

this was caught in devnet-6 runs where for the first time blocks with consecutive blobs were produced