### PR TITLE
New Byte Type Aliases with Byte Length Indicators

### DIFF
--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -6,6 +6,9 @@ import type {
   BigIntLike,
   BytesLike,
   JsonRpcWithdrawal,
+  PrefixedHex20,
+  PrefixedHex32,
+  PrefixedHex8,
   PrefixedHexString,
   WithdrawalBytes,
   WithdrawalData,
@@ -253,10 +256,10 @@ export interface JsonRpcBlock {
 
 // Note: all these strings are 0x-prefixed
 export type WithdrawalV1 = {
-  index: PrefixedHexString // Quantity, 8 Bytes
-  validatorIndex: PrefixedHexString // Quantity, 8 bytes
-  address: PrefixedHexString // DATA, 20 bytes
-  amount: PrefixedHexString // Quantity, 32 bytes
+  index: PrefixedHex8 // Quantity
+  validatorIndex: PrefixedHex8 // Quantity
+  address: PrefixedHex20 // DATA
+  amount: PrefixedHex32 // Quantity
 }
 
 // Note: all these strings are 0x-prefixed

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -25,7 +25,7 @@ import type {
   TxOptions,
   TxValuesArray,
 } from './types.js'
-import type { BigIntLike } from '@ethereumjs/util'
+import type { BigIntLike, Bytes32 } from '@ethereumjs/util'
 
 /**
  * This base class will likely be subject to further
@@ -247,7 +247,7 @@ export abstract class BaseTransaction<T extends TransactionType>
   // Returns the hashed unsigned tx, which is used to sign the transaction.
   abstract getHashedMessageToSign(): Uint8Array
 
-  abstract hash(): Uint8Array
+  abstract hash(): Bytes32
 
   abstract getMessageToVerifySignature(): Uint8Array
 

--- a/packages/tx/src/capabilities/legacy.ts
+++ b/packages/tx/src/capabilities/legacy.ts
@@ -5,6 +5,7 @@ import { BaseTransaction } from '../baseTransaction.js'
 import { Capability } from '../types.js'
 
 import type { LegacyTxInterface } from '../types.js'
+import type { Bytes32 } from '@ethereumjs/util'
 
 export function errorMsg(tx: LegacyTxInterface, msg: string) {
   return `${msg} (${tx.errorStr()})`
@@ -39,7 +40,7 @@ export function getDataFee(tx: LegacyTxInterface, extraCost?: bigint): bigint {
   return cost
 }
 
-export function hash(tx: LegacyTxInterface): Uint8Array {
+export function hash(tx: LegacyTxInterface): Bytes32 {
   if (!tx.isSigned()) {
     const msg = errorMsg(tx, 'Cannot call hash method if transaction is not signed')
     throw new Error(msg)

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -29,6 +29,7 @@ import type {
   TxOptions,
 } from './types.js'
 import type { Common } from '@ethereumjs/common'
+import type { Bytes32 } from '@ethereumjs/util'
 
 type TxData = AllTypesTxData[TransactionType.FeeMarketEIP1559]
 type TxValuesArray = AllTypesTxValuesArray[TransactionType.FeeMarketEIP1559]
@@ -298,7 +299,7 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<TransactionType
    * This method can only be used for signed txs (it throws otherwise).
    * Use {@link FeeMarketEIP1559Transaction.getMessageToSign} to get a tx hash for the purpose of signing.
    */
-  public hash(): Uint8Array {
+  public hash(): Bytes32 {
     return Legacy.hash(this)
   }
 

--- a/packages/tx/src/eip2930Transaction.ts
+++ b/packages/tx/src/eip2930Transaction.ts
@@ -27,6 +27,7 @@ import type {
   TxOptions,
 } from './types.js'
 import type { Common } from '@ethereumjs/common'
+import type { Bytes32 } from '@ethereumjs/util'
 
 type TxData = AllTypesTxData[TransactionType.AccessListEIP2930]
 type TxValuesArray = AllTypesTxValuesArray[TransactionType.AccessListEIP2930]
@@ -266,7 +267,7 @@ export class AccessListEIP2930Transaction extends BaseTransaction<TransactionTyp
    * This method can only be used for signed txs (it throws otherwise).
    * Use {@link AccessListEIP2930Transaction.getMessageToSign} to get a tx hash for the purpose of signing.
    */
-  public hash(): Uint8Array {
+  public hash(): Bytes32 {
     return Legacy.hash(this)
   }
 

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -36,7 +36,7 @@ import type {
   TxOptions,
 } from './types.js'
 import type { Common } from '@ethereumjs/common'
-import type { Kzg } from '@ethereumjs/util'
+import type { Bytes32, Kzg } from '@ethereumjs/util'
 
 type TxData = AllTypesTxData[TransactionType.BlobEIP4844]
 type TxValuesArray = AllTypesTxValuesArray[TransactionType.BlobEIP4844]
@@ -540,7 +540,7 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
    * This method can only be used for signed txs (it throws otherwise).
    * Use {@link BlobEIP4844Transaction.getMessageToSign} to get a tx hash for the purpose of signing.
    */
-  public hash(): Uint8Array {
+  public hash(): Bytes32 {
     return Legacy.hash(this)
   }
 

--- a/packages/tx/src/legacyTransaction.ts
+++ b/packages/tx/src/legacyTransaction.ts
@@ -23,6 +23,7 @@ import type {
   TxOptions,
 } from './types.js'
 import type { Common } from '@ethereumjs/common'
+import type { Bytes32 } from '@ethereumjs/util'
 
 type TxData = AllTypesTxData[TransactionType.Legacy]
 type TxValuesArray = AllTypesTxValuesArray[TransactionType.Legacy]
@@ -252,7 +253,7 @@ export class LegacyTransaction extends BaseTransaction<TransactionType.Legacy> {
    * This method can only be used for signed txs (it throws otherwise).
    * Use {@link Transaction.getMessageToSign} to get a tx hash for the purpose of signing.
    */
-  hash(): Uint8Array {
+  hash(): Bytes32 {
     return Legacy.hash(this)
   }
 

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -5,7 +5,7 @@ import type { AccessListEIP2930Transaction } from './eip2930Transaction.js'
 import type { BlobEIP4844Transaction } from './eip4844Transaction.js'
 import type { LegacyTransaction } from './legacyTransaction.js'
 import type { AccessList, AccessListBytes, Common, Hardfork } from '@ethereumjs/common'
-import type { Address, AddressLike, BigIntLike, BytesLike } from '@ethereumjs/util'
+import type { Address, AddressLike, BigIntLike, Bytes32, BytesLike } from '@ethereumjs/util'
 export type {
   AccessList,
   AccessListBytes,

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -158,7 +158,7 @@ export interface TransactionInterface<T extends TransactionType = TransactionTyp
   serialize(): Uint8Array
   getMessageToSign(): Uint8Array | Uint8Array[]
   getHashedMessageToSign(): Uint8Array
-  hash(): Uint8Array
+  hash(): Bytes32
   getMessageToVerifySignature(): Uint8Array
   getValidationErrors(): string[]
   isSigned(): boolean

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -20,10 +20,30 @@ export type BytesLike =
   | TransformabletoBytes
   | PrefixedHexString
 
+/**
+ * Byte type aliases for Uint8Array with a Byte length indicator
+ *
+ * Every type added here should have a corresponding PrefixedHex[NUM] type
+ * (see below).
+ */
+export type Bytes8 = Uint8Array
+export type Bytes20 = Uint8Array
+export type Bytes32 = Uint8Array
+
 /*
  * A type that represents a `0x`-prefixed hex string.
  */
 export type PrefixedHexString = string
+
+/**
+ * Prefixed hex string type aliases for Uint8Array with a Byte length indicator
+ *
+ * Every type added here should have a corresponding Bytes[NUM] type
+ * (see above).
+ */
+export type PrefixedHex8 = string
+export type PrefixedHex20 = string
+export type PrefixedHex32 = string
 
 /**
  * A type that represents an input that can be converted to an Address.


### PR DESCRIPTION
This is on my plate for a very long time, PR adds simple byte aliases for both `Uint8Array` and `PrefixedHexString` with byte length indication.

As discussed already quite some time back ago, this implementation has none of the eventual backlashes as stricter solutions (like performance drawbacks on actual length checks everywhere in the code base) and should at the same time already bring a lot of the benefits, mostly being a lot better documented function signatures and length hints. VSC mouseover of the one exemplaric type in Block e.g. now look like this:

![Bildschirmfoto 2024-03-25 um 17 10 36](https://github.com/ethereumjs/ethereumjs-monorepo/assets/931137/b37746a7-0ac4-426a-b29b-632c7c7b626a)

For the `PrefixedHex*` thing I tested (and "stared" for quite some time 😂) at the different flavors of a possible naming scheme:

- `PrefixedHexString20`
- `PrefixedHexStr20`
- `PrefixedHex20`

I came to the conclusion that the last version should be sufficiently expressive and is at the same time the easiest to grasp, with the need to only digest 3 word parts instead of 4 (which is a lot), and after 3-4 rounds of usage latest it should be very intrinsic that this is about a string (if not clear from the beginning). So this version would be my personal favorite.

I would give this open for a first look and feedback and then continue a bit with it.

We do not need to get to completion here and merge this in a selectively applied state. Then we can just replace types over time, this is otherwise too tedious to accomplish in one go.