### PR TITLE
vm: add missing gasPrice param to readme example tx

### DIFF
--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -43,6 +43,7 @@ const vm = await VM.create({ common })
 
 const tx = LegacyTransaction.fromTxData({
   gasLimit: BigInt(21000),
+  gasPrice: BigInt(1000000000),
   value: BigInt(1),
   to: Address.zero(),
   v: BigInt(37),

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -270,7 +270,9 @@ async function _runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
     const baseFeePerGas = block.header.baseFeePerGas!
     if (maxFeePerGas < baseFeePerGas) {
       const msg = _errorMsg(
-        `Transaction's maxFeePerGas (${maxFeePerGas}) is less than the block's baseFeePerGas (${baseFeePerGas})`,
+        `Transaction's ${
+          'maxFeePerGas' in tx ? 'maxFeePerGas' : 'gasPrice'
+        } (${maxFeePerGas}) is less than the block's baseFeePerGas (${baseFeePerGas})`,
         this,
         block,
         tx


### PR DESCRIPTION
This PR:

- Fixes the Readme example tx that was missing a gasPrice param
- Improves an error message that made it seem like pre-eip1559 transactions were providing an invalid maxFeePerGas param.