### PR TITLE
Small RC1 Release Cleanup Round

### DIFF
--- a/packages/block/README.md
+++ b/packages/block/README.md
@@ -255,7 +255,7 @@ If you use an ES6-style `import` in your code files from the ESM build will be u
 import { EthereumJSClass } from '@ethereumjs/[PACKAGE_NAME]'
 ```
 
-If you use Node.js specific `require` the CJS build will be used:
+If you use Node.js specific `require`, the CJS build will be used:
 
 ```typescript
 const { EthereumJSClass } = require('@ethereumjs/[PACKAGE_NAME]')

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -60,7 +60,7 @@ Up to this release the backend store for the blockchain library was tied to be a
 
 With this release the database therefore gets an additional abstraction layer which allows to switch the backend to whatever is fitting the best for a use case, see PR [#2669](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2669) and PR [#2673](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2673). The database just needs to conform to the new [DB](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/util/src/db.ts) interface which we provide in the `@ethereumjs/util` package (since this is used in other places as well).
 
-By default the blockchain package is now using a [MapDB](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/util/src/mapDB.ts) non-persistent data storage which is also generically provided in the `@ethereumjs/util` package.
+By default the blockchain package now uses a [MapDB](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/util/src/mapDB.ts) non-persistent data storage which is also generically provided in the `@ethereumjs/util` package.
 
 If you need a persistent data store for your use case you can consider using the wrapper we have written within our [client](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/client/src/execution/level.ts) library.
 

--- a/packages/blockchain/README.md
+++ b/packages/blockchain/README.md
@@ -59,7 +59,7 @@ blockchain.iterator('i', (block) => {
 
 With the v7 release the Blockchain library database has gotten an additional abstraction layer which allows to switch the backend to whatever is fitting the best for a use case, see PR [#2669](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2669) and PR [#2673](https://github.com/ethereumjs/ethereumjs-monorepo/pull/2673). The database just needs to conform to the new [DB](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/util/src/db.ts) interface provided in the `@ethereumjs/util` package (since this is used in other places as well).
 
-By default the blockchain package is now using a [MapDB](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/util/src/mapDB.ts) non-persistent data storage which is also generically provided in the `@ethereumjs/util` package.
+By default the blockchain package now uses a [MapDB](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/util/src/mapDB.ts) non-persistent data storage which is also generically provided in the `@ethereumjs/util` package.
 
 If you need a persistent data store for your use case you can consider using the wrapper we have written within our [client](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/client/src/execution/level.ts) library.
 
@@ -156,7 +156,7 @@ If you use an ES6-style `import` in your code files from the ESM build will be u
 import { EthereumJSClass } from '@ethereumjs/[PACKAGE_NAME]'
 ```
 
-If you use Node.js specific `require` the CJS build will be used:
+If you use Node.js specific `require`, the CJS build will be used:
 
 ```typescript
 const { EthereumJSClass } = require('@ethereumjs/[PACKAGE_NAME]')

--- a/packages/client/libp2pBrowserBuild/net/package.json.browser.deps
+++ b/packages/client/libp2pBrowserBuild/net/package.json.browser.deps
@@ -62,7 +62,7 @@
     "@ethereumjs/common": "4.0.0-rc.1",
     "@ethereumjs/devp2p": "6.0.0-rc.1",
     "@ethereumjs/ethash": "3.0.0-rc.1",
-    "@ethereumjs/evm": "2.0.0-rc.1",
+    "@ethereumjs/evm": "2.0.0-rc.2",
     "@ethereumjs/rlp": "5.0.0-rc.1",
     "@ethereumjs/statemanager": "2.0.0-rc.1",
     "@ethereumjs/trie": "6.0.0-rc.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -62,7 +62,7 @@
     "@ethereumjs/common": "4.0.0-rc.1",
     "@ethereumjs/devp2p": "6.0.0-rc.1",
     "@ethereumjs/ethash": "3.0.0-rc.1",
-    "@ethereumjs/evm": "2.0.0-rc.1",
+    "@ethereumjs/evm": "2.0.0-rc.2",
     "@ethereumjs/genesis": "0.1.0-rc.1",
     "@ethereumjs/rlp": "5.0.0-rc.1",
     "@ethereumjs/statemanager": "2.0.0-rc.1",

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -98,7 +98,7 @@ If you use an ES6-style `import` in your code files from the ESM build will be u
 import { EthereumJSClass } from '@ethereumjs/[PACKAGE_NAME]'
 ```
 
-If you use Node.js specific `require` the CJS build will be used:
+If you use Node.js specific `require`, the CJS build will be used:
 
 ```typescript
 const { EthereumJSClass } = require('@ethereumjs/[PACKAGE_NAME]')

--- a/packages/devp2p/CHANGELOG.md
+++ b/packages/devp2p/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 6.0.0 - 2023-07-11
+## 6.0.0-rc.1 - 2023-07-18
 
 This is the release candidate (RC1) for the upcoming breaking releases on the various EthereumJS libraries. The associated release notes below are the main source of information on the changeset, also for the upcoming final releases, where we'll just provide change addition summaries + references to these RC1 notes.
 

--- a/packages/devp2p/README.md
+++ b/packages/devp2p/README.md
@@ -345,7 +345,7 @@ If you use an ES6-style `import` in your code files from the ESM build will be u
 import { EthereumJSClass } from '@ethereumjs/[PACKAGE_NAME]'
 ```
 
-If you use Node.js specific `require` the CJS build will be used:
+If you use Node.js specific `require`, the CJS build will be used:
 
 ```typescript
 const { EthereumJSClass } = require('@ethereumjs/[PACKAGE_NAME]')

--- a/packages/ethash/README.md
+++ b/packages/ethash/README.md
@@ -84,7 +84,7 @@ If you use an ES6-style `import` in your code files from the ESM build will be u
 import { EthereumJSClass } from '@ethereumjs/[PACKAGE_NAME]'
 ```
 
-If you use Node.js specific `require` the CJS build will be used:
+If you use Node.js specific `require`, the CJS build will be used:
 
 ```typescript
 const { EthereumJSClass } = require('@ethereumjs/[PACKAGE_NAME]')

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.0.0-rc.2 - 2023-07-18
+
+- Add missing `@ethereumjs/statemanager` dependency
+
 ## 2.0.0-rc.1 - 2023-07-18
 
 This is the release candidate (RC1) for the upcoming breaking releases on the various EthereumJS libraries. The associated release notes below are the main source of information on the changeset, also for the upcoming final releases, where we'll just provide change addition summaries + references to these RC1 notes.

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -119,7 +119,7 @@ If you use an ES6-style `import` in your code files from the ESM build will be u
 import { EthereumJSClass } from '@ethereumjs/[PACKAGE_NAME]'
 ```
 
-If you use Node.js specific `require` the CJS build will be used:
+If you use Node.js specific `require`, the CJS build will be used:
 
 ```typescript
 const { EthereumJSClass } = require('@ethereumjs/[PACKAGE_NAME]')

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -193,7 +193,7 @@ outer VM with the respective EIPs, e.g.:
 
 ```typescript
 import { Chain, Common } from '@ethereumjs/common'
-import { VM } from '@ethereumjs/vm'
+import { EVM } from '@ethereumjs/evm'
 
 const common = new Common({ chain: Chain.Mainnet, eips: [2537] })
 const evm = new EVM({ common })

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -196,7 +196,7 @@ import { Chain, Common } from '@ethereumjs/common'
 import { VM } from '@ethereumjs/vm'
 
 const common = new Common({ chain: Chain.Mainnet, eips: [2537] })
-const vm = new VM({ common })
+const evm = new EVM({ common })
 ```
 
 Currently supported EIPs:

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/evm",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "JavaScript Ethereum Virtual Machine (EVM) implementation",
   "keywords": [
     "ethereum",
@@ -46,12 +46,14 @@
     "lint:fix": "../../config/cli/lint-fix.sh",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "profiling": "0x ./benchmarks/run.js profiling",
+    "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run -c=vitest.config.browser.ts --browser.provider=playwright --browser.name=webkit  --browser.headless",
     "test:node": "npx vitest run",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
     "@ethereumjs/common": "4.0.0-rc.1",
+    "@ethereumjs/statemanager": "2.0.0-rc.1",
     "@ethereumjs/tx": "5.0.0-rc.1",
     "@ethereumjs/util": "9.0.0-rc.1",
     "debug": "^4.3.3",
@@ -59,7 +61,6 @@
     "rustbn-wasm": "^0.2.0"
   },
   "devDependencies": {
-    "@ethereumjs/statemanager": "2.0.0-rc.1",
     "@ethersproject/abi": "^5.0.12",
     "@types/benchmark": "^1.0.33",
     "@types/core-js": "^2.5.0",

--- a/packages/statemanager/README.md
+++ b/packages/statemanager/README.md
@@ -123,7 +123,7 @@ If you use an ES6-style `import` in your code files from the ESM build will be u
 import { EthereumJSClass } from '@ethereumjs/[PACKAGE_NAME]'
 ```
 
-If you use Node.js specific `require` the CJS build will be used:
+If you use Node.js specific `require`, the CJS build will be used:
 
 ```typescript
 const { EthereumJSClass } = require('@ethereumjs/[PACKAGE_NAME]')

--- a/packages/trie/README.md
+++ b/packages/trie/README.md
@@ -207,7 +207,7 @@ If you use an ES6-style `import` in your code files from the ESM build will be u
 import { EthereumJSClass } from '@ethereumjs/[PACKAGE_NAME]'
 ```
 
-If you use Node.js specific `require` the CJS build will be used:
+If you use Node.js specific `require`, the CJS build will be used:
 
 ```typescript
 const { EthereumJSClass } = require('@ethereumjs/[PACKAGE_NAME]')

--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -429,7 +429,7 @@ If you use an ES6-style `import` in your code files from the ESM build will be u
 import { EthereumJSClass } from '@ethereumjs/[PACKAGE_NAME]'
 ```
 
-If you use Node.js specific `require` the CJS build will be used:
+If you use Node.js specific `require`, the CJS build will be used:
 
 ```typescript
 const { EthereumJSClass } = require('@ethereumjs/[PACKAGE_NAME]')

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -117,7 +117,7 @@ If you use an ES6-style `import` in your code files from the ESM build will be u
 import { EthereumJSClass } from '@ethereumjs/[PACKAGE_NAME]'
 ```
 
-If you use Node.js specific `require` the CJS build will be used:
+If you use Node.js specific `require`, the CJS build will be used:
 
 ```typescript
 const { EthereumJSClass } = require('@ethereumjs/[PACKAGE_NAME]')

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -91,7 +91,7 @@ import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { VM } from '@ethereumjs/vm'
 
 const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Cancun })
-const vm = new VM({ common })
+const vm = await VM.create({ common })
 ```
 
 See the EVM [EIP-5656 API test file](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/evm/test/eips/eip-5656.spec.ts) for a respective test scenario on the bytecode level.
@@ -109,7 +109,7 @@ import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { VM } from '@ethereumjs/vm'
 
 const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Cancun })
-const vm = new VM({ common })
+const vm = await VM.create({ common })
 ```
 
 See the VM [EIP-6780 API test file](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/vm/test/api/EIPs/eip-6780-selfdestruct-same-tx.spec.ts) for a respective test scenario on the bytecode level.

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -178,7 +178,7 @@ import { hexToBytes } from '@ethereumjs/util'
 import { VM } from '@ethereumjs/vm'
 
 const common = new Common({ chain: Chain.Goerli })
-const vm = new VM({ common, setHardfork: true })
+const vm = await VM.create({ common, setHardfork: true })
 
 const serialized = hexToBytes('0xf901f7a06bfee7294bf4457...')
 const block = Block.fromRLPSerializedBlock(serialized, { setHardfork: true })
@@ -196,7 +196,7 @@ import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { VM } from '@ethereumjs/vm'
 
 const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
-const vm = new VM({ common })
+const vm = await VM.create({ common })
 ```
 
 ### Custom genesis state support
@@ -239,7 +239,7 @@ import { Chain, Common } from '@ethereumjs/common'
 import { VM } from '@ethereumjs/vm'
 
 const common = new Common({ chain: Chain.Mainnet, eips: [2537] })
-const vm = new VM({ common })
+const vm = await VM.create({ common })
 ```
 
 For a list with supported EIPs see the [@ethereumjs/evm](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/evm) documentation.

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -115,7 +115,7 @@ If you use an ES6-style `import` in your code files from the ESM build will be u
 import { EthereumJSClass } from '@ethereumjs/[PACKAGE_NAME]'
 ```
 
-If you use Node.js specific `require` the CJS build will be used:
+If you use Node.js specific `require`, the CJS build will be used:
 
 ```typescript
 const { EthereumJSClass } = require('@ethereumjs/[PACKAGE_NAME]')

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -65,7 +65,7 @@
     "@ethereumjs/block": "5.0.0-rc.1",
     "@ethereumjs/blockchain": "7.0.0-rc.1",
     "@ethereumjs/common": "4.0.0-rc.1",
-    "@ethereumjs/evm": "2.0.0-rc.1",
+    "@ethereumjs/evm": "2.0.0-rc.2",
     "@ethereumjs/rlp": "5.0.0-rc.1",
     "@ethereumjs/statemanager": "2.0.0-rc.1",
     "@ethereumjs/trie": "6.0.0-rc.1",


### PR DESCRIPTION
Follow-up on #2876 

Small release clean-up round including an additional EVM RC.2 release (+ upstream version updates) since RC.1 was broken (missing StateManager dependency).