### PR TITLE
Cancun tests for devnet-8

### DIFF
--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -665,12 +665,24 @@ export class BlockHeader {
   hash(): Uint8Array {
     if (Object.isFrozen(this)) {
       if (!this.cache.hash) {
-        this.cache.hash = keccak256(RLP.encode(this.raw()))
+        if (!this.isGenesis()) {
+          this.cache.hash = keccak256(RLP.encode(this.raw()))
+        } else {
+          const raw = this.raw()
+          const arr = raw.slice(0, raw.length - 1)
+          this.cache.hash = keccak256(RLP.encode(arr))
+        }
       }
       return this.cache.hash
     }
 
-    return keccak256(RLP.encode(this.raw()))
+    if (!this.isGenesis()) {
+      return keccak256(RLP.encode(this.raw()))
+    } else {
+      const raw = this.raw()
+      const arr = raw.slice(0, raw.length - 1)
+      return keccak256(RLP.encode(arr))
+    }
   }
 
   /**

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -665,24 +665,11 @@ export class BlockHeader {
   hash(): Uint8Array {
     if (Object.isFrozen(this)) {
       if (!this.cache.hash) {
-        if (!this.isGenesis()) {
-          this.cache.hash = keccak256(RLP.encode(this.raw()))
-        } else {
-          const raw = this.raw()
-          const arr = raw.slice(0, raw.length - 1)
-          this.cache.hash = keccak256(RLP.encode(arr))
-        }
+        this.cache.hash = keccak256(RLP.encode(this.raw()))
       }
       return this.cache.hash
     }
-
-    if (!this.isGenesis()) {
-      return keccak256(RLP.encode(this.raw()))
-    } else {
-      const raw = this.raw()
-      const arr = raw.slice(0, raw.length - 1)
-      return keccak256(RLP.encode(arr))
-    }
+    return keccak256(RLP.encode(this.raw()))
   }
 
   /**

--- a/packages/client/src/rpc/error-code.ts
+++ b/packages/client/src/rpc/error-code.ts
@@ -6,3 +6,4 @@ export const METHOD_NOT_FOUND = -32601
 export const INVALID_PARAMS = -32602
 export const INTERNAL_ERROR = -32603
 export const TOO_LARGE_REQUEST = -38004
+export const UNSUPPORTED_FORK = -38005

--- a/packages/client/src/rpc/modules/engine.ts
+++ b/packages/client/src/rpc/modules/engine.ts
@@ -13,7 +13,7 @@ import {
 
 import { PendingBlock } from '../../miner'
 import { short } from '../../util'
-import { INTERNAL_ERROR, INVALID_PARAMS, TOO_LARGE_REQUEST } from '../error-code'
+import { INTERNAL_ERROR, INVALID_PARAMS, TOO_LARGE_REQUEST, UNSUPPORTED_FORK } from '../error-code'
 import { CLConnectionManager, middleware as cmMiddleware } from '../util/CLConnectionManager'
 import { middleware, validators } from '../validation'
 
@@ -819,7 +819,7 @@ export class Engine {
     const ts = parseInt(params[0].timestamp)
     if (eip4844Timestamp === null || ts < eip4844Timestamp) {
       throw {
-        code: INVALID_PARAMS,
+        code: UNSUPPORTED_FORK,
         message: 'NewPayloadV{1|2} MUST be used before Cancun is activated',
       }
     }

--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -131,6 +131,7 @@ const jsonRpcBlock = async (
     ...withdrawalsAttr,
     blobGasUsed: header.blobGasUsed,
     excessBlobGas: header.excessBlobGas,
+    parentBeaconBlockRoot: header.parentBeaconBlockRoot,
   }
 }
 

--- a/packages/client/src/service/txpool.ts
+++ b/packages/client/src/service/txpool.ts
@@ -246,9 +246,8 @@ export class TxPool {
 
     if (addedTx instanceof BlobEIP4844Transaction && existingTx instanceof BlobEIP4844Transaction) {
       const minblobGasFee =
-        (existingTx.maxFeePerblobGas *
-          (existingTx.maxFeePerblobGas * BigInt(MIN_GAS_PRICE_BUMP_PERCENT))) /
-        BigInt(100)
+        existingTx.maxFeePerblobGas +
+        (existingTx.maxFeePerblobGas * BigInt(MIN_GAS_PRICE_BUMP_PERCENT)) / BigInt(100)
       if (addedTx.maxFeePerblobGas < minblobGasFee) {
         throw new Error('replacement blob gas too low')
       }

--- a/packages/common/src/hardforks.ts
+++ b/packages/common/src/hardforks.ts
@@ -837,6 +837,6 @@ export const hardforks: HardforksDict = {
       'Next feature hardfork after the shanghai having proto-danksharding EIP 4844 blobs (still WIP hence not for production use), transient storage opcodes, parent beacon block root availability in EVM and selfdestruct only in same transaction',
     url: 'https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md',
     status: Status.Final,
-    eips: [4844, 1153, 4788, 5656, 6780],
+    eips: [4844, 4788, 5656, 6780],
   },
 }


### PR DESCRIPTION
This PR is used to track work on the Cancun tests for devnet-8.

To run;

Git clone https://github.com/marioevz/hive/tree/cancun-dn8-4844-4788

Merge this PR: https://github.com/ethereum/hive/pull/809

Change `hive/clients/ethereumjs/ethereumjs.sh`: `FLAGS="--gethGenesis ./genesis.json --rpc --rpcEngine --saveReceipts --rpcAddr 0.0.0.0 --rpcEngineAddr 0.0.0.0 --rpcEnginePort 8551 --ws false --logLevel debug --rpcDebug --transports rlpx --isSingleNode"`

`./hive --sim ethereum/engine --client ethereumjs --sim.limit "engine-blobs/"`

More output;

`./hive --sim ethereum/engine --client ethereumjs --docker.output --loglevel 5`

Do not merge since this likely finds bugs in hive.
TODOS

- [ ] Get #2935 ready
- [x] Fix above tests (likely devp2p related regarding `eth/68`)
- [ ] Open a PR for hive to patch `ethereumjs.sh`. NOTE: this should allow the websockets to be open. We currently disable the websockets in order to run these tests. (i.e. `-- ws false` should be replaced by the default `--ws`)