### PR TITLE
DEBUG coverage

### DIFF
--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "npx vitest run --coverage.enabled --coverage.reporter=lcov",
+    "coverage": "DEBUG=ethjs npx vitest run --coverage.enabled --coverage.reporter=lcov",
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "ts-node ../../scripts/examples-runner.ts -- block",
     "lint": "../../config/cli/lint.sh",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "npx vitest run --coverage.enabled --coverage.reporter=lcov",
+    "coverage": "DEBUG=ethjs npx vitest run --coverage.enabled --coverage.reporter=lcov",
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "ts-node ../../scripts/examples-runner.ts -- blockchain",
     "lint": "../../config/cli/lint.sh",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "npx vitest run --coverage.enabled --coverage.reporter=lcov",
+    "coverage": "DEBUG=ethjs npx vitest run --coverage.enabled --coverage.reporter=lcov",
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "ts-node ../../scripts/examples-runner.ts -- common",
     "lint": "../../config/cli/lint.sh",

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -33,7 +33,7 @@
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "npx vitest run --coverage.enabled --coverage.reporter=lcov",
+    "coverage": "DEBUG=ethjs npx vitest run --coverage.enabled --coverage.reporter=lcov",
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "ts-node ../../scripts/examples-runner.ts -- ethash",
     "lint": "../../config/cli/lint.sh",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "npx vitest run --coverage.enabled --coverage.reporter=lcov",
+    "coverage": "DEBUG=ethjs npx vitest run --coverage.enabled --coverage.reporter=lcov",
     "coverage:test": "npm run test:node && cd ../vm && npm run tester -- --state",
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "ts-node ../../scripts/examples-runner.ts -- evm",

--- a/packages/rlp/package.json
+++ b/packages/rlp/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "build": "../../config/cli/ts-build.sh node",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "npx vitest run --coverage.enabled --coverage.reporter=lcov",
+    "coverage": "DEBUG=ethjs npx vitest run --coverage.enabled --coverage.reporter=lcov",
     "examples": "ts-node ../../scripts/examples-runner.ts -- rlp",
     "lint": "../../config/cli/lint.sh",
     "lint:diff": "../../config/cli/lint-diff.sh",

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "npx vitest run --coverage.enabled --coverage.reporter=lcov",
+    "coverage": "DEBUG=ethjs npx vitest run --coverage.enabled --coverage.reporter=lcov",
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "ts-node ../../scripts/examples-runner.ts -- statemanager",
     "lint": "../../config/cli/lint.sh",

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -38,7 +38,7 @@
     "benchmarks": "node -r ts-node/register --max-old-space-size=8024 benchmarks",
     "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "npx vitest run --coverage.enabled --coverage.reporter=lcov",
+    "coverage": "DEBUG=ethjs npx vitest run --coverage.enabled --coverage.reporter=lcov",
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "ts-node ../../scripts/examples-runner.ts -- trie",
     "lint": "../../config/cli/lint.sh",

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "npx vitest run --coverage.enabled --coverage.reporter=lcov",
+    "coverage": "DEBUG=ethjs npx vitest run --coverage.enabled --coverage.reporter=lcov",
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "ts-node ../../scripts/examples-runner.ts -- tx",
     "lint": "../../config/cli/lint.sh",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -77,7 +77,7 @@
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "npx vitest run --coverage.enabled --coverage.reporter=lcov",
+    "coverage": "DEBUG=ethjs npx vitest run --coverage.enabled --coverage.reporter=lcov",
     "docs:build": "npx typedoc --options typedoc.cjs",
     "examples": "ts-node ../../scripts/examples-runner.ts -- util",
     "lint": "../../config/cli/lint.sh",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -37,7 +37,7 @@
     "build": "../../config/cli/ts-build.sh",
     "build:benchmarks": "npm run build && tsc -p tsconfig.benchmarks.json",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "npx vitest run --coverage.enabled --coverage.reporter=lcov",
+    "coverage": "DEBUG=ethjs npx vitest run --coverage.enabled --coverage.reporter=lcov",
     "coverage:test": "npm run test:API",
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "ts-node ../../scripts/examples-runner.ts -- vm",


### PR DESCRIPTION
This follows up to [] and []

Enables DEBUG variable in "coverage" test scripts.  By just including the "ethjs" master debug variable, the `if (this.DEBUG) ...`  conditionals present in `DefaultStateManager` et al. will be included in the coverage test.  

Added to  the coverage script in all packages, event though not all packages have DEBUG features yet, and not all packages that do have a debugger have implemented this `if (this.DEBUG) ...` pattern yet.  