### PR TITLE
Common, Block, VM: Unify and Refactor getHardforkBy Options

### DIFF
--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -186,7 +186,7 @@ export class BlockHeader {
     if (hardforkByBlockNumber || options.hardforkByTTD !== undefined) {
       this._common.setHardforkBy({
         blockNumber: number,
-        td: toType(options.hardforkByTTD, TypeOutput.BigInt),
+        td: options.hardforkByTTD,
         timestamp,
       })
     }

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -184,7 +184,11 @@ export class BlockHeader {
 
     const hardforkByBlockNumber = options.hardforkByBlockNumber ?? false
     if (hardforkByBlockNumber || options.hardforkByTTD !== undefined) {
-      this._common.setHardforkByBlockNumber(number, options.hardforkByTTD, timestamp)
+      this._common.setHardforkBy({
+        blockNumber: number,
+        td: toType(options.hardforkByTTD, TypeOutput.BigInt),
+        timestamp,
+      })
     }
 
     // Hardfork defaults which couldn't be paired with earlier defaults

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -1306,7 +1306,7 @@ export class Blockchain implements BlockchainInterface {
   createGenesisBlock(stateRoot: Uint8Array): Block {
     const common = this._common.copy()
     common.setHardforkBy({
-      blockNumber: BigInt(0),
+      blockNumber: 0,
       td: BigInt(common.genesis().difficulty),
       timestamp: common.genesis().timestamp,
     })

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -1232,11 +1232,15 @@ export class Blockchain implements BlockchainInterface {
   }
 
   async checkAndTransitionHardForkByNumber(
-    number: bigint,
+    number: BigIntLike,
     td?: BigIntLike,
     timestamp?: BigIntLike
   ): Promise<void> {
-    this._common.setHardforkByBlockNumber(number, td, timestamp)
+    this._common.setHardforkBy({
+      blockNumber: number,
+      td,
+      timestamp,
+    })
 
     // If custom consensus algorithm is used, skip merge hardfork consensus checks
     if (!Object.values(ConsensusAlgorithm).includes(this.consensus.algorithm as ConsensusAlgorithm))
@@ -1301,11 +1305,11 @@ export class Blockchain implements BlockchainInterface {
    */
   createGenesisBlock(stateRoot: Uint8Array): Block {
     const common = this._common.copy()
-    common.setHardforkByBlockNumber(
-      0,
-      BigInt(common.genesis().difficulty),
-      common.genesis().timestamp
-    )
+    common.setHardforkBy({
+      blockNumber: BigInt(0),
+      td: BigInt(common.genesis().difficulty),
+      timestamp: common.genesis().timestamp,
+    })
 
     const header: BlockData['header'] = {
       ...common.genesis(),

--- a/packages/blockchain/test/customConsensus.spec.ts
+++ b/packages/blockchain/test/customConsensus.spec.ts
@@ -143,7 +143,7 @@ describe('consensus transition checks', () => {
     const blockchain = await Blockchain.create({ common, consensus })
 
     try {
-      await (blockchain as any).checkAndTransitionHardForkByNumber(5)
+      await (blockchain as any).checkAndTransitionHardForkByNumber(5n)
       assert.ok('checkAndTransitionHardForkByNumber does not throw with custom consensus')
     } catch (err: any) {
       assert.fail(
@@ -155,7 +155,7 @@ describe('consensus transition checks', () => {
     ;(blockchain._common as any).consensusAlgorithm = () => 'fibonacci'
 
     try {
-      await (blockchain as any).checkAndTransitionHardForkByNumber(5)
+      await (blockchain as any).checkAndTransitionHardForkByNumber(5n)
       assert.fail(
         'checkAndTransitionHardForkByNumber should throw when using standard consensus (ethash, clique, casper) but consensus algorithm defined in common is different'
       )

--- a/packages/client/src/blockchain/chain.ts
+++ b/packages/client/src/blockchain/chain.ts
@@ -297,11 +297,10 @@ export class Chain {
 
     // Check and log if this is a terminal block and next block could be merge
     if (!this.config.chainCommon.gteHardfork(Hardfork.Paris)) {
-      const nextBlockHf = this.config.chainCommon.getHardforkByBlockNumber(
-        headers.height + BigInt(1),
-        headers.td,
-        undefined
-      )
+      const nextBlockHf = this.config.chainCommon.getHardforkBy({
+        blockNumber: headers.height + BigInt(1),
+        td: headers.td,
+      })
       if (this.config.chainCommon.hardforkGteHardfork(nextBlockHf, Hardfork.Paris)) {
         this.config.logger.info('*'.repeat(85))
         this.config.logger.info(

--- a/packages/client/src/blockchain/chain.ts
+++ b/packages/client/src/blockchain/chain.ts
@@ -289,11 +289,11 @@ export class Chain {
     this._blocks = blocks
 
     const parentTd = await this.blockchain.getParentTD(headers.latest)
-    this.config.chainCommon.setHardforkByBlockNumber(
-      headers.latest.number,
-      parentTd,
-      headers.latest.timestamp
-    )
+    this.config.chainCommon.setHardforkBy({
+      blockNumber: headers.latest.number,
+      td: parentTd,
+      timestamp: headers.latest.timestamp,
+    })
 
     // Check and log if this is a terminal block and next block could be merge
     if (!this.config.chainCommon.gteHardfork(Hardfork.Paris)) {

--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -128,7 +128,7 @@ export class VMExecution extends Execution {
         throw new Error('cannot get iterator head: blockchain has no getTotalDifficulty function')
       }
       const td = await this.vm.blockchain.getTotalDifficulty(headBlock.header.hash())
-      this.config.execCommon.setHardforkByBlockNumber(number, td, timestamp)
+      this.config.execCommon.setHardforkBy({ blockNumber: number, td, timestamp })
       this.hardfork = this.config.execCommon.hardfork()
       this.config.logger.info(`Initializing VM execution hardfork=${this.hardfork}`)
       if (number === BigInt(0)) {
@@ -356,11 +356,11 @@ export class VMExecution extends Execution {
                   this.config.logger.info(
                     `Execution hardfork switch on block number=${number} hash=${hash} old=${this.hardfork} new=${hardfork}`
                   )
-                  this.hardfork = this.config.execCommon.setHardforkByBlockNumber(
-                    number,
+                  this.hardfork = this.config.execCommon.setHardforkBy({
+                    blockNumber: number,
                     td,
-                    timestamp
-                  )
+                    timestamp,
+                  })
                 }
                 let skipBlockValidation = false
                 if (this.config.execCommon.consensusType() === ConsensusType.ProofOfAuthority) {
@@ -446,7 +446,7 @@ export class VMExecution extends Execution {
               this.config.logger.warn(
                 `Set back hardfork along block deletion number=${blockNumber} hash=${hash} old=${this.hardfork} new=${hardfork}`
               )
-              this.config.execCommon.setHardforkByBlockNumber(blockNumber, td)
+              this.config.execCommon.setHardforkBy({ blockNumber, td })
             }*/
               // Option a): set iterator head to the parent block so that an
               // error can repeatedly processed for debugging
@@ -594,7 +594,11 @@ export class VMExecution extends Execution {
         throw new Error('cannot get iterator head: blockchain has no getTotalDifficulty function')
       }
       const td = await vm.blockchain.getTotalDifficulty(block.header.parentHash)
-      vm._common.setHardforkByBlockNumber(blockNumber, td, block.header.timestamp)
+      vm._common.setHardforkBy({
+        blockNumber: BigInt(blockNumber),
+        td,
+        timestamp: block.header.timestamp,
+      })
 
       if (txHashes.length === 0) {
         // we are skipping header validation because the block has been picked from the

--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -346,11 +346,11 @@ export class VMExecution extends Execution {
                 }
                 const td = await blockchain.getTotalDifficulty(block.header.parentHash)
 
-                const hardfork = this.config.execCommon.getHardforkByBlockNumber(
-                  number,
+                const hardfork = this.config.execCommon.getHardforkBy({
+                  blockNumber: number,
                   td,
-                  timestamp
-                )
+                  timestamp,
+                })
                 if (hardfork !== this.hardfork) {
                   const hash = short(block.hash())
                   this.config.logger.info(
@@ -441,7 +441,7 @@ export class VMExecution extends Execution {
               `Deleted block number=${blockNumber} hash=${hash} on failed execution`
             )
 
-            const hardfork = this.config.execCommon.getHardforkByBlockNumber(blockNumber)
+            const hardfork = this.config.execCommon.getHardforkBy({ blockNumber })
             if (hardfork !== this.hardfork) {
               this.config.logger.warn(
                 `Set back hardfork along block deletion number=${blockNumber} hash=${hash} old=${this.hardfork} new=${hardfork}`

--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -595,7 +595,7 @@ export class VMExecution extends Execution {
       }
       const td = await vm.blockchain.getTotalDifficulty(block.header.parentHash)
       vm._common.setHardforkBy({
-        blockNumber: BigInt(blockNumber),
+        blockNumber,
         td,
         timestamp: block.header.timestamp,
       })

--- a/packages/client/src/miner/miner.ts
+++ b/packages/client/src/miner/miner.ts
@@ -92,7 +92,6 @@ export class Miner {
     const nextBlockHf = this.config.chainCommon.getHardforkBy({
       blockNumber: this.service.chain.headers.height + BigInt(1),
       td: this.service.chain.headers.td,
-      timestamp: this.latestBlockHeader().timestamp,
     })
     if (this.config.chainCommon.hardforkGteHardfork(nextBlockHf, Hardfork.Paris)) {
       this.config.logger.info('Miner: reached merge hardfork - stopping')

--- a/packages/client/src/miner/miner.ts
+++ b/packages/client/src/miner/miner.ts
@@ -89,11 +89,11 @@ export class Miner {
     }
 
     // Check if the new block to be minted isn't PoS
-    const nextBlockHf = this.config.chainCommon.getHardforkByBlockNumber(
-      this.service.chain.headers.height + BigInt(1),
-      this.service.chain.headers.td,
-      undefined
-    )
+    const nextBlockHf = this.config.chainCommon.getHardforkBy({
+      blockNumber: this.service.chain.headers.height + BigInt(1),
+      td: this.service.chain.headers.td,
+      timestamp: this.latestBlockHeader().timestamp,
+    })
     if (this.config.chainCommon.hardforkGteHardfork(nextBlockHf, Hardfork.Paris)) {
       this.config.logger.info('Miner: reached merge hardfork - stopping')
       this.stop()

--- a/packages/client/src/miner/pendingBlock.ts
+++ b/packages/client/src/miner/pendingBlock.ts
@@ -126,7 +126,11 @@ export class PendingBlock {
       throw new Error('cannot get iterator head: blockchain has no getTotalDifficulty function')
     }
     const td = await vm.blockchain.getTotalDifficulty(parentBlock.hash())
-    vm._common.setHardforkByBlockNumber(number, td, timestamp)
+    vm._common.setHardforkBy({
+      blockNumber: number,
+      td,
+      timestamp,
+    })
 
     const baseFeePerGas = vm._common.isActivatedEIP(1559)
       ? parentBlock.header.calcNextBaseFee()

--- a/packages/client/src/net/protocol/ethprotocol.ts
+++ b/packages/client/src/net/protocol/ethprotocol.ts
@@ -114,14 +114,14 @@ export class EthProtocol extends Protocol {
       decode: (txs: Uint8Array[]) => {
         if (!this.config.synchronized) return
         const common = this.config.chainCommon.copy()
-        common.setHardforkByBlockNumber(
-          this.chain.headers.latest?.number ?? // Use latest header number if available OR
+        common.setHardforkBy({
+          blockNumber:
+            this.chain.headers.latest?.number ?? // Use latest header number if available OR
             this.config.syncTargetHeight ?? // Use sync target height if available OR
             common.hardforkBlock(common.hardfork()) ?? // Use current hardfork block number OR
             BigInt(0), // Use chainstart,
-          undefined,
-          this.chain.headers.latest?.timestamp ?? Math.floor(Date.now() / 1000)
-        )
+          timestamp: this.chain.headers.latest?.timestamp ?? BigInt(Math.floor(Date.now() / 1000)),
+        })
         return txs.map((txData) => TransactionFactory.fromSerializedData(txData, { common }))
       },
     },
@@ -249,14 +249,14 @@ export class EthProtocol extends Protocol {
       },
       decode: ([reqId, txs]: [Uint8Array, any[]]) => {
         const common = this.config.chainCommon.copy()
-        common.setHardforkByBlockNumber(
-          this.chain.headers.latest?.number ?? // Use latest header number if available OR
+        common.setHardforkBy({
+          blockNumber:
+            this.chain.headers.latest?.number ?? // Use latest header number if available OR
             this.config.syncTargetHeight ?? // Use sync target height if available OR
             common.hardforkBlock(common.hardfork()) ?? // Use current hardfork block number OR
             BigInt(0), // Use chainstart,
-          undefined,
-          this.chain.headers.latest?.timestamp ?? Math.floor(Date.now() / 1000)
-        )
+          timestamp: this.chain.headers.latest?.timestamp ?? BigInt(Math.floor(Date.now() / 1000)),
+        })
         return [
           bytesToBigInt(reqId),
           txs.map((txData) => {

--- a/packages/client/src/net/protocol/ethprotocol.ts
+++ b/packages/client/src/net/protocol/ethprotocol.ts
@@ -120,7 +120,7 @@ export class EthProtocol extends Protocol {
             this.config.syncTargetHeight ?? // Use sync target height if available OR
             common.hardforkBlock(common.hardfork()) ?? // Use current hardfork block number OR
             BigInt(0), // Use chainstart,
-          timestamp: this.chain.headers.latest?.timestamp ?? BigInt(Math.floor(Date.now() / 1000)),
+          timestamp: this.chain.headers.latest?.timestamp ?? Math.floor(Date.now() / 1000),
         })
         return txs.map((txData) => TransactionFactory.fromSerializedData(txData, { common }))
       },
@@ -255,7 +255,7 @@ export class EthProtocol extends Protocol {
             this.config.syncTargetHeight ?? // Use sync target height if available OR
             common.hardforkBlock(common.hardfork()) ?? // Use current hardfork block number OR
             BigInt(0), // Use chainstart,
-          timestamp: this.chain.headers.latest?.timestamp ?? BigInt(Math.floor(Date.now() / 1000)),
+          timestamp: this.chain.headers.latest?.timestamp ?? Math.floor(Date.now() / 1000),
         })
         return [
           bytesToBigInt(reqId),

--- a/packages/client/src/rpc/modules/engine.ts
+++ b/packages/client/src/rpc/modules/engine.ts
@@ -259,7 +259,7 @@ const assembleBlock = async (
   // Can't use hardforkByTTD flag, as the transactions will need to be deserialized
   // first before the header can be constucted with their roots
   const ttd = common.hardforkTTD(Hardfork.Paris)
-  common.setHardforkByBlockNumber(blockNumber, ttd !== null ? ttd : undefined, timestamp)
+  common.setHardforkBy({ blockNumber, td: ttd !== null ? ttd : undefined, timestamp })
 
   try {
     const block = await Block.fromExecutionPayload(payload, { common })

--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -933,7 +933,10 @@ export class Eth {
     if (txTargetHeight <= chainHeight) {
       txTargetHeight = chainHeight + BigInt(1)
     }
-    common.setHardforkByBlockNumber(txTargetHeight, undefined, Math.floor(Date.now() / 1000))
+    common.setHardforkBy({
+      blockNumber: txTargetHeight,
+      timestamp: Math.floor(Date.now() / 1000),
+    })
 
     let tx
     try {

--- a/packages/client/src/sync/beaconsync.ts
+++ b/packages/client/src/sync/beaconsync.ts
@@ -77,7 +77,7 @@ export class BeaconSynchronizer extends Synchronizer {
     const hash = this.chain.blocks.latest!.hash()
     this.startingBlock = number
     const timestamp = this.chain.blocks.latest?.header.timestamp
-    this.config.chainCommon.setHardforkByBlockNumber(number, td, timestamp)
+    this.config.chainCommon.setHardforkBy({ blockNumber: number, td, timestamp })
 
     this.config.logger.info(
       `Latest local block number=${Number(number)} td=${td} hash=${bytesToHex(

--- a/packages/client/src/sync/fullsync.ts
+++ b/packages/client/src/sync/fullsync.ts
@@ -84,7 +84,7 @@ export class FullSynchronizer extends Synchronizer {
     const hash = this.chain.blocks.latest!.hash()
     this.startingBlock = number
     const timestamp = this.chain.blocks.latest?.header.timestamp
-    this.config.chainCommon.setHardforkByBlockNumber(number, td, timestamp)
+    this.config.chainCommon.setHardforkBy({ blockNumber: number, td, timestamp })
 
     this.config.logger.info(
       `Latest local block number=${Number(number)} td=${td} hash=${short(

--- a/packages/client/src/sync/fullsync.ts
+++ b/packages/client/src/sync/fullsync.ts
@@ -232,7 +232,8 @@ export class FullSynchronizer extends Synchronizer {
     if (nextHFBlockNum !== null) {
       const remaining = nextHFBlockNum - last
       if (remaining <= BigInt(10000)) {
-        const nextHF = this.config.chainCommon.getHardforkByBlockNumber(nextHFBlockNum)
+        // TODO: Do something about super-ugly nextHardforkBlockOrTimestamp() method
+        const nextHF = this.config.chainCommon.getHardforkBy({ blockNumber: nextHFBlockNum })
         attentionHF = `${nextHF} HF in ${remaining} blocks`
       }
     } else {

--- a/packages/client/test/integration/beaconsync.spec.ts
+++ b/packages/client/test/integration/beaconsync.spec.ts
@@ -12,7 +12,7 @@ const originalValidate = BlockHeader.prototype._consensusFormatValidation
 
 tape('[Integration:BeaconSync]', async (t) => {
   const common = Common.fromGethGenesis(genesisJSON, { chain: 'post-merge' })
-  common.setHardforkByBlockNumber(BigInt(0), BigInt(0))
+  common.setHardforkBy({ blockNumber: BigInt(0), td: BigInt(0) })
 
   t.test('should sync blocks', async (t) => {
     BlockHeader.prototype._consensusFormatValidation = td.func<any>()

--- a/packages/client/test/integration/fullethereumservice.spec.ts
+++ b/packages/client/test/integration/fullethereumservice.spec.ts
@@ -95,22 +95,9 @@ tape('[Integration:FullEthereumService]', async (t) => {
     )
     await service.txPool.add(tx)
     service.config.chainCommon.getHardforkBy = td.func<typeof config.chainCommon.getHardforkBy>()
-    td.when(
-      service.config.chainCommon.getHardforkBy({
-        blockNumber: td.matchers.anything(),
-        td: td.matchers.anything(),
-        timestamp: td.matchers.anything(),
-      })
-    ).thenReturn(Hardfork.London)
-    td.when(
-      service.config.chainCommon.getHardforkBy({
-        blockNumber: td.matchers.anything(),
-        td: td.matchers.anything(),
-      })
-    ).thenReturn(Hardfork.London)
-    td.when(
-      service.config.chainCommon.getHardforkBy({ blockNumber: td.matchers.anything() })
-    ).thenReturn(Hardfork.London)
+    td.when(service.config.chainCommon.getHardforkBy(td.matchers.anything())).thenReturn(
+      Hardfork.London
+    )
     const [_, txs] = await peer.eth!.getPooledTransactions({ hashes: [tx.hash()] })
     t.ok(equalsBytes(txs[0].hash(), tx.hash()), 'handled GetPooledTransactions')
 

--- a/packages/client/test/integration/fullethereumservice.spec.ts
+++ b/packages/client/test/integration/fullethereumservice.spec.ts
@@ -94,24 +94,23 @@ tape('[Integration:FullEthereumService]', async (t) => {
       new Account(BigInt(0), BigInt('40000000000100000'))
     )
     await service.txPool.add(tx)
-    service.config.chainCommon.getHardforkByBlockNumber =
-      td.func<typeof config.chainCommon.getHardforkByBlockNumber>()
+    service.config.chainCommon.getHardforkBy = td.func<typeof config.chainCommon.getHardforkBy>()
     td.when(
-      service.config.chainCommon.getHardforkByBlockNumber(
-        td.matchers.anything(),
-        td.matchers.anything(),
-        td.matchers.anything()
-      )
+      service.config.chainCommon.getHardforkBy({
+        blockNumber: td.matchers.anything(),
+        td: td.matchers.anything(),
+        timestamp: td.matchers.anything(),
+      })
     ).thenReturn(Hardfork.London)
     td.when(
-      service.config.chainCommon.getHardforkByBlockNumber(
-        td.matchers.anything(),
-        td.matchers.anything()
-      )
+      service.config.chainCommon.getHardforkBy({
+        blockNumber: td.matchers.anything(),
+        td: td.matchers.anything(),
+      })
     ).thenReturn(Hardfork.London)
-    td.when(service.config.chainCommon.getHardforkByBlockNumber(td.matchers.anything())).thenReturn(
-      Hardfork.London
-    )
+    td.when(
+      service.config.chainCommon.getHardforkBy({ blockNumber: td.matchers.anything() })
+    ).thenReturn(Hardfork.London)
     const [_, txs] = await peer.eth!.getPooledTransactions({ hashes: [tx.hash()] })
     t.ok(equalsBytes(txs[0].hash(), tx.hash()), 'handled GetPooledTransactions')
 

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -505,7 +505,7 @@ tape('[Miner]', async (t) => {
       ],
     }
     const common = Common.custom(customChainParams, { baseChain: CommonChain.Rinkeby })
-    common.setHardforkByBlockNumber(0)
+    common.setHardforkBy({ blockNumber: 0 })
     const config = new Config({
       transports: [],
       accountCache: 10000,
@@ -530,20 +530,20 @@ tape('[Miner]', async (t) => {
     await wait(100)
 
     // in this test we need to explicitly update common with
-    // setHardforkByBlockNumber() to test the hardfork() value
+    // setHardforkBy() to test the hardfork() value
     // since the vmexecution run method isn't reached in this
     // stubbed configuration.
 
     // block 1: chainstart
     await (miner as any).queueNextAssembly(0)
     await wait(100)
-    config.execCommon.setHardforkByBlockNumber(1)
+    config.execCommon.setHardforkBy({ blockNumber: 1 })
     t.equal(config.execCommon.hardfork(), Hardfork.Chainstart)
 
     // block 2: berlin
     await (miner as any).queueNextAssembly(0)
     await wait(100)
-    config.execCommon.setHardforkByBlockNumber(2)
+    config.execCommon.setHardforkBy({ blockNumber: 2 })
     t.equal(config.execCommon.hardfork(), Hardfork.Berlin)
     const blockHeader2 = await chain.getCanonicalHeadHeader()
 
@@ -551,7 +551,7 @@ tape('[Miner]', async (t) => {
     await (miner as any).queueNextAssembly(0)
     await wait(100)
     const blockHeader3 = await chain.getCanonicalHeadHeader()
-    config.execCommon.setHardforkByBlockNumber(3)
+    config.execCommon.setHardforkBy({ blockNumber: 3 })
     t.equal(config.execCommon.hardfork(), Hardfork.London)
     t.equal(
       blockHeader2.gasLimit * BigInt(2),
@@ -565,7 +565,7 @@ tape('[Miner]', async (t) => {
     await (miner as any).queueNextAssembly(0)
     await wait(100)
     const blockHeader4 = await chain.getCanonicalHeadHeader()
-    config.execCommon.setHardforkByBlockNumber(4)
+    config.execCommon.setHardforkBy({ blockNumber: 4 })
     t.equal(config.execCommon.hardfork(), Hardfork.London)
     t.equal(
       blockHeader4.baseFeePerGas!,

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -372,7 +372,7 @@ tape('[PendingBlock]', async (t) => {
     await setBalance(vm, A.address, BigInt(500000000000000000))
     const parentBlock = await vm.blockchain.getCanonicalHeadBlock!()
     // stub the vm's common set hf to do nothing but stay in cancun
-    vm._common.setHardforkByBlockNumber = (_a: bigint, _b?: bigint, _c?: bigint) => {
+    vm._common.setHardforkBy = () => {
       return vm._common.hardfork()
     }
     const payloadId = await pendingBlock.start(vm, parentBlock)
@@ -432,7 +432,7 @@ tape('[PendingBlock]', async (t) => {
     await setBalance(vm, A.address, BigInt(500000000000000000))
     const parentBlock = await vm.blockchain.getCanonicalHeadBlock!()
     // stub the vm's common set hf to do nothing but stay in cancun
-    vm._common.setHardforkByBlockNumber = (_a: bigint, _b?: bigint, _c?: bigint) => {
+    vm._common.setHardforkBy = () => {
       return vm._common.hardfork()
     }
     const payloadId = await pendingBlock.start(vm, parentBlock)

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -226,7 +226,10 @@ export async function setupChain(genesisFile: any, chainName = 'dev', clientOpts
     chain: chainName,
     customChains: [genesisParams],
   })
-  common.setHardforkByBlockNumber(0, genesisParams.genesis.difficulty)
+  common.setHardforkBy({
+    blockNumber: 0,
+    td: genesisParams.genesis.difficulty,
+  })
 
   const blockchain = await Blockchain.create({
     common,

--- a/packages/client/test/rpc/util/CLConnectionManager.spec.ts
+++ b/packages/client/test/rpc/util/CLConnectionManager.spec.ts
@@ -49,7 +49,7 @@ tape('[CLConnectionManager]', (t) => {
       chain: params.name,
       customChains: [params],
     })
-    common.setHardforkByBlockNumber(0)
+    common.setHardforkBy({ blockNumber: 0 })
     config = new Config({ common })
     manager = new CLConnectionManager({ config })
     st.ok(manager.running, 'starts on instantiation if hardfork is MergeForkBlock')
@@ -61,7 +61,7 @@ tape('[CLConnectionManager]', (t) => {
     })
     config = new Config({ common })
     manager = new CLConnectionManager({ config })
-    config.chainCommon.setHardforkByBlockNumber(11)
+    config.chainCommon.setHardforkBy({ blockNumber: 11 })
     config.events.on(Event.CHAIN_UPDATED, () => {
       st.ok(manager.running, 'connection manager started on chain update on mergeBlock')
     })

--- a/packages/client/test/service/fullethereumservice.spec.ts
+++ b/packages/client/test/service/fullethereumservice.spec.ts
@@ -333,7 +333,7 @@ tape('[FullEthereumService]', async (t) => {
 
   t.test('should start on beacon sync when past merge', async (t) => {
     const common = Common.fromGethGenesis(genesisJSON, { chain: 'post-merge' })
-    common.setHardforkByBlockNumber(BigInt(0), BigInt(0))
+    common.setHardforkBy({ blockNumber: BigInt(0), td: BigInt(0) })
     const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000, common })
     const chain = await Chain.create({ config })
     let service = new FullEthereumService({ config, chain })

--- a/packages/client/test/sync/fetcher/blockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/blockfetcher.spec.ts
@@ -187,19 +187,21 @@ tape('[BlockFetcher]', async (t) => {
 
   t.test('should parse bodies correctly', async (t) => {
     const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
-    config.chainCommon.getHardforkByBlockNumber =
-      td.func<typeof config.chainCommon.getHardforkByBlockNumber>()
+    config.chainCommon.getHardforkBy = td.func<typeof config.chainCommon.getHardforkBy>()
     td.when(
-      config.chainCommon.getHardforkByBlockNumber(
-        td.matchers.anything(),
-        td.matchers.anything(),
-        td.matchers.anything()
-      )
+      config.chainCommon.getHardforkBy({
+        blockNumber: td.matchers.anything(),
+        td: td.matchers.anything(),
+        timestamp: td.matchers.anything(),
+      })
     ).thenReturn(Hardfork.Shanghai)
     td.when(
-      config.chainCommon.getHardforkByBlockNumber(td.matchers.anything(), td.matchers.anything())
+      config.chainCommon.getHardforkBy({
+        blockNumber: td.matchers.anything(),
+        td: td.matchers.anything(),
+      })
     ).thenReturn(Hardfork.Shanghai)
-    td.when(config.chainCommon.getHardforkByBlockNumber(td.matchers.anything())).thenReturn(
+    td.when(config.chainCommon.getHardforkBy({ blockNumber: td.matchers.anything() })).thenReturn(
       Hardfork.Shanghai
     )
     const pool = new PeerPool() as any

--- a/packages/client/test/sync/skeleton.spec.ts
+++ b/packages/client/test/sync/skeleton.spec.ts
@@ -649,7 +649,7 @@ tape('[Skeleton] / setHead', async (t) => {
         difficulty: '0x1',
       }
       const common = Common.fromGethGenesis(genesis, { chain: 'post-merge' })
-      common.setHardforkByBlockNumber(BigInt(0), BigInt(0))
+      common.setHardforkBy({ blockNumber: BigInt(0), td: BigInt(0) })
       const config = new Config({
         transports: [],
         common,
@@ -757,7 +757,7 @@ tape('[Skeleton] / setHead', async (t) => {
         difficulty: '0x1',
       }
       const common = Common.fromGethGenesis(genesis, { chain: 'post-merge' })
-      common.setHardforkByBlockNumber(BigInt(0), BigInt(0))
+      common.setHardforkBy({ blockNumber: BigInt(0), td: BigInt(0) })
       const config = new Config({
         transports: [],
         common,
@@ -821,7 +821,7 @@ tape('[Skeleton] / setHead', async (t) => {
         difficulty: '0x1',
       }
       const common = Common.fromGethGenesis(genesis, { chain: 'post-merge' })
-      common.setHardforkByBlockNumber(BigInt(0), BigInt(0))
+      common.setHardforkBy({ blockNumber: BigInt(0), td: BigInt(0) })
       const config = new Config({
         transports: [],
         common,

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -316,7 +316,11 @@ export class Common extends EventEmitter {
    * @returns The name of the HF
    */
   getHardforkBy(opts: HardforkByOpts): string {
-    const { blockNumber, timestamp, td } = opts
+    let { blockNumber, timestamp, td } = opts
+
+    blockNumber = toType(blockNumber, TypeOutput.BigInt)
+    td = toType(td, TypeOutput.BigInt)
+    timestamp = toType(timestamp, TypeOutput.BigInt)
 
     // Filter out hardforks with no block number, no ttd or no timestamp (i.e. unapplied hardforks)
     const hfs = this.hardforks().filter(
@@ -337,8 +341,10 @@ export class Common extends EventEmitter {
     // discovering/checking number hardforks.
     let hfIndex = hfs.findIndex(
       (hf) =>
-        (blockNumber !== undefined && hf.block !== null && hf.block > blockNumber) ||
-        (timestamp !== undefined && Number(hf.timestamp) > timestamp)
+        (blockNumber !== undefined &&
+          hf.block !== null &&
+          BigInt(hf.block) > (blockNumber as bigint)) ||
+        (timestamp !== undefined && hf.timestamp !== undefined && hf.timestamp > timestamp)
     )
 
     if (hfIndex === -1) {
@@ -415,27 +421,18 @@ export class Common extends EventEmitter {
   }
 
   /**
-   * Sets a new hardfork based on the block number or an optional
-   * total difficulty (Merge HF) provided.
+   * Sets a new hardfork either based on block numer (older HFs) or
+   * timestamp (Shanghai upwards).
    *
    * An optional TD takes precedence in case the corresponding HF block
    * is set to `null` or otherwise needs to match (if not an error
    * will be thrown).
    *
-   * @param blockNumber
-   * @param td
-   * @param timestamp
+   * @param Opts Block number, timestamp or TD (all optional)
    * @returns The name of the HF set
    */
-  setHardforkByBlockNumber(
-    blockNumber: BigIntLike,
-    td?: BigIntLike,
-    timestamp?: BigIntLike
-  ): string {
-    blockNumber = toType(blockNumber, TypeOutput.BigInt)
-    td = toType(td, TypeOutput.BigInt)
-    timestamp = toType(timestamp, TypeOutput.BigInt)
-    const hardfork = this.getHardforkBy({ blockNumber, td, timestamp })
+  setHardforkBy(opts: HardforkByOpts): string {
+    const hardfork = this.getHardforkBy(opts)
     this.setHardfork(hardfork)
     return hardfork
   }
@@ -571,9 +568,6 @@ export class Common extends EventEmitter {
     td?: BigIntLike,
     timestamp?: BigIntLike
   ): bigint {
-    blockNumber = toType(blockNumber, TypeOutput.BigInt)
-    td = toType(td, TypeOutput.BigInt)
-    timestamp = toType(timestamp, TypeOutput.BigInt)
     const hardfork = this.getHardforkBy({ blockNumber, td, timestamp })
     return this.paramByHardfork(topic, name, hardfork)
   }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -120,3 +120,9 @@ export interface GethConfigOpts extends BaseOpts {
   genesisHash?: Uint8Array
   mergeForkIdPostMerge?: boolean
 }
+
+export interface HardforkByOpts {
+  blockNumber?: bigint
+  timestamp?: bigint
+  td?: bigint
+}

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,4 +1,5 @@
 import type { Chain, ConsensusAlgorithm, ConsensusType, Hardfork } from './enums.js'
+import type { BigIntLike } from '@ethereumjs/util'
 
 export interface ChainName {
   [chainId: string]: string
@@ -122,7 +123,7 @@ export interface GethConfigOpts extends BaseOpts {
 }
 
 export interface HardforkByOpts {
-  blockNumber?: bigint
-  timestamp?: bigint
-  td?: bigint
+  blockNumber?: BigIntLike
+  timestamp?: BigIntLike
+  td?: BigIntLike
 }

--- a/packages/common/test/customChains.spec.ts
+++ b/packages/common/test/customChains.spec.ts
@@ -183,9 +183,9 @@ describe('custom chain setup with hardforks with undefined/null block numbers', 
     ]
 
     const common = Common.custom({ hardforks: nullHardforks })
-    common.setHardforkByBlockNumber(10)
+    common.setHardforkBy({ blockNumber: 10n })
     assert.equal('tangerineWhistle', common.hardfork(), 'set correct hardfork')
-    common.setHardforkByBlockNumber(3)
+    common.setHardforkBy({ blockNumber: 3n })
     assert.equal('chainstart', common.hardfork(), 'set correct hardfork')
   })
 })

--- a/packages/common/test/hardforks.spec.ts
+++ b/packages/common/test/hardforks.spec.ts
@@ -32,21 +32,21 @@ describe('[Common]: Hardfork logic', () => {
     }
   })
 
-  it('getHardforkByBlockNumber() / setHardforkByBlockNumber()', () => {
+  it('getHardforkBy() / setHardforkByBlockNumber()', () => {
     let c = new Common({ chain: Chain.Mainnet })
     let msg = 'should get HF correctly'
 
-    assert.equal(c.getHardforkByBlockNumber(0), Hardfork.Chainstart, msg)
-    assert.equal(c.getHardforkByBlockNumber(1149999), Hardfork.Chainstart, msg)
-    assert.equal(c.getHardforkByBlockNumber(1150000), Hardfork.Homestead, msg)
-    assert.equal(c.getHardforkByBlockNumber(1400000), Hardfork.Homestead, msg)
-    assert.equal(c.getHardforkByBlockNumber(9200000), Hardfork.MuirGlacier, msg)
-    assert.equal(c.getHardforkByBlockNumber(12244000), Hardfork.Berlin, msg)
-    assert.equal(c.getHardforkByBlockNumber(12965000), Hardfork.London, msg)
-    assert.equal(c.getHardforkByBlockNumber(13773000), Hardfork.ArrowGlacier, msg)
-    assert.equal(c.getHardforkByBlockNumber(15050000), Hardfork.GrayGlacier, msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 0n }), Hardfork.Chainstart, msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 1149999n }), Hardfork.Chainstart, msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 1150000n }), Hardfork.Homestead, msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 1400000n }), Hardfork.Homestead, msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 9200000n }), Hardfork.MuirGlacier, msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 12244000n }), Hardfork.Berlin, msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 12965000n }), Hardfork.London, msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 13773000n }), Hardfork.ArrowGlacier, msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 15050000n }), Hardfork.GrayGlacier, msg)
     // merge is now specified at 15537394 in config
-    assert.equal(c.getHardforkByBlockNumber(999999999999), Hardfork.Paris, msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 999999999999n }), Hardfork.Paris, msg)
     msg = 'should set HF correctly'
 
     assert.equal(c.setHardforkByBlockNumber(0), Hardfork.Chainstart, msg)
@@ -82,7 +82,7 @@ describe('[Common]: Hardfork logic', () => {
 
     const c = Common.custom({ hardforks }, { baseChain: Chain.Sepolia })
     const f = () => {
-      c.getHardforkByBlockNumber(0)
+      c.getHardforkBy({ blockNumber: 0n })
     }
     assert.throws(f, undefined, undefined, 'throw since no hardfork qualifies')
 

--- a/packages/common/test/hardforks.spec.ts
+++ b/packages/common/test/hardforks.spec.ts
@@ -32,7 +32,7 @@ describe('[Common]: Hardfork logic', () => {
     }
   })
 
-  it('getHardforkBy() / setHardforkByBlockNumber()', () => {
+  it('getHardforkBy() / setHardforkBy()', () => {
     let c = new Common({ chain: Chain.Mainnet })
     let msg = 'should get HF correctly'
 
@@ -49,19 +49,19 @@ describe('[Common]: Hardfork logic', () => {
     assert.equal(c.getHardforkBy({ blockNumber: 999999999999n }), Hardfork.Paris, msg)
     msg = 'should set HF correctly'
 
-    assert.equal(c.setHardforkByBlockNumber(0), Hardfork.Chainstart, msg)
-    assert.equal(c.setHardforkByBlockNumber(1149999), Hardfork.Chainstart, msg)
-    assert.equal(c.setHardforkByBlockNumber(1150000), Hardfork.Homestead, msg)
-    assert.equal(c.setHardforkByBlockNumber(1400000), Hardfork.Homestead, msg)
-    assert.equal(c.setHardforkByBlockNumber(12244000), Hardfork.Berlin, msg)
-    assert.equal(c.setHardforkByBlockNumber(12965000), Hardfork.London, msg)
-    assert.equal(c.setHardforkByBlockNumber(13773000), Hardfork.ArrowGlacier, msg)
-    assert.equal(c.setHardforkByBlockNumber(15050000), Hardfork.GrayGlacier, msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 0n }), Hardfork.Chainstart, msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 1149999n }), Hardfork.Chainstart, msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 1150000n }), Hardfork.Homestead, msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 1400000n }), Hardfork.Homestead, msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 12244000n }), Hardfork.Berlin, msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 12965000n }), Hardfork.London, msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 13773000n }), Hardfork.ArrowGlacier, msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 15050000n }), Hardfork.GrayGlacier, msg)
     // merge is now specified at 15537394 in config
-    assert.equal(c.setHardforkByBlockNumber(999999999999), Hardfork.Paris, msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 999999999999n }), Hardfork.Paris, msg)
 
     c = new Common({ chain: Chain.Ropsten })
-    assert.equal(c.setHardforkByBlockNumber(0), 'tangerineWhistle', msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 0n }), 'tangerineWhistle', msg)
   })
 
   it('should throw if no hardfork qualifies', () => {
@@ -87,7 +87,7 @@ describe('[Common]: Hardfork logic', () => {
     assert.throws(f, undefined, undefined, 'throw since no hardfork qualifies')
 
     const msg = 'should return correct value'
-    assert.equal(c.setHardforkByBlockNumber(3), Hardfork.SpuriousDragon, msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 3n }), Hardfork.SpuriousDragon, msg)
   })
 
   it('setHardfork(): hardforkChanged event', () => {

--- a/packages/common/test/mergePOS.spec.ts
+++ b/packages/common/test/mergePOS.spec.ts
@@ -18,25 +18,25 @@ describe('[Common]: Merge/POS specific logic', () => {
     )
   })
 
-  it('getHardforkByBlockNumber(), merge block null, with total difficulty', () => {
+  it('getHardforkBy(), merge block null, with total difficulty', () => {
     const customChains = [testnetMerge]
     const c = new Common({ chain: 'testnetMerge', hardfork: Hardfork.Istanbul, customChains })
 
     let msg = 'block number < last HF block number set, without TD set'
-    assert.equal(c.getHardforkByBlockNumber(0), 'chainstart', msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 0n }), 'chainstart', msg)
     msg = 'block number > last HF block number set, without TD set'
-    assert.equal(c.getHardforkByBlockNumber(14), 'london', msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 14n }), 'london', msg)
     msg = 'block number > last HF block number set, TD set and equal'
-    assert.equal(c.getHardforkByBlockNumber(15, 5000), 'paris', msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 15n, td: 5000n }), 'paris', msg)
     msg = 'block number > last HF block number set, TD set and higher'
-    assert.equal(c.getHardforkByBlockNumber(15, 5001), 'paris', msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 15n, td: 5001n }), 'paris', msg)
     msg = 'block number > last HF block number set, TD set and smaller'
-    assert.equal(c.getHardforkByBlockNumber(15, 4999), 'london', msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 15n, td: 4999n }), 'london', msg)
     msg = 'block number < last HF block number set, TD set and smaller'
-    assert.equal(c.getHardforkByBlockNumber(12, 4999), 'berlin', msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 12n, td: 4999n }), 'berlin', msg)
   })
 
-  it('getHardforkByBlockNumber(), merge block set, with total difficulty', () => {
+  it('getHardforkBy(), merge block set, with total difficulty', () => {
     const testnetMergeWithBlockNumber = JSON.parse(JSON.stringify(testnetMerge))
     // Set Merge block to 15
     testnetMergeWithBlockNumber['hardforks'][8]['block'] = 16
@@ -44,25 +44,25 @@ describe('[Common]: Merge/POS specific logic', () => {
     const c = new Common({ chain: 'testnetMerge', hardfork: Hardfork.Istanbul, customChains })
 
     let msg = 'block number < last HF block number set, without TD set'
-    assert.equal(c.getHardforkByBlockNumber(0), 'chainstart', msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 0n }), 'chainstart', msg)
     msg = 'block number > last HF block number set, without TD set'
-    assert.equal(c.getHardforkByBlockNumber(16), 'paris', msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 16n }), 'paris', msg)
     msg = 'block number > last HF block number set, TD set and equal'
-    assert.equal(c.getHardforkByBlockNumber(16, 5000), 'paris', msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 16n, td: 5000n }), 'paris', msg)
     msg = 'block number > last HF block number set, TD set and higher'
-    assert.equal(c.getHardforkByBlockNumber(16, 5001), 'paris', msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 16n, td: 5001n }), 'paris', msg)
     msg = 'block number < last HF block number set, TD set and smaller'
-    assert.equal(c.getHardforkByBlockNumber(12, 4999), 'berlin', msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 12n, td: 4999n }), 'berlin', msg)
 
     try {
-      c.getHardforkByBlockNumber(16, 4999)
+      c.getHardforkBy({ blockNumber: 16n, td: 4999n })
     } catch (e: any) {
       msg = 'block number > last HF block number set, TD set and smaller (should throw)'
       const eMsg = 'Maximum HF determined by total difficulty is lower than the block number HF'
       assert.ok(e.message.includes(eMsg), msg)
     }
     try {
-      c.getHardforkByBlockNumber(14, 5000)
+      c.getHardforkBy({ blockNumber: 14n, td: 5000n })
     } catch (e: any) {
       msg = 'block number < last HF block number set, TD set and higher (should throw)'
       const eMsg = 'HF determined by block number is lower than the minimum total difficulty HF'
@@ -70,7 +70,7 @@ describe('[Common]: Merge/POS specific logic', () => {
     }
   })
 
-  it('getHardforkByBlockNumber(), merge block set + subsequent HF, with total difficulty', () => {
+  it('getHardforkBy(), merge block set + subsequent HF, with total difficulty', () => {
     const testnetMergeWithBlockNumber = JSON.parse(JSON.stringify(testnetMerge))
     // Set Merge block to 15
     testnetMergeWithBlockNumber['hardforks'][8]['block'] = 16
@@ -80,7 +80,7 @@ describe('[Common]: Merge/POS specific logic', () => {
     const c = new Common({ chain: 'testnetMerge', hardfork: Hardfork.Istanbul, customChains })
 
     const msg = 'block number > last HF block number set, TD set and higher'
-    assert.equal(c.getHardforkByBlockNumber(18, 5001), 'shanghai', msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 18n, td: 5001n }), 'shanghai', msg)
   })
 
   it('setHardforkByBlockNumber(), merge block null, with total difficulty', () => {
@@ -161,7 +161,7 @@ describe('[Common]: Merge/POS specific logic', () => {
     )
 
     const msg = 'block number > last HF block number set, TD set (0) and equal'
-    assert.equal(c.getHardforkByBlockNumber(5, 0), 'shanghai', msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 5n, td: 0n }), 'shanghai', msg)
   })
 
   it('Should fail setting invalid hardfork', () => {
@@ -175,33 +175,33 @@ describe('[Common]: Merge/POS specific logic', () => {
   it('should get the correct merge hardfork at genesis', async () => {
     const c = Common.fromGethGenesis(postMergeJSON, { chain: 'post-merge' })
     const msg = 'should get HF correctly'
-    assert.equal(c.getHardforkByBlockNumber(0), Hardfork.London, msg)
-    assert.equal(c.getHardforkByBlockNumber(0, BigInt(0)), Hardfork.Paris, msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 0n }), Hardfork.London, msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 0n, td: 0n }), Hardfork.Paris, msg)
   })
 
   it('test post merge hardforks using Sepolia with block null', () => {
     const c = new Common({ chain: Chain.Sepolia })
     let msg = 'should get HF correctly'
 
-    assert.equal(c.getHardforkByBlockNumber(0), Hardfork.London, msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 0n }), Hardfork.London, msg)
     // Make it null manually as config could be updated later
     const mergeHf = c.hardforks().filter((hf) => hf.ttd !== undefined && hf.ttd !== null)[0]
     const prevMergeBlockVal = mergeHf.block
     mergeHf.block = null
 
     // should get Hardfork.London even though happened with 1450408 as terminal as config doesn't have that info
-    assert.equal(c.getHardforkByBlockNumber(1450409), Hardfork.London, msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 1450409n }), Hardfork.London, msg)
     // however with correct td in input it should select merge
     assert.equal(
-      c.getHardforkByBlockNumber(1450409, BigInt('17000000000000000')),
+      c.getHardforkBy({ blockNumber: 1450409n, td: 17000000000000000n }),
       Hardfork.Paris,
       msg
     )
     // should select MergeForkIdTransition even without td specified as the block is set for this hardfork
-    assert.equal(c.getHardforkByBlockNumber(1735371), Hardfork.MergeForkIdTransition, msg)
+    assert.equal(c.getHardforkBy({ blockNumber: 1735371n }), Hardfork.MergeForkIdTransition, msg)
     // also with td specified
     assert.equal(
-      c.getHardforkByBlockNumber(1735371, BigInt('17000000000000000')),
+      c.getHardforkBy({ blockNumber: 1735371n, td: 17000000000000000n }),
       Hardfork.MergeForkIdTransition,
       msg
     )
@@ -224,7 +224,7 @@ describe('[Common]: Merge/POS specific logic', () => {
     )
 
     let f = () => {
-      c.getHardforkByBlockNumber(1735371, BigInt('15000000000000000'))
+      c.getHardforkBy({ blockNumber: 1735371n, td: 15000000000000000n })
     }
     assert.throws(
       f,

--- a/packages/common/test/mergePOS.spec.ts
+++ b/packages/common/test/mergePOS.spec.ts
@@ -83,25 +83,25 @@ describe('[Common]: Merge/POS specific logic', () => {
     assert.equal(c.getHardforkBy({ blockNumber: 18n, td: 5001n }), 'shanghai', msg)
   })
 
-  it('setHardforkByBlockNumber(), merge block null, with total difficulty', () => {
+  it('setHardforkBy(), merge block null, with total difficulty', () => {
     const customChains = [testnetMerge]
     const c = new Common({ chain: 'testnetMerge', hardfork: Hardfork.Istanbul, customChains })
 
     let msg = 'block number < last HF block number set, without TD set'
-    assert.equal(c.setHardforkByBlockNumber(0), 'chainstart', msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 0n }), 'chainstart', msg)
     msg = 'block number > last HF block number set, without TD set'
-    assert.equal(c.setHardforkByBlockNumber(14), 'london', msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 14n }), 'london', msg)
     msg = 'block number > last HF block number set, TD set and equal'
-    assert.equal(c.setHardforkByBlockNumber(15, 5000), 'paris', msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 15n, td: 5000n }), 'paris', msg)
     msg = 'block number > last HF block number set, TD set and higher'
-    assert.equal(c.setHardforkByBlockNumber(15, 5001), 'paris', msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 15n, td: 5001n }), 'paris', msg)
     msg = 'block number > last HF block number set, TD set and smaller'
-    assert.equal(c.setHardforkByBlockNumber(15, 4999), 'london', msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 15n, td: 4999n }), 'london', msg)
     msg = 'block number < last HF block number set, TD set and smaller'
-    assert.equal(c.setHardforkByBlockNumber(12, 4999), 'berlin', msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 12n, td: 4999n }), 'berlin', msg)
   })
 
-  it('setHardforkByBlockNumber(), merge block set, with total difficulty', () => {
+  it('setHardforkBy(), merge block set, with total difficulty', () => {
     const testnetMergeWithBlockNumber = JSON.parse(JSON.stringify(testnetMerge))
     // Set Merge block to 15
     testnetMergeWithBlockNumber['hardforks'][8]['block'] = 16
@@ -109,18 +109,18 @@ describe('[Common]: Merge/POS specific logic', () => {
     const c = new Common({ chain: 'testnetMerge', hardfork: Hardfork.Istanbul, customChains })
 
     let msg = 'block number < last HF block number set, without TD set'
-    assert.equal(c.setHardforkByBlockNumber(0), 'chainstart', msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 0n }), 'chainstart', msg)
     msg = 'block number > last HF block number set, without TD set'
-    assert.equal(c.setHardforkByBlockNumber(16), 'paris', msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 16n }), 'paris', msg)
     msg = 'block number > last HF block number set, TD set and equal'
-    assert.equal(c.setHardforkByBlockNumber(16, 5000), 'paris', msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 16n, td: 5000n }), 'paris', msg)
     msg = 'block number > last HF block number set, TD set and higher'
-    assert.equal(c.setHardforkByBlockNumber(16, 5001), 'paris', msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 16n, td: 5001n }), 'paris', msg)
     msg = 'block number < last HF block number set, TD set and smaller'
-    assert.equal(c.setHardforkByBlockNumber(12, 4999), 'berlin', msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 12n, td: 4999n }), 'berlin', msg)
 
     try {
-      c.setHardforkByBlockNumber(16, 4999)
+      c.setHardforkBy({ blockNumber: 16n, td: 4999n })
       assert.fail(`should have thrown td < ttd validation error`)
     } catch (e: any) {
       msg = 'block number > last HF block number set, TD set and smaller (should throw)'
@@ -128,7 +128,7 @@ describe('[Common]: Merge/POS specific logic', () => {
       assert.ok(e.message.includes(eMsg), msg)
     }
     try {
-      c.setHardforkByBlockNumber(14, 5000)
+      c.setHardforkBy({ blockNumber: 14n, td: 5000n })
       assert.fail(`should have thrown td > ttd validation error`)
     } catch (e: any) {
       msg = 'block number < last HF block number set, TD set and higher (should throw)'
@@ -137,7 +137,7 @@ describe('[Common]: Merge/POS specific logic', () => {
     }
   })
 
-  it('setHardforkByBlockNumber(), merge block set + subsequent HF, with total difficulty', () => {
+  it('setHardforkBy(), merge block set + subsequent HF, with total difficulty', () => {
     const testnetMergeWithBlockNumber = JSON.parse(JSON.stringify(testnetMerge))
     // Set Merge block to 15
     testnetMergeWithBlockNumber['hardforks'][8]['block'] = 16
@@ -147,7 +147,7 @@ describe('[Common]: Merge/POS specific logic', () => {
     const c = new Common({ chain: 'testnetMerge', hardfork: Hardfork.Istanbul, customChains })
 
     const msg = 'block number > last HF block number set, TD set and higher'
-    assert.equal(c.setHardforkByBlockNumber(18, 5001), 'shanghai', msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 18n, td: 5001n }), 'shanghai', msg)
   })
 
   it('Pure POS testnet', () => {
@@ -235,21 +235,21 @@ describe('[Common]: Merge/POS specific logic', () => {
 
     msg = 'should set HF correctly'
 
-    assert.equal(c.setHardforkByBlockNumber(0), Hardfork.London, msg)
-    assert.equal(c.setHardforkByBlockNumber(1450409), Hardfork.London, msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 0n }), Hardfork.London, msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 1450409n }), Hardfork.London, msg)
     assert.equal(
-      c.setHardforkByBlockNumber(1450409, BigInt('17000000000000000')),
+      c.setHardforkBy({ blockNumber: 1450409n, td: 17000000000000000n }),
       Hardfork.Paris,
       msg
     )
-    assert.equal(c.setHardforkByBlockNumber(1735371), Hardfork.MergeForkIdTransition, msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 1735371n }), Hardfork.MergeForkIdTransition, msg)
     assert.equal(
-      c.setHardforkByBlockNumber(1735371, BigInt('17000000000000000')),
+      c.setHardforkBy({ blockNumber: 1735371n, td: 17000000000000000n }),
       Hardfork.MergeForkIdTransition,
       msg
     )
     f = () => {
-      c.setHardforkByBlockNumber(1735371, BigInt('15000000000000000'))
+      c.setHardforkBy({ blockNumber: 1735371n, td: 15000000000000000n })
     }
     assert.throws(
       f,
@@ -272,15 +272,15 @@ describe('[Common]: Merge/POS specific logic', () => {
     const msg = 'should get HF correctly'
 
     // should get merge even without td supplied as the merge hf now has the block specified
-    assert.equal(c.setHardforkByBlockNumber(1450409), Hardfork.Paris, msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 1450409n }), Hardfork.Paris, msg)
     assert.equal(
-      c.setHardforkByBlockNumber(1450409, BigInt('17000000000000000')),
+      c.setHardforkBy({ blockNumber: 1450409n, td: 17000000000000000n }),
       Hardfork.Paris,
       msg
     )
-    assert.equal(c.setHardforkByBlockNumber(1735371), Hardfork.MergeForkIdTransition, msg)
+    assert.equal(c.setHardforkBy({ blockNumber: 1735371n }), Hardfork.MergeForkIdTransition, msg)
     assert.equal(
-      c.setHardforkByBlockNumber(1735371, BigInt('17000000000000000')),
+      c.setHardforkBy({ blockNumber: 1735371n, td: 17000000000000000n }),
       Hardfork.MergeForkIdTransition,
       msg
     )
@@ -308,7 +308,7 @@ describe('[Common]: Merge/POS specific logic', () => {
       '17000000000000000'
 
     const f = () => {
-      c.setHardforkByBlockNumber(1735371)
+      c.setHardforkBy({ blockNumber: 1735371n })
     }
     assert.throws(f, undefined, undefined, 'throws error as two hardforks with ttd specified')
   })

--- a/packages/common/test/timestamp.spec.ts
+++ b/packages/common/test/timestamp.spec.ts
@@ -11,17 +11,17 @@ describe('[Common]: Timestamp Hardfork logic', () => {
       chain: 'withdrawals',
     })
     assert.equal(
-      c.getHardforkByBlockNumber(1, undefined, 0),
+      c.getHardforkBy({ blockNumber: 1n, timestamp: 0n }),
       Hardfork.MergeForkIdTransition,
       'should match the HF'
     )
     assert.equal(
-      c.getHardforkByBlockNumber(1, undefined, 1668699476),
+      c.getHardforkBy({ blockNumber: 1n, timestamp: 1668699476n }),
       Hardfork.Shanghai,
       'should match the HF'
     )
     assert.equal(
-      c.getHardforkByBlockNumber(1, undefined, 1668699576),
+      c.getHardforkBy({ blockNumber: 1n, timestamp: 1668699576n }),
       Hardfork.Shanghai,
       'should match the HF'
     )
@@ -36,7 +36,7 @@ describe('[Common]: Timestamp Hardfork logic', () => {
       chain: 'modified',
     })
     assert.equal(
-      c.getHardforkByBlockNumber(1, undefined, 0),
+      c.getHardforkBy({ blockNumber: 1n, timestamp: 0n }),
       Hardfork.MergeForkIdTransition,
       'should match the HF'
     )
@@ -56,18 +56,18 @@ describe('[Common]: Timestamp Hardfork logic', () => {
       chain: 'modified',
     })
     assert.equal(
-      c.getHardforkByBlockNumber(1, undefined, 0),
+      c.getHardforkBy({ blockNumber: 1n, timestamp: 0n }),
       Hardfork.MergeForkIdTransition,
       'should match the HF'
     )
     // Should give the shanghai as sharding is schedule a bit post shanghai
     assert.equal(
-      c.getHardforkByBlockNumber(1, undefined, 1668699476),
+      c.getHardforkBy({ blockNumber: 1n, timestamp: 1668699476n }),
       Hardfork.Shanghai,
       'should match the HF'
     )
     assert.equal(
-      c.getHardforkByBlockNumber(1, undefined, 1668699576),
+      c.getHardforkBy({ blockNumber: 1n, timestamp: 1668699576n }),
       Hardfork.Shanghai,
       'should match the HF'
     )

--- a/packages/common/test/utils.spec.ts
+++ b/packages/common/test/utils.spec.ts
@@ -145,35 +145,34 @@ describe('[Utils/Parse]', () => {
       'hardfork parse order should be correct'
     )
 
-    assert.equal(common.getHardforkByBlockNumber(0), Hardfork.London, 'london at genesis')
-    assert.equal(common.getHardforkByBlockNumber(1, BigInt(2)), Hardfork.Paris, 'merge at block 1')
+    assert.equal(common.getHardforkBy({ blockNumber: 0n }), Hardfork.London, 'london at genesis')
+    assert.equal(
+      common.getHardforkBy({ blockNumber: 1n, td: 2n }),
+      Hardfork.Paris,
+      'merge at block 1'
+    )
     // shanghai is at timestamp 8
     assert.equal(
-      common.getHardforkByBlockNumber(8),
+      common.getHardforkBy({ blockNumber: 8n }),
       Hardfork.London,
       'without timestamp still london'
     )
     assert.equal(
-      common.getHardforkByBlockNumber(8, BigInt(2)),
+      common.getHardforkBy({ blockNumber: 8n, td: 2n }),
       Hardfork.Paris,
       'without timestamp at merge'
     )
     assert.equal(
-      common.getHardforkByBlockNumber(8, undefined, 8),
+      common.getHardforkBy({ blockNumber: 8n, timestamp: 8n }),
       Hardfork.Shanghai,
       'with timestamp at shanghai'
     )
     // should be post merge at shanghai
     assert.equal(
-      common.getHardforkByBlockNumber(8, BigInt(2), 8),
+      common.getHardforkBy({ blockNumber: 8n, td: 2n, timestamp: 8n }),
       Hardfork.Shanghai,
       'post merge shanghai'
     )
-    // if not post merge, then should error
-    const f = () => {
-      common.getHardforkByBlockNumber(8, BigInt(1), 8)
-    }
-    assert.throws(f, undefined, undefined, 'correctly fails if merge not completed before shanghai')
     assert.equal(common.hardfork(), Hardfork.Shanghai, 'should correctly infer common hardfork')
   })
 })

--- a/packages/statemanager/test/ethersStateManager.spec.ts
+++ b/packages/statemanager/test/ethersStateManager.spec.ts
@@ -248,7 +248,7 @@ describe('runTx test: replay mainnet transactions', () => {
           : new MockProvider()
 
       const blockTag = 15496077n
-      common.setHardforkByBlockNumber(blockTag)
+      common.setHardforkBy({ blockNumber: blockTag })
       const tx = await TransactionFactory.fromRPC(txData, { common })
       const state = new EthersStateManager({
         provider,
@@ -285,7 +285,7 @@ describe('runBlock test', () => {
 
       // Set the common to HF, doesn't impact this specific blockTag, but will impact much recent
       // blocks, also for post merge network, ttd should also be passed
-      common.setHardforkByBlockNumber(blockTag - 1n)
+      common.setHardforkBy({ blockNumber: blockTag - 1n })
 
       const vm = await VM.create({ common, stateManager: state })
       const block = Block.fromRPC(blockData, [], { common })

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -61,11 +61,11 @@ export async function runBlock(this: VM, opts: RunBlockOpts): Promise<RunBlockRe
     this._hardforkByTTD !== undefined ||
     opts.hardforkByTTD !== undefined
   ) {
-    this._common.setHardforkByBlockNumber(
-      block.header.number,
-      opts.hardforkByTTD ?? this._hardforkByTTD,
-      block.header.timestamp
-    )
+    this._common.setHardforkBy({
+      blockNumber: block.header.number,
+      td: opts.hardforkByTTD ?? this._hardforkByTTD,
+      timestamp: block.header.timestamp,
+    })
   }
 
   if (this.DEBUG) {

--- a/packages/vm/test/api/runTx.spec.ts
+++ b/packages/vm/test/api/runTx.spec.ts
@@ -637,7 +637,7 @@ describe('runTx tests', () => {
       const afterBalance = BigInt(129033829000000000)
 
       const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.SpuriousDragon })
-      common.setHardforkByBlockNumber(2772981)
+      common.setHardforkBy({ blockNumber: 2772981 })
       const vm = await VM.create({ common })
 
       const addr = Address.fromString('0xd3563d8f19a85c95beab50901fd59ca4de69174c')

--- a/packages/vm/test/tester/runners/BlockchainTestsRunner.ts
+++ b/packages/vm/test/tester/runners/BlockchainTestsRunner.ts
@@ -44,7 +44,7 @@ export async function runBlockchainTest(options: any, testData: any, t: tape.Tes
   testData.lastblockhash = stripHexPrefix(testData.lastblockhash)
 
   let common = options.common.copy() as Common
-  common.setHardforkByBlockNumber(0)
+  common.setHardforkBy({ blockNumber: 0 })
 
   let cacheDB = new MapDB()
   let state = new Trie({ useKeyHashing: true })
@@ -147,7 +147,7 @@ export async function runBlockchainTest(options: any, testData: any, t: tape.Tes
         // eslint-disable-next-line no-empty
       } catch (e) {}
 
-      common.setHardforkByBlockNumber(currentBlock, TD, timestamp)
+      common.setHardforkBy({ blockNumber: currentBlock, td: TD, timestamp })
 
       // transactionSequence is provided when txs are expected to be rejected.
       // To run this field we try to import them on the current state.


### PR DESCRIPTION
Partly solves #2774

This PR does the following:

- `Common.getHardforkByBlockNumber()` -> `Common.getHardforkBy()` ~(+ strict bigint types)~
- `Common.setHardforkByBlockNumber()` -> `Common.setHardforkBy()` ~(+ strict bigint types)~ 
- ~`Blockchain.checkAndTransitionHardForkByNumber()` BigIntLike -> strict bigint types~ 