### PR TITLE
VM/EVM profiler: add summary, add Blocks per Slot normalized field

### DIFF
--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -288,9 +288,13 @@ export class VM {
       return
     }
 
+    // Track total calls / time (ms) / gas
+
     let calls = 0
     let totalMs = 0
     let totalGas = 0
+
+    // Order of columns to report (see `EVMPerformanceLogOutput` type)
 
     const colOrder = [
       'tag',
@@ -304,6 +308,8 @@ export class VM {
       'millionGasPerSecond',
       'blocksPerSlot',
     ]
+
+    // The name of this column to report (saves space)
     const colNames = [
       'tag',
       'calls',
@@ -317,13 +323,17 @@ export class VM {
       'BpS',
     ]
 
+    // Special padStr method which inserts whitespace left and right
+    // This ensures that there is at least one whitespace between the columns (denoted by pipe `|` chars)
     function padStr(str: string | number, leftpad: number) {
       return ' ' + str.toString().padStart(leftpad, ' ') + ' '
     }
+    // Returns the string length of this column. Used to calculate how big the header / footer should be
     function strLen(str: string | number) {
       return padStr(str, 0).length - 2
     }
 
+    // Step one: calculate the length of each colum
     const colLength: number[] = []
 
     for (const entry of logs) {
@@ -332,9 +342,11 @@ export class VM {
       for (const key of colOrder) {
         // @ts-ignore
         if (entry[key] !== undefined) {
+          // If entry is available, max out the current column length (this will be the longest string of this column)
           //@ts-ignore
           colLength[ins] = Math.max(colLength[ins] ?? 0, strLen(entry[key]))
           ins++
+          // In this switch statement update the total calls / time / gas used
           switch (key) {
             case 'calls':
               calls += entry[key]
@@ -350,24 +362,30 @@ export class VM {
       }
     }
 
+    // Ensure that the column names also fit on the column length
     for (const i in colLength) {
       colLength[i] = Math.max(colLength[i] ?? 0, strLen(colNames[i]))
     }
 
+    // Calculate the total header length
+    // This is done by summing all columns together, plus adding three extra chars per column (two whitespace, one pipe)
+    // Remove the final pipe character since this is included in the header string (so subtract one)
     const headerLength = colLength.reduce((pv, cv) => pv + cv, 0) + colLength.length * 3 - 1
 
     const blockGasLimit = 30_000_000 // Block gas limit
-    const slotTime = 12000 // Time in milliseconds per slot
+    const slotTime = 12000 // Time in milliseconds (!) per slot
 
     // Normalize constant to check if execution time is above one block per slot (>=1) or not (<1)
     const bpsNormalizer = blockGasLimit / slotTime
 
-    const avgGas = totalGas / totalMs
+    const avgGas = totalGas / totalMs // Gas per millisecond
     const mGasSAvg = Math.round(avgGas) / 1e3
     const bpSAvg = Math.round((avgGas / bpsNormalizer) * 1e3) / 1e3
 
+    // Write the profile title
     // eslint-disable-next-line
     console.log('+== ' + profileTitle + ' ==+')
+    // Write the summary of this profile
     // eslint-disable-next-line
     console.log(
       `+== Calls: ${calls}, Total time: ${
@@ -375,10 +393,12 @@ export class VM {
       }ms, Total gas: ${totalGas}, MGas/s: ${mGasSAvg}, Blocks per Slot (BpS): ${bpSAvg} ==+`
     )
 
+    // Generate and write the header
     const header = '|' + '-'.repeat(headerLength) + '|'
     // eslint-disable-next-line
     console.log(header)
 
+    // Write the columns
     let str = ''
     for (const i in colLength) {
       str += '|' + padStr(colNames[i], colLength[i])
@@ -388,6 +408,7 @@ export class VM {
     // eslint-disable-next-line
     console.log(str)
 
+    // Write each profile entry
     for (const entry of logs) {
       let str = ''
       let i = 0
@@ -404,6 +425,7 @@ export class VM {
       console.log(str)
     }
 
+    // Finally, write the footer
     const footer = '+' + '-'.repeat(headerLength) + '+'
     // eslint-disable-next-line
     console.log(footer)


### PR DESCRIPTION
![image](https://github.com/ethereumjs/ethereumjs-monorepo/assets/29359032/aa5469a1-37ce-41d2-858f-d1ad721720b0)

This PR adds an overall summary of the profiler: the amount of opcodes (calls), the total gas spent, the MGas/S, and the new column Blocks per Slot.

If Blocks per Slot is `>= 1` then we can execute one block within one beacon chain slot (12 seconds). If it is below, we are executing less than one block per slot, i.e. we cannot keep up with the chain because we are too slow.

This BpS is also added for each opcode: if it is below 1, it is too slow. (Note, that if the amount of calls is too low, think less than 10, this might not give a good indication if the opcode is too slow or not)