### PR TITLE
Pin `scanf` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15559,7 +15559,7 @@
         "ethereum-cryptography": "^2.1.2",
         "lru-cache": "^7.18.3",
         "multiaddr": "^10.0.1",
-        "scanf": "^1.1.2",
+        "scanf": "1.1.2",
         "snappyjs": "^0.6.1"
       },
       "devDependencies": {

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -64,7 +64,7 @@
     "ethereum-cryptography": "^2.1.2",
     "lru-cache": "^7.18.3",
     "multiaddr": "^10.0.1",
-    "scanf": "^1.1.2",
+    "scanf": "1.1.2",
     "snappyjs": "^0.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The `vm` nightly tests started failing recently and the issue is because the `scanf` dependency recently released a point update (1.1.20 - notably the first one in 3 years) and it has some broken types in it.  Given that this dep is only used for parsing the ENR string and the underlying functionality should be static, makes sense to just pin to the previous version and leave it there for now.