### PR TITLE
Typescript KZG proof of concept usage with ESM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1736,6 +1736,41 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@crate-crypto/crypto-4844": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@crate-crypto/crypto-4844/-/crypto-4844-0.2.0.tgz",
+      "integrity": "sha512-evlrS7xFf4+2F87hsAMcskfLEjv3d4bUNTnkQ8sf+lTDVyJXzE/Nz1UnA97mpLIO4n9TMHy9HLnRX1MkMXg17g==",
+      "dependencies": {
+        "@noble/curves": "^0.7.3",
+        "montgomery": "^0.2.1"
+      }
+    },
+    "node_modules/@crate-crypto/crypto-4844/node_modules/@noble/curves": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-0.7.3.tgz",
+      "integrity": "sha512-z2dl235V3SFA6EveV/+oCAa9pAgyxxU1pUckS/FTXh5m3IyV0XRr2+NKM+HOJkyH//2DZM5DYZY0kxefU5c1qA==",
+      "deprecated": "Upgrade to 1.0.0 or higher for audited version",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "1.2.0"
+      }
+    },
+    "node_modules/@crate-crypto/crypto-4844/node_modules/@noble/hashes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.2.0.tgz",
+      "integrity": "sha512-FZfhjEDbT5GRswV3C6uvLPHMiVD6lQBmpoX5+eSiPaMTXte/IKqI5dykDxzZB/WBeK/CDuQRBWarPdi3FNY2zQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "dev": true,
@@ -8008,6 +8043,11 @@
         "node": "> 0.1.90"
       }
     },
+    "node_modules/fast-base64": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/fast-base64/-/fast-base64-0.1.8.tgz",
+      "integrity": "sha512-LICiPjlLyh7/P3gcJYDjKEIX41odzqny1VHSnPsAlBb/zcSJJPYrSNHs54e2TytDRTwHZl7KG5c33IMLdT+9Eg=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
@@ -11825,6 +11865,14 @@
       "license": "MIT",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/montgomery": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/montgomery/-/montgomery-0.2.1.tgz",
+      "integrity": "sha512-7ZyUG5BHGKWx0XvVfjoSdMsijseo3PgujDS6/J00eRcpQbowupYDJJoyw7STFIa8qUVkKgzt1kiBvtyhT+paYA==",
+      "dependencies": {
+        "fast-base64": "^0.1.8"
       }
     },
     "node_modules/morphdom": {
@@ -18396,6 +18444,7 @@
       "version": "4.1.2",
       "license": "MPL-2.0",
       "dependencies": {
+        "@crate-crypto/crypto-4844": "^0.2.0",
         "@ethereumjs/common": "^3.1.2",
         "@ethereumjs/rlp": "^4.0.1",
         "@ethereumjs/util": "^8.0.6",

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -56,6 +56,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
+    "@crate-crypto/crypto-4844": "^0.2.0",
     "@ethereumjs/common": "^3.1.2",
     "@ethereumjs/rlp": "^4.0.1",
     "@ethereumjs/util": "^8.0.6",

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -18,12 +18,15 @@ import { assert, describe, it } from 'vitest'
 import gethGenesis from '../../block/test/testdata/4844-hardfork.json'
 import { BlobEIP4844Transaction, TransactionFactory } from '../src/index.js'
 
+import { TSKzg } from './tKzg.js'
 // Hack to detect if running in browser or not
 const isBrowser = new Function('try {return this===window;}catch(e){ return false;}')
 
 const pk = randomBytes(32)
 if (isBrowser() === false) {
   try {
+    const kzg = new TSKzg()
+    //   initKZG(kzg, __dirname + '/../../client/src/trustedSetups/devnet6.txt')
     initKZG(kzg, __dirname + '/../../client/src/trustedSetups/devnet6.txt')
     // eslint-disable-next-line
   } catch {}

--- a/packages/tx/test/tKzg.ts
+++ b/packages/tx/test/tKzg.ts
@@ -1,0 +1,34 @@
+import { Context } from '@crate-crypto/crypto-4844'
+
+import type { Kzg } from '@ethereumjs/util'
+export class TSKzg implements Kzg {
+  tsKzg: any
+
+  constructor() {
+    this.tsKzg = new Context()
+  }
+
+  loadTrustedSetup(_filePath: string): void {}
+  blobToKzgCommitment(blob: Uint8Array): Uint8Array {
+    return this.tsKzg.blobToKZGCommitment(blob)
+  }
+  computeBlobKzgProof(blob: Uint8Array, _Ecommitment: Uint8Array): Uint8Array {
+    const proof = this.tsKzg.computeBlobKZGProf(blob)
+    return proof.proof
+  }
+  verifyKzgProof(
+    polynomialKzg: Uint8Array,
+    z: Uint8Array,
+    y: Uint8Array,
+    kzgProof: Uint8Array
+  ): boolean {
+    return this.tsKzg.verifyKZGProof(polynomialKzg, z, y, kzgProof)
+  }
+  verifyBlobKzgProofBatch(
+    blobs: Uint8Array[],
+    expectedKzgCommitments: Uint8Array[],
+    kzgProofs: Uint8Array[]
+  ): boolean {
+    return this.tsKzg.verifyBlobKZGProofBatch(blobs, expectedKzgCommitments, kzgProofs)
+  }
+}


### PR DESCRIPTION
Supersedes #2725.  I won't do further testing on this until we confirm that the typescript implementation has been updated to the latest KZG spec but this at least answers the question of whether we can import this `@crate-crypto/crypto-4844` module directly since its ESM only.

- [x] Validate that import of ESM only module works now - [d96562f](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2799/commits/d96562f90b9f16807feb259ffb04270bdaac1cd1)
- [ ] Determine if the CJS output of our code will allow this direct import to still work or if it breaks
- [ ] See how this works in browser
- [ ] If we verify it works everywhere, replace `c-kzg` usage across monorepo