### PR TITLE
trie: export "Path" interface

### DIFF
--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -47,7 +47,7 @@ import type { OnFound } from './util/asyncWalk.js'
 import type { BatchDBOp, DB, PutBatch } from '@ethereumjs/util'
 import type { Debugger } from 'debug'
 
-interface Path {
+export interface Path {
   node: TrieNode | null
   remaining: Nibbles
   stack: TrieNode[]

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -37,6 +37,7 @@ import type {
   EmbeddedNode,
   FoundNodeFunction,
   Nibbles,
+  Path,
   Proof,
   TrieNode,
   TrieOpts,
@@ -46,12 +47,6 @@ import type {
 import type { OnFound } from './util/asyncWalk.js'
 import type { BatchDBOp, DB, PutBatch } from '@ethereumjs/util'
 import type { Debugger } from 'debug'
-
-export interface Path {
-  node: TrieNode | null
-  remaining: Nibbles
-  stack: TrieNode[]
-}
 
 /**
  * The basic trie interface, use with `import { Trie } from '@ethereumjs/trie'`.

--- a/packages/trie/src/types.ts
+++ b/packages/trie/src/types.ts
@@ -20,6 +20,12 @@ export interface CommonInterface {
   }
 }
 
+export interface Path {
+  node: TrieNode | null
+  remaining: Nibbles
+  stack: TrieNode[]
+}
+
 export type FoundNodeFunction = (
   nodeRef: Uint8Array,
   node: TrieNode | null,


### PR DESCRIPTION
Users of the `@ethereumjs/trie` library will see this error when using `trie.findPath` in their tooling, specifically when writing a function which returns the result of `trie.findPath`:

> Return type of public method from exported class has or is using private name 'Path'.ts(4055)

This happens because the `Path` interface was not previously exported.  Users were unable to import it directly from the Trie library to declare a return type for their functions.  The Typescript compiler would also be unable to properly infer the return type for the user function, because the expected return type `Path` could not actually be found from the outside.

Fix:
`interface Path {...} ` > `export interface Path {...}`

