### PR TITLE
EVM: BigInt Constants and EXP Optimization

### DIFF
--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -36,6 +36,16 @@ import type { Common } from '@ethereumjs/common'
 
 const EIP3074MAGIC = hexToBytes('0x03')
 
+const BIGINT_0 = BigInt(0)
+const BIGINT_1 = BigInt(1)
+const BIGINT_2 = BigInt(2)
+const BIGINT_96 = BigInt(96)
+const BIGINT_160 = BigInt(160)
+const BIGINT_224 = BigInt(224)
+const BIGINT_2EXP96 = BigInt(79228162514264337593543950336)
+const BIGINT_2EXP160 = BigInt(1461501637330902918203684832716283019655932542976)
+const BIGINT_2EXP224 = BigInt(26959946667150639794667015087019630673637144422540572481103610249216)
+
 export interface SyncOpHandler {
   (runState: RunState, common: Common): void
 }
@@ -88,8 +98,8 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       let r
-      if (b === BigInt(0)) {
-        r = BigInt(0)
+      if (b === BIGINT_0) {
+        r = BIGINT_0
       } else {
         r = mod(a / b, TWO_POW256)
       }
@@ -102,8 +112,8 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       let r
-      if (b === BigInt(0)) {
-        r = BigInt(0)
+      if (b === BIGINT_0) {
+        r = BIGINT_0
       } else {
         r = toTwos(fromTwos(a) / fromTwos(b))
       }
@@ -116,7 +126,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       let r
-      if (b === BigInt(0)) {
+      if (b === BIGINT_0) {
         r = b
       } else {
         r = mod(a, b)
@@ -130,7 +140,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       let r
-      if (b === BigInt(0)) {
+      if (b === BIGINT_0) {
         r = b
       } else {
         r = fromTwos(a) % fromTwos(b)
@@ -144,8 +154,8 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b, c] = runState.stack.popN(3)
       let r
-      if (c === BigInt(0)) {
-        r = BigInt(0)
+      if (c === BIGINT_0) {
+        r = BIGINT_0
       } else {
         r = mod(a + b, c)
       }
@@ -158,8 +168,8 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b, c] = runState.stack.popN(3)
       let r
-      if (c === BigInt(0)) {
-        r = BigInt(0)
+      if (c === BIGINT_0) {
+        r = BIGINT_0
       } else {
         r = mod(a * b, c)
       }
@@ -171,12 +181,25 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x0a,
     function (runState) {
       const [base, exponent] = runState.stack.popN(2)
-      if (exponent === BigInt(0)) {
-        runState.stack.push(BigInt(1))
+      if (base === BIGINT_2) {
+        switch (exponent) {
+          case BIGINT_96:
+            runState.stack.push(BIGINT_2EXP96)
+            return
+          case BIGINT_160:
+            runState.stack.push(BIGINT_2EXP160)
+            return
+          case BIGINT_224:
+            runState.stack.push(BIGINT_2EXP224)
+            return
+        }
+      }
+      if (exponent === BIGINT_0) {
+        runState.stack.push(BIGINT_1)
         return
       }
 
-      if (base === BigInt(0)) {
+      if (base === BIGINT_0) {
         runState.stack.push(base)
         return
       }
@@ -192,8 +215,8 @@ export const handlers: Map<number, OpHandler> = new Map([
       let [k, val] = runState.stack.popN(2)
       if (k < BigInt(31)) {
         const signBit = k * BigInt(8) + BigInt(7)
-        const mask = (BigInt(1) << signBit) - BigInt(1)
-        if ((val >> signBit) & BigInt(1)) {
+        const mask = (BIGINT_1 << signBit) - BIGINT_1
+        if ((val >> signBit) & BIGINT_1) {
           val = val | BigInt.asUintN(256, ~mask)
         } else {
           val = val & mask
@@ -208,7 +231,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x10,
     function (runState) {
       const [a, b] = runState.stack.popN(2)
-      const r = a < b ? BigInt(1) : BigInt(0)
+      const r = a < b ? BIGINT_1 : BIGINT_0
       runState.stack.push(r)
     },
   ],
@@ -217,7 +240,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x11,
     function (runState) {
       const [a, b] = runState.stack.popN(2)
-      const r = a > b ? BigInt(1) : BigInt(0)
+      const r = a > b ? BIGINT_1 : BIGINT_0
       runState.stack.push(r)
     },
   ],
@@ -226,7 +249,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x12,
     function (runState) {
       const [a, b] = runState.stack.popN(2)
-      const r = fromTwos(a) < fromTwos(b) ? BigInt(1) : BigInt(0)
+      const r = fromTwos(a) < fromTwos(b) ? BIGINT_1 : BIGINT_0
       runState.stack.push(r)
     },
   ],
@@ -235,7 +258,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x13,
     function (runState) {
       const [a, b] = runState.stack.popN(2)
-      const r = fromTwos(a) > fromTwos(b) ? BigInt(1) : BigInt(0)
+      const r = fromTwos(a) > fromTwos(b) ? BIGINT_1 : BIGINT_0
       runState.stack.push(r)
     },
   ],
@@ -244,7 +267,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x14,
     function (runState) {
       const [a, b] = runState.stack.popN(2)
-      const r = a === b ? BigInt(1) : BigInt(0)
+      const r = a === b ? BIGINT_1 : BIGINT_0
       runState.stack.push(r)
     },
   ],
@@ -253,7 +276,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x15,
     function (runState) {
       const a = runState.stack.pop()
-      const r = a === BigInt(0) ? BigInt(1) : BigInt(0)
+      const r = a === BIGINT_0 ? BIGINT_1 : BIGINT_0
       runState.stack.push(r)
     },
   ],
@@ -299,7 +322,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [pos, word] = runState.stack.popN(2)
       if (pos > BigInt(32)) {
-        runState.stack.push(BigInt(0))
+        runState.stack.push(BIGINT_0)
         return
       }
 
@@ -313,7 +336,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       if (a > BigInt(256)) {
-        runState.stack.push(BigInt(0))
+        runState.stack.push(BIGINT_0)
         return
       }
 
@@ -327,7 +350,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [a, b] = runState.stack.popN(2)
       if (a > 256) {
-        runState.stack.push(BigInt(0))
+        runState.stack.push(BIGINT_0)
         return
       }
 
@@ -348,7 +371,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         if (isSigned) {
           r = MAX_INTEGER_BIGINT
         } else {
-          r = BigInt(0)
+          r = BIGINT_0
         }
         runState.stack.push(r)
         return
@@ -372,7 +395,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [offset, length] = runState.stack.popN(2)
       let data = new Uint8Array(0)
-      if (length !== BigInt(0)) {
+      if (length !== BIGINT_0) {
         data = runState.memory.read(Number(offset), Number(length))
       }
       const r = BigInt(bytesToHex(keccak256(data)))
@@ -425,7 +448,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const pos = runState.stack.pop()
       if (pos > runState.interpreter.getCallDataSize()) {
-        runState.stack.push(BigInt(0))
+        runState.stack.push(BIGINT_0)
         return
       }
 
@@ -453,7 +476,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [memOffset, dataOffset, dataLength] = runState.stack.popN(3)
 
-      if (dataLength !== BigInt(0)) {
+      if (dataLength !== BIGINT_0) {
         const data = getDataSlice(runState.interpreter.getCallData(), dataOffset, dataLength)
         const memOffsetNum = Number(memOffset)
         const dataLengthNum = Number(dataLength)
@@ -474,7 +497,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [memOffset, codeOffset, dataLength] = runState.stack.popN(3)
 
-      if (dataLength !== BigInt(0)) {
+      if (dataLength !== BIGINT_0) {
         const data = getDataSlice(runState.interpreter.getCode(), codeOffset, dataLength)
         const memOffsetNum = Number(memOffset)
         const lengthNum = Number(dataLength)
@@ -500,7 +523,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     async function (runState) {
       const [addressBigInt, memOffset, codeOffset, dataLength] = runState.stack.popN(4)
 
-      if (dataLength !== BigInt(0)) {
+      if (dataLength !== BIGINT_0) {
         const code = await runState.stateManager.getContractCode(
           new Address(addresstoBytes(addressBigInt))
         )
@@ -520,7 +543,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       const address = new Address(addresstoBytes(addressBigInt))
       const account = await runState.stateManager.getAccount(address)
       if (!account || account.isEmpty()) {
-        runState.stack.push(BigInt(0))
+        runState.stack.push(BIGINT_0)
         return
       }
 
@@ -540,7 +563,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [memOffset, returnDataOffset, dataLength] = runState.stack.popN(3)
 
-      if (dataLength !== BigInt(0)) {
+      if (dataLength !== BIGINT_0) {
         const data = getDataSlice(
           runState.interpreter.getReturnData(),
           returnDataOffset,
@@ -568,8 +591,8 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       const diff = runState.interpreter.getBlockNumber() - number
       // block lookups must be within the past 256 blocks
-      if (diff > BigInt(256) || diff <= BigInt(0)) {
-        runState.stack.push(BigInt(0))
+      if (diff > BigInt(256) || diff <= BIGINT_0) {
+        runState.stack.push(BIGINT_0)
         return
       }
 
@@ -646,7 +669,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       if (runState.env.versionedHashes.length > Number(index)) {
         runState.stack.push(bytesToBigInt(runState.env.versionedHashes[Number(index)]))
       } else {
-        runState.stack.push(BigInt(0))
+        runState.stack.push(BIGINT_0)
       }
     },
   ],
@@ -695,7 +718,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       const key = runState.stack.pop()
       const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
       const value = await runState.interpreter.storageLoad(keyBuf)
-      const valueBigInt = value.length ? bytesToBigInt(value) : BigInt(0)
+      const valueBigInt = value.length ? bytesToBigInt(value) : BIGINT_0
       runState.stack.push(valueBigInt)
     },
   ],
@@ -708,7 +731,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
       // NOTE: this should be the shortest representation
       let value
-      if (val === BigInt(0)) {
+      if (val === BIGINT_0) {
         value = Uint8Array.from([])
       } else {
         value = bigIntToBytes(val)
@@ -740,7 +763,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x57,
     function (runState) {
       const [dest, cond] = runState.stack.popN(2)
-      if (cond !== BigInt(0)) {
+      if (cond !== BIGINT_0) {
         if (dest > runState.interpreter.getCodeSize()) {
           trap(ERROR.INVALID_JUMP + ' at ' + describeLocation(runState))
         }
@@ -790,7 +813,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         const key = runState.stack.pop()
         const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
         const value = runState.interpreter.transientStorageLoad(keyBuf)
-        const valueBN = value.length ? bytesToBigInt(value) : BigInt(0)
+        const valueBN = value.length ? bytesToBigInt(value) : BIGINT_0
         runState.stack.push(valueBN)
       }
     },
@@ -817,7 +840,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
         // NOTE: this should be the shortest representation
         let value
-        if (val === BigInt(0)) {
+        if (val === BIGINT_0) {
           value = Uint8Array.from([])
         } else {
           value = bigIntToBytes(val)
@@ -859,7 +882,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x5f,
     function (runState) {
-      runState.stack.push(BigInt(0))
+      runState.stack.push(BIGINT_0)
     },
   ],
   // 0x60: PUSH
@@ -916,7 +939,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       })
 
       let mem = new Uint8Array(0)
-      if (memLength !== BigInt(0)) {
+      if (memLength !== BIGINT_0) {
         mem = runState.memory.read(Number(memOffset), Number(memLength))
       }
 
@@ -942,7 +965,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       runState.messageGasLimit = undefined
 
       let data = new Uint8Array(0)
-      if (length !== BigInt(0)) {
+      if (length !== BIGINT_0) {
         data = runState.memory.read(Number(offset), Number(length), true)
       }
 
@@ -972,7 +995,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       runState.messageGasLimit = undefined
 
       let data = new Uint8Array(0)
-      if (length !== BigInt(0)) {
+      if (length !== BIGINT_0) {
         data = runState.memory.read(Number(offset), Number(length), true)
       }
 
@@ -994,7 +1017,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       const toAddress = new Address(addresstoBytes(toAddr))
 
       let data = new Uint8Array(0)
-      if (inLength !== BigInt(0)) {
+      if (inLength !== BIGINT_0) {
         data = runState.memory.read(Number(inOffset), Number(inLength), true)
       }
 
@@ -1019,7 +1042,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       runState.messageGasLimit = undefined
 
       let data = new Uint8Array(0)
-      if (inLength !== BigInt(0)) {
+      if (inLength !== BIGINT_0) {
         data = runState.memory.read(Number(inOffset), Number(inLength), true)
       }
 
@@ -1039,7 +1062,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       const toAddress = new Address(addresstoBytes(toAddr))
 
       let data = new Uint8Array(0)
-      if (inLength !== BigInt(0)) {
+      if (inLength !== BIGINT_0) {
         data = runState.memory.read(Number(inOffset), Number(inLength), true)
       }
 
@@ -1087,7 +1110,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         recover = ecrecover(msgHash, yParity + BigInt(27), r, s)
       } catch (e) {
         // Malformed signature, push 0 on stack, clear auth variable
-        runState.stack.push(BigInt(0))
+        runState.stack.push(BIGINT_0)
         runState.auth = undefined
         return
       }
@@ -1100,13 +1123,13 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       if (!expectedAddress.equals(address)) {
         // expected address does not equal the recovered address, clear auth variable
-        runState.stack.push(BigInt(0))
+        runState.stack.push(BIGINT_0)
         runState.auth = undefined
         return
       }
 
       runState.auth = address
-      runState.stack.push(BigInt(1))
+      runState.stack.push(BIGINT_1)
     },
   ],
   // 0xf7: AUTHCALL
@@ -1130,7 +1153,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       runState.messageGasLimit = undefined
 
       let data = new Uint8Array(0)
-      if (argsLength !== BigInt(0)) {
+      if (argsLength !== BIGINT_0) {
         data = runState.memory.read(Number(argsOffset), Number(argsLength))
       }
 
@@ -1144,7 +1167,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0xfa,
     async function (runState) {
-      const value = BigInt(0)
+      const value = BIGINT_0
       const [_currentGasLimit, toAddr, inOffset, inLength, outOffset, outLength] =
         runState.stack.popN(6)
       const toAddress = new Address(addresstoBytes(toAddr))
@@ -1153,7 +1176,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       runState.messageGasLimit = undefined
 
       let data = new Uint8Array(0)
-      if (inLength !== BigInt(0)) {
+      if (inLength !== BIGINT_0) {
         data = runState.memory.read(Number(inOffset), Number(inLength), true)
       }
 
@@ -1169,7 +1192,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [offset, length] = runState.stack.popN(2)
       let returnData = new Uint8Array(0)
-      if (length !== BigInt(0)) {
+      if (length !== BIGINT_0) {
         returnData = runState.memory.read(Number(offset), Number(length))
       }
       runState.interpreter.finish(returnData)
@@ -1181,7 +1204,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [offset, length] = runState.stack.popN(2)
       let returnData = new Uint8Array(0)
-      if (length !== BigInt(0)) {
+      if (length !== BIGINT_0) {
         returnData = runState.memory.read(Number(offset), Number(length))
       }
       runState.interpreter.revert(returnData)

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -19,6 +19,9 @@ import {
 import type { RunState } from '../interpreter.js'
 import type { Common } from '@ethereumjs/common'
 
+const BIGINT_0 = BigInt(0)
+const BIGINT_1 = BigInt(1)
+
 /**
  * This file returns the dynamic parts of opcodes which have dynamic gas
  * These are not pure functions: some edit the size of the memory
@@ -43,7 +46,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       0x0a,
       async function (runState, gas, common): Promise<bigint> {
         const [_base, exponent] = runState.stack.peek(2)
-        if (exponent === BigInt(0)) {
+        if (exponent === BIGINT_0) {
           return gas
         }
         let byteLength = exponent.toString(2).length / 8
@@ -87,7 +90,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         const [memOffset, _dataOffset, dataLength] = runState.stack.peek(3)
 
         gas += subMemUsage(runState, memOffset, dataLength, common)
-        if (dataLength !== BigInt(0)) {
+        if (dataLength !== BIGINT_0) {
           gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BigInt(32))
         }
         return gas
@@ -100,7 +103,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         const [memOffset, _codeOffset, dataLength] = runState.stack.peek(3)
 
         gas += subMemUsage(runState, memOffset, dataLength, common)
-        if (dataLength !== BigInt(0)) {
+        if (dataLength !== BIGINT_0) {
           gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BigInt(32))
         }
         return gas
@@ -131,7 +134,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           gas += accessAddressEIP2929(runState, address, common)
         }
 
-        if (dataLength !== BigInt(0)) {
+        if (dataLength !== BIGINT_0) {
           gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BigInt(32))
         }
         return gas
@@ -149,7 +152,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         gas += subMemUsage(runState, memOffset, dataLength, common)
 
-        if (dataLength !== BigInt(0)) {
+        if (dataLength !== BIGINT_0) {
           gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BigInt(32))
         }
         return gas
@@ -190,7 +193,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       0x53,
       async function (runState, gas, common): Promise<bigint> {
         const offset = runState.stack.peek()[0]
-        gas += subMemUsage(runState, offset, BigInt(1), common)
+        gas += subMemUsage(runState, offset, BIGINT_1, common)
         return gas
       },
     ],
@@ -219,7 +222,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         const keyBytes = setLengthLeft(bigIntToBytes(key), 32)
         // NOTE: this should be the shortest representation
         let value
-        if (val === BigInt(0)) {
+        if (val === BIGINT_0) {
           value = Uint8Array.from([])
         } else {
           value = bigIntToBytes(val)
@@ -331,7 +334,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           runState.stack.peek(7)
         const toAddress = new Address(addresstoBytes(toAddr))
 
-        if (runState.interpreter.isStatic() && value !== BigInt(0)) {
+        if (runState.interpreter.isStatic() && value !== BIGINT_0) {
           trap(ERROR.STATIC_STATE_CHANGE)
         }
         gas += subMemUsage(runState, inOffset, inLength, common)
@@ -340,7 +343,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           gas += accessAddressEIP2929(runState, toAddress, common)
         }
 
-        if (value !== BigInt(0)) {
+        if (value !== BIGINT_0) {
           gas += common.param('gasPrices', 'callValueTransfer')
         }
 
@@ -354,7 +357,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
             deadAccount = true
           }
 
-          if (deadAccount && !(value === BigInt(0))) {
+          if (deadAccount && !(value === BIGINT_0)) {
             gas += common.param('gasPrices', 'callNewAccount')
           }
         } else if ((await runState.stateManager.getAccount(toAddress)) === undefined) {
@@ -379,7 +382,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           trap(ERROR.OUT_OF_GAS)
         }
 
-        if (value !== BigInt(0)) {
+        if (value !== BIGINT_0) {
           const callStipend = common.param('gasPrices', 'callStipend')
           runState.interpreter.addStipend(callStipend)
           gasLimit += callStipend
@@ -404,7 +407,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           gas += accessAddressEIP2929(runState, toAddress, common)
         }
 
-        if (value !== BigInt(0)) {
+        if (value !== BIGINT_0) {
           gas += common.param('gasPrices', 'callValueTransfer')
         }
         let gasLimit = maxCallGas(
@@ -418,7 +421,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         if (gasLimit > runState.interpreter.getGasLeft() - gas) {
           trap(ERROR.OUT_OF_GAS)
         }
-        if (value !== BigInt(0)) {
+        if (value !== BIGINT_0) {
           const callStipend = common.param('gasPrices', 'callStipend')
           runState.interpreter.addStipend(callStipend)
           gasLimit += callStipend
@@ -524,7 +527,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           retLength,
         ] = runState.stack.peek(8)
 
-        if (valueExt !== BigInt(0)) {
+        if (valueExt !== BIGINT_0) {
           trap(ERROR.AUTHCALL_NONZERO_VALUEEXT)
         }
 
@@ -537,7 +540,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         gas += subMemUsage(runState, argsOffset, argsLength, common)
         gas += subMemUsage(runState, retOffset, retLength, common)
 
-        if (value > BigInt(0)) {
+        if (value > BIGINT_0) {
           gas += common.param('gasPrices', 'authcallValueTransfer')
           const account = await runState.stateManager.getAccount(toAddress)
           if (!account) {
@@ -551,7 +554,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           runState,
           common
         )
-        if (currentGasLimit !== BigInt(0)) {
+        if (currentGasLimit !== BIGINT_0) {
           if (currentGasLimit > gasLimit) {
             trap(ERROR.OUT_OF_GAS)
           }
@@ -613,7 +616,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           const balance = await runState.interpreter.getExternalBalance(
             runState.interpreter.getAddress()
           )
-          if (balance > BigInt(0)) {
+          if (balance > BIGINT_0) {
             // This technically checks if account is empty or non-existent
             const account = await runState.stateManager.getAccount(selfdestructToAddress)
             if (account === undefined || account.isEmpty()) {

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -21,6 +21,8 @@ import type { Common } from '@ethereumjs/common'
 
 const BIGINT_0 = BigInt(0)
 const BIGINT_1 = BigInt(1)
+const BIGINT_31 = BigInt(31)
+const BIGINT_32 = BigInt(32)
 
 /**
  * This file returns the dynamic parts of opcodes which have dynamic gas
@@ -67,7 +69,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       async function (runState, gas, common): Promise<bigint> {
         const [offset, length] = runState.stack.peek(2)
         gas += subMemUsage(runState, offset, length, common)
-        gas += common.param('gasPrices', 'keccak256Word') * divCeil(length, BigInt(32))
+        gas += common.param('gasPrices', 'keccak256Word') * divCeil(length, BIGINT_32)
         return gas
       },
     ],
@@ -91,7 +93,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         gas += subMemUsage(runState, memOffset, dataLength, common)
         if (dataLength !== BIGINT_0) {
-          gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BigInt(32))
+          gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BIGINT_32)
         }
         return gas
       },
@@ -104,7 +106,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         gas += subMemUsage(runState, memOffset, dataLength, common)
         if (dataLength !== BIGINT_0) {
-          gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BigInt(32))
+          gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BIGINT_32)
         }
         return gas
       },
@@ -135,7 +137,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         }
 
         if (dataLength !== BIGINT_0) {
-          gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BigInt(32))
+          gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BIGINT_32)
         }
         return gas
       },
@@ -153,7 +155,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         gas += subMemUsage(runState, memOffset, dataLength, common)
 
         if (dataLength !== BIGINT_0) {
-          gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BigInt(32))
+          gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BIGINT_32)
         }
         return gas
       },
@@ -175,7 +177,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       0x51,
       async function (runState, gas, common): Promise<bigint> {
         const pos = runState.stack.peek()[0]
-        gas += subMemUsage(runState, pos, BigInt(32), common)
+        gas += subMemUsage(runState, pos, BIGINT_32, common)
         return gas
       },
     ],
@@ -184,7 +186,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       0x52,
       async function (runState, gas, common): Promise<bigint> {
         const offset = runState.stack.peek()[0]
-        gas += subMemUsage(runState, offset, BigInt(32), common)
+        gas += subMemUsage(runState, offset, BIGINT_32, common)
         return gas
       },
     ],
@@ -269,7 +271,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       0x5e,
       async function (runState, gas, common): Promise<bigint> {
         const [dst, src, length] = runState.stack.peek(3)
-        const wordsCopied = (length + BigInt(31)) / BigInt(32)
+        const wordsCopied = (length + BIGINT_31) / BIGINT_32
         gas += BigInt(3) * wordsCopied
         gas += subMemUsage(runState, src, length, common)
         gas += subMemUsage(runState, dst, length, common)
@@ -313,8 +315,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         }
 
         if (common.isActivatedEIP(3860) === true) {
-          gas +=
-            ((length + BigInt(31)) / BigInt(32)) * common.param('gasPrices', 'initCodeWordCost')
+          gas += ((length + BIGINT_31) / BIGINT_32) * common.param('gasPrices', 'initCodeWordCost')
         }
 
         gas += subMemUsage(runState, offset, length, common)
@@ -488,11 +489,10 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         }
 
         if (common.isActivatedEIP(3860) === true) {
-          gas +=
-            ((length + BigInt(31)) / BigInt(32)) * common.param('gasPrices', 'initCodeWordCost')
+          gas += ((length + BIGINT_31) / BIGINT_32) * common.param('gasPrices', 'initCodeWordCost')
         }
 
-        gas += common.param('gasPrices', 'keccak256Word') * divCeil(length, BigInt(32))
+        gas += common.param('gasPrices', 'keccak256Word') * divCeil(length, BIGINT_32)
         let gasLimit = runState.interpreter.getGasLeft() - gas
         gasLimit = maxCallGas(gasLimit, gasLimit, runState, common) // CREATE2 is only available after TangerineWhistle (Constantinople introduced this opcode)
         runState.messageGasLimit = gasLimit

--- a/packages/evm/src/precompiles/02-sha256.ts
+++ b/packages/evm/src/precompiles/02-sha256.ts
@@ -34,6 +34,6 @@ export function precompile02(opts: PrecompileInput): ExecResult {
 
   return {
     executionGasUsed: gasUsed,
-    returnValue: sha256(data),
+    returnValue: hash,
   }
 }


### PR DESCRIPTION
This is another smallish performance PR, does the following:

Low number and reused bigints (0, 1, 2,...) in central places are replaced by a one-time initialized constant.

Overall gain is hard to measure, but this is noticeable for opcodes which do not do much else - like the `EQ` opcode.

E.g. running `cd ../evm && npm run build && cd ../client && npm run client:start -- --sync=none --vmProfileBlocks --executeBlocks=962960-962970` on master and this PR gives a repeated new total ms value around 0.41 while the old one is at around 0.46.

So the opcode is just this:

```typescript
// 0x14: EQ
  [
    0x14,
    function (runState) {
      const [a, b] = runState.stack.popN(2)
      const r = a === b ? BIGINT_1 : BIGINT_0
      runState.stack.push(r)
    },
  ],
```

So good testbed for the gain, since two bigint constants are used and not much else is happening.

PR further caches some EXP values, since I realized that this opcode is very often run with same values.

This brings down/up EXP dramatically, from something like 9 Mgas/s to something around 30 Mgas/s.

This is nice, overall gain is limited, should be around 1ms per block though. So that is something.

Another fix: hash function on sha256 precompile (not keccak!) was called twice (sigh), this precompile is seldomly called though.

Open for review. 🙂 (everyone feel invited)