### PR TITLE
ethersStateManager: dumpStorage fix / test

### DIFF
--- a/packages/statemanager/src/cache/storage.ts
+++ b/packages/statemanager/src/cache/storage.ts
@@ -354,4 +354,19 @@ export class StorageCache extends Cache {
       this._orderedMapCache!.clear()
     }
   }
+
+  /**
+   * Dumps the RLP-encoded storage values for an `account` specified by `address`.
+   * @param address - The address of the `account` to return storage for
+   * @returns {StorageCacheMap | undefined} - The storage values for the `account` or undefined if the `account` is not in the cache
+   */
+  dump(address: Address): StorageCacheMap | undefined {
+    let storageMap
+    if (this._lruCache) {
+      storageMap = this._lruCache!.get(bytesToUnprefixedHex(address.bytes))
+    } else {
+      storageMap = this._orderedMapCache?.getElementByKey(bytesToUnprefixedHex(address.bytes))
+    }
+    return storageMap
+  }
 }

--- a/packages/statemanager/src/ethersStateManager.ts
+++ b/packages/statemanager/src/ethersStateManager.ts
@@ -182,7 +182,7 @@ export class EthersStateManager implements EVMStateManagerInterface {
    * Both are represented as `0x` prefixed hex strings.
    */
   dumpStorage(address: Address): Promise<StorageDump> {
-    const storageMap = this._storageCache._lruCache?.get(address.toString())
+    const storageMap = this._storageCache.dump(address)
     const dump: StorageDump = {}
     if (storageMap !== undefined) {
       for (const slot of storageMap) {


### PR DESCRIPTION
# StateManager:
## `src/ethersStateManager.ts`:
## + `src/cache/storage.ts`
### EthersStateManager:
#### `dumpStorage`
#### `clearContractStorage`

`npm run coverage`  on the `statemanager` package showed no coverage for the `dumpStorage` or `clearContractStorage` methods.

**`dumpStorage`** should return a `StorageDump` object, representing the current state of the storage trie for an account as a key/value map.  Like calling `getContractStorage` for all of the storage keys in an account at once.

I included a few lines of code in the `ethersStateManager.spec.ts` to cover `dumpStorage` (as well as `clearContractStorage`) , but they did not pass as expected, because `dumpStorage` was only looking in `this._storageCache._lruCache`, and not in `this._storageCache._orderedMapCache`

**(For context -- `ethersStateManager.getContractStorage()` uses whichever cache type is available)**

----

This PR adds a method to the `StorageCache` class: `this.dump(address: Address)`, which mimics the behavior of `get` by looking in the `_orderedMapCache`, and returns a `StorageCacheMap` object.

`ethersStateManager.dumpStorage(address)` will now process the return value of `this._storageCache.dump(address)`.

This change allows the new `dumpStorage` (and `clearContractStorage`) tests to pass.

The added tests bring the covered functions stat for `ethersStateManager.ts` from `17` to `19` / `26`
