### PR TITLE
Common: Fix genesis parsing for 4844

### DIFF
--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -1323,7 +1323,7 @@ export class Blockchain implements BlockchainInterface {
       number: 0,
       stateRoot,
       withdrawalsRoot: common.isActivatedEIP(4895) ? KECCAK256_RLP : undefined,
-      excessDataGas: common.isActivatedEIP(4844) ? BigInt(0) : undefined,
+      excessDataGas: common.isActivatedEIP(4844) ? common.genesis().excessDataGas : undefined,
     }
     if (common.consensusType() === 'poa') {
       if (common.genesis().extraData) {

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -1323,7 +1323,6 @@ export class Blockchain implements BlockchainInterface {
       number: 0,
       stateRoot,
       withdrawalsRoot: common.isActivatedEIP(4895) ? KECCAK256_RLP : undefined,
-      excessDataGas: common.isActivatedEIP(4844) ? common.genesis().excessDataGas : undefined,
     }
     if (common.consensusType() === 'poa') {
       if (common.genesis().extraData) {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -43,6 +43,7 @@ export interface GenesisBlockConfig {
   nonce: string
   extraData: string
   baseFeePerGas?: string
+  excessDataGas?: string
 }
 
 export interface HardforkConfig {

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -37,6 +37,7 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
     gasLimit,
     coinbase,
     baseFeePerGas,
+    excessDataGas,
   }: {
     name: string
     config: any
@@ -45,6 +46,7 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
     gasLimit: string
     coinbase: string
     baseFeePerGas: string
+    excessDataGas: string
   } = json
   let { extraData, timestamp, nonce }: { extraData: string; timestamp: string; nonce: string } =
     json
@@ -85,6 +87,7 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
       mixHash,
       coinbase,
       baseFeePerGas,
+      excessDataGas,
     },
     hardfork: undefined as string | undefined,
     hardforks: [] as ConfigHardfork[],


### PR DESCRIPTION
To test latest hivecancun tests (@ https://github.com/ethereum/hive/commits/fb7ea843fb3935cd49197597a0454691b6a58820 ) : 

```
git remote add spencer-tb git@github.com:spencer-tb/hive.git
git fetch spencer-tb
git checkout fb7ea843fb3935cd49197597a0454691b6a58820
```

Or branch: [hive-cancun-devnet7](https://github.com/spencer-tb/hive/compare/hive-cancun-devnet7)

Run hive:

```
./hive --sim pyspec --sim.limit "pyspec/cancun" --client ethereumjs --docker.output
```

(limits to Cancun tests, remove `sim.limit` to run all pyspec tests since there are also shanghai -> cancun fork tests)

Example command to filter one test and get more output:

```
./hive --sim pyspec --sim.limit "pyspec/cancun/eip4844_blobs/blob_txs/blob_tx_attribute_calldata_opcodes/003-fork=Cancun-tx_gas=500000-single_byte-opcode=CALLDATALOAD" --client ethereumjs --docker.output
```

(Replaces #2846)

Thanks to @spencer-tb :smile: 