### PR TITLE
Trie: findPath without `slice()`

### DIFF
--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -326,9 +326,6 @@ export class Trie {
     let result: Path | null = null
 
     const onFound: FoundNodeFunction = async (_, node, keyProgress, walkController) => {
-      // If we already have a result, exit early
-      if (result) return
-
       stack.push(node!)
 
       if (node instanceof BranchNode) {

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -352,10 +352,10 @@ export class Trie {
         )
 
       if (node instanceof BranchNode) {
-        if (keyRemainder.length === 0) {
+        if (targetKey.length === 0) {
           result = { node, remaining: [], stack }
         } else {
-          const branchIndex = keyRemainder[0]
+          const branchIndex = targetKey.shift()!
           this.DEBUG &&
             this.debug(`Looking for node on branch index: [${branchIndex}]`, [
               'FIND_PATH',
@@ -372,16 +372,16 @@ export class Trie {
               ['FIND_PATH', 'BranchNode', branchIndex.toString()]
             )
           if (!branchNode) {
-            result = { node: null, remaining: keyRemainder, stack }
+            result = { node: null, remaining: [branchIndex, ...targetKey], stack }
           } else {
             walkController.onlyBranchIndex(node, keyProgress, branchIndex)
           }
         }
       } else if (node instanceof LeafNode) {
-        if (doKeysMatch(keyRemainder, node.key())) {
+        if (doKeysMatch(targetKey, node.key())) {
           result = { node, remaining: [], stack }
         } else {
-          result = { node: null, remaining: keyRemainder, stack }
+          result = { node: null, remaining: targetKey, stack }
         }
       } else if (node instanceof ExtensionNode) {
         this.DEBUG &&
@@ -395,11 +395,12 @@ export class Trie {
             `,
             ['FIND_PATH', 'ExtensionNode']
           )
-        if (doKeysMatch(keyRemainder.slice(0, node.key().length), node.key())) {
+        const consumed = targetKey.splice(0, node.key().length)
+        if (doKeysMatch(consumed, node.key())) {
           this.DEBUG && this.debug(`NextNode: ${node.value()}`, ['FIND_PATH', 'ExtensionNode'])
           walkController.allChildren(node, keyProgress)
         } else {
-          result = { node: null, remaining: keyRemainder, stack }
+          result = { node: null, remaining: [...consumed, ...targetKey], stack }
         }
       }
     }

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -329,26 +329,7 @@ export class Trie {
       // If we already have a result, exit early
       if (result) return
 
-      if (node === null) {
-        result = { node: null, remaining: [], stack }
-        return
-      }
-
-      this.DEBUG &&
-        this.debug(
-          `${node.constructor.name} FOUND${'_nibbles' in node ? `: [${node._nibbles}]` : ''}`,
-          ['FIND_PATH', keyProgress.toString()]
-        )
-
-      this.DEBUG && this.debug(`[${keyRemainder}] Remaining`, ['FIND_PATH', keyProgress.toString()])
-      stack.push(node)
-      this.DEBUG &&
-        this.debug(
-          `Adding ${node.constructor.name} to STACK (size: ${stack.length}) ${stack.map(
-            (e, i) => `${i === stack.length - 1 ? '\n|| +' : '\n|| '}` + e.constructor.name
-          )}`,
-          ['FIND_PATH']
-        )
+      stack.push(node!)
 
       if (node instanceof BranchNode) {
         if (targetKey.length === 0) {

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -395,12 +395,11 @@ export class Trie {
             `,
             ['FIND_PATH', 'ExtensionNode']
           )
-        const matchingLen = matchingNibbleLength(keyRemainder, node.key())
-        if (matchingLen !== node.key().length) {
-          result = { node: null, remaining: keyRemainder, stack }
-        } else {
+        if (doKeysMatch(keyRemainder.slice(0, node.key().length), node.key())) {
           this.DEBUG && this.debug(`NextNode: ${node.value()}`, ['FIND_PATH', 'ExtensionNode'])
           walkController.allChildren(node, keyProgress)
+        } else {
+          result = { node: null, remaining: keyRemainder, stack }
         }
       }
     }

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -340,7 +340,6 @@ export class Trie {
           ['FIND_PATH', keyProgress.toString()]
         )
 
-      const keyRemainder = targetKey.slice(matchingNibbleLength(keyProgress, targetKey))
       this.DEBUG && this.debug(`[${keyRemainder}] Remaining`, ['FIND_PATH', keyProgress.toString()])
       stack.push(node)
       this.DEBUG &&

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -251,7 +251,8 @@ export class Trie {
           // stack should be updated as well, so that it points to the right key/value pairs of the path
           const deleteHashes = stack.map((e) => this.hash(e.serialize()))
           ops = deleteHashes.map((e) => {
-            const key = this._opts.keyPrefix ? concatBytes(this._opts.keyPrefix, e) : e
+            const key =
+              this._opts.keyPrefix !== undefined ? concatBytes(this._opts.keyPrefix, e) : e
             return {
               type: 'del',
               key,
@@ -292,7 +293,7 @@ export class Trie {
       // Just as with `put`, the stack items all will have their keyhashes updated
       // So after deleting the node, one can safely delete these from the DB
       ops = deleteHashes.map((e) => {
-        const key = this._opts.keyPrefix ? concatBytes(this._opts.keyPrefix, e) : e
+        const key = this._opts.keyPrefix !== undefined ? concatBytes(this._opts.keyPrefix, e) : e
         return {
           type: 'del',
           key,
@@ -373,11 +374,12 @@ export class Trie {
       } else if (node instanceof ExtensionNode) {
         this.DEBUG &&
           this.debug(
-            `Comparing node key to expected\n|| Node_Key: [${node.key()}]\n|| Expected: [${keyRemainder.slice(
-              0,
-              node.key().length
+            `Comparing node key to expected\n|| Node_Key: [${node.key()}]\n|| Expected: [${targetKey.slice(
+              progress,
+              progress + node.key().length
             )}]\n|| Matching: [${
-              keyRemainder.slice(0, node.key().length).toString() === node.key().toString()
+              targetKey.slice(progress, progress + node.key().length).toString() ===
+              node.key().toString()
             }]
             `,
             ['FIND_PATH', 'ExtensionNode']
@@ -478,7 +480,8 @@ export class Trie {
     const encoded = newNode.serialize()
     this.root(this.hash(encoded))
     let rootKey = this.root()
-    rootKey = this._opts.keyPrefix ? concatBytes(this._opts.keyPrefix, rootKey) : rootKey
+    rootKey =
+      this._opts.keyPrefix !== undefined ? concatBytes(this._opts.keyPrefix, rootKey) : rootKey
     await this._db.put(rootKey, encoded)
     await this.persistRoot()
   }
@@ -493,7 +496,7 @@ export class Trie {
       return decoded
     }
     this.DEBUG && this.debug(`${`${bytesToHex(node)}`}`, ['LOOKUP_NODE', 'BY_HASH'])
-    const key = this._opts.keyPrefix ? concatBytes(this._opts.keyPrefix, node) : node
+    const key = this._opts.keyPrefix !== undefined ? concatBytes(this._opts.keyPrefix, node) : node
     const value = (await this._db.get(key)) ?? null
 
     if (value === null) {
@@ -801,7 +804,8 @@ export class Trie {
 
     if (encoded.length >= 32 || topLevel) {
       const lastRoot = this.hash(encoded)
-      const key = this._opts.keyPrefix ? concatBytes(this._opts.keyPrefix, lastRoot) : lastRoot
+      const key =
+        this._opts.keyPrefix !== undefined ? concatBytes(this._opts.keyPrefix, lastRoot) : lastRoot
 
       if (remove) {
         if (this._opts.useNodePruning) {
@@ -860,7 +864,7 @@ export class Trie {
     this.DEBUG && this.debug(`Saving (${proof.length}) proof nodes in DB`, ['FROM_PROOF'])
     const opStack = proof.map((nodeValue) => {
       let key = Uint8Array.from(this.hash(nodeValue))
-      key = this._opts.keyPrefix ? concatBytes(this._opts.keyPrefix, key) : key
+      key = this._opts.keyPrefix !== undefined ? concatBytes(this._opts.keyPrefix, key) : key
       return {
         type: 'put',
         key,
@@ -1066,7 +1070,7 @@ export class Trie {
           ['PERSIST_ROOT']
         )
       let key = this.appliedKey(ROOT_DB_KEY)
-      key = this._opts.keyPrefix ? concatBytes(this._opts.keyPrefix, key) : key
+      key = this._opts.keyPrefix !== undefined ? concatBytes(this._opts.keyPrefix, key) : key
       await this._db.put(key, this.root())
     }
   }

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -321,15 +321,14 @@ export class Trie {
    * @param throwIfMissing - if true, throws if any nodes are missing. Used for verifying proofs. (default: false)
    */
   async findPath(key: Uint8Array, throwIfMissing = false): Promise<Path> {
-    const stack: TrieNode[] = []
     const targetKey = bytesToNibbles(key)
+    const stack: TrieNode[] = Array.from({ length: targetKey.length })
     this.DEBUG && this.debug(`Target (${targetKey.length}): [${targetKey}]`, ['FIND_PATH'])
     const keyLen = targetKey.length
     let result: Path | null = null
     let progress = 0
     const onFound: FoundNodeFunction = async (_, node, keyProgress, walkController) => {
-      stack.push(node!)
-
+      stack[progress] = node as TrieNode
       if (node instanceof BranchNode) {
         if (progress === keyLen) {
           result = { node, remaining: [], stack }
@@ -417,11 +416,12 @@ export class Trie {
         ['FIND_PATH']
       )
 
+    result.stack = result.stack.filter((e) => e !== undefined)
     this.DEBUG &&
       this.debug(
-        `Result: \n|| Node: ${
-          result.node === null ? 'null' : result.node.constructor.name
-        }\n|| Remaining: [${result.remaining}]\n|| Stack: ${result.stack
+        `Result: \n
+        || Node: ${result.node === null ? 'null' : result.node.constructor.name}\n
+        || Remaining: [${result.remaining}]\n|| Stack: ${result.stack
           .map((e) => e.constructor.name)
           .join(', ')}`,
         ['FIND_PATH']


### PR DESCRIPTION
# Trie
## `src/trie.ts`
### `findPath`

This PR aims to improve performance of `findPath` by eliminating the use of `slice()` operations, which create a shallow copy.

For every node processed in `findPath`, the `onFound` function would compare the current `keyProgress` with a slice of the orignal target key (a shallow copy made with `slice()`).

This also meant that it would recheck all of the previously checked nibbles with each new key.  This alone adds up to a lot of extra work that doesn't need to be done.

In the case of a BranchNode, a shallow copy would be made using `slice`, which we would only use to look at the first nibble in the array.

--

This PR refactors `findPath` to use destructive operations `splice()` and `shift()` on the `targetKey` array, removing nibbles as `findPath` progresses, rather than using shallow copies with `slice()` 

Both `shift()` and `splice()` delete elements from an array and return the deleted element(s).

When `findPath` travels through a branch node, it will look for a node on `targetKey.shift()`, or return itself if the targetKey has been consumed.

When `findPath` hits an ExtensionNode, it will compare the node's keyNibbles to `targetKey.splice(0, node.key().length)`.

When `findPath` hits a LeafNode, it will compare the `node.key()` to what is left of `targetKey`.

--
This PR improves `findPath` by:
1.  Eliminating the use of `slice()` entirely.
2.  Reducing memory with destructive array transformations
3.  Eliminating redundant nibble comparisons.
 
-- 
**Update 9/27/23**
4. Replaced push calls:  `stack.push(node)` with `stack[progress] = node`

Rather than allocate new memory with a `push` to the stack array, we create the stack array with `length: keyLength` (the maximum possible stack size).

The tradeoff is that it does require the final step of removing `undefined` indices from the array before the final return.

Simply using **npm run benchmarks** with the `trie` does not produce consistent enough results to measure these optimizations, unfortunately.