### PR TITLE
statemanager: Fix statemanager Browser Example

### DIFF
--- a/packages/statemanager/examples/browser.html
+++ b/packages/statemanager/examples/browser.html
@@ -10,7 +10,7 @@
 
         const run = async () => {
             const stateManager = new DefaultStateManager()
-            const address = new Address(hexStringToBytes('a94f5374fce5edbc8e2a8697c15331677e6ebf0b'))
+            const address = new Address(hexToBytes('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b'))
             const account = new Account(BigInt(0), BigInt(1000))
             await stateManager.checkpoint()
             await stateManager.putAccount(address, account)

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -102,7 +102,8 @@ export class Trie {
       valueEncoding = ValueEncoding.Bytes
     }
 
-    this.DEBUG = process.env.DEBUG?.includes('ethjs') === true
+    this.DEBUG =
+      typeof window === 'undefined' ? process?.env?.DEBUG?.includes('ethjs') ?? false : false
     this.debug = this.DEBUG
       ? (message: string, namespaces: string[] = []) => {
           let log = this._debug


### PR DESCRIPTION
The `statemanager` package browser example has two errors when it's run. The first error comes from referencing `process` in the trie package:
```
trie.ts:105 Uncaught (in promise) ReferenceError: process is not defined
    at new Trie (trie.ts:105:18)
    at new DefaultStateManager (stateManager.ts:200:23)
    at run (browser.html:19:34)
    at browser.html:31:9
```
The second error results from using `hexStringToBytes` instead of `hexToBytes`. This change fixes both of these issues so that the example successfully runs in the browser.