### PR TITLE
client: fix synced log consistency and add short status summary

### DIFF
--- a/packages/client/src/rpc/modules/engine.ts
+++ b/packages/client/src/rpc/modules/engine.ts
@@ -1111,6 +1111,7 @@ export class Engine {
     // call skeleton sethead with force head change and reset beacon sync if reorg
     const reorged = await this.skeleton.setHead(headBlock, true)
     if (reorged) await this.service.beaconSync?.reorged(headBlock)
+    await this.skeleton.blockingFillWithCutoff(this.chain.config.engineNewpayloadMaxExecute)
 
     // Only validate this as terminal block if this block's difficulty is non-zero,
     // else this is a PoS block but its hardfork could be indeterminable if the skeleton

--- a/packages/client/src/service/skeleton.ts
+++ b/packages/client/src/service/skeleton.ts
@@ -1009,9 +1009,7 @@ export class Skeleton extends MetaDBManager {
         let left = this.bounds().tail - BIGINT_1 - this.chain.blocks.height
         if (this.status.linked) left = BIGINT_0
         if (left > BIGINT_0) {
-          if (this.pulled === BIGINT_0) {
-            this.config.logger.info(`Beacon sync starting left=${left}`)
-          } else {
+          if (this.pulled !== BIGINT_0 && fetching === true) {
             const sinceStarted = (new Date().getTime() - this.started) / 1000
             beaconSyncETA = `${timeDuration((sinceStarted / Number(this.pulled)) * Number(left))}`
             this.config.logger.debug(


### PR DESCRIPTION
 - the SYNCED log was shuffling between SYNCING and SYNCED because on the race between fcU and fillCanonicalChain, now the fcu awaits the fill if chain segment to fill is small (2 blocks)
 - add a small explanation to whats going on in the sync for user to comprehend the data 
![image](https://github.com/ethereumjs/ethereumjs-monorepo/assets/76567250/e27800e7-2b02-48d3-a1ac-1ee8e6605e42)
