### PR TITLE
Client: pendingBlock fix if FCU is called with withdrawals=null pre-cancun

### DIFF
--- a/packages/client/src/miner/pendingBlock.ts
+++ b/packages/client/src/miner/pendingBlock.ts
@@ -133,7 +133,7 @@ export class PendingBlock {
 
     let withdrawalsBuf = zeros(0)
 
-    if (withdrawals !== undefined) {
+    if (withdrawals !== undefined && withdrawals !== null) {
       const withdrawalsBufTemp: Uint8Array[] = []
       for (const withdrawal of withdrawals) {
         const indexBuf = bigIntToUnpaddedBytes(toType(withdrawal.index ?? 0, TypeOutput.BigInt))


### PR DESCRIPTION
Stumbled upon this one in a hive test.

I have explicitly checked client for more of these cases where we test for `!== undefined` but do not have the other check that it should also not be `null`. This was the only occurrence I could find.