### PR TITLE
common: schedule cancun for mainnet

### DIFF
--- a/packages/common/src/chains.ts
+++ b/packages/common/src/chains.ts
@@ -116,7 +116,8 @@ export const chains: ChainsDict = {
       {
         name: 'cancun',
         block: null,
-        forkHash: null,
+        timestamp: '1710338135',
+        forkHash: '0x9f3d2254',
       },
     ],
     bootstrapNodes: [

--- a/packages/common/test/hardforks.spec.ts
+++ b/packages/common/test/hardforks.spec.ts
@@ -121,8 +121,8 @@ describe('[Common]: Hardfork logic', () => {
     msg = 'should return correct next HF (mainnet: byzantium -> constantinople)'
     assert.equal(c.nextHardforkBlockOrTimestamp(Hardfork.Byzantium)!, BigInt(7280000), msg)
 
-    msg = 'should return null if next HF is not available (mainnet: shanghai -> cancun)'
-    assert.equal(c.nextHardforkBlockOrTimestamp(Hardfork.Shanghai), null, msg)
+    msg = 'should return null if next HF is not available (mainnet: cancun -> prague)'
+    assert.equal(c.nextHardforkBlockOrTimestamp(Hardfork.Cancun), null, msg)
 
     const c2 = new Common({ chain: Chain.Goerli, hardfork: Hardfork.Chainstart })
 
@@ -169,9 +169,9 @@ describe('[Common]: Hardfork logic', () => {
     msg = 'should return null for unscheduled hardfork'
     // developer note: when Shanghai is set,
     // update this test to next unscheduled hardfork.
-    assert.equal(c.hardforkBlock(Hardfork.Shanghai), null, msg)
-    assert.equal(c.hardforkBlock(Hardfork.Shanghai), null, msg)
-    assert.equal(c.nextHardforkBlockOrTimestamp(Hardfork.Shanghai), null, msg)
+    assert.equal(c.hardforkBlock(Hardfork.Cancun), null, msg)
+    assert.equal(c.hardforkBlock(Hardfork.Cancun), null, msg)
+    assert.equal(c.nextHardforkBlockOrTimestamp(Hardfork.Cancun), null, msg)
   })
 
   it('hardforkGteHardfork()', () => {


### PR DESCRIPTION
as discussed in today's Feb 8 ACD, cancun confirmed for mainnet

![image](https://github.com/ethereumjs/ethereumjs-monorepo/assets/76567250/edf6c44e-59ec-4831-a2e1-7cebfceccad3)

ref: 
 - https://github.com/ethereum/consensus-specs/pull/3597
 - https://github.com/ethereum/EIPs/pull/8173

and this here confirms the forkhash
https://discord.com/channels/595666850260713488/745077610685661265/1205157653047808071