### PR TITLE
Hotfix Releases (Missing Trie debug dependency)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15678,13 +15678,13 @@
     },
     "packages/block": {
       "name": "@ethereumjs/block",
-      "version": "5.1.0",
+      "version": "5.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/common": "^4.2.0",
         "@ethereumjs/rlp": "^5.0.2",
-        "@ethereumjs/trie": "^6.1.0",
-        "@ethereumjs/tx": "^5.2.0",
+        "@ethereumjs/trie": "^6.1.1",
+        "@ethereumjs/tx": "^5.2.1",
         "@ethereumjs/util": "^9.0.2",
         "ethereum-cryptography": "^2.1.3"
       },
@@ -15700,12 +15700,12 @@
       "version": "7.1.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/block": "^5.1.0",
+        "@ethereumjs/block": "^5.1.1",
         "@ethereumjs/common": "^4.2.0",
         "@ethereumjs/ethash": "^3.0.2",
         "@ethereumjs/rlp": "^5.0.2",
-        "@ethereumjs/trie": "^6.1.0",
-        "@ethereumjs/tx": "^5.2.0",
+        "@ethereumjs/trie": "^6.1.1",
+        "@ethereumjs/tx": "^5.2.1",
         "@ethereumjs/util": "^9.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.1.3",
@@ -15722,17 +15722,17 @@
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/block": "5.1.0",
+        "@ethereumjs/block": "5.1.1",
         "@ethereumjs/blockchain": "7.1.0",
         "@ethereumjs/common": "4.2.0",
-        "@ethereumjs/devp2p": "6.1.0",
+        "@ethereumjs/devp2p": "6.1.1",
         "@ethereumjs/ethash": "3.0.2",
         "@ethereumjs/evm": "2.2.0",
         "@ethereumjs/genesis": "0.2.1",
         "@ethereumjs/rlp": "5.0.2",
-        "@ethereumjs/statemanager": "2.2.0",
-        "@ethereumjs/trie": "6.1.0",
-        "@ethereumjs/tx": "5.2.0",
+        "@ethereumjs/statemanager": "2.2.1",
+        "@ethereumjs/trie": "6.1.1",
+        "@ethereumjs/tx": "5.2.1",
         "@ethereumjs/util": "9.0.2",
         "@ethereumjs/verkle": "^0.0.1",
         "@ethereumjs/vm": "7.2.0",
