### PR TITLE
Add EVM profiler

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -344,6 +344,16 @@ const args: ClientOpts = yargs(hideBin(process.argv))
       'To run client in single node configuration without need to discover the sync height from peer. Particularly useful in test configurations. This flag is automically activated in the "dev" mode',
     boolean: true,
   })
+  .option('vmProfileBlocks', {
+    describe: 'Report the VM profile after running each block',
+    boolean: true,
+    default: false,
+  })
+  .option('vmProfileTxs', {
+    describe: 'Report the VM profile after running each block',
+    boolean: true,
+    default: false,
+  })
   .option('loadBlocksFromRlp', {
     describe: 'path to a file of RLP encoded blocks',
     string: true,
@@ -816,6 +826,8 @@ async function run() {
     mine,
     minerCoinbase: args.minerCoinbase,
     isSingleNode,
+    vmProfileBlocks: args.vmProfileBlocks,
+    vmProfileTxs: args.vmProfileTxs,
     minPeers: args.minPeers,
     multiaddrs,
     port: args.port,

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -11,7 +11,7 @@ import type { Logger } from './logging'
 import type { EventBusType, MultiaddrLike } from './types'
 import type { BlockHeader } from '@ethereumjs/block'
 import type { Address } from '@ethereumjs/util'
-import type { VM } from '@ethereumjs/vm'
+import type { VM, VMProfilerOpts } from '@ethereumjs/vm'
 import type { Multiaddr } from 'multiaddr'
 
 export enum DataDirectory {
@@ -252,6 +252,16 @@ export interface ConfigOptions {
   isSingleNode?: boolean
 
   /**
+   * Whether to profile VM blocks
+   */
+  vmProfileBlocks?: boolean
+
+  /**
+   * Whether to profile VM txs
+   */
+  vmProfileTxs?: boolean
+
+  /**
    * Unlocked accounts of form [address, privateKey]
    * Currently only the first account is used to seal mined PoA blocks
    *
@@ -376,6 +386,7 @@ export class Config {
   public readonly isSingleNode: boolean
   public readonly accounts: [address: Address, privKey: Uint8Array][]
   public readonly minerCoinbase?: Address
+  public readonly vmProfilerOpts?: VMProfilerOpts
 
   public readonly safeReorgDistance: number
   public readonly skeletonFillCanonicalBackStep: number
@@ -434,6 +445,14 @@ export class Config {
     this.debugCode = options.debugCode ?? Config.DEBUGCODE_DEFAULT
     this.mine = options.mine ?? false
     this.isSingleNode = options.isSingleNode ?? false
+
+    if (options.vmProfileBlocks !== undefined || options.vmProfileTxs !== undefined) {
+      this.vmProfilerOpts = {
+        reportProfilerAfterBlock: options.vmProfileBlocks !== false,
+        reportProfilerAfterTx: options.vmProfileTxs !== false,
+      }
+    }
+
     this.accounts = options.accounts ?? []
     this.minerCoinbase = options.minerCoinbase
 

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -448,8 +448,8 @@ export class Config {
 
     if (options.vmProfileBlocks !== undefined || options.vmProfileTxs !== undefined) {
       this.vmProfilerOpts = {
-        reportProfilerAfterBlock: options.vmProfileBlocks !== false,
-        reportProfilerAfterTx: options.vmProfileTxs !== false,
+        reportAfterBlock: options.vmProfileBlocks !== false,
+        reportAfterTx: options.vmProfileTxs !== false,
       }
     }
 

--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -76,6 +76,7 @@ export class VMExecution extends Execution {
         common: this.config.execCommon,
         blockchain: this.chain.blockchain,
         stateManager,
+        profilerOpts: this.config.vmProfilerOpts,
       })
     } else {
       this.vm = this.config.vm

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -157,5 +157,7 @@ export interface ClientOpts {
   txLookupLimit?: number
   startBlock?: number
   isSingleNode?: boolean
+  vmProfileBlocks?: boolean
+  vmProfileTxs?: boolean
   loadBlocksFromRlp?: string
 }

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -20,13 +20,15 @@ import { EOF, getEOFCode } from './eof.js'
 import { ERROR, EvmError } from './exceptions.js'
 import { Interpreter } from './interpreter.js'
 import { Journal } from './journal.js'
+import { EVMPerformanceLogger } from './logger.js'
 import { Message } from './message.js'
 import { getOpcodesForHF } from './opcodes/index.js'
-import { getActivePrecompiles } from './precompiles/index.js'
+import { getActivePrecompiles, getPrecompileName } from './precompiles/index.js'
 import { TransientStorage } from './transientStorage.js'
 import { DefaultBlockchain } from './types.js'
 
 import type { InterpreterOpts } from './interpreter.js'
+import type { Timer } from './logger.js'
 import type { MessageWithTo } from './message.js'
 import type { AsyncDynamicGasHandler, SyncDynamicGasHandler } from './opcodes/gas.js'
 import type { OpHandler, OpcodeList } from './opcodes/index.js'
@@ -38,8 +40,6 @@ import type {
   EVMEvents,
   EVMInterface,
   EVMOpts,
-  EVMPerformanceLogEntry,
-  EVMPerformanceLogs,
   EVMResult,
   EVMRunCallOpts,
   EVMRunCodeOpts,
@@ -110,7 +110,7 @@ export class EVM implements EVMInterface {
 
   protected readonly _optsCached: EVMOpts
 
-  protected _performanceLogs: EVMPerformanceLogs
+  protected performanceLogger: EVMPerformanceLogger
 
   public get precompiles() {
     return this._precompiles
@@ -195,7 +195,7 @@ export class EVM implements EVMInterface {
       return new Promise((resolve) => this.events.emit(topic as keyof EVMEvents, data, resolve))
     }
 
-    this._performanceLogs = this.clearPerformanceLogs()
+    this.performanceLogger = new EVMPerformanceLogger()
 
     // Skip DEBUG calls unless 'ethjs' included in environmental DEBUG variables
     // Additional window check is to prevent vite browser bundling (and potentially other) to break
@@ -271,19 +271,13 @@ export class EVM implements EVMInterface {
 
     let result: ExecResult
     if (message.isCompiled) {
-      let timer: number
+      let timer: Timer
       let target: string
       if (this._optsCached.profiler?.enabled === true) {
         target = bytesToUnprefixedHex(message.codeAddress.bytes)
-        if (this._performanceLogs.precompiles[target] === undefined) {
-          this._performanceLogs.precompiles[target] = {
-            calls: 0,
-            time: 0,
-            gasUsed: 0,
-            gasPerSecond: 0,
-          }
-        }
-        timer = performance.now()
+        // TODO: map target precompile not to address, but to a name
+        target = getPrecompileName(target) ?? target.slice(20)
+        timer = this.performanceLogger.startTimer(target)
       }
       result = await this.runPrecompile(
         message.code as PrecompileFunc,
@@ -292,13 +286,7 @@ export class EVM implements EVMInterface {
       )
 
       if (this._optsCached.profiler?.enabled === true) {
-        const delta = (performance.now() - timer!) / 1000
-
-        const field = this._performanceLogs.precompiles[target!]
-        field.calls++
-        field.gasUsed += Number(result.executionGasUsed)
-        field.time += delta
-        // gas per second is updated when it is being read (i.e. evm.getPerformanceLogs())
+        this.performanceLogger.stopTimer(timer!, Number(result.executionGasUsed), 'precompiles')
       }
       result.gasRefund = message.gasRefund
     } else {
@@ -588,7 +576,7 @@ export class EVM implements EVMInterface {
       env,
       message.gasLimit,
       this.journal,
-      this._performanceLogs,
+      this.performanceLogger,
       this._optsCached.profiler
     )
     if (message.selfdestruct) {
@@ -919,23 +907,11 @@ export class EVM implements EVMInterface {
   }
 
   public getPerformanceLogs() {
-    // Update gas/s
-    function updateFields(fields: { [key: string]: EVMPerformanceLogEntry }) {
-      for (const k in fields) {
-        fields[k].gasPerSecond = fields[k].gasUsed / fields[k].time
-      }
-    }
-    updateFields(this._performanceLogs.opcodes)
-    updateFields(this._performanceLogs.precompiles)
-    return this._performanceLogs
+    return this.performanceLogger.getLogs()
   }
 
   public clearPerformanceLogs() {
-    this._performanceLogs = {
-      opcodes: {},
-      precompiles: {},
-    }
-    return this._performanceLogs
+    this.performanceLogger.clear()
   }
 }
 

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -177,7 +177,8 @@ export class Interpreter {
       returnValue: undefined,
       selfdestruct: new Set(),
     }
-    ;(this.profilerOpts = profilerOpts), (this.performanceLogger = performanceLogs)
+    this.profilerOpts = profilerOpts
+    this.performanceLogger = performanceLogs
   }
 
   async run(code: Uint8Array, opts: InterpreterOpts = {}): Promise<InterpreterResult> {

--- a/packages/evm/src/logger.ts
+++ b/packages/evm/src/logger.ts
@@ -1,0 +1,143 @@
+type EVMPerformanceLogEntry = {
+  calls: number
+  time: number
+  gasUsed: number
+}
+
+export type EVMPerformanceLogOutput = {
+  calls: number // Amount this opcode/precompile was called
+  totalTime: number // Amount of seconds taken for this opcode/precompile (rounded to 3 digits)
+  avgTimePerCall: number // Avg time per call of this opcode/precompile (rounded to 3 digits)
+  gasUsed: number // Total amount of gas used by this opcode/precompile
+  millionGasPerSecond: number // How much million gas is executed per second (rounded to 3 digits)
+  tag: string // opcode/precompile tag
+}
+
+type EVMPerformanceLogs = {
+  [tag: string]: EVMPerformanceLogEntry
+}
+
+export class Timer {
+  private startTime: number
+  private runTime = 0
+  tag: string
+
+  constructor(tag: string) {
+    this.tag = tag
+    this.startTime = performance.now()
+  }
+
+  pause() {
+    this.runTime = this.runTime + performance.now() - this.startTime
+  }
+
+  unpause() {
+    this.startTime = performance.now()
+  }
+
+  time() {
+    return (performance.now() - this.startTime + this.runTime) / 1000
+  }
+}
+
+export class EVMPerformanceLogger {
+  private opcodes!: EVMPerformanceLogs
+  private precompiles!: EVMPerformanceLogs
+
+  private currentTimer?: Timer
+
+  constructor() {
+    this.clear()
+  }
+
+  clear() {
+    this.opcodes = {}
+    this.precompiles = {}
+  }
+
+  getLogs() {
+    // Return nicely formatted logs
+    function getLogsFor(obj: EVMPerformanceLogs) {
+      const output: EVMPerformanceLogOutput[] = []
+      for (const key in obj) {
+        const field = obj[key]
+        const entry = {
+          calls: field.calls,
+          totalTime: Math.round(field.time * 1e6) / 1e3,
+          avgTimePerCall: Math.round((field.time / field.calls) * 1e6) / 1e3,
+          gasUsed: field.gasUsed,
+          millionGasPerSecond: Math.round(field.gasUsed / field.time / 1e3) / 1e3,
+          tag: key,
+        }
+        output.push(entry)
+      }
+
+      output.sort((a, b) => {
+        return b.millionGasPerSecond - a.millionGasPerSecond
+      })
+
+      return output
+    }
+
+    return {
+      opcodes: getLogsFor(this.opcodes),
+      precompiles: getLogsFor(this.precompiles),
+    }
+  }
+
+  // Start a new timer
+  // Only one timer can be timing at the same time
+  startTimer(tag: string) {
+    if (this.currentTimer !== undefined) {
+      throw new Error('Cannot have two timers running at the same time')
+    }
+
+    this.currentTimer = new Timer(tag)
+    return this.currentTimer
+  }
+
+  // Pauses current timer and returns that timer
+  pauseTimer() {
+    const timer = this.currentTimer
+    if (timer === undefined) {
+      throw new Error('No timer to pause')
+    }
+    timer.pause()
+    this.currentTimer = undefined
+    return timer
+  }
+
+  // Unpauses current timer and returns that timer
+  unpauseTimer(timer: Timer) {
+    if (this.currentTimer !== undefined) {
+      throw new Error('Cannot unpause timer: another timer is already running')
+    }
+    timer.unpause()
+    this.currentTimer = timer
+  }
+
+  // Stops a timer from running
+  stopTimer(timer: Timer, gasUsed: number, targetTimer: 'precompiles' | 'opcodes' = 'opcodes') {
+    if (this.currentTimer !== undefined && this.currentTimer !== timer) {
+      throw new Error('Cannot unpause timer: another timer is already running')
+    }
+    const time = timer.time()
+    const tag = timer.tag
+    this.currentTimer = undefined
+
+    // Update the fields
+    const target = this[targetTimer]
+    if (target[tag] === undefined) {
+      target[tag] = {
+        calls: 0,
+        time: 0,
+        gasUsed: 0,
+      }
+    }
+    const obj = target[tag]
+
+    obj.calls++
+    obj.time += time
+    obj.gasUsed += gasUsed
+  }
+}

--- a/packages/evm/src/precompiles/index.ts
+++ b/packages/evm/src/precompiles/index.ts
@@ -19,6 +19,7 @@ interface PrecompileEntry {
   address: string
   check: PrecompileAvailabilityCheckType
   precompile: PrecompileFunc
+  name: string
 }
 
 interface Precompiles {
@@ -54,6 +55,7 @@ const precompileEntries: PrecompileEntry[] = [
       param: Hardfork.Chainstart,
     },
     precompile: precompile01,
+    name: 'ECRECOVER (0x01)',
   },
   {
     address: '0000000000000000000000000000000000000002',
@@ -62,6 +64,7 @@ const precompileEntries: PrecompileEntry[] = [
       param: Hardfork.Chainstart,
     },
     precompile: precompile02,
+    name: 'SHA256 (0x02)',
   },
   {
     address: '0000000000000000000000000000000000000003',
@@ -70,6 +73,7 @@ const precompileEntries: PrecompileEntry[] = [
       param: Hardfork.Chainstart,
     },
     precompile: precompile03,
+    name: 'RIPEMD160 (0x03)',
   },
   {
     address: '0000000000000000000000000000000000000004',
@@ -78,6 +82,7 @@ const precompileEntries: PrecompileEntry[] = [
       param: Hardfork.Chainstart,
     },
     precompile: precompile04,
+    name: 'Identity (0x04)',
   },
   {
     address: '0000000000000000000000000000000000000005',
@@ -86,6 +91,7 @@ const precompileEntries: PrecompileEntry[] = [
       param: Hardfork.Byzantium,
     },
     precompile: precompile05,
+    name: 'MODEXP (0x05)',
   },
   {
     address: '0000000000000000000000000000000000000006',
@@ -94,6 +100,7 @@ const precompileEntries: PrecompileEntry[] = [
       param: Hardfork.Byzantium,
     },
     precompile: precompile06,
+    name: 'ECADD (0x06)',
   },
   {
     address: '0000000000000000000000000000000000000007',
@@ -102,6 +109,7 @@ const precompileEntries: PrecompileEntry[] = [
       param: Hardfork.Byzantium,
     },
     precompile: precompile07,
+    name: 'ECMUL (0x07)',
   },
   {
     address: '0000000000000000000000000000000000000008',
@@ -110,6 +118,7 @@ const precompileEntries: PrecompileEntry[] = [
       param: Hardfork.Byzantium,
     },
     precompile: precompile08,
+    name: 'ECPAIR (0x08)',
   },
   {
     address: '0000000000000000000000000000000000000009',
@@ -118,6 +127,7 @@ const precompileEntries: PrecompileEntry[] = [
       param: Hardfork.Istanbul,
     },
     precompile: precompile09,
+    name: 'BLAKE2f (0x09)',
   },
   {
     address: '000000000000000000000000000000000000000a',
@@ -126,6 +136,7 @@ const precompileEntries: PrecompileEntry[] = [
       param: 4844,
     },
     precompile: precompile0a,
+    name: 'KZG (0x0a)',
   },
 ]
 
@@ -183,6 +194,20 @@ function getActivePrecompiles(
   return precompileMap
 }
 
-export { getActivePrecompiles, precompileEntries, precompiles, ripemdPrecompileAddress }
+function getPrecompileName(addressUnprefixedStr: string) {
+  for (const entry of precompileEntries) {
+    if (entry.address === addressUnprefixedStr) {
+      return entry.name
+    }
+  }
+}
+
+export {
+  getActivePrecompiles,
+  getPrecompileName,
+  precompileEntries,
+  precompiles,
+  ripemdPrecompileAddress,
+}
 
 export type { AddPrecompile, CustomPrecompile, DeletePrecompile, PrecompileFunc, PrecompileInput }

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -163,22 +163,6 @@ export type EVMProfilerOpts = {
   // extra options here (such as use X hardfork for gas)
 }
 
-export type EVMPerformanceLogEntry = {
-  calls: number
-  time: number
-  gasUsed: number
-  gasPerSecond: number
-}
-
-export type EVMPerformanceLogs = {
-  opcodes: {
-    [opcodeName: string]: EVMPerformanceLogEntry
-  }
-  precompiles: {
-    [precompileTag: string]: EVMPerformanceLogEntry
-  }
-}
-
 /**
  * Options for instantiating a {@link EVM}.
  */

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -158,6 +158,27 @@ export interface EVMInterface {
   events?: AsyncEventEmitter<EVMEvents>
 }
 
+export type EVMProfilerOpts = {
+  enabled: boolean
+  // extra options here (such as use X hardfork for gas)
+}
+
+export type EVMPerformanceLogEntry = {
+  calls: number
+  time: number
+  gasUsed: number
+  gasPerSecond: number
+}
+
+export type EVMPerformanceLogs = {
+  opcodes: {
+    [opcodeName: string]: EVMPerformanceLogEntry
+  }
+  precompiles: {
+    [precompileTag: string]: EVMPerformanceLogEntry
+  }
+}
+
 /**
  * Options for instantiating a {@link EVM}.
  */
@@ -254,6 +275,11 @@ export interface EVMOpts {
    *
    */
   blockchain?: Blockchain
+
+  /**
+   *
+   */
+  profiler?: EVMProfilerOpts
 }
 
 /**

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -30,11 +30,12 @@ import type {
   TxReceipt,
 } from './types.js'
 import type { VM } from './vm.js'
-import type { EVMInterface } from '@ethereumjs/evm'
+import type { EVM, EVMInterface } from '@ethereumjs/evm'
 
 const { debug: createDebugLogger } = debugDefault
 
 const debug = createDebugLogger('vm:block')
+const debugProfilerEVM = createDebugLogger('evm:profiler')
 
 const parentBeaconBlockRootAddress = Address.fromString(
   '0x000000000000000000000000000000000000000b'
@@ -222,6 +223,12 @@ export async function runBlock(this: VM, opts: RunBlockOpts): Promise<RunBlockRe
         block.header.number
       } hardfork=${this.common.hardfork()}`
     )
+  }
+
+  if (this._opts.profilerOpts?.reportProfilerAfterBlock === true) {
+    const logs = (<EVM>this.evm).getPerformanceLogs()
+    debugProfilerEVM(logs)
+    ;(<EVM>this.evm).clearPerformanceLogs()
   }
 
   return results

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -35,7 +35,6 @@ import type { EVM, EVMInterface } from '@ethereumjs/evm'
 const { debug: createDebugLogger } = debugDefault
 
 const debug = createDebugLogger('vm:block')
-const debugProfilerEVM = createDebugLogger('evm:profiler')
 
 const parentBeaconBlockRootAddress = Address.fromString(
   '0x000000000000000000000000000000000000000b'
@@ -227,7 +226,9 @@ export async function runBlock(this: VM, opts: RunBlockOpts): Promise<RunBlockRe
 
   if (this._opts.profilerOpts?.reportProfilerAfterBlock === true) {
     const logs = (<EVM>this.evm).getPerformanceLogs()
-    debugProfilerEVM(logs)
+    const tag = ' - Block ' + Number(block.header.number) + ' (' + bytesToHex(block.hash()) + ')'
+    this.emitEVMProfile(logs.precompiles, 'Precompile performance ' + tag)
+    this.emitEVMProfile(logs.opcodes, 'Opcodes performance' + tag)
     ;(<EVM>this.evm).clearPerformanceLogs()
   }
 

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -224,7 +224,7 @@ export async function runBlock(this: VM, opts: RunBlockOpts): Promise<RunBlockRe
     )
   }
 
-  if (this._opts.profilerOpts?.reportProfilerAfterBlock === true) {
+  if (this._opts.profilerOpts?.reportAfterBlock === true) {
     const logs = (<EVM>this.evm).getPerformanceLogs()
     const tag = ' - Block ' + Number(block.header.number) + ' (' + bytesToHex(block.hash()) + ')'
     this.emitEVMProfile(logs.precompiles, 'Precompile performance ' + tag)

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -163,7 +163,7 @@ export async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
       this.evm.journal.cleanJournal()
     }
     this.evm.stateManager.originalStorageCache.clear()
-    if (this._opts.profilerOpts?.reportProfilerAfterTx === true) {
+    if (this._opts.profilerOpts?.reportAfterTx === true) {
       const logs = (<EVM>this.evm).getPerformanceLogs()
       const tag = ' - Tx ' + bytesToHex(opts.tx.hash())
       this.emitEVMProfile(logs.precompiles, 'Precompile performance ' + tag)

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -38,7 +38,6 @@ const { debug: createDebugLogger } = debugDefault
 
 const debug = createDebugLogger('vm:tx')
 const debugGas = createDebugLogger('vm:tx:gas')
-const debugProfilerEVM = createDebugLogger('evm:profiler')
 
 /**
  * Returns the hardfork excluding the merge hf which has
@@ -166,7 +165,9 @@ export async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
     this.evm.stateManager.originalStorageCache.clear()
     if (this._opts.profilerOpts?.reportProfilerAfterTx === true) {
       const logs = (<EVM>this.evm).getPerformanceLogs()
-      debugProfilerEVM(logs)
+      const tag = ' - Tx ' + bytesToHex(opts.tx.hash())
+      this.emitEVMProfile(logs.precompiles, 'Precompile performance ' + tag)
+      this.emitEVMProfile(logs.opcodes, 'Opcodes performance' + tag)
       ;(<EVM>this.evm).clearPerformanceLogs()
     }
   }

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -27,6 +27,7 @@ import type {
 } from './types.js'
 import type { VM } from './vm.js'
 import type { AccessList, AccessListItem } from '@ethereumjs/common'
+import type { EVM } from '@ethereumjs/evm'
 import type {
   AccessListEIP2930Transaction,
   FeeMarketEIP1559Transaction,
@@ -37,6 +38,7 @@ const { debug: createDebugLogger } = debugDefault
 
 const debug = createDebugLogger('vm:tx')
 const debugGas = createDebugLogger('vm:tx:gas')
+const debugProfilerEVM = createDebugLogger('evm:profiler')
 
 /**
  * Returns the hardfork excluding the merge hf which has
@@ -162,6 +164,11 @@ export async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
       this.evm.journal.cleanJournal()
     }
     this.evm.stateManager.originalStorageCache.clear()
+    if (this._opts.profilerOpts?.reportProfilerAfterTx === true) {
+      const logs = (<EVM>this.evm).getPerformanceLogs()
+      debugProfilerEVM(logs)
+      ;(<EVM>this.evm).clearPerformanceLogs()
+    }
   }
 }
 

--- a/packages/vm/src/types.ts
+++ b/packages/vm/src/types.ts
@@ -140,6 +140,12 @@ export interface VMOpts {
    * Use a custom EVM to run Messages on. If this is not present, use the default EVM.
    */
   evm?: EVMInterface
+
+  profilerOpts?: {
+    //evmProfilerOpts: EVMProfilerOpts
+    reportProfilerAfterTx?: boolean
+    reportProfilerAfterBlock?: boolean
+  }
 }
 
 /**

--- a/packages/vm/src/types.ts
+++ b/packages/vm/src/types.ts
@@ -64,11 +64,22 @@ export interface EIP4844BlobTxReceipt extends PostByzantiumTxReceipt {
   blobGasPrice: bigint
 }
 
+export type EVMProfilerOpts = {
+  enabled: boolean
+  // extra options here (such as use X hardfork for gas)
+}
+
 export type VMEvents = {
   beforeBlock: (data: Block, resolve?: (result?: any) => void) => void
   afterBlock: (data: AfterBlockEvent, resolve?: (result?: any) => void) => void
   beforeTx: (data: TypedTransaction, resolve?: (result?: any) => void) => void
   afterTx: (data: AfterTxEvent, resolve?: (result?: any) => void) => void
+}
+
+export type VMProfilerOpts = {
+  //evmProfilerOpts: EVMProfilerOpts
+  reportProfilerAfterTx?: boolean
+  reportProfilerAfterBlock?: boolean
 }
 
 /**
@@ -141,11 +152,7 @@ export interface VMOpts {
    */
   evm?: EVMInterface
 
-  profilerOpts?: {
-    //evmProfilerOpts: EVMProfilerOpts
-    reportProfilerAfterTx?: boolean
-    reportProfilerAfterBlock?: boolean
-  }
+  profilerOpts?: VMProfilerOpts
 }
 
 /**

--- a/packages/vm/src/types.ts
+++ b/packages/vm/src/types.ts
@@ -78,8 +78,8 @@ export type VMEvents = {
 
 export type VMProfilerOpts = {
   //evmProfilerOpts: EVMProfilerOpts
-  reportProfilerAfterTx?: boolean
-  reportProfilerAfterBlock?: boolean
+  reportAfterTx?: boolean
+  reportAfterBlock?: boolean
 }
 
 /**

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -21,6 +21,7 @@ import type {
 import type { BlockchainInterface } from '@ethereumjs/blockchain'
 import type { EVMStateManagerInterface } from '@ethereumjs/common'
 import type { EVMInterface } from '@ethereumjs/evm'
+import type { EVMPerformanceLogOutput } from '@ethereumjs/evm/dist/cjs/logger.js'
 import type { BigIntLike, GenesisState } from '@ethereumjs/util'
 
 /**
@@ -112,6 +113,18 @@ export class VM {
     }
 
     this.blockchain = opts.blockchain ?? new (Blockchain as any)({ common: this.common })
+
+    if (this._opts.profilerOpts !== undefined) {
+      const profilerOpts = this._opts.profilerOpts
+      if (
+        profilerOpts.reportProfilerAfterBlock === true &&
+        profilerOpts.reportProfilerAfterTx === true
+      ) {
+        throw new Error(
+          'Cannot have `reportProfilerAfterBlock` and `reportProfilerAfterTx` set to `true` at the same time'
+        )
+      }
+    }
 
     // TODO tests
     if (opts.evm) {
@@ -246,6 +259,7 @@ export class VM {
       common,
       evm: evmCopy,
       setHardfork: this._setHardfork,
+      profilerOpts: this._opts.profilerOpts,
     })
   }
 
@@ -261,5 +275,82 @@ export class VM {
     }
     const errorStr = `vm hf=${hf}`
     return errorStr
+  }
+
+  /**
+   * Emit EVM profile logs
+   * @param logs
+   * @param profileTitle
+   * @hidden
+   */
+  emitEVMProfile(logs: EVMPerformanceLogOutput[], profileTitle: string) {
+    if (logs.length === 0) {
+      return
+    }
+    const colOrder = [
+      'tag',
+      'calls',
+      'avgTimePerCall',
+      'totalTime',
+      'gasUsed',
+      'millionGasPerSecond',
+    ]
+    const colNames = ['tag', 'calls', 'ms/call', 'total (ms)', 'gas used', 'Mgas/s']
+    function padStr(str: string | number, leftpad: number) {
+      return ' ' + str.toString().padStart(leftpad, ' ') + ' '
+    }
+    function strLen(str: string | number) {
+      return padStr(str, 0).length - 2
+    }
+
+    const colLength: number[] = []
+
+    for (const entry of logs) {
+      let ins = 0
+      colLength[ins] = Math.max(colLength[ins] ?? 0, strLen(colNames[ins]))
+      for (const key of colOrder) {
+        //@ts-ignore
+        colLength[ins] = Math.max(colLength[ins] ?? 0, strLen(entry[key]))
+        ins++
+      }
+    }
+
+    for (const i in colLength) {
+      colLength[i] = Math.max(colLength[i] ?? 0, strLen(colNames[i]))
+    }
+
+    const headerLength = colLength.reduce((pv, cv) => pv + cv, 0) + colLength.length * 3 - 1
+    // eslint-disable-next-line
+    console.log('+== ' + profileTitle + ' ==+')
+
+    const header = '|' + '-'.repeat(headerLength) + '|'
+    // eslint-disable-next-line
+    console.log(header)
+
+    let str = ''
+    for (const i in colLength) {
+      str += '|' + padStr(colNames[i], colLength[i])
+    }
+    str += '|'
+
+    // eslint-disable-next-line
+    console.log(str)
+
+    for (const entry of logs) {
+      let str = ''
+      let i = 0
+      for (const key of colOrder) {
+        //@ts-ignore
+        str += '|' + padStr(entry[key], colLength[i])
+        i++
+      }
+      str += '|'
+      // eslint-disable-next-line
+      console.log(str)
+    }
+
+    const footer = '+' + '-'.repeat(headerLength) + '+'
+    // eslint-disable-next-line
+    console.log(footer)
   }
 }

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -117,10 +117,17 @@ export class VM {
     if (opts.evm) {
       this.evm = opts.evm
     } else {
+      const enableProfiler =
+        this._opts.profilerOpts?.reportProfilerAfterBlock ??
+        this._opts.profilerOpts?.reportProfilerAfterTx ??
+        false
       this.evm = new EVM({
         common: this.common,
         stateManager: this.stateManager,
         blockchain: this.blockchain,
+        profiler: {
+          enabled: enableProfiler,
+        },
       })
     }
 

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -116,10 +116,7 @@ export class VM {
 
     if (this._opts.profilerOpts !== undefined) {
       const profilerOpts = this._opts.profilerOpts
-      if (
-        profilerOpts.reportProfilerAfterBlock === true &&
-        profilerOpts.reportProfilerAfterTx === true
-      ) {
+      if (profilerOpts.reportAfterBlock === true && profilerOpts.reportAfterTx === true) {
         throw new Error(
           'Cannot have `reportProfilerAfterBlock` and `reportProfilerAfterTx` set to `true` at the same time'
         )
@@ -131,9 +128,7 @@ export class VM {
       this.evm = opts.evm
     } else {
       const enableProfiler =
-        this._opts.profilerOpts?.reportProfilerAfterBlock ??
-        this._opts.profilerOpts?.reportProfilerAfterTx ??
-        false
+        this._opts.profilerOpts?.reportAfterBlock ?? this._opts.profilerOpts?.reportAfterTx ?? false
       this.evm = new EVM({
         common: this.common,
         stateManager: this.stateManager,

--- a/packages/vm/test/tester/config.ts
+++ b/packages/vm/test/tester/config.ts
@@ -51,7 +51,7 @@ export const SKIP_SLOW = [
   'CALLBlake2f_MaxRounds',
   // vmPerformance tests
   'loopMul',
-  'loopExp',
+  //  'loopExp',
 ]
 
 /**


### PR DESCRIPTION
This PR adds the feature for an EVM profiler. It features, once enabled, tracking:

- The amount of calls, the time it takes, and the gas it consumes for each opcode
- The same "inside" the precompiles

For precompiles we have the special case that the gas there is not tracked as in normal EVM calls, but instead depends upon what precompile is called. If a precompile is called, the "inner" gas used by that precompile (so without the overhead of the initial CALL opcode to the precompile) is tracked.

The VM gets extra options: `profilerOpts`, which can `reportProfilerAfterBlock` and `reportProfilerAfterTx`. Note that if a profiler is reported, the profiler in the EVM is cleared, so you cannot use both options.

EVM itself has an extra option as well, the `profiler` (should rename this to `profilerOpts` as well for consistency) which currently only has the `enable` flag. This will later support reporting the gas used for different hardforks (while the actual EVM runs on the hardfork it expects for that call) such that we can simulate running Shanghai gas on older blocks (since EVM had many underpriced situations back then).

To run and test:

Add this to `BlockchainTestRunner`: 

```typescript
  let vm = await VM.create({
    stateManager,
    blockchain,
    common,
    setHardfork: true,
    profilerOpts: {
      reportProfilerAfterBlock: true
    }
  })
```

Now run a blockchain test: `npm run test:blockchain -- --fork=Shanghai --test=coinbaseWarmAccountCallGasFail_d3g0v0_Shanghai`

Example output: 

![image](https://github.com/ethereumjs/ethereumjs-monorepo/assets/29359032/3a2288ef-6eba-4deb-ae4b-9e672f110209)

TODOs

- [x] Gas reported for CALL situations is incorrect, this encompasses setting up the CALL, but also all time consumed within that call frame
- - To test: `DEBUG=ethjs,evm:profiler npm run test:blockchain -- --fork=Shanghai --test=ContractCreationSpam_d0g0v0_Shanghai`
- - The total time of each opcode consumed is higher than the total test run
- [x] Test if precompile reporting is correct

TODOs for subsequent PRs

- Add option to set custom hardfork for gas reporting to EVM
- Add option to also profile the pre-EVM-call setup in VM, and also the post-EVM-call setup in VM


