### PR TITLE
client: Return during handling NewPooledTransactionHashes message if txHashes is undefined

### DIFF
--- a/packages/client/src/service/txpool.ts
+++ b/packages/client/src/service/txpool.ts
@@ -571,7 +571,7 @@ export class TxPool {
    * @param peerPool Reference to the peer pool
    */
   async handleAnnouncedTxHashes(txHashes: Uint8Array[], peer: Peer, peerPool: PeerPool) {
-    if (!this.running || txHashes.length === 0) return
+    if (!this.running || txHashes === undefined || txHashes.length === 0) return
     this.addToKnownByPeer(txHashes, peer)
 
     const reqHashes = []


### PR DESCRIPTION
During Holesky sync testing, an error was discovered resulting from an `undefined` value being passed into `handleAnnouncedTxHashes` while processing a `NewPooledTransactionHashes` message:
```
[11-06|17:23:48] INFO [ CL ] New chain head set (forkchoice update) number=262502 head=0x1380…4a8b finalized=0x4429…4727 response=VALID timestampDiff=9 mins
[11-06|17:23:48] DEBUG Forkchoice requested update to new head number=262503 hash=0xd124…b550
[11-06|17:23:48] DEBUG New skeleton head announced number=262503 hash=0xd124…b550 force=true
[11-06|17:23:48] DEBUG Beacon chain extended new head=262503 tail=257593 next=0xa15f…ff48
[11-06|17:23:48] DEBUG Writing SYNCING linked=true subchains=[tail=257593 head=262503 next=0xa15f…ff48] reset=false el=262502 hash=0x1380…4a8b
[11-06|17:23:48] DEBUG Starting canonical chain fill canonicalHead=262502 subchainHead=262503
[11-06|17:23:48] DEBUG Attempting blocking fill
[11-06|17:23:48] DEBUG Running execution startHeadBlock=262502 canonicalHead=262503 loop=true
[11-06|17:23:48] DEBUG Executed blocks count=1 first=262502 hash=0x1380…4a8b baseFee=7 hardfork=shanghai last=262503 hash=0xd124…b550 txs=0
[11-06|17:23:48] DEBUG Successfully put=1 skipped (because already inserted)=0 blocks start=262502 end=262503 skeletonHead=262503 from skeleton chain to canonical syncTargetHeight=262523
[11-06|17:23:48] INFO ---------------
[11-06|17:23:48] INFO TxPool started.
[11-06|17:23:48] INFO ---------------
[11-06|17:23:48] INFO 
[11-06|17:23:48] INFO [ EL ] VALID vm=cl=el=262503 hash=0xd124…b550 peers=4

...

[11-06|17:23:51] DEBUG [ EL ] VALID linked=true subchains=[tail=257593 head=262505 next=0xa15f…ff48] reset=false el=262505 hash=0x3b21…13f3
[11-06|17:23:51] DEBUG engine_forkchoiceUpdatedV2 responded with: { jsonrpc: [32m'2.0'[39m, id: [33m11980[39m, result: {  payloadStatus: {   status: [32m'VALID'[39m,   latestValidHash: ...
[11-06|17:23:51] DEBUG Running execution startHeadBlock=262505 canonicalHead=262505 loop=true
[11-06|17:23:51] DEBUG TxPool: received new tx hashes number=1
[11-06|17:23:51] DEBUG TxPool: requesting txs number=1 pending=1
[11-06|17:23:51] DEBUG TxPool: received new transactions number=1
[11-06|17:23:51] DEBUG Error handling message (eth:NewPooledTransactionHashes): Cannot read properties of undefined (reading 'length')
[11-06|17:23:51] DEBUG TxPool: received new transactions number=1
[11-06|17:23:51] DEBUG Error handling message (eth:NewPooledTransactionHashes): Cannot read properties of undefined (reading 'length')
[11-06|17:23:51] DEBUG TxPool: received requested txs number=1
[11-06|17:23:51] DEBUG Error adding tx to TxPool: Cannot read properties of undefined (reading 'push') (tx hash: 0x30919876153df051f0b0548e30dbf1b707c69c5625fc661e9c694f677386a1d5)
[11-06|17:23:51] DEBUG Error handling message (eth:Transactions): txHashes is not iterable
[11-06|17:23:51] DEBUG Error adding tx to TxPool: Cannot read properties of undefined (reading 'push') (tx hash: 0x30919876153df051f0b0548e30dbf1b707c69c5625fc661e9c694f677386a1d5)
[11-06|17:23:51] DEBUG Error handling message (eth:Transactions): txHashes is not iterable
[11-06|17:23:54] DEBUG TxPool: received new tx hashes number=1
[11-06|17:23:54] DEBUG TxPool: requesting txs number=1 pending=1
[11-06|17:23:54] DEBUG TxPool: received new transactions number=1
[11-06|17:23:54] DEBUG Error handling message (eth:NewPooledTransactionHashes): Cannot read properties of undefined (reading 'length')
[11-06|17:23:54] DEBUG TxPool: received new transactions number=1
[11-06|17:23:54] DEBUG Error handling message (eth:NewPooledTransactionHashes): Cannot read properties of undefined (reading 'length')
[11-06|17:23:54] DEBUG Error adding tx to TxPool: Cannot read properties of undefined (reading 'push') (tx hash: 0xe5823a4284a63884dccd784444ba6f62e1fc93e5968c643731a0c5e2b8a5b5a8)
[11-06|17:23:54] DEBUG Error handling message (eth:Transactions): txHashes is not iterable
[11-06|17:23:54] DEBUG Error adding tx to TxPool: Cannot read properties of undefined (reading 'push') (tx hash: 0xe5823a4284a63884dccd784444ba6f62e1fc93e5968c643731a0c5e2b8a5b5a8)
[11-06|17:23:54] DEBUG Error handling message (eth:Transactions): txHashes is not iterable
[11-06|17:23:54] DEBUG TxPool: received requested txs number=1
[11-06|17:23:54] DEBUG Error adding tx to TxPool: 0xe5823a4284a63884dccd784444ba6f62e1fc93e5968c643731a0c5e2b8a5b5a8: this transaction is already in the TxPool (tx hash: 0xe5823a4284a63884dccd784444ba6f62e1fc93e5968c643731a0c5e2b8a5b5a8)
```
The root cause of this issue is that the `boundprotocol.ts` code does not type check message contents. This short-term fix remedies the issue by returning if the `txHashes` value being passed into `handleAnnouncedTxHashes` is `undefined` until a longer-term solution is found for type checking message contents.