### PR TITLE
trie: test coverage for 'checkRoot'

### DIFF
--- a/packages/trie/test/trie/trie.spec.ts
+++ b/packages/trie/test/trie/trie.spec.ts
@@ -1,4 +1,12 @@
-import { KECCAK256_RLP, MapDB, bytesToHex, equalsBytes, utf8ToBytes } from '@ethereumjs/util'
+import {
+  KECCAK256_RLP,
+  MapDB,
+  bytesToHex,
+  equalsBytes,
+  randomBytes,
+  unprefixedHexToBytes,
+  utf8ToBytes,
+} from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak.js'
 import { assert, describe, it } from 'vitest'
 
@@ -168,6 +176,77 @@ for (const { constructor, defaults, title } of [
         assert.fail("Attempting to set '__root__' should fail but it did not.")
       } catch ({ message }: any) {
         assert.equal(message, "Attempted to set '__root__' key but it is not allowed.")
+      }
+    })
+  })
+
+  describe(`${title} (Check Root)`, async () => {
+    const keyvals = Array.from({ length: 100 }, () => {
+      const key = randomBytes(20)
+      const value = randomBytes(10)
+      return { key, value }
+    })
+    const trie = await constructor.create({
+      ...defaults,
+      db: new MapDB(),
+    })
+    for await (const { key, value } of keyvals) {
+      await trie.put(key, value)
+    }
+    const roots = [...(<any>trie.database().db)._database.keys()]
+    it('should return true for all nodes in the trie', async () => {
+      assert.isTrue(await trie.checkRoot(trie.root()), 'Should return true for root node')
+      for (const root of roots) {
+        assert.isTrue(
+          await trie.checkRoot(unprefixedHexToBytes(root)),
+          'Should return true for all nodes in trie'
+        )
+      }
+    })
+    it('should return false for nodes not in the trie', async () => {
+      for (let i = 0; i < 10; i++) {
+        const key = unprefixedHexToBytes(`${i}`.repeat(64))
+        assert.isFalse(await trie.checkRoot(key), 'Should return false for nodes not in trie')
+      }
+    })
+    it('should return false for all keys if trie is empty', async () => {
+      const emptyTrie = await constructor.create({
+        ...defaults,
+        db: new MapDB(),
+      })
+      assert.deepEqual(emptyTrie.EMPTY_TRIE_ROOT, emptyTrie.root(), 'Should return empty trie root')
+      assert.isTrue(
+        await emptyTrie.checkRoot(emptyTrie.EMPTY_TRIE_ROOT),
+        'Should return true for empty root'
+      )
+      assert.isFalse(
+        await emptyTrie.checkRoot(emptyTrie['appliedKey'](ROOT_DB_KEY)),
+        'Should return false for persistence key'
+      )
+      for (const root of roots) {
+        assert.isFalse(
+          await emptyTrie.checkRoot(unprefixedHexToBytes(root)),
+          'Should always return false'
+        )
+      }
+    })
+    it('Should throw on unrelated errors', async () => {
+      const emptyTrie = await constructor.create({
+        ...defaults,
+        db: new MapDB(),
+        useRootPersistence: true,
+      })
+      await emptyTrie.put(utf8ToBytes('foo'), utf8ToBytes('bar'))
+      await emptyTrie.persistRoot()
+      try {
+        await emptyTrie.checkRoot(ROOT_DB_KEY)
+        assert.fail('Should throw')
+      } catch (e: any) {
+        assert.notEqual(
+          'Missing node in DB',
+          e.message,
+          'Should throw when error is unrelated to checkroot'
+        )
       }
     })
   })


### PR DESCRIPTION
Test coverage for `trie.checkRoot` was at 0%.

This brings coverage to 100%