### PR TITLE
Trie: Debug logging

### DIFF
--- a/packages/trie/README.md
+++ b/packages/trie/README.md
@@ -265,6 +265,62 @@ npm run profiling
 
 0x processes the stacks and generates a profile folder (`<pid>.0x`) containing [`flamegraph.html`](https://github.com/davidmarkclements/0x/blob/master/docs/ui.md).
 
+## Debugging
+
+The `Trie` class features optional debug logging.. Individual debug selections can be activated on the CL with `DEBUG=ethjs,[Logger Selection]`.
+
+`ethjs` **must** be included in the `DEBUG` environment variables to enable **any** logs.
+Additional log selections can be added with a comma separated list (no spaces). Logs with extensions can be enabled with a colon `:`, and `*` can be used to include all extensions.
+
+`DEBUG=ethjs,thislog,thatlog,otherlog,otherlog:sublog,anotherLog:* node myscript.js`
+
+The following options are available:
+
+| Logger            | Description                                    |
+| ----------------- | ---------------------------------------------- |
+| `trie`            | minimal info logging for all trie methods      |
+| `trie:<METHOD>`   | debug logging for specific trie method         |
+| `trie:<METHOD>:*` | verbose debug logging for specific trie method |
+| `trie:*`          | verbose debug logging for all trie methods     |
+
+To observe the logging in action at different levels:
+
+Run with minimal logging:
+
+```shell
+DEBUG=ethjs,trie npx vitest test/util/log.spec.ts
+```
+
+Run with **put** method logging:
+
+```shell
+DEBUG=ethjs,trie:PUT npx vitest test/util/log.spec.ts
+```
+
+Run with **trie** + **put**/**get**/**del** logging:
+
+```shell
+DEBUG=ethjs,trie,trie:PUT,trie:GET,trie:DEL npx vitest test/util/log.spec.ts
+```
+
+Run with **findPath** debug logging:
+
+```shell
+DEBUG=ethjs,trie:FIND_PATH npx vitest test/util/log.spec.ts
+```
+
+Run with **findPath** verbose logging:
+
+```shell
+DEBUG=ethjs,trie:FIND_PATH:* npx vitest test/util/log.spec.ts
+```
+
+Run with max logging:
+
+```shell
+DEBUG=ethjs,trie:* npx vitest test/util/log.spec.ts
+```
+
 ## References
 
 - Wiki

--- a/packages/trie/examples/logDemo.ts
+++ b/packages/trie/examples/logDemo.ts
@@ -1,0 +1,31 @@
+import { utf8ToBytes } from 'ethereum-cryptography/utils'
+import { Trie } from '../dist/cjs/index.js'
+import { debug } from 'debug'
+
+debug.enable('*')
+
+const trie_entries: [string, string | null][] = [
+  ['do', 'verb'],
+  ['ether', 'wookiedoo'],
+  ['horse', 'stallion'],
+  ['shaman', 'horse'],
+  ['doge', 'coin'],
+  ['ether', null],
+  ['dog', 'puppy'],
+  ['shaman', null],
+]
+
+const main = async () => {
+  process.env.DEBUG = 'ethjs,*trie*'
+  const trie = new Trie({
+    useRootPersistence: true,
+  })
+  for (const [key, value] of trie_entries) {
+    await trie.put(utf8ToBytes(key), value === null ? Uint8Array.from([]) : utf8ToBytes(value))
+  }
+  const proof = await trie.createProof(utf8ToBytes('doge'))
+  const valid = await trie.verifyProof(trie.root(), utf8ToBytes('doge'), proof)
+  console.log('valid', valid)
+}
+
+main()

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -1114,6 +1114,7 @@ export class Trie {
    * After this is called, all changes can be reverted until `commit` is called.
    */
   checkpoint() {
+    this.DEBUG && this.debug(`${bytesToHex(this.root())}`, ['CHECKPOINT'])
     this._db.checkpoint(this.root())
   }
 
@@ -1126,7 +1127,7 @@ export class Trie {
     if (!this.hasCheckpoints()) {
       throw new Error('trying to commit when not checkpointed')
     }
-
+    this.DEBUG && this.debug(`${bytesToHex(this.root())}`, ['COMMIT'])
     await this._lock.acquire()
     await this._db.commit()
     await this.persistRoot()
@@ -1143,16 +1144,20 @@ export class Trie {
       throw new Error('trying to revert when not checkpointed')
     }
 
+    this.DEBUG && this.debug(`${bytesToHex(this.root())}`, ['REVERT', 'BEFORE'])
     await this._lock.acquire()
     this.root(await this._db.revert())
     await this.persistRoot()
     this._lock.release()
+    this.DEBUG && this.debug(`${bytesToHex(this.root())}`, ['REVERT', 'AFTER'])
   }
 
   /**
    * Flushes all checkpoints, restoring the initial checkpoint state.
    */
   flushCheckpoints() {
+    this.DEBUG &&
+      this.debug(`Deleting ${this._db.checkpoints.length} checkpoints.`, ['FLUSH_CHECKPOINTS'])
     this._db.checkpoints = []
   }
 }

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -105,6 +105,7 @@ export class Trie {
     if (opts?.root) {
       this.root(opts.root)
     }
+    this.DEBUG && this.debug(`Trie created with root ${bytesToHex(this.root())}`)
   }
 
   static async create(opts?: TrieOpts) {

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -87,7 +87,7 @@ export class Trie {
 
     this.DEBUG = process.env.DEBUG?.includes('ethjs') === true
     this.debug = this.DEBUG
-      ? (namespaces: string[] = [], message: string) => {
+      ? (message: string, namespaces: string[] = []) => {
           let log = this._debug
           for (const name of namespaces) {
             log = log.extend(name)

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -3,6 +3,7 @@ import {
   MapDB,
   RLP_EMPTY_STRING,
   ValueEncoding,
+  bytesToHex,
   bytesToUnprefixedHex,
   bytesToUtf8,
   equalsBytes,
@@ -68,7 +69,10 @@ export class Trie {
   protected _lock = new Lock()
   protected _root: Uint8Array
 
-  protected _debug: Debugger
+  /** Debug logging */
+  protected DEBUG: boolean
+  protected _debug: Debugger = debug('ethjs').extend('trie')
+  protected debug: (...args: any) => void
 
   /**
    * Creates a new trie.
@@ -81,7 +85,16 @@ export class Trie {
       this._opts = { ...this._opts, ...opts }
     }
 
-    this._debug = debug('ethjs').extend('trie')
+    this.DEBUG = process.env.DEBUG?.includes('ethjs') === true
+    this.debug = this.DEBUG
+      ? (namespaces: string[] = [], message: string) => {
+          let log = this._debug
+          for (const name of namespaces) {
+            log = log.extend(name)
+          }
+          log(message)
+        }
+      : (..._: any) => {}
 
     this.database(opts?.db ?? new MapDB<string, string>())
 

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -160,14 +160,13 @@ export class Trie {
       if (value === null) {
         value = this.EMPTY_TRIE_ROOT
       }
-
+      this.DEBUG && this.debug(`Setting root to ${bytesToHex(value)}`)
       if (value.length !== this._hashLen) {
         throw new Error(`Invalid root length. Roots are ${this._hashLen} bytes`)
       }
 
       this._root = value
     }
-
     return this._root
   }
 

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -8,6 +8,7 @@ import {
   equalsBytes,
   unprefixedHexToBytes,
 } from '@ethereumjs/util'
+import debug from 'debug'
 import { keccak256 } from 'ethereum-cryptography/keccak.js'
 
 import { CheckpointDB } from './db/index.js'
@@ -38,6 +39,7 @@ import type {
 } from './types.js'
 import type { OnFound } from './util/asyncWalk.js'
 import type { BatchDBOp, DB, PutBatch } from '@ethereumjs/util'
+import type { Debugger } from 'debug'
 
 interface Path {
   node: TrieNode | null
@@ -66,6 +68,8 @@ export class Trie {
   protected _lock = new Lock()
   protected _root: Uint8Array
 
+  protected _debug: Debugger
+
   /**
    * Creates a new trie.
    * @param opts Options for instantiating the trie
@@ -76,6 +80,8 @@ export class Trie {
     if (opts !== undefined) {
       this._opts = { ...this._opts, ...opts }
     }
+
+    this._debug = debug('ethjs').extend('trie')
 
     this.database(opts?.db ?? new MapDB<string, string>())
 

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -105,7 +105,14 @@ export class Trie {
     if (opts?.root) {
       this.root(opts.root)
     }
-    this.DEBUG && this.debug(`Trie created with root ${bytesToHex(this.root())}`)
+    this.DEBUG &&
+      this.debug(`Trie created:
+    \n Root: ${bytesToHex(this.root())}
+    \n Secure: ${this._opts.useKeyHashing}
+    \n Persistent: ${this._opts.useRootPersistence}
+    \n Pruning: ${this._opts.useNodePruning}
+    \n CacheSize: ${this._opts.cacheSize}
+    \n ----------------`)
   }
 
   static async create(opts?: TrieOpts) {

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -490,8 +490,11 @@ export class Trie {
    */
   async lookupNode(node: Uint8Array | Uint8Array[]): Promise<TrieNode> {
     if (isRawNode(node)) {
-      return decodeRawNode(node)
+      const decoded = decodeRawNode(node)
+      this.DEBUG && this.debug(`${decoded.constructor.name}`, ['LOOKUP_NODE', 'RAW_NODE'])
+      return decoded
     }
+    this.DEBUG && this.debug(`${`${bytesToHex(node)}`}`, ['LOOKUP_NODE', 'BY_HASH'])
     const value = (await this._db.get(node)) ?? null
 
     if (value === null) {
@@ -499,7 +502,9 @@ export class Trie {
       throw new Error('Missing node in DB')
     }
 
-    return decodeNode(value)
+    const decoded = decodeNode(value)
+    this.DEBUG && this.debug(`${decoded.constructor.name} found in DB`, ['LOOKUP_NODE', 'BY_HASH'])
+    return decoded
   }
 
   /**

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -193,11 +193,13 @@ export class Trie {
    * @returns A Promise that resolves to `Uint8Array` if a value was found or `null` if no value was found.
    */
   async get(key: Uint8Array, throwIfMissing = false): Promise<Uint8Array | null> {
+    this.DEBUG && this.debug(`Key: ${bytesToHex(key)}`, ['GET'])
     const { node, remaining } = await this.findPath(this.appliedKey(key), throwIfMissing)
     let value: Uint8Array | null = null
     if (node && remaining.length === 0) {
       value = node.value()
     }
+    this.DEBUG && this.debug(`Value: ${value === null ? 'null' : bytesToHex(value)}`, ['GET'])
     return value
   }
 

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -107,12 +107,12 @@ export class Trie {
     }
     this.DEBUG &&
       this.debug(`Trie created:
-    \n Root: ${bytesToHex(this.root())}
-    \n Secure: ${this._opts.useKeyHashing}
-    \n Persistent: ${this._opts.useRootPersistence}
-    \n Pruning: ${this._opts.useNodePruning}
-    \n CacheSize: ${this._opts.cacheSize}
-    \n ----------------`)
+    || Root: ${bytesToHex(this.root())}
+    || Secure: ${this._opts.useKeyHashing}
+    || Persistent: ${this._opts.useRootPersistence}
+    || Pruning: ${this._opts.useNodePruning}
+    || CacheSize: ${this._opts.cacheSize}
+    || ----------------`)
   }
 
   static async create(opts?: TrieOpts) {
@@ -338,11 +338,9 @@ export class Trie {
       stack.push(node)
       this.DEBUG &&
         this.debug(
-          `Adding ${node.constructor.name} to STACK (size: ${stack.length})
-        \n ${stack
-          .map((e, i) => `${i === stack.length - 1 ? '+' : ''}` + e.constructor.name)
-          .join(`, \n`)}
-        `,
+          `Adding ${node.constructor.name} to STACK (size: ${stack.length}) ${stack.map(
+            (e, i) => `${i === stack.length - 1 ? '\n|| +' : '\n|| '}` + e.constructor.name
+          )}`,
           ['FIND_PATH']
         )
 
@@ -381,12 +379,12 @@ export class Trie {
       } else if (node instanceof ExtensionNode) {
         this.DEBUG &&
           this.debug(
-            `Comparing node key to expected
-          \n || Node_Key: [${node.key()}]
-          \n || Expected: [${keyRemainder.slice(0, node.key().length)}]
-          \n || Matching: [${
-            keyRemainder.slice(0, node.key().length).toString() === node.key().toString()
-          }]
+            `Comparing node key to expected\n|| Node_Key: [${node.key()}]\n|| Expected: [${keyRemainder.slice(
+              0,
+              node.key().length
+            )}]\n|| Matching: [${
+              keyRemainder.slice(0, node.key().length).toString() === node.key().toString()
+            }]
             `,
             ['FIND_PATH', 'ExtensionNode']
           )
@@ -422,10 +420,11 @@ export class Trie {
 
     this.DEBUG &&
       this.debug(
-        `Result: 
-      \n || Node: ${result.node === null ? 'null' : result.node.constructor.name}
-      \n || Remaining: [${result.remaining}]
-      \n || Stack: ${result.stack.map((e) => e.constructor.name).join(', ')}`,
+        `Result: \n|| Node: ${
+          result.node === null ? 'null' : result.node.constructor.name
+        }\n|| Remaining: [${result.remaining}]\n|| Stack: ${result.stack
+          .map((e) => e.constructor.name)
+          .join(', ')}`,
         ['FIND_PATH']
       )
     return result
@@ -909,10 +908,9 @@ export class Trie {
   ): Promise<Uint8Array | null> {
     this.DEBUG &&
       this.debug(
-        `Verifying Proof:
-      \n || Key: ${bytesToHex(key)}
-      \n || Root: ${bytesToHex(rootHash)}
-      \n || Proof: (${proof.length}) nodes
+        `Verifying Proof:\n|| Key: ${bytesToHex(key)}\n|| Root: ${bytesToHex(
+          rootHash
+        )}\n|| Proof: (${proof.length}) nodes
     `,
         ['VERIFY_PROOF']
       )
@@ -1058,9 +1056,9 @@ export class Trie {
     if (this._opts.useRootPersistence) {
       this.DEBUG &&
         this.debug(
-          `Persisting root: 
-          \n || RootHash: ${bytesToHex(this.root())}
-          \n || RootKey: ${bytesToHex(this.appliedKey(ROOT_DB_KEY))}`,
+          `Persisting root: \n|| RootHash: ${bytesToHex(this.root())}\n|| RootKey: ${bytesToHex(
+            this.appliedKey(ROOT_DB_KEY)
+          )}`,
           ['PERSIST_ROOT']
         )
       await this._db.put(this.appliedKey(ROOT_DB_KEY), this.root())

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -71,7 +71,7 @@ export class Trie {
 
   /** Debug logging */
   protected DEBUG: boolean
-  protected _debug: Debugger = debug('ethjs').extend('trie')
+  protected _debug: Debugger = debug('trie')
   protected debug: (...args: any) => void
 
   /**

--- a/packages/trie/test/util/log.spec.ts
+++ b/packages/trie/test/util/log.spec.ts
@@ -3,25 +3,25 @@ import { assert, describe, it } from 'vitest'
 
 import { Trie } from '../../src/trie.js'
 
-const trie_entries: [string, string | null][] = [
-  ['do', 'verb'],
-  ['ether', 'wookiedoo'],
-  ['doge', 'coin'],
-  ['ether', null],
-  ['dog', 'puppy'],
-]
-const trie = new Trie({
-  useNodePruning: true,
-})
-trie['DEBUG'] = true
-for (const [key, value] of trie_entries) {
-  await trie.put(utf8ToBytes(key), value === null ? Uint8Array.from([]) : utf8ToBytes(value))
-}
-
-const proof = await trie.createProof(utf8ToBytes('doge'))
-const valid = await trie.verifyProof(trie.root(), utf8ToBytes('doge'), proof)
-
 describe('Run Trie script with DEBUG enabled', async () => {
+  const trie_entries: [string, string | null][] = [
+    ['do', 'verb'],
+    ['ether', 'wookiedoo'],
+    ['doge', 'coin'],
+    ['ether', null],
+    ['dog', 'puppy'],
+  ]
+  process.env.DEBUG = 'ethjs'
+  const trie = new Trie({
+    useRootPersistence: true,
+  })
+  for (const [key, value] of trie_entries) {
+    await trie.put(utf8ToBytes(key), value === null ? Uint8Array.from([]) : utf8ToBytes(value))
+  }
+
+  const proof = await trie.createProof(utf8ToBytes('doge'))
+  const valid = await trie.verifyProof(trie.root(), utf8ToBytes('doge'), proof)
+
   it('should be valid', async () => {
     assert.deepEqual(valid, utf8ToBytes('coin'))
   })
@@ -29,4 +29,13 @@ describe('Run Trie script with DEBUG enabled', async () => {
   trie.checkpoint()
   await trie.commit()
   trie.flushCheckpoints()
+  trie.checkpoint()
+  await trie.revert()
+  process.env.DEBUG = ''
+  const trie2 = new Trie({})
+  trie2['DEBUG'] = true
+  await trie2.fromProof(proof)
+  it('tries should share root', async () => {
+    assert.deepEqual(trie.root(), trie2.root())
+  })
 })

--- a/packages/trie/test/util/log.spec.ts
+++ b/packages/trie/test/util/log.spec.ts
@@ -1,0 +1,32 @@
+import { utf8ToBytes } from 'ethereum-cryptography/utils'
+import { assert, describe, it } from 'vitest'
+
+import { Trie } from '../../src/trie.js'
+
+const trie_entries: [string, string | null][] = [
+  ['do', 'verb'],
+  ['ether', 'wookiedoo'],
+  ['doge', 'coin'],
+  ['ether', null],
+  ['dog', 'puppy'],
+]
+const trie = new Trie({
+  useNodePruning: true,
+})
+trie['DEBUG'] = true
+for (const [key, value] of trie_entries) {
+  await trie.put(utf8ToBytes(key), value === null ? Uint8Array.from([]) : utf8ToBytes(value))
+}
+
+const proof = await trie.createProof(utf8ToBytes('doge'))
+const valid = await trie.verifyProof(trie.root(), utf8ToBytes('doge'), proof)
+
+describe('Run Trie script with DEBUG enabled', async () => {
+  it('should be valid', async () => {
+    assert.deepEqual(valid, utf8ToBytes('coin'))
+  })
+
+  trie.checkpoint()
+  await trie.commit()
+  trie.flushCheckpoints()
+})


### PR DESCRIPTION
This introduces `debug` logging to the `Trie` class.

Like other packages, all `debug` calls will be wrapped inside of a conditional:
`if (this.DEBUG) { ... } `

`this.DEBUG` will be set to `true` only if the `ethjs` flag has been set in `process.env.DEBUG`

If active, the debugger will log with the namespace: `ethjs:Trie:`

The debugger is available by calling `this.debug(message: string, namespaces: string[])`

`trie.debug()`  will take 1 or 2 parameters.  The first being the string to be logged, the second being a list of added namespaces for that specific message.

So calling `trie.debug('Trie Created')`  will log 
> // **ethjs:trie:**  Trie Created

And calling `trie.debug('Adding value for key: 0xabcd', ['PUT'] )`  will log:
> // **ethjs:trie:PUT** Adding value for key: 0xabcd

----

Also included is `test/util/log.spec.ts`

This runs a minimal trie script with `this.DEBUG` set to true.
The debugger will remain inactive, but `coverage` will touch the code inside of the DEBUG conditionals.
This way the added lines of code for logging do not artificially hurt the `coverage` statistic.