### PR TITLE
Statemanager: Direct Storage Trie Usage Experiment

### DIFF
--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -198,14 +198,32 @@ export class Trie {
    * @param throwIfMissing - if true, throws if any nodes are missing. Used for verifying proofs. (default: false)
    * @returns A Promise that resolves to `Uint8Array` if a value was found or `null` if no value was found.
    */
-  async get(key: Uint8Array, throwIfMissing = false): Promise<Uint8Array | null> {
-    this.DEBUG && this.debug(`Key: ${bytesToHex(key)}`, ['GET'])
-    const { node, remaining } = await this.findPath(this.appliedKey(key), throwIfMissing)
+  async get(
+    key: Uint8Array,
+    throwIfMissing = false,
+    root?: Uint8Array
+  ): Promise<Uint8Array | null> {
     let value: Uint8Array | null = null
-    if (node && remaining.length === 0) {
-      value = node.value()
+    const mainRoot = this.root()
+    try {
+      if (root) {
+        console.log(`main before:${bytesToHex(mainRoot)}`)
+        this.root(root)
+      }
+      this.DEBUG && this.debug(`Key: ${bytesToHex(key)}`, ['GET'])
+      const { node, remaining } = await this.findPath(this.appliedKey(key), throwIfMissing)
+
+      if (node && remaining.length === 0) {
+        value = node.value()
+      }
+      this.DEBUG && this.debug(`Value: ${value === null ? 'null' : bytesToHex(value)}`, ['GET'])
+    } finally {
+      if (root) {
+        this.root(mainRoot)
+        console.log(`main after:${bytesToHex(this.root())}`)
+      }
     }
-    this.DEBUG && this.debug(`Value: ${value === null ? 'null' : bytesToHex(value)}`, ['GET'])
+
     return value
   }
 

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -446,8 +446,6 @@ async function applyTransactions(this: VM, block: Block, opts: RunBlockOpts) {
   if (enableProfiler) {
     // eslint-disable-next-line no-console
     console.timeEnd(processTxsLabel)
-    // eslint-disable-next-line no-console
-    console.timeEnd(entireBlockLabel)
   }
 
   return {


### PR DESCRIPTION
Can someone spot why this approach does not work (yet)? 🤔

I am trying to swap out the copied-storage-trie read (our SLOAD performance still drives me crazy) by using the original trie and temporarily setting a new root.

Running the client with:

```shell
cd ../trie && npm run build && cd ../client && DEBUG=ethjs,trie:* npm run client:start -- --vmProfileBlocks --executeBlocks=1999950-2000005
```

This gives me a `receiptTrie` error though.

<img width="1440" alt="grafik" src="https://github.com/ethereumjs/ethereumjs-monorepo/assets/931137/4c914b3a-fabc-43f4-ae7c-347ac9eb229f">
