### PR TITLE
util/bytes: make unprefixedHexToBytes specific

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21339,7 +21339,7 @@
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.0.0",
         "mcl-wasm": "^0.7.1",
-        "rustbn-wasm": "ethereumjs/rustbn.wasm#9c39b13"
+        "rustbn-wasm": "^0.2.0"
       },
       "devDependencies": {
         "@ethereumjs/statemanager": "^1.0.5",
@@ -23465,13 +23465,13 @@
         "memory-level": "^1.0.0",
         "minimist": "^1.2.5",
         "node-dir": "^0.1.17",
-        "rustbn-wasm": "ethereumjs/rustbn.wasm#9c39b13",
+        "rustbn-wasm": "^0.2.0",
         "solc": "^0.8.1"
       },
       "dependencies": {
         "rustbn-wasm": {
           "version": "git+ssh://git@github.com/ethereumjs/rustbn.wasm.git#9c39b13490021fbff6960306ca10b73b1388216c",
-          "from": "rustbn-wasm@ethereumjs/rustbn.wasm#9c39b13",
+          "from": "git+ssh://git@github.com/ethereumjs/rustbn.wasm.git#9c39b13490021fbff6960306ca10b73b1388216c",
           "requires": {
             "@scure/base": "^1.1.1"
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16931,14 +16931,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rustbn-wasm": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/rustbn-wasm/-/rustbn-wasm-0.1.0.tgz",
-      "integrity": "sha512-aioejicxMxkJJr5LtNlRunhAypkLZfLX73vJYxY17TVMZsfNbsy1xuy3WPR9lANYFd2jDACQ8yKtsfJCX0TY2w==",
-      "dependencies": {
-        "@scure/base": "^1.1.1"
-      }
-    },
     "node_modules/rx-lite": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
@@ -21347,7 +21339,7 @@
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.0.0",
         "mcl-wasm": "^0.7.1",
-        "rustbn-wasm": "^0.1.0"
+        "rustbn-wasm": "ethereumjs/rustbn.wasm#9c39b13"
       },
       "devDependencies": {
         "@ethereumjs/statemanager": "^1.0.5",
@@ -21366,6 +21358,14 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/evm/node_modules/rustbn-wasm": {
+      "name": "rustbn.wasm",
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/ethereumjs/rustbn.wasm.git#9c39b13490021fbff6960306ca10b73b1388216c",
+      "dependencies": {
+        "@scure/base": "^1.1.1"
       }
     },
     "packages/genesis": {
@@ -23465,8 +23465,17 @@
         "memory-level": "^1.0.0",
         "minimist": "^1.2.5",
         "node-dir": "^0.1.17",
-        "rustbn-wasm": "^0.1.0",
+        "rustbn-wasm": "ethereumjs/rustbn.wasm#9c39b13",
         "solc": "^0.8.1"
+      },
+      "dependencies": {
+        "rustbn-wasm": {
+          "version": "git+ssh://git@github.com/ethereumjs/rustbn.wasm.git#9c39b13490021fbff6960306ca10b73b1388216c",
+          "from": "rustbn-wasm@ethereumjs/rustbn.wasm#9c39b13",
+          "requires": {
+            "@scure/base": "^1.1.1"
+          }
+        }
       }
     },
     "@ethereumjs/genesis": {
@@ -34717,14 +34726,6 @@
       "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
       "requires": {
         "queue-microtask": "^1.2.2"
-      }
-    },
-    "rustbn-wasm": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/rustbn-wasm/-/rustbn-wasm-0.1.0.tgz",
-      "integrity": "sha512-aioejicxMxkJJr5LtNlRunhAypkLZfLX73vJYxY17TVMZsfNbsy1xuy3WPR9lANYFd2jDACQ8yKtsfJCX0TY2w==",
-      "requires": {
-        "@scure/base": "^1.1.1"
       }
     },
     "rx-lite": {

--- a/packages/client/src/rpc/modules/debug.ts
+++ b/packages/client/src/rpc/modules/debug.ts
@@ -1,4 +1,4 @@
-import { bigIntToHex, bytesToHex, unprefixedHexToBytes } from '@ethereumjs/util'
+import { bigIntToHex, bytesToHex, hexToBytes } from '@ethereumjs/util'
 
 import { INTERNAL_ERROR, INVALID_PARAMS } from '../error-code'
 import { middleware, validators } from '../validation'
@@ -100,8 +100,9 @@ export class Debug {
     const opts = validateTracerConfig(config)
 
     try {
+      console.log(txHash)
       const result = await this.service.execution.receiptsManager.getReceiptByTxHash(
-        unprefixedHexToBytes(txHash)
+        hexToBytes(txHash)
       )
       if (!result) return null
       const [_, blockHash, txIndex] = result

--- a/packages/client/src/rpc/modules/debug.ts
+++ b/packages/client/src/rpc/modules/debug.ts
@@ -100,7 +100,6 @@ export class Debug {
     const opts = validateTracerConfig(config)
 
     try {
-      console.log(txHash)
       const result = await this.service.execution.receiptsManager.getReceiptByTxHash(
         hexToBytes(txHash)
       )

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -57,7 +57,7 @@
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.0.0",
     "mcl-wasm": "^0.7.1",
-    "rustbn-wasm": "TODO_FIXME_NEED:https://github.com/ethereumjs/rustbn-wasm/pull/5"
+    "rustbn-wasm": "^0.2.0"
   },
   "devDependencies": {
     "@ethereumjs/statemanager": "^1.0.5",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -57,7 +57,7 @@
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.0.0",
     "mcl-wasm": "^0.7.1",
-    "rustbn-wasm": "^0.1.0"
+    "rustbn-wasm": "ethereumjs/rustbn.wasm#9c39b13"
   },
   "devDependencies": {
     "@ethereumjs/statemanager": "^1.0.5",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -57,7 +57,7 @@
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.0.0",
     "mcl-wasm": "^0.7.1",
-    "rustbn-wasm": "ethereumjs/rustbn.wasm#9c39b13"
+    "rustbn-wasm": "TODO_FIXME_NEED:https://github.com/ethereumjs/rustbn-wasm/pull/5"
   },
   "devDependencies": {
     "@ethereumjs/statemanager": "^1.0.5",

--- a/packages/evm/src/precompiles/06-ecadd.ts
+++ b/packages/evm/src/precompiles/06-ecadd.ts
@@ -1,4 +1,10 @@
-import { bytesToHex, bytesToUnprefixedHex, short, unprefixedHexToBytes } from '@ethereumjs/util'
+import {
+  bytesToHex,
+  bytesToUnprefixedHex,
+  hexToBytes,
+  short,
+  unprefixedHexToBytes,
+} from '@ethereumjs/util'
 import { ec_add } from 'rustbn-wasm'
 
 import { OOGResult } from '../evm.js'
@@ -24,7 +30,8 @@ export function precompile06(opts: PrecompileInput): ExecResult {
     return OOGResult(opts.gasLimit)
   }
 
-  const returnData = unprefixedHexToBytes(ec_add(inputData))
+  const ret = ec_add(inputData)
+  const returnData = ret.slice(0, 2) === '0x' ? hexToBytes(ret) : unprefixedHexToBytes(ret)
 
   // check ecadd success or failure by comparing the output length
   if (returnData.length !== 64) {

--- a/packages/evm/src/precompiles/06-ecadd.ts
+++ b/packages/evm/src/precompiles/06-ecadd.ts
@@ -1,4 +1,4 @@
-import { bytesToHex, bytesToUnprefixedHex, short, unprefixedHexToBytes } from '@ethereumjs/util'
+import { bytesToHex, bytesToUnprefixedHex, hexToBytes, short } from '@ethereumjs/util'
 import { ec_add } from 'rustbn-wasm'
 
 import { OOGResult } from '../evm.js'
@@ -24,7 +24,7 @@ export function precompile06(opts: PrecompileInput): ExecResult {
     return OOGResult(opts.gasLimit)
   }
 
-  const returnData = unprefixedHexToBytes(ec_add(inputData))
+  const returnData = hexToBytes(ec_add(inputData))
 
   // check ecadd success or failure by comparing the output length
   if (returnData.length !== 64) {

--- a/packages/evm/src/precompiles/06-ecadd.ts
+++ b/packages/evm/src/precompiles/06-ecadd.ts
@@ -24,8 +24,7 @@ export function precompile06(opts: PrecompileInput): ExecResult {
     return OOGResult(opts.gasLimit)
   }
 
-  const ret = ec_add(inputData)
-  const returnData = hexToBytes(ret)
+  const returnData = hexToBytes(ec_add(inputData))
 
   // check ecadd success or failure by comparing the output length
   if (returnData.length !== 64) {

--- a/packages/evm/src/precompiles/06-ecadd.ts
+++ b/packages/evm/src/precompiles/06-ecadd.ts
@@ -1,4 +1,4 @@
-import { bytesToHex, bytesToUnprefixedHex, hexToBytes, short } from '@ethereumjs/util'
+import { bytesToHex, bytesToUnprefixedHex, short, unprefixedHexToBytes } from '@ethereumjs/util'
 import { ec_add } from 'rustbn-wasm'
 
 import { OOGResult } from '../evm.js'
@@ -24,7 +24,7 @@ export function precompile06(opts: PrecompileInput): ExecResult {
     return OOGResult(opts.gasLimit)
   }
 
-  const returnData = hexToBytes(ec_add(inputData))
+  const returnData = unprefixedHexToBytes(ec_add(inputData))
 
   // check ecadd success or failure by comparing the output length
   if (returnData.length !== 64) {

--- a/packages/evm/src/precompiles/06-ecadd.ts
+++ b/packages/evm/src/precompiles/06-ecadd.ts
@@ -1,10 +1,4 @@
-import {
-  bytesToHex,
-  bytesToUnprefixedHex,
-  hexToBytes,
-  short,
-  unprefixedHexToBytes,
-} from '@ethereumjs/util'
+import { bytesToHex, bytesToUnprefixedHex, hexToBytes, short } from '@ethereumjs/util'
 import { ec_add } from 'rustbn-wasm'
 
 import { OOGResult } from '../evm.js'
@@ -31,7 +25,7 @@ export function precompile06(opts: PrecompileInput): ExecResult {
   }
 
   const ret = ec_add(inputData)
-  const returnData = ret.slice(0, 2) === '0x' ? hexToBytes(ret) : unprefixedHexToBytes(ret)
+  const returnData = hexToBytes(ret)
 
   // check ecadd success or failure by comparing the output length
   if (returnData.length !== 64) {

--- a/packages/evm/src/precompiles/07-ecmul.ts
+++ b/packages/evm/src/precompiles/07-ecmul.ts
@@ -1,10 +1,4 @@
-import {
-  bytesToHex,
-  bytesToUnprefixedHex,
-  hexToBytes,
-  short,
-  unprefixedHexToBytes,
-} from '@ethereumjs/util'
+import { bytesToHex, bytesToUnprefixedHex, hexToBytes, short } from '@ethereumjs/util'
 import { ec_mul } from 'rustbn-wasm'
 
 import { OOGResult } from '../evm.js'
@@ -31,7 +25,7 @@ export function precompile07(opts: PrecompileInput): ExecResult {
   }
 
   const ret = ec_mul(inputData)
-  const returnData = ret.slice(0, 2) === '0x' ? hexToBytes(ret) : unprefixedHexToBytes(ret)
+  const returnData = hexToBytes(ret)
 
   // check ecmul success or failure by comparing the output length
   if (returnData.length !== 64) {

--- a/packages/evm/src/precompiles/07-ecmul.ts
+++ b/packages/evm/src/precompiles/07-ecmul.ts
@@ -1,4 +1,4 @@
-import { bytesToHex, bytesToUnprefixedHex, short, unprefixedHexToBytes } from '@ethereumjs/util'
+import { bytesToHex, bytesToUnprefixedHex, hexToBytes, short } from '@ethereumjs/util'
 import { ec_mul } from 'rustbn-wasm'
 
 import { OOGResult } from '../evm.js'
@@ -24,7 +24,7 @@ export function precompile07(opts: PrecompileInput): ExecResult {
     return OOGResult(opts.gasLimit)
   }
 
-  const returnData = unprefixedHexToBytes(ec_mul(inputData))
+  const returnData = hexToBytes(ec_mul(inputData))
 
   // check ecmul success or failure by comparing the output length
   if (returnData.length !== 64) {

--- a/packages/evm/src/precompiles/07-ecmul.ts
+++ b/packages/evm/src/precompiles/07-ecmul.ts
@@ -24,8 +24,7 @@ export function precompile07(opts: PrecompileInput): ExecResult {
     return OOGResult(opts.gasLimit)
   }
 
-  const ret = ec_mul(inputData)
-  const returnData = hexToBytes(ret)
+  const returnData = hexToBytes(ec_mul(inputData))
 
   // check ecmul success or failure by comparing the output length
   if (returnData.length !== 64) {

--- a/packages/evm/src/precompiles/07-ecmul.ts
+++ b/packages/evm/src/precompiles/07-ecmul.ts
@@ -1,4 +1,4 @@
-import { bytesToHex, bytesToUnprefixedHex, hexToBytes, short } from '@ethereumjs/util'
+import { bytesToHex, bytesToUnprefixedHex, short, unprefixedHexToBytes } from '@ethereumjs/util'
 import { ec_mul } from 'rustbn-wasm'
 
 import { OOGResult } from '../evm.js'
@@ -24,7 +24,7 @@ export function precompile07(opts: PrecompileInput): ExecResult {
     return OOGResult(opts.gasLimit)
   }
 
-  const returnData = hexToBytes(ec_mul(inputData))
+  const returnData = unprefixedHexToBytes(ec_mul(inputData))
 
   // check ecmul success or failure by comparing the output length
   if (returnData.length !== 64) {

--- a/packages/evm/src/precompiles/07-ecmul.ts
+++ b/packages/evm/src/precompiles/07-ecmul.ts
@@ -1,4 +1,10 @@
-import { bytesToHex, bytesToUnprefixedHex, short, unprefixedHexToBytes } from '@ethereumjs/util'
+import {
+  bytesToHex,
+  bytesToUnprefixedHex,
+  hexToBytes,
+  short,
+  unprefixedHexToBytes,
+} from '@ethereumjs/util'
 import { ec_mul } from 'rustbn-wasm'
 
 import { OOGResult } from '../evm.js'
@@ -24,7 +30,8 @@ export function precompile07(opts: PrecompileInput): ExecResult {
     return OOGResult(opts.gasLimit)
   }
 
-  const returnData = unprefixedHexToBytes(ec_mul(inputData))
+  const ret = ec_mul(inputData)
+  const returnData = ret.slice(0, 2) === '0x' ? hexToBytes(ret) : unprefixedHexToBytes(ret)
 
   // check ecmul success or failure by comparing the output length
   if (returnData.length !== 64) {

--- a/packages/evm/src/precompiles/08-ecpairing.ts
+++ b/packages/evm/src/precompiles/08-ecpairing.ts
@@ -1,4 +1,4 @@
-import { bytesToHex, bytesToUnprefixedHex, hexToBytes, short } from '@ethereumjs/util'
+import { bytesToHex, bytesToUnprefixedHex, short, unprefixedHexToBytes } from '@ethereumjs/util'
 import { ec_pairing } from 'rustbn-wasm'
 
 import { OOGResult } from '../evm.js'
@@ -28,7 +28,7 @@ export function precompile08(opts: PrecompileInput): ExecResult {
     return OOGResult(opts.gasLimit)
   }
 
-  const returnData = hexToBytes(ec_pairing(bytesToUnprefixedHex(inputData)))
+  const returnData = unprefixedHexToBytes(ec_pairing(bytesToUnprefixedHex(inputData)))
 
   // check ecpairing success or failure by comparing the output length
   if (returnData.length !== 32) {

--- a/packages/evm/src/precompiles/08-ecpairing.ts
+++ b/packages/evm/src/precompiles/08-ecpairing.ts
@@ -1,4 +1,10 @@
-import { bytesToHex, bytesToUnprefixedHex, short, unprefixedHexToBytes } from '@ethereumjs/util'
+import {
+  bytesToHex,
+  bytesToUnprefixedHex,
+  hexToBytes,
+  short,
+  unprefixedHexToBytes,
+} from '@ethereumjs/util'
 import { ec_pairing } from 'rustbn-wasm'
 
 import { OOGResult } from '../evm.js'
@@ -28,7 +34,8 @@ export function precompile08(opts: PrecompileInput): ExecResult {
     return OOGResult(opts.gasLimit)
   }
 
-  const returnData = unprefixedHexToBytes(ec_pairing(bytesToUnprefixedHex(inputData)))
+  const ret = ec_pairing(bytesToUnprefixedHex(inputData))
+  const returnData = ret.slice(0, 2) === '0x' ? hexToBytes(ret) : unprefixedHexToBytes(ret)
 
   // check ecpairing success or failure by comparing the output length
   if (returnData.length !== 32) {

--- a/packages/evm/src/precompiles/08-ecpairing.ts
+++ b/packages/evm/src/precompiles/08-ecpairing.ts
@@ -1,10 +1,4 @@
-import {
-  bytesToHex,
-  bytesToUnprefixedHex,
-  hexToBytes,
-  short,
-  unprefixedHexToBytes,
-} from '@ethereumjs/util'
+import { bytesToHex, bytesToUnprefixedHex, hexToBytes, short } from '@ethereumjs/util'
 import { ec_pairing } from 'rustbn-wasm'
 
 import { OOGResult } from '../evm.js'
@@ -35,7 +29,7 @@ export function precompile08(opts: PrecompileInput): ExecResult {
   }
 
   const ret = ec_pairing(bytesToUnprefixedHex(inputData))
-  const returnData = ret.slice(0, 2) === '0x' ? hexToBytes(ret) : unprefixedHexToBytes(ret)
+  const returnData = hexToBytes(ret)
 
   // check ecpairing success or failure by comparing the output length
   if (returnData.length !== 32) {

--- a/packages/evm/src/precompiles/08-ecpairing.ts
+++ b/packages/evm/src/precompiles/08-ecpairing.ts
@@ -28,8 +28,7 @@ export function precompile08(opts: PrecompileInput): ExecResult {
     return OOGResult(opts.gasLimit)
   }
 
-  const ret = ec_pairing(bytesToUnprefixedHex(inputData))
-  const returnData = hexToBytes(ret)
+  const returnData = hexToBytes(ec_pairing(bytesToUnprefixedHex(inputData)))
 
   // check ecpairing success or failure by comparing the output length
   if (returnData.length !== 32) {

--- a/packages/evm/src/precompiles/08-ecpairing.ts
+++ b/packages/evm/src/precompiles/08-ecpairing.ts
@@ -1,4 +1,4 @@
-import { bytesToHex, bytesToUnprefixedHex, short, unprefixedHexToBytes } from '@ethereumjs/util'
+import { bytesToHex, bytesToUnprefixedHex, hexToBytes, short } from '@ethereumjs/util'
 import { ec_pairing } from 'rustbn-wasm'
 
 import { OOGResult } from '../evm.js'
@@ -28,7 +28,7 @@ export function precompile08(opts: PrecompileInput): ExecResult {
     return OOGResult(opts.gasLimit)
   }
 
-  const returnData = unprefixedHexToBytes(ec_pairing(bytesToUnprefixedHex(inputData)))
+  const returnData = hexToBytes(ec_pairing(bytesToUnprefixedHex(inputData)))
 
   // check ecpairing success or failure by comparing the output length
   if (returnData.length !== 32) {

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -5,11 +5,6 @@ import {
   hexToBytes as _unprefixedHexToBytes,
 } from 'ethereum-cryptography/utils.js'
 
-// Note: ethereum-cryptography/hexToBytes is imported as "unprefixedHexToBytes"
-// This name is not correct, since it supports prefixed strings. However, internally here we
-// explicitly use it when the strings are known to be unprefixed (for readability and avoid
-// confusion why we would not use our own `hexToBytes`)
-
 import { assertIsArray, assertIsBytes, assertIsHexString } from './helpers.js'
 import { isHexPrefixed, isHexString, padToEven, stripHexPrefix } from './internal.js'
 
@@ -23,7 +18,13 @@ export const bytesToUnprefixedHex = _bytesToUnprefixedHex
 /**
  * @deprecated
  */
-export const unprefixedHexToBytes = _unprefixedHexToBytes
+export const unprefixedHexToBytes = (inp: string) => {
+  if (inp.slice(0, 2) === '0x') {
+    throw new Error('hex string is prefixed with 0x, should be unprefixed')
+  } else {
+    return _unprefixedHexToBytes(padToEven(inp))
+  }
+}
 
 /****************  Borrowed from @chainsafe/ssz */
 // Caching this info costs about ~1000 bytes and speeds up toHexString() by x6

--- a/packages/util/test/bytes.spec.ts
+++ b/packages/util/test/bytes.spec.ts
@@ -24,6 +24,7 @@ import {
   unpadArray,
   unpadBytes,
   unpadHex,
+  unprefixedHexToBytes,
   validateNoLeadingZeroes,
   zeroAddress,
   zeros,
@@ -422,5 +423,21 @@ describe('hexToBytes', () => {
   it('should convert prefixed hex-strings', () => {
     const converted = hexToBytes('0x1')
     assert.deepEqual(converted, new Uint8Array([1]))
+  })
+})
+
+describe('unprefixedHexToBytes', () => {
+  it('should throw on prefixed strings', () => {
+    assert.throws(() => {
+      unprefixedHexToBytes('0xaabbcc112233')
+    })
+  })
+  it('should convert unprefixed hex-strings', () => {
+    const converted = unprefixedHexToBytes('1')
+    assert.deepEqual(converted, new Uint8Array([1]))
+  })
+  it('should convert unprefixed hex-strings', () => {
+    const converted = unprefixedHexToBytes('11')
+    assert.deepEqual(converted, new Uint8Array([17]))
   })
 })


### PR DESCRIPTION
This PR adds an extra guard to the proxy `hexToBytes` from `ethereum-cryptography`. That method supports both prefixed and unprefixed hex strings. The new (deprecated) `unprefixedHexToBytes` now explicitly only accepts unprefixed hex strings.

(Tests seem to pass locally so ready for review)

Follow up of #2845