### PR TITLE
StateManager: deactivate storage/account caches for cache size 0

### DIFF
--- a/packages/statemanager/src/stateManager.ts
+++ b/packages/statemanager/src/stateManager.ts
@@ -195,7 +195,8 @@ export class DefaultStateManager implements EVMStateManagerInterface {
 
     this._prefixCodeHashes = opts.prefixCodeHashes ?? true
     this._accountCacheSettings = {
-      deactivate: opts.accountCacheOpts?.deactivate ?? false,
+      deactivate:
+        (opts.accountCacheOpts?.deactivate === true || opts.accountCacheOpts?.size === 0) ?? false,
       type: opts.accountCacheOpts?.type ?? CacheType.ORDERED_MAP,
       size: opts.accountCacheOpts?.size ?? 100000,
     }
@@ -208,7 +209,8 @@ export class DefaultStateManager implements EVMStateManagerInterface {
     }
 
     this._storageCacheSettings = {
-      deactivate: opts.storageCacheOpts?.deactivate ?? false,
+      deactivate:
+        (opts.storageCacheOpts?.deactivate === true || opts.storageCacheOpts?.size === 0) ?? false,
       type: opts.storageCacheOpts?.type ?? CacheType.ORDERED_MAP,
       size: opts.storageCacheOpts?.size ?? 20000,
     }

--- a/packages/statemanager/test/stateManager.account.spec.ts
+++ b/packages/statemanager/test/stateManager.account.spec.ts
@@ -6,7 +6,11 @@ import { DefaultStateManager } from '../src/index.js'
 import { createAccount } from './util.js'
 
 describe('StateManager -> General/Account', () => {
-  for (const accountCacheOpts of [{ deactivate: false }, { deactivate: true }]) {
+  for (const accountCacheOpts of [
+    { deactivate: false },
+    { deactivate: true },
+    { deactivate: false, size: 0 },
+  ]) {
     it(`should set the state root to empty`, async () => {
       const stateManager = new DefaultStateManager({ accountCacheOpts })
       assert.ok(equalsBytes(stateManager['_trie'].root(), KECCAK256_RLP), 'it has default root')

--- a/packages/statemanager/test/stateManager.code.spec.ts
+++ b/packages/statemanager/test/stateManager.code.spec.ts
@@ -6,7 +6,11 @@ import { DefaultStateManager } from '../src/index.js'
 import { createAccount } from './util.js'
 
 describe('StateManager -> Code', () => {
-  for (const accountCacheOpts of [{ deactivate: false }, { deactivate: true }]) {
+  for (const accountCacheOpts of [
+    { deactivate: false },
+    { deactivate: true },
+    { deactivate: false, size: 0 },
+  ]) {
     it(`should store codehashes using a prefix`, async () => {
       /*
         This test is mostly an example of why a code prefix is necessary

--- a/packages/statemanager/test/stateManager.storage.spec.ts
+++ b/packages/statemanager/test/stateManager.storage.spec.ts
@@ -15,7 +15,11 @@ import { DefaultStateManager } from '../src/index.js'
 import { createAccount } from './util.js'
 
 describe('StateManager -> Storage', () => {
-  for (const storageCacheOpts of [{ deactivate: false }, { deactivate: true }]) {
+  for (const storageCacheOpts of [
+    { deactivate: false },
+    { deactivate: true },
+    { deactivate: false, size: 0 },
+  ]) {
     it(`should dump storage`, async () => {
       const stateManager = new DefaultStateManager({ storageCacheOpts })
       const address = new Address(hexToBytes('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b'))


### PR DESCRIPTION
This PR handles the scenario when size 0 is provided for account or storage cache sizes in the StateManager by then just disabling the cache.

This is generally an optimization which makes sense, also to avoid a somewhat weird "cache initialized but never used and all functions called" scenario.

Beyond this allows for directly passing through 0 values for the `--accountCache` and `--storageCache` options in client.

Also quick side note: the additional state runs in SM are very very fast and not noticeable and I think it generally makes sense to add this case to a broader test run scenario, since it is something we will commonly use and set up the SM cache with.