### PR TITLE
client: add support for multiple same-type messages over devp2p

### DIFF
--- a/packages/client/src/net/protocol/boundprotocol.ts
+++ b/packages/client/src/net/protocol/boundprotocol.ts
@@ -183,11 +183,6 @@ export class BoundProtocol {
       await resolver.lock.acquire()
     }
     return new Promise((resolve, reject) => {
-      resolver.timeout = setTimeout(() => {
-        resolver.timeout = null
-        this.resolvers.delete(message.response!)
-        reject(new Error(`Request timed out after ${this.timeout}ms`))
-      }, this.timeout)
       resolver.resolve = function (e: any) {
         resolver.lock.release()
         resolve(e)
@@ -196,6 +191,11 @@ export class BoundProtocol {
         resolver.lock.release()
         reject(e)
       }
+      resolver.timeout = setTimeout(() => {
+        resolver.timeout = null
+        this.resolvers.delete(message.response!)
+        resolver.reject(new Error(`Request timed out after ${this.timeout}ms`))
+      }, this.timeout)
     })
   }
 

--- a/packages/client/src/net/protocol/boundprotocol.ts
+++ b/packages/client/src/net/protocol/boundprotocol.ts
@@ -1,3 +1,5 @@
+import { Lock } from '@ethereumjs/util'
+
 import { Event } from '../../types'
 
 import type { Config } from '../../config'
@@ -161,26 +163,39 @@ export class BoundProtocol {
    */
   async request(name: string, args: any[]): Promise<any> {
     const message = this.send(name, args)
-    const resolver: any = {
-      timeout: null,
-      resolve: null,
-      reject: null,
-    }
+    let lock
     if (
       typeof message.response === 'number' &&
       this.resolvers.get(message.response) !== undefined
     ) {
-      throw new Error(`Only one active request allowed per message type (${name})`)
+      const res = this.resolvers.get(message.response)
+      lock = res.lock
+      await res.lock.acquire()
+    }
+    const resolver: any = {
+      timeout: null,
+      resolve: null,
+      reject: null,
+      lock: lock ?? new Lock(),
     }
     this.resolvers.set(message.response!, resolver)
+    if (lock === undefined) {
+      await resolver.lock.acquire()
+    }
     return new Promise((resolve, reject) => {
       resolver.timeout = setTimeout(() => {
         resolver.timeout = null
         this.resolvers.delete(message.response!)
         reject(new Error(`Request timed out after ${this.timeout}ms`))
       }, this.timeout)
-      resolver.resolve = resolve
-      resolver.reject = reject
+      resolver.resolve = function (e: any) {
+        resolver.lock.release()
+        resolve(e)
+      }
+      resolver.reject = function (e: any) {
+        resolver.lock.release()
+        reject(e)
+      }
     })
   }
 


### PR DESCRIPTION
This PR fixes a hive test (on top of #2935 which fixes another related timeout problem) where this happens:

There are two clients. These both gets fed messages and it is necessary that upon creating new blocks the peers have exchanged all messages. The block builder client (1) has a race condition without this PR. Here is what happens:

Client (1) gets multiple `NewPooledTransactionHashes` (5 in total, over 5 messages). Therefore, client (1) requests 5 `GetPooledTransactions`. However, at some point client (1) is already requesting a pooled tx without getting a response, and then queries a new `GetPooledTransactions`. Prior to this PR this is not possible because there is only ONE request possible per devp2p message type. This PR has a temporary fix: we now create a Lock for every message which now ensures that if the message is already used, we wait until it is freed and then query this message.

This is **not** ideal: since devp2p now supports Request IDs it is much easier to match up replies to whatever message was sent first. Just check the message type, check the request ID, find in a map the Promise which awaits this request (if available) and then resolve it. However, this temporarily fixes this.

This also fixes (on top of #2935) this hive test: `./hive --sim ethereum/engine --client ethereumjs --sim.limit "engine-blobs/Blob Transaction Ordering, Multiple Clients"`