### PR TITLE
vm: better error message to avoid confusion with EIP1559 base fee

### DIFF
--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -247,7 +247,14 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   const txBaseFee = tx.getBaseFee()
   let gasLimit = tx.gasLimit
   if (gasLimit < txBaseFee) {
-    const msg = _errorMsg('base fee exceeds gas limit', this, block, tx)
+    const msg = _errorMsg(
+      `tx gas limit ${Number(gasLimit)} is lower than the minimum gas limit of ${Number(
+        txBaseFee
+      )}`,
+      this,
+      block,
+      tx
+    )
     throw new Error(msg)
   }
   gasLimit -= txBaseFee


### PR DESCRIPTION
If the gas limit of a tx is lower than the minimum gas limit (this consists of: tx upfront gas of 21000, the tx data cost, and optionally more gas needed for contract creation), previously we had this error message: `base fee exceeds gas limit`. This is confusing with EIP1559s base fee and is completely unrelated. This PR updates the error message.