### PR TITLE
Change rpcDebug option to allow enabling/disabling specific rpc module logs

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -205,9 +205,8 @@ const args: ClientOpts = yargs(hideBin(process.argv))
   })
   .option('rpcDebug', {
     describe:
-      'Additionally log complete RPC calls on log level debug (i.e. --loglevel=debug). Can indicate a specific module or a boolean.',
-    choices: ['true', 'false', 'eth', 'engine'],
-    default: 'false',
+      'Additionally log complete RPC calls filtered by name (prefix), e.g.: "eth,engine_getPayload" (use "all" for all methods).',
+    default: '',
   })
   .option('rpcCors', {
     describe: 'Configure the Access-Control-Allow-Origin CORS header for RPC server',

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -204,8 +204,10 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     default: 5,
   })
   .option('rpcDebug', {
-    describe: 'Additionally log complete RPC calls on log level debug (i.e. --loglevel=debug)',
-    boolean: true,
+    describe:
+      'Additionally log complete RPC calls on log level debug (i.e. --loglevel=debug). Can indicate a specific module or a boolean.',
+    choices: ['true', 'false', 'eth', 'engine'],
+    default: 'false',
   })
   .option('rpcCors', {
     describe: 'Configure the Access-Control-Allow-Origin CORS header for RPC server',

--- a/packages/client/bin/startRpc.ts
+++ b/packages/client/bin/startRpc.ts
@@ -26,7 +26,7 @@ export type RPCArgs = {
   rpcEnginePort: number
   wsEngineAddr: string
   wsEnginePort: number
-  rpcDebug: boolean
+  rpcDebug: string
   helpRpc: boolean
   jwtSecret?: string
   rpcEngineAuth: boolean

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -129,7 +129,7 @@ export interface ClientOpts {
   logLevelFile?: string
   logRotate?: boolean
   logMaxFiles?: number
-  rpcDebug?: boolean
+  rpcDebug?: string
   rpcCors?: string
   maxPerRequest?: number
   maxFetcherJobs?: number

--- a/packages/client/src/util/rpc.ts
+++ b/packages/client/src/util/rpc.ts
@@ -67,7 +67,7 @@ export function createRPCServer(
 
   const onRequest = (request: any) => {
     let msg = ''
-    if (rpcDebug !== '') {
+    if (rpcDebug && rpcDebug !== '') {
       let show = false
       if (rpcDebug === 'all') {
         show = true

--- a/packages/client/src/util/rpc.ts
+++ b/packages/client/src/util/rpc.ts
@@ -17,7 +17,7 @@ const algorithm: TAlgorithm = 'HS256'
 
 type CreateRPCServerOpts = {
   methodConfig: MethodConfig
-  rpcDebug: boolean
+  rpcDebug: string
   logger?: Logger
 }
 type CreateRPCServerReturn = {
@@ -67,7 +67,11 @@ export function createRPCServer(
 
   const onRequest = (request: any) => {
     let msg = ''
-    if (rpcDebug) {
+    if (
+      rpcDebug === 'true' ||
+      (rpcDebug === 'engine' && request.method.includes('engine_') === true) ||
+      (rpcDebug === 'eth' && request.method.includes('eth_') === true)
+    ) {
       msg += `${request.method} called with params:\n${inspectParams(request.params)}`
     } else {
       msg += `${request.method} called with params: ${inspectParams(request.params, 125)}`
@@ -77,7 +81,11 @@ export function createRPCServer(
 
   const handleResponse = (request: any, response: any, batchAddOn = '') => {
     let msg = ''
-    if (rpcDebug) {
+    if (
+      rpcDebug === 'true' ||
+      (rpcDebug === 'engine' && request.method.includes('engine_') === true) ||
+      (rpcDebug === 'eth' && request.method.includes('eth_') === true)
+    ) {
       msg = `${request.method}${batchAddOn} responded with:\n${inspectParams(response)}`
     } else {
       msg = `${request.method}${batchAddOn} responded with: `
@@ -107,11 +115,11 @@ export function createRPCServer(
   }
 
   let methods
-  const ethMethods = manager.getMethods(false, rpcDebug)
+  const ethMethods = manager.getMethods(false, rpcDebug !== 'false')
 
   switch (methodConfig) {
     case MethodConfig.WithEngine:
-      methods = { ...ethMethods, ...manager.getMethods(true, rpcDebug) }
+      methods = { ...ethMethods, ...manager.getMethods(true, rpcDebug !== 'false') }
       break
     case MethodConfig.WithoutEngine:
       methods = { ...ethMethods }

--- a/packages/client/src/util/rpc.ts
+++ b/packages/client/src/util/rpc.ts
@@ -67,16 +67,27 @@ export function createRPCServer(
 
   const onRequest = (request: any) => {
     let msg = ''
-    if (
-      rpcDebug === 'true' ||
-      (rpcDebug === 'engine' && request.method.includes('engine_') === true) ||
-      (rpcDebug === 'eth' && request.method.includes('eth_') === true)
-    ) {
-      msg += `${request.method} called with params:\n${inspectParams(request.params)}`
-    } else {
-      msg += `${request.method} called with params: ${inspectParams(request.params, 125)}`
+    if (rpcDebug !== '') {
+      let show = false
+      if (rpcDebug === 'all') {
+        show = true
+      } else {
+        const filters = rpcDebug.split(',')
+        for (const filter of filters) {
+          if (request.method.includes(filter) === true) {
+            show = true
+          }
+        }
+      }
+      if (show) {
+        if (logger?.level === 'debug') {
+          msg += `${request.method} called with params:\n${inspectParams(request.params)}`
+        } else {
+          msg += `${request.method} called with params: ${inspectParams(request.params, 125)}`
+        }
+        logger?.info(msg)
+      }
     }
-    logger?.debug(msg)
   }
 
   const handleResponse = (request: any, response: any, batchAddOn = '') => {

--- a/packages/client/test/util/rpc.spec.ts
+++ b/packages/client/test/util/rpc.spec.ts
@@ -22,7 +22,7 @@ describe('[Util/RPC]', () => {
     const manager = new RPCManager(client, config)
     const { logger } = config
     for (const methodConfig of Object.values(MethodConfig)) {
-      for (const rpcDebug of [false, true]) {
+      for (const rpcDebug of ['', 'eth']) {
         const { server } = createRPCServer(manager, { methodConfig, rpcDebug, logger })
         const httpServer = createRPCServerListener({
           server,


### PR DESCRIPTION
This change modifies the cli `rpcDebug` option to allow for enabling only the `eth` or `engine` rpc module for log collection so that there is less noise during debugging. Also see #3101.