### PR TITLE
trie:  Rewrite findPath without async-promise-executor

### DIFF
--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -278,68 +278,63 @@ export class Trie {
    * @param throwIfMissing - if true, throws if any nodes are missing. Used for verifying proofs. (default: false)
    */
   async findPath(key: Uint8Array, throwIfMissing = false): Promise<Path> {
-    // eslint-disable-next-line no-async-promise-executor
-    return new Promise(async (resolve, reject) => {
-      const stack: TrieNode[] = []
-      const targetKey = bytesToNibbles(key)
+    const stack: TrieNode[] = []
+    const targetKey = bytesToNibbles(key)
+    let result: Path | null = null
 
-      const onFound: FoundNodeFunction = async (_, node, keyProgress, walkController) => {
-        if (node === null) {
-          return reject(new Error('Path not found'))
-        }
-        const keyRemainder = targetKey.slice(matchingNibbleLength(keyProgress, targetKey))
-        stack.push(node)
+    const onFound: FoundNodeFunction = async (_, node, keyProgress, walkController) => {
+      // If we already have a result, exit early
+      if (result) return
 
-        if (node instanceof BranchNode) {
-          if (keyRemainder.length === 0) {
-            // we exhausted the key without finding a node
-            resolve({ node, remaining: [], stack })
-          } else {
-            const branchIndex = keyRemainder[0]
-            const branchNode = node.getBranch(branchIndex)
-            if (!branchNode) {
-              // there are no more nodes to find and we didn't find the key
-              resolve({ node: null, remaining: keyRemainder, stack })
-            } else {
-              // node found, continuing search
-              // this can be optimized as this calls getBranch again.
-              walkController.onlyBranchIndex(node, keyProgress, branchIndex)
-            }
-          }
-        } else if (node instanceof LeafNode) {
-          if (doKeysMatch(keyRemainder, node.key())) {
-            // keys match, return node with empty key
-            resolve({ node, remaining: [], stack })
-          } else {
-            // reached leaf but keys dont match
-            resolve({ node: null, remaining: keyRemainder, stack })
-          }
-        } else if (node instanceof ExtensionNode) {
-          const matchingLen = matchingNibbleLength(keyRemainder, node.key())
-          if (matchingLen !== node.key().length) {
-            // keys don't match, fail
-            resolve({ node: null, remaining: keyRemainder, stack })
-          } else {
-            // keys match, continue search
-            walkController.allChildren(node, keyProgress)
-          }
-        }
+      if (node === null) {
+        result = { node: null, remaining: [], stack }
+        return
       }
 
-      // walk trie and process nodes
-      try {
-        await this.walkTrie(this.root(), onFound)
-      } catch (error: any) {
-        if (error.message === 'Missing node in DB' && !throwIfMissing) {
-          // pass
+      const keyRemainder = targetKey.slice(matchingNibbleLength(keyProgress, targetKey))
+      stack.push(node)
+
+      if (node instanceof BranchNode) {
+        if (keyRemainder.length === 0) {
+          result = { node, remaining: [], stack }
         } else {
-          reject(error)
+          const branchIndex = keyRemainder[0]
+          const branchNode = node.getBranch(branchIndex)
+          if (!branchNode) {
+            result = { node: null, remaining: keyRemainder, stack }
+          } else {
+            walkController.onlyBranchIndex(node, keyProgress, branchIndex)
+          }
+        }
+      } else if (node instanceof LeafNode) {
+        if (doKeysMatch(keyRemainder, node.key())) {
+          result = { node, remaining: [], stack }
+        } else {
+          result = { node: null, remaining: keyRemainder, stack }
+        }
+      } else if (node instanceof ExtensionNode) {
+        const matchingLen = matchingNibbleLength(keyRemainder, node.key())
+        if (matchingLen !== node.key().length) {
+          result = { node: null, remaining: keyRemainder, stack }
+        } else {
+          walkController.allChildren(node, keyProgress)
         }
       }
+    }
 
-      // Resolve if walkTrie finishes without finding any nodes
-      resolve({ node: null, remaining: [], stack })
-    })
+    try {
+      await this.walkTrie(this.root(), onFound)
+    } catch (error: any) {
+      if (error.message !== 'Missing node in DB' || throwIfMissing) {
+        throw error
+      }
+    }
+
+    if (result === null) {
+      result = { node: null, remaining: [], stack }
+    }
+
+    return result
   }
 
   /**


### PR DESCRIPTION
Followup to #2962 (shelved)

This takes the frist step towards simplifying and improving `trie.findPath()`.
 
While the logic is fundamentally the same, this refactors `findPath` without the `async-promise-executor` API, and uses the `async/await` syntax directly to achieve the same result.  The `resolve` and `reject` calls have been replaced with `return` and `throw` respectively.