### PR TITLE
util: optimize bytesToBigInt for 1-byte bytes

### DIFF
--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -43,7 +43,7 @@ export const bytesToHex = (bytes: Uint8Array): string => {
 
 // BigInt cache for the numbers 0 - 255 (one-byte bytes)
 const BIGINT_CACHE: bigint[] = []
-for (let i = 0; i <= 255; i++) {
+for (let i = 0; i <= 255 * 255; i++) {
   BIGINT_CACHE[i] = BigInt(i)
 }
 
@@ -60,6 +60,9 @@ export const bytesToBigInt = (bytes: Uint8Array): bigint => {
   if (hex.length === 4) {
     // If the byte length is 1 (this is faster than checking `bytes.length === 1`)
     return BIGINT_CACHE[bytes[0]]
+  }
+  if (hex.length === 6) {
+    return BIGINT_CACHE[bytes[0] * 256 + bytes[1]]
   }
   return BigInt(hex)
 }

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -10,6 +10,8 @@ import { isHexPrefixed, isHexString, padToEven, stripHexPrefix } from './interna
 
 import type { PrefixedHexString, TransformabletoBytes } from './types.js'
 
+const BIGINT_0 = BigInt(0)
+
 /**
  * @deprecated
  */
@@ -39,6 +41,12 @@ export const bytesToHex = (bytes: Uint8Array): string => {
   return hex
 }
 
+// BigInt cache for the numbers 0 - 255 (one-byte bytes)
+const BIGINT_CACHE: bigint[] = []
+for (let i = 0; i <= 255; i++) {
+  BIGINT_CACHE[i] = BigInt(i)
+}
+
 /**
  * Converts a {@link Uint8Array} to a {@link bigint}
  * @param {Uint8Array} bytes the bytes to convert
@@ -47,7 +55,11 @@ export const bytesToHex = (bytes: Uint8Array): string => {
 export const bytesToBigInt = (bytes: Uint8Array): bigint => {
   const hex = bytesToHex(bytes)
   if (hex === '0x') {
-    return BigInt(0)
+    return BIGINT_0
+  }
+  if (hex.length === 4) {
+    // If the byte length is 1 (this is faster than checking `bytes.length === 1`)
+    return BIGINT_CACHE[bytes[0]]
   }
   return BigInt(hex)
 }

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -41,9 +41,9 @@ export const bytesToHex = (bytes: Uint8Array): string => {
   return hex
 }
 
-// BigInt cache for the numbers 0 - 255 (one-byte bytes)
+// BigInt cache for the numbers 0 - 256*256-1 (two-byte bytes)
 const BIGINT_CACHE: bigint[] = []
-for (let i = 0; i <= 255 * 255; i++) {
+for (let i = 0; i <= 256 * 256 - 1; i++) {
   BIGINT_CACHE[i] = BigInt(i)
 }
 


### PR DESCRIPTION
This PR:

- Optimizes bytesToBigInt

This only optimizes bytes with length 1 and bytes with length 2 by caching those.

Here are the results: (bytesToBigInt)

```
0 22.67887508869171
0 22.8313969373703
1 38.06730806827545
1 105.89006400108337
2 49.631819009780884
2 120.36363506317139
3 133.02554297447205
3 135.36226105690002
4 149.31096291542053
4 152.2477569580078
```

The format is: first the length of the input byte, then the amount of ms to convert 1 million of those. The first entry is the optimized one (so with this PR), the second entry is current `master`. Note that for `1` byte length we go from 106 ms to 38 ms. For other byte lengths, the times are equal (so there is no performance loss or gain there).

Just for completeness, also "large" bytes:

```
31 635.5747010707855
31 632.2635729312897
32 646.9890819787979
32 642.5601290464401

```

Performance here does not change also.



For bigIntToBytes:

```
0n 26.09515404701233
0n 238.23749196529388
255n 29.19419801235199
255n 231.97074103355408
65025n 28.908851981163025
65025n 283.2230769395828
```

Same format, number input is first. For larger numbers, there is no performance increase or decrease.

**NOTE**: Bytes are NOT immutable so the byte cache can actually be edited externally - I have taken this out of the PR.