### PR TITLE
EVM: Initialize memory with CONTAINER_SIZE bytes

### DIFF
--- a/packages/evm/src/memory.ts
+++ b/packages/evm/src/memory.ts
@@ -19,7 +19,7 @@ export class Memory {
   _store: Uint8Array
 
   constructor() {
-    this._store = new Uint8Array(0)
+    this._store = new Uint8Array(CONTAINER_SIZE)
   }
 
   /**
@@ -34,10 +34,8 @@ export class Memory {
     const newSize = ceil(offset + size, 32)
     const sizeDiff = newSize - this._store.length
     if (sizeDiff > 0) {
-      this._store = concatBytes(
-        this._store,
-        new Uint8Array(Math.ceil(sizeDiff / CONTAINER_SIZE) * CONTAINER_SIZE)
-      )
+      const expandBy = Math.ceil(sizeDiff / CONTAINER_SIZE) * CONTAINER_SIZE
+      this._store = concatBytes(this._store, new Uint8Array(expandBy))
     }
   }
 

--- a/packages/evm/test/memory.spec.ts
+++ b/packages/evm/test/memory.spec.ts
@@ -2,19 +2,21 @@ import { assert, describe, it } from 'vitest'
 
 import { Memory } from '../src/memory.js'
 
+const CONTAINER_SIZE = 8192
+
 describe('Memory', () => {
   const m = new Memory()
-  it('should have 0 capacity initially', () => {
-    assert.equal(m._store.length, 0)
+  it('should have CONTAINER_SIZE capacity initially', () => {
+    assert.equal(m._store.length, CONTAINER_SIZE)
   })
 
   it('should return zeros from empty memory', () => {
     assert.deepEqual(m.read(0, 3), Uint8Array.from([0, 0, 0]))
   })
 
-  it('should extend capacity to 8192 bytes', () => {
-    m.extend(0, 3)
-    assert.equal(m._store.length, 8192)
+  it('should extend capacity to CONTAINER_SIZE + CONTAINER_SIZE bytes', () => {
+    m.extend(CONTAINER_SIZE, 3)
+    assert.equal(m._store.length, CONTAINER_SIZE * 2)
   })
 
   it('should return zeros before writing', () => {
@@ -32,17 +34,27 @@ describe('Memory', () => {
 
   it('should expand by container (8192 bytes) properly when writing to previously untouched location', () => {
     const memory = new Memory()
-    assert.equal(memory._store.length, 0, 'memory should start with zero length')
-    memory.write(0, 1, Uint8Array.from([1]))
-    assert.equal(memory._store.length, 8192, 'memory buffer length expanded to 8192 bytes')
+    memory.write(0, CONTAINER_SIZE, new Uint8Array(CONTAINER_SIZE))
+    assert.equal(
+      memory._store.length,
+      CONTAINER_SIZE,
+      'memory should remain in CONTAINER_SIZE length'
+    )
+    memory.write(CONTAINER_SIZE, 1, Uint8Array.from([1]))
+    assert.equal(
+      memory._store.length,
+      8192 * 2,
+      'memory buffer length expanded by CONTAINER_SIZE bytes'
+    )
   })
 
   it('should expand by container (8192 bytes) when reading a previously untouched location', () => {
     const memory = new Memory()
-    memory.read(0, 8)
-    assert.equal(memory._store.length, 8192)
+    memory.write(0, CONTAINER_SIZE, new Uint8Array(CONTAINER_SIZE))
+    memory.read(CONTAINER_SIZE, 8)
+    assert.equal(memory._store.length, CONTAINER_SIZE * 2)
 
-    memory.read(8190, 8193)
+    memory.read(CONTAINER_SIZE - 2, 8193)
     assert.equal(memory._store.length, 16384)
   })
 })


### PR DESCRIPTION
This is a small performance optimization improving `MLOAD` and `MSTORE` performance by 10-20%.

Performance results (always last block):

cd ../evm && npm run build && cd ../client && npm run client:start -- --sync=none --vmProfileBlocks --executeBlocks=962960-962971 (MLOAD 48, MSTORE 100 times)
MLOAD
New 2.8  2.7 2.8 2.8
Old. 2.65 2.8 2.7 2.5
MSTORE
New 1.85 1.8 1.9 1.8
Old. 1.65  1.8 1.7 1.75

cd ../evm && npm run build && cd ../client && npm run client:start -- --sync=none --vmProfileBlocks --executeBlocks=962960-962970 (MLOAD 1224, MSTORE 2550 times)
MLOAD
New 2.8 2.75 2.7 2.65
Old.  2.85 2.8 2.7 2.55
MSTORE
New 1.85 1.85 1.8 1.7
Old. 1.75. 1.7 1.7 1.65

Ok. So I would think that results are clear enough on this and we can take this in. Ready for review. 🙂 
We should nevertheless really do this normalized MGas/s (as discussed with @jochem-brouwer), still think this would make comparison significantly easier (high level idea: normalize by constant factor to factor out runtime differences).

Might take this on in a separate PR.

Think this should nevertheless be fine.