### PR TITLE
common: handle forkHash on timestamp == genesis timestamp

### DIFF
--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -153,7 +153,7 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
     .filter((fork) => fork.block !== null || fork.timestamp !== undefined) as ConfigHardfork[]
 
   for (const hf of params.hardforks) {
-    if (hf.timestamp !== undefined && hf.timestamp === genesisTimestamp) {
+    if (hf.timestamp === genesisTimestamp) {
       hf.timestamp = 0
     }
   }

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -152,6 +152,12 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
     }))
     .filter((fork) => fork.block !== null || fork.timestamp !== undefined) as ConfigHardfork[]
 
+  for (const hf of params.hardforks) {
+    if (hf.timestamp !== undefined && hf.timestamp === genesisTimestamp) {
+      hf.timestamp = 0
+    }
+  }
+
   params.hardforks.sort(function (a: ConfigHardfork, b: ConfigHardfork) {
     return (a.block ?? Infinity) - (b.block ?? Infinity)
   })


### PR DESCRIPTION
Fixes: 

`./hive --sim "ethereum/engine" --client ethereumjs --sim.parallelism 16 --sim.limit="engine-cancun/Request Blob Pooled Transactions"`

If fork is at timestamp genesisTimestamp then this fork is supposed to be active at timestamp = 0 and not participate in the forkHash calculation of the devp2p/ETH STATUS message.

See also:

https://github.com/hyperledger/besu/issues/5744
https://github.com/ethereum/go-ethereum/pull/27895
https://eips.ethereum.org/EIPS/eip-6122
