### PR TITLE
Export precompileAvailability from evm/precompiles/index.ts

### DIFF
--- a/packages/evm/src/precompiles/index.ts
+++ b/packages/evm/src/precompiles/index.ts
@@ -208,6 +208,6 @@ function getActivePrecompiles(
   return precompileMap
 }
 
-export { getActivePrecompiles, precompiles, ripemdPrecompileAddress }
+export { getActivePrecompiles, precompileAvailability, precompiles, ripemdPrecompileAddress }
 
 export type { AddPrecompile, CustomPrecompile, DeletePrecompile, PrecompileFunc, PrecompileInput }


### PR DESCRIPTION
This is a trivial fix to make the `precompileAvailability` list available, given than `precompiles` is also exported.

### Why?

Unfortunately there are situations where it's necessary to monkey-patch custom precompiles into an application which uses ethereumjs and no other method is easily available.

While `precompiles` is exported the `getPrecompile` function will not let you use anything added to it as it does not pass the availability check. See: https://github.com/ethereumjs/ethereumjs-monorepo/blob/b2df1473b8e3fbf9315236d1099bde516a3d002b/packages/evm/src/precompiles/index.ts#L160

An alternative method is to override the `getPrecompile` function, with a fallback to the original `getPrecompile` method.