### PR TITLE
Use permalink to avoid future breakage of link

### DIFF
--- a/packages/common/src/crc.ts
+++ b/packages/common/src/crc.ts
@@ -1,7 +1,7 @@
 /**
  * This code was duplicated from https://github.com/alexgorbatchev/crc/ under MIT license.
  * The code below is copied largely unmodified from the below file
- * https://github.com/alexgorbatchev/crc/blob/master/src/calculators/crc32.ts
+ * https://github.com/alexgorbatchev/crc/blob/31fc3853e417b5fb5ec83335428805842575f699/src/calculators/crc32.ts
  */
 let TABLE: Array<number> | Int32Array = [
   0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f, 0xe963a535, 0x9e6495a3,


### PR DESCRIPTION
Use permalink in `crc.js` reference to avoid future breakage of link.