### PR TITLE
Common: Cache Parameter Values + activated EIPs for current Hardfork / SM copy() fix

### DIFF
--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -404,14 +404,13 @@ export class BlockHeader {
    */
   protected _consensusFormatValidation() {
     const { nonce, uncleHash, difficulty, extraData, number } = this
-    const hardfork = this.common.hardfork()
 
     // Consensus type dependent checks
     if (this.common.consensusAlgorithm() === ConsensusAlgorithm.Ethash) {
       // PoW/Ethash
       if (
         number > BigInt(0) &&
-        this.extraData.length > this.common.paramByHardfork('vm', 'maxExtraDataSize', hardfork)
+        this.extraData.length > this.common.param('vm', 'maxExtraDataSize')
       ) {
         // Check length of data on all post-genesis blocks
         const msg = this._errorMsg('invalid amount of extra data')
@@ -506,10 +505,8 @@ export class BlockHeader {
       parentGasLimit = parentGasLimit * elasticity
     }
     const gasLimit = this.gasLimit
-    const hardfork = this.common.hardfork()
 
-    const a =
-      parentGasLimit / this.common.paramByHardfork('gasConfig', 'gasLimitBoundDivisor', hardfork)
+    const a = parentGasLimit / this.common.param('gasConfig', 'gasLimitBoundDivisor')
     const maxGasLimit = parentGasLimit + a
     const minGasLimit = parentGasLimit - a
 
@@ -523,10 +520,8 @@ export class BlockHeader {
       throw new Error(msg)
     }
 
-    if (gasLimit < this.common.paramByHardfork('gasConfig', 'minGasLimit', hardfork)) {
-      const msg = this._errorMsg(
-        `gas limit decreased below minimum gas limit for hardfork=${hardfork}`
-      )
+    if (gasLimit < this.common.param('gasConfig', 'minGasLimit')) {
+      const msg = this._errorMsg(`gas limit decreased below minimum gas limit`)
       throw new Error(msg)
     }
   }
@@ -704,18 +699,16 @@ export class BlockHeader {
       )
       throw new Error(msg)
     }
-    const hardfork = this.common.hardfork()
     const blockTs = this.timestamp
     const { timestamp: parentTs, difficulty: parentDif } = parentBlockHeader
-    const minimumDifficulty = this.common.paramByHardfork('pow', 'minimumDifficulty', hardfork)
-    const offset =
-      parentDif / this.common.paramByHardfork('pow', 'difficultyBoundDivisor', hardfork)
+    const minimumDifficulty = this.common.param('pow', 'minimumDifficulty')
+    const offset = parentDif / this.common.param('pow', 'difficultyBoundDivisor')
     let num = this.number
 
     // We use a ! here as TS cannot follow this hardfork-dependent logic, but it always gets assigned
     let dif!: bigint
 
-    if (this.common.hardforkGteHardfork(hardfork, Hardfork.Byzantium) === true) {
+    if (this.common.gteHardfork(Hardfork.Byzantium) === true) {
       // max((2 if len(parent.uncles) else 1) - ((timestamp - parent.timestamp) // 9), -99) (EIP100)
       const uncleAddend = equalsBytes(parentBlockHeader.uncleHash, KECCAK256_RLP_ARRAY) ? 1 : 2
       let a = BigInt(uncleAddend) - (blockTs - parentTs) / BigInt(9)
@@ -727,13 +720,13 @@ export class BlockHeader {
       dif = parentDif + offset * a
     }
 
-    if (this.common.hardforkGteHardfork(hardfork, Hardfork.Byzantium) === true) {
+    if (this.common.gteHardfork(Hardfork.Byzantium) === true) {
       // Get delay as parameter from common
       num = num - this.common.param('pow', 'difficultyBombDelay')
       if (num < BigInt(0)) {
         num = BigInt(0)
       }
-    } else if (this.common.hardforkGteHardfork(hardfork, Hardfork.Homestead) === true) {
+    } else if (this.common.gteHardfork(Hardfork.Homestead) === true) {
       // 1 - (block_timestamp - parent_timestamp) // 10
       let a = BigInt(1) - (blockTs - parentTs) / BigInt(10)
       const cutoff = BigInt(-99)
@@ -744,7 +737,7 @@ export class BlockHeader {
       dif = parentDif + offset * a
     } else {
       // pre-homestead
-      if (parentTs + this.common.paramByHardfork('pow', 'durationLimit', hardfork) > blockTs) {
+      if (parentTs + this.common.param('pow', 'durationLimit') > blockTs) {
         dif = offset + parentDif
       } else {
         dif = parentDif - offset

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -256,7 +256,7 @@ export class Common {
   /**
    * Sets the chain
    * @param chain String ('mainnet') or Number (1) chain representation.
-   *              Or, a Dictionary of chain parameters for a protected network.
+   *              Or, a Dictionary of chain parameters for a private network.
    * @returns The dictionary with parameters set as chain
    */
   setChain(chain: string | number | Chain | bigint | object): ChainConfig {

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -512,6 +512,7 @@ export class Common {
    * Build up a cache for all parameter values for the current HF and all activated EIPs
    */
   protected _buildParamsCache() {
+    this._paramsCache = {}
     // Iterate through all hardforks up to hardfork set
     const hardfork = this.hardfork()
     for (const hfChanges of this.HARDFORK_CHANGES) {

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -46,12 +46,12 @@ type HardforkSpecValues = typeof HARDFORK_SPECS[HardforkSpecKeys]
 export class Common {
   readonly DEFAULT_HARDFORK: string | Hardfork
 
-  private _chainParams: ChainConfig
-  private _hardfork: string | Hardfork
-  private _eips: number[] = []
-  private _customChains: ChainConfig[]
+  protected _chainParams: ChainConfig
+  protected _hardfork: string | Hardfork
+  protected _eips: number[] = []
+  protected _customChains: ChainConfig[]
 
-  private HARDFORK_CHANGES: [HardforkSpecKeys, HardforkSpecValues][]
+  protected HARDFORK_CHANGES: [HardforkSpecKeys, HardforkSpecValues][]
 
   public events: EventEmitter
 
@@ -197,7 +197,7 @@ export class Common {
     return Boolean((initializedChains['names'] as ChainName)[chainId.toString()])
   }
 
-  private static _getChainParams(
+  protected static _getChainParams(
     chain: string | number | Chain | bigint,
     customChains?: ChainConfig[]
   ): ChainConfig {
@@ -243,7 +243,7 @@ export class Common {
   /**
    * Sets the chain
    * @param chain String ('mainnet') or Number (1) chain representation.
-   *              Or, a Dictionary of chain parameters for a private network.
+   *              Or, a Dictionary of chain parameters for a protected network.
    * @returns The dictionary with parameters set as chain
    */
   setChain(chain: string | number | Chain | bigint | object): ChainConfig {
@@ -435,7 +435,7 @@ export class Common {
    * @param hardfork Hardfork name
    * @returns Dictionary with hardfork params or null if hardfork not on chain
    */
-  private _getHardfork(hardfork: string | Hardfork): HardforkTransitionConfig | null {
+  protected _getHardfork(hardfork: string | Hardfork): HardforkTransitionConfig | null {
     const hfs = this.hardforks()
     for (const hf of hfs) {
       if (hf['name'] === hardfork) return hf
@@ -755,7 +755,7 @@ export class Common {
    * @param genesisHash Genesis block hash of the chain
    * @returns Fork hash as hex string
    */
-  private _calcForkHash(hardfork: string | Hardfork, genesisHash: Uint8Array): PrefixedHexString {
+  protected _calcForkHash(hardfork: string | Hardfork, genesisHash: Uint8Array): PrefixedHexString {
     let hfBytes = new Uint8Array(0)
     let prevBlockOrTime = 0
     for (const hf of this.hardforks()) {

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -25,6 +25,7 @@ import type {
   CliqueConfig,
   CommonOpts,
   CustomCommonOpts,
+  EIPOrHFConfig,
   EthashConfig,
   GenesisBlockConfig,
   GethConfigOpts,
@@ -35,6 +36,19 @@ import type { BigIntLike, PrefixedHexString } from '@ethereumjs/util'
 
 type HardforkSpecKeys = string // keyof typeof HARDFORK_SPECS
 type HardforkSpecValues = typeof HARDFORK_SPECS[HardforkSpecKeys]
+
+/**
+ * Superset from EIPConfig and HardforkConfig types from types.ts,
+ * easiest for internally "merging" configs together for the parameter cache
+ * by using the spread operator and keep typing intact.
+ */
+type ParamsCacheConfig = {
+  name: string
+  eips?: number[]
+  minimumHardfork?: Hardfork
+  requiredEIPs?: number[]
+} & EIPOrHFConfig
+
 /**
  * Common class to access chain and hardfork parameters and to provide
  * a unified and shared view on the network and hardfork state.
@@ -50,6 +64,8 @@ export class Common {
   protected _hardfork: string | Hardfork
   protected _eips: number[] = []
   protected _customChains: ChainConfig[]
+
+  protected _paramsCache: ParamsCacheConfig = {}
 
   protected HARDFORK_CHANGES: [HardforkSpecKeys, HardforkSpecValues][]
 
@@ -283,6 +299,7 @@ export class Common {
       if (hfChanges[0] === hardfork) {
         if (this._hardfork !== hardfork) {
           this._hardfork = hardfork
+          this._buildParamsCache()
           this.events.emit('hardforkChanged', hardfork)
         }
         existing = true
@@ -467,6 +484,14 @@ export class Common {
       }
     }
     this._eips = eips
+    this._buildParamsCache()
+  }
+
+  /**
+   * Build up a cache for all parameter values for the current HF and all activated EIPs
+   */
+  protected _buildParamsCache() {
+    console.log(this._paramsCache)
   }
 
   /**

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -246,7 +246,7 @@ export class Common {
     if (opts.eips) {
       this.setEIPs(opts.eips)
     }
-    if (this._paramsCache === undefined) {
+    if (Object.keys(this._paramsCache).length === 0) {
       this._buildParamsCache()
     }
   }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -133,7 +133,7 @@ type ParamDict = {
   d: string
 }
 
-type EIPOrHFConfig = {
+export type EIPOrHFConfig = {
   comment: string
   url: string
   status: string

--- a/packages/common/test/params.spec.ts
+++ b/packages/common/test/params.spec.ts
@@ -80,6 +80,22 @@ describe('[Common]: Parameter access for param(), paramByHardfork()', () => {
     )
   })
 
+  it('Access on copied Common instances', () => {
+    const c = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Shanghai })
+    let msg = 'Should correctly access param with param() on original Common'
+    assert.equal(c.param('pow', 'minerReward'), BigInt(2000000000000000000), msg)
+
+    const cCopy = c.copy()
+    cCopy.setHardfork(Hardfork.Chainstart)
+
+    msg = 'Should correctly access param with param() on copied Common with hardfork changed'
+    assert.equal(cCopy.param('pow', 'minerReward'), BigInt(5000000000000000000), msg)
+
+    msg =
+      'Should correctly access param with param() on original Common after copy and HF change on copied Common'
+    assert.equal(c.param('pow', 'minerReward'), BigInt(2000000000000000000), msg)
+  })
+
   it('EIP param access, paramByEIP()', () => {
     const c = new Common({ chain: Chain.Mainnet })
 

--- a/packages/evm/src/precompiles/0a-kzg-point-evaluation.ts
+++ b/packages/evm/src/precompiles/0a-kzg-point-evaluation.ts
@@ -41,8 +41,8 @@ export async function precompile0a(opts: PrecompileInput): Promise<ExecResult> {
     return EvmErrorResult(new EvmError(ERROR.INVALID_INPUT_LENGTH), opts.gasLimit)
   }
 
-  const version = Number(opts.common.paramByEIP('sharding', 'blobCommitmentVersionKzg', 4844))
-  const fieldElementsPerBlob = opts.common.paramByEIP('sharding', 'fieldElementsPerBlob', 4844)!
+  const version = Number(opts.common.param('sharding', 'blobCommitmentVersionKzg'))
+  const fieldElementsPerBlob = opts.common.param('sharding', 'fieldElementsPerBlob')
   const versionedHash = opts.data.subarray(0, 32)
   const z = opts.data.subarray(32, 64)
   const y = opts.data.subarray(64, 96)

--- a/packages/statemanager/src/stateManager.ts
+++ b/packages/statemanager/src/stateManager.ts
@@ -926,6 +926,9 @@ export class DefaultStateManager implements EVMStateManagerInterface {
    * 2. Cache values are generally not copied along
    */
   shallowCopy(): DefaultStateManager {
+    const common = this.common.copy()
+    common.setHardfork(this.common.hardfork())
+
     const trie = this._trie.shallowCopy(false)
     const prefixCodeHashes = this._prefixCodeHashes
     let accountCacheOpts = { ...this._accountCacheSettings }
@@ -938,6 +941,7 @@ export class DefaultStateManager implements EVMStateManagerInterface {
     }
 
     return new DefaultStateManager({
+      common,
       trie,
       prefixCodeHashes,
       accountCacheOpts,

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -162,9 +162,7 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
         const msg = this._errorMsg('versioned hash is invalid length')
         throw new Error(msg)
       }
-      if (
-        BigInt(hash[0]) !== this.common.paramByEIP('sharding', 'blobCommitmentVersionKzg', 4844)
-      ) {
+      if (BigInt(hash[0]) !== this.common.param('sharding', 'blobCommitmentVersionKzg')) {
         const msg = this._errorMsg('versioned hash does not start with KZG commitment version')
         throw new Error(msg)
       }
@@ -352,7 +350,7 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
       throw Error('BlobEIP4844Transaction can not be send without a valid `to`')
     }
 
-    const version = Number(opts.common.paramByEIP('sharding', 'blobCommitmentVersionKzg', 4844))
+    const version = Number(opts.common.param('sharding', 'blobCommitmentVersionKzg'))
     validateBlobTransactionNetworkWrapper(
       decodedTx.versionedHashes,
       blobs,

--- a/packages/vm/test/api/index.spec.ts
+++ b/packages/vm/test/api/index.spec.ts
@@ -225,8 +225,9 @@ describe('VM -> setHardfork, state (deprecated), blockchain', () => {
       const contractAddress = Address.fromString('0x00000000000000000000000000000000000000ff') // contract address
       // setup the vm
       const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
+      const common2 = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
       const vmNotActivated = await VM.create({ common })
-      const vmActivated = await VM.create({ common, activatePrecompiles: true })
+      const vmActivated = await VM.create({ common: common2, activatePrecompiles: true })
       const code = '0x6000808080347300000000000000000000000000000000000000045AF100'
       /*
         idea: call the Identity precompile with nonzero value in order to trigger "callNewAccount" for the non-activated VM and do not deduct this

--- a/packages/vm/test/api/index.spec.ts
+++ b/packages/vm/test/api/index.spec.ts
@@ -225,9 +225,8 @@ describe('VM -> setHardfork, state (deprecated), blockchain', () => {
       const contractAddress = Address.fromString('0x00000000000000000000000000000000000000ff') // contract address
       // setup the vm
       const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
-      const common2 = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
       const vmNotActivated = await VM.create({ common })
-      const vmActivated = await VM.create({ common: common2, activatePrecompiles: true })
+      const vmActivated = await VM.create({ common, activatePrecompiles: true })
       const code = '0x6000808080347300000000000000000000000000000000000000045AF100'
       /*
         idea: call the Identity precompile with nonzero value in order to trigger "callNewAccount" for the non-activated VM and do not deduct this

--- a/packages/vm/test/tester/index.ts
+++ b/packages/vm/test/tester/index.ts
@@ -200,7 +200,6 @@ async function runTests() {
     tape(name, async (t) => {
       let testIdentifier: string
       const failingTests: Record<string, string[] | undefined> = {}
-
       ;(t as any).on('result', (o: any) => {
         if (
           typeof o.ok !== 'undefined' &&
@@ -218,6 +217,7 @@ async function runTests() {
       // https://github.com/ethereum/tests/releases/tag/v7.0.0-beta.1
 
       const dirs = getTestDirs(FORK_CONFIG_VM, name)
+      console.time('Total (including setup)')
       for (const dir of dirs) {
         await new Promise<void>((resolve, reject) => {
           if (argv.customTestsPath !== undefined) {
@@ -262,6 +262,9 @@ async function runTests() {
         const { assertCount } = t as any
         t.ok(assertCount >= expectedTests, `expected ${expectedTests} checks, got ${assertCount}`)
       }
+
+      console.log()
+      console.timeEnd('Total (including setup)')
 
       t.end()
     })


### PR DESCRIPTION
First-round performance tests suggests that `Common` `param()` reads take a significant amount of time, see:

```typescript
> import { Chain, Common, Hardfork } from '@ethereumjs/common'
undefined
> let c = new Common({ chain: Chain.Mainnet })
undefined
> console.time('Total'); for (let i = 0; i < 100000; i++) { let p = c.param('gasPrices', 'push') }; console.timeEnd('Total');
Total: 151.637ms
```

(a similar issue was already mentioned years ago by Patricio from HardHat in some separate peformance tracking issue, just to mention)

Time used in the 100s of miliseconds is significant, since the iteration set of 100000 is relatively close to real world conditions and an amount realistic to be called in e.g. the EVM during a block execution (since the `param()` method is used for every opcode gas calculation e.g.).

Looking at the code confirms that this is likely inefficiently coded, since every `param()` read again iterates through both all hardfork files and additionally through all EIP files.

This PR therefore aims to introduce a cache with the parameters at hand for currently active set of both hardforks and EIPs. This cache will be rebuild on a hardfork change or an EIP addition (which both either doesn't happen at all or at least doesn't happen often during a Common object livecycle).