### PR TITLE
Guard against rpc port collisions

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -383,7 +383,6 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     if (argv.rpcEngine === true && usedPorts.has(argv.rpcEnginePort)) collision = true
 
     if (collision) throw new Error('cannot reuse ports between RPC instances')
-    process.exit(0)
     return true
   }).argv
 

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -375,20 +375,13 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     let collision = false
     if (argv.ws === true) {
       usedPorts.add(argv.wsPort)
-      if (usedPorts.has(argv.wsEnginePort)) {
-        collision = true
-      } else {
+      if (!usedPorts.has(argv.wsEnginePort)) {
         usedPorts.add(argv.wsEnginePort)
       }
     }
-    if (argv.rpc === true) {
-      if (usedPorts.has(argv.rpcPort)) collision = true
-      else usedPorts.add(argv.rpcPort)
-    }
-    if (argv.rpcEngine === true) {
-      if (usedPorts.has(argv.rpcEnginePort)) collision = true
-      else usedPorts.add(argv.rpcEnginePort)
-    }
+    if (argv.rpc === true && usedPorts.has(argv.rpcPort)) collision = true
+    if (argv.rpcEngine === true && usedPorts.has(argv.rpcEnginePort)) collision = true
+
     if (collision) throw new Error('cannot reuse ports between RPC instances')
     process.exit(0)
     return true

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -135,7 +135,7 @@ const args: ClientOpts = yargs(hideBin(process.argv))
   })
   .option('wsPort', {
     describe: 'WS-RPC server listening port',
-    default: 8545,
+    default: 8546,
   })
   .option('wsAddr', {
     describe: 'WS-RPC server listening address',
@@ -158,7 +158,7 @@ const args: ClientOpts = yargs(hideBin(process.argv))
   .option('wsEnginePort', {
     describe: 'WS-RPC server listening port for Engine namespace',
     number: true,
-    default: 8551,
+    default: 8552,
   })
   .option('wsEngineAddr', {
     describe: 'WS-RPC server listening interface address for Engine namespace',
@@ -369,7 +369,30 @@ const args: ClientOpts = yargs(hideBin(process.argv))
   })
   .completion()
   // strict() ensures that yargs throws when an invalid arg is provided
-  .strict().argv
+  .strict()
+  .check((argv, _options) => {
+    const usedPorts = new Set()
+    let collision = false
+    if (argv.ws === true) {
+      usedPorts.add(argv.wsPort)
+      if (usedPorts.has(argv.wsEnginePort)) {
+        collision = true
+      } else {
+        usedPorts.add(argv.wsEnginePort)
+      }
+    }
+    if (argv.rpc === true) {
+      if (usedPorts.has(argv.rpcPort)) collision = true
+      else usedPorts.add(argv.rpcPort)
+    }
+    if (argv.rpcEngine === true) {
+      if (usedPorts.has(argv.rpcEnginePort)) collision = true
+      else usedPorts.add(argv.rpcEnginePort)
+    }
+    if (collision) throw new Error('cannot reuse ports between RPC instances')
+    process.exit(0)
+    return true
+  }).argv
 
 /**
  * Initializes and returns the databases needed for the client

--- a/packages/client/test/cli/cli.spec.ts
+++ b/packages/client/test/cli/cli.spec.ts
@@ -110,7 +110,7 @@ describe('[CLI]', () => {
     }
     await clientRunHelper(cliArgs, onData, true)
   }, 30000)
-  it.only('should throw error if the same port is assigned to multiple RPC servers', async () => {
+  it('should throw error if the same port is assigned to multiple RPC servers', async () => {
     const cliArgs = ['--ws', '--rpc', '--rpcPort=8546']
     const onData = async (
       message: string,

--- a/packages/client/test/cli/cli.spec.ts
+++ b/packages/client/test/cli/cli.spec.ts
@@ -110,6 +110,21 @@ describe('[CLI]', () => {
     }
     await clientRunHelper(cliArgs, onData, true)
   }, 30000)
+  it.only('should throw error if the same port is assigned to multiple RPC servers', async () => {
+    const cliArgs = ['--ws', '--rpc', '--rpcPort=8546']
+    const onData = async (
+      message: string,
+      child: ChildProcessWithoutNullStreams,
+      resolve: Function
+    ) => {
+      if (message.includes('cannot reuse')) {
+        assert.ok(true, 'cannot reuse ports between HTTP and WS RPCs')
+      }
+      child.kill(9)
+      resolve(undefined)
+    }
+    await clientRunHelper(cliArgs, onData, true)
+  }, 30000)
   // engine rpc tests
   it('should start engine rpc and provide endpoint', async () => {
     const cliArgs = ['--rpcEngine', '--port=30310', '--dev=poa']


### PR DESCRIPTION
Address #2938 
 - Adds new default port settings for websocket RPC to avoid colliding with HTTP RPC defaults
 - Adds new guards in CLI arg parsing to ensure that colliding port values aren't set between WS and HTTP RPCs