### PR TITLE
client: make the newpayload execution of big blocks non blocking

### DIFF
--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -317,6 +317,11 @@ export interface ConfigOptions {
    */
   engineNewpayloadMaxExecute?: number
 
+  /**
+   * Limit max transactions per block to execute in engine's newPayload for responsive engine api
+   */
+  engineNewpayloadMaxTxsExecute?: number
+
   maxStorageRange?: bigint
 }
 
@@ -357,6 +362,8 @@ export class Config {
   // engine new payload calls can come in batch of 64, keeping 128 as the lookup factor
   public static readonly ENGINE_PARENTLOOKUP_MAX_DEPTH = 128
   public static readonly ENGINE_NEWPAYLOAD_MAX_EXECUTE = 2
+  // currently ethereumjs can execute 200 txs in 12 second window so keeping 1/2 target for blocking response
+  public static readonly ENGINE_NEWPAYLOAD_MAX_TXS_EXECUTE = 100
 
   public readonly logger: Logger
   public readonly syncmode: SyncMode
@@ -400,6 +407,7 @@ export class Config {
   public readonly syncedStateRemovalPeriod: number
   public readonly engineParentLookupMaxDepth: number
   public readonly engineNewpayloadMaxExecute: number
+  public readonly engineNewpayloadMaxTxsExecute: number
 
   public readonly disableBeaconSync: boolean
   public readonly forceSnapSync: boolean
@@ -474,6 +482,8 @@ export class Config {
       options.engineParentLookupMaxDepth ?? Config.ENGINE_PARENTLOOKUP_MAX_DEPTH
     this.engineNewpayloadMaxExecute =
       options.engineNewpayloadMaxExecute ?? Config.ENGINE_NEWPAYLOAD_MAX_EXECUTE
+    this.engineNewpayloadMaxTxsExecute =
+      options.engineNewpayloadMaxTxsExecute ?? Config.ENGINE_NEWPAYLOAD_MAX_TXS_EXECUTE
 
     this.disableBeaconSync = options.disableBeaconSync ?? false
     this.forceSnapSync = options.forceSnapSync ?? false

--- a/packages/client/src/rpc/modules/engine.ts
+++ b/packages/client/src/rpc/modules/engine.ts
@@ -769,10 +769,13 @@ export class Engine {
             (await validExecutedChainBlock(bHash, this.chain))) !== null
 
         if (!isBlockExecuted) {
-          // Only execute if number of blocks pending to be executed are within limit
+          // Only execute
+          //   i) if number of blocks pending to be executed are within limit
+          //   ii) Txs to execute in blocking call is within the supported limit
           // else return SYNCING/ACCEPTED and let skeleton led chain execution catch up
           const executed =
-            blocks.length - i <= this.chain.config.engineNewpayloadMaxExecute
+            blocks.length - i <= this.chain.config.engineNewpayloadMaxExecute &&
+            block.transactions.length <= this.chain.config.engineNewpayloadMaxTxsExecute
               ? await this.execution.runWithoutSetHead({
                   block,
                   root: (i > 0 ? blocks[i - 1] : await this.chain.getBlock(block.header.parentHash))

--- a/packages/client/test/rpc/engine/newPayloadV1.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV1.spec.ts
@@ -299,7 +299,7 @@ describe(method, () => {
     }
 
     // set the newpayload limit to 100 for test
-    chain.config.engineNewpayloadMaxTxsExecute = 100
+    ;(chain.config as any).engineNewpayloadMaxTxsExecute = 100
 
     // newpayload shouldn't execute block but just return either SYNCING or ACCEPTED
     let expectRes = (res: any) => {
@@ -309,7 +309,7 @@ describe(method, () => {
     await baseRequest(server, req, 200, expectRes, false, false)
 
     // set the newpayload limit to 101 and the block should be executed
-    chain.config.engineNewpayloadMaxTxsExecute = 101
+    ;(chain.config as any).engineNewpayloadMaxTxsExecute = 101
     expectRes = (res: any) => {
       assert.equal(res.body.result.status, 'VALID')
     }

--- a/packages/client/test/rpc/engine/newPayloadV1.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV1.spec.ts
@@ -256,6 +256,67 @@ describe(method, () => {
     await baseRequest(server, req, 200, expectRes)
   })
 
+  it('call with too many transactions', async () => {
+    const accountPk = hexToBytes(
+      '0xe331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109'
+    )
+    const accountAddress = Address.fromPrivateKey(accountPk)
+    const newGenesisJSON = {
+      ...genesisJSON,
+      alloc: {
+        ...genesisJSON.alloc,
+        [accountAddress.toString()]: {
+          balance: '0x100000000',
+        },
+      },
+    }
+
+    const { chain, server, common } = await setupChain(newGenesisJSON, 'post-merge', {
+      engine: true,
+    })
+
+    const transactions = Array.from({ length: 101 }, (_v, i) => {
+      const tx = FeeMarketEIP1559Transaction.fromTxData(
+        {
+          nonce: i,
+          maxFeePerGas: '0x7',
+          value: 6,
+          gasLimit: 53_000,
+        },
+        { common }
+      ).sign(accountPk)
+
+      return bytesToHex(tx.serialize())
+    })
+    const blockDataWithValidTransaction = {
+      ...blockData,
+      transactions,
+      parentHash: '0x7444bd276e83a1ad90cf2ce8d1cff9ad15ed2489e49928a802bd60e3e81010f4',
+      receiptsRoot: '0x29651db7ce551aae097d75c4c9785e55068a11cf9e365bbe1c3b1780a85621c0',
+      gasUsed: '0x51ae28',
+      stateRoot: '0xd51a194147c26671af9ce46e9f5914d3e64fac15e80e46be5cc8c42c935449bc',
+      blockHash: '0x7c5cc6138adca74b80e6066c30e330b6307ff43bc0dc3dd4e988bb1b9764d199',
+    }
+
+    // set the newpayload limit to 100 for test
+    chain.config.engineNewpayloadMaxTxsExecute = 100
+
+    // newpayload shouldn't execute block but just return either SYNCING or ACCEPTED
+    let expectRes = (res: any) => {
+      assert.equal(res.body.result.status, 'ACCEPTED')
+    }
+    let req = params(method, [blockDataWithValidTransaction])
+    await baseRequest(server, req, 200, expectRes, false, false)
+
+    // set the newpayload limit to 101 and the block should be executed
+    chain.config.engineNewpayloadMaxTxsExecute = 101
+    expectRes = (res: any) => {
+      assert.equal(res.body.result.status, 'VALID')
+    }
+    req = params(method, [blockDataWithValidTransaction])
+    await baseRequest(server, req, 200, expectRes)
+  })
+
   it('re-execute payload and verify that no errors occur', async () => {
     const { server } = await setupChain(genesisJSON, 'post-merge', { engine: true })
 


### PR DESCRIPTION
on devnet9 there is  a range of blocks 1700-2000 where blocks have txs ~1400+. This causes newpayload api to timeout for the CLs causing them to be stuck and/or retry the same blocks over and over again.

This PR, responds `SYNCING` to heavy blocks (for ethereumjs) which can then be independently executed while letting the CL sync moveforward.

tested on devnet-9 with lodestar leading to fast resolution of sync from genesis 