### PR TITLE
perf: improve rlp.decode

### DIFF
--- a/packages/rlp/benchmarks/index.ts
+++ b/packages/rlp/benchmarks/index.ts
@@ -1,0 +1,22 @@
+import Benchmark from 'benchmark'
+import { encode, decode } from '../dist/cjs/index.js'
+
+const suite = new Benchmark.Suite()
+
+const buf = (length: number, start = 0) =>
+  Uint8Array.from(Array.from({ length }, (_, i) => start + i))
+
+const testData = [
+  { type: 'list of small numbers', data: Array.from({ length: 128 }, (_, i) => 1024 + i) },
+  { type: 'list of large numbers', data: Array.from({ length: 128 }, (_, i) => 1099511627776 + i) },
+  { type: 'list of small buffers', data: Array.from({ length: 128 }, (_, i) => buf(32, i)) },
+  { type: 'list of large buffers', data: Array.from({ length: 128 }, (_, i) => buf(1048576, i)) },
+]
+
+for (const { type, data } of testData) {
+  const encoded = encode(data)
+  suite.add(`encode - ${type}`, () => encode(data))
+  suite.add(`decode - ${type}`, () => decode(encoded))
+}
+
+suite.on('cycle', (event: Event) => console.log(String(event.target))).run()

--- a/packages/rlp/package.json
+++ b/packages/rlp/package.json
@@ -42,7 +42,9 @@
     "src"
   ],
   "scripts": {
+    "benchmarks": "node ./benchmarks/index.js",
     "build": "../../config/cli/ts-build.sh node",
+    "build:benchmarks": "npm run build && tsc -p tsconfig.benchmarks.json",
     "clean": "../../config/cli/clean-package.sh",
     "coverage": "c8 --all --reporter=lcov --reporter=text npm run test:node",
     "examples": "tsx ../../scripts/examples-runner.ts -- rlp",
@@ -57,5 +59,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "devDependencies": {
+    "benchmark": "^2.1.4"
   }
 }

--- a/packages/rlp/src/index.ts
+++ b/packages/rlp/src/index.ts
@@ -84,7 +84,10 @@ export function decode(input: Input, stream = false): Uint8Array | NestedUint8Ar
   const decoded = _decode(inputBytes)
 
   if (stream) {
-    return decoded
+    return {
+      data: decoded.data,
+      remainder: decoded.remainder.slice(),
+    }
   }
   if (decoded.remainder.length !== 0) {
     throw new Error('invalid RLP: remainder must be zero')
@@ -103,7 +106,7 @@ function _decode(input: Uint8Array): Decoded {
     // a single byte whose value is in the [0x00, 0x7f] range, that byte is its own RLP encoding.
     return {
       data: input.slice(0, 1),
-      remainder: input.slice(1),
+      remainder: input.subarray(1),
     }
   } else if (firstByte <= 0xb7) {
     // string is 0-55 bytes long. A single byte with value 0x80 plus the length of the string followed by the string
@@ -123,7 +126,7 @@ function _decode(input: Uint8Array): Decoded {
 
     return {
       data,
-      remainder: input.slice(length),
+      remainder: input.subarray(length),
     }
   } else if (firstByte <= 0xbf) {
     // string is greater than 55 bytes long. A single byte with the value (0xb7 plus the length of the length),
@@ -140,7 +143,7 @@ function _decode(input: Uint8Array): Decoded {
 
     return {
       data,
-      remainder: input.slice(length + llength),
+      remainder: input.subarray(length + llength),
     }
   } else if (firstByte <= 0xf7) {
     // a list between 0-55 bytes long
@@ -154,7 +157,7 @@ function _decode(input: Uint8Array): Decoded {
 
     return {
       data: decoded,
-      remainder: input.slice(length),
+      remainder: input.subarray(length),
     }
   } else {
     // a list over 55 bytes long
@@ -178,7 +181,7 @@ function _decode(input: Uint8Array): Decoded {
 
     return {
       data: decoded,
-      remainder: input.slice(totalLength),
+      remainder: input.subarray(totalLength),
     }
   }
 }

--- a/packages/rlp/tsconfig.benchmarks.json
+++ b/packages/rlp/tsconfig.benchmarks.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../config/tsconfig.json",
+  "compilerOptions": {
+    "lib": ["dom"],
+    "sourceMap": false,
+    "declaration": true,
+    "esModuleInterop": true,
+    "module": "esnext"
+  },
+  "include": ["benchmarks/**.ts"]
+}


### PR DESCRIPTION
Improve performance in the inner _decode function by avoiding copying of the remainder.
In the case that the final remainder is returned to the user (ie: stream=true), it is copied before returning.

Results in ~10-30x speedup

benchmarks:
before:
```
decode - list of small numbers x 3,985 ops/sec ±4.57% (42 runs sampled)
decode - list of large numbers x 3,522 ops/sec ±9.29% (32 runs sampled)
decode - list of small buffers x 2,558 ops/sec ±2.94% (41 runs sampled)
decode - list of large buffers x 0.34 ops/sec ±42.70% (5 runs sampled)
```

after:
```
decode - list of small numbers x 50,158 ops/sec ±0.33% (96 runs sampled)
decode - list of large numbers x 50,496 ops/sec ±0.44% (93 runs sampled)
decode - list of small buffers x 46,721 ops/sec ±0.29% (92 runs sampled)
decode - list of large buffers x 11.65 ops/sec ±2.61% (33 runs sampled)
```