### PR TITLE
fix(blockchain): Throw nicer error in putBlock

### DIFF
--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -561,7 +561,10 @@ export class Blockchain implements BlockchainInterface {
           td > currentTd.header ||
           block.common.consensusType() === ConsensusType.ProofOfStake
         ) {
-          const foundCommon = await this.findCommonAncestor(header)
+          const foundCommon = await this.findCommonAncestor(header).catch(e => {
+            console.error(e)
+            throw new Error('Unable to traverse chain and find common ancestor. Are there missing blocks?', {cause: e})
+          })
           commonAncestor = foundCommon.commonAncestor
           ancestorHeaders = foundCommon.ancestorHeaders
 


### PR DESCRIPTION
Error message was confusing for putBlock

```
invalid header. Less values than expected were received. Min: 15, got: 0
```

This catches the error and throws a more informative error message