### PR TITLE
Update ethereum-tests to 13.2

### DIFF
--- a/packages/vm/test/tester/config.ts
+++ b/packages/vm/test/tester/config.ts
@@ -393,7 +393,7 @@ const expectedTestsFull: {
     MuirGlacier: 12271,
     Berlin: 13214,
     London: 19449,
-    Paris: 19727,
+    Paris: 19718,
     Shanghai: 19564,
     ByzantiumToConstantinopleFixAt5: 0,
     EIP158ToByzantiumAt5: 0,


### PR DESCRIPTION
Do not merge, the ethereum/tests are likely wrong. These commits likely have to be deleted:

https://github.com/ethereumjs/ethereumjs-monorepo/pull/3324/commits/66a1918c4afc813b3d8cbe0e5fadbdd96cfdc244
https://github.com/ethereumjs/ethereumjs-monorepo/pull/3324/commits/f841f9d3b676db4a9efce80e8fcd604c883dee5f

With these hotfixes the new tests pass: https://github.com/ethereumjs/ethereumjs-monorepo/actions/runs/8316887875/job/22756952650?pr=3324