### PR TITLE
Add `debug` types to `evm`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2475,10 +2475,9 @@
       "dev": true
     },
     "node_modules/@types/debug": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.8.tgz",
-      "integrity": "sha512-/vPO1EPOs306Cvhwv7KfVfYvOJqA/S/AXjaHQiJboCZzcNDb+TIJFN9/2C9DZ//ijSKWioNyUxD792QmDJ+HKQ==",
-      "dev": true,
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.9.tgz",
+      "integrity": "sha512-8Hz50m2eoS56ldRlepxSBa6PWEVCtzUo/92HgLc2qTMnotJNIm7xP+UZhyWoYsyOdd5dxZ+NZLb24rsKyFs2ow==",
       "dependencies": {
         "@types/ms": "*"
       }
@@ -2603,8 +2602,7 @@
     "node_modules/@types/ms": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
-      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
-      "dev": true
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
     },
     "node_modules/@types/node": {
       "version": "18.11.9",
@@ -15672,6 +15670,7 @@
         "@ethereumjs/statemanager": "^2.0.0",
         "@ethereumjs/tx": "^5.0.0",
         "@ethereumjs/util": "^9.0.0",
+        "@types/debug": "^4.1.9",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.1.2",
         "rustbn-wasm": "^0.2.0"

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -70,7 +70,7 @@
   "devDependencies": {
     "@ethereumjs/block": "^5.0.0",
     "@ethereumjs/tx": "^5.0.0",
-    "@types/debug": "^4.1.4",
+    "@types/debug": "^4.1.9",
     "@types/k-bucket": "^5.0.0",
     "chalk": "^2.4.2",
     "testdouble": "^3.8.2"

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -56,6 +56,7 @@
     "@ethereumjs/statemanager": "^2.0.0",
     "@ethereumjs/tx": "^5.0.0",
     "@ethereumjs/util": "^9.0.0",
+    "@types/debug": "^4.1.9",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.1.2",
     "rustbn-wasm": "^0.2.0"

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -61,6 +61,6 @@
   "devDependencies": {
     "@ethereumjs/block": "^5.0.0",
     "@ethereumjs/genesis": "^0.1.0",
-    "@types/debug": "^4.1.8"
+    "@types/debug": "^4.1.9"
   }
 }


### PR DESCRIPTION
As noted in #3071, the `PrecompileInput` interface exposes a `_debug` property which is of type `debug`.  Since this `PrecompileInput` is be used when somebody is implementing a custom precompile, it makes sens to add the `debug` types to the production dependencies so Typescript can resolve these types.

It also updates the dependency version in two other packages where it is a `devDependency`.