### PR TITLE
common: add forkHash tests

### DIFF
--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -204,8 +204,10 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
  */
 export function parseGethGenesis(json: any, name?: string, mergeForkIdPostMerge?: boolean) {
   try {
-    if (['config', 'difficulty', 'gasLimit', 'alloc'].some((field) => !(field in json))) {
-      throw new Error('Invalid format, expected geth genesis fields missing')
+    const required = ['config', 'difficulty', 'gasLimit', 'nonce', 'alloc']
+    if (required.some((field) => !(field in json))) {
+      const missingField = required.filter((field) => !(field in json))
+      throw new Error(`Invalid format, expected geth genesis field "${missingField}" missing`)
     }
     if (name !== undefined) {
       json.name = name


### PR DESCRIPTION
This PR:

- Adds forkHash tests for fork configs where a fork is scheduled at exactly the genesis block time (this should not change forkHash as discovered by hive, see: https://github.com/ethereumjs/ethereumjs-monorepo/pull/2959)
- Adds the `nonce` field to required Geth fields (otherwise one gets a non-descriptive error)
- Makes the "missing fields" error message more descriptive