### PR TITLE
Clean up logging in vm/evm

### DIFF
--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -702,7 +702,7 @@ export class EVM implements EVMInterface {
       debug(
         `Received message execResult: [ gasUsed=${executionGasUsed} exceptionError=${
           exceptionError ? `'${exceptionError.error}'` : 'none'
-        } returnValue=0x${short(returnValue)} gasRefund=${result.execResult.gasRefund ?? 0} ]`
+        } returnValue=${short(returnValue)} gasRefund=${result.execResult.gasRefund ?? 0} ]`
       )
     }
     const err = result.execResult.exceptionError

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -399,7 +399,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
         tx.isSigned() ? bytesToHex(tx.hash()) : 'unsigned'
       } with caller=${caller} gasLimit=${gasLimit} to=${
         to?.toString() ?? 'none'
-      } value=${value} data=0x${short(data)}`
+      } value=${value} data=${short(data)}`
     )
   }
 

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -424,7 +424,7 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
     debug(
       `Received tx execResult: [ executionGasUsed=${executionGasUsed} exceptionError=${
         exceptionError !== undefined ? `'${exceptionError.error}'` : 'none'
-      } returnValue=0x${short(returnValue)} gasRefund=${results.gasRefund ?? 0} ]`
+      } returnValue=${short(returnValue)} gasRefund=${results.gasRefund ?? 0} ]`
     )
   }
 


### PR DESCRIPTION
Removes some cosmetic `0x` duplication that was leftover when `bytesToHex` was changed to produce prefixed hex strings.

Before fix --
`vm:tx Running tx=0x6143c89384b58f92fceda500e24e3ffe89a30c5441620fd1f3234a98ebc8a8d4 with caller=0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b gasLimit=3972796 to=0x095e7baea6a6c7c4c2dfeb977efac326af552d87 value=100000 data=`**0x0x00**` +0ms`

After fix --
`vm:tx Running tx=0x6143c89384b58f92fceda500e24e3ffe89a30c5441620fd1f3234a98ebc8a8d4 with caller=0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b gasLimit=3972796 to=0x095e7baea6a6c7c4c2dfeb977efac326af552d87 value=100000 data=`**0x00**` +0ms`
