### PR TITLE
tsconfig: fix references

### DIFF
--- a/packages/evm/tsconfig.prod.cjs.json
+++ b/packages/evm/tsconfig.prod.cjs.json
@@ -7,8 +7,6 @@
   },
   "include": ["src/**/*.ts", "src/**/*.json"],
   "references": [
-    { "path": "../block/tsconfig.prod.cjs.json" },
-    { "path": "../blockchain/tsconfig.prod.cjs.json" },
     { "path": "../common/tsconfig.prod.cjs.json" },
     { "path": "../rlp/tsconfig.prod.cjs.json" },
     { "path": "../statemanager/tsconfig.prod.cjs.json" },

--- a/packages/evm/tsconfig.prod.esm.json
+++ b/packages/evm/tsconfig.prod.esm.json
@@ -7,8 +7,6 @@
   },
   "include": ["src/**/*.ts", "src/**/*.json"],
   "references": [
-    { "path": "../block/tsconfig.prod.esm.json" },
-    { "path": "../blockchain/tsconfig.prod.esm.json" },
     { "path": "../common/tsconfig.prod.esm.json" },
     { "path": "../rlp/tsconfig.prod.esm.json" },
     { "path": "../statemanager/tsconfig.prod.esm.json" },

--- a/packages/genesis/tsconfig.prod.cjs.json
+++ b/packages/genesis/tsconfig.prod.cjs.json
@@ -8,7 +8,6 @@
   "include": ["src/**/*.ts", "src/**/*.json"],
   "references": [
     { "path": "../common/tsconfig.prod.cjs.json" },
-    { "path": "../ethash/tsconfig.prod.cjs.json" },
     { "path": "../rlp/tsconfig.prod.cjs.json" },
     { "path": "../util/tsconfig.prod.cjs.json" }
   ]

--- a/packages/genesis/tsconfig.prod.esm.json
+++ b/packages/genesis/tsconfig.prod.esm.json
@@ -8,7 +8,6 @@
   "include": ["src/**/*.ts", "src/**/*.json"],
   "references": [
     { "path": "../common/tsconfig.prod.esm.json" },
-    { "path": "../ethash/tsconfig.prod.esm.json" },
     { "path": "../rlp/tsconfig.prod.esm.json" },
     { "path": "../util/tsconfig.prod.esm.json" }
   ]


### PR DESCRIPTION
When trying to super-optimize hive, I noted that if you partially copy our monorepo and then try to build a package (all dependencies are in the folder) then for `evm` and `genesis` there are references to packages which are not used. I think we can remove those references?