### PR TITLE
Add json type assertions to ESM post build fixes

### DIFF
--- a/config/cli/ts-build.sh
+++ b/config/cli/ts-build.sh
@@ -65,6 +65,8 @@ post_build_fixes() {
     blue "[Post Build Fixes]"
     if [ -f ./dist/esm/index.js ];
     then
+        echo "Adding JSON type assertions to ESM build outputs"
+        find . -wholename "**/dist/esm/**.js" -exec sed -i  '/from \S\+\.json'\''/ s/;//;/from \S\+\.json/ s/.*/& assert {type: \"json\"};/' {} +
         echo "Adding ./dist/cjs/package.json"
         rm -f ./dist/cjs/package.json
         cat <<EOT >> ./dist/cjs/package.json


### PR DESCRIPTION
Adds a step in the build process for adding `assert {type: "json"}` to our JSON imports in the ESM build outputs