### PR TITLE
Bigint constants

### DIFF
--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -3,6 +3,7 @@ import { RLP } from '@ethereumjs/rlp'
 import { Trie } from '@ethereumjs/trie'
 import { BlobEIP4844Transaction, Capability, TransactionFactory } from '@ethereumjs/tx'
 import {
+  BIGINT_0,
   KECCAK256_RLP,
   Withdrawal,
   bigIntToHex,
@@ -468,7 +469,7 @@ export class Block {
    */
   getTransactionsValidationErrors(): string[] {
     const errors: string[] = []
-    let blobGasUsed = BigInt(0)
+    let blobGasUsed = BIGINT_0
     const blobGasLimit = this.common.param('gasConfig', 'maxblobGasPerBlock')
     const blobGasPerBlob = this.common.param('gasConfig', 'blobGasPerBlob')
 
@@ -568,7 +569,7 @@ export class Block {
     if (this.common.isActivatedEIP(4844)) {
       const blobGasLimit = this.common.param('gasConfig', 'maxblobGasPerBlock')
       const blobGasPerBlob = this.common.param('gasConfig', 'blobGasPerBlob')
-      let blobGasUsed = BigInt(0)
+      let blobGasUsed = BIGINT_0
 
       const expectedExcessBlobGas = parentHeader.calcNextExcessBlobGas()
       if (this.header.excessBlobGas !== expectedExcessBlobGas) {

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -2,6 +2,8 @@ import { Chain, Common, ConsensusAlgorithm, ConsensusType, Hardfork } from '@eth
 import { RLP } from '@ethereumjs/rlp'
 import {
   Address,
+  BIGINT_0,
+  BIGINT_1,
   KECCAK256_RLP,
   KECCAK256_RLP_ARRAY,
   TypeOutput,
@@ -158,11 +160,11 @@ export class BlockHeader {
       transactionsTrie: KECCAK256_RLP,
       receiptTrie: KECCAK256_RLP,
       logsBloom: zeros(256),
-      difficulty: BigInt(0),
-      number: BigInt(0),
+      difficulty: BIGINT_0,
+      number: BIGINT_0,
       gasLimit: DEFAULT_GAS_LIMIT,
-      gasUsed: BigInt(0),
-      timestamp: BigInt(0),
+      gasUsed: BIGINT_0,
+      timestamp: BIGINT_0,
       extraData: new Uint8Array(0),
       mixHash: zeros(32),
       nonce: zeros(8),
@@ -210,8 +212,8 @@ export class BlockHeader {
           : BigInt(7)
         : undefined,
       withdrawalsRoot: this.common.isActivatedEIP(4895) ? KECCAK256_RLP : undefined,
-      blobGasUsed: this.common.isActivatedEIP(4844) ? BigInt(0) : undefined,
-      excessBlobGas: this.common.isActivatedEIP(4844) ? BigInt(0) : undefined,
+      blobGasUsed: this.common.isActivatedEIP(4844) ? BIGINT_0 : undefined,
+      excessBlobGas: this.common.isActivatedEIP(4844) ? BIGINT_0 : undefined,
       parentBeaconBlockRoot: this.common.isActivatedEIP(4788) ? zeros(32) : undefined,
     }
 
@@ -358,7 +360,7 @@ export class BlockHeader {
       const londonHfBlock = this.common.hardforkBlock(Hardfork.London)
       if (
         typeof londonHfBlock === 'bigint' &&
-        londonHfBlock !== BigInt(0) &&
+        londonHfBlock !== BIGINT_0 &&
         this.number === londonHfBlock
       ) {
         const initialBaseFee = this.common.param('gasConfig', 'initialBaseFee')
@@ -409,7 +411,7 @@ export class BlockHeader {
     if (this.common.consensusAlgorithm() === ConsensusAlgorithm.Ethash) {
       // PoW/Ethash
       if (
-        number > BigInt(0) &&
+        number > BIGINT_0 &&
         this.extraData.length > this.common.param('vm', 'maxExtraDataSize')
       ) {
         // Check length of data on all post-genesis blocks
@@ -461,9 +463,9 @@ export class BlockHeader {
         )})`
         error = true
       }
-      if (number !== BigInt(0)) {
+      if (number !== BIGINT_0) {
         // Skip difficulty, nonce, and extraData check for PoS genesis block as genesis block may have non-zero difficulty (if TD is > 0)
-        if (difficulty !== BigInt(0)) {
+        if (difficulty !== BIGINT_0) {
           errorMsg += `, difficulty: ${difficulty} (expected: 0)`
           error = true
         }
@@ -498,7 +500,7 @@ export class BlockHeader {
     const londonHardforkBlock = this.common.hardforkBlock(Hardfork.London)
     if (
       typeof londonHardforkBlock === 'bigint' &&
-      londonHardforkBlock !== BigInt(0) &&
+      londonHardforkBlock !== BIGINT_0 &&
       this.number === londonHardforkBlock
     ) {
       const elasticity = this.common.param('gasConfig', 'elasticityMultiplier')
@@ -551,8 +553,7 @@ export class BlockHeader {
 
       const calculatedDelta =
         (this.baseFeePerGas! * gasUsedDelta) / parentGasTarget / baseFeeMaxChangeDenominator
-      nextBaseFee =
-        (calculatedDelta > BigInt(1) ? calculatedDelta : BigInt(1)) + this.baseFeePerGas!
+      nextBaseFee = (calculatedDelta > BIGINT_1 ? calculatedDelta : BIGINT_1) + this.baseFeePerGas!
     } else {
       const gasUsedDelta = parentGasTarget - this.gasUsed
       const baseFeeMaxChangeDenominator = this.common.param(
@@ -563,9 +564,9 @@ export class BlockHeader {
       const calculatedDelta =
         (this.baseFeePerGas! * gasUsedDelta) / parentGasTarget / baseFeeMaxChangeDenominator
       nextBaseFee =
-        this.baseFeePerGas! - calculatedDelta > BigInt(0)
+        this.baseFeePerGas! - calculatedDelta > BIGINT_0
           ? this.baseFeePerGas! - calculatedDelta
-          : BigInt(0)
+          : BIGINT_0
     }
     return nextBaseFee
   }
@@ -604,11 +605,11 @@ export class BlockHeader {
    */
   public calcNextExcessBlobGas(): bigint {
     // The validation of the fields and 4844 activation is already taken care in BlockHeader constructor
-    const targetGasConsumed = (this.excessBlobGas ?? BigInt(0)) + (this.blobGasUsed ?? BigInt(0))
+    const targetGasConsumed = (this.excessBlobGas ?? BIGINT_0) + (this.blobGasUsed ?? BIGINT_0)
     const targetBlobGasPerBlock = this.common.param('gasConfig', 'targetBlobGasPerBlock')
 
     if (targetGasConsumed <= targetBlobGasPerBlock) {
-      return BigInt(0)
+      return BIGINT_0
     } else {
       return targetGasConsumed - targetBlobGasPerBlock
     }
@@ -630,7 +631,7 @@ export class BlockHeader {
       bigIntToUnpaddedBytes(this.number),
       bigIntToUnpaddedBytes(this.gasLimit),
       bigIntToUnpaddedBytes(this.gasUsed),
-      bigIntToUnpaddedBytes(this.timestamp ?? BigInt(0)),
+      bigIntToUnpaddedBytes(this.timestamp ?? BIGINT_0),
       this.extraData,
       this.mixHash,
       this.nonce,
@@ -671,7 +672,7 @@ export class BlockHeader {
    * Checks if the block header is a genesis header.
    */
   isGenesis(): boolean {
-    return this.number === BigInt(0)
+    return this.number === BIGINT_0
   }
 
   protected _requireClique(name: string) {
@@ -723,12 +724,12 @@ export class BlockHeader {
     if (this.common.gteHardfork(Hardfork.Byzantium) === true) {
       // Get delay as parameter from common
       num = num - this.common.param('pow', 'difficultyBombDelay')
-      if (num < BigInt(0)) {
-        num = BigInt(0)
+      if (num < BIGINT_0) {
+        num = BIGINT_0
       }
     } else if (this.common.gteHardfork(Hardfork.Homestead) === true) {
       // 1 - (block_timestamp - parent_timestamp) // 10
-      let a = BigInt(1) - (blockTs - parentTs) / BigInt(10)
+      let a = BIGINT_1 - (blockTs - parentTs) / BigInt(10)
       const cutoff = BigInt(-99)
       // MAX(cutoff, a)
       if (cutoff > a) {
@@ -775,7 +776,7 @@ export class BlockHeader {
     const epoch = BigInt((this.common.consensusConfig() as CliqueConfig).epoch)
     // Epoch transition block if the block number has no
     // remainder on the division by the epoch length
-    return this.number % epoch === BigInt(0)
+    return this.number % epoch === BIGINT_0
   }
 
   /**

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -4,6 +4,9 @@ import {
   Address,
   BIGINT_0,
   BIGINT_1,
+  BIGINT_2,
+  BIGINT_27,
+  BIGINT_7,
   KECCAK256_RLP,
   KECCAK256_RLP_ARRAY,
   TypeOutput,
@@ -209,7 +212,7 @@ export class BlockHeader {
       baseFeePerGas: this.common.isActivatedEIP(1559)
         ? number === this.common.hardforkBlock(Hardfork.London)
           ? this.common.param('gasConfig', 'initialBaseFee')
-          : BigInt(7)
+          : BIGINT_7
         : undefined,
       withdrawalsRoot: this.common.isActivatedEIP(4895) ? KECCAK256_RLP : undefined,
       blobGasUsed: this.common.isActivatedEIP(4844) ? BIGINT_0 : undefined,
@@ -745,9 +748,9 @@ export class BlockHeader {
       }
     }
 
-    const exp = num / BigInt(100000) - BigInt(2)
+    const exp = num / BigInt(100000) - BIGINT_2
     if (exp >= 0) {
-      dif = dif + BigInt(2) ** exp
+      dif = dif + BIGINT_2 ** exp
     }
 
     if (dif < minimumDifficulty) {
@@ -806,11 +809,7 @@ export class BlockHeader {
     this._requireClique('cliqueSealBlock')
 
     const signature = ecsign(this.cliqueSigHash(), privateKey)
-    const signatureB = concatBytes(
-      signature.r,
-      signature.s,
-      bigIntToBytes(signature.v - BigInt(27))
-    )
+    const signatureB = concatBytes(signature.r, signature.s, bigIntToBytes(signature.v - BIGINT_27))
 
     const extraDataWithoutSeal = this.extraData.subarray(
       0,
@@ -874,7 +873,7 @@ export class BlockHeader {
     }
     const r = extraSeal.subarray(0, 32)
     const s = extraSeal.subarray(32, 64)
-    const v = bytesToBigInt(extraSeal.subarray(64, 65)) + BigInt(27)
+    const v = bytesToBigInt(extraSeal.subarray(64, 65)) + BIGINT_27
     const pubKey = ecrecover(this.cliqueSigHash(), v, r, s)
     return Address.fromPublicKey(pubKey)
   }

--- a/packages/block/src/helpers.ts
+++ b/packages/block/src/helpers.ts
@@ -1,5 +1,5 @@
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
-import { TypeOutput, isHexString, toType } from '@ethereumjs/util'
+import { BIGINT_0, BIGINT_1, TypeOutput, isHexString, toType } from '@ethereumjs/util'
 
 import type { BlockHeaderBytes, HeaderData } from './types.js'
 import type { TypedTransaction } from '@ethereumjs/tx'
@@ -98,10 +98,10 @@ export const getNumBlobs = (transactions: TypedTransaction[]) => {
  * Approximates `factor * e ** (numerator / denominator)` using Taylor expansion
  */
 export const fakeExponential = (factor: bigint, numerator: bigint, denominator: bigint) => {
-  let i = BigInt(1)
-  let output = BigInt(0)
+  let i = BIGINT_1
+  let output = BIGINT_0
   let numerator_accum = factor * denominator
-  while (numerator_accum > BigInt(0)) {
+  while (numerator_accum > BIGINT_0) {
     output += numerator_accum
     numerator_accum = (numerator_accum * numerator) / (denominator * i)
     i++

--- a/packages/block/test/util.ts
+++ b/packages/block/test/util.ts
@@ -1,6 +1,6 @@
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
-import { utf8ToBytes } from '@ethereumjs/util'
+import { BIGINT_0, BIGINT_1, utf8ToBytes } from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak'
 
 import { Block } from '../src/index.js'
@@ -26,14 +26,14 @@ function createBlock(
     throw new Error('extra data graffiti must be 32 bytes or less')
   }
 
-  const number = parentBlock.header.number + BigInt(1)
-  const timestamp = parentBlock.header.timestamp + BigInt(1)
+  const number = parentBlock.header.number + BIGINT_1
+  const timestamp = parentBlock.header.timestamp + BIGINT_1
 
   const uncleHash = keccak256(RLP.encode(uncles.map((uh) => uh.raw())))
 
   const londonHfBlock = common.hardforkBlock(Hardfork.London)
   const baseFeePerGas =
-    typeof londonHfBlock === 'bigint' && londonHfBlock !== BigInt(0) && number > londonHfBlock
+    typeof londonHfBlock === 'bigint' && londonHfBlock !== BIGINT_0 && number > londonHfBlock
       ? parentBlock.header.calcNextBaseFee()
       : undefined
 

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -11,6 +11,7 @@ import { genesisStateRoot as genGenesisStateRoot } from '@ethereumjs/trie'
 import {
   BIGINT_0,
   BIGINT_1,
+  BIGINT_8,
   KECCAK256_RLP,
   Lock,
   MapDB,
@@ -589,7 +590,7 @@ export class Blockchain implements BlockchainInterface {
     if (height !== undefined) {
       const dif = height - parentHeader.number
 
-      if (!(dif < BigInt(8) && dif > BIGINT_1)) {
+      if (!(dif < BIGINT_8 && dif > BIGINT_1)) {
         throw new Error(
           `uncle block has a parent that is too old or too young ${header.errorStr()}`
         )

--- a/packages/blockchain/src/consensus/casper.ts
+++ b/packages/blockchain/src/consensus/casper.ts
@@ -1,4 +1,5 @@
 import { ConsensusAlgorithm } from '@ethereumjs/common'
+import { BIGINT_0 } from '@ethereumjs/util'
 
 import type { Consensus } from '../types.js'
 import type { BlockHeader } from '@ethereumjs/block'
@@ -20,7 +21,7 @@ export class CasperConsensus implements Consensus {
   public async validateConsensus(): Promise<void> {}
 
   public async validateDifficulty(header: BlockHeader): Promise<void> {
-    if (header.difficulty !== BigInt(0)) {
+    if (header.difficulty !== BIGINT_0) {
       const msg = 'invalid difficulty.  PoS blocks must have difficulty 0'
       throw new Error(`${msg} ${header.errorStr()}`)
     }

--- a/packages/blockchain/src/consensus/clique.ts
+++ b/packages/blockchain/src/consensus/clique.ts
@@ -2,6 +2,9 @@ import { ConsensusAlgorithm } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import {
   Address,
+  BIGINT_0,
+  BIGINT_1,
+  BIGINT_2,
   TypeOutput,
   bigIntToBytes,
   bytesToBigInt,
@@ -29,9 +32,9 @@ const CLIQUE_VOTES_KEY = 'CliqueVotes'
 const CLIQUE_BLOCK_SIGNERS_SNAPSHOT_KEY = 'CliqueBlockSignersSnapshot'
 
 // Block difficulty for in-turn signatures
-export const CLIQUE_DIFF_INTURN = BigInt(2)
+export const CLIQUE_DIFF_INTURN = BIGINT_2
 // Block difficulty for out-of-turn signatures
-export const CLIQUE_DIFF_NOTURN = BigInt(1)
+export const CLIQUE_DIFF_NOTURN = BIGINT_1
 
 // Clique Signer State
 type CliqueSignerState = [blockNumber: bigint, signers: Address[]]
@@ -193,7 +196,7 @@ export class CliqueConsensus implements Consensus {
     const { header } = block
     const commonAncestorNumber = commonAncestor?.number
     if (commonAncestorNumber !== undefined) {
-      await this._cliqueDeleteSnapshots(commonAncestorNumber + BigInt(1))
+      await this._cliqueDeleteSnapshots(commonAncestorNumber + BIGINT_1)
       for (let number = commonAncestorNumber + BigInt(1); number <= header.number; number++) {
         const canonicalHeader = await this.blockchain!.getCanonicalHeader(number)
         await this._cliqueBuildSnapshots(canonicalHeader)
@@ -208,7 +211,7 @@ export class CliqueConsensus implements Consensus {
    */
   private async cliqueSaveGenesisSigners(genesisBlock: Block) {
     const genesisSignerState: CliqueSignerState = [
-      BigInt(0),
+      BIGINT_0,
       genesisBlock.header.cliqueEpochTransitionSigners(),
     ]
     await this.cliqueUpdateSignerStates(genesisSignerState)

--- a/packages/blockchain/src/db/helpers.ts
+++ b/packages/blockchain/src/db/helpers.ts
@@ -1,5 +1,6 @@
 import { Block } from '@ethereumjs/block'
 import { RLP } from '@ethereumjs/rlp'
+import { BIGINT_0 } from '@ethereumjs/util'
 
 import { bytesBE8 } from './constants.js'
 import { DBOp, DBTarget } from './operation.js'
@@ -40,7 +41,7 @@ function DBSetBlockOrHeader(blockBody: Block | BlockHeader): DBOp[] {
     })
   )
 
-  const isGenesis = header.number === BigInt(0)
+  const isGenesis = header.number === BIGINT_0
 
   if (
     isGenesis ||

--- a/packages/blockchain/src/db/manager.ts
+++ b/packages/blockchain/src/db/manager.ts
@@ -1,6 +1,8 @@
 import { Block, BlockHeader, valuesArrayToHeaderData } from '@ethereumjs/block'
 import { RLP } from '@ethereumjs/rlp'
 import {
+  BIGINT_0,
+  BIGINT_1,
   KECCAK256_RLP,
   KECCAK256_RLP_ARRAY,
   bytesToBigInt,
@@ -128,10 +130,10 @@ export class DBManager {
 
     const blockData = [header.raw(), ...body] as BlockBytes
     const opts: BlockOptions = { common: this.common }
-    if (number === BigInt(0)) {
-      opts.setHardfork = await this.getTotalDifficulty(hash, BigInt(0))
+    if (number === BIGINT_0) {
+      opts.setHardfork = await this.getTotalDifficulty(hash, BIGINT_0)
     } else {
-      opts.setHardfork = await this.getTotalDifficulty(header.parentHash, number - BigInt(1))
+      opts.setHardfork = await this.getTotalDifficulty(header.parentHash, number - BIGINT_1)
     }
     return Block.fromValuesArray(blockData, opts)
   }
@@ -155,14 +157,14 @@ export class DBManager {
     const headerValues = RLP.decode(encodedHeader)
 
     const opts: BlockOptions = { common: this.common }
-    if (blockNumber === BigInt(0)) {
-      opts.setHardfork = await this.getTotalDifficulty(blockHash, BigInt(0))
+    if (blockNumber === BIGINT_0) {
+      opts.setHardfork = await this.getTotalDifficulty(blockHash, BIGINT_0)
     } else {
       // Lets fetch the parent hash but not by number since this block might not
       // be in canonical chain
       const headerData = valuesArrayToHeaderData(headerValues as Uint8Array[])
       const parentHash = headerData.parentHash as Uint8Array
-      opts.setHardfork = await this.getTotalDifficulty(parentHash, blockNumber - BigInt(1))
+      opts.setHardfork = await this.getTotalDifficulty(parentHash, blockNumber - BIGINT_1)
     }
     return BlockHeader.fromValuesArray(headerValues as Uint8Array[], opts)
   }

--- a/packages/client/src/blockchain/chain.ts
+++ b/packages/client/src/blockchain/chain.ts
@@ -1,7 +1,7 @@
 import { Block, BlockHeader } from '@ethereumjs/block'
 import { Blockchain } from '@ethereumjs/blockchain'
 import { ConsensusAlgorithm, Hardfork } from '@ethereumjs/common'
-import { equalsBytes } from '@ethereumjs/util'
+import { BIGINT_0, BIGINT_1, equalsBytes } from '@ethereumjs/util'
 
 import { LevelDB } from '../execution/level'
 import { Event } from '../types'
@@ -125,8 +125,8 @@ export class Chain {
     finalized: null,
     safe: null,
     vm: null,
-    td: BigInt(0),
-    height: BigInt(0),
+    td: BIGINT_0,
+    height: BIGINT_0,
   }
 
   private _blocks: ChainBlocks = {
@@ -134,8 +134,8 @@ export class Chain {
     finalized: null,
     safe: null,
     vm: null,
-    td: BigInt(0),
-    height: BigInt(0),
+    td: BIGINT_0,
+    height: BIGINT_0,
   }
 
   /**
@@ -189,16 +189,16 @@ export class Chain {
       finalized: null,
       safe: null,
       vm: null,
-      td: BigInt(0),
-      height: BigInt(0),
+      td: BIGINT_0,
+      height: BIGINT_0,
     }
     this._blocks = {
       latest: null,
       finalized: null,
       safe: null,
       vm: null,
-      td: BigInt(0),
-      height: BigInt(0),
+      td: BIGINT_0,
+      height: BIGINT_0,
     }
   }
 
@@ -280,16 +280,16 @@ export class Chain {
       finalized: null,
       safe: null,
       vm: null,
-      td: BigInt(0),
-      height: BigInt(0),
+      td: BIGINT_0,
+      height: BIGINT_0,
     }
     const blocks: ChainBlocks = {
       latest: null,
       finalized: null,
       safe: null,
       vm: null,
-      td: BigInt(0),
-      height: BigInt(0),
+      td: BIGINT_0,
+      height: BIGINT_0,
     }
 
     headers.latest = await this.getCanonicalHeadHeader()
@@ -323,7 +323,7 @@ export class Chain {
     // Check and log if this is a terminal block and next block could be merge
     if (!this.config.chainCommon.gteHardfork(Hardfork.Paris)) {
       const nextBlockHf = this.config.chainCommon.getHardforkBy({
-        blockNumber: headers.height + BigInt(1),
+        blockNumber: headers.height + BIGINT_1,
         td: headers.td,
       })
       if (this.config.chainCommon.hardforkGteHardfork(nextBlockHf, Hardfork.Paris)) {
@@ -346,7 +346,7 @@ export class Chain {
         this.config.logger.info('*'.repeat(85))
         this.config.logger.info(
           `Transitioning to PoS! First block for CL-framed execution: block=${
-            headers.height + BigInt(1)
+            headers.height + BIGINT_1
           }`
         )
       }

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -1,6 +1,6 @@
 import { Common, Hardfork } from '@ethereumjs/common'
 import { genPrivateKey } from '@ethereumjs/devp2p'
-import { type Address, BIGINT_0, BIGINT_1 } from '@ethereumjs/util'
+import { type Address, BIGINT_0, BIGINT_1, BIGINT_2, BIGINT_256 } from '@ethereumjs/util'
 import { Level } from 'level'
 
 import { getLogger } from './logging'
@@ -354,10 +354,9 @@ export class Config {
   public static readonly SKELETON_SUBCHAIN_MERGE_MINIMUM = 1000
   public static readonly MAX_RANGE_BYTES = 50000
   // This should get like 100 accounts in this range
-  public static readonly MAX_ACCOUNT_RANGE =
-    (BigInt(2) ** BigInt(256) - BIGINT_1) / BigInt(1_000_000)
+  public static readonly MAX_ACCOUNT_RANGE = (BIGINT_2 ** BIGINT_256 - BIGINT_1) / BigInt(1_000_000)
   // Larger ranges used for storage slots since assumption is slots should be much sparser than accounts
-  public static readonly MAX_STORAGE_RANGE = (BigInt(2) ** BigInt(256) - BIGINT_1) / BigInt(10)
+  public static readonly MAX_STORAGE_RANGE = (BIGINT_2 ** BIGINT_256 - BIGINT_1) / BigInt(10)
   public static readonly SYNCED_STATE_REMOVAL_PERIOD = 60000
   // engine new payload calls can come in batch of 64, keeping 128 as the lookup factor
   public static readonly ENGINE_PARENTLOOKUP_MAX_DEPTH = 128

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -1,5 +1,6 @@
 import { Common, Hardfork } from '@ethereumjs/common'
 import { genPrivateKey } from '@ethereumjs/devp2p'
+import { type Address, BIGINT_0, BIGINT_1 } from '@ethereumjs/util'
 import { Level } from 'level'
 
 import { getLogger } from './logging'
@@ -10,7 +11,6 @@ import { isBrowser, parseTransports, short } from './util'
 import type { Logger } from './logging'
 import type { EventBusType, MultiaddrLike } from './types'
 import type { BlockHeader } from '@ethereumjs/block'
-import type { Address } from '@ethereumjs/util'
 import type { VM, VMProfilerOpts } from '@ethereumjs/vm'
 import type { Multiaddr } from 'multiaddr'
 
@@ -355,9 +355,9 @@ export class Config {
   public static readonly MAX_RANGE_BYTES = 50000
   // This should get like 100 accounts in this range
   public static readonly MAX_ACCOUNT_RANGE =
-    (BigInt(2) ** BigInt(256) - BigInt(1)) / BigInt(1_000_000)
+    (BigInt(2) ** BigInt(256) - BIGINT_1) / BigInt(1_000_000)
   // Larger ranges used for storage slots since assumption is slots should be much sparser than accounts
-  public static readonly MAX_STORAGE_RANGE = (BigInt(2) ** BigInt(256) - BigInt(1)) / BigInt(10)
+  public static readonly MAX_STORAGE_RANGE = (BigInt(2) ** BigInt(256) - BIGINT_1) / BigInt(10)
   public static readonly SYNCED_STATE_REMOVAL_PERIOD = 60000
   // engine new payload calls can come in batch of 64, keeping 128 as the lookup factor
   public static readonly ENGINE_PARENTLOOKUP_MAX_DEPTH = 128
@@ -533,13 +533,13 @@ export class Config {
   updateSynchronizedState(latest?: BlockHeader | null, emitSyncEvent?: boolean) {
     // If no syncTargetHeight has been discovered from peer and neither the client is set
     // for mining/single run (validator), then sync state can't be updated
-    if ((this.syncTargetHeight ?? BigInt(0)) === BigInt(0) && !this.mine && !this.isSingleNode) {
+    if ((this.syncTargetHeight ?? BIGINT_0) === BIGINT_0 && !this.mine && !this.isSingleNode) {
       return
     }
 
     if (latest !== null && latest !== undefined) {
       const height = latest.number
-      if (height >= (this.syncTargetHeight ?? BigInt(0))) {
+      if (height >= (this.syncTargetHeight ?? BIGINT_0)) {
         this.syncTargetHeight = height
         this.lastSyncDate =
           typeof latest.timestamp === 'bigint' && latest.timestamp > 0n

--- a/packages/client/src/execution/receipt.ts
+++ b/packages/client/src/execution/receipt.ts
@@ -1,5 +1,6 @@
 import { RLP } from '@ethereumjs/rlp'
 import {
+  BIGINT_0,
   bigIntToBytes,
   bytesToBigInt,
   bytesToInt,
@@ -259,7 +260,7 @@ export class ReceiptsManager extends MetaDBManager {
           if (this.config.txLookupLimit > 0) {
             // Remove tx hashes for one block past txLookupLimit
             const limit = this.chain.headers.height - BigInt(this.config.txLookupLimit)
-            if (limit < BigInt(0)) return
+            if (limit < BIGINT_0) return
             const blockDelIndexes = await this.chain.getBlock(limit)
             void this.updateIndex(IndexOperation.Delete, IndexType.TxHash, blockDelIndexes)
           }

--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -8,7 +8,7 @@ import { ConsensusType, Hardfork } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
 import { CacheType, DefaultStateManager } from '@ethereumjs/statemanager'
 import { Trie } from '@ethereumjs/trie'
-import { Lock, bytesToHex, equalsBytes } from '@ethereumjs/util'
+import { BIGINT_0, BIGINT_1, Lock, bytesToHex, equalsBytes } from '@ethereumjs/util'
 import { VM } from '@ethereumjs/vm'
 
 import { Event } from '../types'
@@ -134,7 +134,7 @@ export class VMExecution extends Execution {
       this.config.execCommon.setHardforkBy({ blockNumber: number, td, timestamp })
       this.hardfork = this.config.execCommon.hardfork()
       this.config.logger.info(`Initializing VM execution hardfork=${this.hardfork}`)
-      if (number === BigInt(0)) {
+      if (number === BIGINT_0) {
         const genesisState =
           this.chain['_customGenesisState'] ?? getGenesis(Number(this.vm.common.chainId()))
         if (!genesisState) {
@@ -190,7 +190,7 @@ export class VMExecution extends Execution {
         // Bypass updating head by using blockchain db directly
         const [hash, num] = [block.hash(), block.header.number]
         const td =
-          (await this.chain.getTd(block.header.parentHash, block.header.number - BigInt(1))) +
+          (await this.chain.getTd(block.header.parentHash, block.header.number - BIGINT_1)) +
           block.header.difficulty
 
         await this.chain.blockchain.dbManager.batch([

--- a/packages/client/src/miner/miner.ts
+++ b/packages/client/src/miner/miner.ts
@@ -1,7 +1,7 @@
 import { BlockHeader } from '@ethereumjs/block'
 import { ConsensusType, Hardfork } from '@ethereumjs/common'
 import { Ethash } from '@ethereumjs/ethash'
-import { bytesToHex, equalsBytes } from '@ethereumjs/util'
+import { BIGINT_0, BIGINT_1, BIGINT_2, bytesToHex, equalsBytes } from '@ethereumjs/util'
 import { MemoryLevel } from 'memory-level'
 
 import { LevelDB } from '../execution/level'
@@ -89,7 +89,7 @@ export class Miner {
 
     // Check if the new block to be minted isn't PoS
     const nextBlockHf = this.config.chainCommon.getHardforkBy({
-      blockNumber: this.service.chain.headers.height + BigInt(1),
+      blockNumber: this.service.chain.headers.height + BIGINT_1,
       td: this.service.chain.headers.td,
     })
     if (this.config.chainCommon.hardforkGteHardfork(nextBlockHf, Hardfork.Paris)) {
@@ -107,7 +107,7 @@ export class Miner {
       const { blockchain } = this.service.chain
       const parentBlock = this.service.chain.blocks.latest!
       //eslint-disable-next-line
-      const number = parentBlock.header.number + BigInt(1)
+      const number = parentBlock.header.number + BIGINT_1
       const inTurn = await (blockchain.consensus as CliqueConsensus).cliqueSignerInTurn(
         signerAddress,
         number
@@ -155,7 +155,7 @@ export class Miner {
     this.ethashMiner?.stop()
     const latestBlockHeader = this.latestBlockHeader()
     const target = Number(latestBlockHeader.timestamp) * 1000 + this.period - Date.now()
-    const timeout = BigInt(0) > target ? 0 : target
+    const timeout = BIGINT_0 > target ? 0 : target
     this.config.logger.debug(
       `Miner: Chain updated with block ${
         latestBlockHeader.number
@@ -203,7 +203,7 @@ export class Miner {
 
     const parentBlock = this.service.chain.blocks.latest!
     //eslint-disable-next-line
-    const number = parentBlock.header.number + BigInt(1)
+    const number = parentBlock.header.number + BIGINT_1
     let { gasLimit } = parentBlock.header
 
     if (this.config.chainCommon.consensusType() === ConsensusType.ProofOfAuthority) {
@@ -256,14 +256,14 @@ export class Miner {
     const londonHardforkBlock = this.config.chainCommon.hardforkBlock(Hardfork.London)
     if (
       typeof londonHardforkBlock === 'bigint' &&
-      londonHardforkBlock !== BigInt(0) &&
+      londonHardforkBlock !== BIGINT_0 &&
       number === londonHardforkBlock
     ) {
       // Get baseFeePerGas from `paramByEIP` since 1559 not currently active on common
       baseFeePerGas =
-        this.config.chainCommon.paramByEIP('gasConfig', 'initialBaseFee', 1559) ?? BigInt(0)
+        this.config.chainCommon.paramByEIP('gasConfig', 'initialBaseFee', 1559) ?? BIGINT_0
       // Set initial EIP1559 block gas limit to 2x parent gas limit per logic in `block.validateGasLimit`
-      gasLimit = gasLimit * BigInt(2)
+      gasLimit = gasLimit * BIGINT_2
     } else if (this.config.chainCommon.isActivatedEIP(1559) === true) {
       baseFeePerGas = parentBlock.header.calcNextBaseFee()
     }
@@ -295,7 +295,7 @@ export class Miner {
     const txs = await this.service.txPool.txsByPriceAndNonce(vmCopy, { baseFee: baseFeePerGas })
     this.config.logger.info(
       `Miner: Assembling block from ${txs.length} eligible txs ${
-        typeof baseFeePerGas === 'bigint' && baseFeePerGas !== BigInt(0)
+        typeof baseFeePerGas === 'bigint' && baseFeePerGas !== BIGINT_0
           ? `(baseFee: ${baseFeePerGas})`
           : ''
       }`

--- a/packages/client/src/miner/pendingBlock.ts
+++ b/packages/client/src/miner/pendingBlock.ts
@@ -2,6 +2,7 @@ import { Hardfork } from '@ethereumjs/common'
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
 import {
   BIGINT_1,
+  BIGINT_2,
   TypeOutput,
   bigIntToUnpaddedBytes,
   bytesToHex,
@@ -117,7 +118,7 @@ export class PendingBlock {
       : undefined
 
     if (number === vm.common.hardforkBlock(Hardfork.London)) {
-      gasLimit = gasLimit * BigInt(2)
+      gasLimit = gasLimit * BIGINT_2
     }
 
     // payload is uniquely defined by timestamp, parent and mixHash, gasLimit can also be

--- a/packages/client/src/miner/pendingBlock.ts
+++ b/packages/client/src/miner/pendingBlock.ts
@@ -1,6 +1,7 @@
 import { Hardfork } from '@ethereumjs/common'
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
 import {
+  BIGINT_1,
   TypeOutput,
   bigIntToUnpaddedBytes,
   bytesToHex,
@@ -97,7 +98,7 @@ export class PendingBlock {
     headerData: Partial<HeaderData> = {},
     withdrawals?: WithdrawalData[]
   ) {
-    const number = parentBlock.header.number + BigInt(1)
+    const number = parentBlock.header.number + BIGINT_1
     const { timestamp, mixHash, parentBeaconBlockRoot } = headerData
     let { gasLimit } = parentBlock.header
 

--- a/packages/client/src/net/protocol/ethprotocol.ts
+++ b/packages/client/src/net/protocol/ethprotocol.ts
@@ -10,6 +10,7 @@ import {
   isLegacyTx,
 } from '@ethereumjs/tx'
 import {
+  BIGINT_0,
   bigIntToUnpaddedBytes,
   bytesToBigInt,
   bytesToHex,
@@ -90,7 +91,7 @@ function exhaustiveTypeGuard(_value: never, errorMsg: string): never {
  */
 export class EthProtocol extends Protocol {
   private chain: Chain
-  private nextReqId = BigInt(0)
+  private nextReqId = BIGINT_0
   private chainTTD?: BigIntLike
 
   /* eslint-disable no-invalid-this */
@@ -121,7 +122,7 @@ export class EthProtocol extends Protocol {
             this.chain.headers.latest?.number ?? // Use latest header number if available OR
             this.config.syncTargetHeight ?? // Use sync target height if available OR
             common.hardforkBlock(common.hardfork()) ?? // Use current hardfork block number OR
-            BigInt(0), // Use chainstart,
+            BIGINT_0, // Use chainstart,
           timestamp: this.chain.headers.latest?.timestamp ?? Math.floor(Date.now() / 1000),
         })
         return txs.map((txData) => TransactionFactory.fromSerializedData(txData, { common }))
@@ -282,7 +283,7 @@ export class EthProtocol extends Protocol {
             this.chain.headers.latest?.number ?? // Use latest header number if available OR
             this.config.syncTargetHeight ?? // Use sync target height if available OR
             common.hardforkBlock(common.hardfork()) ?? // Use current hardfork block number OR
-            BigInt(0), // Use chainstart,
+            BIGINT_0, // Use chainstart,
           timestamp: this.chain.headers.latest?.timestamp ?? Math.floor(Date.now() / 1000),
         })
         return [

--- a/packages/client/src/net/protocol/lesprotocol.ts
+++ b/packages/client/src/net/protocol/lesprotocol.ts
@@ -1,5 +1,6 @@
 import { BlockHeader } from '@ethereumjs/block'
 import {
+  BIGINT_0,
   bigIntToUnpaddedBytes,
   bytesToBigInt,
   bytesToInt,
@@ -52,7 +53,7 @@ export class LesProtocol extends Protocol {
   private chain: Chain
   private flow: FlowControl | undefined
   private isServer: boolean
-  private nextReqId = BigInt(0)
+  private nextReqId = BIGINT_0
 
   /* eslint-disable no-invalid-this */
   private protocolMessages: Message[] = [

--- a/packages/client/src/net/protocol/snapprotocol.ts
+++ b/packages/client/src/net/protocol/snapprotocol.ts
@@ -1,4 +1,5 @@
 import {
+  BIGINT_0,
   accountBodyFromSlim,
   accountBodyToSlim,
   bigIntToUnpaddedBytes,
@@ -99,7 +100,7 @@ export class SnapProtocol extends Protocol {
   private chain: Chain
   /** If to convert slim body received of an account to normal */
   private convertSlimBody?: boolean
-  private nextReqId = BigInt(0)
+  private nextReqId = BIGINT_0
 
   /* eslint-disable no-invalid-this */
   private protocolMessages: Message[] = [

--- a/packages/client/src/rpc/helpers.ts
+++ b/packages/client/src/rpc/helpers.ts
@@ -1,4 +1,4 @@
-import { bigIntToHex, bytesToHex, intToHex } from '@ethereumjs/util'
+import { BIGINT_0, bigIntToHex, bytesToHex, intToHex } from '@ethereumjs/util'
 
 import { INVALID_PARAMS } from './error-code'
 
@@ -52,7 +52,7 @@ export const getBlockByOption = async (blockOpt: string, chain: Chain) => {
 
   switch (blockOpt) {
     case 'earliest':
-      block = await chain.getBlock(BigInt(0))
+      block = await chain.getBlock(BIGINT_0)
       break
     case 'latest':
       block = latest

--- a/packages/client/src/rpc/modules/engine.ts
+++ b/packages/client/src/rpc/modules/engine.ts
@@ -2,6 +2,8 @@ import { Block } from '@ethereumjs/block'
 import { Hardfork } from '@ethereumjs/common'
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
 import {
+  BIGINT_0,
+  BIGINT_1,
   bigIntToHex,
   bytesToHex,
   bytesToUnprefixedHex,
@@ -317,7 +319,7 @@ const validateTerminalBlock = async (block: Block, chain: Chain): Promise<boolea
   // In case the Genesis block has td >= ttd it is the terminal block
   if (block.isGenesis()) return blockTd >= ttd
 
-  const parentBlockTd = await chain.getTd(block.header.parentHash, block.header.number - BigInt(1))
+  const parentBlockTd = await chain.getTd(block.header.parentHash, block.header.number - BIGINT_1)
   return blockTd >= ttd && parentBlockTd < ttd
 }
 
@@ -969,7 +971,7 @@ export class Engine {
     // Only validate this as terminal block if this block's difficulty is non-zero,
     // else this is a PoS block but its hardfork could be indeterminable if the skeleton
     // is not yet connected.
-    if (!headBlock.common.gteHardfork(Hardfork.Paris) && headBlock.header.difficulty > BigInt(0)) {
+    if (!headBlock.common.gteHardfork(Hardfork.Paris) && headBlock.header.difficulty > BIGINT_0) {
       const validTerminalBlock = await validateTerminalBlock(headBlock, this.chain)
       if (!validTerminalBlock) {
         const response = {
@@ -1092,7 +1094,7 @@ export class Engine {
       if (timestampBigInt <= headBlock.header.timestamp) {
         throw {
           message: `invalid timestamp in payloadAttributes, got ${timestampBigInt}, need at least ${
-            headBlock.header.timestamp + BigInt(1)
+            headBlock.header.timestamp + BIGINT_1
           }`,
           code: INVALID_PARAMS,
         }
@@ -1403,7 +1405,7 @@ export class Engine {
       }
     }
 
-    if (count < BigInt(1) || start < BigInt(1)) {
+    if (count < BIGINT_1 || start < BIGINT_1) {
       throw {
         code: INVALID_PARAMS,
         message: 'Start and Count parameters cannot be less than 1',
@@ -1415,7 +1417,7 @@ export class Engine {
     }
 
     if (start + count > currentChainHeight) {
-      count = currentChainHeight - start + BigInt(1)
+      count = currentChainHeight - start + BIGINT_1
     }
     const blocks = await this.chain.getBlocks(start, Number(count))
     const payloads: (ExecutionPayloadBodyV1 | null)[] = []

--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -1,6 +1,8 @@
 import { BlobEIP4844Transaction, Capability, TransactionFactory } from '@ethereumjs/tx'
 import {
   Address,
+  BIGINT_0,
+  BIGINT_1,
   TypeOutput,
   bigIntToHex,
   bytesToHex,
@@ -342,7 +344,7 @@ export class Eth {
    * @param params An empty array
    */
   async blockNumber(_params = []) {
-    return bigIntToHex(this._chain.headers.latest?.number ?? BigInt(0))
+    return bigIntToHex(this._chain.headers.latest?.number ?? BIGINT_0)
   }
 
   /**
@@ -795,7 +797,7 @@ export class Eth {
       }
     } else {
       if (fromBlock === 'earliest') {
-        from = await this._chain.getBlock(BigInt(0))
+        from = await this._chain.getBlock(BIGINT_0)
       } else if (fromBlock === 'latest' || fromBlock === undefined) {
         from = this._chain.blocks.latest!
       } else {
@@ -882,10 +884,10 @@ export class Eth {
     }
     const common = this.client.config.chainCommon.copy()
     const chainHeight = this.client.chain.headers.height
-    let txTargetHeight = syncTargetHeight ?? BigInt(0)
+    let txTargetHeight = syncTargetHeight ?? BIGINT_0
     // Following step makes sure txTargetHeight > 0
     if (txTargetHeight <= chainHeight) {
-      txTargetHeight = chainHeight + BigInt(1)
+      txTargetHeight = chainHeight + BIGINT_1
     }
     common.setHardforkBy({
       blockNumber: txTargetHeight,
@@ -1009,7 +1011,7 @@ export class Eth {
     const startingBlock = bigIntToHex(synchronizer.startingBlock)
 
     let highestBlock
-    if (typeof syncTargetHeight === 'bigint' && syncTargetHeight !== BigInt(0)) {
+    if (typeof syncTargetHeight === 'bigint' && syncTargetHeight !== BIGINT_0) {
       highestBlock = bigIntToHex(syncTargetHeight)
     } else {
       const bestPeer = await synchronizer.best()
@@ -1051,11 +1053,11 @@ export class Eth {
    */
   async gasPrice() {
     const minGasPrice: bigint = this._chain.config.chainCommon.param('gasConfig', 'minPrice')
-    let gasPrice = BigInt(0)
+    let gasPrice = BIGINT_0
     const latest = await this._chain.getCanonicalHeadHeader()
     if (this._vm !== undefined && this._vm.common.isActivatedEIP(1559)) {
       const baseFee = latest.calcNextBaseFee()
-      let priorityFee = BigInt(0)
+      let priorityFee = BIGINT_0
       const block = await this._chain.getBlock(latest.number)
       for (const tx of block.transactions) {
         const maxPriorityFeePerGas = (tx as FeeMarketEIP1559Transaction).maxPriorityFeePerGas
@@ -1063,13 +1065,13 @@ export class Eth {
       }
 
       priorityFee =
-        priorityFee !== BigInt(0) ? priorityFee / BigInt(block.transactions.length) : BigInt(1)
+        priorityFee !== BIGINT_0 ? priorityFee / BigInt(block.transactions.length) : BIGINT_1
       gasPrice = baseFee + priorityFee > minGasPrice ? baseFee + priorityFee : minGasPrice
     } else {
       // For chains that don't support EIP-1559 we iterate over the last 20
       // blocks to get an average gas price.
       const blockIterations = 20 < latest.number ? 20 : latest.number
-      let txCount = BigInt(0)
+      let txCount = BIGINT_0
       for (let i = 0; i < blockIterations; i++) {
         const block = await this._chain.getBlock(latest.number - BigInt(i))
         if (block.transactions.length === 0) {

--- a/packages/client/src/service/txpool.ts
+++ b/packages/client/src/service/txpool.ts
@@ -10,6 +10,7 @@ import {
   Account,
   Address,
   BIGINT_0,
+  BIGINT_2,
   bytesToHex,
   bytesToUnprefixedHex,
   equalsBytes,
@@ -302,7 +303,7 @@ export class TxPool {
     }
     const block = await this.service.chain.getCanonicalHeadHeader()
     if (typeof block.baseFeePerGas === 'bigint' && block.baseFeePerGas !== BIGINT_0) {
-      if (currentGasPrice.maxFee < block.baseFeePerGas / BigInt(2) && !isLocalTransaction) {
+      if (currentGasPrice.maxFee < block.baseFeePerGas / BIGINT_2 && !isLocalTransaction) {
         throw new Error(
           `Tx cannot pay basefee of ${block.baseFeePerGas}, have ${currentGasPrice.maxFee} (not within 50% range of current basefee)`
         )

--- a/packages/client/src/service/txpool.ts
+++ b/packages/client/src/service/txpool.ts
@@ -9,6 +9,7 @@ import {
 import {
   Account,
   Address,
+  BIGINT_0,
   bytesToHex,
   bytesToUnprefixedHex,
   equalsBytes,
@@ -223,7 +224,7 @@ export class TxPool {
     // If height gte target, we are close enough to the
     // head of the chain that the tx pool can be started
     const target =
-      (this.config.syncTargetHeight ?? BigInt(0)) -
+      (this.config.syncTargetHeight ?? BIGINT_0) -
       BigInt(this.BLOCKS_BEFORE_TARGET_HEIGHT_ACTIVATION)
     if (this.service.chain.headers.height >= target) {
       this.start()
@@ -300,7 +301,7 @@ export class TxPool {
       }
     }
     const block = await this.service.chain.getCanonicalHeadHeader()
-    if (typeof block.baseFeePerGas === 'bigint' && block.baseFeePerGas !== BigInt(0)) {
+    if (typeof block.baseFeePerGas === 'bigint' && block.baseFeePerGas !== BIGINT_0) {
       if (currentGasPrice.maxFee < block.baseFeePerGas / BigInt(2) && !isLocalTransaction) {
         throw new Error(
           `Tx cannot pay basefee of ${block.baseFeePerGas}, have ${currentGasPrice.maxFee} (not within 50% range of current basefee)`
@@ -672,7 +673,7 @@ export class TxPool {
    */
   private normalizedGasPrice(tx: TypedTransaction, baseFee?: bigint) {
     const supports1559 = tx.supports(Capability.EIP1559FeeMarket)
-    if (typeof baseFee === 'bigint' && baseFee !== BigInt(0)) {
+    if (typeof baseFee === 'bigint' && baseFee !== BIGINT_0) {
       if (supports1559) {
         return (tx as FeeMarketEIP1559Transaction).maxPriorityFeePerGas
       } else {
@@ -756,7 +757,7 @@ export class TxPool {
         skippedStats.byNonce += txsSortedByNonce.length
         continue
       }
-      if (typeof baseFee === 'bigint' && baseFee !== BigInt(0)) {
+      if (typeof baseFee === 'bigint' && baseFee !== BIGINT_0) {
         // If any tx has an insufficient gasPrice,
         // remove all txs after that since they cannot be executed
         const found = txsSortedByNonce.findIndex((tx) => this.normalizedGasPrice(tx) < baseFee)
@@ -770,7 +771,7 @@ export class TxPool {
     // Initialize a price based heap with the head transactions
     const byPrice = new Heap({
       comparBefore: (a: TypedTransaction, b: TypedTransaction) =>
-        this.normalizedGasPrice(b, baseFee) - this.normalizedGasPrice(a, baseFee) < BigInt(0),
+        this.normalizedGasPrice(b, baseFee) - this.normalizedGasPrice(a, baseFee) < BIGINT_0,
     }) as QHeap<TypedTransaction>
     for (const [address, txs] of byNonce) {
       byPrice.insert(txs[0])

--- a/packages/client/src/sync/beaconsync.ts
+++ b/packages/client/src/sync/beaconsync.ts
@@ -1,4 +1,4 @@
-import { bytesToHex } from '@ethereumjs/util'
+import { BIGINT_0, BIGINT_1, bytesToHex } from '@ethereumjs/util'
 
 import { Event } from '../types'
 import { short } from '../util'
@@ -236,7 +236,7 @@ export class BeaconSynchronizer extends Synchronizer {
     const height = latest.number
     if (
       typeof this.config.syncTargetHeight !== 'bigint' ||
-      this.config.syncTargetHeight === BigInt(0) ||
+      this.config.syncTargetHeight === BIGINT_0 ||
       this.config.syncTargetHeight < latest.number
     ) {
       this.config.syncTargetHeight = height
@@ -244,7 +244,7 @@ export class BeaconSynchronizer extends Synchronizer {
     }
 
     const { tail } = this.skeleton.bounds()
-    const first = tail - BigInt(1)
+    const first = tail - BIGINT_1
 
     let count
     if (first <= this.chain.blocks.height) {
@@ -253,7 +253,7 @@ export class BeaconSynchronizer extends Synchronizer {
       count = BigInt(this.config.skeletonSubchainMergeMinimum)
     } else {
       // We sync one less because tail's next should be pointing to the block in chain
-      count = tail - this.chain.blocks.height - BigInt(1)
+      count = tail - this.chain.blocks.height - BIGINT_1
     }
 
     // Do not try syncing blocks on/pre genesis
@@ -261,7 +261,7 @@ export class BeaconSynchronizer extends Synchronizer {
       count = first
     }
 
-    if (count > BigInt(0) && (this.fetcher === null || this.fetcher.syncErrored !== undefined)) {
+    if (count > BIGINT_0 && (this.fetcher === null || this.fetcher.syncErrored !== undefined)) {
       this.config.logger.debug(
         `syncWithPeer - new ReverseBlockFetcher peer=${
           peer?.id
@@ -315,7 +315,7 @@ export class BeaconSynchronizer extends Synchronizer {
       this.skeleton.bounds() !== undefined &&
       this.chain.blocks.height > this.skeleton.bounds().head - BigInt(50)
     )
-    if (!shouldRunOnlyBatched || this.chain.blocks.height % BigInt(50) === BigInt(0)) {
+    if (!shouldRunOnlyBatched || this.chain.blocks.height % BigInt(50) === BIGINT_0) {
       void this.execution.run(true, shouldRunOnlyBatched)
     }
   }

--- a/packages/client/src/sync/fetcher/accountfetcher.ts
+++ b/packages/client/src/sync/fetcher/accountfetcher.ts
@@ -3,6 +3,7 @@ import {
   BIGINT_0,
   BIGINT_1,
   BIGINT_2,
+  BIGINT_256,
   KECCAK256_NULL,
   KECCAK256_RLP,
   accountBodyToRLP,
@@ -153,7 +154,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
     super(options)
     this.root = options.root
     this.first = options.first
-    this.count = options.count ?? BIGINT_2 ** BigInt(256) - this.first
+    this.count = options.count ?? BIGINT_2 ** BIGINT_256 - this.first
     this.codeTrie = new Trie({ useKeyHashing: true })
     this.accountTrie = new Trie({ useKeyHashing: true })
     this.accountToStorageTrie = new Map()
@@ -310,7 +311,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
 
     if (
       rangeResult.accounts.length === 0 ||
-      equalsBytes(limit, bigIntToBytes(BIGINT_2 ** BigInt(256))) === true
+      equalsBytes(limit, bigIntToBytes(BIGINT_2 ** BIGINT_256)) === true
     ) {
       // TODO have to check proof of nonexistence -- as a shortcut for now, we can mark as completed if a proof is present
       if (rangeResult.proof.length > 0) {
@@ -419,7 +420,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
           accountHash: account.hash,
           storageRoot,
           first: BIGINT_0,
-          count: BIGINT_2 ** BigInt(256) - BIGINT_1,
+          count: BIGINT_2 ** BIGINT_256 - BIGINT_1,
         })
       }
       // build record of accounts that need bytecode to be fetched

--- a/packages/client/src/sync/fetcher/accountfetcher.ts
+++ b/packages/client/src/sync/fetcher/accountfetcher.ts
@@ -1,5 +1,8 @@
 import { Trie } from '@ethereumjs/trie'
 import {
+  BIGINT_0,
+  BIGINT_1,
+  BIGINT_2,
   KECCAK256_NULL,
   KECCAK256_RLP,
   accountBodyToRLP,
@@ -118,7 +121,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
   /** The origin to start account fetcher from (including), by default starts from 0 (0x0000...) */
   first: bigint
 
-  /** The range to eventually, by default should be set at BigInt(2) ** BigInt(256) + BigInt(1) - first */
+  /** The range to eventually, by default should be set at BIGINT_2 ** BigInt(256) + BIGINT_1 - first */
   count: bigint
 
   storageFetcher: StorageFetcher
@@ -150,7 +153,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
     super(options)
     this.root = options.root
     this.first = options.first
-    this.count = options.count ?? BigInt(2) ** BigInt(256) - this.first
+    this.count = options.count ?? BIGINT_2 ** BigInt(256) - this.first
     this.codeTrie = new Trie({ useKeyHashing: true })
     this.accountTrie = new Trie({ useKeyHashing: true })
     this.accountToStorageTrie = new Map()
@@ -160,7 +163,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
       pool: this.pool,
       root: this.root,
       storageRequests: [],
-      first: BigInt(1),
+      first: BIGINT_1,
       destroyWhenDone: false,
       accountToStorageTrie: this.accountToStorageTrie,
     })
@@ -248,7 +251,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
     const { first } = task
     // Snap protocol will automatically pad it with 32 bytes left, so we don't need to worry
     const origin = partialResult
-      ? bigIntToBytes(bytesToBigInt(partialResult[partialResult.length - 1].hash) + BigInt(1))
+      ? bigIntToBytes(bytesToBigInt(partialResult[partialResult.length - 1].hash) + BIGINT_1)
       : bigIntToBytes(first)
     return setLengthLeft(origin, 32)
   }
@@ -256,7 +259,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
   private getLimit(job: Job<JobTask, AccountData[], AccountData>): Uint8Array {
     const { task } = job
     const { first, count } = task
-    const limit = bigIntToBytes(first + BigInt(count) - BigInt(1))
+    const limit = bigIntToBytes(first + BigInt(count) - BIGINT_1)
     return setLengthLeft(limit, 32)
   }
 
@@ -307,7 +310,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
 
     if (
       rangeResult.accounts.length === 0 ||
-      equalsBytes(limit, bigIntToBytes(BigInt(2) ** BigInt(256))) === true
+      equalsBytes(limit, bigIntToBytes(BIGINT_2 ** BigInt(256))) === true
     ) {
       // TODO have to check proof of nonexistence -- as a shortcut for now, we can mark as completed if a proof is present
       if (rangeResult.proof.length > 0) {
@@ -415,8 +418,8 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
         storageFetchRequests.add({
           accountHash: account.hash,
           storageRoot,
-          first: BigInt(0),
-          count: BigInt(2) ** BigInt(256) - BigInt(1),
+          first: BIGINT_0,
+          count: BIGINT_2 ** BigInt(256) - BIGINT_1,
         })
       }
       // build record of accounts that need bytecode to be fetched
@@ -447,7 +450,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
     const max = this.config.maxAccountRange
     const tasks: JobTask[] = []
     let debugStr = `origin=${short(setLengthLeft(bigIntToBytes(first), 32))}`
-    let pushedCount = BigInt(0)
+    let pushedCount = BIGINT_0
     const startedWith = first
 
     while (count >= BigInt(max) && tasks.length < maxTasks) {
@@ -456,11 +459,11 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
       count -= BigInt(max)
       pushedCount += BigInt(max)
     }
-    if (count > BigInt(0) && tasks.length < maxTasks) {
+    if (count > BIGINT_0 && tasks.length < maxTasks) {
       tasks.push({ first, count })
       first += BigInt(count)
       pushedCount += count
-      count = BigInt(0)
+      count = BIGINT_0
     }
 
     // If we started with where this.first was, i.e. there are no gaps and hence
@@ -471,7 +474,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
     }
 
     debugStr += ` limit=${short(
-      setLengthLeft(bigIntToBytes(startedWith + pushedCount - BigInt(1)), 32)
+      setLengthLeft(bigIntToBytes(startedWith + pushedCount - BIGINT_1), 32)
     )}`
     this.debug(`Created new tasks num=${tasks.length} ${debugStr}`)
     return tasks
@@ -480,7 +483,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
   nextTasks(): void {
     if (
       this.in.length === 0 &&
-      this.count > BigInt(0) &&
+      this.count > BIGINT_0 &&
       this.processed - this.finished < this.config.maxFetcherRequests
     ) {
       // pendingRange is for which new tasks need to be generated
@@ -518,7 +521,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
     error: Error,
     _task: JobTask
   ): { destroyFetcher: boolean; banPeer: boolean; stepBack: bigint } {
-    const stepBack = BigInt(0)
+    const stepBack = BIGINT_0
     const destroyFetcher =
       !(error.message as string).includes(`InvalidRangeProof`) &&
       !(error.message as string).includes(`InvalidAccountRange`)

--- a/packages/client/src/sync/fetcher/blockfetcherbase.ts
+++ b/packages/client/src/sync/fetcher/blockfetcherbase.ts
@@ -1,3 +1,5 @@
+import { BIGINT_0, BIGINT_1 } from '@ethereumjs/util'
+
 import { Fetcher } from './fetcher'
 
 import type { Chain } from '../../blockchain'
@@ -66,7 +68,7 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
     const max = this.config.maxPerRequest
     const tasks: JobTask[] = []
     let debugStr = `first=${first}`
-    let pushedCount = BigInt(0)
+    let pushedCount = BIGINT_0
     const startedWith = first
 
     while (count >= BigInt(max) && tasks.length < maxTasks) {
@@ -75,11 +77,11 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
       count -= BigInt(max)
       pushedCount += BigInt(max)
     }
-    if (count > BigInt(0) && tasks.length < maxTasks) {
+    if (count > BIGINT_0 && tasks.length < maxTasks) {
       tasks.push({ first, count: Number(count) })
       !this.reverse ? (first += BigInt(count)) : (first -= BigInt(count))
       pushedCount += count
-      count = BigInt(0)
+      count = BIGINT_0
     }
 
     // If we started with where this.first was, i.e. there are no gaps and hence
@@ -99,7 +101,7 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
     // Do not generate any new tasks unless maxFetcherRequests are resolved
     if (
       this.in.length === 0 &&
-      this.count > BigInt(0) &&
+      this.count > BIGINT_0 &&
       this.processed - this.finished < this.config.maxFetcherRequests
     ) {
       this.debug(
@@ -122,7 +124,7 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
    */
   clear() {
     let first = this.first
-    let last = this.first + this.count - BigInt(1)
+    let last = this.first + this.count - BIGINT_1
 
     // We have to loop because the jobs won't always be in increasing order.
     // Some jobs could have refetch tasks enqueued, so it is better to find
@@ -133,13 +135,13 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
       if (job.task.first < first) {
         first = job.task.first
       }
-      const jobLast = job.task.first + BigInt(job.task.count) - BigInt(1)
+      const jobLast = job.task.first + BigInt(job.task.count) - BIGINT_1
       if (jobLast > last) {
         last = jobLast
       }
     }
     this.first = first
-    this.count = last - this.first + BigInt(1)
+    this.count = last - this.first + BIGINT_1
     // Already removed jobs from the `in` heap, just pass to super for further cleanup
     super.clear()
   }
@@ -157,7 +159,7 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
    */
   enqueueByNumberList(numberList: bigint[], min: bigint, max: bigint) {
     // Check and update the height
-    const last = this.first + this.count - BigInt(1)
+    const last = this.first + this.count - BIGINT_1
     let updateHeightStr = ''
     if (max > last) {
       this.count += max - last
@@ -208,13 +210,13 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
     error: Error,
     task: JobTask
   ): { destroyFetcher: boolean; banPeer: boolean; stepBack: bigint } {
-    let stepBack = BigInt(0)
+    let stepBack = BIGINT_0
     const destroyFetcher = !(error.message as string).includes('could not find parent header')
     const banPeer = true
 
     // we can step back here for blockfetcher
     if (!destroyFetcher && this.reverse === false) {
-      stepBack = task.first - BigInt(1)
+      stepBack = task.first - BIGINT_1
       if (stepBack > BigInt(this.config.safeReorgDistance)) {
         stepBack = BigInt(this.config.safeReorgDistance)
       }

--- a/packages/client/src/sync/fetcher/bytecodefetcher.ts
+++ b/packages/client/src/sync/fetcher/bytecodefetcher.ts
@@ -1,6 +1,12 @@
 import { CODEHASH_PREFIX } from '@ethereumjs/statemanager'
 import { Trie } from '@ethereumjs/trie'
-import { bytesToHex, bytesToUnprefixedHex, concatBytes, equalsBytes } from '@ethereumjs/util'
+import {
+  BIGINT_0,
+  bytesToHex,
+  bytesToUnprefixedHex,
+  concatBytes,
+  equalsBytes,
+} from '@ethereumjs/util'
 import debugDefault from 'debug'
 import { keccak256 } from 'ethereum-cryptography/keccak'
 
@@ -242,7 +248,7 @@ export class ByteCodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
     error: Error,
     _task: JobTask
   ): { destroyFetcher: boolean; banPeer: boolean; stepBack: bigint } {
-    const stepBack = BigInt(0)
+    const stepBack = BIGINT_0
     const destroyFetcher =
       !(error.message as string).includes(`InvalidRangeProof`) &&
       !(error.message as string).includes(`InvalidAccountRange`)

--- a/packages/client/src/sync/fetcher/reverseblockfetcher.ts
+++ b/packages/client/src/sync/fetcher/reverseblockfetcher.ts
@@ -1,3 +1,5 @@
+import { BIGINT_0 } from '@ethereumjs/util'
+
 import { Event } from '../../types'
 import { errSyncMerged } from '../skeleton'
 
@@ -62,7 +64,7 @@ export class ReverseBlockFetcher extends BlockFetcher {
     error: Error,
     _task: JobTask
   ): { destroyFetcher: boolean; banPeer: boolean; stepBack: bigint } {
-    const stepBack = BigInt(0)
+    const stepBack = BIGINT_0
     const destroyFetcher = !(error.message as string).includes(
       `Blocks don't extend canonical subchain`
     )

--- a/packages/client/src/sync/fetcher/storagefetcher.ts
+++ b/packages/client/src/sync/fetcher/storagefetcher.ts
@@ -1,5 +1,7 @@
 import { Trie } from '@ethereumjs/trie'
 import {
+  BIGINT_0,
+  BIGINT_1,
   bigIntToBytes,
   bigIntToHex,
   bytesToBigInt,
@@ -21,7 +23,7 @@ import type { Job } from './types'
 import type { Debugger } from 'debug'
 const { debug: createDebugLogger } = debugDefault
 
-const TOTAL_RANGE_END = BigInt(2) ** BigInt(256) - BigInt(1)
+const TOTAL_RANGE_END = BigInt(2) ** BigInt(256) - BIGINT_1
 
 type StorageDataResponse = StorageData[][] & { completed?: boolean }
 
@@ -144,18 +146,18 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
    */
   private getOrigin(job: Job<JobTask, StorageData[][], StorageData[]>): Uint8Array {
     const { task, partialResult } = job
-    if (task.storageRequests.length > 1 || task.storageRequests[0].first === BigInt(0)) {
+    if (task.storageRequests.length > 1 || task.storageRequests[0].first === BIGINT_0) {
       // peer does not respect origin or limit for multi-account storage fetch
-      return setLengthLeft(bigIntToBytes(BigInt(0)), 32)
+      return setLengthLeft(bigIntToBytes(BIGINT_0), 32)
     }
     const { first } = task.storageRequests[0]!
     let origin = undefined
     if (partialResult) {
       const lastSlotArray = partialResult[partialResult.length - 1]
       const lastSlot = lastSlotArray[lastSlotArray.length - 1]
-      origin = bigIntToBytes(bytesToBigInt(lastSlot.hash) + BigInt(1))
+      origin = bigIntToBytes(bytesToBigInt(lastSlot.hash) + BIGINT_1)
     } else {
-      origin = bigIntToBytes(first + BigInt(1))
+      origin = bigIntToBytes(first + BIGINT_1)
     }
     return setLengthLeft(origin, 32)
   }
@@ -304,7 +306,7 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
 
           // single account requests should check if task range is satisfied since origin and limit
           // are being respected
-          if (task.storageRequests.length === 1 && !(task.storageRequests[0].first === BigInt(0))) {
+          if (task.storageRequests.length === 1 && !(task.storageRequests[0].first === BIGINT_0)) {
             if (!hasRightElement) {
               // all data has been fetched for account storage trie
               completed = true
@@ -367,7 +369,7 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
     const highestReceivedhash = accountSlots[accountSlots.length - 1].hash
     let updateHighestReceivedHash = false
     const request = job.task.storageRequests[0]
-    if (request.first > BigInt(0)) {
+    if (request.first > BIGINT_0) {
       updateHighestReceivedHash = true
     }
 
@@ -460,7 +462,7 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
    * and turns each range into a task for the fetcher
    */
   tasks(
-    first = BigInt(0),
+    first = BIGINT_0,
     count = TOTAL_RANGE_END,
     maxTasks = this.config.maxFetcherJobs
   ): JobTask[] {
@@ -491,7 +493,7 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
     // single account fetch with moving origin and limit
     const max = this.config.maxStorageRange
     let debugStr = `origin=${short(setLengthLeft(bigIntToBytes(myFirst), 32))}`
-    let pushedCount = BigInt(0)
+    let pushedCount = BIGINT_0
     while (myCount >= BigInt(max) && tasks.length < maxTasks) {
       const task = {
         storageRequests: [
@@ -510,7 +512,7 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
       myCount -= BigInt(max)
       pushedCount += BigInt(max)
     }
-    if (myCount > BigInt(0) && tasks.length < maxTasks) {
+    if (myCount > BIGINT_0 && tasks.length < maxTasks) {
       const task = {
         storageRequests: [
           {
@@ -526,12 +528,12 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
       tasks.push(task)
       myFirst += BigInt(myCount)
       pushedCount += myCount
-      myCount = BigInt(0)
+      myCount = BIGINT_0
     }
 
     // If we started with where this.first was, i.e. there are no gaps and hence
     // we can move this.first to where its now, and reduce count by pushedCount
-    if (myCount !== BigInt(0) && startedWith === whereFirstwas) {
+    if (myCount !== BIGINT_0 && startedWith === whereFirstwas) {
       // create new fragmented request to keep track of where to start building the next set of tasks for fetching the same account
       this.fragmentedRequests.unshift({
         accountHash: storageRequest!.accountHash,
@@ -610,7 +612,7 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
     error: Error,
     _task: JobTask
   ): { destroyFetcher: boolean; banPeer: boolean; stepBack: bigint } {
-    const stepBack = BigInt(0)
+    const stepBack = BIGINT_0
     const destroyFetcher =
       !error.message.includes(`InvalidRangeProof`) && !error.message.includes(`InvalidStorageRange`)
     const banPeer = true

--- a/packages/client/src/sync/fetcher/storagefetcher.ts
+++ b/packages/client/src/sync/fetcher/storagefetcher.ts
@@ -2,6 +2,8 @@ import { Trie } from '@ethereumjs/trie'
 import {
   BIGINT_0,
   BIGINT_1,
+  BIGINT_2,
+  BIGINT_256,
   bigIntToBytes,
   bigIntToHex,
   bytesToBigInt,
@@ -23,7 +25,7 @@ import type { Job } from './types'
 import type { Debugger } from 'debug'
 const { debug: createDebugLogger } = debugDefault
 
-const TOTAL_RANGE_END = BigInt(2) ** BigInt(256) - BIGINT_1
+const TOTAL_RANGE_END = BIGINT_2 ** BIGINT_256 - BIGINT_1
 
 type StorageDataResponse = StorageData[][] & { completed?: boolean }
 

--- a/packages/client/src/sync/fetcher/trienodefetcher.ts
+++ b/packages/client/src/sync/fetcher/trienodefetcher.ts
@@ -7,7 +7,7 @@ import {
   mergeAndFormatKeyPaths,
   pathToHexKey,
 } from '@ethereumjs/trie'
-import { Account, KECCAK256_NULL, KECCAK256_RLP } from '@ethereumjs/util'
+import { Account, BIGINT_0, KECCAK256_NULL, KECCAK256_RLP } from '@ethereumjs/util'
 import { debug as createDebugLogger } from 'debug'
 import { keccak256 } from 'ethereum-cryptography/keccak'
 import { bytesToHex, equalsBytes, hexToBytes } from 'ethereum-cryptography/utils'
@@ -443,7 +443,7 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
     error: Error,
     _task: JobTask
   ): { destroyFetcher: boolean; banPeer: boolean; stepBack: bigint } {
-    const stepBack = BigInt(0)
+    const stepBack = BIGINT_0
     const destroyFetcher =
       !(error.message as string).includes(`InvalidRangeProof`) &&
       !(error.message as string).includes(`InvalidAccountRange`)

--- a/packages/client/src/sync/fullsync.ts
+++ b/packages/client/src/sync/fullsync.ts
@@ -1,5 +1,5 @@
 import { Hardfork } from '@ethereumjs/common'
-import { equalsBytes } from '@ethereumjs/util'
+import { BIGINT_0, BIGINT_1, equalsBytes } from '@ethereumjs/util'
 
 import { Event } from '../types'
 import { short } from '../util'
@@ -139,7 +139,7 @@ export class FullSynchronizer extends Synchronizer {
   checkTxPoolState() {
     if (
       this.config.syncTargetHeight === undefined ||
-      this.config.syncTargetHeight === BigInt(0) ||
+      this.config.syncTargetHeight === BIGINT_0 ||
       this.txPool.running
     ) {
       return
@@ -165,7 +165,7 @@ export class FullSynchronizer extends Synchronizer {
     const height = latest.number
     if (
       this.config.syncTargetHeight === undefined ||
-      this.config.syncTargetHeight === BigInt(0) ||
+      this.config.syncTargetHeight === BIGINT_0 ||
       this.config.syncTargetHeight < latest.number
     ) {
       this.config.syncTargetHeight = height
@@ -176,10 +176,10 @@ export class FullSynchronizer extends Synchronizer {
     // due to a reorg, it would make sense to step back and refetch.
     const first =
       this.chain.blocks.height >= BigInt(this.config.safeReorgDistance)
-        ? this.chain.blocks.height - BigInt(this.config.safeReorgDistance) + BigInt(1)
-        : BigInt(1)
-    const count = height - first + BigInt(1)
-    if (count < BigInt(0)) return false
+        ? this.chain.blocks.height - BigInt(this.config.safeReorgDistance) + BIGINT_1
+        : BIGINT_1
+    const count = height - first + BIGINT_1
+    if (count < BIGINT_0) return false
     if (!this.fetcher || this.fetcher.syncErrored) {
       this.fetcher = new BlockFetcher({
         config: this.config,
@@ -191,7 +191,7 @@ export class FullSynchronizer extends Synchronizer {
         destroyWhenDone: false,
       })
     } else {
-      const fetcherHeight = this.fetcher.first + this.fetcher.count - BigInt(1)
+      const fetcherHeight = this.fetcher.first + this.fetcher.count - BIGINT_1
       if (height > fetcherHeight) {
         this.fetcher.count += height - fetcherHeight
         this.config.logger.info(`Updated fetcher target to height=${height} peer=${peer} `)
@@ -306,7 +306,7 @@ export class FullSynchronizer extends Synchronizer {
       // Don't send NEW_BLOCK announcement to peer that sent original new block message
       this.addToKnownByPeer(block.hash(), peer)
     }
-    if (block.header.number > this.chain.headers.height + BigInt(1)) {
+    if (block.header.number > this.chain.headers.height + BIGINT_1) {
       // If the block number exceeds one past our height we cannot validate it
       return
     }
@@ -336,7 +336,7 @@ export class FullSynchronizer extends Synchronizer {
       const blockNumber = block.header.number
       if (
         this.config.syncTargetHeight === undefined ||
-        this.config.syncTargetHeight === BigInt(0) ||
+        this.config.syncTargetHeight === BIGINT_0 ||
         blockNumber > this.config.syncTargetHeight
       ) {
         this.config.syncTargetHeight = blockNumber
@@ -373,7 +373,7 @@ export class FullSynchronizer extends Synchronizer {
       if (newSyncHeight && blockNumber <= newSyncHeight[1]) continue
       if (
         typeof this.config.syncTargetHeight === 'bigint' &&
-        this.config.syncTargetHeight !== BigInt(0) &&
+        this.config.syncTargetHeight !== BIGINT_0 &&
         blockNumber <= this.config.syncTargetHeight
       )
         continue
@@ -397,7 +397,7 @@ export class FullSynchronizer extends Synchronizer {
     // Batch the execution if we are not close to the head
     const shouldRunOnlyBatched =
       typeof this.config.syncTargetHeight === 'bigint' &&
-      this.config.syncTargetHeight !== BigInt(0) &&
+      this.config.syncTargetHeight !== BIGINT_0 &&
       this.chain.blocks.height <= this.config.syncTargetHeight - BigInt(50)
     this.execution.run(true, shouldRunOnlyBatched).catch((e) => {
       this.config.logger.error(`Full sync execution trigger errored`, {}, e)

--- a/packages/client/src/sync/lightsync.ts
+++ b/packages/client/src/sync/lightsync.ts
@@ -1,4 +1,5 @@
 import { Hardfork } from '@ethereumjs/common'
+import { BIGINT_0, BIGINT_1 } from '@ethereumjs/util'
 
 import { Event } from '../types'
 import { short } from '../util'
@@ -106,7 +107,7 @@ export class LightSynchronizer extends Synchronizer {
     const height = peer!.les!.status.headNum
     if (
       this.config.syncTargetHeight === undefined ||
-      this.config.syncTargetHeight === BigInt(0) ||
+      this.config.syncTargetHeight === BIGINT_0 ||
       this.config.syncTargetHeight < height
     ) {
       this.config.syncTargetHeight = height
@@ -117,10 +118,10 @@ export class LightSynchronizer extends Synchronizer {
     // due to a reorg, it would make sense to step back and refetch.
     const first =
       this.chain.headers.height >= BigInt(this.config.safeReorgDistance)
-        ? this.chain.headers.height - BigInt(this.config.safeReorgDistance) + BigInt(1)
-        : BigInt(1)
-    const count = height - first + BigInt(1)
-    if (count < BigInt(0)) return false
+        ? this.chain.headers.height - BigInt(this.config.safeReorgDistance) + BIGINT_1
+        : BIGINT_1
+    const count = height - first + BIGINT_1
+    if (count < BIGINT_0) return false
     if (!this.fetcher || this.fetcher.syncErrored) {
       this.fetcher = new HeaderFetcher({
         config: this.config,
@@ -133,7 +134,7 @@ export class LightSynchronizer extends Synchronizer {
         destroyWhenDone: false,
       })
     } else {
-      const fetcherHeight = this.fetcher.first + this.fetcher.count - BigInt(1)
+      const fetcherHeight = this.fetcher.first + this.fetcher.count - BIGINT_1
       if (height > fetcherHeight) {
         this.fetcher.count += height - fetcherHeight
         this.config.logger.info(`Updated fetcher target to height=${height} peer=${peer} `)

--- a/packages/client/src/sync/snapsync.ts
+++ b/packages/client/src/sync/snapsync.ts
@@ -1,5 +1,5 @@
 import { DefaultStateManager } from '@ethereumjs/statemanager'
-import { bytesToHex } from '@ethereumjs/util'
+import { BIGINT_0, bytesToHex } from '@ethereumjs/util'
 
 import { Event } from '../types'
 
@@ -132,7 +132,7 @@ export class SnapSynchronizer extends Synchronizer {
       pool: this.pool,
       root: stateRoot,
       // This needs to be determined from the current state of the MPT dump
-      first: BigInt(0),
+      first: BIGINT_0,
     })
 
     return true

--- a/packages/client/src/sync/sync.ts
+++ b/packages/client/src/sync/sync.ts
@@ -1,4 +1,5 @@
 import { Hardfork } from '@ethereumjs/common'
+import { BIGINT_0 } from '@ethereumjs/util'
 
 import { FlowControl } from '../net/protocol'
 import { Event } from '../types'
@@ -63,7 +64,7 @@ export abstract class Synchronizer {
     this.opened = false
     this.running = false
     this.forceSync = false
-    this.startingBlock = BigInt(0)
+    this.startingBlock = BIGINT_0
 
     this.config.events.on(Event.POOL_PEER_ADDED, (peer) => {
       if (this.syncable(peer)) {

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -2,7 +2,13 @@ import { BlockHeader } from '@ethereumjs/block'
 import { Blockchain } from '@ethereumjs/blockchain'
 import { Chain as ChainEnum, Common, parseGethGenesis } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
-import { Address, KECCAK256_RLP, hexToBytes, parseGethGenesisState } from '@ethereumjs/util'
+import {
+  Address,
+  BIGINT_1,
+  KECCAK256_RLP,
+  hexToBytes,
+  parseGethGenesisState,
+} from '@ethereumjs/util'
 import { Server as RPCServer } from 'jayson/promise'
 import { MemoryLevel } from 'memory-level'
 import { assert } from 'vitest'
@@ -282,7 +288,7 @@ export async function runBlockWithTxs(
   const blockBuilder = await vmCopy.buildBlock({
     parentBlock,
     headerData: {
-      timestamp: parentBlock.header.timestamp + BigInt(1),
+      timestamp: parentBlock.header.timestamp + BIGINT_1,
     },
     blockOpts: {
       calcDifficultyFromHeader: parentBlock.header,

--- a/packages/client/test/sim/simutils.ts
+++ b/packages/client/test/sim/simutils.ts
@@ -3,6 +3,7 @@ import { Blockchain } from '@ethereumjs/blockchain'
 import { BlobEIP4844Transaction, FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
 import {
   Address,
+  BIGINT_1,
   blobsToCommitments,
   blobsToProofs,
   bytesToHex,
@@ -340,7 +341,7 @@ export const runBlobTx = async (
   }
 
   txData.maxFeePerGas = '0xff'
-  txData.maxPriorityFeePerGas = BigInt(1)
+  txData.maxPriorityFeePerGas = BIGINT_1
   txData.maxFeePerBlobGas = BigInt(1000)
   txData.gasLimit = BigInt(1000000)
   const nonce = await client.request('eth_getTransactionCount', [sender.toString(), 'latest'], 2.0)

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -1,4 +1,5 @@
 import {
+  BIGINT_0,
   TypeOutput,
   bytesToHex,
   concatBytes,
@@ -685,7 +686,7 @@ export class Common {
     blockNumber = toType(blockNumber, TypeOutput.BigInt)
     hardfork = hardfork ?? this._hardfork
     const hfBlock = this.hardforkBlock(hardfork)
-    if (typeof hfBlock === 'bigint' && hfBlock !== BigInt(0) && blockNumber >= hfBlock) {
+    if (typeof hfBlock === 'bigint' && hfBlock !== BIGINT_0 && blockNumber >= hfBlock) {
       return true
     }
     return false

--- a/packages/common/src/enums.ts
+++ b/packages/common/src/enums.ts
@@ -1,4 +1,4 @@
-import { hexToBytes } from '@ethereumjs/util'
+import { BIGINT_0, hexToBytes } from '@ethereumjs/util'
 
 export enum Chain {
   Mainnet = 1,
@@ -23,19 +23,19 @@ type GenesisState = {
  */
 export const ChainGenesis: Record<Chain, GenesisState> = {
   [Chain.Mainnet]: {
-    blockNumber: BigInt(0),
+    blockNumber: BIGINT_0,
     stateRoot: hexToBytes('0xd7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544'),
   },
   [Chain.Goerli]: {
-    blockNumber: BigInt(0),
+    blockNumber: BIGINT_0,
     stateRoot: hexToBytes('0x5d6cded585e73c4e322c30c2f782a336316f17dd85a4863b9d838d2d4b8b3008'),
   },
   [Chain.Sepolia]: {
-    blockNumber: BigInt(0),
+    blockNumber: BIGINT_0,
     stateRoot: hexToBytes('0x5eb6e371a698b8d68f665192350ffcecbbbf322916f4b51bd79bb6887da3f494'),
   },
   [Chain.Holesky]: {
-    blockNumber: BigInt(0),
+    blockNumber: BIGINT_0,
     stateRoot: hexToBytes('0x69d8c9d72f6fa4ad42d4702b433707212f90db395eb54dc20bc85de253788783'),
   },
 }

--- a/packages/devp2p/src/protocol/eth.ts
+++ b/packages/devp2p/src/protocol/eth.ts
@@ -1,5 +1,6 @@
 import { RLP } from '@ethereumjs/rlp'
 import {
+  BIGINT_0,
   bigIntToBytes,
   bytesToBigInt,
   bytesToHex,
@@ -26,9 +27,9 @@ export class ETH extends Protocol {
 
   // Eth64
   protected _hardfork: string = 'chainstart'
-  protected _latestBlock = BigInt(0)
+  protected _latestBlock = BIGINT_0
   protected _forkHash: string = ''
-  protected _nextForkBlock = BigInt(0)
+  protected _nextForkBlock = BIGINT_0
 
   constructor(version: number, peer: Peer, send: SendMethod) {
     super(peer, send, ProtocolType.ETH, version, ETH.MESSAGE_CODES)
@@ -39,10 +40,10 @@ export class ETH extends Protocol {
       this._hardfork = c.hardfork() ?? this._hardfork
       // Set latestBlock minimally to start block of fork to have some more
       // accurate basis if no latestBlock is provided along status send
-      this._latestBlock = c.hardforkBlock(this._hardfork) ?? BigInt(0)
+      this._latestBlock = c.hardforkBlock(this._hardfork) ?? BIGINT_0
       this._forkHash = c.forkHash(this._hardfork)
       // Next fork block number or 0 if none available
-      this._nextForkBlock = c.nextHardforkBlockOrTimestamp(this._hardfork) ?? BigInt(0)
+      this._nextForkBlock = c.nextHardforkBlockOrTimestamp(this._hardfork) ?? BIGINT_0
     }
 
     // Skip DEBUG calls unless 'ethjs' included in environmental DEBUG variables
@@ -145,7 +146,7 @@ export class ETH extends Protocol {
 
     if (this._forkHash === peerForkHash) {
       // There is a known next fork
-      if (peerNextFork > BigInt(0)) {
+      if (peerNextFork > BIGINT_0) {
         if (this._latestBlock >= peerNextFork) {
           const msg = 'Remote is advertising a future fork that passed locally'
           if (this.DEBUG) {
@@ -292,7 +293,7 @@ export class ETH extends Protocol {
       const forkHashB = hexToBytes(this._forkHash)
 
       const nextForkB =
-        this._nextForkBlock === BigInt(0) ? new Uint8Array() : bigIntToBytes(this._nextForkBlock)
+        this._nextForkBlock === BIGINT_0 ? new Uint8Array() : bigIntToBytes(this._nextForkBlock)
 
       this._status.push([forkHashB, nextForkB])
     }

--- a/packages/ethash/src/index.ts
+++ b/packages/ethash/src/index.ts
@@ -1,6 +1,7 @@
 import { Block, BlockHeader } from '@ethereumjs/block'
 import { RLP } from '@ethereumjs/rlp'
 import {
+  BIGINT_0,
   KeyEncoding,
   TWO_POW256,
   ValueEncoding,
@@ -69,7 +70,7 @@ export class Miner {
     } else {
       throw new Error('unsupported mineObject')
     }
-    this.currentNonce = BigInt(0)
+    this.currentNonce = BIGINT_0
     this.ethash = ethash
     this.stopMining = false
   }

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -4,6 +4,8 @@ import {
   Account,
   Address,
   AsyncEventEmitter,
+  BIGINT_0,
+  BIGINT_1,
   KECCAK256_NULL,
   MAX_INTEGER,
   bigIntToBytes,
@@ -265,7 +267,7 @@ export class EVM implements EVMInterface {
       return {
         execResult: {
           gasRefund: message.gasRefund,
-          executionGasUsed: BigInt(0),
+          executionGasUsed: BIGINT_0,
           exceptionError: errorMessage, // Only defined if addToBalance failed
           returnValue: new Uint8Array(0),
         },
@@ -350,7 +352,7 @@ export class EVM implements EVMInterface {
 
     // Check for collision
     if (
-      (toAccount.nonce && toAccount.nonce > BigInt(0)) ||
+      (toAccount.nonce && toAccount.nonce > BIGINT_0) ||
       !(equalsBytes(toAccount.codeHash, KECCAK256_NULL) === true)
     ) {
       if (this.DEBUG) {
@@ -382,7 +384,7 @@ export class EVM implements EVMInterface {
     }
     // EIP-161 on account creation and CREATE execution
     if (this.common.gteHardfork(Hardfork.SpuriousDragon)) {
-      toAccount.nonce += BigInt(1)
+      toAccount.nonce += BIGINT_1
     }
 
     // Add tx value to the `to` account
@@ -410,7 +412,7 @@ export class EVM implements EVMInterface {
       return {
         createdAddress: message.to,
         execResult: {
-          executionGasUsed: BigInt(0),
+          executionGasUsed: BIGINT_0,
           gasRefund: message.gasRefund,
           exceptionError: errorMessage, // only defined if addToBalance failed
           returnValue: new Uint8Array(0),
@@ -425,7 +427,7 @@ export class EVM implements EVMInterface {
     let result = await this.runInterpreter(message)
     // fee for size of the return value
     let totalGas = result.executionGasUsed
-    let returnFee = BigInt(0)
+    let returnFee = BIGINT_0
     if (!result.exceptionError) {
       returnFee =
         BigInt(result.returnValue.length) * BigInt(this.common.param('gasPrices', 'createData'))
@@ -557,7 +559,7 @@ export class EVM implements EVMInterface {
       address: message.to ?? Address.zero(),
       caller: message.caller ?? Address.zero(),
       callData: message.data ?? Uint8Array.from([0]),
-      callValue: message.value ?? BigInt(0),
+      callValue: message.value ?? BIGINT_0,
       code: message.code as Uint8Array,
       isStatic: message.isStatic ?? false,
       depth: message.depth ?? 0,
@@ -636,12 +638,12 @@ export class EVM implements EVMInterface {
     if (!message) {
       this._block = opts.block ?? defaultBlock()
       this._tx = {
-        gasPrice: opts.gasPrice ?? BigInt(0),
+        gasPrice: opts.gasPrice ?? BIGINT_0,
         origin: opts.origin ?? opts.caller ?? Address.zero(),
       }
       const caller = opts.caller ?? Address.zero()
 
-      const value = opts.value ?? BigInt(0)
+      const value = opts.value ?? BIGINT_0
       if (opts.skipBalance === true) {
         callerAccount = await this.stateManager.getAccount(caller)
         if (!callerAccount) {
@@ -737,7 +739,7 @@ export class EVM implements EVMInterface {
     if (err && err.error !== ERROR.CODESTORE_OUT_OF_GAS) {
       result.execResult.selfdestruct = new Set()
       result.execResult.createdAddresses = new Set()
-      result.execResult.gasRefund = BigInt(0)
+      result.execResult.gasRefund = BIGINT_0
     }
     if (
       err &&
@@ -769,7 +771,7 @@ export class EVM implements EVMInterface {
     this._block = opts.block ?? defaultBlock()
 
     this._tx = {
-      gasPrice: opts.gasPrice ?? BigInt(0),
+      gasPrice: opts.gasPrice ?? BIGINT_0,
       origin: opts.origin ?? opts.caller ?? Address.zero(),
     }
 
@@ -848,7 +850,7 @@ export class EVM implements EVMInterface {
       if (!acc) {
         acc = new Account()
       }
-      const newNonce = acc.nonce - BigInt(1)
+      const newNonce = acc.nonce - BIGINT_1
       addr = generateAddress(message.caller.bytes, bigIntToBytes(newNonce))
     }
     return new Address(addr)
@@ -856,7 +858,7 @@ export class EVM implements EVMInterface {
 
   protected async _reduceSenderBalance(account: Account, message: Message): Promise<void> {
     account.balance -= message.value
-    if (account.balance < BigInt(0)) {
+    if (account.balance < BIGINT_0) {
       throw new EvmError(ERROR.INSUFFICIENT_BALANCE)
     }
     const result = this.journal.putAccount(message.authcallOrigin ?? message.caller, account)
@@ -969,13 +971,13 @@ export function EvmErrorResult(error: EvmError, gasUsed: bigint): ExecResult {
 export function defaultBlock(): Block {
   return {
     header: {
-      number: BigInt(0),
+      number: BIGINT_0,
       cliqueSigner: () => Address.zero(),
       coinbase: Address.zero(),
-      timestamp: BigInt(0),
-      difficulty: BigInt(0),
+      timestamp: BIGINT_0,
+      difficulty: BIGINT_0,
       prevRandao: zeros(32),
-      gasLimit: BigInt(0),
+      gasLimit: BIGINT_0,
       baseFeePerGas: undefined,
       getBlobGasPrice: () => undefined,
     },

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -1,6 +1,8 @@
 import { ConsensusAlgorithm } from '@ethereumjs/common'
 import {
   Account,
+  BIGINT_0,
+  BIGINT_1,
   MAX_UINT64,
   bigIntToHex,
   bytesToBigInt,
@@ -156,8 +158,8 @@ export class Interpreter {
       programCounter: 0,
       opCode: 0xfe, // INVALID opcode
       memory: new Memory(),
-      memoryWordCount: BigInt(0),
-      highestMemCost: BigInt(0),
+      memoryWordCount: BIGINT_0,
+      highestMemCost: BIGINT_0,
       stack: new Stack(),
       returnStack: new Stack(1023), // 1023 return stack height limit per EIP 2315 spec
       code: new Uint8Array(0),
@@ -459,8 +461,8 @@ export class Interpreter {
       }
       debugGas(`${tstr}used ${amount} gas (-> ${this._runState.gasLeft})`)
     }
-    if (this._runState.gasLeft < BigInt(0)) {
-      this._runState.gasLeft = BigInt(0)
+    if (this._runState.gasLeft < BIGINT_0) {
+      this._runState.gasLeft = BIGINT_0
       trap(ERROR.OUT_OF_GAS)
     }
   }
@@ -495,8 +497,8 @@ export class Interpreter {
       )
     }
     this._runState.gasRefund -= amount
-    if (this._runState.gasRefund < BigInt(0)) {
-      this._runState.gasRefund = BigInt(0)
+    if (this._runState.gasRefund < BIGINT_0) {
+      this._runState.gasRefund = BIGINT_0
       trap(ERROR.REFUND_EXHAUSTED)
     }
   }
@@ -918,7 +920,7 @@ export class Interpreter {
       this._env.depth >= Number(this.common.param('vm', 'stackLimit')) ||
       (msg.delegatecall !== true && this._env.contract.balance < msg.value)
     ) {
-      return BigInt(0)
+      return BIGINT_0
     }
 
     let timer: Timer
@@ -962,7 +964,7 @@ export class Interpreter {
         throw new Error('could not read contract account')
       }
       this._env.contract = account
-      this._runState.gasRefund = results.execResult.gasRefund ?? BigInt(0)
+      this._runState.gasRefund = results.execResult.gasRefund ?? BIGINT_0
     }
 
     return this._getReturnCode(results)
@@ -989,15 +991,15 @@ export class Interpreter {
       this._env.depth >= Number(this.common.param('vm', 'stackLimit')) ||
       this._env.contract.balance < value
     ) {
-      return BigInt(0)
+      return BIGINT_0
     }
 
     // EIP-2681 check
     if (this._env.contract.nonce >= MAX_UINT64) {
-      return BigInt(0)
+      return BIGINT_0
     }
 
-    this._env.contract.nonce += BigInt(1)
+    this._env.contract.nonce += BIGINT_1
     await this.journal.putAccount(this._env.address, this._env.contract)
 
     if (this.common.isActivatedEIP(3860)) {
@@ -1005,7 +1007,7 @@ export class Interpreter {
         data.length > Number(this.common.param('vm', 'maxInitCodeSize')) &&
         this._evm.allowUnlimitedInitCodeSize === false
       ) {
-        return BigInt(0)
+        return BIGINT_0
       }
     }
 
@@ -1070,7 +1072,7 @@ export class Interpreter {
         throw new Error('could not read contract account')
       }
       this._env.contract = account
-      this._runState.gasRefund = results.execResult.gasRefund ?? BigInt(0)
+      this._runState.gasRefund = results.execResult.gasRefund ?? BIGINT_0
       if (results.createdAddress) {
         // push the created address to the stack
         return bytesToBigInt(results.createdAddress.bytes)
@@ -1141,7 +1143,7 @@ export class Interpreter {
     // Set contract balance to 0
     if (doModify) {
       await this._stateManager.modifyAccountFields(this._env.address, {
-        balance: BigInt(0),
+        balance: BIGINT_0,
       })
     }
 
@@ -1166,9 +1168,9 @@ export class Interpreter {
 
   private _getReturnCode(results: EVMResult) {
     if (results.execResult.exceptionError) {
-      return BigInt(0)
+      return BIGINT_0
     } else {
-      return BigInt(1)
+      return BIGINT_1
     }
   }
 }

--- a/packages/evm/src/message.ts
+++ b/packages/evm/src/message.ts
@@ -1,16 +1,16 @@
-import { Address } from '@ethereumjs/util'
+import { Address, BIGINT_0 } from '@ethereumjs/util'
 
 import type { PrecompileFunc } from './precompiles/index.js'
 
 const defaults = {
-  value: BigInt(0),
+  value: BIGINT_0,
   caller: Address.zero(),
   data: new Uint8Array(0),
   depth: 0,
   isStatic: false,
   isCompiled: false,
   delegatecall: false,
-  gasRefund: BigInt(0),
+  gasRefund: BIGINT_0,
 }
 
 interface MessageOpts {

--- a/packages/evm/src/opcodes/EIP2929.ts
+++ b/packages/evm/src/opcodes/EIP2929.ts
@@ -1,6 +1,7 @@
+import { type Address, BIGINT_0 } from '@ethereumjs/util'
+
 import type { RunState } from '../interpreter.js'
 import type { Common } from '@ethereumjs/common'
-import type { Address } from '@ethereumjs/util'
 
 /**
  * Adds address to accessedAddresses set if not already included.
@@ -19,7 +20,7 @@ export function accessAddressEIP2929(
   chargeGas = true,
   isSelfdestructOrAuthcall = false
 ): bigint {
-  if (common.isActivatedEIP(2929) === false) return BigInt(0)
+  if (common.isActivatedEIP(2929) === false) return BIGINT_0
 
   const addressStr = address.bytes
 
@@ -36,7 +37,7 @@ export function accessAddressEIP2929(
   } else if (chargeGas && !isSelfdestructOrAuthcall) {
     return common.param('gasPrices', 'warmstorageread')
   }
-  return BigInt(0)
+  return BIGINT_0
 }
 
 /**
@@ -53,7 +54,7 @@ export function accessStorageEIP2929(
   isSstore: boolean,
   common: Common
 ): bigint {
-  if (common.isActivatedEIP(2929) === false) return BigInt(0)
+  if (common.isActivatedEIP(2929) === false) return BIGINT_0
 
   const address = runState.interpreter.getAddress().bytes
   const slotIsCold = !runState.interpreter.journal.isWarmedStorage(address, key)
@@ -65,7 +66,7 @@ export function accessStorageEIP2929(
   } else if (!isSstore) {
     return common.param('gasPrices', 'warmstorageread')
   }
-  return BigInt(0)
+  return BIGINT_0
 }
 
 /**

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -2,7 +2,21 @@ import {
   Address,
   BIGINT_0,
   BIGINT_1,
+  BIGINT_128,
+  BIGINT_160,
   BIGINT_2,
+  BIGINT_224,
+  BIGINT_255,
+  BIGINT_256,
+  BIGINT_27,
+  BIGINT_2EXP160,
+  BIGINT_2EXP224,
+  BIGINT_2EXP96,
+  BIGINT_31,
+  BIGINT_32,
+  BIGINT_7,
+  BIGINT_8,
+  BIGINT_96,
   MAX_INTEGER_BIGINT,
   SECP256K1_ORDER_DIV_2,
   TWO_POW256,
@@ -38,13 +52,6 @@ import type { RunState } from '../interpreter.js'
 import type { Common } from '@ethereumjs/common'
 
 const EIP3074MAGIC = hexToBytes('0x03')
-
-const BIGINT_96 = BigInt(96)
-const BIGINT_160 = BigInt(160)
-const BIGINT_224 = BigInt(224)
-const BIGINT_2EXP96 = BigInt(79228162514264337593543950336)
-const BIGINT_2EXP160 = BigInt(1461501637330902918203684832716283019655932542976)
-const BIGINT_2EXP224 = BigInt(26959946667150639794667015087019630673637144422540572481103610249216)
 
 export interface SyncOpHandler {
   (runState: RunState, common: Common): void
@@ -213,8 +220,8 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       /* eslint-disable-next-line prefer-const */
       let [k, val] = runState.stack.popN(2)
-      if (k < BigInt(31)) {
-        const signBit = k * BigInt(8) + BigInt(7)
+      if (k < BIGINT_31) {
+        const signBit = k * BIGINT_8 + BIGINT_7
         const mask = (BIGINT_1 << signBit) - BIGINT_1
         if ((val >> signBit) & BIGINT_1) {
           val = val | BigInt.asUintN(256, ~mask)
@@ -321,12 +328,12 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x1a,
     function (runState) {
       const [pos, word] = runState.stack.popN(2)
-      if (pos > BigInt(32)) {
+      if (pos > BIGINT_32) {
         runState.stack.push(BIGINT_0)
         return
       }
 
-      const r = (word >> ((BigInt(31) - pos) * BigInt(8))) & BigInt(0xff)
+      const r = (word >> ((BIGINT_31 - pos) * BIGINT_8)) & BIGINT_255
       runState.stack.push(r)
     },
   ],
@@ -335,7 +342,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     0x1b,
     function (runState) {
       const [a, b] = runState.stack.popN(2)
-      if (a > BigInt(256)) {
+      if (a > BIGINT_256) {
         runState.stack.push(BIGINT_0)
         return
       }
@@ -379,7 +386,7 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       const c = b >> a
       if (isSigned) {
-        const shiftedOutWidth = BigInt(255) - a
+        const shiftedOutWidth = BIGINT_255 - a
         const mask = (MAX_INTEGER_BIGINT >> shiftedOutWidth) << shiftedOutWidth
         r = c | mask
       } else {
@@ -457,7 +464,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       loaded = loaded.length ? loaded : Uint8Array.from([0])
       let r = bytesToBigInt(loaded)
       if (loaded.length < 32) {
-        r = r << (BigInt(8) * BigInt(32 - loaded.length))
+        r = r << (BIGINT_8 * BigInt(32 - loaded.length))
       }
       runState.stack.push(r)
     },
@@ -591,7 +598,7 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       const diff = runState.interpreter.getBlockNumber() - number
       // block lookups must be within the past 256 blocks
-      if (diff > BigInt(256) || diff <= BIGINT_0) {
+      if (diff > BIGINT_256 || diff <= BIGINT_0) {
         runState.stack.push(BIGINT_0)
         return
       }
@@ -713,7 +720,7 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState) {
       const [offset, byte] = runState.stack.popN(2)
 
-      const buf = bigIntToBytes(byte & BigInt(0xff))
+      const buf = bigIntToBytes(byte & BIGINT_255)
       const offsetNum = Number(offset)
       runState.memory.write(offsetNum, 1, buf)
     },
@@ -796,7 +803,7 @@ export const handlers: Map<number, OpHandler> = new Map([
   [
     0x59,
     function (runState) {
-      runState.stack.push(runState.memoryWordCount * BigInt(32))
+      runState.stack.push(runState.memoryWordCount * BIGINT_32)
     },
   ],
   // 0x5a: GAS
@@ -1089,8 +1096,8 @@ export const handlers: Map<number, OpHandler> = new Map([
       // eslint-disable-next-line prefer-const
       let [authority, memOffset, memLength] = runState.stack.popN(3)
 
-      if (memLength > BigInt(128)) {
-        memLength = BigInt(128)
+      if (memLength > BIGINT_128) {
+        memLength = BIGINT_128
       }
 
       let mem = runState.memory.read(Number(memOffset), Number(memLength))
@@ -1114,7 +1121,7 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       let recover
       try {
-        recover = ecrecover(msgHash, yParity + BigInt(27), r, s)
+        recover = ecrecover(msgHash, yParity + BIGINT_27, r, s)
       } catch (e) {
         // Malformed signature, push 0 on stack, clear auth variable
         runState.stack.push(BIGINT_0)

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -1,5 +1,8 @@
 import {
   Address,
+  BIGINT_0,
+  BIGINT_1,
+  BIGINT_2,
   MAX_INTEGER_BIGINT,
   SECP256K1_ORDER_DIV_2,
   TWO_POW256,
@@ -36,9 +39,6 @@ import type { Common } from '@ethereumjs/common'
 
 const EIP3074MAGIC = hexToBytes('0x03')
 
-const BIGINT_0 = BigInt(0)
-const BIGINT_1 = BigInt(1)
-const BIGINT_2 = BigInt(2)
 const BIGINT_96 = BigInt(96)
 const BIGINT_160 = BigInt(160)
 const BIGINT_224 = BigInt(224)

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -1,5 +1,5 @@
 import { Hardfork } from '@ethereumjs/common'
-import { Address, bigIntToBytes, setLengthLeft } from '@ethereumjs/util'
+import { Address, BIGINT_0, BIGINT_1, bigIntToBytes, setLengthLeft } from '@ethereumjs/util'
 
 import { ERROR } from '../exceptions.js'
 
@@ -19,8 +19,6 @@ import {
 import type { RunState } from '../interpreter.js'
 import type { Common } from '@ethereumjs/common'
 
-const BIGINT_0 = BigInt(0)
-const BIGINT_1 = BigInt(1)
 const BIGINT_31 = BigInt(31)
 const BIGINT_32 = BigInt(32)
 

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -1,5 +1,14 @@
 import { Hardfork } from '@ethereumjs/common'
-import { Address, BIGINT_0, BIGINT_1, bigIntToBytes, setLengthLeft } from '@ethereumjs/util'
+import {
+  Address,
+  BIGINT_0,
+  BIGINT_1,
+  BIGINT_3,
+  BIGINT_31,
+  BIGINT_32,
+  bigIntToBytes,
+  setLengthLeft,
+} from '@ethereumjs/util'
 
 import { ERROR } from '../exceptions.js'
 
@@ -18,9 +27,6 @@ import {
 
 import type { RunState } from '../interpreter.js'
 import type { Common } from '@ethereumjs/common'
-
-const BIGINT_31 = BigInt(31)
-const BIGINT_32 = BigInt(32)
 
 /**
  * This file returns the dynamic parts of opcodes which have dynamic gas
@@ -270,7 +276,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       async function (runState, gas, common): Promise<bigint> {
         const [dst, src, length] = runState.stack.peek(3)
         const wordsCopied = (length + BIGINT_31) / BIGINT_32
-        gas += BigInt(3) * wordsCopied
+        gas += BIGINT_3 * wordsCopied
         gas += subMemUsage(runState, src, length, common)
         gas += subMemUsage(runState, dst, length, common)
         return gas

--- a/packages/evm/src/opcodes/util.ts
+++ b/packages/evm/src/opcodes/util.ts
@@ -2,7 +2,11 @@ import { Hardfork } from '@ethereumjs/common'
 import {
   BIGINT_0,
   BIGINT_1,
+  BIGINT_160,
   BIGINT_2,
+  BIGINT_32,
+  BIGINT_64,
+  BIGINT_NEG1,
   bigIntToBytes,
   bytesToHex,
   equalsBytes,
@@ -17,7 +21,7 @@ import type { ERROR } from '../exceptions.js'
 import type { RunState } from '../interpreter.js'
 import type { Common } from '@ethereumjs/common'
 
-const MASK_160 = (BIGINT_1 << BigInt(160)) - BIGINT_1
+const MASK_160 = (BIGINT_1 << BIGINT_160) - BIGINT_1
 
 /**
  * Proxy function for @ethereumjs/util's setLengthLeft, except it returns a zero
@@ -153,7 +157,7 @@ export function maxCallGas(
   common: Common
 ): bigint {
   if (common.gteHardfork(Hardfork.TangerineWhistle)) {
-    const gasAllowed = gasLeft - gasLeft / BigInt(64)
+    const gasAllowed = gasLeft - gasLeft / BIGINT_64
     return gasLimit > gasAllowed ? gasAllowed : gasLimit
   } else {
     return gasLimit
@@ -167,7 +171,7 @@ export function subMemUsage(runState: RunState, offset: bigint, length: bigint, 
   // YP (225): access with zero length will not extend the memory
   if (length === BIGINT_0) return BIGINT_0
 
-  const newMemoryWordCount = divCeil(offset + length, BigInt(32))
+  const newMemoryWordCount = divCeil(offset + length, BIGINT_32)
   if (newMemoryWordCount <= runState.memoryWordCount) return BIGINT_0
 
   const words = newMemoryWordCount
@@ -255,7 +259,7 @@ export function abs(a: bigint) {
   if (a > 0) {
     return a
   }
-  return a * BigInt(-1)
+  return a * BIGINT_NEG1
 }
 
 const N = BigInt(115792089237316195423570985008687907853269984665640564039457584007913129639936)

--- a/packages/evm/src/opcodes/util.ts
+++ b/packages/evm/src/opcodes/util.ts
@@ -1,5 +1,8 @@
 import { Hardfork } from '@ethereumjs/common'
 import {
+  BIGINT_0,
+  BIGINT_1,
+  BIGINT_2,
   bigIntToBytes,
   bytesToHex,
   equalsBytes,
@@ -14,7 +17,7 @@ import type { ERROR } from '../exceptions.js'
 import type { RunState } from '../interpreter.js'
 import type { Common } from '@ethereumjs/common'
 
-const MASK_160 = (BigInt(1) << BigInt(160)) - BigInt(1)
+const MASK_160 = (BIGINT_1 << BigInt(160)) - BIGINT_1
 
 /**
  * Proxy function for @ethereumjs/util's setLengthLeft, except it returns a zero
@@ -68,10 +71,10 @@ export function divCeil(a: bigint, b: bigint): bigint {
   const modulus = mod(a, b)
 
   // Fast case - exact division
-  if (modulus === BigInt(0)) return div
+  if (modulus === BIGINT_0) return div
 
   // Round up
-  return div < BigInt(0) ? div - BigInt(1) : div + BigInt(1)
+  return div < BIGINT_0 ? div - BIGINT_1 : div + BIGINT_1
 }
 
 /**
@@ -162,10 +165,10 @@ export function maxCallGas(
  */
 export function subMemUsage(runState: RunState, offset: bigint, length: bigint, common: Common) {
   // YP (225): access with zero length will not extend the memory
-  if (length === BigInt(0)) return BigInt(0)
+  if (length === BIGINT_0) return BIGINT_0
 
   const newMemoryWordCount = divCeil(offset + length, BigInt(32))
-  if (newMemoryWordCount <= runState.memoryWordCount) return BigInt(0)
+  if (newMemoryWordCount <= runState.memoryWordCount) return BIGINT_0
 
   const words = newMemoryWordCount
   const fee = common.param('gasPrices', 'memory')
@@ -195,7 +198,7 @@ export function writeCallOutput(runState: RunState, outOffset: bigint, outLength
     if (BigInt(returnData.length) < dataLength) {
       dataLength = returnData.length
     }
-    const data = getDataSlice(returnData, BigInt(0), BigInt(dataLength))
+    const data = getDataSlice(returnData, BIGINT_0, BigInt(dataLength))
     runState.memory.extend(memOffset, dataLength)
     runState.memory.write(memOffset, dataLength, data)
   }
@@ -234,7 +237,7 @@ export function updateSstoreGas(
 
 export function mod(a: bigint, b: bigint) {
   let r = a % b
-  if (r < BigInt(0)) {
+  if (r < BIGINT_0) {
     r = b + r
   }
   return r
@@ -257,13 +260,13 @@ export function abs(a: bigint) {
 
 const N = BigInt(115792089237316195423570985008687907853269984665640564039457584007913129639936)
 export function exponentiation(bas: bigint, exp: bigint) {
-  let t = BigInt(1)
-  while (exp > BigInt(0)) {
-    if (exp % BigInt(2) !== BigInt(0)) {
+  let t = BIGINT_1
+  while (exp > BIGINT_0) {
+    if (exp % BIGINT_2 !== BIGINT_0) {
       t = (t * bas) % N
     }
     bas = (bas * bas) % N
-    exp = exp / BigInt(2)
+    exp = exp / BIGINT_2
   }
   return t
 }

--- a/packages/evm/src/precompiles/01-ecrecover.ts
+++ b/packages/evm/src/precompiles/01-ecrecover.ts
@@ -1,4 +1,6 @@
 import {
+  BIGINT_27,
+  BIGINT_28,
   bytesToBigInt,
   bytesToHex,
   ecrecover,
@@ -39,7 +41,7 @@ export function precompile01(opts: PrecompileInput): ExecResult {
   // Guard against util's `ecrecover`: without providing chainId this will return
   // a signature in most of the cases in the cases that `v=0` or `v=1`
   // However, this should throw, only 27 and 28 is allowed as input
-  if (vBigInt !== BigInt(27) && vBigInt !== BigInt(28)) {
+  if (vBigInt !== BIGINT_27 && vBigInt !== BIGINT_28) {
     if (opts._debug !== undefined) {
       opts._debug(`ECRECOVER (0x01) failed: v neither 27 nor 28`)
     }

--- a/packages/evm/src/precompiles/05-modexp.ts
+++ b/packages/evm/src/precompiles/05-modexp.ts
@@ -1,4 +1,7 @@
 import {
+  BIGINT_0,
+  BIGINT_1,
+  BIGINT_2,
   bigIntToBytes,
   bytesToBigInt,
   bytesToHex,
@@ -16,15 +19,15 @@ function multComplexity(x: bigint): bigint {
   let fac1
   let fac2
   if (x <= BigInt(64)) {
-    return x ** BigInt(2)
+    return x ** BIGINT_2
   } else if (x <= BigInt(1024)) {
     // return Math.floor(Math.pow(x, 2) / 4) + 96 * x - 3072
-    fac1 = x ** BigInt(2) / BigInt(4)
+    fac1 = x ** BIGINT_2 / BigInt(4)
     fac2 = x * BigInt(96)
     return fac1 + fac2 - BigInt(3072)
   } else {
     // return Math.floor(Math.pow(x, 2) / 16) + 480 * x - 199680
-    fac1 = x ** BigInt(2) / BigInt(16)
+    fac1 = x ** BIGINT_2 / BigInt(16)
     fac2 = x * BigInt(480)
     return fac1 + fac2 - BigInt(199680)
   }
@@ -54,13 +57,13 @@ function getAdjustedExponentLength(data: Uint8Array): bigint {
   firstExpBigInt = firstExpBigInt >> (BigInt(8) * BigInt(Math.max(max32expLen, 0)))
 
   let bitLen = -1
-  while (firstExpBigInt > BigInt(0)) {
+  while (firstExpBigInt > BIGINT_0) {
     bitLen = bitLen + 1
-    firstExpBigInt = firstExpBigInt >> BigInt(1)
+    firstExpBigInt = firstExpBigInt >> BIGINT_1
   }
   let expLenMinus32OrZero = expLen - BigInt(32)
-  if (expLenMinus32OrZero < BigInt(0)) {
-    expLenMinus32OrZero = BigInt(0)
+  if (expLenMinus32OrZero < BIGINT_0) {
+    expLenMinus32OrZero = BIGINT_0
   }
   const eightTimesExpLenMinus32OrZero = expLenMinus32OrZero * BigInt(8)
   let adjustedExpLen = eightTimesExpLenMinus32OrZero
@@ -71,14 +74,14 @@ function getAdjustedExponentLength(data: Uint8Array): bigint {
 }
 
 export function expmod(a: bigint, power: bigint, modulo: bigint) {
-  if (power === BigInt(0)) {
-    return BigInt(1) % modulo
+  if (power === BIGINT_0) {
+    return BIGINT_1 % modulo
   }
-  let res = BigInt(1)
-  while (power > BigInt(0)) {
-    if (power & BigInt(1)) res = (res * a) % modulo
+  let res = BIGINT_1
+  while (power > BIGINT_0) {
+    if (power & BIGINT_1) res = (res * a) % modulo
     a = (a * a) % modulo
-    power >>= BigInt(1)
+    power >>= BIGINT_1
   }
   return res
 }
@@ -87,8 +90,8 @@ export function precompile05(opts: PrecompileInput): ExecResult {
   const data = opts.data
 
   let adjustedELen = getAdjustedExponentLength(data)
-  if (adjustedELen < BigInt(1)) {
-    adjustedELen = BigInt(1)
+  if (adjustedELen < BIGINT_1) {
+    adjustedELen = BIGINT_1
   }
 
   const bLen = bytesToBigInt(data.subarray(0, 32))
@@ -132,14 +135,14 @@ export function precompile05(opts: PrecompileInput): ExecResult {
     return OOGResult(opts.gasLimit)
   }
 
-  if (bLen === BigInt(0)) {
+  if (bLen === BIGINT_0) {
     return {
       executionGasUsed: gasUsed,
-      returnValue: setLengthLeft(bigIntToBytes(BigInt(0)), Number(mLen)),
+      returnValue: setLengthLeft(bigIntToBytes(BIGINT_0), Number(mLen)),
     }
   }
 
-  if (mLen === BigInt(0)) {
+  if (mLen === BIGINT_0) {
     return {
       executionGasUsed: gasUsed,
       returnValue: new Uint8Array(0),
@@ -168,8 +171,8 @@ export function precompile05(opts: PrecompileInput): ExecResult {
   }
 
   let R
-  if (M === BigInt(0)) {
-    R = BigInt(0)
+  if (M === BIGINT_0) {
+    R = BIGINT_0
   } else {
     R = expmod(B, E, M)
   }

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -1,6 +1,7 @@
 import { Chain, Common } from '@ethereumjs/common'
 import {
   Address,
+  BIGINT_0,
   MAX_INTEGER,
   MAX_UINT64,
   bigIntToHex,
@@ -190,7 +191,7 @@ export abstract class BaseTransaction<T extends TransactionType>
     const txDataZero = this.common.param('gasPrices', 'txDataZero')
     const txDataNonZero = this.common.param('gasPrices', 'txDataNonZero')
 
-    let cost = BigInt(0)
+    let cost = BIGINT_0
     for (let i = 0; i < this.data.length; i++) {
       this.data[i] === 0 ? (cost += txDataZero) : (cost += txDataNonZero)
     }

--- a/packages/tx/src/capabilities/eip2718.ts
+++ b/packages/tx/src/capabilities/eip2718.ts
@@ -1,5 +1,5 @@
 import { RLP } from '@ethereumjs/rlp'
-import { concatBytes } from '@ethereumjs/util'
+import { BIGINT_0, BIGINT_1, concatBytes } from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak.js'
 
 import { txTypeBytes } from '../util.js'
@@ -19,7 +19,7 @@ export function serialize(tx: EIP2718CompatibleTx, base?: Input): Uint8Array {
 
 export function validateYParity(tx: EIP2718CompatibleTx) {
   const { v } = tx
-  if (v !== undefined && v !== BigInt(0) && v !== BigInt(1)) {
+  if (v !== undefined && v !== BIGINT_0 && v !== BIGINT_1) {
     const msg = errorMsg(tx, 'The y-parity of the transaction should either be 0 or 1')
     throw new Error(msg)
   }

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -1,5 +1,7 @@
 import { RLP } from '@ethereumjs/rlp'
 import {
+  BIGINT_0,
+  BIGINT_27,
   MAX_INTEGER,
   bigIntToHex,
   bigIntToUnpaddedBytes,
@@ -208,7 +210,7 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<TransactionType
    * The up front amount that an account must have for this transaction to be valid
    * @param baseFee The base fee of the block (will be set to 0 if not provided)
    */
-  getUpfrontCost(baseFee: bigint = BigInt(0)): bigint {
+  getUpfrontCost(baseFee: bigint = BIGINT_0): bigint {
     return EIP1559.getUpfrontCost(this, baseFee)
   }
 
@@ -320,7 +322,7 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<TransactionType
         value: this.value,
         data: this.data,
         accessList: this.accessList,
-        v: v - BigInt(27), // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
+        v: v - BIGINT_27, // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
         r: bytesToBigInt(r),
         s: bytesToBigInt(s),
       },

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -1,5 +1,6 @@
 import { RLP } from '@ethereumjs/rlp'
 import {
+  BIGINT_27,
   MAX_INTEGER,
   bigIntToHex,
   bigIntToUnpaddedBytes,
@@ -292,7 +293,7 @@ export class AccessListEIP2930Transaction extends BaseTransaction<TransactionTyp
         value: this.value,
         data: this.data,
         accessList: this.accessList,
-        v: v - BigInt(27), // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
+        v: v - BIGINT_27, // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
         r: bytesToBigInt(r),
         s: bytesToBigInt(s),
       },

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -1,5 +1,6 @@
 import { RLP } from '@ethereumjs/rlp'
 import {
+  BIGINT_0,
   MAX_INTEGER,
   bigIntToHex,
   bigIntToUnpaddedBytes,
@@ -389,7 +390,7 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
    * The up front amount that an account must have for this transaction to be valid
    * @param baseFee The base fee of the block (will be set to 0 if not provided)
    */
-  getUpfrontCost(baseFee: bigint = BigInt(0)): bigint {
+  getUpfrontCost(baseFee: bigint = BIGINT_0): bigint {
     return EIP1559.getUpfrontCost(this, baseFee)
   }
 

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -1,6 +1,7 @@
 import { RLP } from '@ethereumjs/rlp'
 import {
   BIGINT_0,
+  BIGINT_27,
   MAX_INTEGER,
   bigIntToHex,
   bigIntToUnpaddedBytes,
@@ -533,7 +534,7 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
         value: this.value,
         data: this.data,
         accessList: this.accessList,
-        v: v - BigInt(27), // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
+        v: v - BIGINT_27, // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
         r: bytesToBigInt(r),
         s: bytesToBigInt(s),
         maxFeePerBlobGas: this.maxFeePerBlobGas,

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -1,6 +1,7 @@
 import { RLP } from '@ethereumjs/rlp'
 import {
   BIGINT_2,
+  BIGINT_8,
   MAX_INTEGER,
   bigIntToHex,
   bigIntToUnpaddedBytes,
@@ -273,7 +274,7 @@ export class LegacyTransaction extends BaseTransaction<TransactionType.Legacy> {
    */
   protected _processSignature(v: bigint, r: Uint8Array, s: Uint8Array) {
     if (this.supports(Capability.EIP155ReplayProtection)) {
-      v += this.common.chainId() * BIGINT_2 + BigInt(8)
+      v += this.common.chainId() * BIGINT_2 + BIGINT_8
     }
 
     const opts = { ...this.txOptions, common: this.common }

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -1,5 +1,6 @@
 import { RLP } from '@ethereumjs/rlp'
 import {
+  BIGINT_2,
   MAX_INTEGER,
   bigIntToHex,
   bigIntToUnpaddedBytes,
@@ -272,7 +273,7 @@ export class LegacyTransaction extends BaseTransaction<TransactionType.Legacy> {
    */
   protected _processSignature(v: bigint, r: Uint8Array, s: Uint8Array) {
     if (this.supports(Capability.EIP155ReplayProtection)) {
-      v += this.common.chainId() * BigInt(2) + BigInt(8)
+      v += this.common.chainId() * BIGINT_2 + BigInt(8)
     }
 
     const opts = { ...this.txOptions, common: this.common }
@@ -344,7 +345,7 @@ export class LegacyTransaction extends BaseTransaction<TransactionType.Legacy> {
           numSub = 36
         }
         // Use derived chain ID to create a proper Common
-        chainIdBigInt = BigInt(v - numSub) / BigInt(2)
+        chainIdBigInt = BigInt(v - numSub) / BIGINT_2
       }
     }
     return this._getCommon(common, chainIdBigInt)

--- a/packages/util/src/account.ts
+++ b/packages/util/src/account.ts
@@ -13,13 +13,11 @@ import {
   utf8ToBytes,
   zeros,
 } from './bytes.js'
-import { KECCAK256_NULL, KECCAK256_RLP } from './constants.js'
+import { BIGINT_0, KECCAK256_NULL, KECCAK256_RLP } from './constants.js'
 import { assertIsBytes, assertIsHexString, assertIsString } from './helpers.js'
 import { stripHexPrefix } from './internal.js'
 
 import type { BigIntLike, BytesLike } from './types.js'
-
-const _0n = BigInt(0)
 
 export interface AccountData {
   nonce?: BigIntLike
@@ -67,7 +65,12 @@ export class Account {
    * This constructor assigns and validates the values.
    * Use the static factory methods to assist in creating an Account from varying data types.
    */
-  constructor(nonce = _0n, balance = _0n, storageRoot = KECCAK256_RLP, codeHash = KECCAK256_NULL) {
+  constructor(
+    nonce = BIGINT_0,
+    balance = BIGINT_0,
+    storageRoot = KECCAK256_RLP,
+    codeHash = KECCAK256_NULL
+  ) {
     this.nonce = nonce
     this.balance = balance
     this.storageRoot = storageRoot
@@ -77,10 +80,10 @@ export class Account {
   }
 
   private _validate() {
-    if (this.nonce < _0n) {
+    if (this.nonce < BIGINT_0) {
       throw new Error('nonce must be greater than zero')
     }
-    if (this.balance < _0n) {
+    if (this.balance < BIGINT_0) {
       throw new Error('balance must be greater than zero')
     }
     if (this.storageRoot.length !== 32) {
@@ -123,7 +126,11 @@ export class Account {
    * "An account is considered empty when it has no code and zero nonce and zero balance."
    */
   isEmpty(): boolean {
-    return this.balance === _0n && this.nonce === _0n && equalsBytes(this.codeHash, KECCAK256_NULL)
+    return (
+      this.balance === BIGINT_0 &&
+      this.nonce === BIGINT_0 &&
+      equalsBytes(this.codeHash, KECCAK256_NULL)
+    )
   }
 }
 
@@ -201,7 +208,7 @@ export const generateAddress = function (from: Uint8Array, nonce: Uint8Array): U
   assertIsBytes(from)
   assertIsBytes(nonce)
 
-  if (bytesToBigInt(nonce) === BigInt(0)) {
+  if (bytesToBigInt(nonce) === BIGINT_0) {
     // in RLP we want to encode null in the case of zero nonce
     // read the RLP documentation for an answer if you dare
     return keccak256(RLP.encode([from, Uint8Array.from([])])).subarray(-20)

--- a/packages/util/src/address.ts
+++ b/packages/util/src/address.ts
@@ -6,6 +6,7 @@ import {
   pubToAddress,
 } from './account.js'
 import { bigIntToBytes, bytesToBigInt, bytesToHex, equalsBytes, toBytes, zeros } from './bytes.js'
+import { BIGINT_0 } from './constants.js'
 
 /**
  * Handling and generating Ethereum addresses
@@ -110,7 +111,7 @@ export class Address {
    */
   isPrecompileOrSystemAddress(): boolean {
     const address = bytesToBigInt(this.bytes)
-    const rangeMin = BigInt(0)
+    const rangeMin = BIGINT_0
     const rangeMax = BigInt('0xffff')
     return address >= rangeMin && address <= rangeMax
   }

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -5,11 +5,12 @@ import {
   hexToBytes as _unprefixedHexToBytes,
 } from 'ethereum-cryptography/utils.js'
 
-import { BIGINT_0 } from './constants.js'
 import { assertIsArray, assertIsBytes, assertIsHexString } from './helpers.js'
 import { isHexPrefixed, isHexString, padToEven, stripHexPrefix } from './internal.js'
 
 import type { PrefixedHexString, TransformabletoBytes } from './types.js'
+
+const BIGINT_0 = BigInt(0) // Cannot import from `./constants.js`, otherwise have a circular dependency
 
 /**
  * @deprecated

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -5,6 +5,7 @@ import {
   hexToBytes as _unprefixedHexToBytes,
 } from 'ethereum-cryptography/utils.js'
 
+import { BIGINT_0 } from './constants.js'
 import { assertIsArray, assertIsBytes, assertIsHexString } from './helpers.js'
 import { isHexPrefixed, isHexString, padToEven, stripHexPrefix } from './internal.js'
 
@@ -47,7 +48,7 @@ export const bytesToHex = (bytes: Uint8Array): string => {
 export const bytesToBigInt = (bytes: Uint8Array): bigint => {
   const hex = bytesToHex(bytes)
   if (hex === '0x') {
-    return BigInt(0)
+    return BIGINT_0
   }
   return BigInt(hex)
 }
@@ -267,7 +268,7 @@ export const toBytes = (v: ToBytesInputTypes): Uint8Array => {
   }
 
   if (typeof v === 'bigint') {
-    if (v < BigInt(0)) {
+    if (v < BIGINT_0) {
       throw new Error(`Cannot convert negative bigint to Uint8Array. Given: ${v}`)
     }
     let n = v.toString(16)

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -77,6 +77,29 @@ export const RIPEMD160_ADDRESS_STRING = '000000000000000000000000000000000000000
  * BigInt constants
  */
 
+export const BIGINT_NEG1 = BigInt(-1)
+
 export const BIGINT_0 = BigInt(0)
 export const BIGINT_1 = BigInt(1)
 export const BIGINT_2 = BigInt(2)
+export const BIGINT_3 = BigInt(3)
+export const BIGINT_7 = BigInt(7)
+export const BIGINT_8 = BigInt(8)
+
+export const BIGINT_27 = BigInt(27)
+export const BIGINT_28 = BigInt(28)
+export const BIGINT_31 = BigInt(31)
+export const BIGINT_32 = BigInt(32)
+export const BIGINT_64 = BigInt(64)
+
+export const BIGINT_128 = BigInt(128)
+export const BIGINT_255 = BigInt(255)
+export const BIGINT_256 = BigInt(256)
+
+export const BIGINT_96 = BigInt(96)
+export const BIGINT_160 = BigInt(160)
+export const BIGINT_224 = BigInt(224)
+export const BIGINT_2EXP96 = BigInt(79228162514264337593543950336)
+export const BIGINT_2EXP160 = BigInt(1461501637330902918203684832716283019655932542976)
+export const BIGINT_2EXP224 =
+  BigInt(26959946667150639794667015087019630673637144422540572481103610249216)

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -72,3 +72,11 @@ export const RLP_EMPTY_STRING = Uint8Array.from([0x80])
 export const MAX_WITHDRAWALS_PER_PAYLOAD = 16
 
 export const RIPEMD160_ADDRESS_STRING = '0000000000000000000000000000000000000003'
+
+/**
+ * BigInt constants
+ */
+
+export const BIGINT_0 = BigInt(0)
+export const BIGINT_1 = BigInt(1)
+export const BIGINT_2 = BigInt(2)

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -10,7 +10,13 @@ import {
   toBytes,
   utf8ToBytes,
 } from './bytes.js'
-import { SECP256K1_ORDER, SECP256K1_ORDER_DIV_2 } from './constants.js'
+import {
+  BIGINT_0,
+  BIGINT_1,
+  BIGINT_2,
+  SECP256K1_ORDER,
+  SECP256K1_ORDER_DIV_2,
+} from './constants.js'
 import { assertIsBytes } from './helpers.js'
 
 export interface ECDSASignature {
@@ -38,22 +44,22 @@ export function ecsign(
   const v =
     chainId === undefined
       ? BigInt(sig.recovery! + 27)
-      : BigInt(sig.recovery! + 35) + BigInt(chainId) * BigInt(2)
+      : BigInt(sig.recovery! + 35) + BigInt(chainId) * BIGINT_2
 
   return { r, s, v }
 }
 
 function calculateSigRecovery(v: bigint, chainId?: bigint): bigint {
-  if (v === BigInt(0) || v === BigInt(1)) return v
+  if (v === BIGINT_0 || v === BIGINT_1) return v
 
   if (chainId === undefined) {
     return v - BigInt(27)
   }
-  return v - (chainId * BigInt(2) + BigInt(35))
+  return v - (chainId * BIGINT_2 + BigInt(35))
 }
 
 function isValidSigRecovery(recovery: bigint): boolean {
-  return recovery === BigInt(0) || recovery === BigInt(1)
+  return recovery === BIGINT_0 || recovery === BIGINT_1
 }
 
 /**
@@ -117,7 +123,7 @@ export const toCompactSig = function (
   }
 
   const ss = Uint8Array.from([...s])
-  if ((v > BigInt(28) && v % BigInt(2) === BigInt(1)) || v === BigInt(1) || v === BigInt(28)) {
+  if ((v > BigInt(28) && v % BIGINT_2 === BIGINT_1) || v === BIGINT_1 || v === BigInt(28)) {
     ss[0] |= 0x80
   }
 
@@ -188,9 +194,9 @@ export const isValidSignature = function (
   const sBigInt = bytesToBigInt(s)
 
   if (
-    rBigInt === BigInt(0) ||
+    rBigInt === BIGINT_0 ||
     rBigInt >= SECP256K1_ORDER ||
-    sBigInt === BigInt(0) ||
+    sBigInt === BIGINT_0 ||
     sBigInt >= SECP256K1_ORDER
   ) {
     return false

--- a/packages/util/src/signature.ts
+++ b/packages/util/src/signature.ts
@@ -14,6 +14,7 @@ import {
   BIGINT_0,
   BIGINT_1,
   BIGINT_2,
+  BIGINT_27,
   SECP256K1_ORDER,
   SECP256K1_ORDER_DIV_2,
 } from './constants.js'
@@ -53,7 +54,7 @@ function calculateSigRecovery(v: bigint, chainId?: bigint): bigint {
   if (v === BIGINT_0 || v === BIGINT_1) return v
 
   if (chainId === undefined) {
-    return v - BigInt(27)
+    return v - BIGINT_27
   }
   return v - (chainId * BIGINT_2 + BigInt(35))
 }
@@ -160,7 +161,7 @@ export const fromRpcSig = function (sig: string): ECDSASignature {
 
   // support both versions of `eth_sign` responses
   if (v < 27) {
-    v = v + BigInt(27)
+    v = v + BIGINT_27
   }
 
   return {

--- a/packages/util/src/withdrawal.ts
+++ b/packages/util/src/withdrawal.ts
@@ -1,5 +1,6 @@
 import { Address } from './address.js'
 import { bigIntToHex, bytesToHex, toBytes } from './bytes.js'
+import { BIGINT_0 } from './constants.js'
 import { TypeOutput, toType } from './types.js'
 
 import type { AddressLike, BigIntLike } from './types.js'
@@ -78,18 +79,18 @@ export class Withdrawal {
   public static toBytesArray(withdrawal: Withdrawal | WithdrawalData): WithdrawalBytes {
     const { index, validatorIndex, address, amount } = withdrawal
     const indexBytes =
-      toType(index, TypeOutput.BigInt) === BigInt(0)
+      toType(index, TypeOutput.BigInt) === BIGINT_0
         ? new Uint8Array()
         : toType(index, TypeOutput.Uint8Array)
     const validatorIndexBytes =
-      toType(validatorIndex, TypeOutput.BigInt) === BigInt(0)
+      toType(validatorIndex, TypeOutput.BigInt) === BIGINT_0
         ? new Uint8Array()
         : toType(validatorIndex, TypeOutput.Uint8Array)
     const addressBytes =
       address instanceof Address ? (<Address>address).bytes : toType(address, TypeOutput.Uint8Array)
 
     const amountBytes =
-      toType(amount, TypeOutput.BigInt) === BigInt(0)
+      toType(amount, TypeOutput.BigInt) === BIGINT_0
         ? new Uint8Array()
         : toType(amount, TypeOutput.Uint8Array)
 

--- a/packages/vm/benchmarks/util.ts
+++ b/packages/vm/benchmarks/util.ts
@@ -1,4 +1,4 @@
-import { Account, Address, equalsBytes, toBytes } from '@ethereumjs/util'
+import { Account, Address, BIGINT_0, equalsBytes, toBytes } from '@ethereumjs/util'
 import { Common } from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
@@ -68,7 +68,7 @@ export const verifyResult = (block: Block, result: RunBlockResult) => {
     // check if there are receipts
     const { receipts } = result
     if (receipts) {
-      let cumGasUsed = BigInt(0)
+      let cumGasUsed = BIGINT_0
       for (let index = 0; index < receipts.length; index++) {
         let gasUsedExpected = receipts[index].cumulativeBlockGasUsed
         let cumGasUsedActual = receipts[index].cumulativeBlockGasUsed

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -7,6 +7,7 @@ import {
   Address,
   BIGINT_0,
   BIGINT_1,
+  BIGINT_2,
   GWEI_TO_WEI,
   TypeOutput,
   Withdrawal,
@@ -96,7 +97,7 @@ export class BlockBuilder {
 
     if (typeof this.headerData.gasLimit === 'undefined') {
       if (this.headerData.number === vm.common.hardforkBlock(Hardfork.London)) {
-        this.headerData.gasLimit = opts.parentBlock.header.gasLimit * BigInt(2)
+        this.headerData.gasLimit = opts.parentBlock.header.gasLimit * BIGINT_2
       } else {
         this.headerData.gasLimit = opts.parentBlock.header.gasLimit
       }

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -5,6 +5,8 @@ import { Trie } from '@ethereumjs/trie'
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
 import {
   Address,
+  BIGINT_0,
+  BIGINT_1,
   GWEI_TO_WEI,
   TypeOutput,
   Withdrawal,
@@ -40,16 +42,16 @@ export class BlockBuilder {
   /**
    * The cumulative gas used by the transactions added to the block.
    */
-  gasUsed = BigInt(0)
+  gasUsed = BIGINT_0
   /**
    *  The cumulative blob gas used by the blobs in a block
    */
-  blobGasUsed = BigInt(0)
+  blobGasUsed = BIGINT_0
   /**
    * Value of the block, represented by the final transaction fees
    * acruing to the miner.
    */
-  private _minerValue = BigInt(0)
+  private _minerValue = BIGINT_0
 
   private readonly vm: VM
   private blockOpts: BuilderOpts
@@ -75,7 +77,8 @@ export class BlockBuilder {
     this.headerData = {
       ...opts.headerData,
       parentHash: opts.parentBlock.hash(),
-      number: opts.headerData?.number ?? opts.parentBlock.header.number + BigInt(1),
+      number: opts.headerData?.number ?? opts.parentBlock.header.number + BIGINT_1,
+      gasLimit: opts.headerData?.gasLimit ?? opts.parentBlock.header.gasLimit,
       timestamp: opts.headerData?.timestamp ?? Math.round(Date.now() / 1000),
     }
     this.withdrawals = opts.withdrawals?.map(Withdrawal.fromWithdrawalData)
@@ -300,7 +303,7 @@ export class BlockBuilder {
     const logsBloom = this.logsBloom()
     const gasUsed = this.gasUsed
     // timestamp should already be set in constructor
-    const timestamp = this.headerData.timestamp ?? BigInt(0)
+    const timestamp = this.headerData.timestamp ?? BIGINT_0
 
     let blobGasUsed = undefined
     if (this.vm.common.isActivatedEIP(4844) === true) {

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -7,6 +7,7 @@ import {
   Account,
   Address,
   BIGINT_0,
+  BIGINT_8,
   GWEI_TO_WEI,
   bigIntToBytes,
   bytesToHex,
@@ -451,7 +452,7 @@ function calculateOmmerReward(
   minerReward: bigint
 ): bigint {
   const heightDiff = blockNumber - ommerBlockNumber
-  let reward = ((BigInt(8) - heightDiff) * minerReward) / BigInt(8)
+  let reward = ((BIGINT_8 - heightDiff) * minerReward) / BIGINT_8
   if (reward < BIGINT_0) {
     reward = BIGINT_0
   }

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -6,6 +6,7 @@ import { TransactionType } from '@ethereumjs/tx'
 import {
   Account,
   Address,
+  BIGINT_0,
   GWEI_TO_WEI,
   bigIntToBytes,
   bytesToHex,
@@ -343,7 +344,7 @@ export async function accumulateParentBeaconBlockRoot(
 async function applyTransactions(this: VM, block: Block, opts: RunBlockOpts) {
   const bloom = new Bloom()
   // the total amount of gas used processing these transactions
-  let gasUsed = BigInt(0)
+  let gasUsed = BIGINT_0
   const receiptTrie = new Trie()
   const receipts = []
   const txResults = []
@@ -451,8 +452,8 @@ function calculateOmmerReward(
 ): bigint {
   const heightDiff = blockNumber - ommerBlockNumber
   let reward = ((BigInt(8) - heightDiff) * minerReward) / BigInt(8)
-  if (reward < BigInt(0)) {
-    reward = BigInt(0)
+  if (reward < BIGINT_0) {
+    reward = BIGINT_0
   }
   return reward
 }
@@ -528,7 +529,7 @@ async function _applyDAOHardfork(evm: EVMInterface) {
     }
     DAORefundAccount.balance += account.balance
     // clear the accounts' balance
-    account.balance = BigInt(0)
+    account.balance = BIGINT_0
     await evm.journal.putAccount(address, account)
   }
 

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -4,6 +4,7 @@ import { BlobEIP4844Transaction, Capability, isBlobEIP4844Tx } from '@ethereumjs
 import {
   Account,
   Address,
+  BIGINT_0,
   KECCAK256_NULL,
   bytesToHex,
   bytesToUnprefixedHex,
@@ -291,8 +292,8 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
 
   // Check balance against max potential cost (for EIP 1559 and 4844)
   let maxCost = tx.value
-  let blobGasPrice = BigInt(0)
-  let totalblobGas = BigInt(0)
+  let blobGasPrice = BIGINT_0
+  let totalblobGas = BIGINT_0
   if (tx.supports(Capability.EIP1559FeeMarket)) {
     // EIP-1559 spec:
     // The signer must be able to afford the transaction
@@ -394,8 +395,8 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   const blobGasCost = totalblobGas * blobGasPrice
   fromAccount.balance -= txCost
   fromAccount.balance -= blobGasCost
-  if (opts.skipBalance === true && fromAccount.balance < BigInt(0)) {
-    fromAccount.balance = BigInt(0)
+  if (opts.skipBalance === true && fromAccount.balance < BIGINT_0) {
+    fromAccount.balance = BIGINT_0
   }
   await this.evm.journal.putAccount(caller, fromAccount)
   if (this.DEBUG) {
@@ -463,10 +464,10 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   }
 
   // Process any gas refund
-  let gasRefund = results.execResult.gasRefund ?? BigInt(0)
+  let gasRefund = results.execResult.gasRefund ?? BIGINT_0
   results.gasRefund = gasRefund
   const maxRefundQuotient = this.common.param('gasConfig', 'maxRefundQuotient')
-  if (gasRefund !== BigInt(0)) {
+  if (gasRefund !== BIGINT_0) {
     const maxRefund = results.totalGasSpent / maxRefundQuotient
     gasRefund = gasRefund < maxRefund ? gasRefund : maxRefund
     results.totalGasSpent -= gasRefund


### PR DESCRIPTION
This PR:

- Caches most (not all) constants of BigInts monorepo-wide
- Caches ALL constants in EVM
- The monorepo-wide constants are now exported from `util`

Note: please review https://github.com/ethereumjs/ethereumjs-monorepo/pull/3034 first (and merge in master if OK, or merge this on top if OK and then merge into master)