### PR TITLE
Update eslint config with file extensions rule

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -22,7 +22,9 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-
+        with:
+          submodules: recursive # necessary for block tests to load ethereum/tests
+          
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
@@ -44,8 +46,8 @@ jobs:
       - run: npm run test:browser -w=@ethereumjs/blockchain
       #     No browser tests for ethash
       - run: npm run test:browser -w=@ethereumjs/wallet
-      - run: cd ../statemanager && npm run test:browser
-      - run: cd ../evm && npm run test:browser
+      - run: npm run test:browser -w=@ethereumjs/statemanager
+      - run: npm run test:browser -w=@ethereumjs/evm
 #     VM: several tests not passing yet
 #     - run: npm run test:browser -w=@ethereumjs/vm
 

--- a/config/eslint.cjs
+++ b/config/eslint.cjs
@@ -67,7 +67,7 @@ module.exports = {
     'import/default': 'error',
     'import/export': 'error',
     'import/exports-last': 'off', // TODO: set to `warn` for fixing and then `error`
-    'import/extensions': 'off',
+    'import/extensions': ['error','ignorePackages'],
     'import/first': 'error',
     'import/group-exports': 'off',
     'import/named': 'error',

--- a/packages/client/.eslintrc.cjs
+++ b/packages/client/.eslintrc.cjs
@@ -1,5 +1,8 @@
 module.exports = {
   extends: '../../config/eslint.cjs',
+  rules: {
+    'import/extensions': 'off',
+  },
   parserOptions: {
     project: ['./tsconfig.json', './tsconfig.browser.json', './tsconfig.eslint.json'],
   },

--- a/packages/common/test/utils.spec.ts
+++ b/packages/common/test/utils.spec.ts
@@ -1,9 +1,9 @@
 import { hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Common } from '../src/common'
-import { Hardfork } from '../src/enums'
-import { parseGethGenesis } from '../src/utils'
+import { Common } from '../src/common.js'
+import { Hardfork } from '../src/enums.js'
+import { parseGethGenesis } from '../src/utils.js'
 
 import * as gethGenesisKilnJSON from './data/geth-genesis/geth-genesis-kiln.json'
 import * as invalidSpuriousDragonJSON from './data/geth-genesis/invalid-spurious-dragon.json'

--- a/packages/devp2p/src/dns/dns.ts
+++ b/packages/devp2p/src/dns/dns.ts
@@ -9,7 +9,7 @@ let dns: any
 try {
   dns = require('dns')
 } catch (e: any) {
-  dns = require('../browser/dns')
+  dns = require('../browser/dns.js')
 }
 
 const debug = createDebugLogger('devp2p:dns:dns')

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -46,7 +46,7 @@
     "lint:fix": "../../config/cli/lint-fix.sh",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "profiling": "0x ./benchmarks/run.js profiling",
-    "test:browser": "npx vitest run -c=vitest.config.browser.ts --browser.name=chrome  --browser.headless",
+    "test:browser": "npx vitest run -c=vitest.config.browser.ts --browser.provider=playwright --browser.name=webkit  --browser.headless",
     "test:node": "npx vitest run",
     "tsc": "../../config/cli/ts-compile.sh"
   },

--- a/packages/evm/test/eips/eip-5656.spec.ts
+++ b/packages/evm/test/eips/eip-5656.spec.ts
@@ -2,7 +2,7 @@ import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { bytesToHex, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { EVM } from '../../src'
+import { EVM } from '../../src/index.js'
 
 type Situation = {
   pre: string

--- a/packages/genesis/.eslintrc.cjs
+++ b/packages/genesis/.eslintrc.cjs
@@ -1,0 +1,1 @@
+module.exports = require('../../config/eslint.cjs')

--- a/packages/genesis/.eslintrc.js
+++ b/packages/genesis/.eslintrc.js
@@ -1,1 +1,0 @@
-module.exports = require('../../config/eslint.js')

--- a/packages/genesis/src/genesisStates/goerli.ts
+++ b/packages/genesis/src/genesisStates/goerli.ts
@@ -1,4 +1,4 @@
-import { GenesisState } from '@ethereumjs/util'
+import type { GenesisState } from '@ethereumjs/util'
 
 export const goerliGenesis: GenesisState = {
   '0x0000000000000000000000000000000000000000': '0x1',

--- a/packages/genesis/src/genesisStates/mainnet.ts
+++ b/packages/genesis/src/genesisStates/mainnet.ts
@@ -1,4 +1,4 @@
-import { GenesisState } from '@ethereumjs/util'
+import type { GenesisState } from '@ethereumjs/util'
 
 export const mainnetGenesis: GenesisState = {
   '0x000d836201318ec6899a67540690382780743280': '0xad78ebc5ac6200000',

--- a/packages/genesis/src/genesisStates/sepolia.ts
+++ b/packages/genesis/src/genesisStates/sepolia.ts
@@ -1,4 +1,4 @@
-import { GenesisState } from '@ethereumjs/util'
+import type { GenesisState } from '@ethereumjs/util'
 
 export const sepoliaGenesis: GenesisState = {
   '0xa2A6d93439144FFE4D27c9E088dCD8b783946263': '0xD3C21BCECCEDA1000000',

--- a/packages/genesis/src/index.ts
+++ b/packages/genesis/src/index.ts
@@ -1,10 +1,10 @@
 import { Chain } from '@ethereumjs/common'
 
-import type { GenesisState } from '@ethereumjs/util'
-
-import { mainnetGenesis } from './genesisStates/mainnet.js'
 import { goerliGenesis } from './genesisStates/goerli.js'
+import { mainnetGenesis } from './genesisStates/mainnet.js'
 import { sepoliaGenesis } from './genesisStates/sepolia.js'
+
+import type { GenesisState } from '@ethereumjs/util'
 
 /**
  * Utility to get the genesisState of a well known network

--- a/packages/genesis/test/index.spec.ts
+++ b/packages/genesis/test/index.spec.ts
@@ -1,7 +1,7 @@
 import { Chain } from '@ethereumjs/common'
 import { assert, describe, it } from 'vitest'
 
-import { getGenesis } from '../src/index'
+import { getGenesis } from '../src/index.js'
 
 const chainToName: Record<Chain, string> = {
   [Chain.Mainnet]: 'mainnet',

--- a/packages/util/test/genesis.spec.ts
+++ b/packages/util/test/genesis.spec.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from 'vitest'
 
-import { parseGethGenesisState } from '../src/genesis'
+import { parseGethGenesisState } from '../src/genesis.js'
 
 // kiln genesis with deposit contract storage set
 import gethGenesisKilnJSON from './testdata/geth-genesis-kiln.json'

--- a/packages/vm/.eslintrc.cjs
+++ b/packages/vm/.eslintrc.cjs
@@ -4,6 +4,7 @@ module.exports = {
     '@typescript-eslint/no-use-before-define': 'off',
     'no-invalid-this': 'off',
     'no-restricted-syntax': 'off',
+    'import/extensions': 'off',
   },
   overrides: [
     {


### PR DESCRIPTION
Three things this PR does:

- Turns on the `import/extensions` rule in `eslint` for all packages except `client` and `vm` where we are still running a lot of CJS code (i.e. the entire `client` package and the test runner in `vm`).
- Fix `eslint` setup in the new `genesis` package so it actually runs and fixes various lint issues identified there.
- All lint fixes identified by this new rule
- Pulls in browser CI fixes from #2824

