### PR TITLE
devp2p: increase timeout for failing CI test

### DIFF
--- a/packages/devp2p/test/integration/eth-simulator.spec.ts
+++ b/packages/devp2p/test/integration/eth-simulator.spec.ts
@@ -122,24 +122,28 @@ describe('ETH simulator tests', () => {
     await sendWithProtocolVersion(it, 66)
   })
 
-  it('ETH -> Eth64 -> sendStatus(): should throw on non-matching latest block provided', async () => {
-    await new Promise((resolve) => {
-      const cap = [devp2p.ETH.eth65]
-      const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium })
-      const status0: any = Object.assign({}, status)
-      status0['latestBlock'] = intToBytes(100000) // lower than Byzantium fork block 4370000
+  it(
+    'ETH -> Eth64 -> sendStatus(): should throw on non-matching latest block provided',
+    { timeout: 10000 },
+    async () => {
+      await new Promise((resolve) => {
+        const cap = [devp2p.ETH.eth65]
+        const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium })
+        const status0: any = Object.assign({}, status)
+        status0['latestBlock'] = intToBytes(100000) // lower than Byzantium fork block 4370000
 
-      const rlpxs = util.initTwoPeerRLPXSetup(null, cap, common, 50505)
-      rlpxs[0].events.on('peer:added', function (peer: any) {
-        const protocol = peer.getProtocols()[0]
-        assert.throws(() => {
-          protocol.sendStatus(status0)
-        }, /latest block provided is not matching the HF setting/)
-        util.destroyRLPXs(rlpxs)
-        resolve(undefined)
+        const rlpxs = util.initTwoPeerRLPXSetup(null, cap, common, 50505)
+        rlpxs[0].events.on('peer:added', function (peer: any) {
+          const protocol = peer.getProtocols()[0]
+          assert.throws(() => {
+            protocol.sendStatus(status0)
+          }, /latest block provided is not matching the HF setting/)
+          util.destroyRLPXs(rlpxs)
+          resolve(undefined)
+        })
       })
-    })
-  })
+    }
+  )
 
   it('ETH: send not-allowed eth67', async () => {
     await sendNotAllowed(it, 67, [devp2p.ETH.eth67], ETH.MESSAGE_CODES.GET_NODE_DATA)


### PR DESCRIPTION
This PR increases the timeout for a devp2p test that sometimes led to failures in the CI due to timeout.  