### PR TITLE
Snap sync: use zero-element proof for checking validity of final, empty range result

### DIFF
--- a/packages/client/src/sync/fetcher/accountfetcher.ts
+++ b/packages/client/src/sync/fetcher/accountfetcher.ts
@@ -237,6 +237,12 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
     }
 
     const trie = new Trie()
+    // if (accounts.length === 0) {
+    //   // no-elements proof to check if final range is truly empty
+    //   this.debug('dbg200')
+    //   return trie.verifyRangeProof(stateRoot, origin, null, [], [], <any>proof)
+    // }
+
     const keys = accounts.map((acc: any) => acc.hash)
     const values = accounts.map((acc: any) => accountBodyToRLP(acc.body))
     // convert the request to the right values
@@ -311,6 +317,23 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
     ) {
       // TODO have to check proof of nonexistence -- as a shortcut for now, we can mark as completed if a proof is present
       if (rangeResult.proof.length > 0) {
+        this.debug('dbg100')
+        const t = new Trie()
+        try {
+          const isMissingRightRange = await t.verifyRangeProof(
+            this.root,
+            origin,
+            null,
+            [],
+            [],
+            <any>rangeResult.proof
+          )
+        } catch (e) {
+          console.error(e)
+        }
+
+        this.debug(isMissingRightRange)
+
         this.debug(`Data for last range has been received`)
         // response contains empty object so that task can be terminated in store phase and not reenqueued
         return Object.assign([], [Object.create(null)], { completed: true })

--- a/packages/client/src/sync/fetcher/storagefetcher.ts
+++ b/packages/client/src/sync/fetcher/storagefetcher.ts
@@ -244,6 +244,17 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
       // TODO have to check proof of nonexistence since we are statically partitioning ranges --
       // as a shortcut for now, we can mark as completed if a proof is present
       if (rangeResult.proof.length > 0) {
+        this.debug('dbg100')
+        const isMissingRightRange = await this._proofTrie.verifyRangeProof(
+          task.storageRequests[0].storageRoot,
+          origin,
+          null,
+          [],
+          [],
+          <any>rangeResult.proof
+        )
+        this.debug(isMissingRightRange)
+
         this.debug(`Empty range was requested - Terminating task`)
         // response contains empty object so that task can be terminated in store phase and not reenqueued
         return Object.assign([], [Object.create(null) as any], { completed: true })


### PR DESCRIPTION
During snap sync, if the client requests a range that is both empty and has no elements remaining to the right of it, the peer responds with just a proof. This proof can be checked as part of a zero-element proof to validate that there really are no remaining elements to be fetched past the range.