### PR TITLE
client: fix new payload 4844 validations

### DIFF
--- a/packages/client/src/rpc/modules/engine.ts
+++ b/packages/client/src/rpc/modules/engine.ts
@@ -263,6 +263,9 @@ const assembleBlock = async (
 
   try {
     const block = await Block.fromExecutionPayload(payload, { common })
+    // TODO: validateData is also called in applyBlock while runBlock, may be it can be optimized
+    // by removing/skipping block data validation from there
+    await block.validateData()
     return { block }
   } catch (error) {
     const validationError = `Error assembling block during from payload: ${error}`
@@ -509,13 +512,13 @@ export class Engine {
       // if there was a validation error return invalid
       if (validationError !== null) {
         this.config.logger.debug(validationError)
-        const latestValidHash = await validHash(hexStringToBytes(payload.parentHash), this.chain)
+        const latestValidHash = await validHash(hexStringToBytes(parentHash), this.chain)
         const response = { status: Status.INVALID, latestValidHash, validationError }
         return response
       }
     } else if (versionedHashes !== undefined && versionedHashes !== null) {
       const validationError = `Invalid versionedHashes before EIP-4844 is activated`
-      const latestValidHash = await validHash(hexStringToBytes(payload.parentHash), this.chain)
+      const latestValidHash = await validHash(hexStringToBytes(parentHash), this.chain)
       const response = { status: Status.INVALID, latestValidHash, validationError }
       return response
     }
@@ -552,7 +555,16 @@ export class Engine {
     }
 
     try {
-      const parent = await this.chain.getBlock(hexStringToBytes(parentHash))
+      // get the parent from beacon skeleton or from remoteBlocks cache or from the chain
+      const parent =
+        (await this.service.beaconSync?.skeleton.getBlockByHash(
+          hexStringToBytes(parentHash),
+          true
+        )) ??
+        this.remoteBlocks.get(parentHash.slice(2)) ??
+        (await this.chain.getBlock(hexStringToBytes(parentHash)))
+
+      // Validations with parent
       if (!parent._common.gteHardfork(Hardfork.Paris)) {
         const validTerminalBlock = await validateTerminalBlock(parent, this.chain)
         if (!validTerminalBlock) {
@@ -564,6 +576,20 @@ export class Engine {
           return response
         }
       }
+
+      // validate 4844 transactions and fields as these validations generally happen on putBlocks
+      // when parent is confirmed to be in the chain. But we can do it here early
+      if (block._common.isActivatedEIP(4844)) {
+        try {
+          block.validateBlobTransactions(parent.header)
+        } catch (error: any) {
+          const validationError = `Invalid 4844 transactions: ${error}`
+          const latestValidHash = await validHash(hexStringToBytes(parentHash), this.chain)
+          const response = { status: Status.INVALID, latestValidHash, validationError }
+          return response
+        }
+      }
+
       const isBlockExecuted = await this.vm.stateManager.hasStateRoot(parent.header.stateRoot)
       // If the parent is not executed throw an error, it will be caught and return SYNCING or ACCEPTED.
       if (!isBlockExecuted) {

--- a/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
@@ -78,9 +78,9 @@ tape(`${method}: Cancun validations`, (v1) => {
       {
         ...blockData,
         parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
-        blockHash: '0x3044dc57fc1e7e8adbd4c5db53ee58303f312ee7cda31b851ebbd365ae10f200',
+        blockHash: '0x8346f46bbac879e28dd521762b50de3946fbdb84d1af466eeb1f3c4c9893abff',
         withdrawals: [],
-        dataGasUsed: '0x0',
+        dataGasUsed: '0x40000',
         excessDataGas: '0x0',
         // two blob transactions but missing versioned hash of second
         transactions: [txString, txString],
@@ -101,9 +101,9 @@ tape(`${method}: Cancun validations`, (v1) => {
       {
         ...blockData,
         parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
-        blockHash: '0x3044dc57fc1e7e8adbd4c5db53ee58303f312ee7cda31b851ebbd365ae10f200',
+        blockHash: '0x8346f46bbac879e28dd521762b50de3946fbdb84d1af466eeb1f3c4c9893abff',
         withdrawals: [],
-        dataGasUsed: '0x0',
+        dataGasUsed: '0x40000',
         excessDataGas: '0x0',
         // two blob transactions but mismatching versioned hash of second
         transactions: [txString, txString],
@@ -124,9 +124,9 @@ tape(`${method}: Cancun validations`, (v1) => {
       {
         ...blockData,
         parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
-        blockHash: '0x3044dc57fc1e7e8adbd4c5db53ee58303f312ee7cda31b851ebbd365ae10f200',
+        blockHash: '0x8346f46bbac879e28dd521762b50de3946fbdb84d1af466eeb1f3c4c9893abff',
         withdrawals: [],
-        dataGasUsed: '0x0',
+        dataGasUsed: '0x40000',
         excessDataGas: '0x0',
         // two blob transactions with matching versioned hashes
         transactions: [txString, txString],


### PR DESCRIPTION
Another discovery from devnet-6 test runs:

The verifying of excessDataGas/4844 validations were not fully happening in new payload because of requirement of parent, which in our normal flow would happen once we do a putBlock into chain (which happens in fcU update)

This PR performs those validations