### PR TITLE
Remove nodejs import from trie.ts

### DIFF
--- a/packages/statemanager/src/stateManager.ts
+++ b/packages/statemanager/src/stateManager.ts
@@ -967,14 +967,21 @@ export class DefaultStateManager implements EVMStateManagerInterface {
       throw new Error(`dumpStorage f() can only be called for an existing account`)
     }
     const trie = this._getStorageTrie(address, account)
-    const storage: StorageDump = {}
-    const stream = trie.createAsyncReadStream()
 
-    for await (const chunk of stream) {
-      storage[bytesToHex(chunk.key)] = bytesToHex(chunk.value)
-    }
+    return new Promise((resolve, reject) => {
+      const storage: StorageDump = {}
+      const stream = trie.createReadStream()
 
-    return storage
+      stream.on('data', (val: any) => {
+        storage[bytesToHex(val.key)] = bytesToHex(val.value)
+      })
+      stream.on('end', () => {
+        resolve(storage)
+      })
+      stream.on('error', (e) => {
+        reject(e)
+      })
+    })
   }
 
   /**
@@ -997,35 +1004,44 @@ export class DefaultStateManager implements EVMStateManagerInterface {
       throw new Error(`Account does not exist.`)
     }
     const trie = this._getStorageTrie(address, account)
-    let inRange = false
-    let i = 0
 
-    /** Object conforming to {@link StorageRange.storage}. */
-    const storageMap: StorageRange['storage'] = {}
-    const stream = trie.createAsyncReadStream()
-    for await (const chunk of stream) {
-      if (!inRange) {
-        // Check if the key is already in the correct range.
-        if (bytesToBigInt(chunk.key) >= startKey) {
-          inRange = true
-        } else {
-          continue
+    return new Promise((resolve, reject) => {
+      let inRange = false
+      let i = 0
+
+      /** Object conforming to {@link StorageRange.storage}. */
+      const storageMap: StorageRange['storage'] = {}
+      const stream = trie.createReadStream()
+
+      stream.on('data', (val: any) => {
+        if (!inRange) {
+          // Check if the key is already in the correct range.
+          if (bytesToBigInt(val.key) >= startKey) {
+            inRange = true
+          } else {
+            return
+          }
         }
-      }
-      if (i < limit) {
-        storageMap[bytesToHex(chunk.key)] = { key: null, value: bytesToHex(chunk.value) }
-        i++
-      } else if (i === limit) {
-        return {
+
+        if (i < limit) {
+          storageMap[bytesToHex(val.key)] = { key: null, value: bytesToHex(val.value) }
+          i++
+        } else if (i === limit) {
+          resolve({
+            storage: storageMap,
+            nextKey: bytesToHex(val.key),
+          })
+        }
+      })
+
+      stream.on('end', () => {
+        resolve({
           storage: storageMap,
-          nextKey: bytesToHex(chunk.key),
-        }
-      }
-    }
-    return {
-      storage: storageMap,
-      nextKey: null,
-    }
+          nextKey: null,
+        })
+      })
+      stream.on('error', (e) => reject(e))
+    })
   }
 
   /**

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -30,10 +30,7 @@ import { verifyRangeProof } from './proof/range.js'
 import { ROOT_DB_KEY } from './types.js'
 import { _walkTrie } from './util/asyncWalk.js'
 import { bytesToNibbles, matchingNibbleLength } from './util/nibbles.js'
-import {
-  TrieReadStream as ReadStream,
-  asyncTrieReadStream as asyncReadStream,
-} from './util/readStream.js'
+import { TrieReadStream as ReadStream } from './util/readStream.js'
 import { WalkController } from './util/walkController.js'
 
 import type {
@@ -1198,19 +1195,10 @@ export class Trie {
 
   /**
    * The `data` event is given an `Object` that has two properties; the `key` and the `value`. Both should be Uint8Arrays.
-   * @deprecated Use `createAsyncReadStream`
    * @return Returns a [stream](https://nodejs.org/dist/latest-v12.x/docs/api/stream.html#stream_class_stream_readable) of the contents of the `trie`
    */
   createReadStream(): ReadStream {
     return new ReadStream(this)
-  }
-
-  /**
-   * Use asynchronous iteration over the chunks in a web stream using the for await...of syntax.
-   * @return Returns a [web stream](https://nodejs.org/api/webstreams.html#example-readablestream) of the contents of the `trie`
-   */
-  createAsyncReadStream(): any {
-    return asyncReadStream(this)
   }
 
   /**

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -49,12 +49,6 @@ import type {
 import type { OnFound } from './util/asyncWalk.js'
 import type { BatchDBOp, DB, PutBatch } from '@ethereumjs/util'
 import type { Debugger } from 'debug'
-// Since ReadableStream is from a Web API, the following type import
-// is not needed in and should be ignored by the browser, so an exeption
-// is made here to deviate from our policy to not add Node.js specific
-// package imports. -- 16/01/24
-// eslint-disable-next-line implicit-dependencies/no-implicit
-import type { ReadableStream } from 'node:stream/web'
 
 interface Path {
   node: TrieNode | null
@@ -1215,7 +1209,7 @@ export class Trie {
    * Use asynchronous iteration over the chunks in a web stream using the for await...of syntax.
    * @return Returns a [web stream](https://nodejs.org/api/webstreams.html#example-readablestream) of the contents of the `trie`
    */
-  createAsyncReadStream(): ReadableStream {
+  createAsyncReadStream(): any {
     return asyncReadStream(this)
   }
 

--- a/packages/trie/src/util/readStream.ts
+++ b/packages/trie/src/util/readStream.ts
@@ -1,5 +1,4 @@
 // eslint-disable-next-line implicit-dependencies/no-implicit
-import { ReadableStream } from 'node:stream/web'
 import { Readable } from 'readable-stream'
 
 import { BranchNode, LeafNode } from '../node/index.js'
@@ -64,29 +63,4 @@ export class TrieReadStream extends Readable {
     }
     this.push(null)
   }
-}
-
-export function asyncTrieReadStream(trie: Trie) {
-  return new ReadableStream({
-    async start(controller) {
-      try {
-        await _findValueNodes(trie, async (_, node, key, walkController) => {
-          if (node !== null) {
-            controller.enqueue({
-              key: nibblestoBytes(key),
-              value: node.value(),
-            })
-            walkController.allChildren(node, key)
-          }
-        })
-      } catch (error: any) {
-        if (error.message === 'Missing node in DB') {
-          // pass
-        } else {
-          throw error
-        }
-      }
-      controller.close()
-    },
-  })
 }

--- a/packages/trie/test/stream.spec.ts
+++ b/packages/trie/test/stream.spec.ts
@@ -120,19 +120,6 @@ describe('kv stream test', () => {
       assert.equal(keys.length, 0)
     })
   })
-
-  it('should fetch all of the nodes from async stream', async () => {
-    const stream = trie.createAsyncReadStream()
-    for await (const chunk of stream) {
-      const key = chunk.key.toString()
-      const value = chunk.value.toString()
-      assert.equal(valObj2[key], value)
-      delete valObj2[key]
-    }
-
-    const keys = Object.keys(valObj2)
-    assert.equal(keys.length, 0)
-  })
 })
 
 describe('db stream test', () => {


### PR DESCRIPTION
This change fixes an import error that is coming up in webpack browser builds resulting from a nodejs-specific import being made in the trie package as a result of the readable-stream refactor done in #3231. See https://github.com/ethereumjs/ethereumjs-monorepo/pull/3231#discussion_r1486061100. 