### PR TITLE
monorepo: fix postcss vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11768,9 +11768,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.27",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
-      "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "devOptional": true,
       "funding": [
         {


### PR DESCRIPTION
This PR resolves a medium security postcss vulnerability: https://security.snyk.io/vuln/SNYK-JS-POSTCSS-5926692 

