### PR TITLE
Simplify `client` transports

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -47,7 +47,7 @@ const networks = Object.entries(Common.getInitializedChains().names)
 
 let logger: Logger
 
-// @ts-ignore because yargs isn't typing our args closely enough yet for arrays of strings (i.e. args.transports, args.bootnodes, etc)
+// @ts-ignore because yargs isn't typing our args closely enough yet for arrays of strings (i.e. args.bootnodes, etc)
 const args: ClientOpts = yargs(hideBin(process.argv))
   .parserConfiguration({
     'dot-notation': false,
@@ -100,11 +100,6 @@ const args: ClientOpts = yargs(hideBin(process.argv))
       'Place mergeForkIdTransition hardfork before (false) or after (true) Merge hardfork in the custom gethGenesis',
     boolean: true,
     default: true,
-  })
-  .option('transports', {
-    describe: 'Network transports',
-    default: Config.TRANSPORTS_DEFAULT,
-    array: true,
   })
   .option('bootnodes', {
     describe: 'Comma-separated list of network bootnodes',
@@ -829,7 +824,6 @@ async function run() {
     disableBeaconSync: args.disableBeaconSync,
     forceSnapSync: args.forceSnapSync,
     prefixStorageTrieKeys: args.prefixStorageTrieKeys,
-    transports: args.transports?.length === 0 ? args.transports : undefined,
     txLookupLimit: args.txLookupLimit,
   })
   config.events.setMaxListeners(50)

--- a/packages/client/browser/index.ts
+++ b/packages/client/browser/index.ts
@@ -57,7 +57,6 @@ export async function createClient(args: any) {
   const config = new Config({
     common,
     key,
-    transports: ['rlpx'],
     syncmode: SyncMode.None,
     bootnodes,
     multiaddrs: [],

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -148,13 +148,10 @@ export class EthereumClient {
     this.config.logger.info('Setup networking and services.')
 
     await Promise.all(this.services.map((s) => s.start()))
-    await Promise.all(this.config.servers.map((s) => s.start()))
-    await Promise.all(
-      this.config.servers.map(async (s) => {
-        // Only call bootstrap if servers are actually started
-        if (s.started) await s.bootstrap()
-      })
-    )
+    this.config.server && (await this.config.server.start())
+    // Only call bootstrap if servers are actually started
+    this.config.server && this.config.server.started && (await this.config.server.bootstrap())
+
     this.started = true
   }
 
@@ -167,7 +164,7 @@ export class EthereumClient {
     }
     this.config.events.emit(Event.CLIENT_SHUTDOWN)
     await Promise.all(this.services.map((s) => s.stop()))
-    await Promise.all(this.config.servers.map((s) => s.stop()))
+    this.config.server && this.config.server.started && (await this.config.server.stop())
     this.started = false
   }
 
@@ -177,13 +174,5 @@ export class EthereumClient {
    */
   service(name: string) {
     return this.services.find((s) => s.name === name)
-  }
-
-  /**
-   * Returns the server with the specified name.
-   * @param name name of server
-   */
-  server(name: string) {
-    return this.config.servers.find((s) => s.name === name)
   }
 }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -169,6 +169,13 @@ export class EthereumClient {
   }
 
   /**
+   *
+   * @returns the RLPx server (if it exists)
+   */
+  server() {
+    return this.config.server
+  }
+  /**
    * Returns the service with the specified name.
    * @param name name of service
    */

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -95,13 +95,6 @@ export interface ConfigOptions {
   key?: Uint8Array
 
   /**
-   * Network transports ('rlpx')
-   *
-   * Default: `['rlpx']`
-   */
-  transports?: string[]
-
-  /**
    * Network bootnodes
    * (e.g. abc@18.138.108.67 or /ip4/127.0.0.1/tcp/50505/p2p/QmABC)
    */
@@ -333,7 +326,6 @@ export class Config {
   public static readonly SYNCMODE_DEFAULT = SyncMode.Full
   public static readonly LIGHTSERV_DEFAULT = false
   public static readonly DATADIR_DEFAULT = `./datadir`
-  public static readonly TRANSPORTS_DEFAULT = ['rlpx']
   public static readonly PORT_DEFAULT = 30303
   public static readonly MAXPERREQUEST_DEFAULT = 100
   public static readonly MAXFETCHERJOBS_DEFAULT = 100
@@ -493,12 +485,12 @@ export class Config {
 
     this.logger = options.logger ?? getLogger({ loglevel: 'error' })
 
-    this.logger.info(`Sync Mode ${options.syncmode}`)
+    this.logger.info(`Sync Mode ${options.syncmode ?? 'None'}`)
     if (options.syncmode !== SyncMode.None) {
       if (options.server !== undefined) {
         this.server = options.server
       } else if (isBrowser() !== true) {
-        // Otherwise parse transports from transports option
+        // Otherwise start server
         const bootnodes: MultiaddrLike =
           this.bootnodes ?? (this.chainCommon.bootstrapNodes() as any)
         const dnsNetworks = options.dnsNetworks ?? this.chainCommon.dnsNetworks()

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -485,7 +485,7 @@ export class Config {
 
     this.logger = options.logger ?? getLogger({ loglevel: 'error' })
 
-    this.logger.info(`Sync Mode ${options.syncmode ?? 'None'}`)
+    this.logger.info(`Sync Mode ${this.syncmode}`)
     if (this.syncmode !== SyncMode.None) {
       if (options.server !== undefined) {
         this.server = options.server

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -127,11 +127,9 @@ export interface ConfigOptions {
 
   /**
    * Transport servers (RLPx)
-   * Use `transports` option, only used for testing purposes
-   *
-   * Default: servers created from `transports` option
+   * Only used for testing purposes
    */
-  servers?: RlpxServer[]
+  server?: RlpxServer
 
   /**
    * Save tx receipts and logs in the meta db (default: false)
@@ -421,7 +419,7 @@ export class Config {
   public readonly chainCommon: Common
   public readonly execCommon: Common
 
-  public readonly servers: RlpxServer[] = []
+  public readonly server: RlpxServer | undefined = undefined
 
   constructor(options: ConfigOptions = {}) {
     this.events = new EventBus() as EventBusType
@@ -497,14 +495,14 @@ export class Config {
 
     this.logger.info(`Sync Mode ${options.syncmode}`)
     if (options.syncmode !== SyncMode.None) {
-      if (options.servers) {
-        this.servers = options.servers
+      if (options.server !== undefined) {
+        this.server = options.server
       } else if (isBrowser() !== true) {
         // Otherwise parse transports from transports option
         const bootnodes: MultiaddrLike =
           this.bootnodes ?? (this.chainCommon.bootstrapNodes() as any)
         const dnsNetworks = options.dnsNetworks ?? this.chainCommon.dnsNetworks()
-        this.servers = [new RlpxServer({ config: this, bootnodes, dnsNetworks })]
+        this.server = new RlpxServer({ config: this, bootnodes, dnsNetworks })
       }
     }
 

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -36,7 +36,7 @@ export interface ConfigOptions {
   common?: Common
 
   /**
-   * Synchronization mode ('full' or 'light')
+   * Synchronization mode ('full', 'light', 'none')
    *
    * Default: 'full'
    */
@@ -486,7 +486,7 @@ export class Config {
     this.logger = options.logger ?? getLogger({ loglevel: 'error' })
 
     this.logger.info(`Sync Mode ${options.syncmode ?? 'None'}`)
-    if (options.syncmode !== SyncMode.None) {
+    if (this.syncmode !== SyncMode.None) {
       if (options.server !== undefined) {
         this.server = options.server
       } else if (isBrowser() !== true) {

--- a/packages/client/src/rpc/modules/admin.ts
+++ b/packages/client/src/rpc/modules/admin.ts
@@ -5,7 +5,6 @@ import { middleware } from '../validation'
 
 import type { Chain } from '../../blockchain'
 import type { EthereumClient } from '../../client'
-import type { RlpxServer } from '../../net/server'
 import type { Service } from '../../service'
 
 /**
@@ -34,7 +33,7 @@ export class Admin {
    * @param params An empty array
    */
   async nodeInfo(_params: []) {
-    const rlpxInfo = (this._client.server('rlpx') as RlpxServer).getRlpxInfo()
+    const rlpxInfo = this._client.config.server!.getRlpxInfo()
     const { enode, id, ip, listenAddr, ports } = rlpxInfo
     const { discovery, listener } = ports
     const clientName = getClientVersion()

--- a/packages/client/src/service/service.ts
+++ b/packages/client/src/service/service.ts
@@ -118,6 +118,7 @@ export class Service {
     if (this.opened) {
       return false
     }
+    console.log('openining', this.config.server)
     const protocols = this.protocols
     this.config.server && this.config.server.addProtocols(protocols)
 

--- a/packages/client/src/service/service.ts
+++ b/packages/client/src/service/service.ts
@@ -118,7 +118,6 @@ export class Service {
     if (this.opened) {
       return false
     }
-    console.log('openining', this.config.server)
     const protocols = this.protocols
     this.config.server && this.config.server.addProtocols(protocols)
 

--- a/packages/client/src/service/service.ts
+++ b/packages/client/src/service/service.ts
@@ -119,7 +119,7 @@ export class Service {
       return false
     }
     const protocols = this.protocols
-    this.config.servers.map((s) => s.addProtocols(protocols))
+    this.config.server && this.config.server.addProtocols(protocols)
 
     this.config.events.on(Event.POOL_PEER_BANNED, (peer) =>
       this.config.logger.debug(`Peer banned: ${peer}`)

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -106,7 +106,6 @@ export interface ClientOpts {
   gethGenesis?: string
   trustedSetup?: string
   mergeForkIdPostMerge?: boolean
-  transports?: string[]
   bootnodes?: string | string[]
   port?: number
   extIP?: string

--- a/packages/client/src/util/parse.ts
+++ b/packages/client/src/util/parse.ts
@@ -69,20 +69,6 @@ export function parseMultiaddrs(input: MultiaddrLike): Multiaddr[] {
   }
 }
 
-export function parseTransports(transports: string[]) {
-  return transports.map((t) => {
-    const options: { [key: string]: string } = {}
-    const [name, ...pairs] = t.split(':')
-    if (pairs.length) {
-      for (const p of pairs.join(':').split(',')) {
-        const [key, value] = p.split('=')
-        options[key] = value
-      }
-    }
-    return { name, options }
-  })
-}
-
 /**
  * Returns Uint8Array from input hexadecimal string or Uint8Array
  * @param input hexadecimal string or Uint8Array

--- a/packages/client/test/cli/cli.spec.ts
+++ b/packages/client/test/cli/cli.spec.ts
@@ -509,7 +509,6 @@ describe('[CLI]', () => {
       '--port=30304',
       '--dev=poa',
       '--bootnodes=enode://abc@127.0.0.1:30303',
-      '--transports=rlpx',
       '--multiaddrs=enode://abc@127.0.0.1:30303',
       '--discDns=false',
       '--discV4=false',

--- a/packages/client/test/client.spec.ts
+++ b/packages/client/test/client.spec.ts
@@ -7,7 +7,7 @@ import { PeerPool } from '../src/net/peerpool'
 import { RlpxServer } from '../src/net/server'
 
 describe('[EthereumClient]', async () => {
-  const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+  const config = new Config({ accountCache: 10000, storageCache: 1000 })
   class FullEthereumService {
     open() {}
     start() {}
@@ -41,7 +41,7 @@ describe('[EthereumClient]', async () => {
   })
 
   it('should initialize correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const client = await EthereumClient.create({ config })
     assert.ok('lightserv' in client.services[0], 'added FullEthereumService')
     assert.ok('execution' in client.services[0], 'added FullEthereumService')
@@ -49,8 +49,8 @@ describe('[EthereumClient]', async () => {
   })
 
   it('should open', async () => {
-    const servers = [new RlpxServer({ config: new Config() })]
-    const config = new Config({ servers, accountCache: 10000, storageCache: 1000 })
+    const server = new RlpxServer({ config: new Config() })
+    const config = new Config({ server, accountCache: 10000, storageCache: 1000 })
     const client = await EthereumClient.create({ config, metaDB: new MemoryLevel() })
 
     await client.open()
@@ -59,8 +59,8 @@ describe('[EthereumClient]', async () => {
   }, 30000)
 
   it('should start/stop', async () => {
-    const servers = [new Server()] as any
-    const config = new Config({ servers, accountCache: 10000, storageCache: 1000 })
+    const server = new Server() as any
+    const config = new Config({ server, accountCache: 10000, storageCache: 1000 })
     const client = await EthereumClient.create({ config, metaDB: new MemoryLevel() })
     await client.start()
     assert.ok(client.started, 'started')

--- a/packages/client/test/execution/vmexecution.spec.ts
+++ b/packages/client/test/execution/vmexecution.spec.ts
@@ -17,14 +17,14 @@ import shanghaiJSON from '../testdata/geth-genesis/withdrawals.json'
 describe('[VMExecution]', async () => {
   it('Initialization', async () => {
     const vm = await VM.create()
-    const config = new Config({ vm, transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ vm, accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const exec = new VMExecution({ config, chain })
     assert.equal(exec.vm, vm, 'should use vm provided')
   })
 
   async function testSetup(blockchain: Blockchain, common?: Common) {
-    const config = new Config({ common, transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ common, accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config, blockchain })
     const exec = new VMExecution({ config, chain })
     await chain.open()

--- a/packages/client/test/integration/client.spec.ts
+++ b/packages/client/test/integration/client.spec.ts
@@ -8,9 +8,9 @@ import { MockServer } from './mocks/mockserver'
 
 describe('[Integration:EthereumClient]', async () => {
   const serverConfig = new Config({ accountCache: 10000, storageCache: 1000 })
-  const servers = [new MockServer({ config: serverConfig }) as any]
+  const server = new MockServer({ config: serverConfig }) as any
   const config = new Config({
-    servers,
+    server,
     syncmode: SyncMode.Full,
     lightserv: false,
     accountCache: 10000,
@@ -18,7 +18,7 @@ describe('[Integration:EthereumClient]', async () => {
   })
 
   // attach server to centralized event bus
-  ;(config.servers[0].config as any).events = config.events
+  ;(config.server!.config as any).events = config.events
   const client = await EthereumClient.create({ config })
 
   it('should start/stop', async () => {
@@ -30,7 +30,7 @@ describe('[Integration:EthereumClient]', async () => {
     })
     await client.open()
     ;(client.service('eth') as any).interval = 100
-    client.config.events.emit(Event.SERVER_ERROR, new Error('err0'), client.config.servers[0])
+    client.config.events.emit(Event.SERVER_ERROR, new Error('err0'), client.config.server!)
     await client.start()
     assert.ok((client.service('eth') as any).synchronizer.running, 'sync running')
     await client.stop()

--- a/packages/client/test/integration/fullethereumservice.spec.ts
+++ b/packages/client/test/integration/fullethereumservice.spec.ts
@@ -26,14 +26,14 @@ describe('[Integration:FullEthereumService]', async () => {
     return this
   }
   async function setup(): Promise<[MockServer, FullEthereumService]> {
-    const server = new MockServer({ config })
+    const server = new MockServer({ config }) as any
     const blockchain = await Blockchain.create({
       common: config.chainCommon,
       validateBlocks: false,
       validateConsensus: false,
     })
     const chain = new MockChain({ config, blockchain })
-    const serviceConfig = new Config({ servers: [server as any], lightserv: true })
+    const serviceConfig = new Config({ server, lightserv: true })
     const service = new FullEthereumService({
       config: serviceConfig,
       chain,

--- a/packages/client/test/integration/merge.spec.ts
+++ b/packages/client/test/integration/merge.spec.ts
@@ -73,7 +73,7 @@ describe('[Integration:Merge]', async () => {
   ]
   async function minerSetup(common: Common): Promise<[MockServer, FullEthereumService]> {
     const config = new Config({ common, accountCache: 10000, storageCache: 1000 })
-    const server = new MockServer({ config })
+    const server = new MockServer({ config }) as any
     const blockchain = await Blockchain.create({
       common,
       validateBlocks: false,
@@ -82,7 +82,7 @@ describe('[Integration:Merge]', async () => {
     ;(blockchain.consensus as CliqueConsensus).cliqueActiveSigners = () => [accounts[0][0]] // stub
     const serviceConfig = new Config({
       common,
-      servers: [server as any],
+      server,
       mine: true,
       accounts,
     })

--- a/packages/client/test/integration/miner.spec.ts
+++ b/packages/client/test/integration/miner.spec.ts
@@ -50,7 +50,7 @@ describe('[Integration:Miner]', async () => {
   ]
   async function minerSetup(): Promise<[MockServer, FullEthereumService]> {
     const config = new Config({ common, accountCache: 10000, storageCache: 1000 })
-    const server = new MockServer({ config })
+    const server = new MockServer({ config }) as any
 
     const blockchain = await Blockchain.create({
       common,
@@ -61,7 +61,7 @@ describe('[Integration:Miner]', async () => {
     const chain = await Chain.create({ config, blockchain })
     const serviceConfig = new Config({
       common,
-      servers: [server as any],
+      server,
       mine: true,
       accounts,
     })

--- a/packages/client/test/integration/peerpool.spec.ts
+++ b/packages/client/test/integration/peerpool.spec.ts
@@ -15,7 +15,7 @@ describe('[Integration:PeerPool]', async () => {
     const serverConfig = new Config({ accountCache: 10000, storageCache: 1000 })
     const server = new MockServer({ config: serverConfig }) as any
     server.addProtocols(protocols)
-    const config = new Config({ servers: [server], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ server, accountCache: 10000, storageCache: 1000 })
     await server.start()
     const pool = new PeerPool({ config })
     await pool.open()
@@ -64,7 +64,7 @@ describe('[Integration:PeerPool]', async () => {
   })
 
   it('should handle peer messages', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const blockchain = await Blockchain.create({
       validateBlocks: false,
       validateConsensus: false,

--- a/packages/client/test/integration/pow.spec.ts
+++ b/packages/client/test/integration/pow.spec.ts
@@ -56,7 +56,6 @@ async function setupPowDevnet(prefundAddress: Address, cleanStart: boolean) {
 
   const config = new Config({
     common,
-    transports: ['rlpx'],
     bootnodes: [],
     multiaddrs: [],
     discDns: false,

--- a/packages/client/test/integration/util.ts
+++ b/packages/client/test/integration/util.ts
@@ -38,7 +38,7 @@ export async function setup(
     storageCache: 1000,
   })
 
-  const server = new MockServer({ config, location })
+  const server = new MockServer({ config, location }) as any
   const blockchain = await Blockchain.create({
     validateBlocks: false,
     validateConsensus: false,
@@ -47,10 +47,9 @@ export async function setup(
 
   const chain = new MockChain({ config, blockchain, height })
 
-  const servers = [server] as any
   const serviceConfig = new Config({
     syncmode,
-    servers,
+    server,
     lightserv,
     minPeers,
     common,

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -127,7 +127,6 @@ describe('[Miner]', async () => {
   })
   customCommon.events.setMaxListeners(50)
   const customConfig = new Config({
-    transports: [],
     accountCache: 10000,
     storageCache: 1000,
     accounts,
@@ -139,7 +138,6 @@ describe('[Miner]', async () => {
   const goerliCommon = new Common({ chain: CommonChain.Goerli, hardfork: Hardfork.Berlin })
   goerliCommon.events.setMaxListeners(50)
   const goerliConfig = new Config({
-    transports: [],
     accountCache: 10000,
     storageCache: 1000,
     accounts,
@@ -210,7 +208,7 @@ describe('[Miner]', async () => {
     assert.notOk(miner.running)
 
     // Should not start when config.mine=false
-    const configMineFalse = new Config({ transports: [], accounts, mine: false })
+    const configMineFalse = new Config({ accounts, mine: false })
     miner = new Miner({ config: configMineFalse, service })
     miner.start()
     assert.notOk(miner.running, 'miner should not start when config.mine=false')
@@ -329,7 +327,6 @@ describe('[Miner]', async () => {
   it('assembleBlocks() -> with saveReceipts', async () => {
     const chain = new FakeChain() as any
     const config = new Config({
-      transports: [],
       accountCache: 10000,
       storageCache: 1000,
       accounts,
@@ -393,7 +390,6 @@ describe('[Miner]', async () => {
       hardfork: Hardfork.London,
     })
     const config = new Config({
-      transports: [],
       accountCache: 10000,
       storageCache: 1000,
       accounts,
@@ -505,7 +501,6 @@ describe('[Miner]', async () => {
   it.skip('assembleBlocks() -> should stop assembling when a new block is received', async () => {
     const chain = new FakeChain() as any
     const config = new Config({
-      transports: [],
       accountCache: 10000,
       storageCache: 1000,
       accounts,
@@ -565,7 +560,6 @@ describe('[Miner]', async () => {
     const common = Common.custom(customChainParams, { baseChain: CommonChain.Goerli })
     common.setHardforkBy({ blockNumber: 0 })
     const config = new Config({
-      transports: [],
       accountCache: 10000,
       storageCache: 1000,
       accounts,
@@ -678,7 +672,6 @@ describe('[Miner]', async () => {
     ;(common as any)._chainParams['genesis'].difficulty = 1
     ;(common as any)._chainParams['genesis'].difficulty = 1
     const config = new Config({
-      transports: [],
       accountCache: 10000,
       storageCache: 1000,
       accounts,

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -58,7 +58,6 @@ common
   })
 
 const config = new Config({
-  transports: [],
   common,
   accountCache: 10000,
   storageCache: 1000,

--- a/packages/client/test/net/peer/peer.spec.ts
+++ b/packages/client/test/net/peer/peer.spec.ts
@@ -7,7 +7,7 @@ import { Peer } from '../../../src/net/peer'
 import { Event } from '../../../src/types'
 
 describe('[Peer]', () => {
-  const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+  const config = new Config({ accountCache: 10000, storageCache: 1000 })
   const peer = new Peer({
     config,
     id: '0123456789abcdef',

--- a/packages/client/test/net/peer/rlpxpeer.spec.ts
+++ b/packages/client/test/net/peer/rlpxpeer.spec.ts
@@ -23,7 +23,7 @@ describe('[RlpxPeer]', async () => {
   const { RlpxPeer } = await import('../../../src/net/peer/rlpxpeer')
 
   it('should initialize correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const peer = new RlpxPeer({
       config,
       id: 'abcdef0123',
@@ -57,7 +57,7 @@ describe('[RlpxPeer]', async () => {
   })
 
   it('should connect to peer', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const proto0 = { name: 'les', versions: [4] } as any
     const peer = new RlpxPeer({
       config,
@@ -73,7 +73,7 @@ describe('[RlpxPeer]', async () => {
   })
 
   it('should handle peer events', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const peer = new RlpxPeer({ config, id: 'abcdef0123', host: '10.0.0.1', port: 1234 })
     const rlpxPeer = { id: 'zyx321', getDisconnectPrefix: vi.fn() } as any
     ;(peer as any).bindProtocols = vi.fn().mockResolvedValue(undefined)
@@ -115,7 +115,7 @@ describe('[RlpxPeer]', async () => {
   })
 
   it('should accept peer connection', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const peer: any = new RlpxPeer({ config, id: 'abcdef0123', host: '10.0.0.1', port: 1234 })
     peer.bindProtocols = vi.fn().mockResolvedValue(null)
 
@@ -124,7 +124,7 @@ describe('[RlpxPeer]', async () => {
   })
 
   it('should bind protocols', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const protocols = [{ name: 'proto0' }] as any
     const peer = new RlpxPeer({
       config,

--- a/packages/client/test/net/peerpool.spec.ts
+++ b/packages/client/test/net/peerpool.spec.ts
@@ -5,8 +5,6 @@ import { Config } from '../../src/config'
 import { Event } from '../../src/types'
 import { MockPeer } from '../integration/mocks/mockpeer'
 
-import type { RlpxServer } from '../../src/net/server'
-
 describe('[PeerPool]', async () => {
   const Peer = function (this: any, id: string) {
     this.id = id // eslint-disable-line no-invalid-this
@@ -15,16 +13,16 @@ describe('[PeerPool]', async () => {
   const { PeerPool } = await import('../../src/net/peerpool')
 
   it('should initialize', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool({ config })
     assert.notOk((pool as any).pool.size, 'empty pool')
     assert.notOk((pool as any).opened, 'not open')
   })
 
   it('should open/close', async () => {
-    const server = {}
+    const server = {} as any
     const config = new Config({
-      servers: [server as RlpxServer],
+      server,
       accountCache: 10000,
       storageCache: 1000,
     })
@@ -52,7 +50,7 @@ describe('[PeerPool]', async () => {
 
   it('should connect/disconnect peer', () => {
     const peer = new EventEmitter() as any
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool({ config })
     ;(peer as any).id = 'abc'
     ;(peer as any).handleMessageQueue = vi.fn()
@@ -68,7 +66,7 @@ describe('[PeerPool]', async () => {
 
   it('should check contains', () => {
     const peer = new Peer('abc')
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool({ config })
     pool.add(peer)
     assert.ok(pool.contains(peer.id), 'found peer')
@@ -76,7 +74,7 @@ describe('[PeerPool]', async () => {
 
   it('should get idle peers', () => {
     const peers = [new Peer(1), new Peer(2), new Peer(3)]
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool({ config })
     peers[1].idle = true
     for (const p of peers) {
@@ -92,7 +90,7 @@ describe('[PeerPool]', async () => {
 
   it('should ban peer', () => {
     const peers = [{ id: 1 }, { id: 2, server: { ban: vi.fn() } }]
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool({ config })
     for (const p of peers as any) {
       pool.add(p)

--- a/packages/client/test/net/protocol/boundprotocol.spec.ts
+++ b/packages/client/test/net/protocol/boundprotocol.spec.ts
@@ -29,7 +29,7 @@ describe('[BoundProtocol]', () => {
 
   it('should add methods for messages with a response', () => {
     const sender = new Sender()
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const bound = new BoundProtocol({
       config,
       protocol,
@@ -41,7 +41,7 @@ describe('[BoundProtocol]', () => {
 
   it('should get/set status', () => {
     const sender = new Sender()
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const bound = new BoundProtocol({
       config,
       protocol,
@@ -54,7 +54,7 @@ describe('[BoundProtocol]', () => {
   })
 
   it('should do handshake', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const sender = new EventEmitter() as Sender
     const bound = new BoundProtocol({
       config,
@@ -68,7 +68,7 @@ describe('[BoundProtocol]', () => {
   })
 
   it('should handle incoming without resolver', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const sender = new Sender()
     const bound = new BoundProtocol({
       config,
@@ -89,7 +89,7 @@ describe('[BoundProtocol]', () => {
   })
 
   it('should perform send', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const sender = new Sender()
     sender.sendMessage = td.func<Sender['sendMessage']>()
     const bound = new BoundProtocol({
@@ -105,7 +105,7 @@ describe('[BoundProtocol]', () => {
   })
 
   it('should perform request', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const sender = new Sender()
     const bound = new BoundProtocol({
       config,
@@ -132,7 +132,7 @@ describe('[BoundProtocol]', () => {
   })
 
   it('should timeout request', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const sender = td.object<Sender>('Sender')
     const bound = new BoundProtocol({
       config,

--- a/packages/client/test/net/protocol/ethprotocol.spec.ts
+++ b/packages/client/test/net/protocol/ethprotocol.spec.ts
@@ -10,7 +10,7 @@ import { EthProtocol } from '../../../src/net/protocol'
 
 describe('[EthProtocol]', () => {
   it('should get properties', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new EthProtocol({ config, chain })
     assert.ok(typeof p.name === 'string', 'get name')
@@ -19,7 +19,7 @@ describe('[EthProtocol]', () => {
   })
 
   it('should open correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new EthProtocol({ config, chain })
     await p.open()
@@ -28,7 +28,7 @@ describe('[EthProtocol]', () => {
   })
 
   it('should encode/decode status', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new EthProtocol({ config, chain })
     Object.defineProperty(chain, 'networkId', {
@@ -76,7 +76,7 @@ describe('[EthProtocol]', () => {
   })
 
   it('verify that NewBlock handler encodes/decodes correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new EthProtocol({ config, chain })
     const td = BigInt(100)
@@ -94,7 +94,7 @@ describe('[EthProtocol]', () => {
   })
 
   it('verify that GetReceipts handler encodes/decodes correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new EthProtocol({ config, chain })
     const block = Block.fromBlockData({})
@@ -114,7 +114,6 @@ describe('[EthProtocol]', () => {
 
   it('verify that PooledTransactions handler encodes correctly', async () => {
     const config = new Config({
-      transports: [],
       common: new Common({ chain: Config.CHAIN_DEFAULT, hardfork: Hardfork.London }),
       accountCache: 10000,
       storageCache: 1000,
@@ -140,7 +139,6 @@ describe('[EthProtocol]', () => {
 
   it('verify that Receipts encode/decode correctly', async () => {
     const config = new Config({
-      transports: [],
       common: new Common({ chain: Config.CHAIN_DEFAULT, hardfork: Hardfork.London }),
       accountCache: 10000,
       storageCache: 1000,
@@ -204,7 +202,6 @@ describe('[EthProtocol]', () => {
 
   it('verify that Transactions handler encodes/decodes correctly', async () => {
     const config = new Config({
-      transports: [],
       common: new Common({
         chain: Config.CHAIN_DEFAULT,
         hardfork: Hardfork.Paris,
@@ -243,7 +240,6 @@ describe('[EthProtocol]', () => {
 
   it('verify that NewPooledTransactionHashes encodes/decodes correctly', async () => {
     const config = new Config({
-      transports: [],
       common: new Common({ chain: Config.CHAIN_DEFAULT, hardfork: Hardfork.London }),
       accountCache: 10000,
       storageCache: 1000,

--- a/packages/client/test/net/protocol/lesprotocol.spec.ts
+++ b/packages/client/test/net/protocol/lesprotocol.spec.ts
@@ -7,7 +7,7 @@ import { FlowControl, LesProtocol } from '../../../src/net/protocol'
 
 describe('[LesProtocol]', () => {
   it('should get properties', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new LesProtocol({ config, chain })
     assert.ok(typeof p.name === 'string', 'get name')
@@ -16,7 +16,7 @@ describe('[LesProtocol]', () => {
   })
 
   it('should open correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new LesProtocol({ config, chain })
     await p.open()
@@ -25,7 +25,7 @@ describe('[LesProtocol]', () => {
   })
 
   it('should encode/decode status', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const flow = new FlowControl({
       bl: 1000,

--- a/packages/client/test/net/protocol/protocol.spec.ts
+++ b/packages/client/test/net/protocol/protocol.spec.ts
@@ -13,7 +13,7 @@ describe('[Protocol]', () => {
   }
   class TestProtocol extends Protocol {
     constructor() {
-      const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+      const config = new Config({ accountCache: 10000, storageCache: 1000 })
       super({ config })
     }
 
@@ -35,7 +35,7 @@ describe('[Protocol]', () => {
   }
 
   it('should throw if missing abstract methods', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const p = new Protocol({ config })
     assert.throws(() => p.versions, /Unimplemented/)
     assert.throws(() => p.messages, /Unimplemented/)
@@ -44,7 +44,7 @@ describe('[Protocol]', () => {
   })
 
   it('should handle open', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const p = new Protocol({ config })
     await p.open()
     assert.ok(p.opened, 'is open')

--- a/packages/client/test/net/protocol/snapprotocol.spec.ts
+++ b/packages/client/test/net/protocol/snapprotocol.spec.ts
@@ -23,7 +23,7 @@ import { SnapProtocol } from '../../../src/net/protocol'
 
 describe('[SnapProtocol]', () => {
   it('should get properties', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
     assert.ok(typeof p.name === 'string', 'get name')
@@ -32,7 +32,7 @@ describe('[SnapProtocol]', () => {
   })
 
   it('should open correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
     await p.open()
@@ -41,7 +41,7 @@ describe('[SnapProtocol]', () => {
   })
 
   it('GetAccountRange should encode/decode correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
     const root = new Uint8Array(0)
@@ -94,7 +94,7 @@ describe('[SnapProtocol]', () => {
   })
 
   it('AccountRange should encode/decode correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
     /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -136,7 +136,7 @@ describe('[SnapProtocol]', () => {
   })
 
   it('AccountRange encode/decode should handle account slim body correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const pSlim = new SnapProtocol({ config, chain })
     const pFull = new SnapProtocol({ config, chain, convertSlimBody: true })
@@ -172,7 +172,7 @@ describe('[SnapProtocol]', () => {
   })
 
   it('AccountRange should verify a real sample', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
 
@@ -211,7 +211,7 @@ describe('[SnapProtocol]', () => {
   })
 
   it('GetStorageRanges should encode/decode correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
     const root = new Uint8Array(0)
@@ -273,7 +273,7 @@ describe('[SnapProtocol]', () => {
   })
 
   it('StorageRanges should encode/decode correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
 
@@ -306,7 +306,7 @@ describe('[SnapProtocol]', () => {
   })
 
   it('StorageRanges should verify a real sample', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
 
@@ -350,7 +350,7 @@ describe('[SnapProtocol]', () => {
   })
 
   it('GetByteCodes should encode/decode correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
     const reqId = BigInt(1)
@@ -389,7 +389,7 @@ describe('[SnapProtocol]', () => {
   })
 
   it('ByteCodes should encode/decode correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
 
@@ -412,7 +412,7 @@ describe('[SnapProtocol]', () => {
   })
 
   it('ByteCodes should verify a real sample', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
 
@@ -433,7 +433,7 @@ describe('[SnapProtocol]', () => {
   })
 
   it('GetTrieNodes should encode/decode correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
 
@@ -474,7 +474,7 @@ describe('[SnapProtocol]', () => {
   })
 
   it('TrieNodes should encode/decode correctly with real sample', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
 

--- a/packages/client/test/net/server/rlpxserver.spec.ts
+++ b/packages/client/test/net/server/rlpxserver.spec.ts
@@ -50,7 +50,7 @@ describe('[RlpxServer]', async () => {
   const { RlpxServer } = await import('../../../src/net/server/rlpxserver')
 
   it('should initialize correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const server = new RlpxServer({
       config,
       bootnodes: '10.0.0.1:1234,enode://abcd@10.0.0.2:1234',
@@ -66,11 +66,11 @@ describe('[RlpxServer]', async () => {
   })
 
   it('should start/stop server', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const server = new RlpxServer({
       config,
       bootnodes: '10.0.0.1:1234,10.0.0.2:1234',
-    })
+    }) as any
     ;(server as any).initDpt = vi.fn()
     ;(server as any).initRlpx = vi.fn()
     server.dpt = {
@@ -89,7 +89,7 @@ describe('[RlpxServer]', async () => {
       }),
     }
     server.rlpx = { destroy: vi.fn() }
-    server.config.events.on(Event.PEER_ERROR, (err) =>
+    server.config.events.on(Event.PEER_ERROR, (err: any) =>
       assert.equal(err.message, 'err0', 'got error')
     )
     await server.start()
@@ -107,7 +107,6 @@ describe('[RlpxServer]', async () => {
   it('should bootstrap with dns acquired peers', async () => {
     const dnsPeerInfo = { address: '10.0.0.5', udpPort: 1234, tcpPort: 1234 }
     const config = new Config({
-      transports: [],
       accountCache: 10000,
       storageCache: 1000,
       discDns: true,
@@ -115,7 +114,7 @@ describe('[RlpxServer]', async () => {
     const server = new RlpxServer({
       config,
       dnsNetworks: ['enrtree:A'],
-    })
+    }) as any
     ;(server as any).initDpt = vi.fn()
     ;(server as any).initRlpx = vi.fn()
     server.rlpx = { destroy: vi.fn() }
@@ -133,12 +132,12 @@ describe('[RlpxServer]', async () => {
   })
 
   it('should return rlpx server info with ip4 as default', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const mockId = '0123'
     const server = new RlpxServer({
       config,
       bootnodes: '10.0.0.1:1234,10.0.0.2:1234',
-    })
+    }) as any
     ;(server as any).initDpt = vi.fn()
     ;(server as any).initRlpx = vi.fn()
     server.dpt = {
@@ -181,7 +180,6 @@ describe('[RlpxServer]', async () => {
 
   it('should return rlpx server info with ip6', async () => {
     const config = new Config({
-      transports: [],
       accountCache: 10000,
       storageCache: 1000,
       extIP: '::',
@@ -190,7 +188,7 @@ describe('[RlpxServer]', async () => {
     const server = new RlpxServer({
       config,
       bootnodes: '10.0.0.1:1234,10.0.0.2:1234',
-    })
+    }) as any
     ;(server as any).initDpt = vi.fn()
     ;(server as any).initRlpx = vi.fn()
     server.dpt = {
@@ -233,7 +231,7 @@ describe('[RlpxServer]', async () => {
 
   it('should handle errors', () => {
     let count = 0
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const server = new RlpxServer({ config })
     server.config.events.on(Event.SERVER_ERROR, (err) => {
       count = count + 1
@@ -249,7 +247,7 @@ describe('[RlpxServer]', async () => {
   })
 
   it('should ban peer', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const server = new RlpxServer({ config })
     assert.notOk(server.ban('123'), 'not started')
     server.started = true
@@ -267,7 +265,7 @@ describe('[RlpxServer]', async () => {
   })
 
   it('should init dpt', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const server = new RlpxServer({ config })
     ;(server as any).initDpt().catch((error: Error) => {
       throw error
@@ -281,7 +279,7 @@ describe('[RlpxServer]', async () => {
   })
 
   it('should init rlpx', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const server = new RlpxServer({ config })
     const rlpxPeer = new RlpxPeer()
 
@@ -327,7 +325,7 @@ describe('[RlpxServer]', async () => {
   })
 
   it('should handles errors from id-less peers', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const server = new RlpxServer({ config })
     const rlpxPeer = new RlpxPeer()
     ;(rlpxPeer as any).getId = vi.fn().mockReturnValue(utf8ToBytes('test'))

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -81,7 +81,6 @@ export function createClient(clientOpts: Partial<createClientArgs> = {}) {
   const common: Common = clientOpts.commonChain ?? new Common({ chain: ChainEnum.Mainnet })
   const genesisState = clientOpts.genesisState ?? getGenesis(Number(common.chainId())) ?? {}
   const config = new Config({
-    transports: [],
     common,
     saveReceipts: clientOpts.enableMetaDB,
     txLookupLimit: clientOpts.txLookupLimit,

--- a/packages/client/test/service/fullethereumservice.spec.ts
+++ b/packages/client/test/service/fullethereumservice.spec.ts
@@ -64,7 +64,7 @@ describe('[FullEthereumService]', async () => {
   const { FullEthereumService } = await import('../../src/service/fullethereumservice')
 
   it('should initialize correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
 
@@ -73,12 +73,12 @@ describe('[FullEthereumService]', async () => {
   })
 
   it('should get protocols', async () => {
-    let config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    let config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     let service = new FullEthereumService({ config, chain })
     assert.ok(service.protocols.filter((p) => p.name === 'eth').length > 0, 'full protocol')
     assert.notOk(service.protocols.filter((p) => p.name === 'les').length > 0, 'no light protocol')
-    config = new Config({ transports: [], lightserv: true })
+    config = new Config({ lightserv: true })
     service = new FullEthereumService({ config, chain })
     assert.ok(service.protocols.filter((p) => p.name === 'eth').length > 0, 'full protocol')
     assert.ok(service.protocols.filter((p) => p.name === 'les').length > 0, 'lightserv protocols')
@@ -86,7 +86,7 @@ describe('[FullEthereumService]', async () => {
 
   it('should open', async () => {
     const server = new RlpxServer({} as any)
-    const config = new Config({ servers: [server], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ server, accountCache: 10000, storageCache: 1000 })
 
     const chain = await Chain.create({ config })
     chain.open = vi.fn()
@@ -110,7 +110,7 @@ describe('[FullEthereumService]', async () => {
 
   it('should start/stop', async () => {
     const server = new RlpxServer({} as any)
-    const config = new Config({ servers: [server], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ server, accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
 
     const service = new FullEthereumService({ config, chain })
@@ -125,7 +125,7 @@ describe('[FullEthereumService]', async () => {
   })
 
   it('should correctly handle GetBlockHeaders', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     vi.unmock('../../src/blockchain')
     await import('../../src/blockchain')
     const chain = await Chain.create({ config })
@@ -174,7 +174,7 @@ describe('[FullEthereumService]', async () => {
   })
 
   it('should call handleNewBlock on NewBlock and handleNewBlockHashes on NewBlockHashes', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     await service.handle({ name: 'NewBlock', data: [{}, BigInt(1)] }, 'eth', undefined as any)
@@ -195,7 +195,7 @@ describe('[FullEthereumService]', async () => {
 
   it('should ban peer for sending NewBlock/NewBlockHashes after merge', async () => {
     const common = new Common({ chain: 'mainnet', hardfork: Hardfork.Paris })
-    const config = new Config({ common, transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ common, accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     service.pool.ban = () => {
@@ -207,7 +207,7 @@ describe('[FullEthereumService]', async () => {
   })
 
   it('should send Receipts on GetReceipts', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     const blockHash = new Uint8Array(32).fill(1)
@@ -249,7 +249,7 @@ describe('[FullEthereumService]', async () => {
   })
 
   it('should handle Transactions', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     service.txPool.handleAnnouncedTxs = async (msg, _peer, _pool) => {
@@ -271,7 +271,7 @@ describe('[FullEthereumService]', async () => {
   })
 
   it('should handle NewPooledTransactionHashes', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     service.txPool.handleAnnouncedTxHashes = async (msg, _peer, _pool) => {
@@ -293,7 +293,7 @@ describe('[FullEthereumService]', async () => {
   })
 
   it('should handle GetPooledTransactions', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     ;(service.txPool as any).validate = () => {}
@@ -317,7 +317,7 @@ describe('[FullEthereumService]', async () => {
   it('should handle decoding NewPooledTransactionHashes with eth/68 message format', async () => {
     const txHash = randomBytes(32)
 
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     ;(service.txPool as any).validate = () => {}
@@ -343,7 +343,7 @@ describe('[FullEthereumService]', async () => {
   it('should handle structuring NewPooledTransactionHashes with eth/68 message format', async () => {
     const txHash = randomBytes(32)
 
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const service = new FullEthereumService({ config, chain })
     ;(service.txPool as any).validate = () => {}
@@ -366,11 +366,11 @@ describe('[FullEthereumService]', async () => {
   it('should start on beacon sync when past merge', async () => {
     const common = Common.fromGethGenesis(genesisJSON, { chain: 'post-merge' })
     common.setHardforkBy({ blockNumber: BigInt(0), td: BigInt(0) })
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000, common })
+    const config = new Config({ accountCache: 10000, storageCache: 1000, common })
     const chain = await Chain.create({ config })
     let service = new FullEthereumService({ config, chain })
     assert.ok(service.beaconSync, 'beacon sync should be available')
-    const configDisableBeaconSync = new Config({ transports: [], common, disableBeaconSync: true })
+    const configDisableBeaconSync = new Config({ common, disableBeaconSync: true })
     service = new FullEthereumService({ config: configDisableBeaconSync, chain })
     assert.notOk(service.beaconSync, 'beacon sync should not be available')
   })

--- a/packages/client/test/service/lightethereumservice.spec.ts
+++ b/packages/client/test/service/lightethereumservice.spec.ts
@@ -31,7 +31,7 @@ describe('[LightEthereumService]', async () => {
   const { LightEthereumService } = await import('../../src/service/lightethereumservice')
 
   it('should initialize correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const service = new LightEthereumService({ config, chain })
     assert.ok(service.synchronizer instanceof LightSynchronizer, 'light sync')
@@ -39,7 +39,7 @@ describe('[LightEthereumService]', async () => {
   })
 
   it('should get protocols', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const service = new LightEthereumService({ config, chain })
     assert.ok(service.protocols[0] instanceof LesProtocol, 'light protocols')
@@ -47,7 +47,7 @@ describe('[LightEthereumService]', async () => {
 
   it('should open', async () => {
     const server = new RlpxServer({} as any)
-    const config = new Config({ servers: [server], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ server, accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const service = new LightEthereumService({ config, chain })
     await service.open()
@@ -68,7 +68,7 @@ describe('[LightEthereumService]', async () => {
 
   it('should start/stop', async () => {
     const server = new RlpxServer({} as any)
-    const config = new Config({ servers: [server], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ server, accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const service = new LightEthereumService({ config, chain })
     await service.start()

--- a/packages/client/test/sim/beaconsync.spec.ts
+++ b/packages/client/test/sim/beaconsync.spec.ts
@@ -134,7 +134,7 @@ describe('simple mainnet test run', async () => {
       beaconSyncRelayer = relayer
       assert.ok(ejsClient !== null, 'ethereumjs client started')
 
-      const enode = (ejsClient!.server('rlpx') as RlpxServer)!.getRlpxInfo().enode
+      const enode = (ejsClient!.server() as RlpxServer)!.getRlpxInfo().enode
       const res = await client.request('admin_addPeer', [enode])
       assert.equal(res.result, true, 'successfully requested Geth add EthereumJS as peer')
 
@@ -202,7 +202,6 @@ async function createBeaconSyncClient(
   const logger = getLogger({ logLevel: 'debug' })
   const config = new Config({
     common,
-    transports: ['rlpx'],
     bootnodes,
     multiaddrs: [],
     logger,

--- a/packages/client/test/sim/snapsync.spec.ts
+++ b/packages/client/test/sim/snapsync.spec.ts
@@ -250,7 +250,6 @@ async function createSnapClient(
   const logger = getLogger({ logLevel: 'debug' })
   const config = new Config({
     common,
-    transports: ['rlpx'],
     bootnodes,
     multiaddrs: [],
     logger,

--- a/packages/client/test/sync/beaconsync.spec.ts
+++ b/packages/client/test/sync/beaconsync.spec.ts
@@ -33,7 +33,7 @@ describe('[BeaconSynchronizer]', async () => {
   const { BeaconSynchronizer } = await import('../../src/sync/beaconsync')
 
   it('should initialize correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -42,7 +42,7 @@ describe('[BeaconSynchronizer]', async () => {
   })
 
   it('should open', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -56,7 +56,7 @@ describe('[BeaconSynchronizer]', async () => {
   })
 
   it('should get height', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -71,7 +71,7 @@ describe('[BeaconSynchronizer]', async () => {
   })
 
   it('should find best', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -98,7 +98,6 @@ describe('[BeaconSynchronizer]', async () => {
 
   it('should sync to next subchain head or chain height', async () => {
     const config = new Config({
-      transports: [],
       safeReorgDistance: 0,
       skeletonSubchainMergeMinimum: 0,
       accountCache: 10000,
@@ -151,7 +150,6 @@ describe('[BeaconSynchronizer]', async () => {
 
   it('should not sync pre-genesis', async () => {
     const config = new Config({
-      transports: [],
       safeReorgDistance: 0,
       skeletonSubchainMergeMinimum: 1000,
       accountCache: 10000,
@@ -185,7 +183,7 @@ describe('[BeaconSynchronizer]', async () => {
   })
 
   it('should extend and set with a valid head', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -216,7 +214,7 @@ describe('[BeaconSynchronizer]', async () => {
   })
 
   it('syncWithPeer should return early if skeleton is already linked', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })

--- a/packages/client/test/sync/fetcher/accountfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/accountfetcher.spec.ts
@@ -26,7 +26,7 @@ describe('[AccountFetcher]', async () => {
   )
 
   it('should start/stop', async () => {
-    const config = new Config({ maxPerRequest: 5, transports: [] })
+    const config = new Config({ maxPerRequest: 5 })
     const pool = new PeerPool() as any
     const fetcher = new AccountFetcher({
       config,
@@ -47,7 +47,7 @@ describe('[AccountFetcher]', async () => {
   })
 
   it('should update highest known hash', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const fetcher = new AccountFetcher({
       config,
@@ -79,7 +79,7 @@ describe('[AccountFetcher]', async () => {
   })
 
   it('should process', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const fetcher = new AccountFetcher({
       config,
@@ -115,7 +115,7 @@ describe('[AccountFetcher]', async () => {
   })
 
   it('should adopt correctly', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const fetcher = new AccountFetcher({
       config,
@@ -156,7 +156,7 @@ describe('[AccountFetcher]', async () => {
   })
 
   it('should skip job with limit lower than highest known hash', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const fetcher = new AccountFetcher({
       config,
@@ -193,7 +193,7 @@ describe('[AccountFetcher]', async () => {
   })
 
   it('should request correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const fetcher = new AccountFetcher({
       config,
@@ -234,7 +234,7 @@ describe('[AccountFetcher]', async () => {
   })
 
   it('should verify proof correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const p = new SnapProtocol({ config, chain })
     const pool = new PeerPool() as any
@@ -313,7 +313,7 @@ describe('[AccountFetcher]', async () => {
   })
 
   it('should find a fetchable peer', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const fetcher = new AccountFetcher({
       config,

--- a/packages/client/test/sync/fetcher/blockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/blockfetcher.spec.ts
@@ -20,7 +20,7 @@ describe('[BlockFetcher]', async () => {
   const { BlockFetcher } = await import('../../../src/sync/fetcher/blockfetcher')
 
   it('should start/stop', async () => {
-    const config = new Config({ maxPerRequest: 5, transports: [] })
+    const config = new Config({ maxPerRequest: 5 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const fetcher = new BlockFetcher({
@@ -43,7 +43,7 @@ describe('[BlockFetcher]', async () => {
   })
 
   it('enqueueByNumberList()', async () => {
-    const config = new Config({ maxPerRequest: 5, transports: [] })
+    const config = new Config({ maxPerRequest: 5 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const fetcher = new BlockFetcher({
@@ -92,7 +92,7 @@ describe('[BlockFetcher]', async () => {
   })
 
   it('should process', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const fetcher = new BlockFetcher({
@@ -111,7 +111,7 @@ describe('[BlockFetcher]', async () => {
   })
 
   it('should adopt correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const fetcher = new BlockFetcher({
@@ -137,7 +137,7 @@ describe('[BlockFetcher]', async () => {
   })
 
   it('should find a fetchable peer', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const fetcher = new BlockFetcher({
@@ -152,7 +152,7 @@ describe('[BlockFetcher]', async () => {
   })
 
   it('should request correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const fetcher = new BlockFetcher({
@@ -182,7 +182,7 @@ describe('[BlockFetcher]', async () => {
   })
 
   it('should parse bodies correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     config.chainCommon.getHardforkBy = td.func<typeof config.chainCommon.getHardforkBy>()
     td.when(
       config.chainCommon.getHardforkBy({
@@ -235,7 +235,7 @@ describe('[BlockFetcher]', async () => {
   it('store()', async () => {
     td.reset()
 
-    const config = new Config({ maxPerRequest: 5, transports: [] })
+    const config = new Config({ maxPerRequest: 5 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     chain.putBlocks = td.func<any>()

--- a/packages/client/test/sync/fetcher/bytecodefetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/bytecodefetcher.spec.ts
@@ -27,7 +27,7 @@ describe('[ByteCodeFetcher]', async () => {
   const { ByteCodeFetcher } = await import('../../../src/sync/fetcher/bytecodefetcher')
 
   it('should start/stop', async () => {
-    const config = new Config({ maxPerRequest: 5, transports: [] })
+    const config = new Config({ maxPerRequest: 5 })
     const pool = new PeerPool() as any
     const fetcher = new ByteCodeFetcher({
       config,
@@ -56,7 +56,7 @@ describe('[ByteCodeFetcher]', async () => {
   })
 
   it('should process', () => {
-    const config = new Config({ transports: [] })
+    const config = new Config({})
     const pool = new PeerPool() as any
     const fetcher = new ByteCodeFetcher({
       config,
@@ -84,7 +84,7 @@ describe('[ByteCodeFetcher]', async () => {
   })
 
   it('should adopt correctly', () => {
-    const config = new Config({ transports: [] })
+    const config = new Config({})
     const pool = new PeerPool() as any
     const fetcher = new ByteCodeFetcher({
       config,
@@ -111,7 +111,7 @@ describe('[ByteCodeFetcher]', async () => {
   })
 
   it('should request correctly', async () => {
-    const config = new Config({ transports: [] })
+    const config = new Config({})
     const chain = await Chain.create({ config })
     const pool = new PeerPool() as any
     const p = new SnapProtocol({ config, chain })
@@ -164,7 +164,7 @@ describe('[ByteCodeFetcher]', async () => {
   })
 
   it('should find a fetchable peer', async () => {
-    const config = new Config({ transports: [] })
+    const config = new Config({})
     const pool = new PeerPool() as any
     const fetcher = new ByteCodeFetcher({
       config,

--- a/packages/client/test/sync/fetcher/fetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/fetcher.spec.ts
@@ -26,7 +26,7 @@ class FetcherTest extends Fetcher<any, any, any> {
 
 describe('[Fetcher]', () => {
   it('should handle bad result', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const fetcher = new FetcherTest({ config, pool: td.object() })
     const job: any = { peer: {}, state: 'active' }
     ;(fetcher as any).running = true
@@ -39,7 +39,7 @@ describe('[Fetcher]', () => {
   })
 
   it('should handle failure', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const fetcher = new FetcherTest({ config, pool: td.object() })
     const job = { peer: {}, state: 'active' }
     ;(fetcher as any).running = true
@@ -52,7 +52,7 @@ describe('[Fetcher]', () => {
   })
 
   it('should handle expiration', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const fetcher = new FetcherTest({
       config,
       pool: td.object(),
@@ -83,7 +83,7 @@ describe('[Fetcher]', () => {
   })
 
   it('should handle queue management', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const fetcher = new FetcherTest({
       config,
       pool: td.object(),
@@ -110,7 +110,7 @@ describe('[Fetcher]', () => {
   })
 
   it('should re-enqueue on a non-fatal error', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const fetcher = new FetcherTest({ config, pool: td.object(), timeout: 5000 })
     const task = { first: BigInt(50), count: 10 }
     const job: any = { peer: {}, task, state: 'active', index: 0 }
@@ -141,7 +141,7 @@ describe('[Fetcher]', () => {
   })
 
   it('should handle fatal errors correctly', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const fetcher = new FetcherTest({ config, pool: td.object(), timeout: 5000 })
     const task = { first: BigInt(50), count: 10 }
     const job: any = { peer: {}, task, state: 'active', index: 0 }

--- a/packages/client/test/sync/fetcher/headerfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/headerfetcher.spec.ts
@@ -18,7 +18,7 @@ describe('[HeaderFetcher]', async () => {
   const { HeaderFetcher } = await import('../../../src/sync/fetcher/headerfetcher')
 
   it('should process', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool()
     const flow = { handleReply: vi.fn() }
     const fetcher = new HeaderFetcher({ config, pool, flow })
@@ -38,7 +38,7 @@ describe('[HeaderFetcher]', async () => {
   })
 
   it('should adopt correctly', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const flow = { handleReply: vi.fn() }
     const fetcher = new HeaderFetcher({
@@ -63,7 +63,7 @@ describe('[HeaderFetcher]', async () => {
   })
 
   it('should find a fetchable peer', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool()
     const fetcher = new HeaderFetcher({ config, pool })
     ;(fetcher as any).pool.idle.mockReturnValueOnce('peer0')
@@ -71,7 +71,7 @@ describe('[HeaderFetcher]', async () => {
   })
 
   it('should request correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const flow = { handleReply: vi.fn(), maxRequestCount: vi.fn() }
     const fetcher = new HeaderFetcher({
@@ -96,7 +96,7 @@ describe('[HeaderFetcher]', async () => {
   })
 
   it('store()', async () => {
-    const config = new Config({ maxPerRequest: 5, transports: [] })
+    const config = new Config({ maxPerRequest: 5 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const fetcher = new HeaderFetcher({

--- a/packages/client/test/sync/fetcher/reverseblockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/reverseblockfetcher.spec.ts
@@ -21,7 +21,7 @@ describe('[ReverseBlockFetcher]', async () => {
   const { ReverseBlockFetcher } = await import('../../../src/sync/fetcher/reverseblockfetcher')
 
   it('should start/stop', async () => {
-    const config = new Config({ maxPerRequest: 5, transports: [] })
+    const config = new Config({ maxPerRequest: 5 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -48,7 +48,7 @@ describe('[ReverseBlockFetcher]', async () => {
   })
 
   it('should generate max tasks', async () => {
-    const config = new Config({ maxPerRequest: 5, maxFetcherJobs: 10, transports: [] })
+    const config = new Config({ maxPerRequest: 5, maxFetcherJobs: 10 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -75,7 +75,7 @@ describe('[ReverseBlockFetcher]', async () => {
   })
 
   it('should process', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -96,7 +96,7 @@ describe('[ReverseBlockFetcher]', async () => {
   })
 
   it('should adopt correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -124,7 +124,7 @@ describe('[ReverseBlockFetcher]', async () => {
   })
 
   it('should find a fetchable peer', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -141,7 +141,7 @@ describe('[ReverseBlockFetcher]', async () => {
   })
 
   it('should request correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -174,7 +174,7 @@ describe('[ReverseBlockFetcher]', async () => {
 
   it('store()', async () => {
     td.reset()
-    const config = new Config({ maxPerRequest: 5, transports: [] })
+    const config = new Config({ maxPerRequest: 5 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -218,7 +218,6 @@ describe('[ReverseBlockFetcher]', async () => {
   it('should restart the fetcher when subchains are merged', async () => {
     td.reset()
     const config = new Config({
-      transports: [],
       accountCache: 10000,
       storageCache: 1000,
       skeletonSubchainMergeMinimum: 0,

--- a/packages/client/test/sync/fetcher/storagefetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/storagefetcher.spec.ts
@@ -28,7 +28,7 @@ describe('[StorageFetcher]', async () => {
   const { StorageFetcher } = await import('../../../src/sync/fetcher/storagefetcher')
 
   it('should start/stop', async () => {
-    const config = new Config({ maxPerRequest: 5, transports: [] })
+    const config = new Config({ maxPerRequest: 5 })
     const pool = new PeerPool() as any
     const fetcher = new StorageFetcher({
       config,
@@ -77,7 +77,7 @@ describe('[StorageFetcher]', async () => {
   })
 
   it('should process', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const fetcher = new StorageFetcher({
       config,
@@ -125,7 +125,7 @@ describe('[StorageFetcher]', async () => {
   })
 
   it('should update account highest known slot hash correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const fetcher = new StorageFetcher({
       config,
@@ -190,7 +190,7 @@ describe('[StorageFetcher]', async () => {
   })
 
   it('should adopt correctly', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const fetcher = new StorageFetcher({
       config,
@@ -238,7 +238,7 @@ describe('[StorageFetcher]', async () => {
   })
 
   it('should request correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const pool = new PeerPool() as any
     const p = new SnapProtocol({ config, chain })
@@ -323,7 +323,7 @@ describe('[StorageFetcher]', async () => {
   })
 
   it('should verify proof correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const pool = new PeerPool() as any
     const p = new SnapProtocol({ config, chain })
@@ -419,7 +419,7 @@ describe('[StorageFetcher]', async () => {
   })
 
   it('should find a fetchable peer', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const fetcher = new StorageFetcher({
       config,

--- a/packages/client/test/sync/fetcher/trienodefetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/trienodefetcher.spec.ts
@@ -32,7 +32,7 @@ describe('[TrieNodeFetcher]', async () => {
   const { TrieNodeFetcher } = await import('../../../src/sync/fetcher/trienodefetcher')
 
   it('should start/stop', async () => {
-    const config = new Config({ maxPerRequest: 5, transports: [] })
+    const config = new Config({ maxPerRequest: 5 })
     const pool = new PeerPool() as any
     const fetcher = new TrieNodeFetcher({
       config,
@@ -58,7 +58,7 @@ describe('[TrieNodeFetcher]', async () => {
   })
 
   it('should process', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const fetcher = new TrieNodeFetcher({
       config,
@@ -84,7 +84,7 @@ describe('[TrieNodeFetcher]', async () => {
   })
 
   it('should request correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const fetcher = new TrieNodeFetcher({
       config,
@@ -114,7 +114,7 @@ describe('[TrieNodeFetcher]', async () => {
   })
 
   it('should generate child paths for node correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const chain = await Chain.create({ config })
     const pool = new PeerPool() as any
     const p = new SnapProtocol({ config, chain })
@@ -173,7 +173,7 @@ describe('[TrieNodeFetcher]', async () => {
   })
 
   it('should find a fetchable peer', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const fetcher = new TrieNodeFetcher({
       config,
@@ -189,7 +189,7 @@ describe('[TrieNodeFetcher]', async () => {
   })
 
   it('should return an array of tasks with pathStrings and paths', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const fetcher = new TrieNodeFetcher({
       config,
@@ -212,7 +212,7 @@ describe('[TrieNodeFetcher]', async () => {
   })
 
   it('should return an object with pathStrings', () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const fetcher = new TrieNodeFetcher({
       config,

--- a/packages/client/test/sync/fullsync.spec.ts
+++ b/packages/client/test/sync/fullsync.spec.ts
@@ -35,7 +35,7 @@ describe('[FullSynchronizer]', async () => {
   const { FullSynchronizer } = await import('../../src/sync/fullsync')
 
   it('should initialize correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const sync = new FullSynchronizer({ config, pool, chain, txPool, execution })
@@ -43,7 +43,7 @@ describe('[FullSynchronizer]', async () => {
   })
 
   it('should open', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const sync = new FullSynchronizer({
@@ -61,7 +61,7 @@ describe('[FullSynchronizer]', async () => {
   })
 
   it('should get height', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const sync = new FullSynchronizer({ config, pool, chain, txPool, execution })
@@ -82,7 +82,7 @@ describe('[FullSynchronizer]', async () => {
   })
 
   it('should find best', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const sync = new FullSynchronizer({
@@ -114,7 +114,6 @@ describe('[FullSynchronizer]', async () => {
 
   it('should sync', async () => {
     const config = new Config({
-      transports: [],
       accountCache: 10000,
       storageCache: 1000,
       safeReorgDistance: 0,
@@ -167,7 +166,7 @@ describe('[FullSynchronizer]', async () => {
   })
 
   it('should send NewBlock/NewBlockHashes to right peers', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const sync = new FullSynchronizer({
@@ -257,7 +256,7 @@ describe('[FullSynchronizer]', async () => {
   })
 
   it('should process blocks', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const sync = new FullSynchronizer({

--- a/packages/client/test/sync/lightsync.spec.ts
+++ b/packages/client/test/sync/lightsync.spec.ts
@@ -24,7 +24,7 @@ describe('[LightSynchronizer]', async () => {
   const { LightSynchronizer } = await import('../../src/sync/lightsync')
 
   it('should initialize correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const sync = new LightSynchronizer({ config, pool, chain })
@@ -32,7 +32,7 @@ describe('[LightSynchronizer]', async () => {
   })
 
   it('should find best', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const sync = new LightSynchronizer({
@@ -60,7 +60,6 @@ describe('[LightSynchronizer]', async () => {
 
   it('should sync', async () => {
     const config = new Config({
-      transports: [],
       accountCache: 10000,
       storageCache: 1000,
       safeReorgDistance: 0,
@@ -107,7 +106,6 @@ describe('[LightSynchronizer]', async () => {
     vi.mock('../../src/sync/fetcher/headerfetcher', () => td.object())
     const { LightSynchronizer } = await import('../../src/sync/lightsync')
     const config = new Config({
-      transports: [],
       accountCache: 10000,
       storageCache: 1000,
       safeReorgDistance: 0,
@@ -145,7 +143,7 @@ describe('[LightSynchronizer]', async () => {
 
   it('sync errors', async () => {
     td.reset()
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const sync = new LightSynchronizer({

--- a/packages/client/test/sync/skeleton.spec.ts
+++ b/packages/client/test/sync/skeleton.spec.ts
@@ -189,7 +189,6 @@ describe('[Skeleton] / initSync', async () => {
     it(`${testCase.name}`, async () => {
       const config = new Config({
         common,
-        transports: [],
         logger: getLogger({ logLevel: 'debug' }),
         accountCache: 10000,
         storageCache: 1000,
@@ -305,7 +304,7 @@ describe('[Skeleton] / setHead', async () => {
     it(`${testCase.name}`, async () => {
       const config = new Config({
         common,
-        transports: [],
+
         logger: getLogger({ logLevel: 'debug' }),
         accountCache: 10000,
         storageCache: 1000,
@@ -375,7 +374,7 @@ describe('[Skeleton] / setHead', async () => {
       difficulty: '0x1',
     }
     const common = Common.fromGethGenesis(genesis, { chain: 'merge-not-set' })
-    const config = new Config({ common, transports: [] })
+    const config = new Config({ common })
     const chain = await Chain.create({ config })
     ;(chain.blockchain as any)._validateBlocks = false
     try {
@@ -386,7 +385,7 @@ describe('[Skeleton] / setHead', async () => {
   })
 
   it('should init/setHead properly from genesis', async () => {
-    const config = new Config({ common, transports: [] })
+    const config = new Config({ common })
     const chain = await Chain.create({ config })
     ;(chain.blockchain as any)._validateBlocks = false
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -490,7 +489,7 @@ describe('[Skeleton] / setHead', async () => {
   })
 
   it('should fill the canonical chain after being linked to genesis', async () => {
-    const config = new Config({ common, transports: [], logger: getLogger({ logLevel: 'debug' }) })
+    const config = new Config({ common, logger: getLogger({ logLevel: 'debug' }) })
     const chain = await Chain.create({ config })
     ;(chain.blockchain as any)._validateBlocks = false
     const skeleton = new Skeleton({ chain, config, metaDB: new MemoryLevel() })
@@ -562,7 +561,7 @@ describe('[Skeleton] / setHead', async () => {
   })
 
   it('should fill the canonical chain after being linked to a canonical block past genesis', async () => {
-    const config = new Config({ common, transports: [] })
+    const config = new Config({ common })
     const chain = await Chain.create({ config })
     ;(chain.blockchain as any)._validateBlocks = false
 
@@ -648,7 +647,6 @@ describe('[Skeleton] / setHead', async () => {
     const common = Common.fromGethGenesis(genesis, { chain: 'post-merge' })
     common.setHardforkBy({ blockNumber: BigInt(0), td: BigInt(0) })
     const config = new Config({
-      transports: [],
       common,
       accountCache: 10000,
       storageCache: 1000,
@@ -753,7 +751,6 @@ describe('[Skeleton] / setHead', async () => {
     const common = Common.fromGethGenesis(genesis, { chain: 'post-merge' })
     common.setHardforkBy({ blockNumber: BigInt(0), td: BigInt(0) })
     const config = new Config({
-      transports: [],
       common,
       accountCache: 10000,
       storageCache: 1000,
@@ -814,7 +811,6 @@ describe('[Skeleton] / setHead', async () => {
     const common = Common.fromGethGenesis(genesis, { chain: 'post-merge' })
     common.setHardforkBy({ blockNumber: BigInt(0), td: BigInt(0) })
     const config = new Config({
-      transports: [],
       common,
       logger: getLogger({ logLevel: 'debug' }),
       accountCache: 10000,

--- a/packages/client/test/sync/snapsync.spec.ts
+++ b/packages/client/test/sync/snapsync.spec.ts
@@ -42,7 +42,7 @@ describe('[SnapSynchronizer]', async () => {
   const { SnapSynchronizer } = await import('../../src/sync/snapsync')
 
   it('should initialize correctly', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const sync = new SnapSynchronizer({ config, pool, chain })
@@ -50,7 +50,7 @@ describe('[SnapSynchronizer]', async () => {
   })
 
   it('should open', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const sync = new SnapSynchronizer({ config, pool, chain })
@@ -62,7 +62,7 @@ describe('[SnapSynchronizer]', async () => {
   })
 
   it('should find best', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })
     const sync = new SnapSynchronizer({

--- a/packages/client/test/sync/sync.spec.ts
+++ b/packages/client/test/sync/sync.spec.ts
@@ -27,7 +27,7 @@ describe('[Synchronizer]', async () => {
   PeerPool.prototype.close = td.func<any>()
 
   it('should sync', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     config.syncTargetHeight = BigInt(1)
     const pool = new PeerPool() as any
     const chain = await Chain.create({ config })

--- a/packages/client/test/sync/txpool.spec.ts
+++ b/packages/client/test/sync/txpool.spec.ts
@@ -19,7 +19,6 @@ import { TxPool } from '../../src/service/txpool'
 
 const setup = () => {
   const config = new Config({
-    transports: [],
     accountCache: 10000,
     storageCache: 1000,
     logger: getLogger({ loglevel: 'info' }),
@@ -44,7 +43,7 @@ const setup = () => {
 }
 
 const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
-const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+const config = new Config({ accountCache: 10000, storageCache: 1000 })
 
 const handleTxs = async (
   txs: any[],

--- a/packages/client/test/util/parse.spec.ts
+++ b/packages/client/test/util/parse.spec.ts
@@ -1,7 +1,7 @@
 import { multiaddr } from 'multiaddr'
 import { assert, describe, it } from 'vitest'
 
-import { parseMultiaddrs, parseTransports } from '../../src/util'
+import { parseMultiaddrs } from '../../src/util/parse.js'
 
 describe('[Util/Parse]', () => {
   it('should parse multiaddrs', () => {
@@ -40,31 +40,6 @@ describe('[Util/Parse]', () => {
       parseMultiaddrs('[2607:f8b0:4003:c00::6a]:5678'),
       [multiaddr('/ip6/2607:f8b0:4003:c00::6a/tcp/5678')],
       'parse ipv6 multiaddr'
-    )
-  })
-
-  it('should parse transports', () => {
-    assert.deepEqual(
-      parseTransports(['t1']),
-      [{ name: 't1', options: {} }],
-      'parsed transport without options'
-    )
-    assert.deepEqual<
-      {
-        name: string
-        options: {
-          [key: string]: string | undefined
-        }
-      }[]
-    >(
-      parseTransports(['t2:k1=v1,k:k=v2,k3="v3",k4,k5=']),
-      [
-        {
-          name: 't2',
-          options: { k1: 'v1', 'k:k': 'v2', k3: '"v3"', k4: undefined, k5: '' },
-        },
-      ],
-      'parsed transport with options'
     )
   })
 })

--- a/packages/client/test/util/rpc.spec.ts
+++ b/packages/client/test/util/rpc.spec.ts
@@ -17,7 +17,7 @@ const request = require('supertest')
 
 describe('[Util/RPC]', () => {
   it('should return enabled RPC servers', async () => {
-    const config = new Config({ transports: [], accountCache: 10000, storageCache: 1000 })
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
     const client = await EthereumClient.create({ config, metaDB: new MemoryLevel() })
     const manager = new RPCManager(client, config)
     const { logger } = config
@@ -58,7 +58,6 @@ describe('[Util/RPC]', () => {
 
 describe('[Util/RPC/Engine eth methods]', async () => {
   const config = new Config({
-    transports: [],
     accountCache: 10000,
     storageCache: 1000,
     saveReceipts: true,


### PR DESCRIPTION
This PR entirely removes the `transports` CLI parameter and has a number of related changes:
- Networking (i.e. RLPx server and discv4/dns discovery) is now not activated when `--sync=none` is passed in the command line
- Converts the `servers` property of the `Config` type into a single `server` and adjusts related code
- Removes the `transports` property from `Config` cleans up boatloads of tests 
where the `transports` property was set