### PR TITLE
VM/genesis: Fix small genesis API inconsistency

### DIFF
--- a/packages/genesis/src/index.ts
+++ b/packages/genesis/src/index.ts
@@ -11,7 +11,7 @@ import type { GenesisState } from '@ethereumjs/util'
  * @param: chainId of the network
  * @returns genesisState of the chain
  */
-export function getGenesis(chainId: number): GenesisState | null {
+export function getGenesis(chainId: number): GenesisState | undefined {
   // Use require statements here in favor of import statements
   // to load json files on demand
   // (high memory usage by large mainnet.json genesis state file)
@@ -24,6 +24,6 @@ export function getGenesis(chainId: number): GenesisState | null {
       return sepoliaGenesis
 
     default:
-      return null
+      return undefined
   }
 }

--- a/packages/genesis/test/index.spec.ts
+++ b/packages/genesis/test/index.spec.ts
@@ -15,9 +15,9 @@ describe('genesis test', () => {
     for (const chainId of chainIds) {
       const name = chainToName[chainId as unknown as Chain]
 
-      assert.ok(getGenesis(Number(chainId)) !== null, `${name} genesis found`)
+      assert.ok(getGenesis(Number(chainId)) !== undefined, `${name} genesis found`)
     }
 
-    assert.ok(getGenesis(2) === null, `genesis for chainId 2 not found`)
+    assert.ok(getGenesis(2) === undefined, `genesis for chainId 2 not found`)
   })
 })

--- a/packages/vm/test/api/genesis.spec.ts
+++ b/packages/vm/test/api/genesis.spec.ts
@@ -1,0 +1,19 @@
+import { Blockchain } from '@ethereumjs/blockchain'
+import { Chain } from '@ethereumjs/common'
+import { getGenesis } from '@ethereumjs/genesis'
+import { assert, describe, it } from 'vitest'
+
+import { VM } from '../../src/index.js'
+
+describe('genesis', () => {
+  it('should initialize with predefined genesis states', async () => {
+    const f = async () => {
+      const genesisState = getGenesis(Chain.Mainnet)
+
+      const blockchain = await Blockchain.create({ genesisState })
+      await VM.create({ blockchain, genesisState })
+    }
+
+    assert.doesNotThrow(f, 'should allow for initialization with genesis from genesis package')
+  })
+})


### PR DESCRIPTION
This PR fixes a small inconsistency with the genesis package API I discovered while writing release notes. So the example I added as a test now would break before, because the `getGenesis()` API would give either `GenesisState` or `null` while the other `genesisState` input APIs in VM and Blockchain would take `GenesisState` or `undefined`.

This didn't play well together on the type level and so the example would break.

PR fixes this.