### PR TITLE
Client: Fix initialization order when blocks are preloaded

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -464,27 +464,6 @@ async function startClient(config: Config, customGenesisState?: GenesisState) {
   })
   await client.open()
 
-  if (typeof args.startBlock === 'number') {
-    await startBlock(client)
-  }
-
-  // update client's sync status and start txpool if synchronized
-  client.config.updateSynchronizedState(client.chain.headers.latest)
-  if (client.config.synchronized === true) {
-    const fullService = client.services.find((s) => s.name === 'eth')
-    // The service might not be FullEthereumService even if we cast it as one,
-    // so txPool might not exist on it
-    ;(fullService as FullEthereumService).txPool?.checkRunState()
-  }
-
-  if (args.executeBlocks !== undefined) {
-    // Special block execution debug mode (does not change any state)
-    await executeBlocks(client)
-  } else {
-    // Regular client start
-    await client.start()
-  }
-
   if (args.loadBlocksFromRlp !== undefined) {
     // Specifically for Hive simulator, preload blocks provided in RLP format
     const blockRlp = readFileSync(args.loadBlocksFromRlp)
@@ -517,10 +496,34 @@ async function startClient(config: Config, customGenesisState?: GenesisState) {
       }
 
       await client.chain.putBlocks(blocks)
-      const service = client.service('eth') as FullEthereumService
-      await service.execution.open()
-      await service.execution.run()
     }
+  }
+
+  if (typeof args.startBlock === 'number') {
+    await startBlock(client)
+  }
+
+  // update client's sync status and start txpool if synchronized
+  client.config.updateSynchronizedState(client.chain.headers.latest)
+  if (client.config.synchronized === true) {
+    const fullService = client.services.find((s) => s.name === 'eth')
+    // The service might not be FullEthereumService even if we cast it as one,
+    // so txPool might not exist on it
+    ;(fullService as FullEthereumService).txPool?.checkRunState()
+  }
+
+  if (args.executeBlocks !== undefined) {
+    // Special block execution debug mode (does not change any state)
+    await executeBlocks(client)
+  } else {
+    // Regular client start
+    await client.start()
+  }
+
+  if (args.loadBlocksFromRlp !== undefined && client.chain.opened) {
+    const service = client.service('eth') as FullEthereumService
+    await service.execution.open()
+    await service.execution.run()
   }
   return client
 }


### PR DESCRIPTION
This PR fixes the initialization order when blocks are preloaded with the `--loadBlocksFromRlp` flag.

The semantics of this flag is that this should constitue some kind of pre-state respectively pre-chain history on top of which the client is started. The current order started client services before block addition though, leading e.g. to networking to begin with a misinformed chain-history and e.g. sending wrong status announcements to other peers.

The PR has the potential to fix some Hive devp2p tests, since this is where I actually discovered this by looking at the [log output](https://hivetests.ethdevops.io/viewer.html?suiteid=1692456471-3873d778320d7485b3cc2a610b7c5cc0.json&suitename=eth&testid=15&file=%2Fresults%2Fethereumjs%2Fclient-4244c8aa113feab6093f0f3e3a544f9d9d53e7450913a703e6919457f276bc95.log) for the Eth Hive suite client start. This aligns with the error messages for e.g. the [failing](https://hivetests.ethdevops.io/suite.html?suiteid=1692456471-3873d778320d7485b3cc2a610b7c5cc0.json&suitename=eth#test-25) `TestBlockHashAnnounce` test stating the following:

- `block hash announcement failed: unexpected number of block headers requested: 100`

100 is our requested block number chunk size, so this indicates that our client in the scenario unintendedly sends out block requests while it should find itself in a synchronized state, also reading from its own logs (`DEBUG Client synchronized=true height=999 syncTargetHeight=999 lastSyncDate=1677471439.491 secs ago`).

Fix should be valid with or without Hive tests fixed though, so should be independently ready to be merged.

Didn't test locally on Hive, we'll see on the next remote run what will happen and if things are improved there as well.

Pre-PR Eth test state on Hive is the following:

![grafik](https://github.com/ethereumjs/ethereumjs-monorepo/assets/931137/25296abd-119a-4ed1-a291-8340807f38f5)

