### PR TITLE
DevP2P: ETH: only create DEBUG msgs if debugging

### DIFF
--- a/packages/devp2p/src/protocol/eth.ts
+++ b/packages/devp2p/src/protocol/eth.ts
@@ -59,15 +59,15 @@ export class ETH extends Protocol {
 
   _handleMessage(code: ETH.MESSAGE_CODES, data: Uint8Array) {
     const payload = RLP.decode(data)
-    const debugMsg = this.DEBUG
-      ? // @ts-ignore
-        `Received ${this.getMsgPrefix(code)} message from ${this._peer._socket.remoteAddress}:${
-          // @ts-ignore
-          this._peer._socket.remotePort
-        }`
-      : undefined
 
     if (code !== ETH.MESSAGE_CODES.STATUS && this.DEBUG) {
+      const debugMsg = this.DEBUG
+        ? // @ts-ignore
+          `Received ${this.getMsgPrefix(code)} message from ${this._peer._socket.remoteAddress}:${
+            // @ts-ignore
+            this._peer._socket.remotePort
+          }`
+        : undefined
       const logData = formatLogData(bytesToHex(data), this._verbose)
       this.debug(this.getMsgPrefix(code), `${debugMsg}: ${logData}`)
     }
@@ -85,6 +85,15 @@ export class ETH extends Protocol {
           this._peerStatus !== undefined ? this._getStatusString(this._peerStatus) : ''
         }`
         if (this.DEBUG) {
+          const debugMsg = this.DEBUG
+            ? `Received ${this.getMsgPrefix(code)} message from ${
+                // @ts-ignore
+                this._peer._socket.remoteAddress
+              }:${
+                // @ts-ignore
+                this._peer._socket.remotePort
+              }`
+            : undefined
           this.debug(this.getMsgPrefix(code), `${debugMsg}: ${peerStatusMsg}`)
         }
         this._handleStatus()


### PR DESCRIPTION
Currently, we always construct DEBUG messages on devp2p/ETH even if we are not debugging. This PR ensures these strings are only built when actually debugging. (Slight optimization)