### PR TITLE
Update "--dev" to use the Cancun hardfork.

### DIFF
--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+Update the devnet setting (enabled using `--dev`) to use the Cancun hardfork.
+
 ## 0.10.0 - 2024-02-08
 
 This client release now comes with official Dencun hardfork support 🎉 and by default uses WASM for crypto primitives for faster block execution times.

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -654,6 +654,9 @@ async function setupDevnet(prefundAddress: Address) {
       istanbulBlock: 0,
       berlinBlock: 0,
       londonBlock: 0,
+      mergeForkBlock: 0,
+      shanghaiTime: 0,
+      cancunTime: 0,
       ...consensusConfig,
     },
     nonce: '0x0',
@@ -674,7 +677,7 @@ async function setupDevnet(prefundAddress: Address) {
     extraData,
     alloc: { [addr]: { balance: '0x10000000000000000000' } },
   }
-  const common = Common.fromGethGenesis(chainData, { chain: 'devnet', hardfork: Hardfork.London })
+  const common = Common.fromGethGenesis(chainData, { chain: 'devnet', hardfork: Hardfork.Cancun })
   const customGenesisState = parseGethGenesisState(chainData)
   return { common, customGenesisState }
 }


### PR DESCRIPTION
Currently, calling `ethereumjs --dev=true` starts a network using the london hardfork. This is quite different from mainnet, and IMO is not representative of what dev would expect.

With DenCun hitting mainnet in the next days, I believe that this should be updated to Cancun.