### PR TITLE
trie: use equalsBytes for root check

### DIFF
--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -771,7 +771,11 @@ export class Trie {
       } as PutBatch
     })
 
-    if (this.root() === this.EMPTY_TRIE_ROOT && opStack[0] !== undefined && opStack[0] !== null) {
+    if (
+      equalsBytes(this.root(), this.EMPTY_TRIE_ROOT) &&
+      opStack[0] !== undefined &&
+      opStack[0] !== null
+    ) {
       this.root(opStack[0].key)
     }
 


### PR DESCRIPTION
# `'/trie.ts'`   
## `fromProof()`

### we can not use `===` to check for equal `Uint8Arrays`

### fix by switching to `equalsBytes()`

#### changing
```
    if (this.root() === this.EMPTY_TRIE_ROOT ... ) 

```
#### to

```
    if (equalsBytes(this.root(), this.EMPTY_TRIE_ROOT)  ... ) 
```

