### PR TITLE
Small KZG API Optimization

### DIFF
--- a/packages/block/examples/4844.ts
+++ b/packages/block/examples/4844.ts
@@ -7,7 +7,7 @@ import { randomBytes } from 'crypto'
 
 const main = async () => {
   const kzg = await createKZG()
-  initKZG(kzg, '')
+  initKZG(kzg)
   const common = new Common({
     chain: Chain.Mainnet,
     hardfork: Hardfork.Cancun,

--- a/packages/block/test/eip4844block.spec.ts
+++ b/packages/block/test/eip4844block.spec.ts
@@ -23,7 +23,7 @@ describe('EIP4844 header tests', () => {
 
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -102,7 +102,7 @@ describe('blob gas tests', () => {
   let blobGasPerBlob: bigint
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -156,7 +156,7 @@ describe('transaction validation tests', () => {
   let blobGasPerBlob: bigint
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,

--- a/packages/block/test/from-beacon-payload.spec.ts
+++ b/packages/block/test/from-beacon-payload.spec.ts
@@ -16,7 +16,7 @@ describe('[fromExecutionPayloadJson]: 4844 devnet 5', () => {
   let common: Common
   beforeAll(async () => {
     kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
     const commonJson = { ...shardingJson }
     commonJson.config = { ...commonJson.config, chainId: 4844001005 }
     const network = 'sharding'
@@ -80,7 +80,7 @@ describe('[fromExecutionPayloadJson]: kaustinen', () => {
   let kzg
   beforeAll(async () => {
     kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
   })
   const network = 'kaustinen'
 

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -807,7 +807,7 @@ async function run() {
   const chain = args.networkId ?? args.network ?? Chain.Mainnet
   const cryptoFunctions: CustomCrypto = {}
   const kzg = await createKZG()
-  initKZG(kzg, '')
+  initKZG(kzg)
 
   // Initialize WASM crypto if JS crypto is not specified
   if (args.useJsCrypto === false) {

--- a/packages/client/devnets/4844-interop/tools/txGenerator.ts
+++ b/packages/client/devnets/4844-interop/tools/txGenerator.ts
@@ -29,7 +29,7 @@ async function getNonce(client: Client, account: string) {
 
 async function run(data: any) {
   const kzg = await createKZG()
-  initKZG(kzg, '')
+  initKZG(kzg)
 
   const common = Common.fromGethGenesis(genesisJson, {
     chain: genesisJson.ChainName ?? 'devnet',

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -354,7 +354,7 @@ describe('[PendingBlock]', async () => {
 
   it('construct blob bundles', async () => {
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
     const common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,

--- a/packages/client/test/rpc/engine/getPayloadV3.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadV3.spec.ts
@@ -69,7 +69,7 @@ describe(method, () => {
     }
 
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
 
     const { service, server, common } = await setupChain(genesisJSON, 'post-merge', {
       engine: true,

--- a/packages/client/test/rpc/engine/kaustinen2.spec.ts
+++ b/packages/client/test/rpc/engine/kaustinen2.spec.ts
@@ -34,7 +34,7 @@ async function runBlock(
 
 describe(`valid verkle network setup`, async () => {
   const kzg = await createKZG()
-  initKZG(kzg, '')
+  initKZG(kzg)
 
   const { server, chain, common } = await setupChain(genesisJSON, 'post-merge', {
     engine: true,

--- a/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
@@ -16,7 +16,7 @@ const [blockData] = blocks
 describe(`${method}: Cancun validations`, () => {
   it('blobVersionedHashes', async () => {
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
 
     const { server } = await setupChain(genesisJSON, 'post-merge', {
       engine: true,

--- a/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
+++ b/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
@@ -9,7 +9,7 @@ import { INVALID_PARAMS } from '../../../src/rpc/error-code.js'
 import { createClient, createManager, dummy, getRpcClient, startRPC } from '../helpers.js'
 
 const kzg = await createKZG()
-initKZG(kzg, '')
+initKZG(kzg)
 
 const common = Common.custom({ chainId: 1 }, { customCrypto: { kzg } })
 

--- a/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
@@ -90,7 +90,7 @@ describe(method, () => {
       const gethGenesis = require('../../../../block/test/testdata/4844-hardfork.json')
 
       const kzg = await createKZG()
-      initKZG(kzg, '')
+      initKZG(kzg)
 
       const common = Common.fromGethGenesis(gethGenesis, {
         chain: 'customChain',

--- a/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
+++ b/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
@@ -221,7 +221,7 @@ describe(method, () => {
     const gethGenesis = require('../../../../block/test/testdata/4844-hardfork.json')
 
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
 
     const common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',

--- a/packages/common/examples/initKzg.ts
+++ b/packages/common/examples/initKzg.ts
@@ -4,7 +4,7 @@ import { initKZG } from '@ethereumjs/util'
 
 const main = async () => {
   const kzg = await createKZG()
-  initKZG(kzg, '')
+  initKZG(kzg)
   const common = new Common({
     chain: Chain.Mainnet,
     hardfork: Hardfork.Cancun,

--- a/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
+++ b/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
@@ -23,7 +23,7 @@ describe('Precompiles: point evaluation', () => {
     const genesisJSON = await import('../../../client/test/testdata/geth-genesis/eip4844.json')
 
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
 
     const common = Common.fromGethGenesis(genesisJSON, {
       chain: 'custom',

--- a/packages/tx/examples/blobTx.ts
+++ b/packages/tx/examples/blobTx.ts
@@ -5,7 +5,7 @@ import { createKZG } from 'kzg-wasm'
 
 const main = async () => {
   const kzg = await createKZG()
-  initKZG(kzg, '')
+  initKZG(kzg)
 
   const common = new Common({
     chain: Chain.Mainnet,

--- a/packages/tx/examples/initKzg.ts
+++ b/packages/tx/examples/initKzg.ts
@@ -4,7 +4,7 @@ import { initKZG } from '@ethereumjs/util'
 
 const main = async () => {
   const kzg = await createKZG()
-  initKZG(kzg, '')
+  initKZG(kzg)
 
   // Instantiate `common`
   const common = new Common({

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -26,7 +26,7 @@ describe('EIP4844 addSignature tests', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -91,7 +91,7 @@ describe('EIP4844 constructor tests - valid scenarios', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -130,7 +130,7 @@ describe('fromTxData using from a json', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -202,7 +202,7 @@ describe('EIP4844 constructor tests - invalid scenarios', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -259,7 +259,7 @@ describe('Network wrapper tests', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -503,7 +503,7 @@ describe('hash() and signature verification', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -554,7 +554,7 @@ describe('Network wrapper deserialization test', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,

--- a/packages/util/src/kzg.ts
+++ b/packages/util/src/kzg.ts
@@ -2,7 +2,7 @@
  * Interface for an externally provided kzg library used when creating blob transactions
  */
 export interface Kzg {
-  loadTrustedSetup(filePath: string): void
+  loadTrustedSetup(filePath?: string): void
   blobToKzgCommitment(blob: Uint8Array): Uint8Array
   computeBlobKzgProof(blob: Uint8Array, commitment: Uint8Array): Uint8Array
   verifyKzgProof(
@@ -35,7 +35,7 @@ export let kzg: Kzg = {
  * @param kzgLib a KZG implementation (defaults to c-kzg)
  * @param trustedSetupPath the full path (e.g. "/home/linux/devnet4.txt") to a kzg trusted setup text file
  */
-export function initKZG(kzgLib: Kzg, trustedSetupPath: string) {
+export function initKZG(kzgLib: Kzg, trustedSetupPath?: string) {
   kzg = kzgLib
   kzg.loadTrustedSetup(trustedSetupPath)
 }

--- a/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
@@ -31,7 +31,7 @@ describe('EIP4844 tests', () => {
       try {
         //initKZG(kzg, __dirname + '/../../client/src/trustedSetups/official.txt')
         kzg = await createKZG()
-        initKZG(kzg, '')
+        initKZG(kzg)
       } catch {
         // no-op
       }

--- a/packages/vm/test/api/runTx.spec.ts
+++ b/packages/vm/test/api/runTx.spec.ts
@@ -861,7 +861,7 @@ it('Validate SELFDESTRUCT does not charge new account gas when calling CALLER an
 describe('EIP 4844 transaction tests', () => {
   it('should work', async () => {
     const kzg = await createKZG()
-    initKZG(kzg, '')
+    initKZG(kzg)
 
     const genesisJson = require('../../../block/test/testdata/4844-hardfork.json')
     const common = Common.fromGethGenesis(genesisJson, {

--- a/packages/vm/test/tester/index.ts
+++ b/packages/vm/test/tester/index.ts
@@ -102,7 +102,7 @@ async function runTests() {
    * Run-time configuration
    */
   const kzg = await createKZG()
-  initKZG(kzg, '')
+  initKZG(kzg)
   const runnerArgs: {
     forkConfigVM: string
     forkConfigTestSuite: string


### PR DESCRIPTION
Follow-up on #3294 

This is a small API optimization for the KZG initialization. We can make the `trustedSetupPath` in Util optional while remaining backwards compatiblity.

Then `initKZG(kzg, '')` with this relatively expressionless `''` can be shortened to `initKZG(kzg)`.