### PR TITLE
vm: add performance test script using EthersStateManager

### DIFF
--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -490,17 +490,17 @@ export class Blockchain implements BlockchainInterface {
         // save header/block to the database
         dbOps = dbOps.concat(DBSetBlockOrHeader(block))
 
-        let commonAncestor: undefined | BlockHeader
-        let ancestorHeaders: undefined | BlockHeader[]
+        //let commonAncestor: undefined | BlockHeader
+        //let ancestorHeaders: undefined | BlockHeader[]
         // if total difficulty is higher than current, add it to canonical chain
         if (
           block.isGenesis() ||
           td > currentTd.header ||
           block.common.consensusType() === ConsensusType.ProofOfStake
         ) {
-          const foundCommon = await this.findCommonAncestor(header)
-          commonAncestor = foundCommon.commonAncestor
-          ancestorHeaders = foundCommon.ancestorHeaders
+          //const foundCommon = await this.findCommonAncestor(header)
+          //commonAncestor = foundCommon.commonAncestor
+          //ancestorHeaders = foundCommon.ancestorHeaders
 
           this._headHeaderHash = blockHash
           if (item instanceof Block) {
@@ -530,7 +530,7 @@ export class Blockchain implements BlockchainInterface {
         const ops = dbOps.concat(this._saveHeadOps())
         await this.dbManager.batch(ops)
 
-        await this.consensus.newBlock(block, commonAncestor, ancestorHeaders)
+        //await this.consensus.newBlock(block, commonAncestor, ancestorHeaders)
       } catch (e) {
         // restore head to the previouly sane state
         this._heads = oldHeads
@@ -1191,9 +1191,13 @@ export class Blockchain implements BlockchainInterface {
         staleHeadBlock = true
       }
 
-      header = await this._getHeader(header.parentHash, --currentNumber)
-      if (header === undefined) {
-        staleHeads = []
+      try {
+        header = await this._getHeader(header.parentHash, --currentNumber)
+        if (header === undefined) {
+          staleHeads = []
+          break
+        }
+      } catch (e) {
         break
       }
     }

--- a/packages/blockchain/src/db/manager.ts
+++ b/packages/blockchain/src/db/manager.ts
@@ -133,7 +133,7 @@ export class DBManager {
     } else {
       opts.setHardfork = await this.getTotalDifficulty(header.parentHash, number - BigInt(1))
     }
-    return Block.fromValuesArray(blockData, opts)
+    return Block.fromValuesArray(blockData, { ...opts, setHardfork: false })
   }
 
   /**
@@ -164,7 +164,10 @@ export class DBManager {
       const parentHash = headerData.parentHash as Uint8Array
       opts.setHardfork = await this.getTotalDifficulty(parentHash, blockNumber - BigInt(1))
     }
-    return BlockHeader.fromValuesArray(headerValues as Uint8Array[], opts)
+    return BlockHeader.fromValuesArray(headerValues as Uint8Array[], {
+      ...opts,
+      setHardfork: false,
+    })
   }
 
   /**

--- a/packages/vm/test/runPerformance.ts
+++ b/packages/vm/test/runPerformance.ts
@@ -1,0 +1,76 @@
+import { Block } from '@ethereumjs/block'
+import { Blockchain } from '@ethereumjs/blockchain'
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { EthersStateManager } from '@ethereumjs/statemanager'
+import { VM } from '@ethereumjs/vm'
+
+const blockTag = BigInt(4094286)
+const stateManager = new EthersStateManager({
+  provider: 'http://localhost:8545',
+  blockTag,
+})
+
+const common = new Common({
+  chain: Chain.Sepolia,
+  hardfork: Hardfork.Shanghai,
+})
+
+async function go() {
+  const blockchain = await Blockchain.create({
+    common,
+    validateBlocks: false,
+  })
+
+  const vm = await VM.create({
+    common,
+    stateManager,
+    blockchain,
+  })
+
+  for (let n = blockTag - BigInt(256); n < blockTag; n++) {
+    console.log(n)
+    const block = await Block.fromJsonRpcProvider(stateManager._provider, n, {
+      common,
+      setHardfork: false,
+    })
+    await vm.blockchain.putBlock(block)
+  }
+  const rootBlock = await Block.fromJsonRpcProvider(stateManager._provider, blockTag, {
+    common,
+    setHardfork: false,
+  })
+  const block2 = await Block.fromJsonRpcProvider(stateManager._provider, blockTag + BigInt(1), {
+    common,
+    setHardfork: false,
+  })
+
+  await vm.blockchain.putBlock(rootBlock)
+  await vm.blockchain.putBlock(block2)
+
+  await vm.blockchain.getBlock(blockTag)
+
+  // Setup phase
+  const setupTime = Date.now()
+  const setupBlock = await vm.runBlock({
+    block: block2,
+    skipHeaderValidation: true,
+    generate: true,
+  })
+  console.log('Setup took', (Date.now() - setupTime) / 1000)
+  console.log('Gas used: ' + setupBlock.gasUsed, 'expected gas used: ' + block2.header.gasUsed)
+
+  const time = Date.now()
+
+  ;(<EthersStateManager>vm.stateManager).clearCaches()
+  ;(<EthersStateManager>vm.stateManager)._provider = <any>undefined
+  const block = await vm.runBlock({
+    root: rootBlock.header.stateRoot,
+    block: block2,
+    skipHeaderValidation: true,
+    generate: true,
+  })
+  console.log('Running from cache took', (Date.now() - time) / 1000)
+  console.log('Gas used: ' + block.gasUsed, 'expected gas used: ' + block2.header.gasUsed)
+}
+
+void go()

--- a/packages/vm/test/runPerformanceTrie.ts
+++ b/packages/vm/test/runPerformanceTrie.ts
@@ -1,0 +1,83 @@
+import { Block } from '@ethereumjs/block'
+import { Blockchain } from '@ethereumjs/blockchain'
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { EthersStateManager } from '@ethereumjs/statemanager'
+import { bigIntToHex } from '@ethereumjs/util'
+import { VM } from '@ethereumjs/vm'
+
+const blockTag = BigInt(4094286)
+const smProvider = new EthersStateManager({
+  provider: 'http://localhost:8545',
+  blockTag,
+})
+const provider = smProvider._provider
+
+const common = new Common({
+  chain: Chain.Sepolia,
+  hardfork: Hardfork.Shanghai,
+})
+
+async function go() {
+  const blockchain = await Blockchain.create({
+    common,
+    validateBlocks: false,
+  })
+
+  const vm = await VM.create({
+    common,
+    blockchain,
+  })
+
+  ;(<any>vm.stateManager)._trie._provider = provider
+  ;(<any>vm.stateManager)._blockTag = bigIntToHex(blockTag)
+
+  console.log('Setting up blocks for BLOCKHASH')
+  for (let n = blockTag - BigInt(256); n < blockTag; n++) {
+    const block = await Block.fromJsonRpcProvider(provider, n, {
+      common,
+      setHardfork: false,
+    })
+    await vm.blockchain.putBlock(block)
+  }
+  console.log('Done')
+
+  const rootBlock = await Block.fromJsonRpcProvider(provider, blockTag, {
+    common,
+    setHardfork: false,
+  })
+  const block2 = await Block.fromJsonRpcProvider(provider, blockTag + BigInt(1), {
+    common,
+    setHardfork: false,
+  })
+
+  await vm.blockchain.putBlock(rootBlock)
+  await vm.blockchain.putBlock(block2)
+
+  await vm.blockchain.getBlock(blockTag)
+
+  // Setup phase
+  const setupTime = Date.now()
+  const setupBlock = await vm.runBlock({
+    block: block2,
+    skipHeaderValidation: true,
+    generate: true,
+    root: rootBlock.header.stateRoot,
+  })
+  console.log('Setup took', (Date.now() - setupTime) / 1000)
+  console.log('Gas used: ' + setupBlock.gasUsed, 'expected gas used: ' + block2.header.gasUsed)
+
+  const time = Date.now()
+
+  ;(<EthersStateManager>vm.stateManager).clearCaches()
+  ;(<EthersStateManager>vm.stateManager)._provider = <any>undefined
+  const block = await vm.runBlock({
+    root: rootBlock.header.stateRoot,
+    block: block2,
+    skipHeaderValidation: true,
+    generate: true,
+  })
+  console.log('Running from cache took', (Date.now() - time) / 1000)
+  console.log('Gas used: ' + block.gasUsed, 'expected gas used: ' + block2.header.gasUsed)
+}
+
+void go()


### PR DESCRIPTION
This PR is not intended to be merged since it hacks into some packages to get around not having to download all blocks in order to figure out what Common should be used.

To use it, the main script is `./packages/vm/test/runPerformance.ts`. Setup the right provider, blockTag, and common in this script. Ensure that a node is running which has access to the requested storage / account / code items for the blockTag. Note: blockTag should be set to the block you want to run minus one.

This script first setups the local caches of state manager and then re-runs the block to check the run time. I noticed that the reported block gas is not correct, but this is somewhat usable to start benchmarking EVM against realistic blocks.

Note: this current setup ONLY tests EVM. It does not test using a disk DB (all is read from memory) and it also does not use a Trie, so lookup items in memory are a single operation while trie lookups on disk (or in memory as well) usually take multiple operations to get the actual value.