### PR TITLE
util: Rename mapdb copy function

### DIFF
--- a/packages/client/src/execution/level.ts
+++ b/packages/client/src/execution/level.ts
@@ -112,7 +112,7 @@ export class LevelDB<
   /**
    * @inheritDoc
    */
-  copy(): DB<TKey, TValue> {
+  shallowCopy(): DB<TKey, TValue> {
     return new LevelDB<TKey, TValue>(this._leveldb)
   }
 

--- a/packages/trie/src/db/checkpoint.ts
+++ b/packages/trie/src/db/checkpoint.ts
@@ -252,7 +252,7 @@ export class CheckpointDB implements DB {
   /**
    * @inheritDoc
    */
-  copy(): CheckpointDB {
+  shallowCopy(): CheckpointDB {
     return new CheckpointDB({ db: this.db, cacheSize: this.cacheSize })
   }
 

--- a/packages/trie/src/trie/trie.ts
+++ b/packages/trie/src/trie/trie.ts
@@ -898,7 +898,7 @@ export class Trie {
   copy(includeCheckpoints = true): Trie {
     const trie = new Trie({
       ...this._opts,
-      db: this._db.db.copy(),
+      db: this._db.db.shallowCopy(),
       root: this.root(),
       cacheSize: 0,
     })

--- a/packages/util/src/db.ts
+++ b/packages/util/src/db.ts
@@ -72,7 +72,7 @@ export interface DB<
    * Returns a copy of the DB instance, with a reference
    * to the **same** underlying db instance.
    */
-  copy(): DB<TKey, TValue>
+  shallowCopy(): DB<TKey, TValue>
 
   /**
    * Opens the database -- if applicable

--- a/packages/util/src/mapDB.ts
+++ b/packages/util/src/mapDB.ts
@@ -40,7 +40,7 @@ export class MapDB<
     }
   }
 
-  copy(): DB<TKey, TValue> {
+  shallowCopy(): DB<TKey, TValue> {
     return new MapDB<TKey, TValue>(this._database)
   }
 

--- a/packages/util/test/mapDB.spec.ts
+++ b/packages/util/test/mapDB.spec.ts
@@ -66,6 +66,20 @@ describe('MapDB: batch', () => {
   })
 })
 
+describe('MapDB: shallowCopy', () => {
+  it('should reuse underlying database in case of a shallowCopy', async () => {
+    const database = new Map()
+    database.set('key1', 'value1')
+    const mapDB = new MapDB(database)
+
+    const shallowCopyDB = mapDB.shallowCopy()
+    database.delete('key1')
+
+    const result = await shallowCopyDB.get('key1')
+    assert.equal(result, undefined, 'should reuse underlying database in case of a shallowCopy')
+  })
+})
+
 describe('MapDB: open', () => {
   it('should return a resolved promise', async () => {
     const mapDB = new MapDB()


### PR DESCRIPTION
The current implementation of the `copy` function of the `DB` interface does not create a new underlying db but rather reuses the same db of the original object being copied. This PR renames the `copy` function to `shallowCopy` in order to reflect this behavior and make it's name more intuitive and less confusing.