### PR TITLE
Update `EthersStateManager` 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13712,14 +13712,6 @@
       "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
       "dev": true
     },
-    "node_modules/mcl-wasm": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-0.7.9.tgz",
-      "integrity": "sha512-iJIUcQWA88IJB/5L15GnJVnSQJmf/YaxxV6zRavv83HILHaJQb6y0iFyDMdDO0gN8X37tdxmAOrH/P8B6RB8sQ==",
-      "engines": {
-        "node": ">=8.9.0"
-      }
-    },
     "node_modules/md5-hex": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-3.0.1.tgz",
@@ -21337,7 +21329,6 @@
         "@ethereumjs/util": "^8.0.6",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.0.0",
-        "mcl-wasm": "^0.7.1",
         "rustbn-wasm": "^0.2.0"
       },
       "devDependencies": {
@@ -21536,8 +21527,7 @@
         "@ethereumjs/tx": "^4.1.2",
         "@ethereumjs/util": "^8.0.6",
         "debug": "^4.3.3",
-        "ethereum-cryptography": "^2.0.0",
-        "mcl-wasm": "^0.7.1"
+        "ethereum-cryptography": "^2.0.0"
       },
       "devDependencies": {
         "@ethersproject/abi": "^5.0.12",
@@ -23461,7 +23451,6 @@
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.0.0",
         "level": "^8.0.0",
-        "mcl-wasm": "^0.7.1",
         "memory-level": "^1.0.0",
         "minimist": "^1.2.5",
         "node-dir": "^0.1.17",
@@ -23595,7 +23584,6 @@
         "c-kzg": "^2.1.0",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.0.0",
-        "mcl-wasm": "^0.7.1",
         "minimist": "^1.2.5",
         "node-dir": "^0.1.17",
         "nyc": "^15.1.0",
@@ -32275,11 +32263,6 @@
       "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
       "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
       "dev": true
-    },
-    "mcl-wasm": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-0.7.9.tgz",
-      "integrity": "sha512-iJIUcQWA88IJB/5L15GnJVnSQJmf/YaxxV6zRavv83HILHaJQb6y0iFyDMdDO0gN8X37tdxmAOrH/P8B6RB8sQ=="
     },
     "md5-hex": {
       "version": "3.0.1",

--- a/packages/statemanager/examples/browser.html
+++ b/packages/statemanager/examples/browser.html
@@ -6,7 +6,7 @@
     <script type="module">
         import { Account, Address } from '@ethereumjs/util'
         import { DefaultStateManager } from '@ethereumjs/statemanager'
-        import { hexStringToBytes } from '@ethereumjs/util'
+        import { hexToBytes } from '@ethereumjs/util'
 
         const run = async () => {
             const stateManager = new DefaultStateManager()


### PR DESCRIPTION
Updates the `EthersStateManager` API and caching logic:

1. Updates `putAccount` to match `DefaultStateManager` API for deleting an account where `account` parameter is not provided
2. Updates `revert` logic to revert the storage cache and clear the `contractCache`
3.  Adds new tests to validate `revert` logic changes
4. Updates `MockProvider` API to deal with ethers `JsonProviderRpc` batched request logic