### PR TITLE
client: apply engine api changes for devnet 8

### DIFF
--- a/packages/client/src/rpc/modules/engine.ts
+++ b/packages/client/src/rpc/modules/engine.ts
@@ -418,11 +418,16 @@ export class Engine {
     )
 
     this.newPayloadV3 = cmMiddleware(
-      middleware(this.newPayloadV3.bind(this), 1, [
-        [validators.object(executionPayloadV3FieldValidators)],
-        [validators.array(validators.bytes32)],
-        [validators.bytes32],
-      ]),
+      middleware(
+        this.newPayloadV3.bind(this),
+        3,
+        [
+          [validators.object(executionPayloadV3FieldValidators)],
+          [validators.array(validators.bytes32)],
+          [validators.bytes32],
+        ],
+        ['executionPayload', 'versionedHashes', 'parentBeaconBlockRoot']
+      ),
       ([payload], response) => this.connectionManager.lastNewPayload({ payload, response })
     )
 

--- a/packages/client/src/rpc/modules/engine.ts
+++ b/packages/client/src/rpc/modules/engine.ts
@@ -773,7 +773,7 @@ export class Engine {
     if (shanghaiTimestamp !== null && ts >= shanghaiTimestamp) {
       throw {
         code: INVALID_PARAMS,
-        message: 'NewPayloadV2 MUST be used after Cancun is activated',
+        message: 'NewPayloadV2 MUST be used after Shanghai is activated',
       }
     }
 

--- a/packages/client/src/rpc/validation.ts
+++ b/packages/client/src/rpc/validation.ts
@@ -7,13 +7,18 @@ import { INVALID_PARAMS } from './error-code'
  * @param requiredParamsCount required parameters count
  * @param validators array of validators
  */
-export function middleware(method: any, requiredParamsCount: number, validators: any[] = []): any {
+export function middleware(
+  method: any,
+  requiredParamsCount: number,
+  validators: any[] = [],
+  names: string[] = []
+): any {
   return function (params: any[] = []) {
     return new Promise((resolve, reject) => {
       if (params.length < requiredParamsCount) {
         const error = {
           code: INVALID_PARAMS,
-          message: `missing value for required argument ${params.length}`,
+          message: `missing value for required argument ${names[params.length] ?? params.length}`,
         }
         return reject(error)
       }

--- a/packages/client/test/rpc/engine/getPayloadV3.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadV3.spec.ts
@@ -33,7 +33,14 @@ const validPayloadAttributes = {
   suggestedFeeRecipient: '0xaa00000000000000000000000000000000000000',
 }
 
-const validPayload = [validForkChoiceState, { ...validPayloadAttributes, withdrawals: [] }]
+const validPayload = [
+  validForkChoiceState,
+  {
+    ...validPayloadAttributes,
+    withdrawals: [],
+    parentBeaconBlockRoot: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  },
+]
 
 try {
   initKZG(kzg, __dirname + '/../../../src/trustedSetups/devnet6.txt')
@@ -81,7 +88,7 @@ describe(method, () => {
 
     account!.balance = 0xfffffffffffffffn
     await service.execution.vm.stateManager.putAccount(address, account!)
-    let req = params('engine_forkchoiceUpdatedV2', validPayload)
+    let req = params('engine_forkchoiceUpdatedV3', validPayload)
     let payloadId
     let expectRes = (res: any) => {
       payloadId = res.body.result.payloadId

--- a/packages/client/test/rpc/engine/newPayloadV3.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV3.spec.ts
@@ -27,7 +27,7 @@ export const batchBlocks = async (server: HttpServer) => {
 }
 const parentBeaconBlockRoot = '0x42942949c4ed512cd85c2cb54ca88591338cbb0564d3a2bea7961a639ef29d64'
 
-describe(`${method}: call with executionPayloadV1`, () => {
+describe(`${method}: call with executionPayloadV3`, () => {
   it('invalid call before Cancun', async () => {
     const { server } = await setupChain(genesisJSON, 'post-merge', {
       engine: true,

--- a/packages/client/test/rpc/engine/newPayloadV3.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV3.spec.ts
@@ -1,13 +1,12 @@
 import { BlockHeader } from '@ethereumjs/block'
-import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
-import { Address, bytesToHex, hexToBytes, zeros } from '@ethereumjs/util'
+import { bigIntToHex } from '@ethereumjs/util'
 import * as td from 'testdouble'
 import { assert, describe, it } from 'vitest'
 
 import { INVALID_PARAMS } from '../../../src/rpc/error-code'
 import blocks from '../../testdata/blocks/beacon.json'
 import genesisJSON from '../../testdata/geth-genesis/post-merge.json'
-import { baseRequest, baseSetup, params, setupChain } from '../helpers'
+import { baseRequest, params, setupChain } from '../helpers'
 import { checkError } from '../util'
 
 import type { HttpServer } from 'jayson'
@@ -27,273 +26,57 @@ export const batchBlocks = async (server: HttpServer) => {
     await baseRequest(server, req, 200, expectRes, false, false)
   }
 }
+const parentBeaconBlockRoot = '0x42942949c4ed512cd85c2cb54ca88591338cbb0564d3a2bea7961a639ef29d64'
 
 describe(`${method}: call with executionPayloadV1`, () => {
-  it('call with invalid block hash without 0x', async () => {
-    const { server } = baseSetup({ engine: true, includeVM: true })
-
-    const blockDataWithInvalidParentHash = [
-      {
-        ...blockData,
-        parentHash: blockData.parentHash.slice(2),
-      },
-    ]
-
-    const req = params(method, blockDataWithInvalidParentHash)
-    const expectRes = checkError(
-      INVALID_PARAMS,
-      "invalid argument 0 for key 'parentHash': hex string without 0x prefix"
-    )
-    await baseRequest(server, req, 200, expectRes)
-  })
-
-  it('call with invalid hex string as block hash', async () => {
-    const { server } = baseSetup({ engine: true, includeVM: true })
-
-    const blockDataWithInvalidBlockHash = [{ ...blockData, blockHash: '0x-invalid-block-hash' }]
-    const req = params(method, blockDataWithInvalidBlockHash)
-    const expectRes = checkError(
-      INVALID_PARAMS,
-      "invalid argument 0 for key 'blockHash': invalid block hash"
-    )
-    await baseRequest(server, req, 200, expectRes)
-  })
-
-  it('call with non existent block hash', async () => {
-    const { server } = await setupChain(genesisJSON, 'merge', { engine: true })
-
-    const blockDataNonExistentBlockHash = [
-      {
-        ...blockData,
-        blockHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
-      },
-    ]
-    const req = params(method, blockDataNonExistentBlockHash)
-    const expectRes = (res: any) => {
-      assert.equal(res.body.result.status, 'INVALID')
-    }
-
-    await baseRequest(server, req, 200, expectRes)
-  })
-
-  it('call with non existent parent hash', async () => {
-    const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
-
-    const blockDataNonExistentParentHash = [
-      {
-        ...blockData,
-        parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
-        blockHash: '0xf31969a769bfcdbcc1c05f2542fdc7aa9336fc1ea9a82c4925320c035095d649',
-      },
-    ]
-    const req = params(method, blockDataNonExistentParentHash)
-    const expectRes = (res: any) => {
-      assert.equal(res.body.result.status, 'ACCEPTED')
-    }
-
-    await baseRequest(server, req, 200, expectRes)
-  })
-
-  it('call with unknown parent hash to store in remoteBlocks, then call valid ancestor in fcU', async () => {
-    const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
-
-    let req = params(method, [blocks[1]])
-    let expectRes = (res: any) => {
-      assert.equal(res.body.result.status, 'ACCEPTED')
-    }
-    await baseRequest(server, req, 200, expectRes, false, false)
-
-    req = params(method, [blocks[0]])
-    expectRes = (res: any) => {
-      assert.equal(res.body.result.status, 'VALID')
-    }
-    await baseRequest(server, req, 200, expectRes, false, false)
-
-    const state = {
-      headBlockHash: blocks[1].blockHash,
-      safeBlockHash: blocks[1].blockHash,
-      finalizedBlockHash: blocks[0].blockHash,
-    }
-    req = params('engine_forkchoiceUpdatedV1', [state])
-    expectRes = (res: any) => {
-      assert.equal(res.body.result.payloadStatus.status, 'VALID')
-    }
-
-    await baseRequest(server, req, 200, expectRes)
-  })
-
-  it('invalid terminal block', async () => {
-    const genesisWithHigherTtd = {
-      ...genesisJSON,
-      config: {
-        ...genesisJSON.config,
-        terminalTotalDifficulty: 17179869185,
-      },
-    }
-
-    ;(BlockHeader as any).prototype._consensusFormatValidation = td.func<any>()
-    td.replace<any>('@ethereumjs/block', { BlockHeader })
-
-    const { server } = await setupChain(genesisWithHigherTtd, 'post-merge', {
+  it('invalid call before Cancun', async () => {
+    const { server } = await setupChain(genesisJSON, 'post-merge', {
       engine: true,
     })
-
-    const req = params(method, [blockData, null])
-    const expectRes = (res: any) => {
-      assert.equal(res.body.result.status, 'INVALID')
-      assert.equal(res.body.result.latestValidHash, bytesToHex(zeros(32)))
+    // get the genesis json with current date
+    const validBlock = {
+      ...blockData,
+      withdrawals: [],
+      dataGasUsed: '0x0',
+      excessDataGas: '0x0',
     }
+
+    const req = params(method, [validBlock, [], parentBeaconBlockRoot])
+    let expectRes = checkError(
+      INVALID_PARAMS,
+      'NewPayloadV{1|2} MUST be used before Cancun is activated'
+    )
     await baseRequest(server, req, 200, expectRes)
-  })
-
-  it('call with valid data', async () => {
-    const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
-
-    const req = params(method, [blockData])
-    const expectRes = (res: any) => {
+    expectRes = (res: any) => {
       assert.equal(res.body.result.status, 'VALID')
       assert.equal(res.body.result.latestValidHash, blockData.blockHash)
     }
-    await baseRequest(server, req, 200, expectRes)
   })
 
-  it('call with valid data but invalid transactions', async () => {
-    const { chain, server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
-    chain.config.logger.silent = true
-    const blockDataWithInvalidTransaction = {
+  it('valid data', async () => {
+    // get the genesis json with current date
+    const cancunTime = 1689945325
+    // deep copy json and add shanghai and cancun to genesis to avoid contamination
+    const cancunJson = JSON.parse(JSON.stringify(genesisJSON))
+    cancunJson.config.shanghaiTime = cancunTime
+    cancunJson.config.cancunTime = cancunTime
+    const { server } = await setupChain(cancunJson, 'post-merge', { engine: true })
+
+    const validBlock = {
       ...blockData,
-      transactions: ['0x1'],
-    }
-    const expectRes = (res: any) => {
-      assert.equal(res.body.result.status, 'INVALID')
-      assert.equal(res.body.result.latestValidHash, blockData.parentHash)
-      const expectedError =
-        'Invalid tx at index 0: Error: Invalid serialized tx input: must be array'
-      assert.ok(
-        res.body.result.validationError.includes(expectedError),
-        `should error with - ${expectedError}`
-      )
+      timestamp: bigIntToHex(BigInt(cancunTime)),
+      withdrawals: [],
+      dataGasUsed: '0x0',
+      excessDataGas: '0x0',
+      blockHash: '0x6ec6f32e6931199f8f84faf46a59bc9a1e65a23aa73ca21278b5cb48aa2d059d',
+      stateRoot: '0x454a9db6943b17a5f88aea507d0c3f4420d533d143b4eb5194cc7589d721b024',
     }
 
-    const req = params(method, [blockDataWithInvalidTransaction])
-    await baseRequest(server, req, 200, expectRes)
-  })
-
-  it('call with valid data & valid transaction but not signed', async () => {
-    const { server, common, chain } = await setupChain(genesisJSON, 'post-merge', { engine: true })
-    chain.config.logger.silent = true
-
-    // Let's mock a non-signed transaction so execution fails
-    const tx = FeeMarketEIP1559Transaction.fromTxData(
-      {
-        gasLimit: 21_000,
-        maxFeePerGas: 10,
-        value: 1,
-        to: Address.fromString('0x61FfE691821291D02E9Ba5D33098ADcee71a3a17'),
-      },
-      { common }
-    )
-
-    const transactions = [bytesToHex(tx.serialize())]
-    const blockDataWithValidTransaction = {
-      ...blockData,
-      transactions,
-      blockHash: '0x308f490332a31fade8b2b46a8e1132cd15adeaffbb651cb523c067b3f007dd9e',
-    }
-    const expectRes = (res: any) => {
-      assert.equal(res.body.result.status, 'INVALID')
-      assert.isTrue(
-        res.body.result.validationError.includes('Error verifying block while running:')
-      )
-    }
-
-    const req = params(method, [blockDataWithValidTransaction])
-    await baseRequest(server, req, 200, expectRes)
-  })
-
-  it('call with valid data & valid transaction', async () => {
-    const accountPk = hexToBytes(
-      '0xe331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109'
-    )
-    const accountAddress = Address.fromPrivateKey(accountPk)
-    const newGenesisJSON = {
-      ...genesisJSON,
-      alloc: {
-        ...genesisJSON.alloc,
-        [accountAddress.toString()]: {
-          balance: '0x1000000',
-        },
-      },
-    }
-
-    const { server, common } = await setupChain(newGenesisJSON, 'post-merge', { engine: true })
-
-    const tx = FeeMarketEIP1559Transaction.fromTxData(
-      {
-        maxFeePerGas: '0x7',
-        value: 6,
-        gasLimit: 53_000,
-      },
-      { common }
-    ).sign(accountPk)
-    const transactions = [bytesToHex(tx.serialize())]
-    const blockDataWithValidTransaction = {
-      ...blockData,
-      transactions,
-      parentHash: '0xefc1993f08864165c42195966b3f12794a1a42afa84b1047a46ab6b105828c5c',
-      receiptsRoot: '0xc508745f9f8b6847a127bbc58b7c6b2c0f073c7ca778b6f020138f0d6d782adf',
-      gasUsed: '0xcf08',
-      stateRoot: '0x5a7123ab8bdd4f172438671a2a3de143f2105aa1ac3338c97e5f433e8e380d8d',
-      blockHash: '0x625f2fd36bf278f92211376cbfe5acd7ac5da694e28f3d94d59488b7dbe213a4',
-    }
+    const req = params(method, [validBlock, [], parentBeaconBlockRoot])
     const expectRes = (res: any) => {
       assert.equal(res.body.result.status, 'VALID')
+      assert.equal(res.body.result.latestValidHash, validBlock.blockHash)
     }
-    const req = params(method, [blockDataWithValidTransaction])
-    await baseRequest(server, req, 200, expectRes)
-  })
-
-  it('re-execute payload and verify that no errors occur', async () => {
-    const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
-
-    await batchBlocks(server)
-
-    let req = params('engine_forkchoiceUpdatedV1', [
-      {
-        headBlockHash: blocks[2].blockHash,
-        finalizedBlockHash: blocks[2].blockHash,
-        safeBlockHash: blocks[2].blockHash,
-      },
-    ])
-
-    // Let's set new head hash
-    const expectResFcu = (res: any) => {
-      assert.equal(res.body.result.payloadStatus.status, 'VALID')
-    }
-    await baseRequest(server, req, 200, expectResFcu, false, false)
-
-    // Now let's try to re-execute payload
-    req = params(method, [blockData])
-
-    const expectRes = (res: any) => {
-      assert.equal(res.body.result.status, 'VALID')
-    }
-    await baseRequest(server, req, 200, expectRes)
-  })
-
-  it('parent hash equals to block hash', async () => {
-    const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
-    const blockDataHasBlockHashSameAsParentHash = [
-      {
-        ...blockData,
-        blockHash: blockData.parentHash,
-      },
-    ]
-    const req = params(method, blockDataHasBlockHashSameAsParentHash)
-    const expectRes = (res: any) => {
-      assert.equal(res.body.result.status, 'INVALID')
-    }
-
     await baseRequest(server, req, 200, expectRes)
   })
 

--- a/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
@@ -32,16 +32,20 @@ describe(`${method}: Cancun validations`, () => {
   it('versionedHashes', async () => {
     const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
 
+    const parentBeaconBlockRoot =
+      '0x42942949c4ed512cd85c2cb54ca88591338cbb0564d3a2bea7961a639ef29d64'
     const blockDataExtraVersionedHashes = [
       {
         ...blockData,
         parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
-        blockHash: '0x42942949c4ed512cd85c2cb54ca88591338cbb0564d3a2bea7961a639ef29d64',
+        blockHash: '0xb8b9607bd09f0c18bccfa4dcb6fe355f07d383c902f0fc2a1671cf20792e131c',
         withdrawals: [],
         dataGasUsed: '0x0',
         excessDataGas: '0x0',
       },
+      // versioned hashes
       ['0x3434', '0x2334'],
+      parentBeaconBlockRoot,
     ]
     let req = params(method, blockDataExtraVersionedHashes)
     let expectRes = (res: any) => {
@@ -64,20 +68,43 @@ describe(`${method}: Cancun validations`, () => {
       {
         ...blockData,
         parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
-        blockHash: '0x701f665755524486783d70ea3808f6d013ddfcd03972bd87eace1f29a44a83e8',
+        blockHash: '0x141462264b2c27594e8cfcafcadd3545e08c657af4e5882096191632dd4cfc1c',
         // two blob transactions but no versioned hashes
         transactions: [txString, txString],
+        withdrawals: [],
+        dataGasUsed: '0x40000',
+        excessDataGas: '0x0',
       },
     ]
     req = params(method, blockDataNoneHashes)
-    expectRes = checkError(INVALID_PARAMS, 'Missing versionedHashes after Cancun is activated')
+    expectRes = checkError(INVALID_PARAMS, 'missing value for required argument versionedHashes')
+    await baseRequest(server, req, 200, expectRes, false)
+
+    const blockDataMissingParentBeaconRoot = [
+      {
+        ...blockData,
+        parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
+        blockHash: '0x141462264b2c27594e8cfcafcadd3545e08c657af4e5882096191632dd4cfc1c',
+        // two blob transactions but no versioned hashes
+        transactions: [txString, txString],
+        withdrawals: [],
+        dataGasUsed: '0x40000',
+        excessDataGas: '0x0',
+      },
+      txVersionedHashesString,
+    ]
+    req = params(method, blockDataMissingParentBeaconRoot)
+    expectRes = checkError(
+      INVALID_PARAMS,
+      'missing value for required argument parentBeaconBlockRoot'
+    )
     await baseRequest(server, req, 200, expectRes, false)
 
     const blockDataExtraMissingHashes1 = [
       {
         ...blockData,
         parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
-        blockHash: '0x141462264b2c27594e8cfcafcadd3545e08c657af4e5882096191632dd4cfc1c',
+        blockHash: '0xeea272bb9ac158550c645a1b0666727a5fefa4a865f8d4c642a87143d2abef39',
         withdrawals: [],
         dataGasUsed: '0x40000',
         excessDataGas: '0x0',
@@ -85,6 +112,7 @@ describe(`${method}: Cancun validations`, () => {
         transactions: [txString, txString],
       },
       txVersionedHashesString,
+      parentBeaconBlockRoot,
     ]
     req = params(method, blockDataExtraMissingHashes1)
     expectRes = (res: any) => {
@@ -100,7 +128,7 @@ describe(`${method}: Cancun validations`, () => {
       {
         ...blockData,
         parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
-        blockHash: '0x141462264b2c27594e8cfcafcadd3545e08c657af4e5882096191632dd4cfc1c',
+        blockHash: '0xeea272bb9ac158550c645a1b0666727a5fefa4a865f8d4c642a87143d2abef39',
         withdrawals: [],
         dataGasUsed: '0x40000',
         excessDataGas: '0x0',
@@ -108,6 +136,7 @@ describe(`${method}: Cancun validations`, () => {
         transactions: [txString, txString],
       },
       [...txVersionedHashesString, '0x3456'],
+      parentBeaconBlockRoot,
     ]
     req = params(method, blockDataExtraMisMatchingHashes1)
     expectRes = (res: any) => {
@@ -123,7 +152,7 @@ describe(`${method}: Cancun validations`, () => {
       {
         ...blockData,
         parentHash: '0x2559e851470f6e7bbed1db474980683e8c315bfce99b2a6ef47c057c04de7858',
-        blockHash: '0x141462264b2c27594e8cfcafcadd3545e08c657af4e5882096191632dd4cfc1c',
+        blockHash: '0xeea272bb9ac158550c645a1b0666727a5fefa4a865f8d4c642a87143d2abef39',
         withdrawals: [],
         dataGasUsed: '0x40000',
         excessDataGas: '0x0',
@@ -131,6 +160,7 @@ describe(`${method}: Cancun validations`, () => {
         transactions: [txString, txString],
       },
       [...txVersionedHashesString, ...txVersionedHashesString],
+      parentBeaconBlockRoot,
     ]
     req = params(method, blockDataMatchingVersionedHashes)
     expectRes = (res: any) => {


### PR DESCRIPTION
pending tasks to make client devnet 8 compatible

 - fcu v3
 - change validations of newpayload v3 and make them 1-1

Could have further changes depending on the acceptance of 
  - https://github.com/ethereum/consensus-specs/pull/3454