### PR TITLE
client: track and respond to invalid blocks in engine api and other hive engine-cancun fixes

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -362,6 +362,11 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     describe: 'path to a file of RLP encoded blocks',
     string: true,
   })
+  .option('pruneEngineCache', {
+    describe: 'Enable/Disable pruning engine block cache (disable for testing against hive etc)',
+    boolean: true,
+    default: true,
+  })
   .completion()
   // strict() ensures that yargs throws when an invalid arg is provided
   .strict().argv
@@ -831,6 +836,7 @@ async function run() {
     forceSnapSync: args.forceSnapSync,
     prefixStorageTrieKeys: args.prefixStorageTrieKeys,
     txLookupLimit: args.txLookupLimit,
+    pruneEngineCache: args.pruneEngineCache,
   })
   config.events.setMaxListeners(50)
   config.events.on(Event.SERVER_LISTENING, (details) => {

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -323,6 +323,11 @@ export interface ConfigOptions {
   engineNewpayloadMaxTxsExecute?: number
 
   maxStorageRange?: bigint
+
+  /**
+   * Cache size of invalid block hashes and their errors
+   */
+  maxInvalidBlocksErrorCache?: number
 }
 
 export class Config {
@@ -353,11 +358,15 @@ export class Config {
   public static readonly SAFE_REORG_DISTANCE = 100
   public static readonly SKELETON_FILL_CANONICAL_BACKSTEP = 100
   public static readonly SKELETON_SUBCHAIN_MERGE_MINIMUM = 1000
+
   public static readonly MAX_RANGE_BYTES = 50000
   // This should get like 100 accounts in this range
   public static readonly MAX_ACCOUNT_RANGE = (BIGINT_2 ** BIGINT_256 - BIGINT_1) / BigInt(1_000_000)
   // Larger ranges used for storage slots since assumption is slots should be much sparser than accounts
   public static readonly MAX_STORAGE_RANGE = (BIGINT_2 ** BIGINT_256 - BIGINT_1) / BigInt(10)
+
+  public static readonly MAX_INVALID_BLOCKS_ERROR_CACHE = 128
+
   public static readonly SYNCED_STATE_REMOVAL_PERIOD = 60000
   // engine new payload calls can come in batch of 64, keeping 128 as the lookup factor
   public static readonly ENGINE_PARENTLOOKUP_MAX_DEPTH = 128
@@ -404,6 +413,7 @@ export class Config {
   public readonly maxRangeBytes: number
   public readonly maxAccountRange: bigint
   public readonly maxStorageRange: bigint
+  public readonly maxInvalidBlocksErrorCache: number
   public readonly syncedStateRemovalPeriod: number
   public readonly engineParentLookupMaxDepth: number
   public readonly engineNewpayloadMaxExecute: number
@@ -473,9 +483,14 @@ export class Config {
       options.skeletonFillCanonicalBackStep ?? Config.SKELETON_FILL_CANONICAL_BACKSTEP
     this.skeletonSubchainMergeMinimum =
       options.skeletonSubchainMergeMinimum ?? Config.SKELETON_SUBCHAIN_MERGE_MINIMUM
+
     this.maxRangeBytes = options.maxRangeBytes ?? Config.MAX_RANGE_BYTES
     this.maxAccountRange = options.maxAccountRange ?? Config.MAX_ACCOUNT_RANGE
     this.maxStorageRange = options.maxStorageRange ?? Config.MAX_STORAGE_RANGE
+
+    this.maxInvalidBlocksErrorCache =
+      options.maxInvalidBlocksErrorCache ?? Config.MAX_INVALID_BLOCKS_ERROR_CACHE
+
     this.syncedStateRemovalPeriod =
       options.syncedStateRemovalPeriod ?? Config.SYNCED_STATE_REMOVAL_PERIOD
     this.engineParentLookupMaxDepth =

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -328,6 +328,7 @@ export interface ConfigOptions {
    * Cache size of invalid block hashes and their errors
    */
   maxInvalidBlocksErrorCache?: number
+  pruneEngineCache?: boolean
 }
 
 export class Config {
@@ -366,6 +367,7 @@ export class Config {
   public static readonly MAX_STORAGE_RANGE = (BIGINT_2 ** BIGINT_256 - BIGINT_1) / BigInt(10)
 
   public static readonly MAX_INVALID_BLOCKS_ERROR_CACHE = 128
+  public static readonly PRUNE_ENGINE_CACHE = true
 
   public static readonly SYNCED_STATE_REMOVAL_PERIOD = 60000
   // engine new payload calls can come in batch of 64, keeping 128 as the lookup factor
@@ -414,6 +416,7 @@ export class Config {
   public readonly maxAccountRange: bigint
   public readonly maxStorageRange: bigint
   public readonly maxInvalidBlocksErrorCache: number
+  public readonly pruneEngineCache: boolean
   public readonly syncedStateRemovalPeriod: number
   public readonly engineParentLookupMaxDepth: number
   public readonly engineNewpayloadMaxExecute: number
@@ -490,6 +493,7 @@ export class Config {
 
     this.maxInvalidBlocksErrorCache =
       options.maxInvalidBlocksErrorCache ?? Config.MAX_INVALID_BLOCKS_ERROR_CACHE
+    this.pruneEngineCache = options.pruneEngineCache ?? Config.PRUNE_ENGINE_CACHE
 
     this.syncedStateRemovalPeriod =
       options.syncedStateRemovalPeriod ?? Config.SYNCED_STATE_REMOVAL_PERIOD

--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -162,6 +162,7 @@ export class VMExecution extends Execution {
    * the entire procedure.
    * @param receipts If we built this block, pass the receipts to not need to run the block again
    * @param optional param if runWithoutSetHead should block for execution
+   * @param optional param if runWithoutSetHead should skip putting block into chain
    * @returns if the block was executed or not, throws on block execution failure
    */
   async runWithoutSetHead(

--- a/packages/client/src/miner/pendingBlock.ts
+++ b/packages/client/src/miner/pendingBlock.ts
@@ -100,7 +100,7 @@ export class PendingBlock {
     withdrawals?: WithdrawalData[]
   ) {
     const number = parentBlock.header.number + BIGINT_1
-    const { timestamp, mixHash, parentBeaconBlockRoot } = headerData
+    const { timestamp, mixHash, parentBeaconBlockRoot, coinbase } = headerData
     let { gasLimit } = parentBlock.header
 
     if (typeof vm.blockchain.getTotalDifficulty !== 'function') {
@@ -128,6 +128,7 @@ export class PendingBlock {
     const mixHashBuf = toType(mixHash!, TypeOutput.Uint8Array) ?? zeros(32)
     const parentBeaconBlockRootBuf =
       toType(parentBeaconBlockRoot!, TypeOutput.Uint8Array) ?? zeros(32)
+    const coinbaseBuf = toType(coinbase ?? zeros(20), TypeOutput.Uint8Array)
 
     const payloadIdBytes = toBytes(
       keccak256(
@@ -136,7 +137,8 @@ export class PendingBlock {
           mixHashBuf,
           timestampBuf,
           gasLimitBuf,
-          parentBeaconBlockRootBuf
+          parentBeaconBlockRootBuf,
+          coinbaseBuf
         )
       ).subarray(0, 8)
     )

--- a/packages/client/src/rpc/modules/engine.ts
+++ b/packages/client/src/rpc/modules/engine.ts
@@ -666,7 +666,7 @@ export class Engine {
       this.chain,
       this.chainCache
     )
-    if (!block || error) {
+    if (block === undefined || error) {
       let response = error
       if (!response) {
         const validationError = `Error assembling block during init`
@@ -805,8 +805,8 @@ export class Engine {
     // We still can't switch to beacon sync here especially if the chain is pre merge and there
     // is pow block which this client would like to mint and attempt proposing it
     //
-    // call skeleton setHead without forcing head change to return if its reorged or not
-    // and flip it go get lookup flag
+    // Call skeleton.setHead without forcing head change to return if the block is reorged or not
+    // Do optimistic lookup if not reorged
     const optimisticLookup = !(await this.skeleton.setHead(block, false))
     this.remoteBlocks.set(bytesToUnprefixedHex(block.hash()), block)
 

--- a/packages/client/src/rpc/modules/engine.ts
+++ b/packages/client/src/rpc/modules/engine.ts
@@ -808,6 +808,7 @@ export class Engine {
     // call skeleton setHead without forcing head change to return if its reorged or not
     // and flip it go get lookup flag
     const optimisticLookup = !(await this.skeleton.setHead(block, false))
+    this.remoteBlocks.set(bytesToUnprefixedHex(block.hash()), block)
 
     // we should check if the block exits executed in remoteBlocks or in chain as a check that stateroot
     // exists in statemanager is not sufficient because an invalid crafted block with valid block hash with
@@ -876,6 +877,7 @@ export class Engine {
       const latestValidHash = await validHash(block.header.parentHash, this.chain, this.chainCache)
       const response = { status: Status.INVALID, latestValidHash, validationError }
       this.invalidBlocks.set(blockHash.slice(2), error as Error)
+      this.remoteBlocks.delete(blockHash.slice(2))
       try {
         await this.chain.blockchain.delBlock(lastBlock!.hash())
         // eslint-disable-next-line no-empty
@@ -886,8 +888,6 @@ export class Engine {
       } catch {}
       return response
     }
-
-    this.remoteBlocks.set(bytesToUnprefixedHex(block.hash()), block)
 
     const response = {
       status: Status.VALID,

--- a/packages/client/src/rpc/modules/engine.ts
+++ b/packages/client/src/rpc/modules/engine.ts
@@ -810,9 +810,9 @@ export class Engine {
     const optimisticLookup = !(await this.skeleton.setHead(block, false))
     this.remoteBlocks.set(bytesToUnprefixedHex(block.hash()), block)
 
-    // we should check if the block exits executed in remoteBlocks or in chain as a check that stateroot
+    // we should check if the block exists executed in remoteBlocks or in chain as a check since stateroot
     // exists in statemanager is not sufficient because an invalid crafted block with valid block hash with
-    // some pre-executed stateroot can be send
+    // some pre-executed stateroot can be sent
     const executedBlockExists =
       this.executedBlocks.get(blockHash.slice(2)) ??
       (await validExecutedChainBlock(hexToBytes(blockHash), this.chain))

--- a/packages/client/src/rpc/modules/engine.ts
+++ b/packages/client/src/rpc/modules/engine.ts
@@ -674,10 +674,7 @@ export class Engine {
         const latestValidHash = await validHash(hexToBytes(parentHash), this.chain, this.chainCache)
         response = { status: Status.INVALID, latestValidHash, validationError }
       }
-      this.invalidBlocks.set(
-        blockHash.slice(2),
-        new Error(response.validationError ?? `Error assembling block during init`)
-      )
+      // skip marking the block invalid as this is more of a data issue from CL
       return response
     }
 
@@ -802,7 +799,7 @@ export class Engine {
             this.chainCache
           )
           const response = { status: Status.INVALID, latestValidHash, validationError }
-          this.invalidBlocks.set(blockHash.slice(2), error)
+          // skip marking the block invalid as this is more of a data issue from CL
           return response
         }
       }

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -161,4 +161,5 @@ export interface ClientOpts {
   vmProfileBlocks?: boolean
   vmProfileTxs?: boolean
   loadBlocksFromRlp?: string
+  pruneEngineCache?: boolean
 }


### PR DESCRIPTION
in cancun-engine hive tests, there are lots of `Invalid` scenario tests where the new payload evaluates to `INVALID` but we don't respond accordingly in fcU (rather end up throwing error instead of `INVALID` status)

this PR caches invalids and use it in fcU responses.

What scenario this PR changes/Fixes
 - add invalid block cache populated in new payload and use it in fcu
 - skip adding the payloads generated in getPayload to the chain without going through new payload
 - add a cli option to run hive without engine pruning via `--pruneEngineCache false` as some tests require deep cache
 - fix validHash lookup
 - cache remoteblocks early in newpayload after successful block and parent block validations
 


TODO
- [x] some related invalid responses for hive are still being debugged and fixed

#### Progress
From 69 failing cases 
![image](https://github.com/ethereumjs/ethereumjs-monorepo/assets/76567250/0b4003f0-e088-470d-a934-92077705a995)

this PR reduces to 61 failing cases
![image](https://github.com/ethereumjs/ethereumjs-monorepo/assets/76567250/8b313fec-6ae4-42e8-a7a1-32a331b0a4c4)

#### Clarifications requested
Requested some clarifications for the cases where ethereumjs seems to be behaving correctly:
- [ ] the fields validations happen before the call is actually processed, this test case expects to process fcUv3 even if the parentBeaconBlockRoot is missing (https://discord.com/channels/595666850260713488/1155879392732520578/1157960831204597761)
- [ ] for another test case: Test: Invalid Transaction Nonce NewPayload - Syncing (Cancun) (ethereumjs_cancun-git)the block is rejected with this error: Error: nonce cannot equal or exceed MAX_UINT64 (2^64-1) (https://discord.com/channels/595666850260713488/1155879392732520578/1157963080035209256)
  - Further discussion on this lead to acknowledgment that INVALID should be acceptabled response, ALSO this would resolve most of our invalid transaction failure cases 
- [ ] for "engine-cancun/Replace Blob Transactions the 1st and 3rd txs are correctly selected along with their blobs, while the test expects to only get 1 blob(for just 1 tx) (https://discord.com/channels/595666850260713488/1155879392732520578/1158056029091811438)