### PR TITLE
Fix `npm run test:API` script

### DIFF
--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -47,7 +47,7 @@
     "prepublishOnly": "../../config/cli/prepublish.sh && npm run test:buildIntegrity",
     "profiling": "0x ./benchmarks/run.js profiling",
     "test": "echo \"[INFO] Generic test cmd not used. See package.json for more specific test run cmds.\"",
-    "test:API": "npx vitest run ./test/api/**/*.spec.ts",
+    "test:API": "npx vitest run ./test/api/",
     "test:browser": "npx vitest run ./test/api/**/*.spec.ts --browser.name=chrome --browser.headless",
     "test:blockchain": "npm run tester -- --blockchain",
     "test:blockchain:allForks": "echo 'Chainstart Homestead dao TangerineWhistle SpuriousDragon Byzantium Constantinople Petersburg Istanbul MuirGlacier Berlin London ByzantiumToConstantinopleFixAt5 EIP158ToByzantiumAt5 FrontierToHomesteadAt5 HomesteadToDaoAt5 HomesteadToEIP150At5 BerlinToLondonAt5' | xargs -n1 | xargs -I v1 npm run tester -- --blockchain --fork=v1 --verify-test-amount-alltests",


### PR DESCRIPTION
Fixes the `test:API` script so it picks up all tests in the `test/api` directory.