### PR TITLE
util: optimize hexToBytes

### DIFF
--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -82,6 +82,19 @@ export const bytesToInt = (bytes: Uint8Array): number => {
   return res
 }
 
+const hexToBytesMapFirstKey: { [key: string]: number } = {}
+const hexToBytesMapSecondKey: { [key: string]: number } = {}
+
+for (let i = 0; i < 16; i++) {
+  const vSecondKey = i
+  const vFirstKey = i * 16
+  const key = i.toString(16).toLowerCase()
+  hexToBytesMapSecondKey[key] = vSecondKey
+  hexToBytesMapSecondKey[key.toUpperCase()] = vSecondKey
+  hexToBytesMapFirstKey[key] = vFirstKey
+  hexToBytesMapFirstKey[key.toUpperCase()] = vFirstKey
+}
+
 export const hexToBytes = (hex: string): Uint8Array => {
   if (typeof hex !== 'string') {
     throw new Error(`hex argument type ${typeof hex} must be of type string`)
@@ -100,8 +113,7 @@ export const hexToBytes = (hex: string): Uint8Array => {
   const byteLen = hex.length
   const bytes = new Uint8Array(byteLen / 2)
   for (let i = 0; i < byteLen; i += 2) {
-    const byte = parseInt(hex.slice(i, i + 2), 16)
-    bytes[i / 2] = byte
+    bytes[i / 2] = hexToBytesMapFirstKey[hex[i]] + hexToBytesMapSecondKey[hex[i + 1]]
   }
   return bytes
 }


### PR DESCRIPTION
This PR optimizes hexToBytes.

**NOTE**: I also changed `unprefixedHexToBytes` to use this, because we call `unprefixedHexToBytes` in `toBytes` in case we convert a BigInt to Bytes! 

To test:

```typescript
import { hexToBytes as hexToBytesCrypto } from 'ethereum-cryptography/utils'
import { hexToBytes, padToEven } from '../src'

const allHexChars = 'aabbccddeeffAABBCCDDEEFF00112233445566778899'
const storageSlotMax = '0x' + ('ff').repeat(32)
const cases = ['0x', '0xaA', storageSlotMax, '0x' + allHexChars, '0x' + allHexChars.repeat(32)]
const iter = 1_000_000

const oldHexToBytes = (hex: string): Uint8Array => {
  if (typeof hex !== 'string') {
    throw new Error(`hex argument type ${typeof hex} must be of type string`)
  }

  if (!/^0x[0-9a-fA-F]*$/.test(hex)) {
    throw new Error(`Input must be a 0x-prefixed hexadecimal string, got ${hex}`)
  }

  hex = hex.slice(2)

  if (hex.length % 2 !== 0) {
    hex = padToEven(hex)
  }

  const byteLen = hex.length
  const bytes = new Uint8Array(byteLen / 2)
  for (let i = 0; i < byteLen; i += 2) {
    const byte = parseInt(hex.slice(i, i + 2), 16)
    bytes[i / 2] = byte
  }
  return bytes
}

function benchOld(hex: string) {
  oldHexToBytes(hex)
}

function benchNew(hex: string) {
  hexToBytes(hex)
}

function benchEthCrypo(hex: string) {
    hexToBytesCrypto(hex)
}

function loop(func: Function, name?: string, warmup: boolean = true) {
  let testC = 0
  for (const input of cases) {
    if (!warmup) console.time(name + ' - ' + testC)
    else {
      console.log(name + ' - ' + testC)
    }
    for (let i = 0; i < iter; i++) {
      func(input)
    }

    if (!warmup) console.timeEnd(name + ' - ' + testC)

    testC++
  }
}

loop(benchOld, 'old - warmup')
loop(benchEthCrypo, 'oldCrypto - warmup')
loop(benchNew, 'new - warmup')

loop(benchOld, 'old', false)
loop(benchEthCrypo, 'oldCrypto', false)
loop(benchNew, 'new', false)

```

Sample output;

```
old - 0: 71.902ms
old - 1: 128.238ms
old - 2: 1.675s
old - 3: 1.160s
old - 4: 35.893s
oldCrypto - 0: 63.829ms
oldCrypto - 1: 148.783ms
oldCrypto - 2: 2.083s
oldCrypto - 3: 1.534s
oldCrypto - 4: 42.828s
new - 0: 60.571ms
new - 1: 113.212ms
new - 2: 907.089ms
new - 3: 809.084ms
new - 4: 23.068s

```

Note: the test marked with "2" is a test on the largest item in the EVM (so 2^256 - 1). In `bigIntToBytes` we eventually call `hexToBytes` with a potential speedup here of ~45% !?

Please review thorougly.