### PR TITLE
trie: improve util types and handling

### DIFF
--- a/packages/trie/src/node/util.ts
+++ b/packages/trie/src/node/util.ts
@@ -7,6 +7,8 @@ import { BranchNode } from './branch.js'
 import { ExtensionNode } from './extension.js'
 import { LeafNode } from './leaf.js'
 
+import type { NestedUint8Array } from '@ethereumjs/util'
+
 export function decodeRawNode(raw: Uint8Array[]) {
   if (raw.length === 17) {
     return BranchNode.fromArray(raw)
@@ -21,14 +23,14 @@ export function decodeRawNode(raw: Uint8Array[]) {
   }
 }
 
-export function decodeNode(raw: Uint8Array) {
-  const des = RLP.decode(Uint8Array.from(raw)) as Uint8Array[]
-  if (!Array.isArray(des)) {
-    throw new Error('Invalid node')
-  }
-  return decodeRawNode(des)
+export function isRawNode(n: Uint8Array | NestedUint8Array): n is Uint8Array[] {
+  return Array.isArray(n) && !(n instanceof Uint8Array)
 }
 
-export function isRawNode(n: any) {
-  return Array.isArray(n) && !(n instanceof Uint8Array)
+export function decodeNode(node: Uint8Array) {
+  const decodedNode = RLP.decode(Uint8Array.from(node))
+  if (!isRawNode(decodedNode)) {
+    throw new Error('Invalid node')
+  }
+  return decodeRawNode(decodedNode)
 }

--- a/packages/trie/src/proof/range.ts
+++ b/packages/trie/src/proof/range.ts
@@ -78,7 +78,7 @@ async function unset(
       return pos - 1
     } else {
       const _child = await trie.lookupNode(child.value())
-      if (_child && _child instanceof LeafNode) {
+      if (_child instanceof LeafNode) {
         // The child of this node is leaf node, remove it from parent too
         ;(parent as BranchNode).setBranch(key[pos - 1], null)
         return pos - 1
@@ -247,7 +247,7 @@ async function unsetInternal(trie: Trie, left: Nibbles, right: Nibbles): Promise
       }
 
       const child = await trie.lookupNode(node._value)
-      if (child && child instanceof LeafNode) {
+      if (child instanceof LeafNode) {
         return removeSelfFromParentAndSaveStack(left)
       }
 
@@ -264,7 +264,7 @@ async function unsetInternal(trie: Trie, left: Nibbles, right: Nibbles): Promise
       }
 
       const child = await trie.lookupNode(node._value)
-      if (child && child instanceof LeafNode) {
+      if (child instanceof LeafNode) {
         return removeSelfFromParentAndSaveStack(right)
       }
 
@@ -351,7 +351,7 @@ async function verifyProof(
  */
 async function hasRightElement(trie: Trie, key: Nibbles): Promise<boolean> {
   let pos = 0
-  let node = await trie.lookupNode(trie.root())
+  let node: TrieNode | null = await trie.lookupNode(trie.root())
   while (node !== null) {
     if (node instanceof BranchNode) {
       for (let i = key[pos] + 1; i < 16; i++) {

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -403,15 +403,16 @@ export class Trie {
     if (isRawNode(node)) {
       return decodeRawNode(node)
     }
-
-    const value = (await this._db.get(node)) ?? null
-
-    if (value === null) {
+    let value = null
+    let foundNode = null
+    value = await this._db.get(node)
+    if (value) {
+      foundNode = decodeNode(value)
+    } else {
       // Dev note: this error message text is used for error checking in `checkRoot`, `verifyProof`, and `findPath`
       throw new Error('Missing node in DB')
     }
-
-    return decodeNode(value) ?? null
+    return foundNode
   }
 
   /**

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -399,7 +399,7 @@ export class Trie {
   /**
    * Retrieves a node from db by hash.
    */
-  async lookupNode(node: Uint8Array | Uint8Array[]): Promise<TrieNode | null> {
+  async lookupNode(node: Uint8Array | Uint8Array[]): Promise<TrieNode> {
     if (isRawNode(node)) {
       return decodeRawNode(node)
     }
@@ -410,7 +410,7 @@ export class Trie {
       throw new Error('Missing node in DB')
     }
 
-    return decodeNode(value) ?? null
+    return decodeNode(value)
   }
 
   /**
@@ -637,16 +637,10 @@ export class Trie {
 
       // look up node
       const foundNode = await this.lookupNode(branchNode)
-      if (foundNode) {
-        key = processBranchNode(
-          key,
-          branchNodeKey,
-          foundNode as TrieNode,
-          parentNode as TrieNode,
-          stack
-        )
-        await this.saveStack(key, stack, opStack)
-      }
+      // if (foundNode) {
+      key = processBranchNode(key, branchNodeKey, foundNode, parentNode as TrieNode, stack)
+      await this.saveStack(key, stack, opStack)
+      // }
     } else {
       // simple removing a leaf and recalculation the stack
       if (parentNode) {

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -403,16 +403,14 @@ export class Trie {
     if (isRawNode(node)) {
       return decodeRawNode(node)
     }
-    let value = null
-    let foundNode = null
-    value = await this._db.get(node)
-    if (value) {
-      foundNode = decodeNode(value)
-    } else {
+    const value = (await this._db.get(node)) ?? null
+
+    if (value === null) {
       // Dev note: this error message text is used for error checking in `checkRoot`, `verifyProof`, and `findPath`
       throw new Error('Missing node in DB')
     }
-    return foundNode
+
+    return decodeNode(value) ?? null
   }
 
   /**

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -401,18 +401,17 @@ export class Trie {
    */
   async lookupNode(node: Uint8Array | Uint8Array[]): Promise<TrieNode | null> {
     if (isRawNode(node)) {
-      return decodeRawNode(node as Uint8Array[])
+      return decodeRawNode(node)
     }
-    let value = null
-    let foundNode = null
-    value = await this._db.get(node as Uint8Array)
-    if (value) {
-      foundNode = decodeNode(value)
-    } else {
+
+    const value = (await this._db.get(node)) ?? null
+
+    if (value === null) {
       // Dev note: this error message text is used for error checking in `checkRoot`, `verifyProof`, and `findPath`
       throw new Error('Missing node in DB')
     }
-    return foundNode
+
+    return decodeNode(value) ?? null
   }
 
   /**


### PR DESCRIPTION
This PR makes a few minor improvements to the trie library util types.

- Improves the `isRawNode` util into a typeguard, which removes the need for typecasting in some instances.
- Slightly simplifies the logic of the `lookupNode` and `decodeNode` methods