### PR TITLE
verke: update verkle crypto helpers

### DIFF
--- a/packages/verkle/src/util/crypto.ts
+++ b/packages/verkle/src/util/crypto.ts
@@ -1,4 +1,4 @@
-import { type Address, concatBytes, int32ToBytes, setLengthLeft, toBytes } from '@ethereumjs/util'
+import { type Address, concatBytes, int32ToBytes, setLengthLeft } from '@ethereumjs/util'
 import { pedersen_hash, verify_update } from 'rust-verkle-wasm'
 
 import type { Point } from '../types'
@@ -16,26 +16,38 @@ export function pedersenHash(input: Uint8Array): Uint8Array {
 }
 
 /**
- * @dev Returns the tree key for a given address, tree index, and sub index.
+ * @dev Returns the 31-bytes verkle tree stem for a given address and tree index.
  * @dev Assumes that the verkle node width = 256
  * @param address The address to generate the tree key for.
  * @param treeIndex The index of the tree to generate the key for.
+ * @return The 31-bytes verkle tree stem as a Uint8Array.
+ */
+export function getStem(address: Address, treeIndex: number): Uint8Array {
+  const address32 = setLengthLeft(address.toBytes(), 32)
+
+  const treeIndexBytes = int32ToBytes(treeIndex, true)
+
+  const input = concatBytes(address32, treeIndexBytes)
+
+  const treeStem = pedersenHash(input).slice(0, 31)
+
+  return treeStem
+}
+
+/**
+ * @dev Returns the tree key for a given verkle tree stem, and sub index.
+ * @dev Assumes that the verkle node width = 256
+ * @param stem The 31-bytes verkle tree stem as a Uint8Array.
  * @param subIndex The sub index of the tree to generate the key for.
  * @return The tree key as a Uint8Array.
  */
-export function getTreeKey(address: Address, treeIndex: number, subIndex: number): Uint8Array {
-  const address32 = setLengthLeft(address.toBytes(), 32)
-
-  const treeIndexB = int32ToBytes(treeIndex, true)
-
-  const input = concatBytes(address32, treeIndexB)
-
-  const treeKey = concatBytes(pedersenHash(input).slice(0, 31), toBytes(subIndex))
+export function getKey(stem: Uint8Array, subIndex: Uint8Array): Uint8Array {
+  const treeKey = concatBytes(stem, subIndex)
 
   return treeKey
 }
 
-export function verifyUpdate(
+export function verifyProof(
   root: Uint8Array,
   proof: Uint8Array,
   keyValues: Map<any, any>


### PR DESCRIPTION
This PR improves the verkle cryptography helpers, notably:

- Extracting the computationally heavier `getStem` logic (which uses `pedersenHash`) from the `getTreeKey` (now renamed `getKey`) to avoid recomputing the stem again and again. 
- Minor renaming. 