### PR TITLE
Integrate Simplified kzg-wasm Version / Deprecate Util.initKZG()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "eslint-plugin-prettier": "4.2.1",
         "eslint-plugin-simple-import-sort": "7.0.0",
         "eslint-plugin-sonarjs": "0.19.0",
-        "kzg-wasm": "^0.2.0",
+        "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
         "lint-staged": "13.0.3",
         "lockfile-lint-api": "^5.5.1",
         "prettier": "2.7.1",
@@ -9399,9 +9399,10 @@
       }
     },
     "node_modules/kzg-wasm": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/kzg-wasm/-/kzg-wasm-0.2.0.tgz",
-      "integrity": "sha512-Gv54Edtv7GnzZ253t1ooEtPuD+pCa5SavNmyQ7MQPdlMpLZZHXzX8vIvNIWlMHfPy+TvPX8ubRUzy1AoPxl5jA=="
+      "version": "0.3.1",
+      "resolved": "git+ssh://git@github.com/ethereumjs/kzg-wasm.git#6d82761ec36bba94f06c8638c7a9e5983310c504",
+      "integrity": "sha512-TBiRFwZnJvxVqotSg1cpPrr7u2qYZdzK0MIc2gNqoIS5TMuSIGzrTlNxkukcYgEeC6SIsBIudL2gkXtoEIOHgA==",
+      "license": "MIT"
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",
@@ -15670,7 +15671,7 @@
         "ethereum-cryptography": "^2.1.3"
       },
       "devDependencies": {
-        "kzg-wasm": "^0.2.0"
+        "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504"
       },
       "engines": {
         "node": ">=18"
@@ -15731,7 +15732,7 @@
         "jayson": "^4.0.0",
         "js-sdsl": "^4.4.0",
         "jwt-simple": "^0.5.6",
-        "kzg-wasm": "^0.2.0",
+        "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
         "level": "^8.0.0",
         "memory-level": "^1.0.0",
         "multiaddr": "^10.0.1",
@@ -16060,7 +16061,7 @@
         "@types/minimist": "^1.2.2",
         "@types/node-dir": "^0.0.34",
         "benchmark": "^2.1.4",
-        "kzg-wasm": "^0.2.0",
+        "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
         "level": "^8.0.0",
         "memory-level": "^1.0.0",
         "minimist": "^1.2.5",
@@ -16164,7 +16165,7 @@
       "devDependencies": {
         "@types/minimist": "^1.2.0",
         "@types/node-dir": "^0.0.34",
-        "kzg-wasm": "^0.2.0",
+        "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
         "minimist": "^1.2.0",
         "node-dir": "^0.1.16"
       },
@@ -16181,7 +16182,7 @@
         "ethereum-cryptography": "^2.1.3"
       },
       "devDependencies": {
-        "kzg-wasm": "^0.2.0"
+        "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504"
       },
       "engines": {
         "node": ">=18"
@@ -16216,8 +16217,7 @@
         "@ethereumjs/tx": "^5.2.1",
         "@ethereumjs/util": "^9.0.2",
         "debug": "^4.3.3",
-        "ethereum-cryptography": "^2.1.3",
-        "rustbn-wasm": "^0.4.0"
+        "ethereum-cryptography": "^2.1.3"
       },
       "devDependencies": {
         "@ethersproject/abi": "^5.0.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15671,7 +15671,7 @@
         "ethereum-cryptography": "^2.1.3"
       },
       "devDependencies": {
-        "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504"
+        "kzg-wasm": "^0.3.1"
       },
       "engines": {
         "node": ">=18"
@@ -15732,7 +15732,7 @@
         "jayson": "^4.0.0",
         "js-sdsl": "^4.4.0",
         "jwt-simple": "^0.5.6",
-        "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
+        "kzg-wasm": "^0.3.1",
         "level": "^8.0.0",
         "memory-level": "^1.0.0",
         "multiaddr": "^10.0.1",
@@ -16061,7 +16061,7 @@
         "@types/minimist": "^1.2.2",
         "@types/node-dir": "^0.0.34",
         "benchmark": "^2.1.4",
-        "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
+        "kzg-wasm": "^0.3.1",
         "level": "^8.0.0",
         "memory-level": "^1.0.0",
         "minimist": "^1.2.5",
@@ -16165,7 +16165,7 @@
       "devDependencies": {
         "@types/minimist": "^1.2.0",
         "@types/node-dir": "^0.0.34",
-        "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
+        "kzg-wasm": "^0.3.1",
         "minimist": "^1.2.0",
         "node-dir": "^0.1.16"
       },
@@ -16182,7 +16182,7 @@
         "ethereum-cryptography": "^2.1.3"
       },
       "devDependencies": {
-        "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504"
+        "kzg-wasm": "^0.3.1"
       },
       "engines": {
         "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "eslint-plugin-prettier": "4.2.1",
         "eslint-plugin-simple-import-sort": "7.0.0",
         "eslint-plugin-sonarjs": "0.19.0",
-        "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
         "lint-staged": "13.0.3",
         "lockfile-lint-api": "^5.5.1",
         "prettier": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-simple-import-sort": "7.0.0",
     "eslint-plugin-sonarjs": "0.19.0",
-    "kzg-wasm": "^0.2.0",
+    "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
     "lint-staged": "13.0.3",
     "lockfile-lint-api": "^5.5.1",
     "prettier": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-simple-import-sort": "7.0.0",
     "eslint-plugin-sonarjs": "0.19.0",
-    "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
     "lint-staged": "13.0.3",
     "lockfile-lint-api": "^5.5.1",
     "prettier": "2.7.1",

--- a/packages/block/examples/4844.ts
+++ b/packages/block/examples/4844.ts
@@ -2,11 +2,11 @@ import { Common, Chain, Hardfork } from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
 import { Address } from '@ethereumjs/util'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { randomBytes } from 'crypto'
 
 const main = async () => {
-  const kzg = await createKZG()
+  const kzg = await initKZG()
   const common = new Common({
     chain: Chain.Mainnet,
     hardfork: Hardfork.Cancun,

--- a/packages/block/examples/4844.ts
+++ b/packages/block/examples/4844.ts
@@ -1,7 +1,7 @@
 import { Common, Chain, Hardfork } from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
-import { Address, initKZG } from '@ethereumjs/util'
+import { Address } from '@ethereumjs/util'
 import { createKZG } from 'kzg-wasm'
 import { randomBytes } from 'crypto'
 

--- a/packages/block/examples/4844.ts
+++ b/packages/block/examples/4844.ts
@@ -2,11 +2,12 @@ import { Common, Chain, Hardfork } from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
 import { Address } from '@ethereumjs/util'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { randomBytes } from 'crypto'
 
 const main = async () => {
-  const kzg = await initKZG()
+  const kzg = await loadKZG()
+
   const common = new Common({
     chain: Chain.Mainnet,
     hardfork: Hardfork.Cancun,

--- a/packages/block/examples/4844.ts
+++ b/packages/block/examples/4844.ts
@@ -7,7 +7,6 @@ import { randomBytes } from 'crypto'
 
 const main = async () => {
   const kzg = await createKZG()
-  initKZG(kzg)
   const common = new Common({
     chain: Chain.Mainnet,
     hardfork: Hardfork.Cancun,

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -54,7 +54,7 @@
     "ethereum-cryptography": "^2.1.3"
   },
   "devDependencies": {
-    "kzg-wasm": "git://github.com/ethereumjs/kzg-wasm.git#c0f05e56f4728f46bf322514f421997d96f63387"
+    "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504"
   },
   "engines": {
     "node": ">=18"

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -54,7 +54,7 @@
     "ethereum-cryptography": "^2.1.3"
   },
   "devDependencies": {
-    "kzg-wasm": "^0.2.0"
+    "kzg-wasm": "git://github.com/ethereumjs/kzg-wasm.git#c0f05e56f4728f46bf322514f421997d96f63387"
   },
   "engines": {
     "node": ">=18"

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -54,7 +54,7 @@
     "ethereum-cryptography": "^2.1.3"
   },
   "devDependencies": {
-    "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504"
+    "kzg-wasm": "^0.3.1"
   },
   "engines": {
     "node": ">=18"

--- a/packages/block/test/eip4844block.spec.ts
+++ b/packages/block/test/eip4844block.spec.ts
@@ -23,7 +23,6 @@ describe('EIP4844 header tests', () => {
 
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -102,7 +101,6 @@ describe('blob gas tests', () => {
   let blobGasPerBlob: bigint
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -159,7 +157,6 @@ describe('transaction validation tests', () => {
   let blobGasPerBlob: bigint
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,

--- a/packages/block/test/eip4844block.spec.ts
+++ b/packages/block/test/eip4844block.spec.ts
@@ -16,6 +16,7 @@ import { Block } from '../src/index.js'
 import gethGenesis from './testdata/4844-hardfork.json'
 
 import type { TypedTransaction } from '@ethereumjs/tx'
+import type { Kzg } from '@ethereumjs/util'
 
 describe('EIP4844 header tests', () => {
   let common: Common
@@ -153,10 +154,11 @@ describe('blob gas tests', () => {
 })
 
 describe('transaction validation tests', () => {
+  let kzg: Kzg
   let common: Common
   let blobGasPerBlob: bigint
   beforeAll(async () => {
-    const kzg = await loadKZG()
+    kzg = await loadKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -166,7 +168,7 @@ describe('transaction validation tests', () => {
   })
   it('should work', () => {
     const blobs = getBlobs('hello world')
-    const commitments = blobsToCommitments(blobs)
+    const commitments = blobsToCommitments(kzg, blobs)
     const blobVersionedHashes = commitmentsToVersionedHashes(commitments)
 
     const tx1 = BlobEIP4844Transaction.fromTxData(

--- a/packages/block/test/eip4844block.spec.ts
+++ b/packages/block/test/eip4844block.spec.ts
@@ -6,7 +6,7 @@ import {
   getBlobs,
   randomBytes,
 } from '@ethereumjs/util'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { assert, beforeAll, describe, it } from 'vitest'
 
 import { BlockHeader } from '../src/header.js'
@@ -21,7 +21,8 @@ describe('EIP4844 header tests', () => {
   let common: Common
 
   beforeAll(async () => {
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
+
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -99,7 +100,7 @@ describe('blob gas tests', () => {
   let common: Common
   let blobGasPerBlob: bigint
   beforeAll(async () => {
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -155,7 +156,7 @@ describe('transaction validation tests', () => {
   let common: Common
   let blobGasPerBlob: bigint
   beforeAll(async () => {
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,

--- a/packages/block/test/eip4844block.spec.ts
+++ b/packages/block/test/eip4844block.spec.ts
@@ -4,7 +4,6 @@ import {
   blobsToCommitments,
   commitmentsToVersionedHashes,
   getBlobs,
-  initKZG,
   randomBytes,
 } from '@ethereumjs/util'
 import { createKZG } from 'kzg-wasm'

--- a/packages/block/test/eip4844block.spec.ts
+++ b/packages/block/test/eip4844block.spec.ts
@@ -6,7 +6,7 @@ import {
   getBlobs,
   randomBytes,
 } from '@ethereumjs/util'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { assert, beforeAll, describe, it } from 'vitest'
 
 import { BlockHeader } from '../src/header.js'
@@ -21,7 +21,7 @@ describe('EIP4844 header tests', () => {
   let common: Common
 
   beforeAll(async () => {
-    const kzg = await createKZG()
+    const kzg = await initKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -99,7 +99,7 @@ describe('blob gas tests', () => {
   let common: Common
   let blobGasPerBlob: bigint
   beforeAll(async () => {
-    const kzg = await createKZG()
+    const kzg = await initKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -155,7 +155,7 @@ describe('transaction validation tests', () => {
   let common: Common
   let blobGasPerBlob: bigint
   beforeAll(async () => {
-    const kzg = await createKZG()
+    const kzg = await initKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,

--- a/packages/block/test/from-beacon-payload.spec.ts
+++ b/packages/block/test/from-beacon-payload.spec.ts
@@ -16,7 +16,6 @@ describe('[fromExecutionPayloadJson]: 4844 devnet 5', () => {
   let common: Common
   beforeAll(async () => {
     kzg = await createKZG()
-    initKZG(kzg)
     const commonJson = { ...shardingJson }
     commonJson.config = { ...commonJson.config, chainId: 4844001005 }
     const network = 'sharding'
@@ -80,7 +79,6 @@ describe('[fromExecutionPayloadJson]: kaustinen', () => {
   let kzg
   beforeAll(async () => {
     kzg = await createKZG()
-    initKZG(kzg)
   })
   const network = 'kaustinen'
 

--- a/packages/block/test/from-beacon-payload.spec.ts
+++ b/packages/block/test/from-beacon-payload.spec.ts
@@ -1,5 +1,5 @@
 import { Common, Hardfork } from '@ethereumjs/common'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { assert, beforeAll, describe, it } from 'vitest'
 
 import * as shardingJson from '../../client/test/sim/configs/4844-devnet.json'
@@ -14,7 +14,8 @@ describe('[fromExecutionPayloadJson]: 4844 devnet 5', () => {
   let kzg
   let common: Common
   beforeAll(async () => {
-    kzg = await initKZG()
+    kzg = await loadKZG()
+
     const commonJson = { ...shardingJson }
     commonJson.config = { ...commonJson.config, chainId: 4844001005 }
     const network = 'sharding'
@@ -77,7 +78,7 @@ describe('[fromExecutionPayloadJson]: 4844 devnet 5', () => {
 describe('[fromExecutionPayloadJson]: kaustinen', () => {
   let kzg
   beforeAll(async () => {
-    kzg = await initKZG()
+    kzg = await loadKZG()
   })
   const network = 'kaustinen'
 

--- a/packages/block/test/from-beacon-payload.spec.ts
+++ b/packages/block/test/from-beacon-payload.spec.ts
@@ -11,10 +11,9 @@ import * as payload87475 from './testdata/payload-slot-87475.json'
 import * as testnetVerkleKaustinen from './testdata/testnetVerkleKaustinen.json'
 
 describe('[fromExecutionPayloadJson]: 4844 devnet 5', () => {
-  let kzg
   let common: Common
   beforeAll(async () => {
-    kzg = await loadKZG()
+    const kzg = await loadKZG()
 
     const commonJson = { ...shardingJson }
     commonJson.config = { ...commonJson.config, chainId: 4844001005 }
@@ -78,7 +77,7 @@ describe('[fromExecutionPayloadJson]: 4844 devnet 5', () => {
 describe('[fromExecutionPayloadJson]: kaustinen', () => {
   let kzg
   beforeAll(async () => {
-    kzg = await loadKZG()
+    const kzg = await loadKZG()
   })
   const network = 'kaustinen'
 

--- a/packages/block/test/from-beacon-payload.spec.ts
+++ b/packages/block/test/from-beacon-payload.spec.ts
@@ -1,5 +1,5 @@
 import { Common, Hardfork } from '@ethereumjs/common'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { assert, beforeAll, describe, it } from 'vitest'
 
 import * as shardingJson from '../../client/test/sim/configs/4844-devnet.json'
@@ -14,7 +14,7 @@ describe('[fromExecutionPayloadJson]: 4844 devnet 5', () => {
   let kzg
   let common: Common
   beforeAll(async () => {
-    kzg = await createKZG()
+    kzg = await initKZG()
     const commonJson = { ...shardingJson }
     commonJson.config = { ...commonJson.config, chainId: 4844001005 }
     const network = 'sharding'
@@ -77,7 +77,7 @@ describe('[fromExecutionPayloadJson]: 4844 devnet 5', () => {
 describe('[fromExecutionPayloadJson]: kaustinen', () => {
   let kzg
   beforeAll(async () => {
-    kzg = await createKZG()
+    kzg = await initKZG()
   })
   const network = 'kaustinen'
 

--- a/packages/block/test/from-beacon-payload.spec.ts
+++ b/packages/block/test/from-beacon-payload.spec.ts
@@ -1,5 +1,4 @@
 import { Common, Hardfork } from '@ethereumjs/common'
-import { initKZG } from '@ethereumjs/util'
 import { createKZG } from 'kzg-wasm'
 import { assert, beforeAll, describe, it } from 'vitest'
 

--- a/packages/block/test/from-beacon-payload.spec.ts
+++ b/packages/block/test/from-beacon-payload.spec.ts
@@ -75,10 +75,6 @@ describe('[fromExecutionPayloadJson]: 4844 devnet 5', () => {
 })
 
 describe('[fromExecutionPayloadJson]: kaustinen', () => {
-  let kzg
-  beforeAll(async () => {
-    const kzg = await loadKZG()
-  })
   const network = 'kaustinen'
 
   // safely change chainId without modifying undelying json

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -13,7 +13,6 @@ import {
   ecrecover,
   ecsign,
   hexToBytes,
-  initKZG,
   parseGethGenesisState,
   randomBytes,
   setLengthLeft,

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -32,7 +32,7 @@ import { ecdsaRecover, ecdsaSign } from 'ethereum-cryptography/secp256k1-compat'
 import { sha256 } from 'ethereum-cryptography/sha256'
 import { existsSync, writeFileSync } from 'fs'
 import { ensureDirSync, readFileSync, removeSync } from 'fs-extra'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { Level } from 'level'
 import { homedir } from 'os'
 import * as path from 'path'
@@ -807,7 +807,7 @@ async function run() {
   // Give network id precedence over network name
   const chain = args.networkId ?? args.network ?? Chain.Mainnet
   const cryptoFunctions: CustomCrypto = {}
-  const kzg = await initKZG()
+  const kzg = await loadKZG()
 
   // Initialize WASM crypto if JS crypto is not specified
   if (args.useJsCrypto === false) {

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -809,7 +809,6 @@ async function run() {
   const chain = args.networkId ?? args.network ?? Chain.Mainnet
   const cryptoFunctions: CustomCrypto = {}
   const kzg = await createKZG()
-  initKZG(kzg)
 
   // Initialize WASM crypto if JS crypto is not specified
   if (args.useJsCrypto === false) {

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -32,7 +32,7 @@ import { ecdsaRecover, ecdsaSign } from 'ethereum-cryptography/secp256k1-compat'
 import { sha256 } from 'ethereum-cryptography/sha256'
 import { existsSync, writeFileSync } from 'fs'
 import { ensureDirSync, readFileSync, removeSync } from 'fs-extra'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { Level } from 'level'
 import { homedir } from 'os'
 import * as path from 'path'
@@ -807,7 +807,7 @@ async function run() {
   // Give network id precedence over network name
   const chain = args.networkId ?? args.network ?? Chain.Mainnet
   const cryptoFunctions: CustomCrypto = {}
-  const kzg = await createKZG()
+  const kzg = await initKZG()
 
   // Initialize WASM crypto if JS crypto is not specified
   if (args.useJsCrypto === false) {

--- a/packages/client/devnets/4844-interop/tools/txGenerator.ts
+++ b/packages/client/devnets/4844-interop/tools/txGenerator.ts
@@ -12,7 +12,7 @@ import {
 
 import { randomBytes } from '@ethereumjs/util'
 import { Client } from 'jayson/promise'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 
 // CLI Args
 const clientPort = parseInt(process.argv[2]) // EL client port number
@@ -27,7 +27,7 @@ async function getNonce(client: Client, account: string) {
 }
 
 async function run(data: any) {
-  const kzg = await initKZG()
+  const kzg = await loadKZG()
 
   const common = Common.fromGethGenesis(genesisJson, {
     chain: genesisJson.ChainName ?? 'devnet',

--- a/packages/client/devnets/4844-interop/tools/txGenerator.ts
+++ b/packages/client/devnets/4844-interop/tools/txGenerator.ts
@@ -12,7 +12,7 @@ import {
 
 import { randomBytes } from '@ethereumjs/util'
 import { Client } from 'jayson/promise'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 
 // CLI Args
 const clientPort = parseInt(process.argv[2]) // EL client port number
@@ -27,7 +27,7 @@ async function getNonce(client: Client, account: string) {
 }
 
 async function run(data: any) {
-  const kzg = await createKZG()
+  const kzg = await initKZG()
 
   const common = Common.fromGethGenesis(genesisJson, {
     chain: genesisJson.ChainName ?? 'devnet',

--- a/packages/client/devnets/4844-interop/tools/txGenerator.ts
+++ b/packages/client/devnets/4844-interop/tools/txGenerator.ts
@@ -38,7 +38,7 @@ async function run(data: any) {
   const client = Client.http({ port: clientPort })
 
   const blobs = getBlobs(data)
-  const commitments = blobsToCommitments(blobs)
+  const commitments = blobsToCommitments(kzg, blobs)
   const hashes = commitmentsToVersionedHashes(commitments)
 
   const account = Address.fromPrivateKey(randomBytes(32))

--- a/packages/client/devnets/4844-interop/tools/txGenerator.ts
+++ b/packages/client/devnets/4844-interop/tools/txGenerator.ts
@@ -8,7 +8,6 @@ import {
   getBlobs,
   bytesToHex,
   hexToBytes,
-  initKZG,
 } from '@ethereumjs/util'
 
 import { randomBytes } from '@ethereumjs/util'

--- a/packages/client/devnets/4844-interop/tools/txGenerator.ts
+++ b/packages/client/devnets/4844-interop/tools/txGenerator.ts
@@ -29,7 +29,6 @@ async function getNonce(client: Client, account: string) {
 
 async function run(data: any) {
   const kzg = await createKZG()
-  initKZG(kzg)
 
   const common = Common.fromGethGenesis(genesisJson, {
     chain: genesisJson.ChainName ?? 'devnet',

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -74,7 +74,7 @@
     "@polkadot/wasm-crypto": "^7.3.2",
     "abstract-level": "^1.0.3",
     "body-parser": "^1.19.2",
-    "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
+    "kzg-wasm": "^0.3.1",
     "chalk": "^4.1.2",
     "connect": "^3.7.0",
     "cors": "^2.8.5",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -74,7 +74,7 @@
     "@polkadot/wasm-crypto": "^7.3.2",
     "abstract-level": "^1.0.3",
     "body-parser": "^1.19.2",
-    "kzg-wasm": "git://github.com/ethereumjs/kzg-wasm.git#c0f05e56f4728f46bf322514f421997d96f63387",
+    "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
     "chalk": "^4.1.2",
     "connect": "^3.7.0",
     "cors": "^2.8.5",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -74,7 +74,7 @@
     "@polkadot/wasm-crypto": "^7.3.2",
     "abstract-level": "^1.0.3",
     "body-parser": "^1.19.2",
-    "kzg-wasm": "^0.2.0",
+    "kzg-wasm": "git://github.com/ethereumjs/kzg-wasm.git#c0f05e56f4728f46bf322514f421997d96f63387",
     "chalk": "^4.1.2",
     "connect": "^3.7.0",
     "cors": "^2.8.5",

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -16,7 +16,6 @@ import {
   equalsBytes,
   getBlobs,
   hexToBytes,
-  initKZG,
   randomBytes,
 } from '@ethereumjs/util'
 import { VM } from '@ethereumjs/vm'

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -19,7 +19,7 @@ import {
   randomBytes,
 } from '@ethereumjs/util'
 import { VM } from '@ethereumjs/vm'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { assert, describe, it, vi } from 'vitest'
 
 import gethGenesis from '../../../block/test/testdata/4844-hardfork.json'
@@ -352,7 +352,7 @@ describe('[PendingBlock]', async () => {
   })
 
   it('construct blob bundles', async () => {
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
     const common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -432,7 +432,7 @@ describe('[PendingBlock]', async () => {
 
   it('should exclude missingBlobTx', async () => {
     const gethGenesis = require('../../../block/test/testdata/4844-hardfork.json')
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
 
     const common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -19,7 +19,7 @@ import {
   randomBytes,
 } from '@ethereumjs/util'
 import { VM } from '@ethereumjs/vm'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { assert, describe, it, vi } from 'vitest'
 
 import gethGenesis from '../../../block/test/testdata/4844-hardfork.json'
@@ -352,7 +352,7 @@ describe('[PendingBlock]', async () => {
   })
 
   it('construct blob bundles', async () => {
-    const kzg = await createKZG()
+    const kzg = await initKZG()
     const common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -432,7 +432,7 @@ describe('[PendingBlock]', async () => {
 
   it('should exclude missingBlobTx', async () => {
     const gethGenesis = require('../../../block/test/testdata/4844-hardfork.json')
-    const kzg = await createKZG()
+    const kzg = await initKZG()
 
     const common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -364,9 +364,9 @@ describe('[PendingBlock]', async () => {
     const { txPool } = setup()
 
     const blobs = getBlobs('hello world')
-    const commitments = blobsToCommitments(blobs)
+    const commitments = blobsToCommitments(kzg, blobs)
     const blobVersionedHashes = commitmentsToVersionedHashes(commitments)
-    const proofs = blobsToProofs(blobs, commitments)
+    const proofs = blobsToProofs(kzg, blobs, commitments)
 
     // Create 3 txs with 2 blobs each so that only 2 of them can be included in a build
     for (let x = 0; x <= 2; x++) {
@@ -443,9 +443,9 @@ describe('[PendingBlock]', async () => {
     const { txPool } = setup()
 
     const blobs = getBlobs('hello world')
-    const commitments = blobsToCommitments(blobs)
+    const commitments = blobsToCommitments(kzg, blobs)
     const blobVersionedHashes = commitmentsToVersionedHashes(commitments)
-    const proofs = blobsToProofs(blobs, commitments)
+    const proofs = blobsToProofs(kzg, blobs, commitments)
 
     // create a tx with missing blob data which should be excluded from the build
     const missingBlobTx = BlobEIP4844Transaction.fromTxData(

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -354,7 +354,6 @@ describe('[PendingBlock]', async () => {
 
   it('construct blob bundles', async () => {
     const kzg = await createKZG()
-    initKZG(kzg)
     const common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,

--- a/packages/client/test/net/protocol/ethprotocol.spec.ts
+++ b/packages/client/test/net/protocol/ethprotocol.spec.ts
@@ -2,6 +2,7 @@ import { Block } from '@ethereumjs/block'
 import { Common, Chain as CommonChain, Hardfork } from '@ethereumjs/common'
 import { FeeMarketEIP1559Transaction, TransactionFactory, TransactionType } from '@ethereumjs/tx'
 import { Address, bigIntToBytes, bytesToBigInt, hexToBytes, randomBytes } from '@ethereumjs/util'
+import { loadKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import { Chain } from '../../../src/blockchain/chain'
@@ -202,11 +203,15 @@ describe('[EthProtocol]', () => {
   })
 
   it('verify that Transactions handler encodes/decodes correctly', async () => {
+    const kzg = await loadKZG()
     const config = new Config({
       common: new Common({
         chain: CommonChain.Holesky,
         hardfork: Hardfork.Paris,
         eips: [4895, 4844],
+        customCrypto: {
+          kzg,
+        },
       }),
       accountCache: 10000,
       storageCache: 1000,

--- a/packages/client/test/rpc/engine/getPayloadV3.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadV3.spec.ts
@@ -89,9 +89,9 @@ describe(method, () => {
     assert.ok(payloadId !== undefined && payloadId !== null, 'valid payloadId should be received')
 
     const txBlobs = getBlobs('hello world')
-    const txCommitments = blobsToCommitments(txBlobs)
+    const txCommitments = blobsToCommitments(kzg, txBlobs)
     const txVersionedHashes = commitmentsToVersionedHashes(txCommitments)
-    const txProofs = blobsToProofs(txBlobs, txCommitments)
+    const txProofs = blobsToProofs(kzg, txBlobs, txCommitments)
 
     const tx = TransactionFactory.fromTxData(
       {

--- a/packages/client/test/rpc/engine/getPayloadV3.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadV3.spec.ts
@@ -10,7 +10,6 @@ import {
   commitmentsToVersionedHashes,
   getBlobs,
   hexToBytes,
-  initKZG,
 } from '@ethereumjs/util'
 import { createKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'

--- a/packages/client/test/rpc/engine/getPayloadV3.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadV3.spec.ts
@@ -11,7 +11,7 @@ import {
   getBlobs,
   hexToBytes,
 } from '@ethereumjs/util'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import { INVALID_PARAMS } from '../../../src/rpc/error-code.js'
@@ -67,7 +67,7 @@ describe(method, () => {
       return this
     }
 
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
 
     const { service, server, common } = await setupChain(genesisJSON, 'post-merge', {
       engine: true,

--- a/packages/client/test/rpc/engine/getPayloadV3.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadV3.spec.ts
@@ -69,7 +69,6 @@ describe(method, () => {
     }
 
     const kzg = await createKZG()
-    initKZG(kzg)
 
     const { service, server, common } = await setupChain(genesisJSON, 'post-merge', {
       engine: true,

--- a/packages/client/test/rpc/engine/getPayloadV3.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadV3.spec.ts
@@ -11,7 +11,7 @@ import {
   getBlobs,
   hexToBytes,
 } from '@ethereumjs/util'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import { INVALID_PARAMS } from '../../../src/rpc/error-code.js'
@@ -67,7 +67,7 @@ describe(method, () => {
       return this
     }
 
-    const kzg = await createKZG()
+    const kzg = await initKZG()
 
     const { service, server, common } = await setupChain(genesisJSON, 'post-merge', {
       engine: true,

--- a/packages/client/test/rpc/engine/kaustinen2.spec.ts
+++ b/packages/client/test/rpc/engine/kaustinen2.spec.ts
@@ -1,5 +1,4 @@
 import { Block, BlockHeader, executionPayloadFromBeaconPayload } from '@ethereumjs/block'
-import { initKZG } from '@ethereumjs/util'
 import { createKZG } from 'kzg-wasm'
 import * as td from 'testdouble'
 import { assert, describe, it } from 'vitest'

--- a/packages/client/test/rpc/engine/kaustinen2.spec.ts
+++ b/packages/client/test/rpc/engine/kaustinen2.spec.ts
@@ -34,7 +34,6 @@ async function runBlock(
 
 describe(`valid verkle network setup`, async () => {
   const kzg = await createKZG()
-  initKZG(kzg)
 
   const { server, chain, common } = await setupChain(genesisJSON, 'post-merge', {
     engine: true,

--- a/packages/client/test/rpc/engine/kaustinen2.spec.ts
+++ b/packages/client/test/rpc/engine/kaustinen2.spec.ts
@@ -1,5 +1,5 @@
 import { Block, BlockHeader, executionPayloadFromBeaconPayload } from '@ethereumjs/block'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import * as td from 'testdouble'
 import { assert, describe, it } from 'vitest'
 
@@ -32,7 +32,7 @@ async function runBlock(
 }
 
 describe(`valid verkle network setup`, async () => {
-  const kzg = await createKZG()
+  const kzg = await initKZG()
 
   const { server, chain, common } = await setupChain(genesisJSON, 'post-merge', {
     engine: true,

--- a/packages/client/test/rpc/engine/kaustinen2.spec.ts
+++ b/packages/client/test/rpc/engine/kaustinen2.spec.ts
@@ -1,5 +1,5 @@
 import { Block, BlockHeader, executionPayloadFromBeaconPayload } from '@ethereumjs/block'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import * as td from 'testdouble'
 import { assert, describe, it } from 'vitest'
 
@@ -32,7 +32,7 @@ async function runBlock(
 }
 
 describe(`valid verkle network setup`, async () => {
-  const kzg = await initKZG()
+  const kzg = await loadKZG()
 
   const { server, chain, common } = await setupChain(genesisJSON, 'post-merge', {
     engine: true,

--- a/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
@@ -1,4 +1,4 @@
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import { INVALID_PARAMS } from '../../../src/rpc/error-code.js'
@@ -14,7 +14,7 @@ const [blockData] = blocks
 
 describe(`${method}: Cancun validations`, () => {
   it('blobVersionedHashes', async () => {
-    const kzg = await createKZG()
+    const kzg = await initKZG()
 
     const { server } = await setupChain(genesisJSON, 'post-merge', {
       engine: true,

--- a/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
@@ -1,4 +1,4 @@
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import { INVALID_PARAMS } from '../../../src/rpc/error-code.js'
@@ -14,7 +14,7 @@ const [blockData] = blocks
 
 describe(`${method}: Cancun validations`, () => {
   it('blobVersionedHashes', async () => {
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
 
     const { server } = await setupChain(genesisJSON, 'post-merge', {
       engine: true,

--- a/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
@@ -1,4 +1,3 @@
-import { initKZG } from '@ethereumjs/util'
 import { createKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 

--- a/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV3VersionedHashes.spec.ts
@@ -16,7 +16,6 @@ const [blockData] = blocks
 describe(`${method}: Cancun validations`, () => {
   it('blobVersionedHashes', async () => {
     const kzg = await createKZG()
-    initKZG(kzg)
 
     const { server } = await setupChain(genesisJSON, 'post-merge', {
       engine: true,

--- a/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
+++ b/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
@@ -2,13 +2,13 @@ import { Block } from '@ethereumjs/block'
 import { Common } from '@ethereumjs/common'
 import { BlobEIP4844Transaction, LegacyTransaction } from '@ethereumjs/tx'
 import { Address, hexToBytes } from '@ethereumjs/util'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import { INVALID_PARAMS } from '../../../src/rpc/error-code.js'
 import { createClient, createManager, dummy, getRpcClient, startRPC } from '../helpers.js'
 
-const kzg = await createKZG()
+const kzg = await initKZG()
 
 const common = Common.custom({ chainId: 1 }, { customCrypto: { kzg } })
 

--- a/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
+++ b/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
@@ -9,7 +9,6 @@ import { INVALID_PARAMS } from '../../../src/rpc/error-code.js'
 import { createClient, createManager, dummy, getRpcClient, startRPC } from '../helpers.js'
 
 const kzg = await createKZG()
-initKZG(kzg)
 
 const common = Common.custom({ chainId: 1 }, { customCrypto: { kzg } })
 

--- a/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
+++ b/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
@@ -1,7 +1,7 @@
 import { Block } from '@ethereumjs/block'
 import { Common } from '@ethereumjs/common'
 import { BlobEIP4844Transaction, LegacyTransaction } from '@ethereumjs/tx'
-import { Address, hexToBytes, initKZG } from '@ethereumjs/util'
+import { Address, hexToBytes } from '@ethereumjs/util'
 import { createKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 

--- a/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
+++ b/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
@@ -2,13 +2,13 @@ import { Block } from '@ethereumjs/block'
 import { Common } from '@ethereumjs/common'
 import { BlobEIP4844Transaction, LegacyTransaction } from '@ethereumjs/tx'
 import { Address, hexToBytes } from '@ethereumjs/util'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import { INVALID_PARAMS } from '../../../src/rpc/error-code.js'
 import { createClient, createManager, dummy, getRpcClient, startRPC } from '../helpers.js'
 
-const kzg = await initKZG()
+const kzg = await loadKZG()
 
 const common = Common.custom({ chainId: 1 }, { customCrypto: { kzg } })
 

--- a/packages/client/test/rpc/eth/getFeeHistory.spec.ts
+++ b/packages/client/test/rpc/eth/getFeeHistory.spec.ts
@@ -9,7 +9,6 @@ import {
   bytesToBigInt,
   commitmentsToVersionedHashes,
   getBlobs,
-  initKZG,
 } from '@ethereumjs/util'
 import { hexToBytes } from 'ethereum-cryptography/utils'
 import { createKZG } from 'kzg-wasm'

--- a/packages/client/test/rpc/eth/getFeeHistory.spec.ts
+++ b/packages/client/test/rpc/eth/getFeeHistory.spec.ts
@@ -122,7 +122,6 @@ const produceBlockWith4844Tx = async (
   blobsCount: number[]
 ) => {
   const kzg = await createKZG()
-  initKZG(kzg)
   // 4844 sample blob
   const sampleBlob = getBlobs('hello world')
   const commitment = blobsToCommitments(sampleBlob)
@@ -402,7 +401,6 @@ describe(method, () => {
     `${method} - Should correctly return the right blob base fees and ratios for a chain with 4844 active`,
     async () => {
       const kzg = await createKZG()
-      initKZG(kzg)
       const { chain, execution, server } = await setupChain(genesisJSON, 'post-merge', {
         engine: true,
         hardfork: Hardfork.Cancun,

--- a/packages/client/test/rpc/eth/getFeeHistory.spec.ts
+++ b/packages/client/test/rpc/eth/getFeeHistory.spec.ts
@@ -11,7 +11,7 @@ import {
   getBlobs,
 } from '@ethereumjs/util'
 import { hexToBytes } from 'ethereum-cryptography/utils'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import genesisJSON from '../../testdata/geth-genesis/eip4844.json'
@@ -120,7 +120,7 @@ const produceBlockWith4844Tx = async (
   chain: Chain,
   blobsCount: number[]
 ) => {
-  const kzg = await createKZG()
+  const kzg = await initKZG()
   // 4844 sample blob
   const sampleBlob = getBlobs('hello world')
   const commitment = blobsToCommitments(sampleBlob)
@@ -399,7 +399,7 @@ describe(method, () => {
   it(
     `${method} - Should correctly return the right blob base fees and ratios for a chain with 4844 active`,
     async () => {
-      const kzg = await createKZG()
+      const kzg = await initKZG()
       const { chain, execution, server } = await setupChain(genesisJSON, 'post-merge', {
         engine: true,
         hardfork: Hardfork.Cancun,

--- a/packages/client/test/rpc/eth/getFeeHistory.spec.ts
+++ b/packages/client/test/rpc/eth/getFeeHistory.spec.ts
@@ -123,7 +123,7 @@ const produceBlockWith4844Tx = async (
   const kzg = await loadKZG()
   // 4844 sample blob
   const sampleBlob = getBlobs('hello world')
-  const commitment = blobsToCommitments(sampleBlob)
+  const commitment = blobsToCommitments(kzg, sampleBlob)
   const blobVersionedHash = commitmentsToVersionedHashes(commitment)
 
   const { vm } = execution

--- a/packages/client/test/rpc/eth/getFeeHistory.spec.ts
+++ b/packages/client/test/rpc/eth/getFeeHistory.spec.ts
@@ -11,7 +11,7 @@ import {
   getBlobs,
 } from '@ethereumjs/util'
 import { hexToBytes } from 'ethereum-cryptography/utils'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import genesisJSON from '../../testdata/geth-genesis/eip4844.json'
@@ -120,7 +120,7 @@ const produceBlockWith4844Tx = async (
   chain: Chain,
   blobsCount: number[]
 ) => {
-  const kzg = await initKZG()
+  const kzg = await loadKZG()
   // 4844 sample blob
   const sampleBlob = getBlobs('hello world')
   const commitment = blobsToCommitments(sampleBlob)
@@ -399,7 +399,7 @@ describe(method, () => {
   it(
     `${method} - Should correctly return the right blob base fees and ratios for a chain with 4844 active`,
     async () => {
-      const kzg = await initKZG()
+      const kzg = await loadKZG()
       const { chain, execution, server } = await setupChain(genesisJSON, 'post-merge', {
         engine: true,
         hardfork: Hardfork.Cancun,

--- a/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
@@ -11,7 +11,7 @@ import {
   getBlobs,
   randomBytes,
 } from '@ethereumjs/util'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import pow from '../../testdata/geth-genesis/pow.json'
@@ -88,7 +88,7 @@ describe(method, () => {
     } else {
       const gethGenesis = require('../../../../block/test/testdata/4844-hardfork.json')
 
-      const kzg = await initKZG()
+      const kzg = await loadKZG()
 
       const common = Common.fromGethGenesis(gethGenesis, {
         chain: 'customChain',

--- a/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
@@ -11,7 +11,7 @@ import {
   getBlobs,
   randomBytes,
 } from '@ethereumjs/util'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import pow from '../../testdata/geth-genesis/pow.json'
@@ -88,7 +88,7 @@ describe(method, () => {
     } else {
       const gethGenesis = require('../../../../block/test/testdata/4844-hardfork.json')
 
-      const kzg = await createKZG()
+      const kzg = await initKZG()
 
       const common = Common.fromGethGenesis(gethGenesis, {
         chain: 'customChain',

--- a/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
@@ -104,7 +104,7 @@ describe(method, () => {
       const rpc = getRpcClient(server)
 
       const blobs = getBlobs('hello world')
-      const commitments = blobsToCommitments(blobs)
+      const commitments = blobsToCommitments(kzg, blobs)
       const blobVersionedHashes = commitmentsToVersionedHashes(commitments)
       const proofs = blobs.map((blob, ctx) => kzg.computeBlobKzgProof(blob, commitments[ctx]))
       const tx = BlobEIP4844Transaction.fromTxData(

--- a/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
@@ -9,7 +9,6 @@ import {
   bytesToHex,
   commitmentsToVersionedHashes,
   getBlobs,
-  initKZG,
   randomBytes,
 } from '@ethereumjs/util'
 import { createKZG } from 'kzg-wasm'

--- a/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
@@ -90,7 +90,6 @@ describe(method, () => {
       const gethGenesis = require('../../../../block/test/testdata/4844-hardfork.json')
 
       const kzg = await createKZG()
-      initKZG(kzg)
 
       const common = Common.fromGethGenesis(gethGenesis, {
         chain: 'customChain',

--- a/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
+++ b/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
@@ -221,7 +221,6 @@ describe(method, () => {
     const gethGenesis = require('../../../../block/test/testdata/4844-hardfork.json')
 
     const kzg = await createKZG()
-    initKZG(kzg)
 
     const common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',

--- a/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
+++ b/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
@@ -13,7 +13,6 @@ import {
   commitmentsToVersionedHashes,
   getBlobs,
   hexToBytes,
-  initKZG,
   randomBytes,
 } from '@ethereumjs/util'
 import { createKZG } from 'kzg-wasm'

--- a/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
+++ b/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
@@ -233,7 +233,7 @@ describe(method, () => {
       syncTargetHeight: 100n,
     })
     const blobs = getBlobs('hello world')
-    const commitments = blobsToCommitments(blobs)
+    const commitments = blobsToCommitments(kzg, blobs)
     const blobVersionedHashes = commitmentsToVersionedHashes(commitments)
     const proofs = blobs.map((blob, ctx) => kzg.computeBlobKzgProof(blob, commitments[ctx]))
     const pk = randomBytes(32)

--- a/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
+++ b/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
@@ -15,7 +15,7 @@ import {
   hexToBytes,
   randomBytes,
 } from '@ethereumjs/util'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import { INTERNAL_ERROR, INVALID_PARAMS, PARSE_ERROR } from '../../../src/rpc/error-code.js'
@@ -219,7 +219,7 @@ describe(method, () => {
     BlockHeader.prototype['_consensusFormatValidation'] = (): any => {}
     const gethGenesis = require('../../../../block/test/testdata/4844-hardfork.json')
 
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
 
     const common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',

--- a/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
+++ b/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
@@ -15,7 +15,7 @@ import {
   hexToBytes,
   randomBytes,
 } from '@ethereumjs/util'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import { INTERNAL_ERROR, INVALID_PARAMS, PARSE_ERROR } from '../../../src/rpc/error-code.js'
@@ -219,7 +219,7 @@ describe(method, () => {
     BlockHeader.prototype['_consensusFormatValidation'] = (): any => {}
     const gethGenesis = require('../../../../block/test/testdata/4844-hardfork.json')
 
-    const kzg = await createKZG()
+    const kzg = await initKZG()
 
     const common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',

--- a/packages/client/test/sim/simutils.ts
+++ b/packages/client/test/sim/simutils.ts
@@ -13,6 +13,7 @@ import {
   randomBytes,
 } from '@ethereumjs/util'
 import * as fs from 'fs/promises'
+import { loadKZG } from 'kzg-wasm'
 import { Level } from 'level'
 import { execSync, spawn } from 'node:child_process'
 import * as net from 'node:net'
@@ -28,6 +29,8 @@ import type { Common } from '@ethereumjs/common'
 import type { TransactionType, TxData, TxOptions } from '@ethereumjs/tx'
 import type { ChildProcessWithoutNullStreams } from 'child_process'
 import type { Client } from 'jayson/promise'
+
+const kzg = await loadKZG()
 
 export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
 // This function switches between the native web implementation and a nodejs implementation
@@ -315,8 +318,8 @@ export const runBlobTx = async (
   opts?: TxOptions
 ) => {
   const blobs = getBlobs(bytesToHex(randomBytes(blobSize)))
-  const commitments = blobsToCommitments(blobs)
-  const proofs = blobsToProofs(blobs, commitments)
+  const commitments = blobsToCommitments(kzg, blobs)
+  const proofs = blobsToProofs(kzg, blobs, commitments)
   const hashes = commitmentsToVersionedHashes(commitments)
 
   const sender = Address.fromPrivateKey(pkey)
@@ -385,8 +388,8 @@ export const createBlobTxs = async (
   const blobSize = txMeta.blobSize ?? 2 ** 17 - 1
 
   const blobs = getBlobs(bytesToHex(randomBytes(blobSize)))
-  const commitments = blobsToCommitments(blobs)
-  const proofs = blobsToProofs(blobs, commitments)
+  const commitments = blobsToCommitments(kzg, blobs)
+  const proofs = blobsToProofs(kzg, blobs, commitments)
   const hashes = commitmentsToVersionedHashes(commitments)
   const txns = []
 

--- a/packages/client/test/sim/txGenerator.ts
+++ b/packages/client/test/sim/txGenerator.ts
@@ -9,6 +9,7 @@ import {
   randomBytes,
 } from '@ethereumjs/util'
 import { Client } from 'jayson/promise'
+import { loadKZG } from 'kzg-wasm'
 
 import type { TransactionType, TxData } from '@ethereumjs/tx'
 
@@ -24,6 +25,8 @@ const BLOB_SIZE = BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB
 
 const pkey = hexToBytes('0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8')
 const sender = Address.fromPrivateKey(pkey)
+
+const kzg = await loadKZG()
 
 function get_padded(data: any, blobs_len: number) {
   const pdata = new Uint8Array(blobs_len * USEFUL_BYTES_PER_BLOB)
@@ -94,7 +97,7 @@ async function run(data: any) {
   }
 
   const blobs = get_blobs(data)
-  const commitments = blobsToCommitments(blobs)
+  const commitments = blobsToCommitments(kzg, blobs)
   const hashes = commitmentsToVersionedHashes(commitments)
 
   const account = Address.fromPrivateKey(randomBytes(32))

--- a/packages/common/examples/initKzg.ts
+++ b/packages/common/examples/initKzg.ts
@@ -4,7 +4,6 @@ import { initKZG } from '@ethereumjs/util'
 
 const main = async () => {
   const kzg = await createKZG()
-  initKZG(kzg)
   const common = new Common({
     chain: Chain.Mainnet,
     hardfork: Hardfork.Cancun,

--- a/packages/common/examples/initKzg.ts
+++ b/packages/common/examples/initKzg.ts
@@ -1,6 +1,5 @@
 import { createKZG } from 'kzg-wasm'
 import { Common, Chain, Hardfork } from '@ethereumjs/common'
-import { initKZG } from '@ethereumjs/util'
 
 const main = async () => {
   const kzg = await createKZG()

--- a/packages/common/examples/initKzg.ts
+++ b/packages/common/examples/initKzg.ts
@@ -1,8 +1,8 @@
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { Common, Chain, Hardfork } from '@ethereumjs/common'
 
 const main = async () => {
-  const kzg = await createKZG()
+  const kzg = await initKZG()
   const common = new Common({
     chain: Chain.Mainnet,
     hardfork: Hardfork.Cancun,

--- a/packages/common/examples/initKzg.ts
+++ b/packages/common/examples/initKzg.ts
@@ -1,8 +1,8 @@
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { Common, Chain, Hardfork } from '@ethereumjs/common'
 
 const main = async () => {
-  const kzg = await initKZG()
+  const kzg = await loadKZG()
   const common = new Common({
     chain: Chain.Mainnet,
     hardfork: Hardfork.Cancun,

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -69,7 +69,7 @@
     "@types/minimist": "^1.2.2",
     "@types/node-dir": "^0.0.34",
     "benchmark": "^2.1.4",
-    "kzg-wasm": "git://github.com/ethereumjs/kzg-wasm.git#c0f05e56f4728f46bf322514f421997d96f63387",
+    "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
     "level": "^8.0.0",
     "memory-level": "^1.0.0",
     "minimist": "^1.2.5",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -69,7 +69,7 @@
     "@types/minimist": "^1.2.2",
     "@types/node-dir": "^0.0.34",
     "benchmark": "^2.1.4",
-    "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
+    "kzg-wasm": "^0.3.1",
     "level": "^8.0.0",
     "memory-level": "^1.0.0",
     "minimist": "^1.2.5",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -69,7 +69,7 @@
     "@types/minimist": "^1.2.2",
     "@types/node-dir": "^0.0.34",
     "benchmark": "^2.1.4",
-    "kzg-wasm": "^0.2.0",
+    "kzg-wasm": "git://github.com/ethereumjs/kzg-wasm.git#c0f05e56f4728f46bf322514f421997d96f63387",
     "level": "^8.0.0",
     "memory-level": "^1.0.0",
     "minimist": "^1.2.5",

--- a/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
+++ b/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
@@ -6,7 +6,7 @@ import {
   hexToBytes,
   unpadBytes,
 } from '@ethereumjs/util'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import { EVM, getActivePrecompiles } from '../../src/index.js'
@@ -21,7 +21,7 @@ describe('Precompiles: point evaluation', () => {
   it('should work', async () => {
     const genesisJSON = await import('../../../client/test/testdata/geth-genesis/eip4844.json')
 
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
 
     const common = Common.fromGethGenesis(genesisJSON, {
       chain: 'custom',

--- a/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
+++ b/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
@@ -4,7 +4,6 @@ import {
   computeVersionedHash,
   concatBytes,
   hexToBytes,
-  initKZG,
   unpadBytes,
 } from '@ethereumjs/util'
 import { createKZG } from 'kzg-wasm'

--- a/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
+++ b/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
@@ -6,7 +6,7 @@ import {
   hexToBytes,
   unpadBytes,
 } from '@ethereumjs/util'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import { EVM, getActivePrecompiles } from '../../src/index.js'
@@ -21,7 +21,7 @@ describe('Precompiles: point evaluation', () => {
   it('should work', async () => {
     const genesisJSON = await import('../../../client/test/testdata/geth-genesis/eip4844.json')
 
-    const kzg = await createKZG()
+    const kzg = await initKZG()
 
     const common = Common.fromGethGenesis(genesisJSON, {
       chain: 'custom',

--- a/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
+++ b/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
@@ -23,7 +23,6 @@ describe('Precompiles: point evaluation', () => {
     const genesisJSON = await import('../../../client/test/testdata/geth-genesis/eip4844.json')
 
     const kzg = await createKZG()
-    initKZG(kzg)
 
     const common = Common.fromGethGenesis(genesisJSON, {
       chain: 'custom',

--- a/packages/tx/examples/blobTx.ts
+++ b/packages/tx/examples/blobTx.ts
@@ -5,7 +5,6 @@ import { createKZG } from 'kzg-wasm'
 
 const main = async () => {
   const kzg = await createKZG()
-  initKZG(kzg)
 
   const common = new Common({
     chain: Chain.Mainnet,

--- a/packages/tx/examples/blobTx.ts
+++ b/packages/tx/examples/blobTx.ts
@@ -1,6 +1,6 @@
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
-import { bytesToHex, initKZG } from '@ethereumjs/util'
+import { bytesToHex } from '@ethereumjs/util'
 import { createKZG } from 'kzg-wasm'
 
 const main = async () => {

--- a/packages/tx/examples/blobTx.ts
+++ b/packages/tx/examples/blobTx.ts
@@ -1,10 +1,10 @@
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
 import { bytesToHex } from '@ethereumjs/util'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 
 const main = async () => {
-  const kzg = await createKZG()
+  const kzg = await initKZG()
 
   const common = new Common({
     chain: Chain.Mainnet,

--- a/packages/tx/examples/blobTx.ts
+++ b/packages/tx/examples/blobTx.ts
@@ -1,10 +1,10 @@
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
 import { bytesToHex } from '@ethereumjs/util'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 
 const main = async () => {
-  const kzg = await initKZG()
+  const kzg = await loadKZG()
 
   const common = new Common({
     chain: Chain.Mainnet,

--- a/packages/tx/examples/initKzg.ts
+++ b/packages/tx/examples/initKzg.ts
@@ -1,8 +1,8 @@
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 
 const main = async () => {
-  const kzg = await initKZG()
+  const kzg = await loadKZG()
 
   // Instantiate `common`
   const common = new Common({

--- a/packages/tx/examples/initKzg.ts
+++ b/packages/tx/examples/initKzg.ts
@@ -1,6 +1,5 @@
 import { createKZG } from 'kzg-wasm'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
-import { initKZG } from '@ethereumjs/util'
 
 const main = async () => {
   const kzg = await createKZG()

--- a/packages/tx/examples/initKzg.ts
+++ b/packages/tx/examples/initKzg.ts
@@ -1,8 +1,8 @@
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 
 const main = async () => {
-  const kzg = await createKZG()
+  const kzg = await initKZG()
 
   // Instantiate `common`
   const common = new Common({

--- a/packages/tx/examples/initKzg.ts
+++ b/packages/tx/examples/initKzg.ts
@@ -4,7 +4,6 @@ import { initKZG } from '@ethereumjs/util'
 
 const main = async () => {
   const kzg = await createKZG()
-  initKZG(kzg)
 
   // Instantiate `common`
   const common = new Common({

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@types/minimist": "^1.2.0",
     "@types/node-dir": "^0.0.34",
-    "kzg-wasm": "git://github.com/ethereumjs/kzg-wasm.git#c0f05e56f4728f46bf322514f421997d96f63387",
+    "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
     "minimist": "^1.2.0",
     "node-dir": "^0.1.16"
   },

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@types/minimist": "^1.2.0",
     "@types/node-dir": "^0.0.34",
-    "kzg-wasm": "^0.2.0",
+    "kzg-wasm": "git://github.com/ethereumjs/kzg-wasm.git#c0f05e56f4728f46bf322514f421997d96f63387",
     "minimist": "^1.2.0",
     "node-dir": "^0.1.16"
   },

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "@types/minimist": "^1.2.0",
     "@types/node-dir": "^0.0.34",
-    "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504",
+    "kzg-wasm": "^0.3.1",
     "minimist": "^1.2.0",
     "node-dir": "^0.1.16"
   },

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -190,6 +190,12 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
   }
 
   public static fromTxData(txData: TxData, opts?: TxOptions) {
+    if (opts?.common?.customCrypto?.kzg === undefined) {
+      throw new Error(
+        'A common object with customCrypto.kzg initialized required to instantiate a 4844 blob tx'
+      )
+    }
+    const kzg = opts!.common!.customCrypto!.kzg!
     if (txData.blobsData !== undefined) {
       if (txData.blobs !== undefined) {
         throw new Error('cannot have both raw blobs data and encoded blobs in constructor')
@@ -204,11 +210,12 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
         throw new Error('cannot have both raw blobs data and KZG proofs in constructor')
       }
       txData.blobs = getBlobs(txData.blobsData.reduce((acc, cur) => acc + cur))
-      txData.kzgCommitments = blobsToCommitments(txData.blobs as Uint8Array[])
+      txData.kzgCommitments = blobsToCommitments(kzg, txData.blobs as Uint8Array[])
       txData.blobVersionedHashes = commitmentsToVersionedHashes(
         txData.kzgCommitments as Uint8Array[]
       )
       txData.kzgProofs = blobsToProofs(
+        kzg,
         txData.blobs as Uint8Array[],
         txData.kzgCommitments as Uint8Array[]
       )
@@ -237,7 +244,9 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
     opts?: TxOptions
   ): BlobEIP4844Transaction {
     if (opts?.common?.customCrypto?.kzg === undefined) {
-      throw new Error('kzg instance required to instantiate blob tx')
+      throw new Error(
+        'A common object with customCrypto.kzg initialized required to instantiate a 4844 blob tx'
+      )
     }
 
     const tx = BlobEIP4844Transaction.fromTxData(
@@ -258,7 +267,9 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
    */
   public static fromSerializedTx(serialized: Uint8Array, opts: TxOptions = {}) {
     if (opts.common?.customCrypto?.kzg === undefined) {
-      throw new Error('kzg instance required to instantiate blob tx')
+      throw new Error(
+        'A common object with customCrypto.kzg initialized required to instantiate a 4844 blob tx'
+      )
     }
 
     if (
@@ -288,7 +299,9 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
    */
   public static fromValuesArray(values: TxValuesArray, opts: TxOptions = {}) {
     if (opts.common?.customCrypto?.kzg === undefined) {
-      throw new Error('kzg instance required to instantiate blob tx')
+      throw new Error(
+        'A common object with customCrypto.kzg initialized required to instantiate a 4844 blob tx'
+      )
     }
 
     if (values.length !== 11 && values.length !== 14) {
@@ -364,7 +377,9 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
     }
 
     if (opts.common?.customCrypto?.kzg === undefined) {
-      throw new Error('kzg instance required to instantiate blob tx')
+      throw new Error(
+        'A common object with customCrypto.kzg initialized required to instantiate a 4844 blob tx'
+      )
     }
 
     if (

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -26,7 +26,6 @@ describe('EIP4844 addSignature tests', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -91,7 +90,6 @@ describe('EIP4844 constructor tests - valid scenarios', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -130,7 +128,6 @@ describe('fromTxData using from a json', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -202,7 +199,6 @@ describe('EIP4844 constructor tests - invalid scenarios', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -259,7 +255,6 @@ describe('Network wrapper tests', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -503,7 +498,6 @@ describe('hash() and signature verification', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -580,7 +574,6 @@ describe('Network wrapper deserialization test', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await createKZG()
-    initKZG(kzg)
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -20,6 +20,8 @@ import { BlobEIP4844Transaction, TransactionFactory } from '../src/index.js'
 
 import blobTx from './json/serialized4844tx.json'
 
+import type { Kzg } from '@ethereumjs/util'
+
 const pk = randomBytes(32)
 describe('EIP4844 addSignature tests', () => {
   let common: Common
@@ -251,9 +253,10 @@ describe('EIP4844 constructor tests - invalid scenarios', () => {
 })
 
 describe('Network wrapper tests', () => {
+  let kzg: Kzg
   let common: Common
   beforeAll(async () => {
-    const kzg = await loadKZG()
+    kzg = await loadKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -262,9 +265,9 @@ describe('Network wrapper tests', () => {
   })
   it('should work', async () => {
     const blobs = getBlobs('hello world')
-    const commitments = blobsToCommitments(blobs)
+    const commitments = blobsToCommitments(kzg, blobs)
     const blobVersionedHashes = commitmentsToVersionedHashes(commitments)
-    const proofs = blobsToProofs(blobs, commitments)
+    const proofs = blobsToProofs(kzg, blobs, commitments)
     const unsignedTx = BlobEIP4844Transaction.fromTxData(
       {
         blobVersionedHashes,
@@ -569,9 +572,10 @@ it('getEffectivePriorityFee()', async () => {
 })
 
 describe('Network wrapper deserialization test', () => {
+  let kzg: Kzg
   let common: Common
   beforeAll(async () => {
-    const kzg = await loadKZG()
+    kzg = await loadKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -610,8 +614,8 @@ describe('Network wrapper deserialization test', () => {
 
     const blobs = getBlobs('hello world')
 
-    const commitments = blobsToCommitments(blobs)
-    const proofs = blobsToProofs(blobs, commitments)
+    const commitments = blobsToCommitments(kzg, blobs)
+    const proofs = blobsToProofs(kzg, blobs, commitments)
 
     /* eslint-disable @typescript-eslint/no-use-before-define */
     const wrapper = hexToBytes(blobTx.tx)

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -12,7 +12,7 @@ import {
   hexToBytes,
 } from '@ethereumjs/util'
 import { randomBytes } from 'crypto'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { assert, beforeAll, describe, it } from 'vitest'
 
 import gethGenesis from '../../block/test/testdata/4844-hardfork.json'
@@ -24,7 +24,7 @@ const pk = randomBytes(32)
 describe('EIP4844 addSignature tests', () => {
   let common: Common
   beforeAll(async () => {
-    const kzg = await createKZG()
+    const kzg = await initKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -88,7 +88,7 @@ describe('EIP4844 addSignature tests', () => {
 describe('EIP4844 constructor tests - valid scenarios', () => {
   let common: Common
   beforeAll(async () => {
-    const kzg = await createKZG()
+    const kzg = await initKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -126,7 +126,7 @@ describe('EIP4844 constructor tests - valid scenarios', () => {
 describe('fromTxData using from a json', () => {
   let common: Common
   beforeAll(async () => {
-    const kzg = await createKZG()
+    const kzg = await initKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -197,7 +197,7 @@ describe('fromTxData using from a json', () => {
 describe('EIP4844 constructor tests - invalid scenarios', () => {
   let common: Common
   beforeAll(async () => {
-    const kzg = await createKZG()
+    const kzg = await initKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -253,7 +253,7 @@ describe('EIP4844 constructor tests - invalid scenarios', () => {
 describe('Network wrapper tests', () => {
   let common: Common
   beforeAll(async () => {
-    const kzg = await createKZG()
+    const kzg = await initKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -496,7 +496,7 @@ describe('Network wrapper tests', () => {
 describe('hash() and signature verification', () => {
   let common: Common
   beforeAll(async () => {
-    const kzg = await createKZG()
+    const kzg = await initKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -544,7 +544,7 @@ describe('hash() and signature verification', () => {
 })
 
 it('getEffectivePriorityFee()', async () => {
-  const kzg = await createKZG()
+  const kzg = await initKZG()
   const common = Common.fromGethGenesis(gethGenesis, {
     chain: 'customChain',
     hardfork: Hardfork.Cancun,
@@ -571,7 +571,7 @@ it('getEffectivePriorityFee()', async () => {
 describe('Network wrapper deserialization test', () => {
   let common: Common
   beforeAll(async () => {
-    const kzg = await createKZG()
+    const kzg = await initKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -10,7 +10,6 @@ import {
   equalsBytes,
   getBlobs,
   hexToBytes,
-  initKZG,
 } from '@ethereumjs/util'
 import { randomBytes } from 'crypto'
 import { createKZG } from 'kzg-wasm'
@@ -546,7 +545,6 @@ describe('hash() and signature verification', () => {
 
 it('getEffectivePriorityFee()', async () => {
   const kzg = await createKZG()
-  initKZG(kzg, '')
   const common = Common.fromGethGenesis(gethGenesis, {
     chain: 'customChain',
     hardfork: Hardfork.Cancun,

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -12,7 +12,7 @@ import {
   hexToBytes,
 } from '@ethereumjs/util'
 import { randomBytes } from 'crypto'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { assert, beforeAll, describe, it } from 'vitest'
 
 import gethGenesis from '../../block/test/testdata/4844-hardfork.json'
@@ -24,7 +24,7 @@ const pk = randomBytes(32)
 describe('EIP4844 addSignature tests', () => {
   let common: Common
   beforeAll(async () => {
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -88,7 +88,7 @@ describe('EIP4844 addSignature tests', () => {
 describe('EIP4844 constructor tests - valid scenarios', () => {
   let common: Common
   beforeAll(async () => {
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -126,7 +126,7 @@ describe('EIP4844 constructor tests - valid scenarios', () => {
 describe('fromTxData using from a json', () => {
   let common: Common
   beforeAll(async () => {
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -197,7 +197,7 @@ describe('fromTxData using from a json', () => {
 describe('EIP4844 constructor tests - invalid scenarios', () => {
   let common: Common
   beforeAll(async () => {
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -253,7 +253,7 @@ describe('EIP4844 constructor tests - invalid scenarios', () => {
 describe('Network wrapper tests', () => {
   let common: Common
   beforeAll(async () => {
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -496,7 +496,7 @@ describe('Network wrapper tests', () => {
 describe('hash() and signature verification', () => {
   let common: Common
   beforeAll(async () => {
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
@@ -544,7 +544,7 @@ describe('hash() and signature verification', () => {
 })
 
 it('getEffectivePriorityFee()', async () => {
-  const kzg = await initKZG()
+  const kzg = await loadKZG()
   const common = Common.fromGethGenesis(gethGenesis, {
     chain: 'customChain',
     hardfork: Hardfork.Cancun,
@@ -571,7 +571,7 @@ it('getEffectivePriorityFee()', async () => {
 describe('Network wrapper deserialization test', () => {
   let common: Common
   beforeAll(async () => {
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
     common = Common.fromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -95,7 +95,7 @@
     "ethereum-cryptography": "^2.1.3"
   },
   "devDependencies": {
-    "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504"
+    "kzg-wasm": "^0.3.1"
   },
   "engines": {
     "node": ">=18"

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -95,7 +95,7 @@
     "ethereum-cryptography": "^2.1.3"
   },
   "devDependencies": {
-    "kzg-wasm": "git://github.com/ethereumjs/kzg-wasm.git#c0f05e56f4728f46bf322514f421997d96f63387"
+    "kzg-wasm": "github:ethereumjs/kzg-wasm#6d82761ec36bba94f06c8638c7a9e5983310c504"
   },
   "engines": {
     "node": ">=18"

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -95,7 +95,7 @@
     "ethereum-cryptography": "^2.1.3"
   },
   "devDependencies": {
-    "kzg-wasm": "^0.2.0"
+    "kzg-wasm": "git://github.com/ethereumjs/kzg-wasm.git#c0f05e56f4728f46bf322514f421997d96f63387"
   },
   "engines": {
     "node": ">=18"

--- a/packages/util/src/blobs.ts
+++ b/packages/util/src/blobs.ts
@@ -1,7 +1,8 @@
 import { sha256 } from 'ethereum-cryptography/sha256.js'
 
 import { utf8ToBytes } from './bytes.js'
-import { kzg } from './kzg.js'
+
+import type { Kzg } from './kzg.js'
 
 /**
  * These utilities for constructing blobs are borrowed from https://github.com/Inphi/eip4844-interop.git
@@ -55,7 +56,7 @@ export const getBlobs = (input: string) => {
   return blobs
 }
 
-export const blobsToCommitments = (blobs: Uint8Array[]) => {
+export const blobsToCommitments = (kzg: Kzg, blobs: Uint8Array[]) => {
   const commitments: Uint8Array[] = []
   for (const blob of blobs) {
     commitments.push(kzg.blobToKzgCommitment(blob))
@@ -63,7 +64,7 @@ export const blobsToCommitments = (blobs: Uint8Array[]) => {
   return commitments
 }
 
-export const blobsToProofs = (blobs: Uint8Array[], commitments: Uint8Array[]) => {
+export const blobsToProofs = (kzg: Kzg, blobs: Uint8Array[], commitments: Uint8Array[]) => {
   const proofs = blobs.map((blob, ctx) => kzg.computeBlobKzgProof(blob, commitments[ctx]))
 
   return proofs

--- a/packages/util/src/kzg.ts
+++ b/packages/util/src/kzg.ts
@@ -23,19 +23,6 @@ export interface Kzg {
   ): boolean
 }
 
-function kzgNotLoaded(): never {
-  throw Error('kzg library not loaded')
-}
-
-// eslint-disable-next-line import/no-mutable-exports
-export let kzg: Kzg = {
-  loadTrustedSetup: kzgNotLoaded,
-  blobToKzgCommitment: kzgNotLoaded,
-  computeBlobKzgProof: kzgNotLoaded,
-  verifyKzgProof: kzgNotLoaded,
-  verifyBlobKzgProofBatch: kzgNotLoaded,
-}
-
 /**
  * @deprecated This initialization method is deprecated since trusted setup loading is done directly in the reference KZG library
  * initialization or should othewise be assured independently before KZG libary usage.
@@ -43,7 +30,6 @@ export let kzg: Kzg = {
  * @param kzgLib a KZG implementation (defaults to c-kzg)
  * @param a dictionary of trusted setup options
  */
-export function loadKZG(kzgLib: Kzg, _trustedSetupPath?: string) {
-  kzg = kzgLib
+export function initKZG(kzg: Kzg, _trustedSetupPath?: string) {
   kzg.loadTrustedSetup()
 }

--- a/packages/util/src/kzg.ts
+++ b/packages/util/src/kzg.ts
@@ -2,7 +2,12 @@
  * Interface for an externally provided kzg library used when creating blob transactions
  */
 export interface Kzg {
-  loadTrustedSetup(filePath?: string): void
+  loadTrustedSetup(trustedSetup?: {
+    g1: string // unprefixed hex string
+    g2: string // unprefixed hex string
+    n1: number // bytes per element
+    n2: number // 65
+  }): void
   blobToKzgCommitment(blob: Uint8Array): Uint8Array
   computeBlobKzgProof(blob: Uint8Array, commitment: Uint8Array): Uint8Array
   verifyKzgProof(
@@ -36,9 +41,9 @@ export let kzg: Kzg = {
  * initialization or should othewise be assured independently before KZG libary usage.
  *
  * @param kzgLib a KZG implementation (defaults to c-kzg)
- * @param trustedSetupPath the full path (e.g. "/home/linux/devnet4.txt") to a kzg trusted setup text file
+ * @param a dictionary of trusted setup options
  */
-export function initKZG(kzgLib: Kzg, trustedSetupPath?: string) {
+export function loadKZG(kzgLib: Kzg, _trustedSetupPath?: string) {
   kzg = kzgLib
-  kzg.loadTrustedSetup(trustedSetupPath)
+  kzg.loadTrustedSetup()
 }

--- a/packages/util/src/kzg.ts
+++ b/packages/util/src/kzg.ts
@@ -32,6 +32,9 @@ export let kzg: Kzg = {
 }
 
 /**
+ * @deprecated This initialization method is deprecated since trusted setup loading is done directly in the reference KZG library
+ * initialization or should othewise be assured independently before KZG libary usage.
+ *
  * @param kzgLib a KZG implementation (defaults to c-kzg)
  * @param trustedSetupPath the full path (e.g. "/home/linux/devnet4.txt") to a kzg trusted setup text file
  */

--- a/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
@@ -62,9 +62,9 @@ describe('EIP4844 tests', () => {
 
     // Set up tx
     const blobs = getBlobs('hello world')
-    const commitments = blobsToCommitments(blobs)
+    const commitments = blobsToCommitments(kzg, blobs)
     const blobVersionedHashes = commitmentsToVersionedHashes(commitments)
-    const proofs = blobsToProofs(blobs, commitments)
+    const proofs = blobsToProofs(kzg, blobs, commitments)
     const unsignedTx = BlobEIP4844Transaction.fromTxData(
       {
         blobVersionedHashes,

--- a/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
@@ -10,7 +10,6 @@ import {
   commitmentsToVersionedHashes,
   getBlobs,
   hexToBytes,
-  initKZG,
   privateToAddress,
   zeros,
 } from '@ethereumjs/util'
@@ -29,7 +28,7 @@ describe('EIP4844 tests', () => {
     let kzg
     {
       try {
-        //initKZG(kzg, __dirname + '/../../client/src/trustedSetups/official.txt')
+        //createKZG(__dirname + '/../../client/src/trustedSetups/official.txt')
         kzg = await createKZG()
       } catch {
         // no-op

--- a/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
@@ -13,7 +13,7 @@ import {
   privateToAddress,
   zeros,
 } from '@ethereumjs/util'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import * as genesisJSON from '../../../../client/test/testdata/geth-genesis/eip4844.json'
@@ -25,15 +25,8 @@ const sender = bytesToHex(privateToAddress(pk))
 
 describe('EIP4844 tests', () => {
   it('should build a block correctly with blobs', async () => {
-    let kzg
-    {
-      try {
-        //initKZG(__dirname + '/../../client/src/trustedSetups/official.txt')
-        kzg = await initKZG()
-      } catch {
-        // no-op
-      }
-    }
+    const kzg = await loadKZG()
+
     const common = Common.fromGethGenesis(genesisJSON, {
       chain: 'eip4844',
       hardfork: Hardfork.Cancun,

--- a/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
@@ -13,7 +13,7 @@ import {
   privateToAddress,
   zeros,
 } from '@ethereumjs/util'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import * as genesisJSON from '../../../../client/test/testdata/geth-genesis/eip4844.json'
@@ -28,8 +28,8 @@ describe('EIP4844 tests', () => {
     let kzg
     {
       try {
-        //createKZG(__dirname + '/../../client/src/trustedSetups/official.txt')
-        kzg = await createKZG()
+        //initKZG(__dirname + '/../../client/src/trustedSetups/official.txt')
+        kzg = await initKZG()
       } catch {
         // no-op
       }

--- a/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
@@ -31,7 +31,6 @@ describe('EIP4844 tests', () => {
       try {
         //initKZG(kzg, __dirname + '/../../client/src/trustedSetups/official.txt')
         kzg = await createKZG()
-        initKZG(kzg)
       } catch {
         // no-op
       }

--- a/packages/vm/test/api/runTx.spec.ts
+++ b/packages/vm/test/api/runTx.spec.ts
@@ -16,7 +16,6 @@ import {
   bytesToHex,
   equalsBytes,
   hexToBytes,
-  initKZG,
   zeros,
 } from '@ethereumjs/util'
 import { createKZG } from 'kzg-wasm'

--- a/packages/vm/test/api/runTx.spec.ts
+++ b/packages/vm/test/api/runTx.spec.ts
@@ -881,7 +881,6 @@ it('Validate SELFDESTRUCT does not charge new account gas when calling CALLER an
 describe('EIP 4844 transaction tests', () => {
   it('should work', async () => {
     const kzg = await createKZG()
-    initKZG(kzg)
 
     const genesisJson = require('../../../block/test/testdata/4844-hardfork.json')
     const common = Common.fromGethGenesis(genesisJson, {

--- a/packages/vm/test/api/runTx.spec.ts
+++ b/packages/vm/test/api/runTx.spec.ts
@@ -18,7 +18,7 @@ import {
   hexToBytes,
   zeros,
 } from '@ethereumjs/util'
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import { VM } from '../../src/vm'
@@ -879,7 +879,7 @@ it('Validate SELFDESTRUCT does not charge new account gas when calling CALLER an
 
 describe('EIP 4844 transaction tests', () => {
   it('should work', async () => {
-    const kzg = await createKZG()
+    const kzg = await initKZG()
 
     const genesisJson = require('../../../block/test/testdata/4844-hardfork.json')
     const common = Common.fromGethGenesis(genesisJson, {

--- a/packages/vm/test/api/runTx.spec.ts
+++ b/packages/vm/test/api/runTx.spec.ts
@@ -18,7 +18,7 @@ import {
   hexToBytes,
   zeros,
 } from '@ethereumjs/util'
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import { VM } from '../../src/vm'
@@ -879,7 +879,7 @@ it('Validate SELFDESTRUCT does not charge new account gas when calling CALLER an
 
 describe('EIP 4844 transaction tests', () => {
   it('should work', async () => {
-    const kzg = await initKZG()
+    const kzg = await loadKZG()
 
     const genesisJson = require('../../../block/test/testdata/4844-hardfork.json')
     const common = Common.fromGethGenesis(genesisJson, {

--- a/packages/vm/test/api/utils.ts
+++ b/packages/vm/test/api/utils.ts
@@ -101,9 +101,9 @@ export function getTransaction(
     txParams['maxPriorityFeePerGas'] = BigInt(10)
     txParams['maxFeePerBlobGas'] = BigInt(100)
     txParams['blobs'] = getBlobs('hello world')
-    txParams['kzgCommitments'] = blobsToCommitments(txParams['blobs'])
+    txParams['kzgCommitments'] = blobsToCommitments(common.customCrypto!.kzg!, txParams['blobs'])
     txParams['kzgProofs'] = txParams['blobs'].map((blob: Uint8Array, ctx: number) =>
-      common.customCrypto?.kzg?.computeBlobKzgProof(
+      common.customCrypto!.kzg!.computeBlobKzgProof(
         blob,
         txParams['kzgCommitments'][ctx] as Uint8Array
       )

--- a/packages/vm/test/tester/index.ts
+++ b/packages/vm/test/tester/index.ts
@@ -1,4 +1,3 @@
-import { initKZG } from '@ethereumjs/util'
 import { createKZG } from 'kzg-wasm'
 import * as minimist from 'minimist'
 import * as path from 'path'

--- a/packages/vm/test/tester/index.ts
+++ b/packages/vm/test/tester/index.ts
@@ -104,7 +104,6 @@ async function runTests() {
    * Run-time configuration
    */
   const kzg = await createKZG()
-  initKZG(kzg)
   const bn128 = await initRustBN()
   const runnerArgs: {
     forkConfigVM: string

--- a/packages/vm/test/tester/index.ts
+++ b/packages/vm/test/tester/index.ts
@@ -1,4 +1,4 @@
-import { initKZG } from 'kzg-wasm'
+import { loadKZG } from 'kzg-wasm'
 import * as minimist from 'minimist'
 import * as path from 'path'
 import * as process from 'process'
@@ -102,7 +102,7 @@ async function runTests() {
   /**
    * Run-time configuration
    */
-  const kzg = await initKZG()
+  const kzg = await loadKZG()
   const bn128 = await initRustBN()
   const runnerArgs: {
     forkConfigVM: string

--- a/packages/vm/test/tester/index.ts
+++ b/packages/vm/test/tester/index.ts
@@ -1,4 +1,4 @@
-import { createKZG } from 'kzg-wasm'
+import { initKZG } from 'kzg-wasm'
 import * as minimist from 'minimist'
 import * as path from 'path'
 import * as process from 'process'
@@ -102,7 +102,7 @@ async function runTests() {
   /**
    * Run-time configuration
    */
-  const kzg = await createKZG()
+  const kzg = await initKZG()
   const bn128 = await initRustBN()
   const runnerArgs: {
     forkConfigVM: string


### PR DESCRIPTION
This PR integrates a new `kzg-wasm` version from https://github.com/ethereumjs/kzg-wasm/pull/6 providing a simplified interface with a direct setup loading and additionally removes the usage of `Util.loadKZG()` on the monorepo side and deprecates the respective method.

Currently `kzg-wasm` is referenced by Git commit, so this still needs a release before merging here.