### PR TITLE
Fix retesteth runner

### DIFF
--- a/packages/vm/test/retesteth/transition-child.cts
+++ b/packages/vm/test/retesteth/transition-child.cts
@@ -8,7 +8,8 @@ import { hexToBytes } from 'ethereum-cryptography/utils'
 import { readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 
-import { BlockBuilder, VM } from '../../dist/cjs'
+import { VM } from '../../dist/cjs'
+import { BlockBuilder } from '../../dist/cjs/buildBlock'
 import { getCommon } from '../tester/config'
 import { makeBlockFromEnv, setupPreConditions } from '../util'
 
@@ -82,7 +83,7 @@ async function runTransition(argsIn: any) {
   let txCounter = 0
 
   vm.events.on('afterTx', async (afterTx, continueFn) => {
-    const receipt = <PostByzantiumTxReceipt>afterTx.receipt
+    const receipt = afterTx.receipt as PostByzantiumTxReceipt
     const pushReceipt = {
       root: '0x',
       status: receipt.status === 0 ? '0x' : '0x1',
@@ -100,10 +101,10 @@ async function runTransition(argsIn: any) {
     continueFn!(undefined)
   })
 
-  const rejected = []
+  const rejected: any = []
 
   let index = 0
-  for (const txData of <NestedUint8Array>txsData) {
+  for (const txData of txsData as NestedUint8Array) {
     try {
       let tx: TypedTransaction
       if (txData instanceof Uint8Array) {
@@ -137,7 +138,7 @@ async function runTransition(argsIn: any) {
   }
 
   if (rejected.length > 0) {
-    ;(<any>output).rejected = rejected
+    ;(output as any).rejected = rejected
   }
 
   const outputAlloc = alloc //{}

--- a/packages/vm/test/retesteth/transition-child.ts
+++ b/packages/vm/test/retesteth/transition-child.ts
@@ -8,12 +8,11 @@ import { hexToBytes } from 'ethereum-cryptography/utils'
 import { readFileSync, writeFileSync } from 'fs'
 import { join } from 'path'
 
-import { VM } from '../../src'
-import { BlockBuilder } from '../../src/buildBlock'
+import { BlockBuilder, VM } from '../../dist/cjs'
 import { getCommon } from '../tester/config'
 import { makeBlockFromEnv, setupPreConditions } from '../util'
 
-import type { PostByzantiumTxReceipt } from '../../src'
+import type { PostByzantiumTxReceipt } from '../../dist/cjs'
 import type { TypedTransaction } from '@ethereumjs/tx'
 import type { NestedUint8Array } from '@ethereumjs/util'
 

--- a/packages/vm/test/retesteth/transition-cluster.cts
+++ b/packages/vm/test/retesteth/transition-cluster.cts
@@ -1,9 +1,8 @@
+import { fork } from 'child_process'
+import { createServer } from 'http'
 import { resolve } from 'path'
 
-const fork = require('child_process').fork
-const http = require('http')
-
-const program = resolve('test/retesteth/transition-child.ts')
+const program = resolve('test/retesteth/transition-child.cts')
 const parameters: any = []
 const options = {
   //stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
@@ -50,7 +49,7 @@ function runTest(message: any) {
   })
 }
 
-const server = http.createServer((request: any, result: any) => {
+const server = createServer((request: any, result: any) => {
   if (request.method === 'POST') {
     let message = ''
     request.on('data', (data: any) => {


### PR DESCRIPTION
WIP. And this is likely temporary since if we switch tests to `import x from foo.js` then it will likely start to fail too.