### PR TITLE
common: configure kaustinen6 network

### DIFF
--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -548,7 +548,7 @@ export class Config {
     this.discDns = this.getDnsDiscovery(options.discDns)
     this.discV4 = options.discV4 ?? true
 
-    this.logger = options.logger ?? getLogger({ loglevel: 'error' })
+    this.logger = options.logger ?? getLogger({ logLevel: 'error' })
 
     this.logger.info(`Sync Mode ${this.syncmode}`)
     if (this.syncmode !== SyncMode.None) {

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -99,6 +99,7 @@ export async function createClient(clientOpts: Partial<createClientArgs> = {}) {
     accountCache: 10000,
     storageCache: 1000,
     savePreimages: clientOpts.savePreimages,
+    logger: getLogger({}),
   })
   const blockchain = clientOpts.blockchain ?? mockBlockchain()
 

--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -414,7 +414,7 @@ export const EIPs: EIPsDict = {
     gasPrices: {},
     vm: {
       historicalRootsLength: {
-        v: 8191,
+        v: 8192,
         d: 'The modulo parameter of the beaconroot ring buffer in the beaconroot statefull precompile',
       },
     },

--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -226,7 +226,7 @@ export const EIPs: EIPsDict = {
         d: 'The address where the historical blockhashes are stored',
       },
       historyServeWindow: {
-        v: BigInt(256),
+        v: BigInt(8192),
         d: 'The amount of blocks to be served by the historical blockhash contract',
       },
     },
@@ -414,7 +414,7 @@ export const EIPs: EIPsDict = {
     gasPrices: {},
     vm: {
       historicalRootsLength: {
-        v: 8192,
+        v: 8191,
         d: 'The modulo parameter of the beaconroot ring buffer in the beaconroot statefull precompile',
       },
     },

--- a/packages/evm/src/opcodes/EIP2929.ts
+++ b/packages/evm/src/opcodes/EIP2929.ts
@@ -51,7 +51,8 @@ export function accessStorageEIP2929(
   runState: RunState,
   key: Uint8Array,
   isSstore: boolean,
-  common: Common
+  common: Common,
+  chargeGas = true
 ): bigint {
   if (common.isActivatedEIP(2929) === false) return BIGINT_0
 
@@ -61,8 +62,10 @@ export function accessStorageEIP2929(
   // Cold (SLOAD and SSTORE)
   if (slotIsCold) {
     runState.interpreter.journal.addWarmedStorage(address, key)
-    return common.param('gasPrices', 'coldsload')
-  } else if (!isSstore || common.isActivatedEIP(6800) === true) {
+    if (chargeGas && common.isActivatedEIP(6800) === false) {
+      return common.param('gasPrices', 'coldsload')
+    }
+  } else if (chargeGas && (!isSstore || common.isActivatedEIP(6800) === true)) {
     return common.param('gasPrices', 'warmstorageread')
   }
   return BIGINT_0

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -629,12 +629,13 @@ export const handlers: Map<number, OpHandler> = new Map([
 
         if (common.isActivatedEIP(6800) === true) {
           const { treeIndex, subIndex } = getTreeIndexesForStorageSlot(number)
-          // just create access witnesses without charging for the gas
-          runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
+          // create witnesses and charge gas
+          const statelessGas = runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
             historyAddress,
             treeIndex,
             subIndex
           )
+          runState.interpreter.useGas(statelessGas, `BLOCKHASH`)
         }
         const storage = await runState.stateManager.getContractStorage(historyAddress, key)
 

--- a/packages/statemanager/src/statelessVerkleStateManager.ts
+++ b/packages/statemanager/src/statelessVerkleStateManager.ts
@@ -421,7 +421,8 @@ export class StatelessVerkleStateManager implements EVMStateManagerInterface {
 
     // allocate the code and copy onto it from the available witness chunks
     const codeSize = account.codeSize
-    const accessedCode = new Uint8Array(codeSize)
+    // allocate enough to fit the last chunk
+    const accessedCode = new Uint8Array(codeSize + 31)
 
     const chunks = Math.floor(codeSize / 31) + 1
     for (let chunkId = 0; chunkId < chunks; chunkId++) {
@@ -447,7 +448,12 @@ export class StatelessVerkleStateManager implements EVMStateManagerInterface {
     }
 
     // Return accessedCode where only accessed code has been copied
-    return accessedCode
+    const contactCode = accessedCode.slice(0, codeSize)
+    if (!this._codeCacheSettings.deactivate) {
+      this._codeCache?.put(address, contactCode)
+    }
+
+    return contactCode
   }
 
   async getContractCodeSize(address: Address): Promise<number> {


### PR DESCRIPTION
followup of 
 - https://github.com/ethereumjs/ethereumjs-monorepo/pull/3343
 
test and fix issues against the next iteration of verkle kaustinen5 as a stateless client


How to run:


1. clean the client datadir (`/data/k6data`)  and start the client  providing where to save payload of invalid blocks (`/data/k6data/invalidblocks`):
  `npm run client:start:ts --  --ignoreStatelessInvalidExecs /data/k6data/invalidblocks  --dataDir /data/k6data --network kaustinen6 --rpcEngine --rpcEngineAuth false --logLevel warn`

  the loglevel is kept warn so that only failures so unexpected warns/errors show up to reduce noise while syncing

2.  clean the lodestra quickstart datadir's lodestar folder (here `k6data/lodestar` and run the following:
   `/setup.sh --dataDir k6data --network kaustinen6 --justCL`
  to start lodestar
