### PR TITLE
evm/vm: ensure  backwards compatability reportPreimages

### DIFF
--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -154,7 +154,7 @@ export interface EVMInterface {
     addAlwaysWarmAddress(address: string, addToAccessList?: boolean): void
     addAlwaysWarmSlot(address: string, slot: string, addToAccessList?: boolean): void
     startReportingAccessList(): void
-    startReportingPreimages(): void
+    startReportingPreimages?(): void
   }
   stateManager: EVMStateManagerInterface
   precompiles: Map<string, PrecompileFunc>

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -390,7 +390,7 @@ async function applyBlock(this: VM, block: Block, opts: RunBlockOpts): Promise<A
   }
 
   if (this.common.isActivatedEIP(4895)) {
-    if (opts.reportPreimages === true) this.evm.journal.startReportingPreimages()
+    if (opts.reportPreimages === true) this.evm.journal.startReportingPreimages!()
     await assignWithdrawals.bind(this)(block)
     if (opts.reportPreimages === true && this.evm.journal.preimages !== undefined) {
       for (const [key, preimage] of this.evm.journal.preimages) {

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -129,7 +129,7 @@ export async function runTx(this: VM, opts: RunTxOpts): Promise<RunTxResult> {
   }
 
   if (opts.reportPreimages === true) {
-    this.evm.journal.startReportingPreimages()
+    this.evm.journal.startReportingPreimages!()
   }
 
   await this.evm.journal.checkpoint()


### PR DESCRIPTION
This PR guards `startReportingPreimages` of EVM

This is OK because:

- The only way this is called is within VM `reportPreimages` -> therefore, we already assume that `startReportingPreimages` is available