### PR TITLE
Fix node versions

### DIFF
--- a/packages/client/test/sync/fetcher/fetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/fetcher.spec.ts
@@ -72,9 +72,9 @@ describe('should handle expiration', async () => {
   fetcher['total'] = 10
   fetcher.next()
   await new Promise((resolve) => {
-    setTimeout(resolve, 10)
+    setTimeout(resolve, 1000)
   })
-  it('should expire', () => {
+  it('should expire', async () => {
     assert.equal((fetcher as any).in.length, 1, 'enqueued job')
     assert.deepEqual(
       job as any,


### PR DESCRIPTION
Closes #3279 

TODO

- [x] Fix node version tests
- [x] Remove node-versions job from being triggered on PRs
- [x] Restore the old CI jobs back (remove this commit: aabeb3fd5befa89c6378481e291662d3fa7d0c96)

Note: the client test seems to rely upon the internal timing of the NodeJS timers. I think if we make this longer (I made it 100 times longer) then we are ok. (Although this raises the question if we should take a deeper look if we can improve this test)