### PR TITLE
docker: catch signals like SIGTERM by running node via dumb-init

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN npm install @ethereumjs/client@$VERSION
 
 FROM node:18-alpine
 WORKDIR /usr/app
+RUN apk --no-cache add dumb-init
 COPY --from=build /usr/app .
 
 # Sanity check
@@ -18,4 +19,4 @@ RUN node /usr/app/node_modules/.bin/ethereumjs --help
 # since memory may spike during certain network conditions.
 ENV NODE_OPTIONS=--max_old_space_size=6144
 
-ENTRYPOINT ["node", "/usr/app/node_modules/.bin/ethereumjs"]
+ENTRYPOINT ["dumb-init", "node", "/usr/app/node_modules/.bin/ethereumjs"]

--- a/Dockerfile.fromSource
+++ b/Dockerfile.fromSource
@@ -11,6 +11,7 @@ RUN npm i
 
 FROM node:18-alpine
 WORKDIR /usr/app
+RUN apk --no-cache add dumb-init
 COPY --from=build /usr/app .
 
 # Sanity check
@@ -23,4 +24,4 @@ RUN node /usr/app/node_modules/.bin/ethereumjs --help
 # since memory may spike during certain network conditions.
 ENV NODE_OPTIONS=--max_old_space_size=6144
 
-ENTRYPOINT ["node", "/usr/app/node_modules/.bin/ethereumjs"]
+ENTRYPOINT ["dumb-init", "node", "/usr/app/node_modules/.bin/ethereumjs"]


### PR DESCRIPTION
### Problem:

When a container is stopped, the node process isn't terminated like it should. The reason for that is that signals aren't handled well by node. 

## Solution:

[dumb-init](https://github.com/Yelp/dumb-init) enables you to simply prefix your command with dumb-init. It acts as PID 1 and immediately spawns your command as a child process, taking care to properly handle and forward signals as they are received.

### Reproducing: 

Without the fix, run `docker run --rm -it ethereumjs`. You'll see ethereumjs starting. Now press CTRL+C to send a SIGTERM. You'll notice that it won't work. 

Build the image now with the fix and retry. Pressing CTRL+C will send the SIGTERM which will be propagated correctly now via dumb-init and the ethereumjs process will terminate gracefully. 
