### PR TITLE
client: improve new payload and fcu block executions

### DIFF
--- a/packages/client/src/blockchain/chain.ts
+++ b/packages/client/src/blockchain/chain.ts
@@ -54,6 +54,12 @@ export interface ChainBlocks {
   safe: Block | null
 
   /**
+   * The header signalled as `vm` head
+   * This corresponds to the last executed block in the canonical chain
+   */
+  vm: Block | null
+
+  /**
    * The total difficulty of the blockchain
    */
   td: bigint
@@ -74,16 +80,22 @@ export interface ChainHeaders {
   latest: BlockHeader | null
 
   /**
-   * The block as signalled `finalized` in the fcU
+   * The header as signalled `finalized` in the fcU
    * This corresponds to the last finalized beacon block
    */
   finalized: BlockHeader | null
 
   /**
-   * The block as signalled `safe` in the fcU
+   * The header as signalled `safe` in the fcU
    * This corresponds to the last justified beacon block
    */
   safe: BlockHeader | null
+
+  /**
+   * The header signalled as `vm` head
+   * This corresponds to the last executed block in the canonical chain
+   */
+  vm: BlockHeader | null
 
   /**
    * The total difficulty of the headerchain
@@ -112,6 +124,7 @@ export class Chain {
     latest: null,
     finalized: null,
     safe: null,
+    vm: null,
     td: BigInt(0),
     height: BigInt(0),
   }
@@ -120,6 +133,7 @@ export class Chain {
     latest: null,
     finalized: null,
     safe: null,
+    vm: null,
     td: BigInt(0),
     height: BigInt(0),
   }
@@ -174,6 +188,7 @@ export class Chain {
       latest: null,
       finalized: null,
       safe: null,
+      vm: null,
       td: BigInt(0),
       height: BigInt(0),
     }
@@ -181,6 +196,7 @@ export class Chain {
       latest: null,
       finalized: null,
       safe: null,
+      vm: null,
       td: BigInt(0),
       height: BigInt(0),
     }
@@ -263,6 +279,7 @@ export class Chain {
       latest: null,
       finalized: null,
       safe: null,
+      vm: null,
       td: BigInt(0),
       height: BigInt(0),
     }
@@ -270,6 +287,7 @@ export class Chain {
       latest: null,
       finalized: null,
       safe: null,
+      vm: null,
       td: BigInt(0),
       height: BigInt(0),
     }
@@ -279,10 +297,12 @@ export class Chain {
     // before they can be saved in chain
     headers.finalized = (await this.getCanonicalFinalizedBlock()).header
     headers.safe = (await this.getCanonicalSafeBlock()).header
+    headers.vm = (await this.getCanonicalVmHead()).header
 
     blocks.latest = await this.getCanonicalHeadBlock()
     blocks.finalized = await this.getCanonicalFinalizedBlock()
     blocks.safe = await this.getCanonicalSafeBlock()
+    blocks.vm = await this.getCanonicalVmHead()
 
     headers.height = headers.latest.number
     blocks.height = blocks.latest.header.number
@@ -498,6 +518,14 @@ export class Chain {
   async getCanonicalFinalizedBlock(): Promise<Block> {
     if (!this.opened) throw new Error('Chain closed')
     return this.blockchain.getIteratorHead('finalized')
+  }
+
+  /**
+   * Gets the latest block in the canonical chain
+   */
+  async getCanonicalVmHead(): Promise<Block> {
+    if (!this.opened) throw new Error('Chain closed')
+    return this.blockchain.getIteratorHead()
   }
 
   /**

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -293,6 +293,16 @@ export interface ConfigOptions {
    */
   syncedStateRemovalPeriod?: number
 
+  /**
+   * Max depth for parent lookups in engine's newPayload and forkchoiceUpdated
+   */
+  engineParentLookupMaxDepth?: number
+
+  /**
+   * Max blocks including unexecuted parents to be executed in engine's newPayload
+   */
+  engineNewpayloadMaxExecute?: number
+
   maxStorageRange?: bigint
 }
 
@@ -331,6 +341,9 @@ export class Config {
   // Larger ranges used for storage slots since assumption is slots should be much sparser than accounts
   public static readonly MAX_STORAGE_RANGE = (BigInt(2) ** BigInt(256) - BigInt(1)) / BigInt(10)
   public static readonly SYNCED_STATE_REMOVAL_PERIOD = 60000
+  // engine new payload calls can come in batch of 64, keeping 128 as the lookup factor
+  public static readonly ENGINE_PARENTLOOKUP_MAX_DEPTH = 128
+  public static readonly ENGINE_NEWPAYLOAD_MAX_EXECUTE = 2
 
   public readonly logger: Logger
   public readonly syncmode: SyncMode
@@ -371,6 +384,8 @@ export class Config {
   public readonly maxAccountRange: bigint
   public readonly maxStorageRange: bigint
   public readonly syncedStateRemovalPeriod: number
+  public readonly engineParentLookupMaxDepth: number
+  public readonly engineNewpayloadMaxExecute: number
 
   public readonly disableBeaconSync: boolean
   public readonly forceSnapSync: boolean
@@ -432,6 +447,10 @@ export class Config {
     this.maxStorageRange = options.maxStorageRange ?? Config.MAX_STORAGE_RANGE
     this.syncedStateRemovalPeriod =
       options.syncedStateRemovalPeriod ?? Config.SYNCED_STATE_REMOVAL_PERIOD
+    this.engineParentLookupMaxDepth =
+      options.engineParentLookupMaxDepth ?? Config.ENGINE_PARENTLOOKUP_MAX_DEPTH
+    this.engineNewpayloadMaxExecute =
+      options.engineNewpayloadMaxExecute ?? Config.ENGINE_NEWPAYLOAD_MAX_EXECUTE
 
     this.disableBeaconSync = options.disableBeaconSync ?? false
     this.forceSnapSync = options.forceSnapSync ?? false

--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -154,38 +154,46 @@ export class VMExecution extends Execution {
    * the entire procedure.
    * @param receipts If we built this block, pass the receipts to not need to run the block again
    */
-  async runWithoutSetHead(opts: RunBlockOpts, receipts?: TxReceipt[]): Promise<void> {
-    return this.runWithLock<void>(async () => {
-      const { block, root } = opts
+  async runWithoutSetHead(opts: RunBlockOpts, receipts?: TxReceipt[]): Promise<boolean> {
+    if (this.running || !this.started || this.config.shutdown) return false
+    this.running = true
 
-      if (receipts === undefined) {
-        // Check if we need to pass flag to clear statemanager cache or not
-        const prevVMStateRoot = await this.vm.stateManager.getStateRoot()
-        // If root is not provided its mean to be run on the same set state
-        const parentState = root ?? prevVMStateRoot
-        const clearCache = !equalsBytes(prevVMStateRoot, parentState)
+    try {
+      await this.runWithLock<void>(async () => {
+        const { block, root } = opts
 
-        const result = await this.vm.runBlock({ clearCache, ...opts })
-        receipts = result.receipts
-      }
-      if (receipts !== undefined) {
-        // Save receipts
-        this.pendingReceipts?.set(bytesToHex(block.hash()), receipts)
-      }
-      // Bypass updating head by using blockchain db directly
-      const [hash, num] = [block.hash(), block.header.number]
-      const td =
-        (await this.chain.getTd(block.header.parentHash, block.header.number - BigInt(1))) +
-        block.header.difficulty
+        if (receipts === undefined) {
+          // Check if we need to pass flag to clear statemanager cache or not
+          const prevVMStateRoot = await this.vm.stateManager.getStateRoot()
+          // If root is not provided its mean to be run on the same set state
+          const parentState = root ?? prevVMStateRoot
+          const clearCache = !equalsBytes(prevVMStateRoot, parentState)
 
-      await this.chain.blockchain.dbManager.batch([
-        DBSetTD(td, num, hash),
-        ...DBSetBlockOrHeader(block),
-        DBSetHashToNumber(hash, num),
-        // Skip the op for number to hash to not alter canonical chain
-        ...DBSaveLookups(hash, num, true),
-      ])
-    })
+          const result = await this.vm.runBlock({ clearCache, ...opts })
+          receipts = result.receipts
+        }
+        if (receipts !== undefined) {
+          // Save receipts
+          this.pendingReceipts?.set(bytesToHex(block.hash()), receipts)
+        }
+        // Bypass updating head by using blockchain db directly
+        const [hash, num] = [block.hash(), block.header.number]
+        const td =
+          (await this.chain.getTd(block.header.parentHash, block.header.number - BigInt(1))) +
+          block.header.difficulty
+
+        await this.chain.blockchain.dbManager.batch([
+          DBSetTD(td, num, hash),
+          ...DBSetBlockOrHeader(block),
+          DBSetHashToNumber(hash, num),
+          // Skip the op for number to hash to not alter canonical chain
+          ...DBSaveLookups(hash, num, true),
+        ])
+      })
+      return true
+    } finally {
+      this.running = false
+    }
   }
 
   /**
@@ -271,168 +279,170 @@ export class VMExecution extends Execution {
     if (this.running || !this.started || this.config.shutdown) return 0
     this.running = true
 
-    // run inside a lock so as to not be entangle with runWithoutSetHead or setHead
-    return this.runWithLock<number>(async () => {
-      let numExecuted: number | null | undefined = undefined
+    try {
+      // 1. await the run so as to switch this.running to false even in case of errors
+      // 2. run inside a lock so as to not be entangle with runWithoutSetHead or setHead
+      return await this.runWithLock<number>(async () => {
+        let numExecuted: number | null | undefined = undefined
 
-      const { blockchain } = this.vm
-      if (typeof blockchain.getIteratorHead !== 'function') {
-        throw new Error('cannot get iterator head: blockchain has no getIteratorHead function')
-      }
-      let startHeadBlock = await blockchain.getIteratorHead()
-      if (typeof blockchain.getCanonicalHeadBlock !== 'function') {
-        throw new Error(
-          'cannot get iterator head: blockchain has no getCanonicalHeadBlock function'
+        const { blockchain } = this.vm
+        if (typeof blockchain.getIteratorHead !== 'function') {
+          throw new Error('cannot get iterator head: blockchain has no getIteratorHead function')
+        }
+        let startHeadBlock = await blockchain.getIteratorHead()
+        if (typeof blockchain.getCanonicalHeadBlock !== 'function') {
+          throw new Error(
+            'cannot get iterator head: blockchain has no getCanonicalHeadBlock function'
+          )
+        }
+        let canonicalHead = await blockchain.getCanonicalHeadBlock()
+
+        this.config.logger.debug(
+          `Running execution startHeadBlock=${startHeadBlock?.header.number} canonicalHead=${canonicalHead?.header.number} loop=${loop}`
         )
-      }
-      let canonicalHead = await blockchain.getCanonicalHeadBlock()
 
-      this.config.logger.debug(
-        `Running execution startHeadBlock=${startHeadBlock?.header.number} canonicalHead=${canonicalHead?.header.number} loop=${loop}`
-      )
+        let headBlock: Block | undefined
+        let parentState: Uint8Array | undefined
+        let errorBlock: Block | undefined
 
-      let headBlock: Block | undefined
-      let parentState: Uint8Array | undefined
-      let errorBlock: Block | undefined
+        // flag for vm to clear statemanager cache on runBlock
+        //  i) If on start of iterator the last run state is not same as the block's parent
+        //  ii) If reorg happens on the block iterator
+        let clearCache = false
 
-      // flag for vm to clear statemanager cache on runBlock
-      //  i) If on start of iterator the last run state is not same as the block's parent
-      //  ii) If reorg happens on the block iterator
-      let clearCache = false
+        while (
+          this.started &&
+          !this.config.shutdown &&
+          (!runOnlybatched ||
+            (runOnlybatched &&
+              canonicalHead.header.number - startHeadBlock.header.number >=
+                BigInt(this.config.numBlocksPerIteration))) &&
+          (numExecuted === undefined ||
+            (loop && numExecuted === this.config.numBlocksPerIteration)) &&
+          equalsBytes(startHeadBlock.hash(), canonicalHead.hash()) === false
+        ) {
+          let txCounter = 0
+          headBlock = undefined
+          parentState = undefined
+          errorBlock = undefined
+          this.vmPromise = blockchain
+            .iterator(
+              'vm',
+              async (block: Block, reorg: boolean) => {
+                // determine starting state for block run
+                // if we are just starting or if a chain reorg has happened
+                if (headBlock === undefined || reorg) {
+                  const headBlock = await blockchain.getBlock(block.header.parentHash)
+                  parentState = headBlock.header.stateRoot
 
-      while (
-        this.started &&
-        !this.config.shutdown &&
-        (!runOnlybatched ||
-          (runOnlybatched &&
-            canonicalHead.header.number - startHeadBlock.header.number >=
-              BigInt(this.config.numBlocksPerIteration))) &&
-        (numExecuted === undefined ||
-          (loop && numExecuted === this.config.numBlocksPerIteration)) &&
-        equalsBytes(startHeadBlock.hash(), canonicalHead.hash()) === false
-      ) {
-        let txCounter = 0
-        headBlock = undefined
-        parentState = undefined
-        errorBlock = undefined
-        this.vmPromise = blockchain
-          .iterator(
-            'vm',
-            async (block: Block, reorg: boolean) => {
-              // determine starting state for block run
-              // if we are just starting or if a chain reorg has happened
-              if (headBlock === undefined || reorg) {
-                const headBlock = await blockchain.getBlock(block.header.parentHash)
-                parentState = headBlock.header.stateRoot
-
-                if (reorg) {
-                  clearCache = true
-                  this.config.logger.info(
-                    `VM run: Chain reorged, setting new head to block number=${headBlock.header.number} clearCache=${clearCache}.`
-                  )
+                  if (reorg) {
+                    clearCache = true
+                    this.config.logger.info(
+                      `VM run: Chain reorged, setting new head to block number=${headBlock.header.number} clearCache=${clearCache}.`
+                    )
+                  } else {
+                    const prevVMStateRoot = await this.vm.stateManager.getStateRoot()
+                    clearCache = !equalsBytes(prevVMStateRoot, parentState)
+                  }
                 } else {
-                  const prevVMStateRoot = await this.vm.stateManager.getStateRoot()
-                  clearCache = !equalsBytes(prevVMStateRoot, parentState)
+                  // Continuation of last vm run, no need to clearCache
+                  clearCache = false
                 }
-              } else {
-                // Continuation of last vm run, no need to clearCache
-                clearCache = false
-              }
 
-              // run block, update head if valid
-              try {
-                const { number, timestamp } = block.header
-                if (typeof blockchain.getTotalDifficulty !== 'function') {
-                  throw new Error(
-                    'cannot get iterator head: blockchain has no getTotalDifficulty function'
-                  )
-                }
-                const td = await blockchain.getTotalDifficulty(block.header.parentHash)
+                // run block, update head if valid
+                try {
+                  const { number, timestamp } = block.header
+                  if (typeof blockchain.getTotalDifficulty !== 'function') {
+                    throw new Error(
+                      'cannot get iterator head: blockchain has no getTotalDifficulty function'
+                    )
+                  }
+                  const td = await blockchain.getTotalDifficulty(block.header.parentHash)
 
-                const hardfork = this.config.execCommon.getHardforkBy({
-                  blockNumber: number,
-                  td,
-                  timestamp,
-                })
-                if (hardfork !== this.hardfork) {
-                  const hash = short(block.hash())
-                  this.config.logger.info(
-                    `Execution hardfork switch on block number=${number} hash=${hash} old=${this.hardfork} new=${hardfork}`
-                  )
-                  this.hardfork = this.config.execCommon.setHardforkBy({
+                  const hardfork = this.config.execCommon.getHardforkBy({
                     blockNumber: number,
                     td,
                     timestamp,
                   })
+                  if (hardfork !== this.hardfork) {
+                    const hash = short(block.hash())
+                    this.config.logger.info(
+                      `Execution hardfork switch on block number=${number} hash=${hash} old=${this.hardfork} new=${hardfork}`
+                    )
+                    this.hardfork = this.config.execCommon.setHardforkBy({
+                      blockNumber: number,
+                      td,
+                      timestamp,
+                    })
+                  }
+                  let skipBlockValidation = false
+                  if (this.config.execCommon.consensusType() === ConsensusType.ProofOfAuthority) {
+                    // Block validation is redundant here and leads to consistency problems
+                    // on PoA clique along blockchain-including validation checks
+                    // (signer states might have moved on when sync is ahead)
+                    skipBlockValidation = true
+                  }
+
+                  // we are skipping header validation because the block has been picked from the
+                  // blockchain and header should have already been validated while putBlock
+                  if (!this.started) {
+                    throw Error('Execution stopped')
+                  }
+
+                  const beforeTS = Date.now()
+                  this.stats(this.vm)
+                  const result = await this.vm.runBlock({
+                    block,
+                    root: parentState,
+                    clearCache,
+                    skipBlockValidation,
+                    skipHeaderValidation: true,
+                  })
+                  const afterTS = Date.now()
+                  const diffSec = Math.round((afterTS - beforeTS) / 1000)
+
+                  if (diffSec > this.MAX_TOLERATED_BLOCK_TIME) {
+                    const msg = `Slow block execution for block num=${
+                      block.header.number
+                    } hash=${bytesToHex(block.hash())} txs=${block.transactions.length} gasUsed=${
+                      result.gasUsed
+                    } time=${diffSec}secs`
+                    this.config.logger.warn(msg)
+                  }
+
+                  void this.receiptsManager?.saveReceipts(block, result.receipts)
+
+                  txCounter += block.transactions.length
+                  // set as new head block
+                  headBlock = block
+                  parentState = block.header.stateRoot
+                } catch (error: any) {
+                  // Store error block and throw which will make iterator stop, exit and save
+                  // last successfully executed head as vmHead
+                  errorBlock = block
+                  throw error
                 }
-                let skipBlockValidation = false
-                if (this.config.execCommon.consensusType() === ConsensusType.ProofOfAuthority) {
-                  // Block validation is redundant here and leads to consistency problems
-                  // on PoA clique along blockchain-including validation checks
-                  // (signer states might have moved on when sync is ahead)
-                  skipBlockValidation = true
-                }
-
-                // we are skipping header validation because the block has been picked from the
-                // blockchain and header should have already been validated while putBlock
-                if (!this.started) {
-                  throw Error('Execution stopped')
-                }
-
-                const beforeTS = Date.now()
-                this.stats(this.vm)
-                const result = await this.vm.runBlock({
-                  block,
-                  root: parentState,
-                  clearCache,
-                  skipBlockValidation,
-                  skipHeaderValidation: true,
-                })
-                const afterTS = Date.now()
-                const diffSec = Math.round((afterTS - beforeTS) / 1000)
-
-                if (diffSec > this.MAX_TOLERATED_BLOCK_TIME) {
-                  const msg = `Slow block execution for block num=${
-                    block.header.number
-                  } hash=${bytesToHex(block.hash())} txs=${block.transactions.length} gasUsed=${
-                    result.gasUsed
-                  } time=${diffSec}secs`
-                  this.config.logger.warn(msg)
-                }
-
-                void this.receiptsManager?.saveReceipts(block, result.receipts)
-
-                txCounter += block.transactions.length
-                // set as new head block
-                headBlock = block
-                parentState = block.header.stateRoot
-              } catch (error: any) {
-                // Store error block and throw which will make iterator stop, exit and save
-                // last successfully executed head as vmHead
-                errorBlock = block
-                throw error
-              }
-            },
-            this.config.numBlocksPerIteration,
-            // release lock on this callback so other blockchain ops can happen while this block is being executed
-            true
-          )
-          // Ensure to catch and not throw as this would lead to unCaughtException with process exit
-          .catch(async (error) => {
-            if (errorBlock !== undefined) {
-              // TODO: determine if there is a way to differentiate between the cases
-              // a) a bad block is served by a bad peer -> delete the block and restart sync
-              //    sync from parent block
-              // b) there is a consensus error in the VM -> stop execution until the
-              //    consensus error is fixed
-              //
-              // For now only option b) is implemented, atm this is a very likely case
-              // and the implemented behavior helps on debugging.
-              // Option a) would likely need some block comparison of the same blocks
-              // received by different peer to decide on bad blocks
-              // (minimal solution: receive block from 3 peers and take block if there is
-              // is equally served from at least 2 peers)
-              /*try {
+              },
+              this.config.numBlocksPerIteration,
+              // release lock on this callback so other blockchain ops can happen while this block is being executed
+              true
+            )
+            // Ensure to catch and not throw as this would lead to unCaughtException with process exit
+            .catch(async (error) => {
+              if (errorBlock !== undefined) {
+                // TODO: determine if there is a way to differentiate between the cases
+                // a) a bad block is served by a bad peer -> delete the block and restart sync
+                //    sync from parent block
+                // b) there is a consensus error in the VM -> stop execution until the
+                //    consensus error is fixed
+                //
+                // For now only option b) is implemented, atm this is a very likely case
+                // and the implemented behavior helps on debugging.
+                // Option a) would likely need some block comparison of the same blocks
+                // received by different peer to decide on bad blocks
+                // (minimal solution: receive block from 3 peers and take block if there is
+                // is equally served from at least 2 peers)
+                /*try {
             // remove invalid block
               await blockchain!.delBlock(block.header.hash())
             } catch (error: any) {
@@ -451,70 +461,76 @@ export class VMExecution extends Execution {
               )
               this.config.execCommon.setHardforkBy({ blockNumber, td })
             }*/
-              // Option a): set iterator head to the parent block so that an
-              // error can repeatedly processed for debugging
-              const { number } = errorBlock.header
-              const hash = short(errorBlock.hash())
-              this.config.logger.warn(
-                `Execution of block number=${number} hash=${hash} hardfork=${this.hardfork} failed:\n${error}`
-              )
-              if (this.config.debugCode) {
-                await debugCodeReplayBlock(this, errorBlock)
+                // Option a): set iterator head to the parent block so that an
+                // error can repeatedly processed for debugging
+                const { number } = errorBlock.header
+                const hash = short(errorBlock.hash())
+                this.config.logger.warn(
+                  `Execution of block number=${number} hash=${hash} hardfork=${this.hardfork} failed:\n${error}`
+                )
+                if (this.config.debugCode) {
+                  await debugCodeReplayBlock(this, errorBlock)
+                }
+                this.config.events.emit(Event.SYNC_EXECUTION_VM_ERROR, error)
+                const actualExecuted = Number(
+                  errorBlock.header.number - startHeadBlock.header.number
+                )
+                return actualExecuted
+              } else {
+                this.config.logger.error(`VM execution failed with error`, error)
+                return null
               }
-              this.config.events.emit(Event.SYNC_EXECUTION_VM_ERROR, error)
-              const actualExecuted = Number(errorBlock.header.number - startHeadBlock.header.number)
-              return actualExecuted
+            })
+
+          numExecuted = await this.vmPromise
+          if (numExecuted !== null) {
+            let endHeadBlock
+            if (typeof this.vm.blockchain.getIteratorHead === 'function') {
+              endHeadBlock = await this.vm.blockchain.getIteratorHead('vm')
             } else {
-              this.config.logger.error(`VM execution failed with error`, error)
-              return null
+              throw new Error(
+                'cannot get iterator head: blockchain has no getIteratorHead function'
+              )
             }
-          })
 
-        numExecuted = await this.vmPromise
-        if (numExecuted !== null) {
-          let endHeadBlock
-          if (typeof this.vm.blockchain.getIteratorHead === 'function') {
-            endHeadBlock = await this.vm.blockchain.getIteratorHead('vm')
-          } else {
-            throw new Error('cannot get iterator head: blockchain has no getIteratorHead function')
+            if (typeof numExecuted === 'number' && numExecuted > 0) {
+              const firstNumber = startHeadBlock.header.number
+              const firstHash = short(startHeadBlock.hash())
+              const lastNumber = endHeadBlock.header.number
+              const lastHash = short(endHeadBlock.hash())
+              const baseFeeAdd =
+                this.config.execCommon.gteHardfork(Hardfork.London) === true
+                  ? `baseFee=${endHeadBlock.header.baseFeePerGas} `
+                  : ''
+              const tdAdd =
+                this.config.execCommon.gteHardfork(Hardfork.Paris) === true
+                  ? ''
+                  : `td=${this.chain.blocks.td} `
+              this.config.logger.info(
+                `Executed blocks count=${numExecuted} first=${firstNumber} hash=${firstHash} ${tdAdd}${baseFeeAdd}hardfork=${this.hardfork} last=${lastNumber} hash=${lastHash} txs=${txCounter}`
+              )
+            } else {
+              this.config.logger.debug(
+                `No blocks executed past chain head hash=${short(endHeadBlock.hash())} number=${
+                  endHeadBlock.header.number
+                }`
+              )
+            }
+            startHeadBlock = endHeadBlock
+            if (typeof this.vm.blockchain.getCanonicalHeadBlock !== 'function') {
+              throw new Error(
+                'cannot get iterator head: blockchain has no getCanonicalHeadBlock function'
+              )
+            }
+            canonicalHead = await this.vm.blockchain.getCanonicalHeadBlock()
           }
-
-          if (typeof numExecuted === 'number' && numExecuted > 0) {
-            const firstNumber = startHeadBlock.header.number
-            const firstHash = short(startHeadBlock.hash())
-            const lastNumber = endHeadBlock.header.number
-            const lastHash = short(endHeadBlock.hash())
-            const baseFeeAdd =
-              this.config.execCommon.gteHardfork(Hardfork.London) === true
-                ? `baseFee=${endHeadBlock.header.baseFeePerGas} `
-                : ''
-            const tdAdd =
-              this.config.execCommon.gteHardfork(Hardfork.Paris) === true
-                ? ''
-                : `td=${this.chain.blocks.td} `
-            this.config.logger.info(
-              `Executed blocks count=${numExecuted} first=${firstNumber} hash=${firstHash} ${tdAdd}${baseFeeAdd}hardfork=${this.hardfork} last=${lastNumber} hash=${lastHash} txs=${txCounter}`
-            )
-          } else {
-            this.config.logger.debug(
-              `No blocks executed past chain head hash=${short(endHeadBlock.hash())} number=${
-                endHeadBlock.header.number
-              }`
-            )
-          }
-          startHeadBlock = endHeadBlock
-          if (typeof this.vm.blockchain.getCanonicalHeadBlock !== 'function') {
-            throw new Error(
-              'cannot get iterator head: blockchain has no getCanonicalHeadBlock function'
-            )
-          }
-          canonicalHead = await this.vm.blockchain.getCanonicalHeadBlock()
         }
-      }
 
+        return numExecuted ?? 0
+      })
+    } finally {
       this.running = false
-      return numExecuted ?? 0
-    })
+    }
   }
 
   /**

--- a/packages/client/src/rpc/modules/engine.ts
+++ b/packages/client/src/rpc/modules/engine.ts
@@ -631,19 +631,17 @@ export class Engine {
     }
 
     blocks.push(block)
-    let areBlocksPreExecuted = true
 
     let lastBlock: Block
     try {
       for (const [i, block] of blocks.entries()) {
         lastBlock = block
-        const bHash = bytesToHex(block.hash())
+        const bHash = block.hash()
         const isBlockExecuted =
-          (this.remoteBlocks.get(bHash.slice(2)) ??
-            (await validExecutedChainBlock(hexToBytes(bHash), this.chain))) !== null
+          (this.remoteBlocks.get(bytesToUnprefixedHex(bHash)) ??
+            (await validExecutedChainBlock(bHash, this.chain))) !== null
 
-        areBlocksPreExecuted = areBlocksPreExecuted && isBlockExecuted
-        if (!areBlocksPreExecuted) {
+        if (!isBlockExecuted) {
           const root = (i > 0 ? blocks[i - 1] : await this.chain.getBlock(block.header.parentHash))
             .header.stateRoot
           await this.execution.runWithoutSetHead({

--- a/packages/client/src/rpc/modules/engine.ts
+++ b/packages/client/src/rpc/modules/engine.ts
@@ -553,11 +553,9 @@ export class Engine {
     // is pow block which this client would like to mint and attempt proposing it
     const optimisticLookup = await this.service.beaconSync?.extendChain(block)
 
-    // we should check block exits because an invalid crafted block with valid block hash with same stateroot
-    // as parent can be send
-    //
-    // TODO: if not in remoteBlocks, check where the vmHead is and see if parent's state root and blocks
-    // stateroot differ to see if this block was actually executed
+    // we should check if the block exits executed in remoteBlocks or in chain as a check that stateroot
+    // exists in statemanager is not sufficient because an invalid crafted block with valid block hash with
+    // some pre-executed stateroot can be send
     const executedBlockExists =
       this.remoteBlocks.get(blockHash.slice(2)) ??
       (await validExecutedChainBlock(hexToBytes(blockHash), this.chain))

--- a/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
+++ b/packages/client/test/rpc/engine/forkchoiceUpdatedV1.spec.ts
@@ -212,14 +212,14 @@ tape(`${method}: call with deep parent lookup`, async (t) => {
   let expectRes = (res: any) => {
     t.equal(res.body.result.payloadStatus.status, 'VALID')
   }
-  await baseRequest(t, server, req, 200, expectRes, false)
+  await baseRequest(t, server, req, 200, expectRes, false, false)
 
   for (let i = 0; i < 3; i++) {
     const req = params('engine_newPayloadV1', [blocks[i]])
     const expectRes = (res: any) => {
       t.equal(res.body.result.status, 'VALID')
     }
-    await baseRequest(t, server, req, 200, expectRes, false)
+    await baseRequest(t, server, req, 200, expectRes, false, false)
   }
 
   // Now set the head to the last hash
@@ -237,7 +237,7 @@ tape(`${method}: call with deep parent lookup and with stored safe block hash`, 
   let expectRes = (res: any) => {
     t.equal(res.body.result.payloadStatus.status, 'VALID')
   }
-  await baseRequest(t, server, req, 200, expectRes, false)
+  await baseRequest(t, server, req, 200, expectRes, false, false)
 
   await batchBlocks(t, server)
 
@@ -285,7 +285,7 @@ tape(`${method}: latest block after reorg`, async (t) => {
   let expectRes = (res: any) => {
     t.equal(res.body.result.payloadStatus.status, 'VALID')
   }
-  await baseRequest(t, server, req, 200, expectRes, false)
+  await baseRequest(t, server, req, 200, expectRes, false, false)
 
   await batchBlocks(t, server)
 
@@ -299,20 +299,20 @@ tape(`${method}: latest block after reorg`, async (t) => {
   expectRes = (res: any) => {
     t.equal(res.body.result.payloadStatus.status, 'VALID')
   }
-  await baseRequest(t, server, req, 200, expectRes, false)
+  await baseRequest(t, server, req, 200, expectRes, false, false)
 
   // check safe and finalized
   req = params('eth_getBlockByNumber', ['finalized', false])
   expectRes = (res: any) => {
     t.equal(res.body.result.number, '0x0', 'finalized should be set to genesis')
   }
-  await baseRequest(t, server, req, 200, expectRes, false)
+  await baseRequest(t, server, req, 200, expectRes, false, false)
 
   req = params('eth_getBlockByNumber', ['safe', false])
   expectRes = (res: any) => {
     t.equal(res.body.result.number, '0x1', 'safe should be set to first block')
   }
-  await baseRequest(t, server, req, 200, expectRes, false)
+  await baseRequest(t, server, req, 200, expectRes, false, false)
 
   req = params(method, [
     {

--- a/packages/client/test/rpc/engine/getPayloadV1.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadV1.spec.ts
@@ -36,13 +36,13 @@ tape(`${method}: call with known payload`, async (t) => {
   let expectRes = (res: any) => {
     payloadId = res.body.result.payloadId
   }
-  await baseRequest(t, server, req, 200, expectRes, false)
+  await baseRequest(t, server, req, 200, expectRes, false, false)
 
   req = params(method, [payloadId])
   expectRes = (res: any) => {
     t.equal(res.body.result.blockNumber, '0x1')
   }
-  await baseRequest(t, server, req, 200, expectRes, false)
+  await baseRequest(t, server, req, 200, expectRes, false, false)
 
   expectRes = (res: any) => {
     t.equal(res.body.result.payloadStatus.status, 'VALID')

--- a/packages/client/test/rpc/engine/getPayloadV3.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadV3.spec.ts
@@ -87,7 +87,7 @@ tape(`${method}: call with known payload`, async (t) => {
     payloadId = res.body.result.payloadId
     t.ok(payloadId !== undefined && payloadId !== null, 'valid payloadId should be received')
   }
-  await baseRequest(t, server, req, 200, expectRes, false)
+  await baseRequest(t, server, req, 200, expectRes, false, false)
 
   const txBlobs = getBlobs('hello world')
   const txCommitments = blobsToCommitments(txBlobs)
@@ -132,7 +132,7 @@ tape(`${method}: call with known payload`, async (t) => {
     t.equal(blobs[0], bytesToHex(txBlobs[0]), 'blob should match')
   }
 
-  await baseRequest(t, server, req, 200, expectRes, false)
+  await baseRequest(t, server, req, 200, expectRes)
   DefaultStateManager.prototype.setStateRoot = originalSetStateRoot
   DefaultStateManager.prototype.shallowCopy = originalStateManagerCopy
 })

--- a/packages/client/test/rpc/engine/newPayloadV1.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV1.spec.ts
@@ -31,7 +31,7 @@ export const batchBlocks = async (t: Test, server: HttpServer, inputBlocks: any[
     const expectRes = (res: any) => {
       t.equal(res.body.result.status, 'VALID')
     }
-    await baseRequest(t, server, req, 200, expectRes, false)
+    await baseRequest(t, server, req, 200, expectRes, false, false)
   }
 }
 
@@ -111,13 +111,13 @@ tape(
     let expectRes = (res: any) => {
       t.equal(res.body.result.status, 'ACCEPTED')
     }
-    await baseRequest(t, server, req, 200, expectRes, false)
+    await baseRequest(t, server, req, 200, expectRes, false, false)
 
     req = params(method, [blocks[0]])
     expectRes = (res: any) => {
       t.equal(res.body.result.status, 'VALID')
     }
-    await baseRequest(t, server, req, 200, expectRes, false)
+    await baseRequest(t, server, req, 200, expectRes, false, false)
 
     const state = {
       headBlockHash: blocks[1].blockHash,

--- a/packages/client/test/rpc/engine/newPayloadV2.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV2.spec.ts
@@ -25,7 +25,7 @@ export const batchBlocks = async (t: Test, server: HttpServer) => {
     const expectRes = (res: any) => {
       t.equal(res.body.result.status, 'VALID')
     }
-    await baseRequest(t, server, req, 200, expectRes, false)
+    await baseRequest(t, server, req, 200, expectRes, false, false)
   }
 }
 
@@ -106,13 +106,13 @@ tape(`${method}: call with executionPayloadV1`, (v1) => {
       let expectRes = (res: any) => {
         t.equal(res.body.result.status, 'ACCEPTED')
       }
-      await baseRequest(t, server, req, 200, expectRes, false)
+      await baseRequest(t, server, req, 200, expectRes, false, false)
 
       req = params(method, [blocks[0]])
       expectRes = (res: any) => {
         t.equal(res.body.result.status, 'VALID')
       }
-      await baseRequest(t, server, req, 200, expectRes, false)
+      await baseRequest(t, server, req, 200, expectRes, false, false)
 
       const state = {
         headBlockHash: blocks[1].blockHash,
@@ -274,7 +274,7 @@ tape(`${method}: call with executionPayloadV1`, (v1) => {
     const expectResFcu = (res: any) => {
       t.equal(res.body.result.payloadStatus.status, 'VALID')
     }
-    await baseRequest(t, server, req, 200, expectResFcu, false)
+    await baseRequest(t, server, req, 200, expectResFcu, false, false)
 
     // Now let's try to re-execute payload
     req = params(method, [blockData])

--- a/packages/client/test/rpc/engine/newPayloadV3.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV3.spec.ts
@@ -25,7 +25,7 @@ export const batchBlocks = async (t: Test, server: HttpServer) => {
     const expectRes = (res: any) => {
       t.equal(res.body.result.status, 'VALID')
     }
-    await baseRequest(t, server, req, 200, expectRes, false)
+    await baseRequest(t, server, req, 200, expectRes, false, false)
   }
 }
 
@@ -106,13 +106,13 @@ tape(`${method}: call with executionPayloadV1`, (v1) => {
       let expectRes = (res: any) => {
         t.equal(res.body.result.status, 'ACCEPTED')
       }
-      await baseRequest(t, server, req, 200, expectRes, false)
+      await baseRequest(t, server, req, 200, expectRes, false, false)
 
       req = params(method, [blocks[0]])
       expectRes = (res: any) => {
         t.equal(res.body.result.status, 'VALID')
       }
-      await baseRequest(t, server, req, 200, expectRes, false)
+      await baseRequest(t, server, req, 200, expectRes, false, false)
 
       const state = {
         headBlockHash: blocks[1].blockHash,
@@ -274,7 +274,7 @@ tape(`${method}: call with executionPayloadV1`, (v1) => {
     const expectResFcu = (res: any) => {
       t.equal(res.body.result.payloadStatus.status, 'VALID')
     }
-    await baseRequest(t, server, req, 200, expectResFcu, false)
+    await baseRequest(t, server, req, 200, expectResFcu, false, false)
 
     // Now let's try to re-execute payload
     req = params(method, [blockData])

--- a/packages/client/test/rpc/engine/withdrawals.spec.ts
+++ b/packages/client/test/rpc/engine/withdrawals.spec.ts
@@ -115,7 +115,7 @@ for (const { name, withdrawals, withdrawalsRoot, gethBlockRlp } of testCases) {
       INVALID_PARAMS,
       'PayloadAttributesV2 MUST be used after Shanghai is activated'
     )
-    await baseRequest(t, server, req, 200, expectRes, false)
+    await baseRequest(t, server, req, 200, expectRes, false, false)
 
     req = params('engine_forkchoiceUpdatedV2', [
       validForkChoiceState,
@@ -126,7 +126,7 @@ for (const { name, withdrawals, withdrawalsRoot, gethBlockRlp } of testCases) {
       t.equal(res.body.result.payloadId !== undefined, true)
       payloadId = res.body.result.payloadId
     }
-    await baseRequest(t, server, req, 200, expectRes, false)
+    await baseRequest(t, server, req, 200, expectRes, false, false)
 
     let payload: ExecutionPayload | undefined = undefined
     req = params('engine_getPayloadV2', [payloadId])
@@ -137,7 +137,7 @@ for (const { name, withdrawals, withdrawalsRoot, gethBlockRlp } of testCases) {
       t.equal(blockValue, '0x0', 'No value should be returned')
       payload = executionPayload
     }
-    await baseRequest(t, server, req, 200, expectRes, false)
+    await baseRequest(t, server, req, 200, expectRes, false, false)
 
     if (gethBlockRlp !== undefined) {
       // check if stateroot matches
@@ -152,7 +152,7 @@ for (const { name, withdrawals, withdrawalsRoot, gethBlockRlp } of testCases) {
     expectRes = (res: any) => {
       t.equal(res.body.result.status, 'VALID')
     }
-    await baseRequest(t, server, req, 200, expectRes, false)
+    await baseRequest(t, server, req, 200, expectRes, false, false)
 
     req = params('engine_forkchoiceUpdatedV2', [
       {


### PR DESCRIPTION
fix and optimize the block execution for engine's new payload and fcUs, supersedes https://github.com/ethereumjs/ethereumjs-monorepo/pull/2787

- chain head was being used for getting `vmHead` instead of the actual `vm` head
- optimize and correct checks if the parent(s) have been executed (track and use `executedBlocks` ) 
- recursively find parents would only find just 1 parent, `vmHead` hash should have been used as its used to find parents till `vmHead`
- add `executedBlocks` map in engine for easy figuring out what has been executed (rather than checking `stateRoot` in state manager because a bad block can be formed with previously executed `stateRoot` which would of course be declared valid) ,
- and better pruning of `executedBlocks` and `remoteBlocks` based on `finalized` and `vm` head
- skip block executions if too many blocks (including parents) are pending to be executed for new payload or if the `VmExecution` s already busy - and return optimistic `SYNCING` response which would be resolved later to valids or invalids
- make sure that `running` flag is switched to false even if `run(..)` of `VmExecution` fails

A branch of this (devnet 7 compatible) seems to be working fine on devnet-7
