### PR TITLE
Hybrid EVM Stack Experiment

### DIFF
--- a/packages/evm/src/hybridStack.ts
+++ b/packages/evm/src/hybridStack.ts
@@ -1,0 +1,314 @@
+import { bigIntToBytes, bytesToBigInt } from '@ethereumjs/util'
+
+import { ERROR, EvmError } from './exceptions.js'
+
+import type { EVMStack } from './types.js'
+
+/**
+ * Hybrid stack implementation for the EVM, containing either bytes (preferred) or bigint values.
+ *
+ * This stack implementation is significantly more performant than the single type stack. Atm it is however
+ * not activated by default for backwards compatibility reasons.
+ *
+ * In the current EVM version this stack performs significantly worse than the hybrid type stack on the EVM
+ * `step` event (if used), since there is mapping to a single type stack needed on each step.
+ *
+ * Developer notes:
+ *
+ * 1. If there are bigint/bytes conversions in opcode implementations before or after accessing the stack,
+ * direct calling into the type-named methods here should be preferred and the conversion removed from the
+ * opcode implementation.
+ * 2. If a byte-based opcode implementation has no direct performance penalties towards the bigint version,
+ * the bytes version should be used (respectively: replace the bigint version)
+ */
+
+type StackElement = [bigint | undefined, Uint8Array | undefined]
+type Store = StackElement[]
+
+export class HybridStack implements EVMStack {
+  // This array is initialized as an empty array. Once values are pushed, the array size will never decrease.
+  private _store: Store
+  private _maxHeight: number
+
+  private _len: number = 0
+
+  constructor(maxHeight?: number) {
+    // It is possible to initialize the array with `maxHeight` items. However,
+    // this makes the constructor 10x slower and there do not seem to be any observable performance gains
+    this._store = []
+    this._maxHeight = maxHeight ?? 1024
+  }
+
+  get length() {
+    return this._len
+  }
+
+  /**
+   * Push an item to the stack.
+   * @deprecated use the type-named version of the method
+   * @param value
+   */
+  push(value: bigint) {
+    this.pushBigInt(value)
+  }
+
+  /**
+   * Push an item to the stack.
+   * @param value
+   */
+  pushBigInt(value: bigint) {
+    if (this._len >= this._maxHeight) {
+      throw new EvmError(ERROR.STACK_OVERFLOW)
+    }
+
+    // Read current length, set `_store` to value, and then increase the length
+    this._store[this._len++] = [value, undefined]
+  }
+
+  /**
+   * Push an item to the stack.
+   * @param value
+   */
+  pushBytes(value: Uint8Array) {
+    if (this._len >= this._maxHeight) {
+      throw new EvmError(ERROR.STACK_OVERFLOW)
+    }
+
+    // Read current length, set `_store` to value, and then increase the length
+    this._store[this._len++] = [undefined, value]
+  }
+
+  /**
+   * Pop an item from the stack.
+   * @deprecated use the type-named version of the method
+   * @param value
+   */
+  pop(): bigint {
+    return this.popBigInt()
+  }
+
+  /**
+   * Pop an item from the stack.
+   * @param value
+   */
+  popBigInt(): bigint {
+    if (this._len < 1) {
+      throw new EvmError(ERROR.STACK_UNDERFLOW)
+    }
+
+    // Length is checked above, so pop shouldn't return undefined
+    // First decrease current length, then read the item and return it
+    // Note: this does thus not delete the item from the internal array
+    // However, the length is decreased, so it is not accessible to external observors
+    const elem = this._store[--this._len]
+    if (elem[0] !== undefined) {
+      return elem[0]
+    }
+    return bytesToBigInt(elem[1]!)
+  }
+
+  /**
+   * Pop an item from the stack.
+   * @param value
+   */
+  popBytes(): Uint8Array {
+    if (this._len < 1) {
+      throw new EvmError(ERROR.STACK_UNDERFLOW)
+    }
+
+    // Length is checked above, so pop shouldn't return undefined
+    // First decrease current length, then read the item and return it
+    // Note: this does thus not delete the item from the internal array
+    // However, the length is decreased, so it is not accessible to external observors
+    const elem = this._store[--this._len]
+    if (elem[1] !== undefined) {
+      return elem[1]
+    }
+    return bigIntToBytes(elem[0]!)
+  }
+
+  /**
+   * Pop multiple items from stack. Top of stack is first item
+   * in returned array.
+   * @deprecated use the type-named version of the method
+   * @param num - Number of items to pop
+   */
+  popN(num: number = 1): bigint[] {
+    return this.popNBigInt(num)
+  }
+
+  /**
+   * Pop multiple items from stack. Top of stack is first item
+   * in returned array.
+   * @param num - Number of items to pop
+   */
+  popNBigInt(num: number = 1): bigint[] {
+    if (this._len < num) {
+      throw new EvmError(ERROR.STACK_UNDERFLOW)
+    }
+
+    if (num === 0) {
+      return []
+    }
+
+    const arr: bigint[] = Array(num)
+    const cache = this._store
+
+    for (let pop = 0; pop < num; pop++) {
+      // Note: this thus also (correctly) reduces the length of the internal array (without deleting items)
+      const elem = cache[--this._len]
+      if (elem[0] !== undefined) {
+        arr[pop] = elem[0]
+      } else {
+        arr[pop] = bytesToBigInt(elem[1]!)
+      }
+    }
+
+    return arr
+  }
+
+  /**
+   * Pop multiple items from stack. Top of stack is first item
+   * in returned array.
+   * @param num - Number of items to pop
+   */
+  popNBytes(num: number = 1): Uint8Array[] {
+    if (this._len < num) {
+      throw new EvmError(ERROR.STACK_UNDERFLOW)
+    }
+
+    if (num === 0) {
+      return []
+    }
+
+    const arr: Uint8Array[] = Array(num)
+    const cache = this._store
+
+    for (let pop = 0; pop < num; pop++) {
+      // Note: this thus also (correctly) reduces the length of the internal array (without deleting items)
+      const elem = cache[--this._len]
+      if (elem[1] !== undefined) {
+        arr[pop] = elem[1]
+      } else {
+        arr[pop] = bigIntToBytes(elem[0]!)
+      }
+    }
+
+    return arr
+  }
+
+  /**
+   * Return items from the stack
+   * @deprecated use the type-named version of the method
+   * @param num Number of items to return
+   * @throws {@link ERROR.STACK_UNDERFLOW}
+   */
+  peek(num: number = 1): bigint[] {
+    return this.peekBigInt(num)
+  }
+
+  /**
+   * Return items from the stack
+   * @param num Number of items to return
+   * @throws {@link ERROR.STACK_UNDERFLOW}
+   */
+  peekBigInt(num: number = 1): bigint[] {
+    const peekArray: bigint[] = Array(num)
+    let start = this._len
+
+    for (let peek = 0; peek < num; peek++) {
+      const index = --start
+      if (index < 0) {
+        throw new EvmError(ERROR.STACK_UNDERFLOW)
+      }
+      if (this._store[index][0] !== undefined) {
+        peekArray[peek] = this._store[index][0]!
+      } else {
+        const valueBigInt = bytesToBigInt(this._store[index][1]!)
+        this._store[index][0] = valueBigInt
+        peekArray[peek] = valueBigInt
+      }
+    }
+    return peekArray
+  }
+
+  /**
+   * Return items from the stack
+   * @param num Number of items to return
+   * @throws {@link ERROR.STACK_UNDERFLOW}
+   */
+  peekBytes(num: number = 1): Uint8Array[] {
+    const peekArray: Uint8Array[] = Array(num)
+    let start = this._len
+
+    for (let peek = 0; peek < num; peek++) {
+      const index = --start
+      if (index < 0) {
+        throw new EvmError(ERROR.STACK_UNDERFLOW)
+      }
+      if (this._store[index][1] !== undefined) {
+        peekArray[peek] = this._store[index][1]!
+      } else {
+        const valueBytes = bigIntToBytes(this._store[index][0]!)
+        this._store[index][1] = valueBytes
+        peekArray[peek] = valueBytes
+      }
+    }
+    return peekArray
+  }
+
+  /**
+   * Swap top of stack with an item in the stack.
+   * @param position - Index of item from top of the stack (0-indexed)
+   */
+  swap(position: number) {
+    if (this._len <= position) {
+      throw new EvmError(ERROR.STACK_UNDERFLOW)
+    }
+
+    const head = this._len - 1
+    const i = head - position
+    const storageCached = this._store
+
+    const tmp = storageCached[head]
+    storageCached[head] = storageCached[i]
+    storageCached[i] = tmp
+  }
+
+  /**
+   * Pushes a copy of an item in the stack.
+   * @param position - Index of item to be copied (1-indexed)
+   */
+  // I would say that we do not need this method any more
+  // since you can't copy a primitive data type
+  // Nevertheless not sure if we "loose" something here?
+  // Will keep commented out for now
+  dup(position: number) {
+    const len = this._len
+    if (len < position) {
+      throw new EvmError(ERROR.STACK_UNDERFLOW)
+    }
+
+    // Note: this code is borrowed from `push()` (avoids a call)
+    if (len >= this._maxHeight) {
+      throw new EvmError(ERROR.STACK_OVERFLOW)
+    }
+
+    const i = len - position
+    this._store[this._len++] = this._store[i]
+  }
+
+  /**
+   * Returns a copy of the current stack. This represents the actual state of the stack
+   * (not the internal state of the stack, which might have unreachable elements in it)
+   */
+  getStack() {
+    return this._store.slice(0, this._len).map((elem: StackElement) => {
+      if (elem[0] !== undefined) {
+        return elem[0]
+      } else {
+        return bytesToBigInt(elem[1]!)
+      }
+    })
+  }
+}

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -78,7 +78,7 @@ export interface RunState {
   code: Uint8Array
   shouldDoJumpAnalysis: boolean
   validJumps: Uint8Array // array of values where validJumps[index] has value 0 (default), 1 (jumpdest), 2 (beginsub)
-  cachedPushes: { [pc: number]: bigint }
+  cachedPushes: { [pc: number]: Uint8Array }
   stateManager: EVMStateManagerInterface
   blockchain: Blockchain
   env: Env
@@ -416,7 +416,7 @@ export class Interpreter {
   // Returns all valid jump and jumpsub destinations.
   _getValidJumpDests(code: Uint8Array) {
     const jumps = new Uint8Array(code.length).fill(0)
-    const pushes: { [pc: number]: bigint } = {}
+    const pushes: { [pc: number]: Uint8Array } = {}
 
     const opcodesCached = Array(code.length)
 
@@ -427,7 +427,7 @@ export class Interpreter {
       if (opcode <= 0x7f) {
         if (opcode >= 0x60) {
           const extraSteps = opcode - 0x5f
-          const push = bytesToBigInt(code.slice(i + 1, i + opcode - 0x5e))
+          const push = code.slice(i + 1, i + opcode - 0x5e)
           pushes[i + 1] = push
           i += extraSteps
         } else if (opcode === 0x5b) {
@@ -634,8 +634,8 @@ export class Interpreter {
    * Returns caller address. This is the address of the account
    * that is directly responsible for this execution.
    */
-  getCaller(): bigint {
-    return bytesToBigInt(this._env.caller.bytes)
+  getCaller(): Uint8Array {
+    return this._env.caller.bytes
   }
 
   /**
@@ -696,8 +696,8 @@ export class Interpreter {
    * sender of original transaction; it is never an account with
    * non-empty associated code.
    */
-  getTxOrigin(): bigint {
-    return bytesToBigInt(this._env.origin.bytes)
+  getTxOrigin(): Uint8Array {
+    return this._env.origin.bytes
   }
 
   /**
@@ -710,14 +710,14 @@ export class Interpreter {
   /**
    * Returns the block's beneficiary address.
    */
-  getBlockCoinbase(): bigint {
+  getBlockCoinbase(): Uint8Array {
     let coinbase: Address
     if (this.common.consensusAlgorithm() === ConsensusAlgorithm.Clique) {
       coinbase = this._env.block.header.cliqueSigner()
     } else {
       coinbase = this._env.block.header.coinbase
     }
-    return bytesToBigInt(coinbase.toBytes())
+    return coinbase.toBytes()
   }
 
   /**
@@ -737,8 +737,8 @@ export class Interpreter {
   /**
    * Returns the block's prevRandao field.
    */
-  getBlockPrevRandao(): bigint {
-    return bytesToBigInt(this._env.block.header.prevRandao)
+  getBlockPrevRandao(): Uint8Array {
+    return this._env.block.header.prevRandao
   }
 
   /**

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -20,7 +20,7 @@ import type { EVM } from './evm.js'
 import type { Journal } from './journal.js'
 import type { EVMPerformanceLogger, Timer } from './logger.js'
 import type { AsyncOpHandler, Opcode, OpcodeMapEntry } from './opcodes/index.js'
-import type { Block, Blockchain, EVMProfilerOpts, EVMResult, Log } from './types.js'
+import type { Block, Blockchain, EVMProfilerOpts, EVMResult, EVMStack, Log } from './types.js'
 import type { Common, EVMStateManagerInterface } from '@ethereumjs/common'
 import type { Address } from '@ethereumjs/util'
 const { debug: createDebugLogger } = debugDefault
@@ -73,8 +73,8 @@ export interface RunState {
   memory: Memory
   memoryWordCount: bigint
   highestMemCost: bigint
-  stack: Stack
-  returnStack: Stack
+  stack: EVMStack
+  returnStack: EVMStack
   code: Uint8Array
   shouldDoJumpAnalysis: boolean
   validJumps: Uint8Array // array of values where validJumps[index] has value 0 (default), 1 (jumpdest), 2 (beginsub)

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -11,10 +11,10 @@ import debugDefault from 'debug'
 
 import { EOF } from './eof.js'
 import { ERROR, EvmError } from './exceptions.js'
+import { HybridStack } from './hybridStack.js'
 import { Memory } from './memory.js'
 import { Message } from './message.js'
 import { trap } from './opcodes/index.js'
-import { Stack } from './stack.js'
 
 import type { EVM } from './evm.js'
 import type { Journal } from './journal.js'
@@ -158,8 +158,8 @@ export class Interpreter {
       memory: new Memory(),
       memoryWordCount: BigInt(0),
       highestMemCost: BigInt(0),
-      stack: new Stack(),
-      returnStack: new Stack(1023), // 1023 return stack height limit per EIP 2315 spec
+      stack: new HybridStack(),
+      returnStack: new HybridStack(1023), // 1023 return stack height limit per EIP 2315 spec
       code: new Uint8Array(0),
       validJumps: Uint8Array.from([]),
       cachedPushes: {},

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -59,7 +59,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x01,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       const r = mod(a + b, TWO_POW256)
       runState.stack.pushBigInt(r)
     },
@@ -68,7 +68,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x02,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       const r = mod(a * b, TWO_POW256)
       runState.stack.pushBigInt(r)
     },
@@ -77,7 +77,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x03,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       const r = mod(a - b, TWO_POW256)
       runState.stack.pushBigInt(r)
     },
@@ -86,7 +86,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x04,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       let r
       if (b === BigInt(0)) {
         r = BigInt(0)
@@ -100,7 +100,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x05,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       let r
       if (b === BigInt(0)) {
         r = BigInt(0)
@@ -114,7 +114,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x06,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       let r
       if (b === BigInt(0)) {
         r = b
@@ -128,7 +128,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x07,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       let r
       if (b === BigInt(0)) {
         r = b
@@ -142,7 +142,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x08,
     function (runState) {
-      const [a, b, c] = runState.stack.popN(3)
+      const [a, b, c] = runState.stack.popNBigInt(3)
       let r
       if (c === BigInt(0)) {
         r = BigInt(0)
@@ -156,7 +156,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x09,
     function (runState) {
-      const [a, b, c] = runState.stack.popN(3)
+      const [a, b, c] = runState.stack.popNBigInt(3)
       let r
       if (c === BigInt(0)) {
         r = BigInt(0)
@@ -170,7 +170,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x0a,
     function (runState) {
-      const [base, exponent] = runState.stack.popN(2)
+      const [base, exponent] = runState.stack.popNBigInt(2)
       if (exponent === BigInt(0)) {
         runState.stack.pushBigInt(BigInt(1))
         return
@@ -189,7 +189,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x0b,
     function (runState) {
       /* eslint-disable-next-line prefer-const */
-      let [k, val] = runState.stack.popN(2)
+      let [k, val] = runState.stack.popNBigInt(2)
       if (k < BigInt(31)) {
         const signBit = k * BigInt(8) + BigInt(7)
         const mask = (BigInt(1) << signBit) - BigInt(1)
@@ -207,7 +207,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x10,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       const r = a < b ? BigInt(1) : BigInt(0)
       runState.stack.pushBigInt(r)
     },
@@ -216,7 +216,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x11,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       const r = a > b ? BigInt(1) : BigInt(0)
       runState.stack.pushBigInt(r)
     },
@@ -225,7 +225,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x12,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       const r = fromTwos(a) < fromTwos(b) ? BigInt(1) : BigInt(0)
       runState.stack.pushBigInt(r)
     },
@@ -234,7 +234,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x13,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       const r = fromTwos(a) > fromTwos(b) ? BigInt(1) : BigInt(0)
       runState.stack.pushBigInt(r)
     },
@@ -243,7 +243,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x14,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       const r = a === b ? BigInt(1) : BigInt(0)
       runState.stack.pushBigInt(r)
     },
@@ -261,7 +261,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x16,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       const r = a & b
       runState.stack.pushBigInt(r)
     },
@@ -270,7 +270,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x17,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       const r = a | b
       runState.stack.pushBigInt(r)
     },
@@ -279,7 +279,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x18,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       const r = a ^ b
       runState.stack.pushBigInt(r)
     },
@@ -297,7 +297,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x1a,
     function (runState) {
-      const [pos, word] = runState.stack.popN(2)
+      const [pos, word] = runState.stack.popNBigInt(2)
       if (pos > BigInt(32)) {
         runState.stack.pushBigInt(BigInt(0))
         return
@@ -311,7 +311,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x1b,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       if (a > BigInt(256)) {
         runState.stack.pushBigInt(BigInt(0))
         return
@@ -325,7 +325,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x1c,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
       if (a > 256) {
         runState.stack.pushBigInt(BigInt(0))
         return
@@ -339,7 +339,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x1d,
     function (runState) {
-      const [a, b] = runState.stack.popN(2)
+      const [a, b] = runState.stack.popNBigInt(2)
 
       let r
       const bComp = BigInt.asIntN(256, b)
@@ -370,7 +370,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x20,
     function (runState) {
-      const [offset, length] = runState.stack.popN(2)
+      const [offset, length] = runState.stack.popNBigInt(2)
       let data = new Uint8Array(0)
       if (length !== BigInt(0)) {
         data = runState.memory.read(Number(offset), Number(length))
@@ -451,7 +451,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x37,
     function (runState) {
-      const [memOffset, dataOffset, dataLength] = runState.stack.popN(3)
+      const [memOffset, dataOffset, dataLength] = runState.stack.popNBigInt(3)
 
       if (dataLength !== BigInt(0)) {
         const data = getDataSlice(runState.interpreter.getCallData(), dataOffset, dataLength)
@@ -472,7 +472,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x39,
     function (runState) {
-      const [memOffset, codeOffset, dataLength] = runState.stack.popN(3)
+      const [memOffset, codeOffset, dataLength] = runState.stack.popNBigInt(3)
 
       if (dataLength !== BigInt(0)) {
         const data = getDataSlice(runState.interpreter.getCode(), codeOffset, dataLength)
@@ -498,7 +498,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x3c,
     async function (runState) {
-      const [addressBigInt, memOffset, codeOffset, dataLength] = runState.stack.popN(4)
+      const [addressBigInt, memOffset, codeOffset, dataLength] = runState.stack.popNBigInt(4)
 
       if (dataLength !== BigInt(0)) {
         const code = await runState.stateManager.getContractCode(
@@ -538,7 +538,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x3e,
     function (runState) {
-      const [memOffset, returnDataOffset, dataLength] = runState.stack.popN(3)
+      const [memOffset, returnDataOffset, dataLength] = runState.stack.popNBigInt(3)
 
       if (dataLength !== BigInt(0)) {
         const data = getDataSlice(
@@ -671,7 +671,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x52,
     function (runState) {
-      const [offset, word] = runState.stack.popN(2)
+      const [offset, word] = runState.stack.popNBigInt(2)
       const buf = setLengthLeft(bigIntToBytes(word), 32)
       const offsetNum = Number(offset)
       runState.memory.write(offsetNum, 32, buf)
@@ -681,7 +681,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x53,
     function (runState) {
-      const [offset, byte] = runState.stack.popN(2)
+      const [offset, byte] = runState.stack.popNBigInt(2)
 
       const buf = bigIntToBytes(byte & BigInt(0xff))
       const offsetNum = Number(offset)
@@ -703,7 +703,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x55,
     async function (runState) {
-      const [key, val] = runState.stack.popN(2)
+      const [key, val] = runState.stack.popNBigInt(2)
 
       const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
       // NOTE: this should be the shortest representation
@@ -739,7 +739,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x57,
     function (runState) {
-      const [dest, cond] = runState.stack.popN(2)
+      const [dest, cond] = runState.stack.popNBigInt(2)
       if (cond !== BigInt(0)) {
         if (dest > runState.interpreter.getCodeSize()) {
           trap(ERROR.INVALID_JUMP + ' at ' + describeLocation(runState))
@@ -812,7 +812,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         if (runState.interpreter.isStatic()) {
           trap(ERROR.STATIC_STATE_CHANGE)
         }
-        const [key, val] = runState.stack.popN(2)
+        const [key, val] = runState.stack.popNBigInt(2)
 
         const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
         // NOTE: this should be the shortest representation
@@ -849,7 +849,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         runState.programCounter = destNum + 1
       } else if (common.isActivatedEIP(5656)) {
         // MCOPY
-        const [dst, src, length] = runState.stack.popN(3)
+        const [dst, src, length] = runState.stack.popNBigInt(3)
         const data = runState.memory.read(Number(src), Number(length), true)
         runState.memory.write(Number(dst), Number(length), data)
       }
@@ -906,11 +906,11 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0xa0,
     function (runState) {
-      const [memOffset, memLength] = runState.stack.popN(2)
+      const [memOffset, memLength] = runState.stack.popNBigInt(2)
 
       const topicsCount = runState.opCode - 0xa0
 
-      const topics = runState.stack.popN(topicsCount)
+      const topics = runState.stack.popNBigInt(topicsCount)
       const topicsBuf = topics.map(function (a: bigint) {
         return setLengthLeft(bigIntToBytes(a), 32)
       })
@@ -928,7 +928,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0xf0,
     async function (runState, common) {
-      const [value, offset, length] = runState.stack.popN(3)
+      const [value, offset, length] = runState.stack.popNBigInt(3)
 
       if (
         common.isActivatedEIP(3860) &&
@@ -958,7 +958,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         trap(ERROR.STATIC_STATE_CHANGE)
       }
 
-      const [value, offset, length, salt] = runState.stack.popN(4)
+      const [value, offset, length, salt] = runState.stack.popNBigInt(4)
 
       if (
         common.isActivatedEIP(3860) &&
@@ -990,7 +990,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     0xf1,
     async function (runState: RunState) {
       const [_currentGasLimit, toAddr, value, inOffset, inLength, outOffset, outLength] =
-        runState.stack.popN(7)
+        runState.stack.popNBigInt(7)
       const toAddress = new Address(addresstoBytes(toAddr))
 
       let data = new Uint8Array(0)
@@ -1012,7 +1012,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     0xf2,
     async function (runState: RunState) {
       const [_currentGasLimit, toAddr, value, inOffset, inLength, outOffset, outLength] =
-        runState.stack.popN(7)
+        runState.stack.popNBigInt(7)
       const toAddress = new Address(addresstoBytes(toAddr))
 
       const gasLimit = runState.messageGasLimit!
@@ -1035,7 +1035,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     async function (runState) {
       const value = runState.interpreter.getCallValue()
       const [_currentGasLimit, toAddr, inOffset, inLength, outOffset, outLength] =
-        runState.stack.popN(6)
+        runState.stack.popNBigInt(6)
       const toAddress = new Address(addresstoBytes(toAddr))
 
       let data = new Uint8Array(0)
@@ -1057,7 +1057,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     0xf6,
     async function (runState) {
       // eslint-disable-next-line prefer-const
-      let [authority, memOffset, memLength] = runState.stack.popN(3)
+      let [authority, memOffset, memLength] = runState.stack.popNBigInt(3)
 
       if (memLength > BigInt(128)) {
         memLength = BigInt(128)
@@ -1122,7 +1122,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         argsLength,
         retOffset,
         retLength,
-      ] = runState.stack.popN(8)
+      ] = runState.stack.popNBigInt(8)
 
       const toAddress = new Address(addresstoBytes(addr))
 
@@ -1146,7 +1146,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     async function (runState) {
       const value = BigInt(0)
       const [_currentGasLimit, toAddr, inOffset, inLength, outOffset, outLength] =
-        runState.stack.popN(6)
+        runState.stack.popNBigInt(6)
       const toAddress = new Address(addresstoBytes(toAddr))
 
       const gasLimit = runState.messageGasLimit!
@@ -1167,7 +1167,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0xf3,
     function (runState) {
-      const [offset, length] = runState.stack.popN(2)
+      const [offset, length] = runState.stack.popNBigInt(2)
       let returnData = new Uint8Array(0)
       if (length !== BigInt(0)) {
         returnData = runState.memory.read(Number(offset), Number(length))
@@ -1179,7 +1179,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0xfd,
     function (runState) {
-      const [offset, length] = runState.stack.popN(2)
+      const [offset, length] = runState.stack.popNBigInt(2)
       let returnData = new Uint8Array(0)
       if (length !== BigInt(0)) {
         returnData = runState.memory.read(Number(offset), Number(length))

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -805,7 +805,7 @@ export const handlers: Map<number, OpHandler> = new Map([
           trap(ERROR.INVALID_RETURNSUB)
         }
 
-        const dest = runState.returnStack.pop()
+        const dest = runState.returnStack.popBigInt()
         runState.programCounter = Number(dest)
       } else if (common.isActivatedEIP(1153)) {
         // TSTORE
@@ -845,7 +845,7 @@ export const handlers: Map<number, OpHandler> = new Map([
           trap(ERROR.INVALID_JUMPSUB + ' at ' + describeLocation(runState))
         }
 
-        runState.returnStack.push(BigInt(runState.programCounter))
+        runState.returnStack.pushBigInt(BigInt(runState.programCounter))
         runState.programCounter = destNum + 1
       } else if (common.isActivatedEIP(5656)) {
         // MCOPY

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -252,7 +252,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x15,
     function (runState) {
-      const a = runState.stack.pop()
+      const a = runState.stack.popBigInt()
       const r = a === BigInt(0) ? BigInt(1) : BigInt(0)
       runState.stack.pushBigInt(r)
     },
@@ -288,7 +288,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x19,
     function (runState) {
-      const a = runState.stack.pop()
+      const a = runState.stack.popBigInt()
       const r = BigInt.asUintN(256, ~a)
       runState.stack.pushBigInt(r)
     },
@@ -392,7 +392,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x31,
     async function (runState) {
-      const addressBigInt = runState.stack.pop()
+      const addressBigInt = runState.stack.popBigInt()
       const address = new Address(addresstoBytes(addressBigInt))
       const balance = await runState.interpreter.getExternalBalance(address)
       runState.stack.pushBigInt(balance)
@@ -423,7 +423,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x35,
     function (runState) {
-      const pos = runState.stack.pop()
+      const pos = runState.stack.popBigInt()
       if (pos > runState.interpreter.getCallDataSize()) {
         runState.stack.pushBigInt(BigInt(0))
         return
@@ -486,7 +486,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x3b,
     async function (runState) {
-      const addressBigInt = runState.stack.pop()
+      const addressBigInt = runState.stack.popBigInt()
       const size = BigInt(
         (await runState.stateManager.getContractCode(new Address(addresstoBytes(addressBigInt))))
           .length
@@ -516,7 +516,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x3f,
     async function (runState) {
-      const addressBigInt = runState.stack.pop()
+      const addressBigInt = runState.stack.popBigInt()
       const address = new Address(addresstoBytes(addressBigInt))
       const account = await runState.stateManager.getAccount(address)
       if (!account || account.isEmpty()) {
@@ -564,7 +564,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x40,
     async function (runState) {
-      const number = runState.stack.pop()
+      const number = runState.stack.popBigInt()
 
       const diff = runState.interpreter.getBlockNumber() - number
       // block lookups must be within the past 256 blocks
@@ -642,7 +642,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x49,
     function (runState) {
-      const index = runState.stack.pop()
+      const index = runState.stack.popBigInt()
       if (runState.env.versionedHashes.length > Number(index)) {
         runState.stack.pushBigInt(bytesToBigInt(runState.env.versionedHashes[Number(index)]))
       } else {
@@ -655,14 +655,14 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x50,
     function (runState) {
-      runState.stack.pop()
+      runState.stack.popBigInt()
     },
   ],
   // 0x51: MLOAD
   [
     0x51,
     function (runState) {
-      const pos = runState.stack.pop()
+      const pos = runState.stack.popBigInt()
       const word = runState.memory.read(Number(pos), 32, true)
       runState.stack.pushBigInt(bytesToBigInt(word))
     },
@@ -692,7 +692,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x54,
     async function (runState) {
-      const key = runState.stack.pop()
+      const key = runState.stack.popBigInt()
       const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
       const value = await runState.interpreter.storageLoad(keyBuf)
       const valueBigInt = value.length ? bytesToBigInt(value) : BigInt(0)
@@ -721,7 +721,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x56,
     function (runState) {
-      const dest = runState.stack.pop()
+      const dest = runState.stack.popBigInt()
       if (dest > runState.interpreter.getCodeSize()) {
         trap(ERROR.INVALID_JUMP + ' at ' + describeLocation(runState))
       }
@@ -787,7 +787,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         trap(ERROR.INVALID_BEGINSUB + ' at ' + describeLocation(runState))
       } else if (common.isActivatedEIP(1153)) {
         // TLOAD
-        const key = runState.stack.pop()
+        const key = runState.stack.popBigInt()
         const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
         const value = runState.interpreter.transientStorageLoad(keyBuf)
         const valueBN = value.length ? bytesToBigInt(value) : BigInt(0)
@@ -833,7 +833,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState, common) {
       if (common.isActivatedEIP(2315)) {
         // JUMPSUB
-        const dest = runState.stack.pop()
+        const dest = runState.stack.popBigInt()
 
         if (dest > runState.interpreter.getCodeSize()) {
           trap(ERROR.INVALID_JUMPSUB + ' at ' + describeLocation(runState))
@@ -1192,7 +1192,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0xff,
     async function (runState) {
-      const selfdestructToAddressBigInt = runState.stack.pop()
+      const selfdestructToAddressBigInt = runState.stack.popBigInt()
       const selfdestructToAddress = new Address(addresstoBytes(selfdestructToAddressBigInt))
       return runState.interpreter.selfDestruct(selfdestructToAddress)
     },

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -61,7 +61,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       const r = mod(a + b, TWO_POW256)
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x02: MUL
@@ -70,7 +70,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       const r = mod(a * b, TWO_POW256)
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x03: SUB
@@ -79,7 +79,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       const r = mod(a - b, TWO_POW256)
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x04: DIV
@@ -93,7 +93,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       } else {
         r = mod(a / b, TWO_POW256)
       }
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x05: SDIV
@@ -107,7 +107,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       } else {
         r = toTwos(fromTwos(a) / fromTwos(b))
       }
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x06: MOD
@@ -121,7 +121,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       } else {
         r = mod(a, b)
       }
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x07: SMOD
@@ -135,7 +135,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       } else {
         r = fromTwos(a) % fromTwos(b)
       }
-      runState.stack.push(toTwos(r))
+      runState.stack.pushBigInt(toTwos(r))
     },
   ],
   // 0x08: ADDMOD
@@ -149,7 +149,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       } else {
         r = mod(a + b, c)
       }
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x09: MULMOD
@@ -163,7 +163,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       } else {
         r = mod(a * b, c)
       }
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x0a: EXP
@@ -172,16 +172,16 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [base, exponent] = runState.stack.popN(2)
       if (exponent === BigInt(0)) {
-        runState.stack.push(BigInt(1))
+        runState.stack.pushBigInt(BigInt(1))
         return
       }
 
       if (base === BigInt(0)) {
-        runState.stack.push(base)
+        runState.stack.pushBigInt(base)
         return
       }
       const r = exponentiation(base, exponent)
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x0b: SIGNEXTEND
@@ -199,7 +199,7 @@ export const handlers: Map<number, OpHandler> = new Map([
           val = val & mask
         }
       }
-      runState.stack.push(val)
+      runState.stack.pushBigInt(val)
     },
   ],
   // 0x10 range - bit ops
@@ -209,7 +209,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       const r = a < b ? BigInt(1) : BigInt(0)
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x11: GT
@@ -218,7 +218,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       const r = a > b ? BigInt(1) : BigInt(0)
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x12: SLT
@@ -227,7 +227,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       const r = fromTwos(a) < fromTwos(b) ? BigInt(1) : BigInt(0)
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x13: SGT
@@ -236,7 +236,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       const r = fromTwos(a) > fromTwos(b) ? BigInt(1) : BigInt(0)
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x14: EQ
@@ -245,7 +245,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       const r = a === b ? BigInt(1) : BigInt(0)
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x15: ISZERO
@@ -254,7 +254,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const a = runState.stack.pop()
       const r = a === BigInt(0) ? BigInt(1) : BigInt(0)
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x16: AND
@@ -263,7 +263,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       const r = a & b
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x17: OR
@@ -272,7 +272,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       const r = a | b
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x18: XOR
@@ -281,7 +281,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       const r = a ^ b
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x19: NOT
@@ -290,7 +290,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const a = runState.stack.pop()
       const r = BigInt.asUintN(256, ~a)
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x1a: BYTE
@@ -299,12 +299,12 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [pos, word] = runState.stack.popN(2)
       if (pos > BigInt(32)) {
-        runState.stack.push(BigInt(0))
+        runState.stack.pushBigInt(BigInt(0))
         return
       }
 
       const r = (word >> ((BigInt(31) - pos) * BigInt(8))) & BigInt(0xff)
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x1b: SHL
@@ -313,12 +313,12 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       if (a > BigInt(256)) {
-        runState.stack.push(BigInt(0))
+        runState.stack.pushBigInt(BigInt(0))
         return
       }
 
       const r = (b << a) & MAX_INTEGER_BIGINT
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x1c: SHR
@@ -327,12 +327,12 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       if (a > 256) {
-        runState.stack.push(BigInt(0))
+        runState.stack.pushBigInt(BigInt(0))
         return
       }
 
       const r = b >> a
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x1d: SAR
@@ -350,7 +350,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         } else {
           r = BigInt(0)
         }
-        runState.stack.push(r)
+        runState.stack.pushBigInt(r)
         return
       }
 
@@ -362,7 +362,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       } else {
         r = c
       }
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x20 range - crypto
@@ -376,7 +376,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         data = runState.memory.read(Number(offset), Number(length))
       }
       const r = BigInt(bytesToHex(keccak256(data)))
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x30 range - closure state
@@ -385,7 +385,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x30,
     function (runState) {
       const address = bytesToBigInt(runState.interpreter.getAddress().bytes)
-      runState.stack.push(address)
+      runState.stack.pushBigInt(address)
     },
   ],
   // 0x31: BALANCE
@@ -395,28 +395,28 @@ export const handlers: Map<number, OpHandler> = new Map([
       const addressBigInt = runState.stack.pop()
       const address = new Address(addresstoBytes(addressBigInt))
       const balance = await runState.interpreter.getExternalBalance(address)
-      runState.stack.push(balance)
+      runState.stack.pushBigInt(balance)
     },
   ],
   // 0x32: ORIGIN
   [
     0x32,
     function (runState) {
-      runState.stack.push(runState.interpreter.getTxOrigin())
+      runState.stack.pushBigInt(runState.interpreter.getTxOrigin())
     },
   ],
   // 0x33: CALLER
   [
     0x33,
     function (runState) {
-      runState.stack.push(runState.interpreter.getCaller())
+      runState.stack.pushBigInt(runState.interpreter.getCaller())
     },
   ],
   // 0x34: CALLVALUE
   [
     0x34,
     function (runState) {
-      runState.stack.push(runState.interpreter.getCallValue())
+      runState.stack.pushBigInt(runState.interpreter.getCallValue())
     },
   ],
   // 0x35: CALLDATALOAD
@@ -425,7 +425,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const pos = runState.stack.pop()
       if (pos > runState.interpreter.getCallDataSize()) {
-        runState.stack.push(BigInt(0))
+        runState.stack.pushBigInt(BigInt(0))
         return
       }
 
@@ -436,7 +436,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       if (loaded.length < 32) {
         r = r << (BigInt(8) * BigInt(32 - loaded.length))
       }
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x36: CALLDATASIZE
@@ -444,7 +444,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x36,
     function (runState) {
       const r = runState.interpreter.getCallDataSize()
-      runState.stack.push(r)
+      runState.stack.pushBigInt(r)
     },
   ],
   // 0x37: CALLDATACOPY
@@ -465,7 +465,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x38,
     function (runState) {
-      runState.stack.push(runState.interpreter.getCodeSize())
+      runState.stack.pushBigInt(runState.interpreter.getCodeSize())
     },
   ],
   // 0x39: CODECOPY
@@ -491,7 +491,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         (await runState.stateManager.getContractCode(new Address(addresstoBytes(addressBigInt))))
           .length
       )
-      runState.stack.push(size)
+      runState.stack.pushBigInt(size)
     },
   ],
   // 0x3c: EXTCODECOPY
@@ -520,18 +520,18 @@ export const handlers: Map<number, OpHandler> = new Map([
       const address = new Address(addresstoBytes(addressBigInt))
       const account = await runState.stateManager.getAccount(address)
       if (!account || account.isEmpty()) {
-        runState.stack.push(BigInt(0))
+        runState.stack.pushBigInt(BigInt(0))
         return
       }
 
-      runState.stack.push(BigInt(bytesToHex(account.codeHash)))
+      runState.stack.pushBigInt(BigInt(bytesToHex(account.codeHash)))
     },
   ],
   // 0x3d: RETURNDATASIZE
   [
     0x3d,
     function (runState) {
-      runState.stack.push(runState.interpreter.getReturnDataSize())
+      runState.stack.pushBigInt(runState.interpreter.getReturnDataSize())
     },
   ],
   // 0x3e: RETURNDATACOPY
@@ -556,7 +556,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x3a,
     function (runState) {
-      runState.stack.push(runState.interpreter.getTxGasPrice())
+      runState.stack.pushBigInt(runState.interpreter.getTxGasPrice())
     },
   ],
   // '0x40' range - block operations
@@ -569,34 +569,34 @@ export const handlers: Map<number, OpHandler> = new Map([
       const diff = runState.interpreter.getBlockNumber() - number
       // block lookups must be within the past 256 blocks
       if (diff > BigInt(256) || diff <= BigInt(0)) {
-        runState.stack.push(BigInt(0))
+        runState.stack.pushBigInt(BigInt(0))
         return
       }
 
       const block = await runState.blockchain.getBlock(Number(number))
 
-      runState.stack.push(bytesToBigInt(block.hash()))
+      runState.stack.pushBigInt(bytesToBigInt(block.hash()))
     },
   ],
   // 0x41: COINBASE
   [
     0x41,
     function (runState) {
-      runState.stack.push(runState.interpreter.getBlockCoinbase())
+      runState.stack.pushBigInt(runState.interpreter.getBlockCoinbase())
     },
   ],
   // 0x42: TIMESTAMP
   [
     0x42,
     function (runState) {
-      runState.stack.push(runState.interpreter.getBlockTimestamp())
+      runState.stack.pushBigInt(runState.interpreter.getBlockTimestamp())
     },
   ],
   // 0x43: NUMBER
   [
     0x43,
     function (runState) {
-      runState.stack.push(runState.interpreter.getBlockNumber())
+      runState.stack.pushBigInt(runState.interpreter.getBlockNumber())
     },
   ],
   // 0x44: DIFFICULTY (EIP-4399: supplanted as PREVRANDAO)
@@ -604,9 +604,9 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x44,
     function (runState, common) {
       if (common.isActivatedEIP(4399)) {
-        runState.stack.push(runState.interpreter.getBlockPrevRandao())
+        runState.stack.pushBigInt(runState.interpreter.getBlockPrevRandao())
       } else {
-        runState.stack.push(runState.interpreter.getBlockDifficulty())
+        runState.stack.pushBigInt(runState.interpreter.getBlockDifficulty())
       }
     },
   ],
@@ -614,28 +614,28 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x45,
     function (runState) {
-      runState.stack.push(runState.interpreter.getBlockGasLimit())
+      runState.stack.pushBigInt(runState.interpreter.getBlockGasLimit())
     },
   ],
   // 0x46: CHAINID
   [
     0x46,
     function (runState) {
-      runState.stack.push(runState.interpreter.getChainId())
+      runState.stack.pushBigInt(runState.interpreter.getChainId())
     },
   ],
   // 0x47: SELFBALANCE
   [
     0x47,
     function (runState) {
-      runState.stack.push(runState.interpreter.getSelfBalance())
+      runState.stack.pushBigInt(runState.interpreter.getSelfBalance())
     },
   ],
   // 0x48: BASEFEE
   [
     0x48,
     function (runState) {
-      runState.stack.push(runState.interpreter.getBlockBaseFee())
+      runState.stack.pushBigInt(runState.interpreter.getBlockBaseFee())
     },
   ],
   // 0x49: BLOBHASH
@@ -644,9 +644,9 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const index = runState.stack.pop()
       if (runState.env.versionedHashes.length > Number(index)) {
-        runState.stack.push(bytesToBigInt(runState.env.versionedHashes[Number(index)]))
+        runState.stack.pushBigInt(bytesToBigInt(runState.env.versionedHashes[Number(index)]))
       } else {
-        runState.stack.push(BigInt(0))
+        runState.stack.pushBigInt(BigInt(0))
       }
     },
   ],
@@ -664,7 +664,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const pos = runState.stack.pop()
       const word = runState.memory.read(Number(pos), 32, true)
-      runState.stack.push(bytesToBigInt(word))
+      runState.stack.pushBigInt(bytesToBigInt(word))
     },
   ],
   // 0x52: MSTORE
@@ -696,7 +696,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
       const value = await runState.interpreter.storageLoad(keyBuf)
       const valueBigInt = value.length ? bytesToBigInt(value) : BigInt(0)
-      runState.stack.push(valueBigInt)
+      runState.stack.pushBigInt(valueBigInt)
     },
   ],
   // 0x55: SSTORE
@@ -759,21 +759,21 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x58,
     function (runState) {
-      runState.stack.push(BigInt(runState.programCounter - 1))
+      runState.stack.pushBigInt(BigInt(runState.programCounter - 1))
     },
   ],
   // 0x59: MSIZE
   [
     0x59,
     function (runState) {
-      runState.stack.push(runState.memoryWordCount * BigInt(32))
+      runState.stack.pushBigInt(runState.memoryWordCount * BigInt(32))
     },
   ],
   // 0x5a: GAS
   [
     0x5a,
     function (runState) {
-      runState.stack.push(runState.interpreter.getGasLeft())
+      runState.stack.pushBigInt(runState.interpreter.getGasLeft())
     },
   ],
   // 0x5b: JUMPDEST
@@ -791,7 +791,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
         const value = runState.interpreter.transientStorageLoad(keyBuf)
         const valueBN = value.length ? bytesToBigInt(value) : BigInt(0)
-        runState.stack.push(valueBN)
+        runState.stack.pushBigInt(valueBN)
       }
     },
   ],
@@ -859,7 +859,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x5f,
     function (runState) {
-      runState.stack.push(BigInt(0))
+      runState.stack.pushBigInt(BigInt(0))
     },
   ],
   // 0x60: PUSH
@@ -875,14 +875,14 @@ export const handlers: Map<number, OpHandler> = new Map([
       }
 
       if (!runState.shouldDoJumpAnalysis) {
-        runState.stack.push(runState.cachedPushes[runState.programCounter])
+        runState.stack.pushBigInt(runState.cachedPushes[runState.programCounter])
         runState.programCounter += numToPush
       } else {
         const loaded = bytesToBigInt(
           runState.code.subarray(runState.programCounter, runState.programCounter + numToPush)
         )
         runState.programCounter += numToPush
-        runState.stack.push(loaded)
+        runState.stack.pushBigInt(loaded)
       }
     },
   ],
@@ -947,7 +947,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       }
 
       const ret = await runState.interpreter.create(gasLimit, value, data)
-      runState.stack.push(ret)
+      runState.stack.pushBigInt(ret)
     },
   ],
   // 0xf5: CREATE2
@@ -982,7 +982,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         data,
         setLengthLeft(bigIntToBytes(salt), 32)
       )
-      runState.stack.push(ret)
+      runState.stack.pushBigInt(ret)
     },
   ],
   // 0xf1: CALL
@@ -1004,7 +1004,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       const ret = await runState.interpreter.call(gasLimit, toAddress, value, data)
       // Write return data to memory
       writeCallOutput(runState, outOffset, outLength)
-      runState.stack.push(ret)
+      runState.stack.pushBigInt(ret)
     },
   ],
   // 0xf2: CALLCODE
@@ -1026,7 +1026,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       const ret = await runState.interpreter.callCode(gasLimit, toAddress, value, data)
       // Write return data to memory
       writeCallOutput(runState, outOffset, outLength)
-      runState.stack.push(ret)
+      runState.stack.pushBigInt(ret)
     },
   ],
   // 0xf4: DELEGATECALL
@@ -1049,7 +1049,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       const ret = await runState.interpreter.callDelegate(gasLimit, toAddress, value, data)
       // Write return data to memory
       writeCallOutput(runState, outOffset, outLength)
-      runState.stack.push(ret)
+      runState.stack.pushBigInt(ret)
     },
   ],
   // 0xf6: AUTH
@@ -1087,7 +1087,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         recover = ecrecover(msgHash, yParity + BigInt(27), r, s)
       } catch (e) {
         // Malformed signature, push 0 on stack, clear auth variable
-        runState.stack.push(BigInt(0))
+        runState.stack.pushBigInt(BigInt(0))
         runState.auth = undefined
         return
       }
@@ -1100,13 +1100,13 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       if (!expectedAddress.equals(address)) {
         // expected address does not equal the recovered address, clear auth variable
-        runState.stack.push(BigInt(0))
+        runState.stack.pushBigInt(BigInt(0))
         runState.auth = undefined
         return
       }
 
       runState.auth = address
-      runState.stack.push(BigInt(1))
+      runState.stack.pushBigInt(BigInt(1))
     },
   ],
   // 0xf7: AUTHCALL
@@ -1137,7 +1137,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       const ret = await runState.interpreter.authcall(gasLimit, toAddress, value, data)
       // Write return data to memory
       writeCallOutput(runState, retOffset, retLength)
-      runState.stack.push(ret)
+      runState.stack.pushBigInt(ret)
     },
   ],
   // 0xfa: STATICCALL
@@ -1160,7 +1160,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       const ret = await runState.interpreter.callStatic(gasLimit, toAddress, value, data)
       // Write return data to memory
       writeCallOutput(runState, outOffset, outLength)
-      runState.stack.push(ret)
+      runState.stack.pushBigInt(ret)
     },
   ],
   // 0xf3: RETURN

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -73,7 +73,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       0x31,
       async function (runState, gas, common): Promise<bigint> {
         if (common.isActivatedEIP(2929) === true) {
-          const addressBytes = runState.stack.peekBytes()[0]
+          const addressBytes = runState.stack.peekBytes(1)[0]
           const address = new Address(addressBytes)
           gas += accessAddressEIP2929(runState, address, common)
         }
@@ -111,7 +111,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       0x3b,
       async function (runState, gas, common): Promise<bigint> {
         if (common.isActivatedEIP(2929) === true) {
-          const addressBytes = runState.stack.peekBytes()[0]
+          const addressBytes = runState.stack.peekBytes(1)[0]
           const address = new Address(addressBytes)
           gas += accessAddressEIP2929(runState, address, common)
         }
@@ -122,7 +122,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* EXTCODECOPY */
       0x3c,
       async function (runState, gas, common): Promise<bigint> {
-        const addressBytes = runState.stack.peekBytes()[0]
+        const addressBytes = runState.stack.peekBytes(1)[0]
         const [memOffset, _codeOffset, dataLength] = runState.stack.peekBigInt(3)
 
         gas += subMemUsage(runState, memOffset, dataLength, common)
@@ -161,7 +161,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       0x3f,
       async function (runState, gas, common): Promise<bigint> {
         if (common.isActivatedEIP(2929) === true) {
-          const addressBytes = runState.stack.peekBytes()[0]
+          const addressBytes = runState.stack.peekBytes(1)[0]
           const address = new Address(addressBytes)
           gas += accessAddressEIP2929(runState, address, common)
         }
@@ -172,7 +172,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* MLOAD */
       0x51,
       async function (runState, gas, common): Promise<bigint> {
-        const pos = runState.stack.peekBigInt()[0]
+        const pos = runState.stack.peekBigInt(1)[0]
         gas += subMemUsage(runState, pos, BigInt(32), common)
         return gas
       },
@@ -181,7 +181,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* MSTORE */
       0x52,
       async function (runState, gas, common): Promise<bigint> {
-        const offset = runState.stack.peekBigInt()[0]
+        const offset = runState.stack.peekBigInt(1)[0]
         gas += subMemUsage(runState, offset, BigInt(32), common)
         return gas
       },
@@ -190,7 +190,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* MSTORE8 */
       0x53,
       async function (runState, gas, common): Promise<bigint> {
-        const offset = runState.stack.peekBigInt()[0]
+        const offset = runState.stack.peekBigInt(1)[0]
         gas += subMemUsage(runState, offset, BigInt(1), common)
         return gas
       },
@@ -199,7 +199,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* SLOAD */
       0x54,
       async function (runState, gas, common): Promise<bigint> {
-        const key = runState.stack.peekBytes()[0]
+        const key = runState.stack.peekBytes(1)[0]
         const keyBuf = setLengthLeft(key, 32)
 
         if (common.isActivatedEIP(2929) === true) {
@@ -598,7 +598,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         if (runState.interpreter.isStatic()) {
           trap(ERROR.STATIC_STATE_CHANGE)
         }
-        const selfdestructToaddressBigInt = runState.stack.peekBigInt()[0]
+        const selfdestructToaddressBigInt = runState.stack.peekBigInt(1)[0]
 
         const selfdestructToAddress = new Address(addresstoBytes(selfdestructToaddressBigInt))
         let deductGas = false

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -42,7 +42,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* EXP */
       0x0a,
       async function (runState, gas, common): Promise<bigint> {
-        const [_base, exponent] = runState.stack.peek(2)
+        const [_base, exponent] = runState.stack.peekBigInt(2)
         if (exponent === BigInt(0)) {
           return gas
         }
@@ -62,7 +62,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* KECCAK256 */
       0x20,
       async function (runState, gas, common): Promise<bigint> {
-        const [offset, length] = runState.stack.peek(2)
+        const [offset, length] = runState.stack.peekBigInt(2)
         gas += subMemUsage(runState, offset, length, common)
         gas += common.param('gasPrices', 'keccak256Word') * divCeil(length, BigInt(32))
         return gas
@@ -73,7 +73,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       0x31,
       async function (runState, gas, common): Promise<bigint> {
         if (common.isActivatedEIP(2929) === true) {
-          const addressBigInt = runState.stack.peek()[0]
+          const addressBigInt = runState.stack.peekBigInt()[0]
           const address = new Address(addresstoBytes(addressBigInt))
           gas += accessAddressEIP2929(runState, address, common)
         }
@@ -84,7 +84,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* CALLDATACOPY */
       0x37,
       async function (runState, gas, common): Promise<bigint> {
-        const [memOffset, _dataOffset, dataLength] = runState.stack.peek(3)
+        const [memOffset, _dataOffset, dataLength] = runState.stack.peekBigInt(3)
 
         gas += subMemUsage(runState, memOffset, dataLength, common)
         if (dataLength !== BigInt(0)) {
@@ -97,7 +97,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* CODECOPY */
       0x39,
       async function (runState, gas, common): Promise<bigint> {
-        const [memOffset, _codeOffset, dataLength] = runState.stack.peek(3)
+        const [memOffset, _codeOffset, dataLength] = runState.stack.peekBigInt(3)
 
         gas += subMemUsage(runState, memOffset, dataLength, common)
         if (dataLength !== BigInt(0)) {
@@ -111,7 +111,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       0x3b,
       async function (runState, gas, common): Promise<bigint> {
         if (common.isActivatedEIP(2929) === true) {
-          const addressBigInt = runState.stack.peek()[0]
+          const addressBigInt = runState.stack.peekBigInt()[0]
           const address = new Address(addresstoBytes(addressBigInt))
           gas += accessAddressEIP2929(runState, address, common)
         }
@@ -122,7 +122,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* EXTCODECOPY */
       0x3c,
       async function (runState, gas, common): Promise<bigint> {
-        const [addressBigInt, memOffset, _codeOffset, dataLength] = runState.stack.peek(4)
+        const [addressBigInt, memOffset, _codeOffset, dataLength] = runState.stack.peekBigInt(4)
 
         gas += subMemUsage(runState, memOffset, dataLength, common)
 
@@ -141,7 +141,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* RETURNDATACOPY */
       0x3e,
       async function (runState, gas, common): Promise<bigint> {
-        const [memOffset, returnDataOffset, dataLength] = runState.stack.peek(3)
+        const [memOffset, returnDataOffset, dataLength] = runState.stack.peekBigInt(3)
 
         if (returnDataOffset + dataLength > runState.interpreter.getReturnDataSize()) {
           trap(ERROR.OUT_OF_GAS)
@@ -160,7 +160,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       0x3f,
       async function (runState, gas, common): Promise<bigint> {
         if (common.isActivatedEIP(2929) === true) {
-          const addressBigInt = runState.stack.peek()[0]
+          const addressBigInt = runState.stack.peekBigInt()[0]
           const address = new Address(addresstoBytes(addressBigInt))
           gas += accessAddressEIP2929(runState, address, common)
         }
@@ -171,7 +171,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* MLOAD */
       0x51,
       async function (runState, gas, common): Promise<bigint> {
-        const pos = runState.stack.peek()[0]
+        const pos = runState.stack.peekBigInt()[0]
         gas += subMemUsage(runState, pos, BigInt(32), common)
         return gas
       },
@@ -180,7 +180,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* MSTORE */
       0x52,
       async function (runState, gas, common): Promise<bigint> {
-        const offset = runState.stack.peek()[0]
+        const offset = runState.stack.peekBigInt()[0]
         gas += subMemUsage(runState, offset, BigInt(32), common)
         return gas
       },
@@ -189,7 +189,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* MSTORE8 */
       0x53,
       async function (runState, gas, common): Promise<bigint> {
-        const offset = runState.stack.peek()[0]
+        const offset = runState.stack.peekBigInt()[0]
         gas += subMemUsage(runState, offset, BigInt(1), common)
         return gas
       },
@@ -198,7 +198,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* SLOAD */
       0x54,
       async function (runState, gas, common): Promise<bigint> {
-        const key = runState.stack.peek()[0]
+        const key = runState.stack.peekBigInt()[0]
         const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
 
         if (common.isActivatedEIP(2929) === true) {
@@ -214,7 +214,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         if (runState.interpreter.isStatic()) {
           trap(ERROR.STATIC_STATE_CHANGE)
         }
-        const [key, val] = runState.stack.peek(2)
+        const [key, val] = runState.stack.peekBigInt(2)
 
         const keyBytes = setLengthLeft(bigIntToBytes(key), 32)
         // NOTE: this should be the shortest representation
@@ -265,7 +265,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* MCOPY */
       0x5e,
       async function (runState, gas, common): Promise<bigint> {
-        const [dst, src, length] = runState.stack.peek(3)
+        const [dst, src, length] = runState.stack.peekBigInt(3)
         const wordsCopied = (length + BigInt(31)) / BigInt(32)
         gas += BigInt(3) * wordsCopied
         gas += subMemUsage(runState, src, length, common)
@@ -281,7 +281,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           trap(ERROR.STATIC_STATE_CHANGE)
         }
 
-        const [memOffset, memLength] = runState.stack.peek(2)
+        const [memOffset, memLength] = runState.stack.peekBigInt(2)
 
         const topicsCount = runState.opCode - 0xa0
 
@@ -303,7 +303,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         if (runState.interpreter.isStatic()) {
           trap(ERROR.STATIC_STATE_CHANGE)
         }
-        const [_value, offset, length] = runState.stack.peek(3)
+        const [_value, offset, length] = runState.stack.peekBigInt(3)
 
         if (common.isActivatedEIP(2929) === true) {
           gas += accessAddressEIP2929(runState, runState.interpreter.getAddress(), common, false)
@@ -328,7 +328,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       0xf1,
       async function (runState, gas, common): Promise<bigint> {
         const [currentGasLimit, toAddr, value, inOffset, inLength, outOffset, outLength] =
-          runState.stack.peek(7)
+          runState.stack.peekBigInt(7)
         const toAddress = new Address(addresstoBytes(toAddr))
 
         if (runState.interpreter.isStatic() && value !== BigInt(0)) {
@@ -394,7 +394,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       0xf2,
       async function (runState, gas, common): Promise<bigint> {
         const [currentGasLimit, toAddr, value, inOffset, inLength, outOffset, outLength] =
-          runState.stack.peek(7)
+          runState.stack.peekBigInt(7)
 
         gas += subMemUsage(runState, inOffset, inLength, common)
         gas += subMemUsage(runState, outOffset, outLength, common)
@@ -432,7 +432,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* RETURN */
       0xf3,
       async function (runState, gas, common): Promise<bigint> {
-        const [offset, length] = runState.stack.peek(2)
+        const [offset, length] = runState.stack.peekBigInt(2)
         gas += subMemUsage(runState, offset, length, common)
         return gas
       },
@@ -442,7 +442,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       0xf4,
       async function (runState, gas, common): Promise<bigint> {
         const [currentGasLimit, toAddr, inOffset, inLength, outOffset, outLength] =
-          runState.stack.peek(6)
+          runState.stack.peekBigInt(6)
 
         gas += subMemUsage(runState, inOffset, inLength, common)
         gas += subMemUsage(runState, outOffset, outLength, common)
@@ -476,7 +476,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           trap(ERROR.STATIC_STATE_CHANGE)
         }
 
-        const [_value, offset, length, _salt] = runState.stack.peek(4)
+        const [_value, offset, length, _salt] = runState.stack.peekBigInt(4)
 
         gas += subMemUsage(runState, offset, length, common)
 
@@ -500,7 +500,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* AUTH */
       0xf6,
       async function (runState, gas, common): Promise<bigint> {
-        const [_address, memOffset, memLength] = runState.stack.peek(3)
+        const [_address, memOffset, memLength] = runState.stack.peekBigInt(3)
         gas += subMemUsage(runState, memOffset, memLength, common)
         return gas
       },
@@ -522,7 +522,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           argsLength,
           retOffset,
           retLength,
-        ] = runState.stack.peek(8)
+        ] = runState.stack.peekBigInt(8)
 
         if (valueExt !== BigInt(0)) {
           trap(ERROR.AUTHCALL_NONZERO_VALUEEXT)
@@ -567,7 +567,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       0xfa,
       async function (runState, gas, common): Promise<bigint> {
         const [currentGasLimit, toAddr, inOffset, inLength, outOffset, outLength] =
-          runState.stack.peek(6)
+          runState.stack.peekBigInt(6)
 
         gas += subMemUsage(runState, inOffset, inLength, common)
         gas += subMemUsage(runState, outOffset, outLength, common)
@@ -592,7 +592,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       /* REVERT */
       0xfd,
       async function (runState, gas, common): Promise<bigint> {
-        const [offset, length] = runState.stack.peek(2)
+        const [offset, length] = runState.stack.peekBigInt(2)
         gas += subMemUsage(runState, offset, length, common)
         return gas
       },
@@ -604,7 +604,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         if (runState.interpreter.isStatic()) {
           trap(ERROR.STATIC_STATE_CHANGE)
         }
-        const selfdestructToaddressBigInt = runState.stack.peek()[0]
+        const selfdestructToaddressBigInt = runState.stack.peekBigInt()[0]
 
         const selfdestructToAddress = new Address(addresstoBytes(selfdestructToaddressBigInt))
         let deductGas = false

--- a/packages/evm/src/stack.ts
+++ b/packages/evm/src/stack.ts
@@ -98,6 +98,10 @@ export class Stack {
     return peekArray
   }
 
+  peekBigInt(num: number = 1): bigint[] {
+    return this.peek(num)
+  }
+
   /**
    * Swap top of stack with an item in the stack.
    * @param position - Index of item from top of the stack (0-indexed)

--- a/packages/evm/src/stack.ts
+++ b/packages/evm/src/stack.ts
@@ -2,6 +2,8 @@ import { bigIntToBytes, bytesToBigInt } from '@ethereumjs/util'
 
 import { ERROR, EvmError } from './exceptions.js'
 
+import type { EVMStack } from './types.js'
+
 /**
  * Simple single type (BigInt) stack implementation for the EVM.
  *
@@ -19,7 +21,7 @@ import { ERROR, EvmError } from './exceptions.js'
  * 2. If a byte-based opcode implementation has no direct performance penalties towards the bigint version,
  * the bytes version should be used (respectively: replace the bigint version)
  */
-export class Stack {
+export class Stack implements EVMStack {
   // This array is initialized as an empty array. Once values are pushed, the array size will never decrease.
   private _store: bigint[]
   private _maxHeight: number

--- a/packages/evm/src/stack.ts
+++ b/packages/evm/src/stack.ts
@@ -30,6 +30,10 @@ export class Stack {
     this._store[this._len++] = value
   }
 
+  pushBigInt(value: bigint) {
+    this.push(value)
+  }
+
   pop(): bigint {
     if (this._len < 1) {
       throw new EvmError(ERROR.STACK_UNDERFLOW)

--- a/packages/evm/src/stack.ts
+++ b/packages/evm/src/stack.ts
@@ -75,6 +75,10 @@ export class Stack {
     return arr
   }
 
+  popNBigInt(num: number = 1): bigint[] {
+    return this.popN(num)
+  }
+
   /**
    * Return items from the stack
    * @param num Number of items to return

--- a/packages/evm/src/stack.ts
+++ b/packages/evm/src/stack.ts
@@ -46,6 +46,10 @@ export class Stack {
     return this._store[--this._len]
   }
 
+  popBigInt(): bigint {
+    return this.pop()
+  }
+
   /**
    * Pop multiple items from stack. Top of stack is first item
    * in returned array.

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -266,6 +266,21 @@ export interface EVMOpts {
   profiler?: EVMProfilerOpts
 }
 
+export interface EVMStack {
+  length: number
+  pushBigInt(value: bigint): void
+  pushBytes(value: Uint8Array): void
+  popBigInt(): bigint
+  popBytes(): Uint8Array
+  popNBigInt(num: number): bigint[]
+  popNBytes(num: number): Uint8Array[]
+  peekBigInt(num: number): bigint[]
+  peekBytes(num: number): Uint8Array[]
+  swap(position: number): void
+  dup(position: number): void
+  getStack(): bigint[]
+}
+
 /**
  * Result of executing a message via the {@link EVM}.
  */

--- a/packages/evm/test/customOpcodes.spec.ts
+++ b/packages/evm/test/customOpcodes.spec.ts
@@ -40,7 +40,7 @@ describe('VM: custom opcodes', () => {
       gasLimit: BigInt(gas),
     })
     assert.ok(res.executionGasUsed === totalFee, 'successfully charged correct gas')
-    assert.ok(res.runState!.stack.peekBigInt()[0] === stackPush, 'successfully ran opcode logic')
+    assert.ok(res.runState!.stack.peekBigInt(1)[0] === stackPush, 'successfully ran opcode logic')
     assert.ok(correctOpcodeName, 'successfully set opcode name')
   })
 
@@ -97,7 +97,7 @@ describe('VM: custom opcodes', () => {
       gasLimit: BigInt(gas),
     })
     assert.ok(res.executionGasUsed === totalFee, 'successfully charged correct gas')
-    assert.ok(res.runState!.stack.peekBigInt()[0] === stackPush, 'successfully ran opcode logic')
+    assert.ok(res.runState!.stack.peekBigInt(1)[0] === stackPush, 'successfully ran opcode logic')
   })
 
   it('should pass the correct EVM options when copying the EVM', async () => {

--- a/packages/evm/test/customOpcodes.spec.ts
+++ b/packages/evm/test/customOpcodes.spec.ts
@@ -20,7 +20,7 @@ describe('VM: custom opcodes', () => {
       return gas + logicFee
     },
     logicFunction(runState: RunState) {
-      runState.stack.push(BigInt(stackPush))
+      runState.stack.pushBigInt(BigInt(stackPush))
     },
   }
 
@@ -109,7 +109,7 @@ describe('VM: custom opcodes', () => {
       opcodeName: 'TEST',
       baseFee: fee,
       logicFunction(runState: RunState) {
-        runState.stack.push(BigInt(stackPush))
+        runState.stack.pushBigInt(BigInt(stackPush))
       },
     }
 

--- a/packages/evm/test/customOpcodes.spec.ts
+++ b/packages/evm/test/customOpcodes.spec.ts
@@ -40,7 +40,7 @@ describe('VM: custom opcodes', () => {
       gasLimit: BigInt(gas),
     })
     assert.ok(res.executionGasUsed === totalFee, 'successfully charged correct gas')
-    assert.ok(res.runState!.stack.peek()[0] === stackPush, 'successfully ran opcode logic')
+    assert.ok(res.runState!.stack.peekBigInt()[0] === stackPush, 'successfully ran opcode logic')
     assert.ok(correctOpcodeName, 'successfully set opcode name')
   })
 
@@ -97,7 +97,7 @@ describe('VM: custom opcodes', () => {
       gasLimit: BigInt(gas),
     })
     assert.ok(res.executionGasUsed === totalFee, 'successfully charged correct gas')
-    assert.ok(res.runState!.stack.peek()[0] === stackPush, 'successfully ran opcode logic')
+    assert.ok(res.runState!.stack.peekBigInt()[0] === stackPush, 'successfully ran opcode logic')
   })
 
   it('should pass the correct EVM options when copying the EVM', async () => {

--- a/packages/evm/test/stack.spec.ts
+++ b/packages/evm/test/stack.spec.ts
@@ -26,7 +26,7 @@ describe('Stack', () => {
     const s = new Stack()
     const v = BigInt(5)
     s.pushBigInt(v)
-    assert.deepEqual(s.peekBigInt(), [v])
+    assert.deepEqual(s.peekBigInt(1), [v])
     assert.equal(s.popBigInt(), v)
   })
 
@@ -34,7 +34,7 @@ describe('Stack', () => {
     const s = new Stack()
     const v = new Uint8Array([5])
     s.pushBytes(v)
-    assert.deepEqual(s.peekBytes(), [v])
+    assert.deepEqual(s.peekBytes(1), [v])
     assert.deepEqual(s.popBytes(), v)
   })
 

--- a/packages/evm/test/stack.spec.ts
+++ b/packages/evm/test/stack.spec.ts
@@ -11,37 +11,70 @@ describe('Stack', () => {
     const s = new Stack()
     assert.equal(s.length, 0)
     assert.throws(() => s.popBigInt())
+    assert.throws(() => s.popBytes())
   })
 
   it('popN should throw for empty stack', () => {
     const s = new Stack()
     assert.deepEqual(s.popNBigInt(0), [])
+    assert.deepEqual(s.popNBytes(0), [])
     assert.throws(() => s.popNBigInt(1))
+    assert.throws(() => s.popNBytes(1))
   })
 
-  it('should push item', () => {
+  it('should push/peek/pop item (BigInt)', () => {
     const s = new Stack()
-    s.pushBigInt(BigInt(5))
-    assert.equal(s.popBigInt(), BigInt(5))
+    const v = BigInt(5)
+    s.pushBigInt(v)
+    assert.deepEqual(s.peekBigInt(), [v])
+    assert.equal(s.popBigInt(), v)
   })
 
-  it('popN should return array for n = 1', () => {
+  it('should push/peek/pop item (Bytes)', () => {
     const s = new Stack()
-    s.pushBigInt(BigInt(5))
-    assert.deepEqual(s.popNBigInt(1), [BigInt(5)])
+    const v = new Uint8Array([5])
+    s.pushBytes(v)
+    assert.deepEqual(s.peekBytes(), [v])
+    assert.deepEqual(s.popBytes(), v)
+  })
+
+  it('popN should return array for n = 1 (BigInt)', () => {
+    const s = new Stack()
+    const v = BigInt(5)
+    s.pushBigInt(v)
+    assert.deepEqual(s.popNBigInt(1), [v])
+  })
+
+  it('popN should return array for n = 1 (Bytes)', () => {
+    const s = new Stack()
+    const v = new Uint8Array([5])
+    s.pushBytes(v)
+    assert.deepEqual(s.popNBytes(1), [v])
   })
 
   it('popN should fail on underflow', () => {
     const s = new Stack()
     s.pushBigInt(BigInt(5))
     assert.throws(() => s.popNBigInt(2))
+    assert.throws(() => s.popNBytes(2))
   })
 
-  it('popN should return in correct order', () => {
+  it('popN should return in correct order (BigInt)', () => {
     const s = new Stack()
-    s.pushBigInt(BigInt(5))
-    s.pushBigInt(BigInt(7))
-    assert.deepEqual(s.popNBigInt(2), [BigInt(7), BigInt(5)])
+    const v1 = BigInt(5)
+    const v2 = BigInt(7)
+    s.pushBigInt(v1)
+    s.pushBigInt(v2)
+    assert.deepEqual(s.popNBigInt(2), [v2, v1])
+  })
+
+  it('popN should return in correct order (Bytes)', () => {
+    const s = new Stack()
+    const v1 = new Uint8Array([5])
+    const v2 = new Uint8Array([7])
+    s.pushBytes(v1)
+    s.pushBytes(v2)
+    assert.deepEqual(s.popNBytes(2), [v2, v1])
   })
 
   it('should throw on overflow', () => {
@@ -50,6 +83,7 @@ describe('Stack', () => {
       s.pushBigInt(BigInt(i))
     }
     assert.throws(() => s.pushBigInt(BigInt(1024)))
+    assert.throws(() => s.pushBytes(new Uint8Array([7])))
   })
 
   it('overflow limit should be configurable', () => {
@@ -94,6 +128,20 @@ describe('Stack', () => {
     s.pushBigInt(BigInt(7))
     s.dup(2)
     assert.deepEqual(s.popBigInt(), BigInt(5))
+  })
+
+  it('should work with mixed BigInt/Bytes usage', () => {
+    const s = new Stack()
+    const v1BigInt = BigInt(5)
+    const v1Bytes = new Uint8Array([5])
+    const v2BigInt = BigInt(7)
+    const v2Bytes = new Uint8Array([7])
+    s.pushBigInt(v1BigInt)
+    s.pushBytes(v2Bytes)
+    assert.deepEqual(s.peekBigInt(1), [v2BigInt])
+    assert.deepEqual(s.peekBytes(1), [v2Bytes])
+    assert.equal(s.popBigInt(), v2BigInt)
+    assert.deepEqual(s.popBytes(), v1Bytes)
   })
 
   it('stack items should not change if they are DUPed', async () => {

--- a/packages/evm/test/stack.spec.ts
+++ b/packages/evm/test/stack.spec.ts
@@ -10,90 +10,90 @@ describe('Stack', () => {
   it('should be empty initially', () => {
     const s = new Stack()
     assert.equal(s.length, 0)
-    assert.throws(() => s.pop())
+    assert.throws(() => s.popBigInt())
   })
 
   it('popN should throw for empty stack', () => {
     const s = new Stack()
-    assert.deepEqual(s.popN(0), [])
-    assert.throws(() => s.popN(1))
+    assert.deepEqual(s.popNBigInt(0), [])
+    assert.throws(() => s.popNBigInt(1))
   })
 
   it('should push item', () => {
     const s = new Stack()
-    s.push(BigInt(5))
-    assert.equal(s.pop(), BigInt(5))
+    s.pushBigInt(BigInt(5))
+    assert.equal(s.popBigInt(), BigInt(5))
   })
 
   it('popN should return array for n = 1', () => {
     const s = new Stack()
-    s.push(BigInt(5))
-    assert.deepEqual(s.popN(1), [BigInt(5)])
+    s.pushBigInt(BigInt(5))
+    assert.deepEqual(s.popNBigInt(1), [BigInt(5)])
   })
 
   it('popN should fail on underflow', () => {
     const s = new Stack()
-    s.push(BigInt(5))
-    assert.throws(() => s.popN(2))
+    s.pushBigInt(BigInt(5))
+    assert.throws(() => s.popNBigInt(2))
   })
 
   it('popN should return in correct order', () => {
     const s = new Stack()
-    s.push(BigInt(5))
-    s.push(BigInt(7))
-    assert.deepEqual(s.popN(2), [BigInt(7), BigInt(5)])
+    s.pushBigInt(BigInt(5))
+    s.pushBigInt(BigInt(7))
+    assert.deepEqual(s.popNBigInt(2), [BigInt(7), BigInt(5)])
   })
 
   it('should throw on overflow', () => {
     const s = new Stack()
     for (let i = 0; i < 1024; i++) {
-      s.push(BigInt(i))
+      s.pushBigInt(BigInt(i))
     }
-    assert.throws(() => s.push(BigInt(1024)))
+    assert.throws(() => s.pushBigInt(BigInt(1024)))
   })
 
   it('overflow limit should be configurable', () => {
     const s = new Stack(1023)
     for (let i = 0; i < 1023; i++) {
-      s.push(BigInt(i))
+      s.pushBigInt(BigInt(i))
     }
-    assert.throws(() => s.push(BigInt(1023)))
+    assert.throws(() => s.pushBigInt(BigInt(1023)))
   })
 
   it('should swap top with itself', () => {
     const s = new Stack()
-    s.push(BigInt(5))
+    s.pushBigInt(BigInt(5))
     s.swap(0)
-    assert.deepEqual(s.pop(), BigInt(5))
+    assert.deepEqual(s.popBigInt(), BigInt(5))
   })
 
   it('swap should throw on underflow', () => {
     const s = new Stack()
-    s.push(BigInt(5))
+    s.pushBigInt(BigInt(5))
     assert.throws(() => s.swap(1))
   })
 
   it('should swap', () => {
     const s = new Stack()
-    s.push(BigInt(5))
-    s.push(BigInt(7))
+    s.pushBigInt(BigInt(5))
+    s.pushBigInt(BigInt(7))
     s.swap(1)
-    assert.deepEqual(s.pop(), BigInt(5))
+    assert.deepEqual(s.popBigInt(), BigInt(5))
   })
 
   it('dup should throw on underflow', () => {
     const s = new Stack()
     assert.throws(() => s.dup(1))
-    s.push(BigInt(5))
+    s.pushBigInt(BigInt(5))
     assert.throws(() => s.dup(2))
   })
 
   it('should dup', () => {
     const s = new Stack()
-    s.push(BigInt(5))
-    s.push(BigInt(7))
+    s.pushBigInt(BigInt(5))
+    s.pushBigInt(BigInt(7))
     s.dup(2)
-    assert.deepEqual(s.pop(), BigInt(5))
+    assert.deepEqual(s.popBigInt(), BigInt(5))
   })
 
   it('stack items should not change if they are DUPed', async () => {
@@ -141,10 +141,10 @@ describe('Stack', () => {
 
   it('stack should report actual stack correctly', () => {
     const s = new Stack()
-    s.push(BigInt(4))
-    s.push(BigInt(6))
-    s.push(BigInt(8))
-    s.pop()
+    s.pushBigInt(BigInt(4))
+    s.pushBigInt(BigInt(6))
+    s.pushBigInt(BigInt(8))
+    s.popBigInt()
     const reportedStack = s.getStack()
     assert.deepEqual(reportedStack, [BigInt(4), BigInt(6)])
   })

--- a/packages/evm/test/stack.spec.ts
+++ b/packages/evm/test/stack.spec.ts
@@ -1,199 +1,202 @@
 import { Account, Address, bigIntToBytes, hexToBytes, setLengthLeft } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
+import { HybridStack } from '../src/hybridStack.js'
 import { EVM } from '../src/index.js'
 import { Stack } from '../src/stack.js'
 
 import { createAccount } from './utils.js'
 
-describe('Stack', () => {
-  it('should be empty initially', () => {
-    const s = new Stack()
-    assert.equal(s.length, 0)
-    assert.throws(() => s.popBigInt())
-    assert.throws(() => s.popBytes())
-  })
+for (const StackClass of [Stack, HybridStack]) {
+  describe('Stack', () => {
+    it('should be empty initially', () => {
+      const s = new StackClass()
+      assert.equal(s.length, 0)
+      assert.throws(() => s.popBigInt())
+      assert.throws(() => s.popBytes())
+    })
 
-  it('popN should throw for empty stack', () => {
-    const s = new Stack()
-    assert.deepEqual(s.popNBigInt(0), [])
-    assert.deepEqual(s.popNBytes(0), [])
-    assert.throws(() => s.popNBigInt(1))
-    assert.throws(() => s.popNBytes(1))
-  })
+    it('popN should throw for empty stack', () => {
+      const s = new StackClass()
+      assert.deepEqual(s.popNBigInt(0), [])
+      assert.deepEqual(s.popNBytes(0), [])
+      assert.throws(() => s.popNBigInt(1))
+      assert.throws(() => s.popNBytes(1))
+    })
 
-  it('should push/peek/pop item (BigInt)', () => {
-    const s = new Stack()
-    const v = BigInt(5)
-    s.pushBigInt(v)
-    assert.deepEqual(s.peekBigInt(1), [v])
-    assert.equal(s.popBigInt(), v)
-  })
+    it('should push/peek/pop item (BigInt)', () => {
+      const s = new StackClass()
+      const v = BigInt(5)
+      s.pushBigInt(v)
+      assert.deepEqual(s.peekBigInt(1), [v])
+      assert.equal(s.popBigInt(), v)
+    })
 
-  it('should push/peek/pop item (Bytes)', () => {
-    const s = new Stack()
-    const v = new Uint8Array([5])
-    s.pushBytes(v)
-    assert.deepEqual(s.peekBytes(1), [v])
-    assert.deepEqual(s.popBytes(), v)
-  })
+    it('should push/peek/pop item (Bytes)', () => {
+      const s = new StackClass()
+      const v = new Uint8Array([5])
+      s.pushBytes(v)
+      assert.deepEqual(s.peekBytes(1), [v])
+      assert.deepEqual(s.popBytes(), v)
+    })
 
-  it('popN should return array for n = 1 (BigInt)', () => {
-    const s = new Stack()
-    const v = BigInt(5)
-    s.pushBigInt(v)
-    assert.deepEqual(s.popNBigInt(1), [v])
-  })
+    it('popN should return array for n = 1 (BigInt)', () => {
+      const s = new StackClass()
+      const v = BigInt(5)
+      s.pushBigInt(v)
+      assert.deepEqual(s.popNBigInt(1), [v])
+    })
 
-  it('popN should return array for n = 1 (Bytes)', () => {
-    const s = new Stack()
-    const v = new Uint8Array([5])
-    s.pushBytes(v)
-    assert.deepEqual(s.popNBytes(1), [v])
-  })
+    it('popN should return array for n = 1 (Bytes)', () => {
+      const s = new StackClass()
+      const v = new Uint8Array([5])
+      s.pushBytes(v)
+      assert.deepEqual(s.popNBytes(1), [v])
+    })
 
-  it('popN should fail on underflow', () => {
-    const s = new Stack()
-    s.pushBigInt(BigInt(5))
-    assert.throws(() => s.popNBigInt(2))
-    assert.throws(() => s.popNBytes(2))
-  })
+    it('popN should fail on underflow', () => {
+      const s = new StackClass()
+      s.pushBigInt(BigInt(5))
+      assert.throws(() => s.popNBigInt(2))
+      assert.throws(() => s.popNBytes(2))
+    })
 
-  it('popN should return in correct order (BigInt)', () => {
-    const s = new Stack()
-    const v1 = BigInt(5)
-    const v2 = BigInt(7)
-    s.pushBigInt(v1)
-    s.pushBigInt(v2)
-    assert.deepEqual(s.popNBigInt(2), [v2, v1])
-  })
+    it('popN should return in correct order (BigInt)', () => {
+      const s = new StackClass()
+      const v1 = BigInt(5)
+      const v2 = BigInt(7)
+      s.pushBigInt(v1)
+      s.pushBigInt(v2)
+      assert.deepEqual(s.popNBigInt(2), [v2, v1])
+    })
 
-  it('popN should return in correct order (Bytes)', () => {
-    const s = new Stack()
-    const v1 = new Uint8Array([5])
-    const v2 = new Uint8Array([7])
-    s.pushBytes(v1)
-    s.pushBytes(v2)
-    assert.deepEqual(s.popNBytes(2), [v2, v1])
-  })
+    it('popN should return in correct order (Bytes)', () => {
+      const s = new StackClass()
+      const v1 = new Uint8Array([5])
+      const v2 = new Uint8Array([7])
+      s.pushBytes(v1)
+      s.pushBytes(v2)
+      assert.deepEqual(s.popNBytes(2), [v2, v1])
+    })
 
-  it('should throw on overflow', () => {
-    const s = new Stack()
-    for (let i = 0; i < 1024; i++) {
-      s.pushBigInt(BigInt(i))
-    }
-    assert.throws(() => s.pushBigInt(BigInt(1024)))
-    assert.throws(() => s.pushBytes(new Uint8Array([7])))
-  })
+    it('should throw on overflow', () => {
+      const s = new StackClass()
+      for (let i = 0; i < 1024; i++) {
+        s.pushBigInt(BigInt(i))
+      }
+      assert.throws(() => s.pushBigInt(BigInt(1024)))
+      assert.throws(() => s.pushBytes(new Uint8Array([7])))
+    })
 
-  it('overflow limit should be configurable', () => {
-    const s = new Stack(1023)
-    for (let i = 0; i < 1023; i++) {
-      s.pushBigInt(BigInt(i))
-    }
-    assert.throws(() => s.pushBigInt(BigInt(1023)))
-  })
+    it('overflow limit should be configurable', () => {
+      const s = new Stack(1023)
+      for (let i = 0; i < 1023; i++) {
+        s.pushBigInt(BigInt(i))
+      }
+      assert.throws(() => s.pushBigInt(BigInt(1023)))
+    })
 
-  it('should swap top with itself', () => {
-    const s = new Stack()
-    s.pushBigInt(BigInt(5))
-    s.swap(0)
-    assert.deepEqual(s.popBigInt(), BigInt(5))
-  })
+    it('should swap top with itself', () => {
+      const s = new StackClass()
+      s.pushBigInt(BigInt(5))
+      s.swap(0)
+      assert.deepEqual(s.popBigInt(), BigInt(5))
+    })
 
-  it('swap should throw on underflow', () => {
-    const s = new Stack()
-    s.pushBigInt(BigInt(5))
-    assert.throws(() => s.swap(1))
-  })
+    it('swap should throw on underflow', () => {
+      const s = new StackClass()
+      s.pushBigInt(BigInt(5))
+      assert.throws(() => s.swap(1))
+    })
 
-  it('should swap', () => {
-    const s = new Stack()
-    s.pushBigInt(BigInt(5))
-    s.pushBigInt(BigInt(7))
-    s.swap(1)
-    assert.deepEqual(s.popBigInt(), BigInt(5))
-  })
+    it('should swap', () => {
+      const s = new StackClass()
+      s.pushBigInt(BigInt(5))
+      s.pushBigInt(BigInt(7))
+      s.swap(1)
+      assert.deepEqual(s.popBigInt(), BigInt(5))
+    })
 
-  it('dup should throw on underflow', () => {
-    const s = new Stack()
-    assert.throws(() => s.dup(1))
-    s.pushBigInt(BigInt(5))
-    assert.throws(() => s.dup(2))
-  })
+    it('dup should throw on underflow', () => {
+      const s = new StackClass()
+      assert.throws(() => s.dup(1))
+      s.pushBigInt(BigInt(5))
+      assert.throws(() => s.dup(2))
+    })
 
-  it('should dup', () => {
-    const s = new Stack()
-    s.pushBigInt(BigInt(5))
-    s.pushBigInt(BigInt(7))
-    s.dup(2)
-    assert.deepEqual(s.popBigInt(), BigInt(5))
-  })
+    it('should dup', () => {
+      const s = new StackClass()
+      s.pushBigInt(BigInt(5))
+      s.pushBigInt(BigInt(7))
+      s.dup(2)
+      assert.deepEqual(s.popBigInt(), BigInt(5))
+    })
 
-  it('should work with mixed BigInt/Bytes usage', () => {
-    const s = new Stack()
-    const v1BigInt = BigInt(5)
-    const v1Bytes = new Uint8Array([5])
-    const v2BigInt = BigInt(7)
-    const v2Bytes = new Uint8Array([7])
-    s.pushBigInt(v1BigInt)
-    s.pushBytes(v2Bytes)
-    assert.deepEqual(s.peekBigInt(1), [v2BigInt])
-    assert.deepEqual(s.peekBytes(1), [v2Bytes])
-    assert.equal(s.popBigInt(), v2BigInt)
-    assert.deepEqual(s.popBytes(), v1Bytes)
-  })
+    it('should work with mixed BigInt/Bytes usage', () => {
+      const s = new StackClass()
+      const v1BigInt = BigInt(5)
+      const v1Bytes = new Uint8Array([5])
+      const v2BigInt = BigInt(7)
+      const v2Bytes = new Uint8Array([7])
+      s.pushBigInt(v1BigInt)
+      s.pushBytes(v2Bytes)
+      assert.deepEqual(s.peekBigInt(1), [v2BigInt])
+      assert.deepEqual(s.peekBytes(1), [v2Bytes])
+      assert.equal(s.popBigInt(), v2BigInt)
+      assert.deepEqual(s.popBytes(), v1Bytes)
+    })
 
-  it('stack items should not change if they are DUPed', async () => {
-    const caller = new Address(hexToBytes('0x00000000000000000000000000000000000000ee'))
-    const addr = new Address(hexToBytes('0x00000000000000000000000000000000000000ff'))
-    const evm = new EVM()
-    const account = createAccount(BigInt(0), BigInt(0))
-    const code = '0x60008080808060013382F15060005260206000F3'
-    const expectedReturnValue = setLengthLeft(bigIntToBytes(BigInt(0)), 32)
-    /*
-      code:             remarks: (top of the stack is at the zero index)
-          PUSH1 0x00
-          DUP1
-          DUP1
-          DUP1
-          DUP1
-          PUSH1 0x01
-          CALLER
-          DUP3
-          CALL          stack: [0, CALLER, 1, 0, 0, 0, 0, 0]
-          POP           pop the call result (1)
-          PUSH1 0x00
-          MSTORE        we now expect that the stack (prior to MSTORE) is [0, 0]
-          PUSH1 0x20
-          PUSH1 0x00
-          RETURN        stack: [0, 0x20] (we thus return the stack item which was originally pushed as 0, and then DUPed)
-    */
-    await evm.stateManager.putAccount(addr, account)
-    await evm.stateManager.putContractCode(addr, hexToBytes(code))
-    await evm.stateManager.putAccount(caller, new Account(BigInt(0), BigInt(0x11)))
-    const runCallArgs = {
-      caller,
-      gasLimit: BigInt(0xffffffffff),
-      to: addr,
-      value: BigInt(1),
-    }
-    try {
-      const res = await evm.runCall(runCallArgs)
-      const executionReturnValue = res.execResult.returnValue
-      assert.deepEqual(executionReturnValue, expectedReturnValue)
-    } catch (e: any) {
-      assert.fail(e.message)
-    }
-  })
+    it('stack items should not change if they are DUPed', async () => {
+      const caller = new Address(hexToBytes('0x00000000000000000000000000000000000000ee'))
+      const addr = new Address(hexToBytes('0x00000000000000000000000000000000000000ff'))
+      const evm = new EVM()
+      const account = createAccount(BigInt(0), BigInt(0))
+      const code = '0x60008080808060013382F15060005260206000F3'
+      const expectedReturnValue = setLengthLeft(bigIntToBytes(BigInt(0)), 32)
+      /*
+        code:             remarks: (top of the stack is at the zero index)
+            PUSH1 0x00
+            DUP1
+            DUP1
+            DUP1
+            DUP1
+            PUSH1 0x01
+            CALLER
+            DUP3
+            CALL          stack: [0, CALLER, 1, 0, 0, 0, 0, 0]
+            POP           pop the call result (1)
+            PUSH1 0x00
+            MSTORE        we now expect that the stack (prior to MSTORE) is [0, 0]
+            PUSH1 0x20
+            PUSH1 0x00
+            RETURN        stack: [0, 0x20] (we thus return the stack item which was originally pushed as 0, and then DUPed)
+      */
+      await evm.stateManager.putAccount(addr, account)
+      await evm.stateManager.putContractCode(addr, hexToBytes(code))
+      await evm.stateManager.putAccount(caller, new Account(BigInt(0), BigInt(0x11)))
+      const runCallArgs = {
+        caller,
+        gasLimit: BigInt(0xffffffffff),
+        to: addr,
+        value: BigInt(1),
+      }
+      try {
+        const res = await evm.runCall(runCallArgs)
+        const executionReturnValue = res.execResult.returnValue
+        assert.deepEqual(executionReturnValue, expectedReturnValue)
+      } catch (e: any) {
+        assert.fail(e.message)
+      }
+    })
 
-  it('stack should report actual stack correctly', () => {
-    const s = new Stack()
-    s.pushBigInt(BigInt(4))
-    s.pushBigInt(BigInt(6))
-    s.pushBigInt(BigInt(8))
-    s.popBigInt()
-    const reportedStack = s.getStack()
-    assert.deepEqual(reportedStack, [BigInt(4), BigInt(6)])
+    it('stack should report actual stack correctly', () => {
+      const s = new StackClass()
+      s.pushBigInt(BigInt(4))
+      s.pushBigInt(BigInt(6))
+      s.pushBigInt(BigInt(8))
+      s.popBigInt()
+      const reportedStack = s.getStack()
+      assert.deepEqual(reportedStack, [BigInt(4), BigInt(6)])
+    })
   })
-})
+}


### PR DESCRIPTION
This is a pretty extensive experiment switching the current BigInt based EVM stack with a hybrid stack which stores either the Bytes or the BigInt values and - if matches - serves the respetive values without conversion.

Results are unfortunately a lot more mixed than I anticipated. One opcode significantly increases in performance (`MLOAD`, going from 2.9 to 4.4 or so), but other values are mixed throughout the range, some somewhat faster, some somewhat slower.

Might come back to this with some distance, atm I am bit baffled that there is "not more to see".

Here is e.g. a resultset on the same block (left is with the hybrid stack).

![grafik](https://github.com/ethereumjs/ethereumjs-monorepo/assets/931137/e63dd0f7-ae81-4bff-9659-85419587da41)

My initial idea was to keep the old stack, but introduce a flag which would allow to switch to the new one. If results remain this mixed this might be obsolete though.

This work might nevertheless be useful for some things, e.g. it is now extremely easily possible to switch e.g. arithmetic operations from being done bigint based to byte based and see how performance reacts.