### PR TITLE
Additional `wasm-crypto` replacements in devp2p

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -30,6 +30,7 @@ import {
 } from '@polkadot/wasm-crypto'
 import * as kzg from 'c-kzg'
 import { keccak256 } from 'ethereum-cryptography/keccak'
+import { ecdsaRecover, ecdsaSign } from 'ethereum-cryptography/secp256k1-compat'
 import { sha256 } from 'ethereum-cryptography/sha256'
 import { existsSync, writeFileSync } from 'fs'
 import { ensureDirSync, readFileSync, removeSync } from 'fs-extra'
@@ -839,11 +840,23 @@ async function run() {
 
       return { r, s, v }
     }
+    cryptoFunctions.ecdsaSign = (hash: Uint8Array, pk: Uint8Array) => {
+      const sig = secp256k1Sign(hash, pk)
+      return {
+        signature: sig.slice(0, 64),
+        recid: sig[64],
+      }
+    }
+    cryptoFunctions.ecdsaRecover = (sig: Uint8Array, recId: number, hash: Uint8Array) => {
+      return secp256k1Recover(hash, sig, recId)
+    }
   } else {
     cryptoFunctions.keccak256 = keccak256
     cryptoFunctions.ecrecover = ecrecover
     cryptoFunctions.sha256 = sha256
     cryptoFunctions.ecsign = ecsign
+    cryptoFunctions.ecdsaSign = ecdsaSign
+    cryptoFunctions.ecdsaRecover = ecdsaRecover
   }
   // Configure accounts for mining and prefunding in a local devnet
   const accounts: Account[] = []

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -81,6 +81,8 @@ export interface CustomCrypto {
   ) => Uint8Array
   sha256?: (msg: Uint8Array) => Uint8Array
   ecsign?: (msg: Uint8Array, pk: Uint8Array, chainId?: bigint) => ECDSASignature
+  ecdsaSign?: (msg: Uint8Array, pk: Uint8Array) => { signature: Uint8Array; recid: number }
+  ecdsaRecover?: (sig: Uint8Array, recId: number, hash: Uint8Array) => Uint8Array
 }
 
 interface BaseOpts {

--- a/packages/devp2p/src/dpt/message.ts
+++ b/packages/devp2p/src/dpt/message.ts
@@ -175,7 +175,7 @@ export function encode<T>(typename: string, data: T, privateKey: Uint8Array, com
   const typedata = concatBytes(Uint8Array.from([type]), RLP.encode(encodedMsg))
 
   const sighash = (common?.customCrypto.keccak256 ?? keccak256)(typedata)
-  const sig = ecdsaSign(sighash, privateKey)
+  const sig = (common?.customCrypto.ecdsaSign ?? ecdsaSign)(sighash, privateKey)
   const hashdata = concatBytes(sig.signature, Uint8Array.from([sig.recid]), typedata)
   const hash = (common?.customCrypto.keccak256 ?? keccak256)(hashdata)
   return concatBytes(hash, hashdata)
@@ -194,6 +194,11 @@ export function decode(bytes: Uint8Array, common?: Common) {
   const sighash = (common?.customCrypto.keccak256 ?? keccak256)(typedata)
   const signature = bytes.subarray(32, 96)
   const recoverId = bytes[96]
-  const publicKey = ecdsaRecover(signature, recoverId, sighash, false)
+  const publicKey = (common?.customCrypto.ecdsaRecover ?? ecdsaRecover)(
+    signature,
+    recoverId,
+    sighash,
+    false
+  )
   return { typename, data, publicKey }
 }


### PR DESCRIPTION
This adds additional cryptographic primitives from `@polkadot/wasm-crypto`, mainly for use in devp2p.  Partially addresses #3246 