### PR TITLE
evm/types: rename EVMCreateOpts -> EVMRunOpts

### DIFF
--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -59,7 +59,7 @@ if (isBrowser() === false) {
 /**
  * Options for instantiating a {@link EVM}.
  */
-export interface EVMCreateOpts {
+export interface EVMOpts {
   /**
    * Use a {@link Common} instance for EVM instantiation.
    *
@@ -203,7 +203,7 @@ export class EVM {
 
   protected _precompiles!: Map<string, PrecompileFunc>
 
-  protected readonly _optsCached: EVMCreateOpts
+  protected readonly _optsCached: EVMOpts
 
   public get precompiles() {
     return this._precompiles
@@ -239,13 +239,13 @@ export class EVM {
    *
    * @param opts EVM engine constructor options
    */
-  static async create(opts: EVMCreateOpts = {}): Promise<EVM> {
+  static async create(opts: EVMOpts = {}): Promise<EVM> {
     const evm = new this(opts)
     await evm.init()
     return evm
   }
 
-  constructor(opts: EVMCreateOpts) {
+  constructor(opts: EVMOpts) {
     this.events = new AsyncEventEmitter()
 
     this._optsCached = opts

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -22,9 +22,9 @@ export type AddOpcode = {
 export type CustomOpcode = AddOpcode | DeleteOpcode
 
 /**
- * Base optiosn for the `EVM.runCode()` / `EVM.runCall()` method.
+ * Base options for the `EVM.runCode()` / `EVM.runCall()` method.
  */
-interface EVMOpts {
+interface EVMRunOpts {
   /**
    * The `block` the `tx` belongs to. If omitted a default blank block will be used.
    */
@@ -79,7 +79,7 @@ interface EVMOpts {
   versionedHashes?: Uint8Array[]
 }
 
-export interface EVMRunCodeOpts extends EVMOpts {
+export interface EVMRunCodeOpts extends EVMRunOpts {
   /*
    * The initial program counter. Defaults to `0`
    */
@@ -89,7 +89,7 @@ export interface EVMRunCodeOpts extends EVMOpts {
 /**
  * Options for running a call (or create) operation with `EVM.runCall()`
  */
-export interface EVMRunCallOpts extends EVMOpts {
+export interface EVMRunCallOpts extends EVMRunOpts {
   /**
    * If the code location is a precompile.
    */


### PR DESCRIPTION
The original PR #2861 changed `EVMOpts` -> `EVMCreateOpts` (in two places, for both the constructor EVM as the argument type for `runCall` and `runCode`)

Now, the constructor argument for EVM is `EVMCreateOpts`. The runtime arguments are now `EVMRunCallOpts` and `EVMRunCreateOpts`, which have a base type which it extends: `EVMRunOpts`.

@holgerd77 If wanted I can also revert the `EVMCreateOpts` (so EVM constructor argument type) back to `EVMOpts`. (But, I think this type name is slightly more clear)