### PR TITLE
Add runCallOpts and runCodeOpts to `evm` exports

### DIFF
--- a/packages/evm/src/index.ts
+++ b/packages/evm/src/index.ts
@@ -4,7 +4,14 @@ import { ERROR as EVMErrorMessage, EvmError } from './exceptions.js'
 import { InterpreterStep } from './interpreter.js'
 import { Message } from './message.js'
 import { PrecompileInput, getActivePrecompiles } from './precompiles/index.js'
-import { EVMInterface, EVMResult, ExecResult, Log } from './types.js'
+import {
+  EVMInterface,
+  EVMResult,
+  EVMRunCallOpts,
+  EVMRunCodeOpts,
+  ExecResult,
+  Log,
+} from './types.js'
 export {
   EOF,
   EVM,
@@ -12,6 +19,8 @@ export {
   EVMErrorMessage,
   EVMInterface,
   EVMResult,
+  EVMRunCallOpts,
+  EVMRunCodeOpts,
   ExecResult,
   getActivePrecompiles,
   InterpreterStep,


### PR DESCRIPTION
While working on #3167, I noticed that we do not export `EVMRunCallOpts` and `EVMRunCodeOpts` from the `evm` package even though these are the type definitions for the `evm.runCall` and `evm.runCode` public methods of the EVM.  This fixes that.