### PR TITLE
client: include parent beacon block root for proposal payload uniquness

### DIFF
--- a/packages/client/src/miner/pendingBlock.ts
+++ b/packages/client/src/miner/pendingBlock.ts
@@ -97,7 +97,7 @@ export class PendingBlock {
     withdrawals?: WithdrawalData[]
   ) {
     const number = parentBlock.header.number + BigInt(1)
-    const { timestamp, mixHash } = headerData
+    const { timestamp, mixHash, parentBeaconBlockRoot } = headerData
     const { gasLimit } = parentBlock.header
 
     // payload is uniquely defined by timestamp, parent and mixHash, gasLimit can also be
@@ -105,11 +105,19 @@ export class PendingBlock {
     const timestampBuf = bigIntToUnpaddedBytes(toType(timestamp ?? 0, TypeOutput.BigInt))
     const gasLimitBuf = bigIntToUnpaddedBytes(gasLimit)
     const mixHashBuf = toType(mixHash!, TypeOutput.Uint8Array) ?? zeros(32)
+    const parentBeaconBlockRootBuf =
+      toType(parentBeaconBlockRoot!, TypeOutput.Uint8Array) ?? zeros(32)
+
     const payloadIdBytes = toBytes(
-      keccak256(concatBytes(parentBlock.hash(), mixHashBuf, timestampBuf, gasLimitBuf)).subarray(
-        0,
-        8
-      )
+      keccak256(
+        concatBytes(
+          parentBlock.hash(),
+          mixHashBuf,
+          timestampBuf,
+          gasLimitBuf,
+          parentBeaconBlockRootBuf
+        )
+      ).subarray(0, 8)
     )
     const payloadId = bytesToHex(payloadIdBytes)
 


### PR DESCRIPTION
Lighthouse seems to have an optimization where they send a fcU before updating head as well as after updating head. this seems to result into two calls with different parentBeaconBlockRoot (which is the CL head on which proposal is being build) 

Since we have not been using parent beacon block root for uniqueness of payload being build, we were returning same payload if to second fcU call (which has an updated parent beacon block root). 

This was leading to invalid evaluation of the block hash later in new payload where the correct parent beacon block root supplied by the CL is injected into payload

This PR attempts to fix the same



- [x] TODO : test on the dencun network with lighthouse: successful block production
  ![image](https://github.com/ethereumjs/ethereumjs-monorepo/assets/76567250/bddb9474-03ff-4ef0-af17-b3d694b35fe2)
