### PR TITLE
StateManager: some devDependencies move to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15724,7 +15724,8 @@
       },
       "devDependencies": {
         "@ethereumjs/block": "^5.0.0",
-        "@ethereumjs/genesis": "^0.1.0"
+        "@ethereumjs/genesis": "^0.1.0",
+        "@types/debug": "^4.1.8"
       }
     },
     "packages/statemanager/node_modules/lru-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15714,6 +15714,8 @@
       "dependencies": {
         "@ethereumjs/common": "^4.0.0",
         "@ethereumjs/rlp": "^5.0.0",
+        "@ethereumjs/trie": "^6.0.0",
+        "@ethereumjs/util": "^9.0.0",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.1.2",
         "ethers": "^6.4.0",
@@ -15722,11 +15724,7 @@
       },
       "devDependencies": {
         "@ethereumjs/block": "^5.0.0",
-        "@ethereumjs/genesis": "^0.1.0",
-        "@ethereumjs/trie": "^6.0.0",
-        "@ethereumjs/util": "^9.0.0",
-        "debug": "^4.3.3",
-        "ethereum-cryptography": "^2.1.2"
+        "@ethereumjs/genesis": "^0.1.0"
       }
     },
     "packages/statemanager/node_modules/lru-cache": {

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@ethereumjs/block": "^5.0.0",
-    "@ethereumjs/genesis": "^0.1.0"
+    "@ethereumjs/genesis": "^0.1.0",
+    "@types/debug": "^4.1.8"
   }
 }

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -50,6 +50,8 @@
   "dependencies": {
     "@ethereumjs/common": "^4.0.0",
     "@ethereumjs/rlp": "^5.0.0",
+    "@ethereumjs/trie": "^6.0.0",
+    "@ethereumjs/util": "^9.0.0",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.1.2",
     "ethers": "^6.4.0",
@@ -58,10 +60,6 @@
   },
   "devDependencies": {
     "@ethereumjs/block": "^5.0.0",
-    "@ethereumjs/genesis": "^0.1.0",
-    "@ethereumjs/trie": "^6.0.0",
-    "@ethereumjs/util": "^9.0.0",
-    "debug": "^4.3.3",
-    "ethereum-cryptography": "^2.1.2"
+    "@ethereumjs/genesis": "^0.1.0"
   }
 }


### PR DESCRIPTION
Hi I am using hardhat with yarn berry.
I met this error a few days ago whenever i try to compile and test. 

```
Error: @nomicfoundation/ethereumjs-statemanager tried to access @nomicfoundation/ethereumjs-trie, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: @nomicfoundation/ethereumjs-trie
Required by: @nomicfoundation/ethereumjs-statemanager@npm:2.0.2 (via <my-repository-path>/.yarn/cache/@nomicfoundation-ethereumjs-statemanager-npm-2.0.2-5465bc8cbc-3ab6578e25.zip/node_modules/@nomicfoundation/ethereumjs-statemanager/dist/)
```

it means that some packages are using as "dependencies" but these declared as "devDependencies".
i think this pr is a very tiny thing, but it would help for lots of yarn users 😂
