### PR TITLE
Client: fix `readline` library import

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -36,7 +36,7 @@ import { loadKZG } from 'kzg-wasm'
 import { Level } from 'level'
 import { homedir } from 'os'
 import * as path from 'path'
-import readline from 'readline'
+import * as readline from 'readline'
 import * as yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
 


### PR DESCRIPTION
`npm run client:start -- --unlock 0x...`

fails with

`TypeError: Cannot read properties of undefined (reading 'createInterface')`
