### PR TITLE
fixed kademlia kbucket add

### DIFF
--- a/packages/devp2p/src/ext/kbucket.ts
+++ b/packages/devp2p/src/ext/kbucket.ts
@@ -149,7 +149,7 @@ export class KBucket {
     }
 
     // the bucket is full
-    if (node.dontSplit !== undefined) {
+    if (node.dontSplit) {
       // we are not allowed to split the bucket
       // we need to ping the first this._numberOfNodesToPing
       // in order to determine if they are alive


### PR DESCRIPTION
in the kbucket implementation the dontSplit attribute of KBucketNode is typed as bool, but was checked wit "!== undefined" which always was true. This caused KBucket.add to never split the leaf node and therefore kept the kbucket as a single level tree with a maximum of _numberOfNodesPerKBucket entrys in total.
tiny modification with huge impact :D