### PR TITLE
Add error handling for async errors in client

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -670,6 +670,14 @@ function generateAccount(): Account {
 const stopClient = async (config: Config, clientStartPromise: any) => {
   config.logger.info('Caught interrupt signal. Obtaining client handle for clean shutdown...')
   config.logger.info('(This might take a little longer if client not yet fully started)')
+  let timeoutHandle
+  if (clientStartPromise.toString().includes('Promise') === true)
+    // Client hasn't finished starting up so setting timeout to terminate process if not already shutdown gracefully
+    timeoutHandle = setTimeout(() => {
+      config.logger.warn('Client has become unresponsive while starting up.')
+      config.logger.warn('Check logging output for potential errors.  Exiting...')
+      process.exit(1)
+    }, 30000)
   const clientHandle = await clientStartPromise
   if (clientHandle !== null) {
     config.logger.info('Shutting down the client and the servers...')
@@ -682,7 +690,7 @@ const stopClient = async (config: Config, clientStartPromise: any) => {
   } else {
     config.logger.info('Client did not start properly, exiting ...')
   }
-
+  clearTimeout(timeoutHandle)
   process.exit()
 }
 
@@ -860,6 +868,15 @@ async function run() {
 
   process.on('SIGTERM', async () => {
     await stopClient(config, clientStartPromise)
+  })
+
+  process.on('uncaughtException', (err) => {
+    // Handles uncaught exceptions that are thrown in async events/functions and aren't caught in
+    // main client process
+    config.logger.error(`Uncaught error: ${err.message}`)
+    config.logger.error(err)
+
+    void stopClient(config, clientStartPromise)
   })
 }
 

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -149,7 +149,12 @@ export class EthereumClient {
 
     await Promise.all(this.services.map((s) => s.start()))
     await Promise.all(this.config.servers.map((s) => s.start()))
-    await Promise.all(this.config.servers.map((s) => s.bootstrap()))
+    await Promise.all(
+      this.config.servers.map(async (s) => {
+        // Only call bootstrap if servers are actually started
+        if (s.started) await s.bootstrap()
+      })
+    )
     this.started = true
   }
 

--- a/packages/client/src/net/server/rlpxserver.ts
+++ b/packages/client/src/net/server/rlpxserver.ts
@@ -223,7 +223,11 @@ export class RlpxServer extends Server {
         dnsAddr: this.config.dnsAddr,
       })
 
-      this.dpt.events.on('error', (e: Error) => this.error(e))
+      this.dpt.events.on('error', (e: Error) => {
+        this.error(e)
+        // If DPT can't bind to port, resolve anyway so client startup doesn't hang
+        if (e.message.includes('EADDRINUSE')) resolve()
+      })
 
       this.dpt.events.on('listening', () => {
         resolve()
@@ -292,7 +296,11 @@ export class RlpxServer extends Server {
         this.error(error)
       )
 
-      this.rlpx.events.on('error', (e: Error) => this.error(e))
+      this.rlpx.events.on('error', (e: Error) => {
+        this.error(e)
+        // If DPT can't bind to port, resolve anyway so client startup doesn't hang
+        if (e.message.includes('EADDRINUSE')) resolve()
+      })
 
       this.rlpx.events.on('listening', () => {
         this.config.events.emit(Event.SERVER_LISTENING, {


### PR DESCRIPTION
Fixes #2983 as well as adds an additional layer of error handling to the client top-level `run` function for errors thrown in eventemitter functions (that normally bypass the `run().catch...` call).

You can test the fix for #2983 by starting geth with default settings and then try to start our client with same defaults.  You will observe an error message like `Server error - EADDRINUSE...` or something indicating that geth is already listening on port 30303.  

On master branch, once this error occurs, you will not be able to shut down the client using Ctrl + C because the client startup function hangs mid promise and never resolves.  This handles the error gracefully and starts the client up.  Oddly enough, the client seems to be able to use the port in contention and still be able to sync mainnet.

I also add some additional error handling for other (as yet unknown) errors thrown during async processes like `EventEmitter` events.  This will log these errors and their stack trace to the console and then call the client shutdown function.  If the client did not successfully start up and the `clientStartPromise` has hung, it will ungracefully terminate the client after 30 seconds.