### PR TITLE
client: fix newPayloadV2 having PayloadV3 params

### DIFF
--- a/packages/client/src/rpc/modules/engine.ts
+++ b/packages/client/src/rpc/modules/engine.ts
@@ -806,6 +806,21 @@ export class Engine {
           message: 'ExecutionPayloadV2 MUST be used after Shanghai is activated',
         }
       }
+      const payloadAsV3 = params[0] as ExecutionPayloadV3
+      const { excessBlobGas, blobGasUsed } = payloadAsV3
+
+      if (excessBlobGas !== undefined && excessBlobGas !== null) {
+        throw {
+          code: INVALID_PARAMS,
+          message: 'Invalid PayloadV2: excessBlobGas is defined',
+        }
+      }
+      if (blobGasUsed !== undefined && excessBlobGas !== null) {
+        throw {
+          code: INVALID_PARAMS,
+          message: 'Invalid PayloadV2: blobGasUsed is defined',
+        }
+      }
     }
     const newPayloadRes = await this.newPayload(params)
     if (newPayloadRes.status === Status.INVALID_BLOCK_HASH) {


### PR DESCRIPTION
This fixes a mismatch in `newPayloadV2` of the Shanghai spec: https://github.com/ethereum/execution-apis/blob/main/src/engine/shanghai.md#specification

It states:

Client software **MUST** return `-32602: Invalid params` error if the wrong version of the structure is used in the method call.

(structure = the payload).  

It fixes these 3 hive tests:

![image](https://github.com/ethereumjs/ethereumjs-monorepo/assets/29359032/7e645cdc-3fb0-4207-809c-420b355788f4)
