### PR TITLE
tx: add `addSignature` method

### DIFF
--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -346,10 +346,10 @@ export abstract class BaseTransaction<T extends TransactionType>
    * @param r The `r` value of the signature
    * @param s The `s` value of the signature
    * @param convertV Set this to `true` if the raw output of `ecsign` is used. If this is `false` (default)
-   *                 then theraw value passed of `v` will be used for the signature. For legacy transactions,
+   *                 then the raw value passed for `v` will be used for the signature. For legacy transactions,
    *                 if this is set to `true`, it will also set the right `v` value for the chain id.
    */
-  protected abstract addSignature(
+  abstract addSignature(
     v: bigint,
     r: Uint8Array | bigint,
     s: Uint8Array | bigint,

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -309,7 +309,7 @@ export abstract class BaseTransaction<T extends TransactionType>
 
     const msgHash = this.getHashedMessageToSign()
     const { v, r, s } = ecsign(msgHash, privateKey)
-    const tx = this._processSignature(v, r, s)
+    const tx = this.addSignature(v, r, s, true)
 
     // Hack part 2
     if (hackApplied) {
@@ -339,8 +339,21 @@ export abstract class BaseTransaction<T extends TransactionType>
     }
   }
 
-  // Accept the v,r,s values from the `sign` method, and convert this into a T
-  protected abstract _processSignature(v: bigint, r: Uint8Array, s: Uint8Array): Transaction[T]
+  /**
+   * Returns a new transaction with the same data fields as the current, but now signed
+   * @param v The `v` value of the signature
+   * @param r The `r` value of the signature
+   * @param s The `s` value of the signature
+   * @param convertV Set this to `true` if the raw output of `ecsign` is used. If this is `false` (default)
+   *                 then theraw value passed of `v` will be used for the signature. For legacy transactions,
+   *                 if this is set to `true`, it will also set the right `v` value for the chain id.
+   */
+  protected abstract addSignature(
+    v: bigint,
+    r: Uint8Array | bigint,
+    s: Uint8Array | bigint,
+    convertV?: boolean
+  ): Transaction[T]
 
   /**
    * Does chain ID checks on common and returns a common

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -308,7 +308,14 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<TransactionType
     return Legacy.getSenderPublicKey(this)
   }
 
-  protected _processSignature(v: bigint, r: Uint8Array, s: Uint8Array) {
+  addSignature(
+    v: bigint,
+    r: Uint8Array | bigint,
+    s: Uint8Array | bigint,
+    convertV: boolean = false
+  ): FeeMarketEIP1559Transaction {
+    r = toBytes(r)
+    s = toBytes(s)
     const opts = { ...this.txOptions, common: this.common }
 
     return FeeMarketEIP1559Transaction.fromTxData(
@@ -322,7 +329,7 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<TransactionType
         value: this.value,
         data: this.data,
         accessList: this.accessList,
-        v: v - BIGINT_27, // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
+        v: convertV ? v - BIGINT_27 : v, // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
         r: bytesToBigInt(r),
         s: bytesToBigInt(s),
       },

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -280,7 +280,14 @@ export class AccessListEIP2930Transaction extends BaseTransaction<TransactionTyp
     return Legacy.getSenderPublicKey(this)
   }
 
-  protected _processSignature(v: bigint, r: Uint8Array, s: Uint8Array) {
+  addSignature(
+    v: bigint,
+    r: Uint8Array | bigint,
+    s: Uint8Array | bigint,
+    convertV: boolean = false
+  ): AccessListEIP2930Transaction {
+    r = toBytes(r)
+    s = toBytes(s)
     const opts = { ...this.txOptions, common: this.common }
 
     return AccessListEIP2930Transaction.fromTxData(
@@ -293,7 +300,7 @@ export class AccessListEIP2930Transaction extends BaseTransaction<TransactionTyp
         value: this.value,
         data: this.data,
         accessList: this.accessList,
-        v: v - BIGINT_27, // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
+        v: convertV ? v - BIGINT_27 : v, // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
         r: bytesToBigInt(r),
         s: bytesToBigInt(s),
       },

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -529,7 +529,14 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
     }
   }
 
-  protected _processSignature(v: bigint, r: Uint8Array, s: Uint8Array): BlobEIP4844Transaction {
+  addSignature(
+    v: bigint,
+    r: Uint8Array | bigint,
+    s: Uint8Array | bigint,
+    convertV: boolean = false
+  ): BlobEIP4844Transaction {
+    r = toBytes(r)
+    s = toBytes(s)
     const opts = { ...this.txOptions, common: this.common }
 
     return BlobEIP4844Transaction.fromTxData(
@@ -543,7 +550,7 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
         value: this.value,
         data: this.data,
         accessList: this.accessList,
-        v: v - BIGINT_27, // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
+        v: convertV ? v - BIGINT_27 : v, // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
         r: bytesToBigInt(r),
         s: bytesToBigInt(s),
         maxFeePerBlobGas: this.maxFeePerBlobGas,

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -269,11 +269,15 @@ export class LegacyTransaction extends BaseTransaction<TransactionType.Legacy> {
     return Legacy.getSenderPublicKey(this)
   }
 
-  /**
-   * Process the v, r, s values from the `sign` method of the base transaction.
-   */
-  protected _processSignature(v: bigint, r: Uint8Array, s: Uint8Array) {
-    if (this.supports(Capability.EIP155ReplayProtection)) {
+  addSignature(
+    v: bigint,
+    r: Uint8Array | bigint,
+    s: Uint8Array | bigint,
+    convertV: boolean = false
+  ): LegacyTransaction {
+    r = toBytes(r)
+    s = toBytes(s)
+    if (convertV && this.supports(Capability.EIP155ReplayProtection)) {
       v += this.common.chainId() * BIGINT_2 + BIGINT_8
     }
 


### PR DESCRIPTION
This PR adds `addSignature` method. It is essentially the old `protected _processSignature` method.

This allows users to add raw values of the signature, without having to use `tx.sign` (where the pkey is necessary). This is, for instance, handy for hardware wallets.

Please take care reviewing the Legacy transactions, since those are somewhat exceptional.

Ref: https://github.com/ethereumjs/ethereumjs-monorepo/discussions/3229