### PR TITLE
Fix block validation order for EIP4844

### DIFF
--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -570,9 +570,18 @@ export class Block {
       const blobGasPerBlob = this.common.param('gasConfig', 'blobGasPerBlob')
       let blobGasUsed = BigInt(0)
 
+      const expectedExcessBlobGas = parentHeader.calcNextExcessBlobGas()
+      if (this.header.excessBlobGas !== expectedExcessBlobGas) {
+        throw new Error(
+          `block excessBlobGas mismatch: have ${this.header.excessBlobGas}, want ${expectedExcessBlobGas}`
+        )
+      }
+
+      let blobGasPrice
+
       for (const tx of this.transactions) {
         if (tx instanceof BlobEIP4844Transaction) {
-          const blobGasPrice = this.header.getBlobGasPrice()
+          blobGasPrice = blobGasPrice ?? this.header.getBlobGasPrice()
           if (tx.maxFeePerblobGas < blobGasPrice) {
             throw new Error(
               `blob transaction maxFeePerblobGas ${
@@ -594,13 +603,6 @@ export class Block {
       if (this.header.blobGasUsed !== blobGasUsed) {
         throw new Error(
           `block blobGasUsed mismatch: have ${this.header.blobGasUsed}, want ${blobGasUsed}`
-        )
-      }
-
-      const expectedExcessBlobGas = parentHeader.calcNextExcessBlobGas()
-      if (this.header.excessBlobGas !== expectedExcessBlobGas) {
-        throw new Error(
-          `block excessBlobGas mismatch: have ${this.header.excessBlobGas}, want ${expectedExcessBlobGas}`
         )
       }
     }

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -238,11 +238,11 @@ export class BlockHeader {
     }
 
     if (!this.common.isActivatedEIP(4844)) {
-      if (headerData.blobGasUsed !== undefined) {
+      if (blobGasUsed !== undefined) {
         throw new Error('blob gas used can only be provided with EIP4844 activated')
       }
 
-      if (headerData.excessBlobGas !== undefined) {
+      if (excessBlobGas !== undefined) {
         throw new Error('excess blob gas can only be provided with EIP4844 activated')
       }
     }


### PR DESCRIPTION
The problem this fixes is that we first validate the blob transactions (this calls into fake_exponential) and then validate the excess blob gas. This is problematic, because if the excess blob gas check is incorrect it calls with very large numbers into fake_exponential, essentially an infinite loop.

This also optimizes the blob gas price calculation: this is constant, but we calculated it for each blob tx before.