@@ -16003,7 +16003,7 @@
     },
     "packages/devp2p": {
       "name": "@ethereumjs/devp2p",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "MIT",
       "dependencies": {
         "@ethereumjs/common": "^4.2.0",
@@ -16018,8 +16018,8 @@
         "snappyjs": "^0.6.1"
       },
       "devDependencies": {
-        "@ethereumjs/block": "^5.1.0",
-        "@ethereumjs/tx": "^5.2.0",
+        "@ethereumjs/block": "^5.1.1",
+        "@ethereumjs/tx": "^5.2.1",
         "@types/debug": "^4.1.9",
         "@types/k-bucket": "^5.0.0",
         "chalk": "^4.1.2",
@@ -16045,7 +16045,7 @@
       "version": "3.0.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/block": "^5.1.0",
+        "@ethereumjs/block": "^5.1.1",
         "@ethereumjs/rlp": "^5.0.2",
         "@ethereumjs/util": "^9.0.2",
         "bigint-crypto-utils": "^3.2.2",
@@ -16064,8 +16064,8 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/common": "^4.2.0",
-        "@ethereumjs/statemanager": "^2.2.0",
-        "@ethereumjs/tx": "^5.2.0",
+        "@ethereumjs/statemanager": "^2.2.1",
+        "@ethereumjs/tx": "^5.2.1",
         "@ethereumjs/util": "^9.0.2",
         "@types/debug": "^4.1.9",
         "debug": "^4.3.3",
@@ -16099,7 +16099,7 @@
         "@ethereumjs/util": "^9.0.2"
       },
       "devDependencies": {
-        "@ethereumjs/trie": "^6.1.0"
+        "@ethereumjs/trie": "^6.1.1"
       },
       "engines": {
         "node": ">=18"
@@ -16121,12 +16121,12 @@
     },
     "packages/statemanager": {
       "name": "@ethereumjs/statemanager",
-      "version": "2.2.0",
+      "version": "2.2.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/common": "^4.2.0",
         "@ethereumjs/rlp": "^5.0.2",
-        "@ethereumjs/trie": "^6.1.0",
+        "@ethereumjs/trie": "^6.1.1",
         "@ethereumjs/util": "^9.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.1.3",
@@ -16134,7 +16134,7 @@
         "lru-cache": "^10.0.0"
       },
       "devDependencies": {
-        "@ethereumjs/block": "^5.1.0",
+        "@ethereumjs/block": "^5.1.1",
         "@ethereumjs/genesis": "^0.2.1",
         "@types/debug": "^4.1.9"
       },
@@ -16149,12 +16149,13 @@
     },
     "packages/trie": {
       "name": "@ethereumjs/trie",
-      "version": "6.1.0",
+      "version": "6.1.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
         "@ethereumjs/util": "^9.0.2",
         "@types/readable-stream": "^2.3.13",
+        "debug": "^4.3.4",
         "ethereum-cryptography": "^2.1.3",
         "lru-cache": "^10.0.0",
         "readable-stream": "^3.6.0"
@@ -16163,7 +16164,6 @@
         "@ethereumjs/genesis": "^0.2.1",
         "@types/benchmark": "^1.0.33",
         "abstract-level": "^1.0.3",
-        "debug": "^4.3.4",
         "level": "^8.0.0",
         "level-legacy": "npm:level@^7.0.0",
         "level-mem": "^6.0.1",
@@ -16178,7 +16178,7 @@
     },
     "packages/tx": {
       "name": "@ethereumjs/tx",
-      "version": "5.2.0",
+      "version": "5.2.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/common": "^4.2.0",
@@ -16244,14 +16244,14 @@
       "version": "7.2.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/block": "^5.1.0",
+        "@ethereumjs/block": "^5.1.1",
         "@ethereumjs/blockchain": "^7.1.0",
         "@ethereumjs/common": "^4.2.0",
         "@ethereumjs/evm": "^2.2.0",
         "@ethereumjs/rlp": "^5.0.2",
-        "@ethereumjs/statemanager": "^2.2.0",
-        "@ethereumjs/trie": "^6.1.0",
-        "@ethereumjs/tx": "^5.2.0",
+        "@ethereumjs/statemanager": "^2.2.1",
+        "@ethereumjs/trie": "^6.1.1",
+        "@ethereumjs/tx": "^5.2.1",
         "@ethereumjs/util": "^9.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.1.3"

--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 5.1.0 - 2024-02-01
+## 5.1.0 - 2024-02-08
 
 ### Dencun Hardfork Support
 

--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -15,9 +15,20 @@ While all EIPs contained in the upcoming Dencun hardfork run pretty much stable 
 Dencun hardfork on the execution side is called [Cancun](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md) and can be activated within the EthereumJS libraries (default hardfork still `Shanghai`) with a following `common` instance:
 
 ```typescript
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
-const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Cancun })
+import * as kzg from 'c-kzg'
+import { Common, Chain, Hardfork } from '@ethereumjs/common'
+import { initKZG } from '@ethereumjs/util'
+
+initKZG(kzg, __dirname + '/../../client/src/trustedSetups/official.txt')
+const common = new Common({
+  chain: Chain.Mainnet,
+  hardfork: Hardfork.Cancun,
+  customCrypto: { kzg: kzg },
+})
+console.log(common.customCrypto.kzg) // Should print the initialized KZG interface
 ```
+
+Note that the `kzg` initialization slightly changed from previous experimental releases and a custom KZG instance is now passed to `Common` by using the `customCrypto` parameter, see PR [#3262](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3262).
 
 While `EIP-4844` - activating shard blob transactions - is for sure the most prominent EIP from this hardfork, enabling better scaling for the Ethereum ecosystem by providing cheaper block space for L2s, there are in total 6 EIPs contained in the Dencun hardfork. The following is an overview of which EthereumJS libraries mainly implement the various EIPs:
 

--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.1.1 - 2024-02-08
+
+- Hotfix release adding a missing `debug` dependency to the `@ethereumjs/trie` package (dependency), PR [#3271](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3271)
+
 ## 5.1.0 - 2024-02-08
 
 ### Dencun Hardfork Support

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/block",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Provides Block serialization and help functions",
   "keywords": [
     "ethereum",

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@ethereumjs/common": "^4.2.0",
     "@ethereumjs/rlp": "^5.0.2",
-    "@ethereumjs/trie": "^6.1.0",
+    "@ethereumjs/trie": "^6.1.1",
     "@ethereumjs/tx": "^5.2.0",
     "@ethereumjs/util": "^9.0.2",
     "ethereum-cryptography": "^2.1.3"

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -49,7 +49,7 @@
     "@ethereumjs/common": "^4.2.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/trie": "^6.1.1",
-    "@ethereumjs/tx": "^5.2.0",
+    "@ethereumjs/tx": "^5.2.1",
     "@ethereumjs/util": "^9.0.2",
     "ethereum-cryptography": "^2.1.3"
   },

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 7.1.0 - 2024-02-01
+## 7.1.0 - 2024-02-08
 
 ### Dencun Hardfork Support
 

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -15,9 +15,22 @@ While all EIPs contained in the upcoming Dencun hardfork run pretty much stable 
 Dencun hardfork on the execution side is called [Cancun](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md) and can be activated within the EthereumJS libraries (default hardfork still `Shanghai`) with a following `common` instance:
 
 ```typescript
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
-const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Cancun })
+import * as kzg from 'c-kzg'
+import { Common, Chain, Hardfork } from '@ethereumjs/common'
+import { initKZG } from '@ethereumjs/util'
+
+initKZG(kzg, __dirname + '/../../client/src/trustedSetups/official.txt')
+const common = new Common({
+  chain: Chain.Mainnet,
+  hardfork: Hardfork.Cancun,
+  customCrypto: { kzg: kzg },
+})
+console.log(common.customCrypto.kzg) // Should print the initialized KZG interface
 ```
+
+Note that the `kzg` initialization slightly changed from previous experimental releases and a custom KZG instance is now passed to `Common` by using the `customCrypto` parameter, see PR [#3262](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3262).
+
+At the moment using the Node.js bindings for the `c-kzg` library is the only option to get KZG related functionality to work, note that this solution is not browser compatible. We are currently working on a WASM build of that respective library. Let us know on the urgency of this task! 😆
 
 While `EIP-4844` - activating shard blob transactions - is for sure the most prominent EIP from this hardfork, enabling better scaling for the Ethereum ecosystem by providing cheaper block space for L2s, there are in total 6 EIPs contained in the Dencun hardfork. The following is an overview of which EthereumJS libraries mainly implement the various EIPs:
 

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -46,7 +46,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/block": "^5.1.0",
+    "@ethereumjs/block": "^5.1.1",
     "@ethereumjs/common": "^4.2.0",
     "@ethereumjs/ethash": "^3.0.2",
     "@ethereumjs/rlp": "^5.0.2",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -51,7 +51,7 @@
     "@ethereumjs/ethash": "^3.0.2",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/trie": "^6.1.1",
-    "@ethereumjs/tx": "^5.2.0",
+    "@ethereumjs/tx": "^5.2.1",
     "@ethereumjs/util": "^9.0.2",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.1.3",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -50,7 +50,7 @@
     "@ethereumjs/common": "^4.2.0",
     "@ethereumjs/ethash": "^3.0.2",
     "@ethereumjs/rlp": "^5.0.2",
-    "@ethereumjs/trie": "^6.1.0",
+    "@ethereumjs/trie": "^6.1.1",
     "@ethereumjs/tx": "^5.2.0",
     "@ethereumjs/util": "^9.0.2",
     "debug": "^4.3.3",

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 0.10.0 - 2024-02-01
+## 0.10.0 - 2024-02-08
 
 This client release now comes with official Dencun hardfork support 🎉 and by default uses WASM for crypto primitives for faster block execution times.
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -64,7 +64,7 @@
     "@ethereumjs/evm": "2.2.0",
     "@ethereumjs/genesis": "0.2.1",
     "@ethereumjs/rlp": "5.0.2",
-    "@ethereumjs/statemanager": "2.2.0",
+    "@ethereumjs/statemanager": "2.2.1",
     "@ethereumjs/trie": "6.1.1",
     "@ethereumjs/tx": "5.2.1",
     "@ethereumjs/util": "9.0.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -65,7 +65,7 @@
     "@ethereumjs/genesis": "0.2.1",
     "@ethereumjs/rlp": "5.0.2",
     "@ethereumjs/statemanager": "2.2.0",
-    "@ethereumjs/trie": "6.1.0",
+    "@ethereumjs/trie": "6.1.1",
     "@ethereumjs/tx": "5.2.0",
     "@ethereumjs/util": "9.0.2",
     "@ethereumjs/verkle": "^0.0.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -59,7 +59,7 @@
     "@ethereumjs/block": "5.1.0",
     "@ethereumjs/blockchain": "7.1.0",
     "@ethereumjs/common": "4.2.0",
-    "@ethereumjs/devp2p": "6.1.0",
+    "@ethereumjs/devp2p": "6.1.1",
     "@ethereumjs/ethash": "3.0.2",
     "@ethereumjs/evm": "2.2.0",
     "@ethereumjs/genesis": "0.2.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -66,7 +66,7 @@
     "@ethereumjs/rlp": "5.0.2",
     "@ethereumjs/statemanager": "2.2.0",
     "@ethereumjs/trie": "6.1.1",
-    "@ethereumjs/tx": "5.2.0",
+    "@ethereumjs/tx": "5.2.1",
     "@ethereumjs/util": "9.0.2",
     "@ethereumjs/verkle": "^0.0.1",
     "@ethereumjs/vm": "7.2.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -56,7 +56,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/block": "5.1.0",
+    "@ethereumjs/block": "5.1.1",
     "@ethereumjs/blockchain": "7.1.0",
     "@ethereumjs/common": "4.2.0",
     "@ethereumjs/devp2p": "6.1.1",

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -15,9 +15,22 @@ While all EIPs contained in the upcoming Dencun hardfork run pretty much stable 
 Dencun hardfork on the execution side is called [Cancun](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md) and can be activated within the EthereumJS libraries (default hardfork still `Shanghai`) with a following `common` instance:
 
 ```typescript
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
-const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Cancun })
+import * as kzg from 'c-kzg'
+import { Common, Chain, Hardfork } from '@ethereumjs/common'
+import { initKZG } from '@ethereumjs/util'
+
+initKZG(kzg, __dirname + '/../../client/src/trustedSetups/official.txt')
+const common = new Common({
+  chain: Chain.Mainnet,
+  hardfork: Hardfork.Cancun,
+  customCrypto: { kzg: kzg },
+})
+console.log(common.customCrypto.kzg) // Should print the initialized KZG interface
 ```
+
+Note that the `kzg` initialization slightly changed from previous experimental releases and a custom KZG instance is now passed to `Common` by using the `customCrypto` parameter, see PR [#3262](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3262).
+
+At the moment using the Node.js bindings for the `c-kzg` library is the only option to get KZG related functionality to work, note that this solution is not browser compatible. We are currently working on a WASM build of that respective library. Let us know on the urgency of this task! 😆
 
 While `EIP-4844` - activating shard blob transactions - is for sure the most prominent EIP from this hardfork, enabling better scaling for the Ethereum ecosystem by providing cheaper block space for L2s, there are in total 6 EIPs contained in the Dencun hardfork. The following is an overview of which EthereumJS libraries mainly implement the various EIPs:
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 4.2.0 - 2024-02-01
+## 4.2.0 - 2024-02-08
 
 ### Dencun Hardfork Support
 

--- a/packages/devp2p/CHANGELOG.md
+++ b/packages/devp2p/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 6.1.1 - 2024-02-08
+
+- Hotfix release adding a missing `debug` dependency to the `@ethereumjs/trie` package (dependency), PR [#3271](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3271)
+
 ## 6.1.0 - 2024-02-08
 
 ### WASM Crypto Support

--- a/packages/devp2p/CHANGELOG.md
+++ b/packages/devp2p/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 6.1.0 - 2024-02-01
+## 6.1.0 - 2024-02-08
 
 ### WASM Crypto Support
 

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -70,7 +70,7 @@
   },
   "devDependencies": {
     "@ethereumjs/block": "^5.1.0",
-    "@ethereumjs/tx": "^5.2.0",
+    "@ethereumjs/tx": "^5.2.1",
     "@types/debug": "^4.1.9",
     "@types/k-bucket": "^5.0.0",
     "chalk": "^4.1.2",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -69,7 +69,7 @@
     "snappyjs": "^0.6.1"
   },
   "devDependencies": {
-    "@ethereumjs/block": "^5.1.0",
+    "@ethereumjs/block": "^5.1.1",
     "@ethereumjs/tx": "^5.2.1",
     "@types/debug": "^4.1.9",
     "@types/k-bucket": "^5.0.0",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/devp2p",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "A JavaScript implementation of ÐΞVp2p",
   "keywords": [
     "ethereum",

--- a/packages/ethash/CHANGELOG.md
+++ b/packages/ethash/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-### 3.0.2 - 2024-02-01
+### 3.0.2 - 2024-02-08
 
 Maintenance release with dependency updates, see PR [#3261](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3261)
 

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -45,7 +45,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/block": "^5.1.0",
+    "@ethereumjs/block": "^5.1.1",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/util": "^9.0.2",
     "bigint-crypto-utils": "^3.2.2",

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 2.2.0 - 2024-02-01
+## 2.2.0 - 2024-02-08
 
 ### Dencun Hardfork Support
 

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -15,9 +15,22 @@ While all EIPs contained in the upcoming Dencun hardfork run pretty much stable 
 Dencun hardfork on the execution side is called [Cancun](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md) and can be activated within the EthereumJS libraries (default hardfork still `Shanghai`) with a following `common` instance:
 
 ```typescript
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
-const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Cancun })
+import * as kzg from 'c-kzg'
+import { Common, Chain, Hardfork } from '@ethereumjs/common'
+import { initKZG } from '@ethereumjs/util'
+
+initKZG(kzg, __dirname + '/../../client/src/trustedSetups/official.txt')
+const common = new Common({
+  chain: Chain.Mainnet,
+  hardfork: Hardfork.Cancun,
+  customCrypto: { kzg: kzg },
+})
+console.log(common.customCrypto.kzg) // Should print the initialized KZG interface
 ```
+
+Note that the `kzg` initialization slightly changed from previous experimental releases and a custom KZG instance is now passed to `Common` by using the `customCrypto` parameter, see PR [#3262](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3262).
+
+At the moment using the Node.js bindings for the `c-kzg` library is the only option to get KZG related functionality to work, note that this solution is not browser compatible. We are currently working on a WASM build of that respective library. Let us know on the urgency of this task! 😆
 
 While `EIP-4844` - activating shard blob transactions - is for sure the most prominent EIP from this hardfork, enabling better scaling for the Ethereum ecosystem by providing cheaper block space for L2s, there are in total 6 EIPs contained in the Dencun hardfork. The following is an overview of which EthereumJS libraries mainly implement the various EIPs:
 

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@ethereumjs/common": "^4.2.0",
     "@ethereumjs/statemanager": "^2.2.0",
-    "@ethereumjs/tx": "^5.2.0",
+    "@ethereumjs/tx": "^5.2.1",
     "@ethereumjs/util": "^9.0.2",
     "@types/debug": "^4.1.9",
     "debug": "^4.3.3",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@ethereumjs/common": "^4.2.0",
-    "@ethereumjs/statemanager": "^2.2.0",
+    "@ethereumjs/statemanager": "^2.2.1",
     "@ethereumjs/tx": "^5.2.1",
     "@ethereumjs/util": "^9.0.2",
     "@types/debug": "^4.1.9",

--- a/packages/genesis/CHANGELOG.md
+++ b/packages/genesis/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-### 0.2.1 - 2024-02-01
+### 0.2.1 - 2024-02-08
 
 Maintenance release with dependency updates, see PR [#3261](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3261)
 

--- a/packages/genesis/package.json
+++ b/packages/genesis/package.json
@@ -65,6 +65,6 @@
     "node": ">=18"
   },
   "devDependencies": {
-    "@ethereumjs/trie": "^6.1.0"
+    "@ethereumjs/trie": "^6.1.1"
   }
 }

--- a/packages/rlp/CHANGELOG.md
+++ b/packages/rlp/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 5.0.2 - 2024-02-01
+## 5.0.2 - 2024-02-08
 
 ### 10-30x Decode Speedup
 

--- a/packages/statemanager/CHANGELOG.md
+++ b/packages/statemanager/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 2.2.0 - 2024-02-01
+## 2.2.0 - 2024-02-08
 
 ### StateManager Proof Instantiation
 

--- a/packages/statemanager/CHANGELOG.md
+++ b/packages/statemanager/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.2.1 - 2024-02-08
+
+- Hotfix release adding a missing `debug` dependency to the `@ethereumjs/trie` package (dependency), PR [#3271](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3271)
+
 ## 2.2.0 - 2024-02-08
 
 ### StateManager Proof Instantiation

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -59,7 +59,7 @@
     "lru-cache": "^10.0.0"
   },
   "devDependencies": {
-    "@ethereumjs/block": "^5.1.0",
+    "@ethereumjs/block": "^5.1.1",
     "@ethereumjs/genesis": "^0.2.1",
     "@types/debug": "^4.1.9"
   },

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@ethereumjs/common": "^4.2.0",
     "@ethereumjs/rlp": "^5.0.2",
-    "@ethereumjs/trie": "^6.1.0",
+    "@ethereumjs/trie": "^6.1.1",
     "@ethereumjs/util": "^9.0.2",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.1.3",

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/statemanager",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "An Ethereum statemanager implementation",
   "keywords": [
     "ethereum",

--- a/packages/trie/CHANGELOG.md
+++ b/packages/trie/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 6.1.1 - 2024-02-08
+
+- Hotfix release adding a missing `debug` dependency, PR [#3271](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3271)
+
 ## 6.1.0 - 2024-02-08
 
 ### Extended EIP-1186 Proof Functionality

--- a/packages/trie/CHANGELOG.md
+++ b/packages/trie/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 6.1.0 - 2024-02-01
+## 6.1.0 - 2024-02-08
 
 ### Extended EIP-1186 Proof Functionality
 

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/trie",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "description": "Implementation of the modified merkle patricia tree as specified in Ethereum's yellow paper.",
   "keywords": [
     "merkle",
@@ -56,6 +56,7 @@
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/util": "^9.0.2",
     "@types/readable-stream": "^2.3.13",
+    "debug": "^4.3.4",
     "lru-cache": "^10.0.0",
     "ethereum-cryptography": "^2.1.3",
     "readable-stream": "^3.6.0"
@@ -64,7 +65,6 @@
     "@ethereumjs/genesis": "^0.2.1",
     "@types/benchmark": "^1.0.33",
     "abstract-level": "^1.0.3",
-    "debug": "^4.3.4",
     "level": "^8.0.0",
     "level-legacy": "npm:level@^7.0.0",
     "level-mem": "^6.0.1",

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.2.1 - 2024-02-08
+
+- Hotfix release adding a missing `debug` dependency to the `@ethereumjs/trie` package (dependency), PR [#3271](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3271)
+
 ## 5.2.0 - 2024-02-08
 
 ### Dencun Hardfork Support

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 5.2.0 - 2024-02-01
+## 5.2.0 - 2024-02-08
 
 ### Dencun Hardfork Support
 

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -15,9 +15,22 @@ While all EIPs contained in the upcoming Dencun hardfork run pretty much stable 
 Dencun hardfork on the execution side is called [Cancun](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md) and can be activated within the EthereumJS libraries (default hardfork still `Shanghai`) with a following `common` instance:
 
 ```typescript
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
-const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Cancun })
+import * as kzg from 'c-kzg'
+import { Common, Chain, Hardfork } from '@ethereumjs/common'
+import { initKZG } from '@ethereumjs/util'
+
+initKZG(kzg, __dirname + '/../../client/src/trustedSetups/official.txt')
+const common = new Common({
+  chain: Chain.Mainnet,
+  hardfork: Hardfork.Cancun,
+  customCrypto: { kzg: kzg },
+})
+console.log(common.customCrypto.kzg) // Should print the initialized KZG interface
 ```
+
+Note that the `kzg` initialization slightly changed from previous experimental releases and a custom KZG instance is now passed to `Common` by using the `customCrypto` parameter, see PR [#3262](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3262).
+
+At the moment using the Node.js bindings for the `c-kzg` library is the only option to get KZG related functionality to work, note that this solution is not browser compatible. We are currently working on a WASM build of that respective library. Let us know on the urgency of this task! 😆
 
 While `EIP-4844` - activating shard blob transactions - is for sure the most prominent EIP from this hardfork, enabling better scaling for the Ethereum ecosystem by providing cheaper block space for L2s, there are in total 6 EIPs contained in the Dencun hardfork. The following is an overview of which EthereumJS libraries mainly implement the various EIPs:
 

--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -58,6 +58,8 @@ const common = new Common({
 console.log(common.customCrypto.kzg) // should output the KZG API as an object
 ```
 
+At the moment using the Node.js bindings for the `c-kzg` library is the only option to get KZG related functionality to work, note that this solution is not browser compatible. We are currently working on a WASM build of that respective library which can hopefully be released soon [TM].
+
 ## Usage
 
 ### Static Constructor Methods

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/tx",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Implementation of the various Ethereum Transaction Types",
   "keywords": [
     "ethereum",

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 9.0.2 - 2024-02-01
+## 9.0.2 - 2024-02-08
 
 ### Self-Contained (and Working 🙂) README Examples
 

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -15,9 +15,22 @@ While all EIPs contained in the upcoming Dencun hardfork run pretty much stable 
 Dencun hardfork on the execution side is called [Cancun](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md) and can be activated within the EthereumJS libraries (default hardfork still `Shanghai`) with a following `common` instance:
 
 ```typescript
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
-const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Cancun })
+import * as kzg from 'c-kzg'
+import { Common, Chain, Hardfork } from '@ethereumjs/common'
+import { initKZG } from '@ethereumjs/util'
+
+initKZG(kzg, __dirname + '/../../client/src/trustedSetups/official.txt')
+const common = new Common({
+  chain: Chain.Mainnet,
+  hardfork: Hardfork.Cancun,
+  customCrypto: { kzg: kzg },
+})
+console.log(common.customCrypto.kzg) // Should print the initialized KZG interface
 ```
+
+Note that the `kzg` initialization slightly changed from previous experimental releases and a custom KZG instance is now passed to `Common` by using the `customCrypto` parameter, see PR [#3262](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3262).
+
+At the moment using the Node.js bindings for the `c-kzg` library is the only option to get KZG related functionality to work, note that this solution is not browser compatible. We are currently working on a WASM build of that respective library. Let us know on the urgency of this task! 😆
 
 While `EIP-4844` - activating shard blob transactions - is for sure the most prominent EIP from this hardfork, enabling better scaling for the Ethereum ecosystem by providing cheaper block space for L2s, there are in total 6 EIPs contained in the Dencun hardfork. The following is an overview of which EthereumJS libraries mainly implement the various EIPs:
 

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -69,7 +69,7 @@
     "@ethereumjs/evm": "^2.2.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/statemanager": "^2.2.0",
-    "@ethereumjs/trie": "^6.1.0",
+    "@ethereumjs/trie": "^6.1.1",
     "@ethereumjs/tx": "^5.2.0",
     "@ethereumjs/util": "^9.0.2",
     "debug": "^4.3.3",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -68,7 +68,7 @@
     "@ethereumjs/common": "^4.2.0",
     "@ethereumjs/evm": "^2.2.0",
     "@ethereumjs/rlp": "^5.0.2",
-    "@ethereumjs/statemanager": "^2.2.0",
+    "@ethereumjs/statemanager": "^2.2.1",
     "@ethereumjs/trie": "^6.1.1",
     "@ethereumjs/tx": "^5.2.1",
     "@ethereumjs/util": "^9.0.2",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -63,7 +63,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/block": "^5.1.0",
+    "@ethereumjs/block": "^5.1.1",
     "@ethereumjs/blockchain": "^7.1.0",
     "@ethereumjs/common": "^4.2.0",
     "@ethereumjs/evm": "^2.2.0",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -70,7 +70,7 @@
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/statemanager": "^2.2.0",
     "@ethereumjs/trie": "^6.1.1",
-    "@ethereumjs/tx": "^5.2.0",
+    "@ethereumjs/tx": "^5.2.1",
     "@ethereumjs/util": "^9.0.2",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.1.3"

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 2.0.2 - 2024-02-01
+## 2.0.2 - 2024-02-08
 
 ### Self-Contained (and Working 🙂) README Examples
 


### PR DESCRIPTION
Hotfix releases following #3261 with new releases for the already published versions adding a missing `debug` dependency to the `@ethereumjs/trie` package.

Additionally some README and CHANGELOG additions I forgot to commit before pushing, not necessary for the releases itself to be merged, can be taken in afterwards (or at any time).