### PR TITLE
Fix RPCStateManager Inconsistincy

### DIFF
--- a/packages/statemanager/src/rpcStateManager.ts
+++ b/packages/statemanager/src/rpcStateManager.ts
@@ -1,9 +1,11 @@
 import { Chain, Common } from '@ethereumjs/common'
+import { RLP } from '@ethereumjs/rlp'
 import { Trie } from '@ethereumjs/trie'
 import {
   Account,
   bigIntToHex,
   bytesToHex,
+  equalsBytes,
   fetchFromProvider,
   hexToBytes,
   intToHex,
@@ -34,6 +36,8 @@ export interface RPCStateManagerOpts {
    */
   common?: Common
 }
+
+const KECCAK256_RLP_EMPTY_ACCOUNT = RLP.encode(new Account().serialize()).slice(2)
 
 export class RPCStateManager implements EVMStateManagerInterface {
   protected _provider: string
@@ -257,8 +261,12 @@ export class RPCStateManager implements EVMStateManagerInterface {
     }
 
     const rlp = (await this.getAccountFromProvider(address)).serialize()
-    const account = rlp !== null ? Account.fromRlpSerializedAccount(rlp) : undefined
+    const account =
+      equalsBytes(rlp, KECCAK256_RLP_EMPTY_ACCOUNT) === false
+        ? Account.fromRlpSerializedAccount(rlp)
+        : undefined
     this._accountCache?.put(address, account)
+
     return account
   }
 

--- a/packages/statemanager/test/rpcStateManager.spec.ts
+++ b/packages/statemanager/test/rpcStateManager.spec.ts
@@ -17,6 +17,7 @@ import { VM } from '@ethereumjs/vm'
 import { assert, describe, expect, it, vi } from 'vitest'
 
 import { RPCBlockChain, RPCStateManager } from '../src/rpcStateManager.js'
+import { DefaultStateManager } from '../src/stateManager.js'
 
 import * as blockData from './testdata/providerData/blocks/block0x7a120.json'
 import { getValues } from './testdata/providerData/mockProvider.js'
@@ -338,3 +339,18 @@ describe('blockchain', () =>
       '0xd5ba853bc7151fc044b9d273a57e3f9ed35e66e0248ab4a571445650cc4fcaa6'
     )
   }))
+
+describe('Should return same value as DefaultStateManager when account does not exist', () => {
+  it('should work', async () => {
+    const rpcState = new RPCStateManager({ provider, blockTag: 1n })
+    const defaultState = new DefaultStateManager()
+
+    const account0 = await rpcState.getAccount(new Address(hexToBytes('0x' + '01'.repeat(20))))
+    const account1 = await defaultState.getAccount(new Address(hexToBytes('0x' + '01'.repeat(20))))
+    assert.equal(
+      account0,
+      account1,
+      'Should return same value as DefaultStateManager when account does not exist'
+    )
+  })
+})


### PR DESCRIPTION
This change fixes a bug in the `RPCStateManager` that results in an empty account being returned when provider is responding that account does not exist.