### PR TITLE
monorepo: fix tsc errors

### DIFF
--- a/packages/block/test/header.spec.ts
+++ b/packages/block/test/header.spec.ts
@@ -457,9 +457,13 @@ describe('[Block]: Header functions', () => {
     const bcBlockGasLimitTestData = testData.tests.BlockGasLimit2p63m1
 
     for (const key of Object.keys(bcBlockGasLimitTestData)) {
-      const genesisRlp = toBytes(bcBlockGasLimitTestData[key].genesisRLP)
+      const genesisRlp = toBytes(
+        bcBlockGasLimitTestData[key as keyof typeof bcBlockGasLimitTestData].genesisRLP
+      )
       const parentBlock = Block.fromRLPSerializedBlock(genesisRlp, { common })
-      const blockRlp = toBytes(bcBlockGasLimitTestData[key].blocks[0].rlp)
+      const blockRlp = toBytes(
+        bcBlockGasLimitTestData[key as keyof typeof bcBlockGasLimitTestData].blocks[0].rlp
+      )
       const block = Block.fromRLPSerializedBlock(blockRlp, { common })
       assert.doesNotThrow(() => block.validateGasLimit(parentBlock))
     }

--- a/packages/common/test/hardforks.spec.ts
+++ b/packages/common/test/hardforks.spec.ts
@@ -218,20 +218,20 @@ describe('[Common]: Hardfork logic', () => {
     let c = new Common({ chain: Chain.Mainnet })
     const mainnetGenesisHash = chains[0][1]
     let msg = 'should calc correctly for chainstart (only genesis)'
-    assert.equal(c._calcForkHash(Hardfork.Chainstart, mainnetGenesisHash), '0xfc64ec04', msg)
+    assert.equal(c['_calcForkHash'](Hardfork.Chainstart, mainnetGenesisHash), '0xfc64ec04', msg)
 
     msg = 'should calc correctly for first applied HF'
-    assert.equal(c._calcForkHash(Hardfork.Homestead, mainnetGenesisHash), '0x97c2c34c', msg)
+    assert.equal(c['_calcForkHash'](Hardfork.Homestead, mainnetGenesisHash), '0x97c2c34c', msg)
 
     msg = 'should calc correctly for in-between applied HF'
-    assert.equal(c._calcForkHash(Hardfork.Byzantium, mainnetGenesisHash), '0xa00bc324', msg)
+    assert.equal(c['_calcForkHash'](Hardfork.Byzantium, mainnetGenesisHash), '0xa00bc324', msg)
 
     for (const [chain, genesisHash] of chains) {
       c = new Common({ chain })
       for (const hf of c.hardforks()) {
         if (typeof hf.forkHash === 'string') {
           const msg = `Verify forkHash calculation for: ${Chain[chain]} -> ${hf.name}`
-          assert.equal(c._calcForkHash(hf.name, genesisHash), hf.forkHash, msg)
+          assert.equal(c['_calcForkHash'](hf.name, genesisHash), hf.forkHash, msg)
         }
       }
     }

--- a/packages/common/test/timestamp.spec.ts
+++ b/packages/common/test/timestamp.spec.ts
@@ -100,7 +100,7 @@ describe('[Common]: Timestamp Hardfork logic', () => {
     for (const hf of c.hardforks()) {
       if (typeof hf.forkHash === 'string') {
         const msg = `Verify forkHash calculation for: ${hf.name}`
-        assert.equal(c._calcForkHash(hf.name, mainnetGenesisHash), hf.forkHash, msg)
+        assert.equal(c['_calcForkHash'](hf.name, mainnetGenesisHash), hf.forkHash, msg)
       }
     }
 

--- a/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
+++ b/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
@@ -90,10 +90,9 @@ describe('Precompiles: point evaluation', () => {
       }
 
       res = await pointEvaluation(optsWithInvalidCommitment)
-      assert.equal(
-        res.exceptionError?.error,
-        'kzg commitment does not match versioned hash',
-        'precompile throws when commitment doesnt match versioned hash'
+      assert.ok(
+        res.exceptionError?.error.match('kzg commitment does not match versioned hash'),
+        'precompile throws when commitment does not match versioned hash'
       )
     }
   })

--- a/packages/evm/test/runCall.spec.ts
+++ b/packages/evm/test/runCall.spec.ts
@@ -546,9 +546,8 @@ describe('RunCall tests', () => {
     }
 
     const res2 = await evm.runCall({ ...runCallArgs, skipBalance: false })
-    assert.equal(
-      res2.execResult.exceptionError?.error,
-      'insufficient balance',
+    assert.ok(
+      res2.execResult.exceptionError?.error.match('insufficient balance'),
       'runCall reverts when insufficient sender balance and skipBalance is false'
     )
   })

--- a/packages/statemanager/test/proofStateManager.spec.ts
+++ b/packages/statemanager/test/proofStateManager.spec.ts
@@ -132,7 +132,7 @@ describe('ProofStateManager', () => {
     }
     storageTrie.root(hexToBytes(storageRoot))
     const addressHex = bytesToUnprefixedHex(address.bytes)
-    stateManager._storageTries[addressHex] = storageTrie
+    stateManager['_storageTries'][addressHex] = storageTrie
     trie.root(stateRoot!)
 
     const proof = await stateManager.getProof(address, storageKeys)
@@ -172,7 +172,7 @@ describe('ProofStateManager', () => {
     }
     storageTrie.root(hexToBytes(storageRoot))
     const addressHex = bytesToHex(address.bytes)
-    stateManager._storageTries[addressHex] = storageTrie
+    stateManager['_storageTries'][addressHex] = storageTrie
     trie.root(stateRoot!)
 
     // tamper with account data
@@ -231,7 +231,7 @@ describe('ProofStateManager', () => {
     const storageTrie = new Trie({ useKeyHashing: true })
     storageTrie.root(hexToBytes(storageRoot))
     const addressHex = bytesToHex(address.bytes)
-    stateManager._storageTries[addressHex] = storageTrie
+    stateManager['_storageTries'][addressHex] = storageTrie
     trie.root(stateRoot!)
 
     // tamper with account data

--- a/packages/statemanager/test/stateManager.account.spec.ts
+++ b/packages/statemanager/test/stateManager.account.spec.ts
@@ -11,7 +11,7 @@ describe('StateManager -> General/Account', () => {
   for (const accountCacheOpts of [{ deactivate: false }, { deactivate: true }]) {
     it(`should set the state root to empty`, async () => {
       const stateManager = new DefaultStateManager({ accountCacheOpts })
-      assert.ok(equalsBytes(stateManager._trie.root(), KECCAK256_RLP), 'it has default root')
+      assert.ok(equalsBytes(stateManager['_trie'].root(), KECCAK256_RLP), 'it has default root')
 
       // commit some data to the trie
       const address = new Address(hexToBytes('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b'))
@@ -20,7 +20,7 @@ describe('StateManager -> General/Account', () => {
       await stateManager.putAccount(address, account)
       await stateManager.commit()
       await stateManager.flush()
-      assert.ok(!equalsBytes(stateManager._trie.root(), KECCAK256_RLP), 'it has a new root')
+      assert.ok(!equalsBytes(stateManager['_trie'].root(), KECCAK256_RLP), 'it has a new root')
 
       // set state root to empty trie root
       await stateManager.setStateRoot(KECCAK256_RLP)
@@ -84,7 +84,7 @@ describe('StateManager -> General/Account', () => {
       assert.equal(res1!.balance, BigInt(0xfff384))
 
       await stateManager.flush()
-      stateManager._accountCache?.clear()
+      stateManager['_accountCache']?.clear()
 
       const res2 = await stateManager.getAccount(address)
 

--- a/packages/statemanager/test/statemanager.spec.ts
+++ b/packages/statemanager/test/statemanager.spec.ts
@@ -7,7 +7,7 @@ describe('StateManager -> General', () => {
   it(`should instantiate`, async () => {
     const sm = new DefaultStateManager()
 
-    assert.deepEqual(sm._trie.root(), KECCAK256_RLP, 'it has default root')
+    assert.deepEqual(sm['_trie'].root(), KECCAK256_RLP, 'it has default root')
     const res = await sm.getStateRoot()
     assert.deepEqual(res, KECCAK256_RLP, 'it has default root')
   })

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -502,7 +502,7 @@ describe('Network wrapper deserialization test', () => {
       })
 
       const jsonData = deserializedTx.toJSON()
-      assert.deepEqual(txData, jsonData, 'toJSON should give correct json')
+      assert.deepEqual(txData, jsonData as any, 'toJSON should give correct json')
 
       assert.equal(deserializedTx.blobs?.length, 1, 'contains the correct number of blobs')
       assert.ok(equalsBytes(deserializedTx.blobs![0], blobs[0]), 'blobs should match')

--- a/packages/tx/test/transactionFactory.spec.ts
+++ b/packages/tx/test/transactionFactory.spec.ts
@@ -118,7 +118,11 @@ describe('[TransactionFactory]: Basic functions', () => {
           `round-trip serialization should match (${txType.name})`
         )
       } else {
-        assert.deepEqual(tx.raw(), rawTx, `round-trip raw() creation should match (${txType.name})`)
+        assert.deepEqual(
+          tx.raw(),
+          rawTx as Uint8Array[],
+          `round-trip raw() creation should match (${txType.name})`
+        )
       }
     }
   })

--- a/packages/vm/test/api/EIPs/eip-2930-accesslists.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-2930-accesslists.spec.ts
@@ -68,12 +68,12 @@ describe('EIP-2930 Optional Access Lists tests', () => {
     await vm.runTx({ tx: txnWithAccessList })
     assert.ok(trace[1][0] === 'SLOAD')
     let gasUsed = trace[1][1] - trace[2][1]
-    assert.equal(gasUsed, BigInt(100), 'charge warm sload gas')
+    assert.equal(gasUsed, 100, 'charge warm sload gas')
 
     trace = []
     await vm.runTx({ tx: txnWithoutAccessList, skipNonce: true })
     assert.ok(trace[1][0] === 'SLOAD')
     gasUsed = trace[1][1] - trace[2][1]
-    assert.equal(gasUsed, BigInt(2100), 'charge cold sload gas')
+    assert.equal(gasUsed, 2100, 'charge cold sload gas')
   })
 })

--- a/packages/vm/test/api/index.spec.ts
+++ b/packages/vm/test/api/index.spec.ts
@@ -36,7 +36,7 @@ describe('VM -> basic instantiation / boolean switches', () => {
     const vm = await VM.create()
     assert.ok(vm.stateManager)
     assert.deepEqual(
-      (vm.stateManager as DefaultStateManager)._trie.root(),
+      (vm.stateManager as DefaultStateManager)['_trie'].root(),
       KECCAK256_RLP,
       'it has default trie'
     )
@@ -46,7 +46,7 @@ describe('VM -> basic instantiation / boolean switches', () => {
   it('should be able to activate precompiles', async () => {
     const vm = await VM.create({ activatePrecompiles: true })
     assert.notDeepEqual(
-      (vm.stateManager as DefaultStateManager)._trie.root(),
+      (vm.stateManager as DefaultStateManager)['_trie'].root(),
       KECCAK256_RLP,
       'it has different root'
     )
@@ -165,7 +165,7 @@ describe('VM -> setHardfork, state (deprecated), blockchain', () => {
   it('should instantiate', async () => {
     const vm = await setupVM()
     assert.deepEqual(
-      (vm.stateManager as DefaultStateManager)._trie.root(),
+      (vm.stateManager as DefaultStateManager)['_trie'].root(),
       KECCAK256_RLP,
       'it has default trie'
     )

--- a/packages/wallet/test/index.spec.ts
+++ b/packages/wallet/test/index.spec.ts
@@ -230,7 +230,7 @@ describe('Wallet tests', () => {
         .split('')
         .map((v) => parseInt(v, 10))
       const obj: any = {}
-      zip(selectors, keys).forEach(([sel, k]: [number, string]) => {
+      ;(zip(selectors, keys) as [number, string][]).forEach(([sel, k]: [number, string]) => {
         if ((objs as any)[sel].hasOwnProperty(k) === true) {
           obj[k] = (objs as any)[sel][k]
         }


### PR DESCRIPTION
This PR fixes several errors that were showing up when running `npm run tsc --workspaces`. Likely a side-effect of some of the recent changes. 