### PR TITLE
Fix ts-doc typo

### DIFF
--- a/packages/util/src/provider.ts
+++ b/packages/util/src/provider.ts
@@ -18,7 +18,7 @@ type rpcParams = {
  *   method: 'eth_getBlockByNumber',
  *   params: ['latest', false],
  * }
- *  const block = await fetchFromProvider(provider, params)
+ * const block = await fetchFromProvider(provider, params)
  * ```
  */
 export const fetchFromProvider = async (url: string, params: rpcParams) => {

--- a/packages/util/src/provider.ts
+++ b/packages/util/src/provider.ts
@@ -19,6 +19,7 @@ type rpcParams = {
  *   params: ['latest', false],
  * }
  *  const block = await fetchFromProvider(provider, params)
+ * ```
  */
 export const fetchFromProvider = async (url: string, params: rpcParams) => {
   const data = JSON.stringify({


### PR DESCRIPTION
The ts-doc example code block was not closed with ` ``` `, as a result the [docs page](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/util/docs/README.md#fetchfromprovider) is wrongly rendered.

I just fixed it by adding the missing ` ``` ` 👍