### PR TITLE
Remove debug loggers devp2p

### DIFF
--- a/packages/devp2p/src/dns/dns.ts
+++ b/packages/devp2p/src/dns/dns.ts
@@ -24,12 +24,17 @@ export class DNS {
   protected _DNSTreeCache: { [key: string]: string }
   protected readonly _errorTolerance: number = 10
 
+  private DEBUG: boolean
+
   constructor(options: DNSOptions = {}) {
     this._DNSTreeCache = {}
 
     if (typeof options.dnsServerAddress === 'string') {
       dns.setServers([options.dnsServerAddress])
     }
+
+    this.DEBUG =
+      typeof window === 'undefined' ? process?.env?.DEBUG?.includes('ethjs') ?? false : false
   }
 
   /**
@@ -60,7 +65,9 @@ export class DNS {
 
       if (this._isNewPeer(peer, peers)) {
         peers.push(peer)
-        debug(`got new peer candidate from DNS address=${peer.address}`)
+        if (this.DEBUG) {
+          debug(`got new peer candidate from DNS address=${peer.address}`)
+        }
       }
 
       totalSearches++
@@ -98,7 +105,9 @@ export class DNS {
           return null
       }
     } catch (error: any) {
-      debug(`Errored searching DNS tree at subdomain ${subdomain}: ${error}`)
+      if (this.DEBUG) {
+        debug(`Errored searching DNS tree at subdomain ${subdomain}: ${error}`)
+      }
       return null
     }
   }

--- a/packages/devp2p/src/dpt/ban-list.ts
+++ b/packages/devp2p/src/dpt/ban-list.ts
@@ -15,14 +15,19 @@ const verbose = createDebugLogger('verbose').enabled
 
 export class BanList {
   private _lru: LRUCache<string, boolean>
+  private DEBUG: boolean
   constructor() {
     this._lru = new LRU({ max: 10000 })
+    this.DEBUG =
+      typeof window === 'undefined' ? process?.env?.DEBUG?.includes('ethjs') ?? false : false
   }
 
   add(obj: string | Uint8Array | PeerInfo, maxAge?: number) {
     for (const key of KBucket.getKeys(obj)) {
       this._lru.set(key, true, { ttl: maxAge })
-      debug(`Added peer ${formatLogId(key, verbose)}, size: ${this._lru.size}`)
+      if (this.DEBUG) {
+        debug(`Added peer ${formatLogId(key, verbose)}, size: ${this._lru.size}`)
+      }
     }
   }
 

--- a/packages/devp2p/src/dpt/dpt.ts
+++ b/packages/devp2p/src/dpt/dpt.ts
@@ -35,6 +35,8 @@ export class DPT {
   protected _onlyConfirmed: boolean
   protected _confirmedPeers: Set<string>
 
+  private DEBUG: boolean
+
   constructor(privateKey: Uint8Array, options: DPTOptions) {
     this.events = new EventEmitter()
     this._privateKey = privateKey
@@ -76,6 +78,9 @@ export class DPT {
     // By default calls refresh every 3s
     const refreshIntervalSubdivided = Math.floor((options.refreshInterval ?? 60000) / 10) // 60 sec * 1000
     this._refreshIntervalId = setInterval(() => this.refresh(), refreshIntervalSubdivided)
+
+    this.DEBUG =
+      typeof window === 'undefined' ? process?.env?.DEBUG?.includes('ethjs') ?? false : false
   }
 
   bind(...args: any[]): void {
@@ -139,7 +144,9 @@ export class DPT {
 
   async addPeer(obj: PeerInfo): Promise<PeerInfo> {
     if (this._banlist.has(obj)) throw new Error('Peer is banned')
-    this._debug(`attempt adding peer ${obj.address}:${obj.udpPort}`)
+    if (this.DEBUG) {
+      this._debug(`attempt adding peer ${obj.address}:${obj.udpPort}`)
+    }
 
     // check k-bucket first
     const peer = this._kbucket.get(obj)
@@ -216,9 +223,11 @@ export class DPT {
       this._refreshIntervalSelectionCounter = (this._refreshIntervalSelectionCounter + 1) % 10
 
       const peers = this.getPeers()
-      this._debug(
-        `call .refresh() (selector ${this._refreshIntervalSelectionCounter}) (${peers.length} peers in table)`
-      )
+      if (this.DEBUG) {
+        this._debug(
+          `call .refresh() (selector ${this._refreshIntervalSelectionCounter}) (${peers.length} peers in table)`
+        )
+      }
 
       for (const peer of peers) {
         // Randomly distributed selector based on peer ID
@@ -240,11 +249,13 @@ export class DPT {
     if (this._shouldGetDnsPeers) {
       const dnsPeers = await this.getDnsPeers()
 
-      this._debug(
-        `.refresh() Adding ${dnsPeers.length} from DNS tree, (${
-          this.getPeers().length
-        } current peers in table)`
-      )
+      if (this.DEBUG) {
+        this._debug(
+          `.refresh() Adding ${dnsPeers.length} from DNS tree, (${
+            this.getPeers().length
+          } current peers in table)`
+        )
+      }
 
       this._addPeerBatch(dnsPeers)
     }

--- a/packages/devp2p/src/protocol/snap.ts
+++ b/packages/devp2p/src/protocol/snap.ts
@@ -11,8 +11,12 @@ import type { Peer } from '../rlpx/peer.js'
 import type { SendMethod } from '../types.js'
 
 export class SNAP extends Protocol {
+  private DEBUG: boolean
+
   constructor(version: number, peer: Peer, send: SendMethod) {
     super(peer, send, ProtocolType.SNAP, version, SNAP.MESSAGE_CODES)
+    this.DEBUG =
+      typeof window === 'undefined' ? process?.env?.DEBUG?.includes('ethjs') ?? false : false
   }
 
   static snap = { name: 'snap', version: 1, length: 8, constructor: SNAP }
@@ -21,14 +25,16 @@ export class SNAP extends Protocol {
     const payload = RLP.decode(data)
 
     // Note, this needs optimization, see issue #1882
-    this.debug(
-      this.getMsgPrefix(code),
-      // @ts-ignore
-      `Received ${this.getMsgPrefix(code)} message from ${this._peer._socket.remoteAddress}:${
+    if (this.DEBUG) {
+      this.debug(
+        this.getMsgPrefix(code),
         // @ts-ignore
-        this._peer._socket.remotePort
-      }: ${formatLogData(bytesToHex(data), this._verbose)}`
-    )
+        `Received ${this.getMsgPrefix(code)} message from ${this._peer._socket.remoteAddress}:${
+          // @ts-ignore
+          this._peer._socket.remotePort
+        }: ${formatLogData(bytesToHex(data), this._verbose)}`
+      )
+    }
 
     switch (code) {
       case SNAP.MESSAGE_CODES.GET_ACCOUNT_RANGE:
@@ -57,14 +63,16 @@ export class SNAP extends Protocol {
    * @param payload Payload (including reqId, e.g. `[1, [437000, 1, 0, 0]]`)
    */
   sendMessage(code: SNAP.MESSAGE_CODES, payload: any) {
-    this.debug(
-      this.getMsgPrefix(code),
-      // @ts-ignore
-      `Send ${this.getMsgPrefix(code)} message to ${this._peer._socket.remoteAddress}:${
+    if (this.DEBUG) {
+      this.debug(
+        this.getMsgPrefix(code),
         // @ts-ignore
-        this._peer._socket.remotePort
-      }: ${formatLogData(utils.bytesToHex(RLP.encode(payload)), this._verbose)}`
-    )
+        `Send ${this.getMsgPrefix(code)} message to ${this._peer._socket.remoteAddress}:${
+          // @ts-ignore
+          this._peer._socket.remotePort
+        }: ${formatLogData(utils.bytesToHex(RLP.encode(payload)), this._verbose)}`
+      )
+    }
 
     switch (code) {
       case SNAP.MESSAGE_CODES.GET_ACCOUNT_RANGE:

--- a/packages/devp2p/src/rlpx/rlpx.ts
+++ b/packages/devp2p/src/rlpx/rlpx.ts
@@ -52,6 +52,8 @@ export class RLPx {
   protected _refillIntervalId: NodeJS.Timeout
   protected _refillIntervalSelectionCounter: number = 0
 
+  private DEBUG: boolean
+
   constructor(privateKey: Uint8Array, options: RLPxOptions) {
     this.events = new EventEmitter()
     this._privateKey = privateKey
@@ -113,18 +115,25 @@ export class RLPx {
     const REFILL_INTERVALL = 10000 // 10 sec * 1000
     const refillIntervalSubdivided = Math.floor(REFILL_INTERVALL / 10)
     this._refillIntervalId = setInterval(() => this._refillConnections(), refillIntervalSubdivided)
+
+    this.DEBUG =
+      typeof window === 'undefined' ? process?.env?.DEBUG?.includes('ethjs') ?? false : false
   }
 
   listen(...args: any[]) {
     this._isAliveCheck()
-    this._debug('call .listen')
+    if (this.DEBUG) {
+      this._debug('call .listen')
+    }
 
     if (this._server) this._server.listen(...args)
   }
 
   destroy(...args: any[]) {
     this._isAliveCheck()
-    this._debug('call .destroy')
+    if (this.DEBUG) {
+      this._debug('call .destroy')
+    }
 
     clearInterval(this._refillIntervalId)
 
@@ -144,7 +153,11 @@ export class RLPx {
     if (this._peers.has(peerKey)) throw new Error('Already connected')
     if (this._getOpenSlots() === 0) throw new Error('Too many peers already connected')
 
-    this._debug(`connect to ${peer.address}:${peer.tcpPort} (id: ${formatLogId(peerKey, verbose)})`)
+    if (this.DEBUG) {
+      this._debug(
+        `connect to ${peer.address}:${peer.tcpPort} (id: ${formatLogId(peerKey, verbose)})`
+      )
+    }
     const deferred = createDeferred()
 
     const socket = new net.Socket()
@@ -199,7 +212,9 @@ export class RLPx {
   }
 
   _onConnect(socket: net.Socket, peerId: Uint8Array | null) {
-    this._debug(`connected to ${socket.remoteAddress}:${socket.remotePort}, handshake waiting..`)
+    if (this.DEBUG) {
+      this._debug(`connected to ${socket.remoteAddress}:${socket.remotePort}, handshake waiting..`)
+    }
 
     const peer: Peer = new Peer({
       socket,
@@ -232,7 +247,9 @@ export class RLPx {
       if (peer['_eciesSession']['_gotEIP8Ack'] === true) {
         msg += ` (peer eip8 ack)`
       }
-      this._debug(msg)
+      if (this.DEBUG) {
+        this._debug(msg)
+      }
       const id = peer.getId()
       if (id && equalsBytes(id, this.id)) {
         return peer.disconnect(DISCONNECT_REASON.SAME_IDENTITY)
@@ -250,10 +267,12 @@ export class RLPx {
 
     peer.events.once('close', (reason, disconnectWe) => {
       if (disconnectWe === true) {
-        this._debug(
-          `disconnect from ${socket.remoteAddress}:${socket.remotePort}, reason: ${DISCONNECT_REASON[reason]}`,
-          `disconnect`
-        )
+        if (this.DEBUG) {
+          this._debug(
+            `disconnect from ${socket.remoteAddress}:${socket.remotePort}, reason: ${DISCONNECT_REASON[reason]}`,
+            `disconnect`
+          )
+        }
       }
 
       if (disconnectWe !== true && reason === DISCONNECT_REASON.TOO_MANY_PEERS) {
@@ -284,13 +303,15 @@ export class RLPx {
   _refillConnections() {
     if (!this._isAlive()) return
     if (this._refillIntervalSelectionCounter === 0) {
-      this._debug(
-        `Restart connection refill .. with selector ${
-          this._refillIntervalSelectionCounter
-        } peers: ${this._peers.size}, queue size: ${
-          this._peersQueue.length
-        }, open slots: ${this._getOpenSlots()}`
-      )
+      if (this.DEBUG) {
+        this._debug(
+          `Restart connection refill .. with selector ${
+            this._refillIntervalSelectionCounter
+          } peers: ${this._peers.size}, queue size: ${
+            this._peersQueue.length
+          }, open slots: ${this._getOpenSlots()}`
+        )
+      }
     }
     // Rotating selection counter going in loop from 0..9
     this._refillIntervalSelectionCounter = (this._refillIntervalSelectionCounter + 1) % 10


### PR DESCRIPTION
This PR removes debug calls in the devp2p package if no DEBUG flag is set. This ensures that we do not create debug strings which we later throw away if no logger is attached. This was already the case in the eth protocol, but this is now package-wide. the only place where it is not added is in `assertEq` in `util.ts`