### PR TITLE
client: add lodestar quickstart to client readme

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -138,7 +138,13 @@ The client currently supports `full` sync being set as a default and has experim
 
 ## Running with a Consensus Layer (CL) Client
 
-In most scenarios you will want to run the EthereumJS client in a combination with a consensus layer (CL) client. The most tested combination is to run the client with the [Lodestar](https://github.com/ChainSafe/lodestar) TypeScript CL client. Other possible options are to run with [Prysm](https://github.com/prysmaticlabs/prysm) (Go), [Lighthouse](https://github.com/sigp/lighthouse) (Rust), [Nimbus](https://github.com/status-im/nimbus-eth2) (Nim) or [Teku](https://github.com/ConsenSys/teku) (Java).
+In most scenarios you will want to run the EthereumJS client in a combination with a consensus layer (CL) client. The most tested combination is to run the client with the [Lodestar](https://github.com/ChainSafe/lodestar) TypeScript CL client. Lodestar provides a [quick-start repository](https://github.com/ChainSafe/lodestar-quickstart) that allows users to get started quickly with minimal configuration. After cloning the linked quick-start repository, all that should be necessary to get the Lodestar consensus client started with EthereumJS is to run the following command:
+
+```shell
+./setup.sh --network sepolia --dataDir sepolia-data --elClient ethereumjs
+```
+
+Other possible options are to run with [Prysm](https://github.com/prysmaticlabs/prysm) (Go), [Lighthouse](https://github.com/sigp/lighthouse) (Rust), [Nimbus](https://github.com/status-im/nimbus-eth2) (Nim) or [Teku](https://github.com/ConsenSys/teku) (Java).
 
 ### Necessary CLI Options
 


### PR DESCRIPTION
This PR adds a mention and instructions related to using the lodestar quickstart repository, which seems to me like the easiest way to get our client running. 

Related to #3081 