### PR TITLE
Ethereum cryptography version fix

### DIFF
--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -59,7 +59,7 @@
     "@ethereumjs/common": "^3.1.2",
     "@ethereumjs/rlp": "^4.0.1",
     "@ethereumjs/util": "^8.0.6",
-    "ethereum-cryptography": "^2.0.0"
+    "ethereum-cryptography": "2.0.0"
   },
   "peerDependencies": {
     "c-kzg": "^2.1.0"

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -91,7 +91,7 @@
   },
   "dependencies": {
     "@ethereumjs/rlp": "^4.0.1",
-    "ethereum-cryptography": "^2.0.0"
+    "ethereum-cryptography": "2.0.0"
   },
   "devDependencies": {
     "@types/bn.js": "^5.1.0",


### PR DESCRIPTION
removed carrot symbol, as new version not compatible.

<img width="1440" alt="Screenshot 2023-07-11 at 3 38 58 PM" src="https://github.com/torusresearch/metadata-helpers/assets/104764504/4d073fc2-bb58-4944-a58a-042527c8b400">
