### PR TITLE
Add genesis workflow

### DIFF
--- a/.github/workflows/genesis-build.yml
+++ b/.github/workflows/genesis-build.yml
@@ -1,0 +1,42 @@
+name: genesis
+on:
+  push:
+    branches: [master, develop]
+    tags: ['*']
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+env:
+  cwd: ${{github.workspace}}/packages/genesis
+
+defaults:
+  run:
+    working-directory: packages/genesis
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  test-genesis:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - run: npm ci --omit=peer
+        working-directory: ${{github.workspace}}
+
+      - run: npm run lint
+      - run: npm run test:node # Only run node tests for now until vitest browser test issues are sorted out


### PR DESCRIPTION
This change adds a workflow for the genesis package so that the package's tests are automatically run as a part of CI workflows.