### PR TITLE
Fix imports

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -6,7 +6,7 @@ import {
   intToBytes,
   toType,
 } from '@ethereumjs/util'
-import crc from 'crc/crc32'
+import { crc32 as crc } from 'crc'
 import { EventEmitter } from 'events'
 
 import * as goerli from './chains/goerli.json'

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -1,6 +1,6 @@
 import { secp256k1 } from 'ethereum-cryptography/secp256k1.js'
 
-import { hexToBytes } from './bytes'
+import { hexToBytes } from './bytes.js'
 
 /**
  * 2^64-1

--- a/packages/util/src/internal.ts
+++ b/packages/util/src/internal.ts
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE
  */
 
-import { bytesToHex, utf8ToBytes } from './bytes'
+import { bytesToHex, utf8ToBytes } from './bytes.js'
 
 /**
  * Returns a `Boolean` on whether or not the a `String` starts with '0x'


### PR DESCRIPTION
Replaces one default export with a named export (to help with bundler compatibility) and also adds two missing file extensions to internal imports to `util/bytes`