### PR TITLE
Trie: make NULL available as type option for put value

### DIFF
--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -182,7 +182,11 @@ export class Trie {
    * @param value
    * @returns A Promise that resolves once value is stored.
    */
-  async put(key: Uint8Array, value: Uint8Array, skipKeyTransform: boolean = false): Promise<void> {
+  async put(
+    key: Uint8Array,
+    value: Uint8Array | null,
+    skipKeyTransform: boolean = false
+  ): Promise<void> {
     if (this._opts.useRootPersistence && equalsBytes(key, ROOT_DB_KEY) === true) {
       throw new Error(`Attempted to set '${bytesToUtf8(ROOT_DB_KEY)}' key but it is not allowed.`)
     }


### PR DESCRIPTION
`trie.put(key, null)` 
and
`trie.put(key, Uint8Array.from([])`
both should (and do) delete the value for that key: 

https://github.com/ethereumjs/ethereumjs-monorepo/blob/e2dc88bab0cdb073ee3dbc1154959cd718634527/packages/trie/src/trie.ts#L194-L198
 
--

However, `Null` is left out of the type options for the value paremeter:
`async put(key: Uint8Array, value: Uint8Array, skipKeyTransform: boolean = false): Promise<void>`

The `official` trie tests actually do use `null`  as a value.  The reason the test does not throw a Type error is that the `null` values are wrapped in a variable with type `any`

Since PUT does not actually accept `Null` values outright, users are forced to use empty Uint8Arrays, or `as any` to access this part of the implementation.

----
This PR adds `| null` as a type options for the `value` parameter, bringing into alignment with the implementation itself.  