### PR TITLE
client: add a cli option for backward compatibility with non prefixed storage tries

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -328,6 +328,14 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     describe: 'Force a snap sync run (for testing and development purposes)',
     boolean: true,
   })
+  .option('prefixStorageTrieKeys', {
+    describe:
+      'Enable/Disable storage trie prefixes (specify `false` for backward compatibility with previous states synced without prefixes)',
+    boolean: true,
+    default: true,
+    deprecated:
+      'Support for `--prefixStorageTrieKeys=false` is temporary. Please sync new instances with prefixStorageTrieKeys enabled',
+  })
   .option('txLookupLimit', {
     describe:
       'Number of recent blocks to maintain transactions index for (default = about one year, 0 = entire chain)',
@@ -835,6 +843,7 @@ async function run() {
     syncmode: args.sync,
     disableBeaconSync: args.disableBeaconSync,
     forceSnapSync: args.forceSnapSync,
+    prefixStorageTrieKeys: args.prefixStorageTrieKeys,
     transports: args.transports,
     txLookupLimit: args.txLookupLimit,
   })

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -334,7 +334,7 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     boolean: true,
     default: true,
     deprecated:
-      'Support for `--prefixStorageTrieKeys=false` is temporary. Please sync new instances with prefixStorageTrieKeys enabled',
+      'Support for `--prefixStorageTrieKeys=false` is temporary. Please sync new instances with `prefixStorageTrieKeys` enabled',
   })
   .option('txLookupLimit', {
     describe:

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -61,8 +61,8 @@ export interface ConfigOptions {
   forceSnapSync?: boolean
 
   /**
-   * A temporary option to offer backward compatibility with state already synced
-   * with prefixed storage tries
+   * A temporary option to offer backward compatibility with already-synced databases that are
+using non-prefixed keys for storage tries
    *
    * Default: true
    */

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -62,7 +62,7 @@ export interface ConfigOptions {
 
   /**
    * A temporary option to offer backward compatibility with already-synced databases that are
-using non-prefixed keys for storage tries
+   * using non-prefixed keys for storage tries
    *
    * Default: true
    */

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -61,6 +61,14 @@ export interface ConfigOptions {
   forceSnapSync?: boolean
 
   /**
+   * A temporary option to offer backward compatibility with state already synced
+   * with prefixed storage tries
+   *
+   * Default: true
+   */
+  prefixStorageTrieKeys?: boolean
+
+  /**
    * Provide a custom VM instance to process blocks
    *
    * Default: VM instance created by client
@@ -402,6 +410,7 @@ export class Config {
   public readonly forceSnapSync: boolean
   // Just a development only flag, will/should be removed
   public readonly disableSnapSync: boolean = false
+  public readonly prefixStorageTrieKeys: boolean
 
   public synchronized: boolean
   /** lastSyncDate in ms */
@@ -473,6 +482,7 @@ export class Config {
 
     this.disableBeaconSync = options.disableBeaconSync ?? false
     this.forceSnapSync = options.forceSnapSync ?? false
+    this.prefixStorageTrieKeys = options.prefixStorageTrieKeys ?? true
 
     // Start it off as synchronized if this is configured to mine or as single node
     this.synchronized = this.isSingleNode ?? this.mine

--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -60,7 +60,7 @@ export class VMExecution extends Execution {
       this.config.logger.info(`Initializing trie cache size=${this.config.trieCache}`)
       const stateManager = new DefaultStateManager({
         trie,
-        prefixStorageTrieKeys: true,
+        prefixStorageTrieKeys: this.config.prefixStorageTrieKeys,
         accountCacheOpts: {
           deactivate: false,
           type: CacheType.LRU,

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -154,6 +154,7 @@ export interface ClientOpts {
   saveReceipts?: boolean
   disableBeaconSync?: boolean
   forceSnapSync?: boolean
+  prefixStorageTrieKeys?: boolean
   txLookupLimit?: number
   startBlock?: number
   isSingleNode?: boolean


### PR DESCRIPTION
Followup for 
 - https://github.com/ethereumjs/ethereumjs-monorepo/pull/3023

to enable running the client from previously unprefixed storage tries synced pre #3023