### PR TITLE
Fix Genesis parsing for 4844

### DIFF
--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -1322,7 +1322,7 @@ export class Blockchain implements BlockchainInterface {
       number: 0,
       stateRoot,
       withdrawalsRoot: common.isActivatedEIP(4895) ? KECCAK256_RLP : undefined,
-      excessDataGas: common.isActivatedEIP(4844) ? BigInt(0) : undefined,
+      excessDataGas: common.isActivatedEIP(4844) ? common.genesis().excessDataGas : undefined,
     }
     if (common.consensusType() === 'poa') {
       if (common.genesis().extraData) {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -43,6 +43,7 @@ export interface GenesisBlockConfig {
   nonce: string
   extraData: string
   baseFeePerGas?: string
+  excessDataGas?: string
 }
 
 export interface HardforkConfig {

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -37,6 +37,7 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
     gasLimit,
     coinbase,
     baseFeePerGas,
+    excessDataGas,
   }: {
     name: string
     config: any
@@ -45,6 +46,7 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
     gasLimit: string
     coinbase: string
     baseFeePerGas: string
+    excessDataGas: string
   } = json
   let { extraData, timestamp, nonce }: { extraData: string; timestamp: string; nonce: string } =
     json
@@ -85,6 +87,7 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
       mixHash,
       coinbase,
       baseFeePerGas,
+      excessDataGas,
     },
     hardfork: undefined as string | undefined,
     hardforks: [] as ConfigHardfork[],


### PR DESCRIPTION
@spencer-tb found this bug when running 4844 pyspec tests on hive. We do not parse the geth genesis correctly. 