### PR TITLE
Finishes typing client opts

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -47,7 +47,6 @@ const networks = Object.entries(Common.getInitializedChains().names)
 
 let logger: Logger
 
-// @ts-ignore because yargs isn't typing our args closely enough yet for arrays of strings (i.e. args.bootnodes, etc)
 const args: ClientOpts = yargs(hideBin(process.argv))
   .parserConfiguration({
     'dot-notation': false,
@@ -105,6 +104,7 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     describe:
       'Comma-separated list of network bootnodes (format: "enode://<id>@<host:port>,enode://..." ("[?discport=<port>]" not supported) or path to a bootnode.txt file',
     array: true,
+    coerce: (arr) => arr.filter((el: any) => el !== undefined).map((el: any) => el.toString()),
   })
   .option('port', {
     describe: 'RLPx listening port',
@@ -117,6 +117,7 @@ const args: ClientOpts = yargs(hideBin(process.argv))
   .option('multiaddrs', {
     describe: 'Network multiaddrs',
     array: true,
+    coerce: (arr) => arr.filter((el: any) => el !== undefined).map((el: any) => el.toString()),
   })
   .option('rpc', {
     describe: 'Enable the JSON-RPC server with HTTP endpoint',
@@ -249,6 +250,7 @@ const args: ClientOpts = yargs(hideBin(process.argv))
   .option('dnsNetworks', {
     describe: 'EIP-1459 ENR tree urls to query for peer discovery targets',
     array: true,
+    coerce: (arr) => arr.filter((el: any) => el !== undefined).map((el: any) => el.toString()),
   })
   .option('execution', {
     describe: 'Start continuous VM execution (pre-Merge setting)',
@@ -317,6 +319,7 @@ const args: ClientOpts = yargs(hideBin(process.argv))
     describe:
       'Address for mining rewards (etherbase). If not provided, defaults to the primary account',
     string: true,
+    coerce: (coinbase) => Address.fromString(coinbase),
   })
   .option('saveReceipts', {
     describe:
@@ -396,7 +399,8 @@ const args: ClientOpts = yargs(hideBin(process.argv))
 
     if (collision) throw new Error('cannot reuse ports between RPC instances')
     return true
-  }).argv
+  })
+  .parseSync()
 
 /**
  * Initializes and returns the databases needed for the client

--- a/packages/client/test/cli/cli.spec.ts
+++ b/packages/client/test/cli/cli.spec.ts
@@ -53,14 +53,14 @@ describe('[CLI]', () => {
     }
     await clientRunHelper(cliArgs, onData)
   }, 30000)
-  it('should successfully start client with custom inputs for PoW network', async () => {
+  it('should successfully start client with custom inputs for PoA network', async () => {
     const cliArgs = [
       '--rpc',
       '--rpcPort=8562',
       '--rpcAddr=0.0.0.0',
       '--dev=poa',
       '--port=30306',
-      '--minerCoinbase="abc"',
+      '--minerCoinbase="0x7e5f4552091a69125d5dfcb7b8c2659029395bdf"',
       '--saveReceipts=false',
       '--execution=false',
     ]
@@ -78,11 +78,14 @@ describe('[CLI]', () => {
           host: '0.0.0.0',
         })
         const res = await client.request('eth_coinbase', [], 2.0)
-        assert.ok(res.result === 'abc', 'correct coinbase address set')
+        assert.ok(
+          res.result === '0x7e5f4552091a69125d5dfcb7b8c2659029395bdf',
+          'correct coinbase address set'
+        )
         count -= 1
       }
       if (message.includes('Client started successfully')) {
-        assert.ok(message, 'Client started successfully with custom inputs for PoW network')
+        assert.ok(message, 'Client started successfully with custom inputs for PoA network')
         count -= 1
       }
       if (count === 0) {
@@ -91,7 +94,7 @@ describe('[CLI]', () => {
       }
     }
     await clientRunHelper(cliArgs, onData)
-  }, 30000)
+  }, 10000)
   it('should throw error if "dev" option is passed in without a value', async () => {
     const cliArgs = ['--dev']
     const onData = async (


### PR DESCRIPTION
This finishes up the work identified in #3045 by adding complete typing to the `args` passed in the CLI.  No more `//@ts-ignore`