### PR TITLE
util: check that hex to byte conversion is valid in hexToBytes

### DIFF
--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -87,8 +87,8 @@ export const hexToBytes = (hex: string): Uint8Array => {
     throw new Error(`hex argument type ${typeof hex} must be of type string`)
   }
 
-  if (!hex.startsWith('0x')) {
-    throw new Error(`prefixed hex input should start with 0x, got ${hex.substring(0, 2)}`)
+  if (!/^0x[0-9a-fA-F]*$/.test(hex)) {
+    throw new Error(`Input must be a hexadecimal string, got ${hex}`)
   }
 
   hex = hex.slice(2)
@@ -97,14 +97,11 @@ export const hexToBytes = (hex: string): Uint8Array => {
     hex = padToEven(hex)
   }
 
-  const byteLen = hex.length / 2
-  const bytes = new Uint8Array(byteLen)
-  for (let i = 0; i < byteLen; i++) {
-    const byte = parseInt(hex.slice(i * 2, (i + 1) * 2), 16)
-    if (Number.isNaN(byte)) {
-      throw 'Invalid hex'
-    }
-    bytes[i] = byte
+  const byteLen = hex.length
+  const bytes = new Uint8Array(byteLen / 2)
+  for (let i = 0; i < byteLen; i += 2) {
+    const byte = parseInt(hex.slice(i, i + 2), 16)
+    bytes[i / 2] = byte
   }
   return bytes
 }

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -88,7 +88,7 @@ export const hexToBytes = (hex: string): Uint8Array => {
   }
 
   if (!/^0x[0-9a-fA-F]*$/.test(hex)) {
-    throw new Error(`Input must be a hexadecimal string, got ${hex}`)
+    throw new Error(`Input must be a 0x-prefixed hexadecimal string, got ${hex}`)
   }
 
   hex = hex.slice(2)

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -101,6 +101,9 @@ export const hexToBytes = (hex: string): Uint8Array => {
   const bytes = new Uint8Array(byteLen)
   for (let i = 0; i < byteLen; i++) {
     const byte = parseInt(hex.slice(i * 2, (i + 1) * 2), 16)
+    if (Number.isNaN(byte)) {
+      throw 'Invalid hex'
+    }
     bytes[i] = byte
   }
   return bytes

--- a/packages/util/test/bytes.spec.ts
+++ b/packages/util/test/bytes.spec.ts
@@ -425,6 +425,9 @@ describe('hexToBytes', () => {
     assert.throws(() => {
       hexToBytes('0xinvalidhexstring')
     })
+    assert.throws(() => {
+      hexToBytes('0xfz')
+    })
   })
 
   it('should convert prefixed hex-strings', () => {

--- a/packages/util/test/bytes.spec.ts
+++ b/packages/util/test/bytes.spec.ts
@@ -420,6 +420,13 @@ describe('hexToBytes', () => {
       hexToBytes('aabbcc112233')
     })
   })
+
+  it('should throw on invalid hex', () => {
+    assert.throws(() => {
+      hexToBytes('0xinvalidhexstring')
+    })
+  })
+
   it('should convert prefixed hex-strings', () => {
     const converted = hexToBytes('0x1')
     assert.deepEqual(converted, new Uint8Array([1]))


### PR DESCRIPTION
This addresses an issue where an invalid hex (e.g. `'0x\x19Ethereum Signed Message:\n32')` ) wouldn't throw. 

We now validate that every parsing of hex to int (through parseInt in base 16) returns a valid int and not a NaN.  