### PR TITLE
VM: Small Profiler UX improvements / Fix client reportAfterTx option propagation to EVM

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -350,7 +350,7 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     default: false,
   })
   .option('vmProfileTxs', {
-    describe: 'Report the VM profile after running each block',
+    describe: 'Report the VM profile after running each tx',
     boolean: true,
     default: false,
   })

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -225,10 +225,19 @@ export async function runBlock(this: VM, opts: RunBlockOpts): Promise<RunBlockRe
   }
 
   if (this._opts.profilerOpts?.reportAfterBlock === true) {
+    const title = `Profiler run - Block ${block.header.number} (${bytesToHex(block.hash())} with ${
+      block.transactions.length
+    } txs`
+    // eslint-disable-next-line
+    console.log(title)
     const logs = (<EVM>this.evm).getPerformanceLogs()
-    const tag = ' - Block ' + Number(block.header.number) + ' (' + bytesToHex(block.hash()) + ')'
-    this.emitEVMProfile(logs.precompiles, 'Precompile performance ' + tag)
-    this.emitEVMProfile(logs.opcodes, 'Opcodes performance' + tag)
+    if (logs.precompiles.length === 0 && logs.opcodes.length === 0) {
+      // eslint-disable-next-line
+      console.log('No block txs with precompile or opcode execution.')
+    }
+
+    this.emitEVMProfile(logs.precompiles, 'Precompile performance')
+    this.emitEVMProfile(logs.opcodes, 'Opcodes performance')
     ;(<EVM>this.evm).clearPerformanceLogs()
   }
 

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -164,10 +164,16 @@ export async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
     }
     this.evm.stateManager.originalStorageCache.clear()
     if (this._opts.profilerOpts?.reportAfterTx === true) {
+      const title = `Profiler run - Tx ${bytesToHex(opts.tx.hash())}`
+      // eslint-disable-next-line
+      console.log(title)
       const logs = (<EVM>this.evm).getPerformanceLogs()
-      const tag = ' - Tx ' + bytesToHex(opts.tx.hash())
-      this.emitEVMProfile(logs.precompiles, 'Precompile performance ' + tag)
-      this.emitEVMProfile(logs.opcodes, 'Opcodes performance' + tag)
+      if (logs.precompiles.length === 0 && logs.opcodes.length === 0) {
+        // eslint-disable-next-line
+        console.log('No precompile or opcode execution.')
+      }
+      this.emitEVMProfile(logs.precompiles, 'Precompile performance')
+      this.emitEVMProfile(logs.opcodes, 'Opcodes performance')
       ;(<EVM>this.evm).clearPerformanceLogs()
     }
   }

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -127,8 +127,13 @@ export class VM {
     if (opts.evm) {
       this.evm = opts.evm
     } else {
-      const enableProfiler =
-        this._opts.profilerOpts?.reportAfterBlock ?? this._opts.profilerOpts?.reportAfterTx ?? false
+      let enableProfiler = false
+      if (
+        this._opts.profilerOpts?.reportAfterBlock === true ||
+        this._opts.profilerOpts?.reportAfterTx === true
+      ) {
+        enableProfiler = true
+      }
       this.evm = new EVM({
         common: this.common,
         stateManager: this.stateManager,


### PR DESCRIPTION
PR includes some small improvements to the VM block/tx profiler UX to better locate on what blocks/txs profiler is applicable and has been running.

Additionally `reportAfterTx` option has been fixed to now propagate correctly to the EVM, since before the nullish coalescent operator chaining was not working correctly and the option omitted. This also affects the `--vmProfileTxs` CLI option in the client.