### PR TITLE
client: Check for undefined pathStrings

### DIFF
--- a/packages/client/src/sync/fetcher/trienodefetcher.ts
+++ b/packages/client/src/sync/fetcher/trienodefetcher.ts
@@ -211,8 +211,8 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
       for (const nodeData of result[0]) {
         const node = decodeNode(nodeData as unknown as Uint8Array)
         const nodeHash = bytesToHex(this.keccakFunction(nodeData as unknown as Uint8Array))
-        const pathString = this.requestedNodeToPath.get(nodeHash) as string
-        const [accountPath, storagePath] = pathString!.split('/')
+        const pathString = this.requestedNodeToPath.get(nodeHash) ?? ''
+        const [accountPath, storagePath] = pathString.split('/')
         const nodePath = storagePath ?? accountPath
         const childNodes = []
         let unknownChildNodeCount = 0

--- a/packages/client/src/util/rpc.ts
+++ b/packages/client/src/util/rpc.ts
@@ -50,7 +50,7 @@ const ALLOWED_DRIFT = 60_000
  * @returns
  */
 function checkFilter(method: string, filterStringCSV: string) {
-  if (filterStringCSV === '') {
+  if (!filterStringCSV || filterStringCSV === '') {
     return false
   }
   if (filterStringCSV === 'all') {

--- a/packages/client/test/sync/fetcher/trienodefetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/trienodefetcher.spec.ts
@@ -171,6 +171,21 @@ describe('[TrieNodeFetcher]', async () => {
       'Should generate requests for all child nodes'
     )
   })
+  it('should not throw if undefined', async () => {
+    const config = new Config()
+    const pool = new PeerPool() as any
+    const fetcher = new TrieNodeFetcher({
+      config,
+      pool,
+      root: new Uint8Array(),
+    })
+    try {
+      await fetcher.store(undefined as any)
+      assert.ok('should run without error')
+    } catch (err: any) {
+      assert.fail(err.message)
+    }
+  })
 
   it('should find a fetchable peer', async () => {
     const config = new Config({ accountCache: 10000, storageCache: 1000 })

--- a/packages/client/test/util/rpc.spec.ts
+++ b/packages/client/test/util/rpc.spec.ts
@@ -59,6 +59,31 @@ describe('[Util/RPC]', () => {
       }
     }
   })
+  it('should not throw if rpcDebugVerbose string is undefined', async () => {
+    const config = new Config({ accountCache: 10000, storageCache: 1000 })
+    const client = await EthereumClient.create({ config, metaDB: new MemoryLevel() })
+    const manager = new RPCManager(client, config)
+    const { logger } = config
+    const methodConfig = Object.values(MethodConfig)[0]
+    const { server } = createRPCServer(manager, {
+      methodConfig,
+      rpcDebug: 'eth',
+      logger,
+      rpcDebugVerbose: undefined as any,
+    })
+    const httpServer = createRPCServerListener({
+      server,
+      withEngineMiddleware: { jwtSecret: new Uint8Array(32) },
+    })
+    const wsServer = createWsRPCServerListener({
+      server,
+      withEngineMiddleware: { jwtSecret: new Uint8Array(32) },
+    })
+    assert.ok(
+      httpServer !== undefined && wsServer !== undefined,
+      'should return http and ws servers'
+    )
+  })
 })
 
 describe('[Util/RPC/Engine eth methods]', async () => {


### PR DESCRIPTION
# package: **client**
## Fix for issue #3244

Also fixes the same error, thrown during sync from the `checkFiilter` method in `client/src/util/rpc.ts`.

- ### `trieNodeFetcher.store` 
  - A possible `undefined` was ignored with a `!` and an `as string`.
  - Fixed by assigning an empty string in place of the possible `undefined` string.
- ### `util/rpc.ts -- checkFilter(method: string, filterStringCSV: string)`
  - Function expects a string value for `filterStringCSV`, but can potentially be fed an `undefined` 
  - This probably happens from the same `as string` issue above, or the same bug somewhere else
  - Fixed by checking for `undefined` and treating it the same as an empty string.

Running the script from the Issue with these two fixes resulted in the elimination of that error, and allowed the `sync` process to run smoothly.


