### PR TITLE
monorepo: cleanup ts-ignore and ts-expect-error

### DIFF
--- a/packages/blockchain/test/customConsensus.spec.ts
+++ b/packages/blockchain/test/customConsensus.spec.ts
@@ -143,7 +143,7 @@ describe('consensus transition checks', () => {
     const blockchain = await Blockchain.create({ common, consensus })
 
     try {
-      await (blockchain as any).checkAndTransitionHardForkByNumber(5n)
+      await blockchain.checkAndTransitionHardForkByNumber(5n)
       assert.ok('checkAndTransitionHardForkByNumber does not throw with custom consensus')
     } catch (err: any) {
       assert.fail(
@@ -151,11 +151,11 @@ describe('consensus transition checks', () => {
       )
     }
 
-    ;(blockchain as any).consensus = new EthashConsensus()
-    ;(blockchain.common as any).consensusAlgorithm = () => 'fibonacci'
+    blockchain.consensus = new EthashConsensus()
+    blockchain.common.consensusAlgorithm = () => 'fibonacci'
 
     try {
-      await (blockchain as any).checkAndTransitionHardForkByNumber(5n)
+      await blockchain.checkAndTransitionHardForkByNumber(5n)
       assert.fail(
         'checkAndTransitionHardForkByNumber should throw when using standard consensus (ethash, clique, casper) but consensus algorithm defined in common is different'
       )

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -995,8 +995,7 @@ async function run() {
       chain: chainName,
       mergeForkIdPostMerge: args.mergeForkIdPostMerge,
     })
-    //@ts-ignore
-    common.customCrypto = cryptoFunctions
+    ;(common.customCrypto as any) = cryptoFunctions
     customGenesisState = parseGethGenesisState(genesisFile)
   }
 

--- a/packages/client/src/net/server/rlpxserver.ts
+++ b/packages/client/src/net/server/rlpxserver.ts
@@ -267,14 +267,10 @@ export class RlpxServer extends Server {
         let peer: RlpxPeer | null = new RlpxPeer({
           config: this.config,
           id: bytesToUnprefixedHex(rlpxPeer.getId()!),
-          // @ts-ignore
-          host: rlpxPeer._socket.remoteAddress!,
-          // @ts-ignore
-          port: rlpxPeer._socket.remotePort!,
+          host: rlpxPeer['_socket'].remoteAddress!,
+          port: rlpxPeer['_socket'].remotePort!,
           protocols: Array.from(this.protocols),
-          // @ts-ignore: Property 'server' does not exist on type 'Socket'.
-          // TODO: check this error
-          inbound: rlpxPeer._socket.server !== undefined,
+          inbound: (rlpxPeer['_socket'] as any).server !== undefined,
         })
         try {
           await peer.accept(rlpxPeer, this)

--- a/packages/client/src/rpc/modules/engine/CLConnectionManager.ts
+++ b/packages/client/src/rpc/modules/engine/CLConnectionManager.ts
@@ -55,7 +55,6 @@ type PayloadToPayloadStats = {
 }
 
 const logCLStatus = (logger: winston.Logger, logMsg: string, logLevel: logLevel) => {
-  //@ts-ignore
   logger[logLevel](enginePrefix + logMsg)
 }
 export class CLConnectionManager {

--- a/packages/client/test/net/server/rlpxserver.spec.ts
+++ b/packages/client/test/net/server/rlpxserver.spec.ts
@@ -159,7 +159,6 @@ describe('should return rlpx server info with ip4 as default', async () => {
   }
   ;(server as any).rlpx = { destroy: vi.fn() }
 
-  // @ts-ignore
   server.rlpx!.id = hexToBytes('0x' + mockId)
   await server.start()
   const nodeInfo = server.getRlpxInfo()
@@ -209,7 +208,6 @@ describe('should return rlpx server info with ip6', async () => {
   }
   ;(server as any).rlpx = { destroy: vi.fn() }
 
-  // @ts-ignore
   server.rlpx!.id = hexToBytes('0x' + mockId)
 
   config.events.on(Event.SERVER_ERROR, (err) => {
@@ -346,8 +344,6 @@ describe('should init rlpx', async () => {
   ;(server as any).peers.set('01', { id: '01' } as any)
   server.rlpx!.events.emit('peer:removed', rlpxPeer)
   server.rlpx!.events.emit('peer:error', rlpxPeer, new Error('err0'))
-
-  // @ts-ignore
-  server.rlpx!.id = hexToBytes('0xff')
+  ;(server.rlpx!.id as any) = hexToBytes('0xff')
   server.rlpx!.events.emit('listening')
 })

--- a/packages/client/test/rpc/engine/kaustinen6.spec.ts
+++ b/packages/client/test/rpc/engine/kaustinen6.spec.ts
@@ -99,8 +99,7 @@ describe(`valid verkle network setup`, async () => {
         testData = JSON.parse(readFileSync(fileName, 'utf8'))[testCase]
         isBeaconData = false
       } else {
-        // @ts-expect-error -- Typescript complains that `testCase` can't index the `blocks` object
-        testData = blocks[testCase]
+        testData = blocks[testCase as keyof typeof blocks]
         isBeaconData = true
       }
       if (testData === undefined) {

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -101,11 +101,9 @@ export async function createClient(clientOpts: Partial<createClientArgs> = {}) {
     savePreimages: clientOpts.savePreimages,
     logger: getLogger({}),
   })
-  const blockchain = clientOpts.blockchain ?? mockBlockchain()
+  const blockchain = clientOpts.blockchain ?? (mockBlockchain() as unknown as Blockchain)
 
-  const chain =
-    // @ts-ignore TODO Move to async Chain.create() initialization
-    clientOpts.chain ?? new Chain({ config, blockchain: blockchain as any, genesisState })
+  const chain = clientOpts.chain ?? (await Chain.create({ config, blockchain, genesisState }))
   chain.opened = true
 
   // if blockchain has not been bundled with chain, add the mock blockchain

--- a/packages/client/test/sync/fetcher/headerfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/headerfetcher.spec.ts
@@ -23,12 +23,13 @@ describe('[HeaderFetcher]', async () => {
     const fetcher = new HeaderFetcher({ config, pool, flow })
     const headers = [{ number: 1 }, { number: 2 }]
     assert.deepEqual(
-      //@ts-ignore
-      fetcher.process({ task: { count: 2 }, peer: 'peer0' }, { headers, bv: BigInt(1) }),
+      fetcher.process(
+        { task: { count: 2 }, peer: 'peer0' } as any,
+        { headers, bv: BigInt(1) } as any
+      ),
       headers as any,
       'got results'
     )
-    //@ts-ignore
     assert.notOk(
       fetcher.process({ task: { count: 2 } } as any, { headers: [], bv: BigInt(1) } as any),
       'bad results'

--- a/packages/client/test/sync/fetcher/storagefetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/storagefetcher.spec.ts
@@ -179,8 +179,6 @@ describe('[StorageFetcher]', async () => {
       JSON.stringify(utf8ToBytes(highestReceivedhash)),
       'should set new highest known hash'
     )
-
-    // @ts-ignore
     ;(job.task.storageRequests[0] as any).first = BigInt(3)
     ;(job.task.storageRequests[0] as any).count = BigInt(4)
     const result = (await fetcher.request(job as any)) as any

--- a/packages/common/test/customChains.spec.ts
+++ b/packages/common/test/customChains.spec.ts
@@ -7,6 +7,8 @@ import * as testnet from './data/testnet.json'
 import * as testnet2 from './data/testnet2.json'
 import * as testnet3 from './data/testnet3.json'
 
+import type { HardforkTransitionConfig } from '../src/index.js'
+
 describe('[Common]: Custom chains', () => {
   it('chain -> object: should provide correct access to private network chain parameters', () => {
     const c = new Common({ chain: testnet, hardfork: Hardfork.Byzantium })
@@ -219,8 +221,7 @@ describe('custom chain setup with hardforks with undefined/null block numbers', 
     ]
 
     assert.throws(
-      //@ts-expect-error -- Disabling type check to verify that error is thrown
-      () => Common.custom({ hardforks: undefinedHardforks }),
+      () => Common.custom({ hardforks: undefinedHardforks as HardforkTransitionConfig[] }),
       undefined,
       undefined,
       'throws when a hardfork with an undefined block number is passed'

--- a/packages/devp2p/examples/peer-communication-les.ts
+++ b/packages/devp2p/examples/peer-communication-les.ts
@@ -36,8 +36,7 @@ const REMOTE_CLIENTID_FILTER = [
   'prichain',
 ]
 
-// @ts-ignore
-const getPeerAddr = (peer: Peer) => `${peer._socket.remoteAddress}:${peer._socket.remotePort}`
+const getPeerAddr = (peer: Peer) => `${peer['_socket'].remoteAddress}:${peer['_socket'].remotePort}`
 
 // DPT
 const dpt = new devp2p.DPT(PRIVATE_KEY, {
@@ -224,11 +223,9 @@ setInterval(() => {
   const peersCount = dpt.getPeers().length
   const openSlots = rlpx._getOpenSlots()
 
-  // @ts-ignore
-  const queueLength = rlpx._peersQueue.length
+  const queueLength = rlpx['_peersQueue'].length
 
-  // @ts-ignore
-  const queueLength2 = rlpx._peersQueue.filter((o) => o.ts <= Date.now()).length
+  const queueLength2 = rlpx['_peersQueue'].filter((o) => o.ts <= Date.now()).length
 
   console.log(
     chalk.yellow(

--- a/packages/devp2p/examples/peer-communication.ts
+++ b/packages/devp2p/examples/peer-communication.ts
@@ -48,8 +48,7 @@ const CHECK_BLOCK_HEADER = RLP.decode(
   '0xf90219a0d44a4d33e28d7ea9edd12b69bd32b394587eee498b0e2543ce2bad1877ffbeaca01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347941ad91ee08f21be3de0ba2ba6918e714da6b45836a0fdec060ee45e55da9e36060fc95dddd0bdc47e447224666a895d9f0dc9adaa0ca0092d9fcc02ca9b372daec726704ce720d3aa366739868f4820ecaabadb9ac309a0974fee017515a46303f467b6fd50872994db1b0ea64d3455bad93ff9678aced9b90100356050004c5c89691add79838a01d4c302419252a4d3c96e9273908b7ee84660886c070607b4928c416a1800746a0d1dbb442d0baf06eea321422263726748600cc200e82aec08336863514d12d665718016989189c116bc0947046cc6718110586c11464a189000a11a41cc96991970153d88840768170244197e164c6204249b9091a0052ac85088c8108a4418dd2903690a036722623888ea14e90458a390a305a2342cb02766094f68c4100036330719848b48411614686717ab6068a46318204232429dc42020608802ceecd66c3c33a3a1fc6e82522049470328a4a81ba07c6604228ba94f008476005087a6804463696b41002650c0fdf548448a90408717ca31b6d618e883bad42083be153b83bdfbb1846078104798307834383639373636353666366532303530366636663663a0ae1de0acd35a98e211c7e276ad7524bb84a5e1b8d33dd7d1c052b095b564e8b888cca66773148b6e12'
 )
 
-// @ts-ignore
-const getPeerAddr = (peer: Peer) => `${peer._socket.remoteAddress}:${peer._socket.remotePort}`
+const getPeerAddr = (peer: Peer) => `${peer['_socket'].remoteAddress}:${peer['_socket'].remotePort}`
 
 // DPT
 const dpt = new devp2p.DPT(PRIVATE_KEY, {
@@ -373,11 +372,9 @@ setInterval(() => {
   const peersCount = dpt.getPeers().length
   const openSlots = rlpx._getOpenSlots()
 
-  // @ts-ignore
-  const queueLength = rlpx._peersQueue.length
+  const queueLength = rlpx['_peersQueue'].length
 
-  // @ts-ignore
-  const queueLength2 = rlpx._peersQueue.filter((o) => o.ts <= Date.now()).length
+  const queueLength2 = rlpx['_peersQueue'].filter((o) => o.ts <= Date.now()).length
 
   console.log(
     chalk.yellow(

--- a/packages/devp2p/src/protocol/eth.ts
+++ b/packages/devp2p/src/protocol/eth.ts
@@ -63,11 +63,9 @@ export class ETH extends Protocol {
 
     if (code !== ETH.MESSAGE_CODES.STATUS && this.DEBUG) {
       const debugMsg = this.DEBUG
-        ? // @ts-ignore
-          `Received ${this.getMsgPrefix(code)} message from ${this._peer._socket.remoteAddress}:${
-            // @ts-ignore
-            this._peer._socket.remotePort
-          }`
+        ? `Received ${this.getMsgPrefix(code)} message from ${
+            this._peer['_socket'].remoteAddress
+          }:${this._peer['_socket'].remotePort}`
         : undefined
       const logData = formatLogData(bytesToHex(data), this._verbose)
       this.debug(this.getMsgPrefix(code), `${debugMsg}: ${logData}`)
@@ -88,12 +86,8 @@ export class ETH extends Protocol {
         if (this.DEBUG) {
           const debugMsg = this.DEBUG
             ? `Received ${this.getMsgPrefix(code)} message from ${
-                // @ts-ignore
-                this._peer._socket.remoteAddress
-              }:${
-                // @ts-ignore
-                this._peer._socket.remotePort
-              }`
+                this._peer['_socket'].remoteAddress
+              }:${this._peer['_socket'].remotePort}`
             : undefined
           this.debug(this.getMsgPrefix(code), `${debugMsg}: ${peerStatusMsg}`)
         }
@@ -302,10 +296,8 @@ export class ETH extends Protocol {
       this.debug(
         'STATUS',
 
-        // @ts-ignore
-        `Send STATUS message to ${this._peer._socket.remoteAddress}:${
-          // @ts-ignore
-          this._peer._socket.remotePort
+        `Send STATUS message to ${this._peer['_socket'].remoteAddress}:${
+          this._peer['_socket'].remotePort
         } (eth${this._version}): ${this._getStatusString(this._status)}`
       )
     }
@@ -313,8 +305,7 @@ export class ETH extends Protocol {
     let payload = RLP.encode(this._status)
 
     // Use snappy compression if peer supports DevP2P >=v5
-    // @ts-ignore
-    if (this._peer._hello !== null && this._peer._hello.protocolVersion >= 5) {
+    if (this._peer['_hello'] !== null && this._peer['_hello'].protocolVersion >= 5) {
       payload = snappy.compress(payload)
     }
 
@@ -326,8 +317,7 @@ export class ETH extends Protocol {
     if (this.DEBUG) {
       const logData = formatLogData(bytesToHex(RLP.encode(payload)), this._verbose)
       const messageName = this.getMsgPrefix(code)
-      // @ts-ignore
-      const debugMsg = `Send ${messageName} message to ${this._peer._socket.remoteAddress}:${this._peer._socket.remotePort}: ${logData}`
+      const debugMsg = `Send ${messageName} message to ${this._peer['_socket'].remoteAddress}:${this._peer['_socket'].remotePort}: ${logData}`
 
       this.debug(messageName, debugMsg)
     }
@@ -369,8 +359,7 @@ export class ETH extends Protocol {
     payload = RLP.encode(payload)
 
     // Use snappy compression if peer supports DevP2P >=v5
-    // @ts-ignore
-    if (this._peer._hello !== null && this._peer._hello.protocolVersion >= 5) {
+    if (this._peer['_hello'] !== null && this._peer['_hello'].protocolVersion >= 5) {
       payload = snappy.compress(payload)
     }
 

--- a/packages/devp2p/src/protocol/les.ts
+++ b/packages/devp2p/src/protocol/les.ts
@@ -49,11 +49,8 @@ export class LES extends Protocol {
         this.debug(
           this.getMsgPrefix(code),
           `${`Received ${this.getMsgPrefix(code)} message from ${
-            (<any>this._peer)._socket.remoteAddress
-          }:${
-            // @ts-ignore
-            this._peer._socket.remotePort
-          }`}: ${logData}`
+            this._peer['_socket'].remoteAddress
+          }:${this._peer['_socket'].remotePort}`}: ${logData}`
         )
       }
     }
@@ -75,10 +72,8 @@ export class LES extends Protocol {
           this.debug(
             this.getMsgPrefix(code),
             `${`Received ${this.getMsgPrefix(code)} message from ${
-              // @ts-ignore
-              this._peer._socket.remoteAddress
-              // @ts-ignore
-            }:${this._peer._socket.remotePort}`}: ${this._getStatusString(this._peerStatus)}`
+              this._peer['_socket'].remoteAddress
+            }:${this._peer['_socket'].remotePort}`}: ${this._getStatusString(this._peerStatus)}`
           )
         }
         this._handleStatus()
@@ -201,10 +196,8 @@ export class LES extends Protocol {
     if (this.DEBUG) {
       this.debug(
         'STATUS',
-        // @ts-ignore
-        `Send STATUS message to ${this._peer._socket.remoteAddress}:${
-          // @ts-ignore
-          this._peer._socket.remotePort
+        `Send STATUS message to ${this._peer['_socket'].remoteAddress}:${
+          this._peer['_socket'].remotePort
         } (les${this._version}): ${this._getStatusString(this._status)}`
       )
     }
@@ -212,8 +205,7 @@ export class LES extends Protocol {
     let payload = RLP.encode(statusList)
 
     // Use snappy compression if peer supports DevP2P >=v5
-    // @ts-ignore
-    if (this._peer._hello !== null && this._peer._hello.protocolVersion >= 5) {
+    if (this._peer['_hello'] !== null && this._peer['_hello'].protocolVersion >= 5) {
       payload = snappy.compress(payload)
     }
 
@@ -230,10 +222,8 @@ export class LES extends Protocol {
     if (this.DEBUG) {
       this.debug(
         this.getMsgPrefix(code),
-        // @ts-ignore
-        `Send ${this.getMsgPrefix(code)} message to ${this._peer._socket.remoteAddress}:${
-          // @ts-ignore
-          this._peer._socket.remotePort
+        `Send ${this.getMsgPrefix(code)} message to ${this._peer['_socket'].remoteAddress}:${
+          this._peer['_socket'].remotePort
         }: ${formatLogData(bytesToHex(RLP.encode(payload)), this._verbose)}`
       )
     }
@@ -278,8 +268,7 @@ export class LES extends Protocol {
     payload = RLP.encode(payload)
 
     // Use snappy compression if peer supports DevP2P >=v5
-    // @ts-ignore
-    if (this._peer._hello !== null && this._peer._hello.protocolVersion >= 5) {
+    if (this._peer['_hello'] !== null && this._peer['_hello'].protocolVersion >= 5) {
       payload = snappy.compress(payload)
     }
 

--- a/packages/devp2p/src/protocol/protocol.ts
+++ b/packages/devp2p/src/protocol/protocol.ts
@@ -63,8 +63,8 @@ export abstract class Protocol {
     }
 
     // Remote Peer IP logger
-    // @ts-ignore
-    const ip = this._peer._socket.remoteAddress
+
+    const ip = this._peer['_socket'].remoteAddress
     if (typeof ip === 'string') {
       this.msgDebuggers[ip] = devp2pDebug.extend(ip)
     }
@@ -77,8 +77,7 @@ export abstract class Protocol {
    * Can be used together with the `devp2p:FIRST_PEER` debugger.
    */
   _addFirstPeerDebugger() {
-    // @ts-ignore
-    const ip = this._peer._socket.remoteAddress
+    const ip = this._peer['_socket'].remoteAddress
     if (typeof ip === 'string') {
       this.msgDebuggers[ip] = devp2pDebug.extend('FIRST_PEER')
       this._peer._addFirstPeerDebugger()
@@ -98,8 +97,7 @@ export abstract class Protocol {
       this.msgDebuggers[messageName](msg)
     }
 
-    // @ts-ignore
-    const ip = this._peer._socket.remoteAddress
+    const ip = this._peer['_socket'].remoteAddress
     if (typeof ip === 'string' && this.msgDebuggers[ip] !== undefined) {
       this.msgDebuggers[ip](msg)
     }

--- a/packages/devp2p/src/protocol/snap.ts
+++ b/packages/devp2p/src/protocol/snap.ts
@@ -28,10 +28,8 @@ export class SNAP extends Protocol {
     if (this.DEBUG) {
       this.debug(
         this.getMsgPrefix(code),
-        // @ts-ignore
-        `Received ${this.getMsgPrefix(code)} message from ${this._peer._socket.remoteAddress}:${
-          // @ts-ignore
-          this._peer._socket.remotePort
+        `Received ${this.getMsgPrefix(code)} message from ${this._peer['_socket'].remoteAddress}:${
+          this._peer['_socket'].remotePort
         }: ${formatLogData(bytesToHex(data), this._verbose)}`
       )
     }
@@ -66,10 +64,8 @@ export class SNAP extends Protocol {
     if (this.DEBUG) {
       this.debug(
         this.getMsgPrefix(code),
-        // @ts-ignore
-        `Send ${this.getMsgPrefix(code)} message to ${this._peer._socket.remoteAddress}:${
-          // @ts-ignore
-          this._peer._socket.remotePort
+        `Send ${this.getMsgPrefix(code)} message to ${this._peer['_socket'].remoteAddress}:${
+          this._peer['_socket'].remotePort
         }: ${formatLogData(utils.bytesToHex(RLP.encode(payload)), this._verbose)}`
       )
     }
@@ -91,8 +87,7 @@ export class SNAP extends Protocol {
     payload = RLP.encode(payload)
 
     // Use snappy compression if peer supports DevP2P >=v5
-    // @ts-ignore
-    const protocolVersion = this._peer._hello?.protocolVersion
+    const protocolVersion = this._peer['_hello']?.protocolVersion
     if (protocolVersion !== undefined && protocolVersion >= 5) {
       payload = snappy.compress(payload)
     }

--- a/packages/devp2p/src/rlpx/peer.ts
+++ b/packages/devp2p/src/rlpx/peer.ts
@@ -174,11 +174,10 @@ export class Peer {
   _sendAck() {
     if (this._closed) return
     this._logger(
-      // @ts-ignore
-      `Send ack (EIP8: ${this._eciesSession._gotEIP8Auth}) to ${this._socket.remoteAddress}:${this._socket.remotePort}`
+      `Send ack (EIP8: ${this._eciesSession['_gotEIP8Auth']}) to ${this._socket.remoteAddress}:${this._socket.remotePort}`
     )
-    // @ts-ignore
-    if (this._eciesSession._gotEIP8Auth) {
+
+    if (this._eciesSession['_gotEIP8Auth']) {
       const ackEIP8 = this._eciesSession.createAckEIP8()
       if (!ackEIP8) return
       this._socket.write(ackEIP8)
@@ -315,13 +314,11 @@ export class Peer {
   _handleAuth() {
     const bytesCount = this._nextPacketSize
     const parseData = this._socketData.subarray(0, bytesCount)
-    // @ts-ignore
-    if (!this._eciesSession._gotEIP8Auth) {
+    if (!this._eciesSession['_gotEIP8Auth']) {
       if (parseData.subarray(0, 1) === hexToBytes('0x04')) {
         this._eciesSession.parseAuthPlain(parseData)
       } else {
-        // @ts-ignore
-        this._eciesSession._gotEIP8Auth = true
+        this._eciesSession['_gotEIP8Auth'] = true
         this._nextPacketSize = bytesToInt(this._socketData.subarray(0, 2)) + 2
         return
       }
@@ -340,16 +337,14 @@ export class Peer {
   _handleAck() {
     const bytesCount = this._nextPacketSize
     const parseData = this._socketData.subarray(0, bytesCount)
-    // @ts-ignore
-    if (!this._eciesSession._gotEIP8Ack) {
+    if (!this._eciesSession['_gotEIP8Ack']) {
       if (parseData.subarray(0, 1) === hexToBytes('0x04')) {
         this._eciesSession.parseAckPlain(parseData)
         this._logger(
           `Received ack (old format) from ${this._socket.remoteAddress}:${this._socket.remotePort}`
         )
       } else {
-        // @ts-ignore
-        this._eciesSession._gotEIP8Ack = true
+        this._eciesSession['_gotEIP8Ack'] = true
         this._nextPacketSize = bytesToInt(this._socketData.subarray(0, 2)) + 2
         return
       }

--- a/packages/devp2p/src/rlpx/rlpx.ts
+++ b/packages/devp2p/src/rlpx/rlpx.ts
@@ -284,10 +284,8 @@ export class RLPx {
           this._peersQueue.push({
             peer: {
               id: peer.getId()!,
-              // @ts-ignore
-              address: peer._socket.remoteAddress,
-              // @ts-ignore
-              tcpPort: peer._socket.remotePort,
+              address: peer['_socket'].remoteAddress,
+              tcpPort: peer['_socket'].remotePort,
             },
             ts: (Date.now() + 300000) as number, // 5 min * 60 * 1000
           })

--- a/packages/devp2p/test/integration/dpt-simulator.spec.ts
+++ b/packages/devp2p/test/integration/dpt-simulator.spec.ts
@@ -56,8 +56,7 @@ describe('DPT simulator tests', () => {
         dpts[0].banPeer(peer)
       })
       dpts[0].events.once('peer:removed', async (peer) => {
-        // @ts-ignore
-        assert.equal(dpts[0]._banlist.has(peer), true, 'ban-list should contain peer')
+        assert.equal(dpts[0]['_banlist'].has(peer), true, 'ban-list should contain peer')
         assert.equal(
           dpts[0].getPeers().length,
           0,
@@ -142,8 +141,7 @@ describe('DPT simulator tests', () => {
       dpts[0].destroy()
       assert.ok(true, 'got peer from DNS')
     }
-    // @ts-ignore
-    dpts[0]._dns.__setNativeDNSModuleResolve(mockDns)
+    dpts[0]['_dns'].__setNativeDNSModuleResolve(mockDns)
     await dpts[0].refresh()
   })
 })

--- a/packages/devp2p/test/integration/util.ts
+++ b/packages/devp2p/test/integration/util.ts
@@ -84,8 +84,7 @@ export function getTestRLPXs(
   const dpts = getTestDPTs(numRLPXs, basePort)
 
   for (let i = 0; i < numRLPXs; ++i) {
-    // @ts-ignore
-    const rlpx = new RLPx(dpts[i]._privateKey, {
+    const rlpx = new RLPx(dpts[i]['_privateKey'], {
       dpt: dpts[i],
       maxPeers,
       capabilities,

--- a/packages/statemanager/test/proofStateManager.spec.ts
+++ b/packages/statemanager/test/proofStateManager.spec.ts
@@ -118,8 +118,7 @@ describe('ProofStateManager', () => {
       if (stateRoot === undefined) {
         stateRoot = key
       }
-      // @ts-expect-error
-      await trie._db.put(key, bufferData)
+      await trie['_db'].put(key, bufferData)
     }
     trie.root(stateRoot!)
     const proof = await stateManager.getProof(address)
@@ -143,8 +142,7 @@ describe('ProofStateManager', () => {
       if (stateRoot === undefined) {
         stateRoot = key
       }
-      // @ts-expect-error
-      await trie._db.put(key, bufferData)
+      await trie['_db'].put(key, bufferData)
     }
     trie.root(stateRoot!)
     const proof = await stateManager.getProof(address)
@@ -168,8 +166,7 @@ describe('ProofStateManager', () => {
       if (stateRoot === undefined) {
         stateRoot = key
       }
-      // @ts-expect-error
-      await trie._db.put(key, bufferData)
+      await trie['_db'].put(key, bufferData)
     }
     const storageRoot = ropsten_contractWithStorage.storageHash
     const storageTrie = new Trie({ useKeyHashing: true })
@@ -178,8 +175,7 @@ describe('ProofStateManager', () => {
       storageKeys.push(hexToBytes(storageProofsData.key))
       for (const storageProofData of storageProofsData.proof) {
         const key = keccak256(hexToBytes(storageProofData))
-        // @ts-expect-error
-        await storageTrie._db.put(key, hexToBytes(storageProofData))
+        await storageTrie['_db'].put(key, hexToBytes(storageProofData))
       }
     }
     storageTrie.root(hexToBytes(storageRoot))
@@ -208,8 +204,7 @@ describe('ProofStateManager', () => {
       if (stateRoot === undefined) {
         stateRoot = key
       }
-      // @ts-expect-error
-      await trie._db.put(key, bufferData)
+      await trie['_db'].put(key, bufferData)
     }
     const storageRoot = ropsten_contractWithStorage.storageHash
     const storageTrie = new Trie({ useKeyHashing: true })
@@ -218,8 +213,7 @@ describe('ProofStateManager', () => {
       storageKeys.push(hexToBytes(storageProofsData.key))
       for (const storageProofData of storageProofsData.proof) {
         const key = keccak256(hexToBytes(storageProofData))
-        // @ts-expect-error
-        await storageTrie._db.put(key, hexToBytes(storageProofData))
+        await storageTrie['_db'].put(key, hexToBytes(storageProofData))
       }
     }
     storageTrie.root(hexToBytes(storageRoot))
@@ -276,8 +270,7 @@ describe('ProofStateManager', () => {
       if (stateRoot === undefined) {
         stateRoot = key
       }
-      // @ts-expect-error
-      await trie._db.put(key, bufferData)
+      await trie['_db'].put(key, bufferData)
     }
     const storageRoot = ropsten_nonexistentAccount.storageHash
     const storageTrie = new Trie({ useKeyHashing: true })

--- a/packages/statemanager/test/stateManager.code.spec.ts
+++ b/packages/statemanager/test/stateManager.code.spec.ts
@@ -16,7 +16,6 @@ describe('StateManager -> Code', () => {
         This test is mostly an example of why a code prefix is necessary
         I an address, we put two storage values. The preimage of the (storage trie) root hash is known
         This preimage is used as codeHash
-  
         NOTE: Currently, the only problem which this code prefix fixes, is putting 0x80 as contract code
         -> This hashes to the empty trie node hash (0x80 = RLP([])), so keccak256(0x80) = empty trie node hash
         -> Therefore, each empty state trie now points to 0x80, which is not a valid trie node, which crashes @ethereumjs/trie
@@ -34,8 +33,7 @@ describe('StateManager -> Code', () => {
       await stateManager.putContractStorage(address1, key1, key2)
       await stateManager.putContractStorage(address1, key2, key2)
       const root = await stateManager.getStateRoot()
-      // @ts-expect-error
-      const rawNode = await stateManager._trie._db.get(root)
+      const rawNode = await stateManager['_trie']['_db'].get(root)
 
       await codeStateManager.putContractCode(address1, rawNode!)
 

--- a/packages/trie/src/db/checkpoint.ts
+++ b/packages/trie/src/db/checkpoint.ts
@@ -55,7 +55,6 @@ export class CheckpointDB implements DB {
     this.checkpoints = []
 
     if (this.cacheSize > 0) {
-      // @ts-ignore
       this._cache = new LRUCache({
         max: this.cacheSize,
         updateAgeOnGet: true,

--- a/packages/trie/test/index.spec.ts
+++ b/packages/trie/test/index.spec.ts
@@ -252,8 +252,7 @@ for (const keyPrefix of [undefined, hexToBytes('0x1234')]) {
         assert.ok(path.node !== null, 'findPath should find a node')
 
         const { stack } = await trie.findPath(utf8ToBytes('aaa'))
-        // @ts-expect-error
-        await trie._db.del(keccak256(stack[1].serialize())) // delete the BranchNode -> value1 from the DB
+        await trie['_db'].del(keccak256(stack[1].serialize())) // delete the BranchNode -> value1 from the DB
 
         path = await trie.findPath(utf8ToBytes('aaa'))
 

--- a/packages/trie/test/trie/checkpoint.spec.ts
+++ b/packages/trie/test/trie/checkpoint.spec.ts
@@ -64,8 +64,7 @@ describe('testing checkpoints', () => {
   it('should copy trie and get upstream and cache values after checkpoint', async () => {
     trieCopy = trie.shallowCopy()
     assert.equal(bytesToHex(trieCopy.root()), postRoot)
-    // @ts-expect-error
-    assert.equal(trieCopy._db.checkpoints.length, 1)
+    assert.equal(trieCopy['_db'].checkpoints.length, 1)
     assert.ok(trieCopy.hasCheckpoints())
     const res = await trieCopy.get(utf8ToBytes('do'))
     assert.ok(equalsBytes(utf8ToBytes('verb'), res!))
@@ -234,8 +233,7 @@ describe('testing checkpoints', () => {
     // The CommittedState should not change (not the key/value pairs, not the root, and not the root in DB)
     assert.equal(bytesToUtf8((await CommittedState.get(KEY))!), '1')
     assert.equal(
-      // @ts-expect-error
-      bytesToHex(await CommittedState._db.get(KEY_ROOT)),
+      bytesToHex((await CommittedState['_db'].get(KEY_ROOT))!),
       '0x77ddd505d2a5b76a2a6ee34b827a0d35ca19f8d358bee3d74a84eab59794487c'
     )
     assert.equal(
@@ -244,9 +242,9 @@ describe('testing checkpoints', () => {
     )
 
     // From MemoryState, now take the final checkpoint
-    const finalCheckpoint = (<any>MemoryState)._db.checkpoints[0]
+    const finalCheckpoint = MemoryState['_db'].checkpoints[0]
     // Insert this into CommittedState
-    ;(<any>CommittedState)._db.checkpoints.push(finalCheckpoint)
+    CommittedState['_db'].checkpoints.push(finalCheckpoint)
 
     // Now all operations done on MemoryState (including pruning) can be
     // committed into CommittedState

--- a/packages/trie/test/trie/trie.spec.ts
+++ b/packages/trie/test/trie/trie.spec.ts
@@ -90,13 +90,11 @@ for (const { constructor, defaults, title } of [
         useRootPersistence: true,
       })
 
-      // @ts-expect-error
-      assert.equal(await trie._db.get(ROOT_DB_KEY), undefined)
+      assert.equal(await trie['_db'].get(ROOT_DB_KEY), undefined)
 
       await trie.put(utf8ToBytes('foo'), utf8ToBytes('bar'))
 
-      // @ts-expect-error
-      assert.equal(bytesToHex(await trie._db.get(ROOT_DB_KEY)), EXPECTED_ROOTS)
+      assert.equal(bytesToHex((await trie['_db'].get(ROOT_DB_KEY))!), EXPECTED_ROOTS)
     })
 
     it('persist the root if the `root` option is given', async () => {
@@ -107,13 +105,11 @@ for (const { constructor, defaults, title } of [
         useRootPersistence: true,
       })
 
-      // @ts-expect-error
-      assert.ok(equalsBytes((await trie._db.get(ROOT_DB_KEY))!, KECCAK256_RLP))
+      assert.ok(equalsBytes((await trie['_db'].get(ROOT_DB_KEY))!, KECCAK256_RLP))
 
       await trie.put(utf8ToBytes('foo'), utf8ToBytes('bar'))
 
-      // @ts-expect-error
-      assert.isFalse(equalsBytes((await trie._db.get(ROOT_DB_KEY))!, KECCAK256_RLP))
+      assert.isFalse(equalsBytes((await trie['_db'].get(ROOT_DB_KEY))!, KECCAK256_RLP))
     })
 
     it('does not persist the root if the `useRootPersistence` option is `false`', async () => {
@@ -123,41 +119,34 @@ for (const { constructor, defaults, title } of [
         useRootPersistence: false,
       })
 
-      // @ts-expect-error
-      assert.equal(await trie._db.get(ROOT_DB_KEY), undefined)
+      assert.equal(await trie['_db'].get(ROOT_DB_KEY), undefined)
 
       await trie.put(utf8ToBytes('do_not_persist_with_db'), utf8ToBytes('bar'))
 
-      // @ts-expect-error
-      assert.equal(await trie._db.get(ROOT_DB_KEY), undefined)
+      assert.equal(await trie['_db'].get(ROOT_DB_KEY), undefined)
     })
 
     it('persists the root if the `db` option is not provided', async () => {
       const trie = await constructor.create({ ...defaults, useRootPersistence: true })
 
-      // @ts-expect-error
-      assert.equal(await trie._db.get(ROOT_DB_KEY), undefined)
+      assert.equal(await trie['_db'].get(ROOT_DB_KEY), undefined)
 
       await trie.put(utf8ToBytes('do_not_persist_without_db'), utf8ToBytes('bar'))
 
-      // @ts-expect-error
-      assert.notEqual(await trie._db.get(ROOT_DB_KEY), undefined)
+      assert.notEqual(await trie['_db'].get(ROOT_DB_KEY), undefined)
     })
 
     it('persist and restore the root', async () => {
       const db = new MapDB<string, string>()
 
       const trie = await constructor.create({ ...defaults, db, useRootPersistence: true })
-      // @ts-expect-error
-      assert.equal(await trie._db.get(ROOT_DB_KEY), undefined)
+      assert.equal(await trie['_db'].get(ROOT_DB_KEY), undefined)
       await trie.put(utf8ToBytes('foo'), utf8ToBytes('bar'))
-      // @ts-expect-error
-      assert.equal(bytesToHex(await trie._db.get(ROOT_DB_KEY)), EXPECTED_ROOTS)
+      assert.equal(bytesToHex((await trie['_db'].get(ROOT_DB_KEY))!), EXPECTED_ROOTS)
 
       // Using the same database as `trie` so we should have restored the root
       const copy = await constructor.create({ ...defaults, db, useRootPersistence: true })
-      // @ts-expect-error
-      assert.equal(bytesToHex(await copy._db.get(ROOT_DB_KEY)), EXPECTED_ROOTS)
+      assert.equal(bytesToHex((await copy['_db'].get(ROOT_DB_KEY))!), EXPECTED_ROOTS)
 
       // New trie with a new database so we shouldn't find a root to restore
       const empty = await constructor.create({
@@ -165,8 +154,7 @@ for (const { constructor, defaults, title } of [
         db: new MapDB(),
         useRootPersistence: true,
       })
-      // @ts-expect-error
-      assert.equal(await empty._db.get(ROOT_DB_KEY), undefined)
+      assert.equal(await empty['_db'].get(ROOT_DB_KEY), undefined)
     })
 
     it('put fails if the key is the ROOT_DB_KEY', async () => {

--- a/packages/tx/test/fromRpc.spec.ts
+++ b/packages/tx/test/fromRpc.spec.ts
@@ -9,6 +9,8 @@ import optimismTx from './json/optimismTx.json'
 import rpcTx from './json/rpcTx.json'
 import v0Tx from './json/v0tx.json'
 
+import type { TypedTxData } from '../src/index.js'
+
 const txTypes = [
   TransactionType.Legacy,
   TransactionType.AccessListEIP2930,
@@ -77,7 +79,7 @@ describe('fromRPC: interpret v/r/s vals of 0x0 as undefined for Optimism system 
   it('should work', async () => {
     for (const txType of txTypes) {
       ;(optimismTx as any).type = txType
-      const tx = await TransactionFactory.fromRPC(optimismTx)
+      const tx = await TransactionFactory.fromRPC(optimismTx as TypedTxData)
       assert.ok(tx.v === undefined)
       assert.ok(tx.s === undefined)
       assert.ok(tx.r === undefined)
@@ -96,7 +98,7 @@ describe('fromRPC: ensure `v="0x0"` is correctly decoded for signed txs', () => 
         continue
       }
       ;(v0Tx as any).type = txType
-      const tx = await TransactionFactory.fromRPC(v0Tx)
+      const tx = await TransactionFactory.fromRPC(v0Tx as TypedTxData)
       assert.ok(tx.isSigned())
     }
   })

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -291,7 +291,7 @@ export class VM {
 
     // Order of columns to report (see `EVMPerformanceLogOutput` type)
 
-    const colOrder = [
+    const colOrder: (keyof EVMPerformanceLogOutput)[] = [
       'tag',
       'calls',
       'avgTimePerCall',
@@ -335,11 +335,9 @@ export class VM {
       let ins = 0
       colLength[ins] = Math.max(colLength[ins] ?? 0, strLen(colNames[ins]))
       for (const key of colOrder) {
-        // @ts-ignore
         if (entry[key] !== undefined) {
           // If entry is available, max out the current column length (this will be the longest string of this column)
-          //@ts-ignore
-          colLength[ins] = Math.max(colLength[ins] ?? 0, strLen(entry[key]))
+          colLength[ins] = Math.max(colLength[ins] ?? 0, strLen(entry[key]!))
           ins++
           // In this switch statement update the total calls / time / gas used
           switch (key) {
@@ -408,10 +406,8 @@ export class VM {
       let str = ''
       let i = 0
       for (const key of colOrder) {
-        //@ts-ignore
         if (entry[key] !== undefined) {
-          //@ts-ignore
-          str += '|' + padStr(entry[key], colLength[i])
+          str += '|' + padStr(entry[key]!, colLength[i])
           i++
         }
       }

--- a/packages/vm/test/api/runBlock.spec.ts
+++ b/packages/vm/test/api/runBlock.spec.ts
@@ -23,6 +23,7 @@ import type {
   PreByzantiumTxReceipt,
   RunBlockOpts,
 } from '../../src/types'
+import type { DefaultStateManager } from '@ethereumjs/statemanager'
 import type { TypedTransaction } from '@ethereumjs/tx'
 
 const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Berlin })
@@ -35,20 +36,17 @@ describe('runBlock() -> successful API parameter usage', async () => {
     const blockRlp = toBytes(testData.blocks[0].rlp)
     const block = Block.fromRLPSerializedBlock(blockRlp, { common })
 
-    //@ts-ignore
     await setupPreConditions(vm.stateManager, testData)
 
     assert.deepEqual(
-      //@ts-ignore
-      vm.stateManager._trie.root(),
+      (vm.stateManager as DefaultStateManager)['_trie'].root(),
       genesis.header.stateRoot,
       'genesis state root should match calculated state root'
     )
 
     const res = await vm.runBlock({
       block,
-      // @ts-ignore
-      root: vm.stateManager._trie.root(),
+      root: (vm.stateManager as DefaultStateManager)['_trie'].root(),
       skipBlockValidation: true,
       skipHardForkValidation: true,
     })
@@ -70,8 +68,7 @@ describe('runBlock() -> successful API parameter usage', async () => {
     const block1 = Block.fromRLPSerializedBlock(block1Rlp, { common })
     await vm.runBlock({
       block: block1,
-      // @ts-ignore
-      root: vm.stateManager._trie.root(),
+      root: (vm.stateManager as DefaultStateManager)['_trie'].root(),
       skipBlockValidation: true,
       skipHardForkValidation: true,
     })
@@ -80,8 +77,8 @@ describe('runBlock() -> successful API parameter usage', async () => {
     const block2 = Block.fromRLPSerializedBlock(block2Rlp, { common })
     await vm.runBlock({
       block: block2,
-      // @ts-ignore
-      root: vm.stateManager._trie.root(),
+
+      root: (vm.stateManager as DefaultStateManager)['_trie'].root(),
       skipBlockValidation: true,
       skipHardForkValidation: true,
     })
@@ -90,8 +87,8 @@ describe('runBlock() -> successful API parameter usage', async () => {
     const block3 = Block.fromRLPSerializedBlock(block3Rlp, { common })
     await vm.runBlock({
       block: block3,
-      // @ts-ignore
-      root: vm.stateManager._trie.root(),
+
+      root: (vm.stateManager as DefaultStateManager)['_trie'].root(),
       skipBlockValidation: true,
       skipHardForkValidation: true,
     })
@@ -214,7 +211,6 @@ describe('runBlock() -> API parameter usage/data errors', async () => {
 
     const block = Block.fromBlockData({
       header: {
-        ...testData.blocks[0].header,
         gasLimit: hexToBytes('0x8000000000000000'),
       },
     })
@@ -290,7 +286,7 @@ describe('runBlock() -> runtime behavior', async () => {
     // edit extra data of this block to "dao-hard-fork"
     block1[0][12] = utf8ToBytes('dao-hard-fork')
     const block = Block.fromValuesArray(block1, { common })
-    // @ts-ignore
+
     await setupPreConditions(vm.stateManager, testData)
 
     // fill two original DAO child-contracts with funds and the recovery account with funds in order to verify that the balance gets summed correctly
@@ -427,7 +423,6 @@ async function runWithHf(hardfork: string) {
   const blockRlp = toBytes(testData.blocks[0].rlp)
   const block = Block.fromRLPSerializedBlock(blockRlp, { common })
 
-  // @ts-ignore
   await setupPreConditions(vm.stateManager, testData)
 
   const res = await vm.runBlock({
@@ -464,15 +459,14 @@ describe('runBlock() -> tx types', async () => {
     const blockRlp = toBytes(testData.blocks[0].rlp)
     const block = Block.fromRLPSerializedBlock(blockRlp, { common, freeze: false })
 
-    //@ts-ignore overwrite transactions
+    //@e transactions
     block.transactions = transactions
 
     if (transactions.some((t) => t.supports(Capability.EIP1559FeeMarket))) {
-      // @ts-ignore overwrite read-only property
+      // @e read-only property
       block.header.baseFeePerGas = BigInt(7)
     }
 
-    //@ts-ignore
     await setupPreConditions(vm.stateManager, testData)
 
     const res = await vm.runBlock({

--- a/packages/vm/test/api/state/accountExists.spec.ts
+++ b/packages/vm/test/api/state/accountExists.spec.ts
@@ -4,6 +4,8 @@ import { assert, describe, it } from 'vitest'
 
 import { VM } from '../../../src/vm'
 
+import type { DefaultStateManager } from '@ethereumjs/statemanager'
+
 describe('correctly apply new account gas fee on pre-Spurious Dragon hardforks', () => {
   it('should work', async () => {
     // This transaction https://etherscan.io/tx/0x26ea8719eeca5737f8ca872bca1ac53cea9bf6e11462dd83317c2e66a4e43d7b produced an error
@@ -68,9 +70,11 @@ describe('do not apply new account gas fee for empty account in DB on pre-Spurio
     // add empty account to DB
     const emptyAddress = new Address(hexToBytes('0xf48a1bdc65d9ccb4b569ffd4bffff415b90783d6'))
     await vm.stateManager.putAccount(emptyAddress, new Account())
-    const emptyAccount = await vm.stateManager.getAccount(emptyAddress)
-    //@ts-ignore
-    await vm.stateManager._trie.put(toBytes(emptyAddress), emptyAccount.serialize())
+    const emptyAccount = (await vm.stateManager.getAccount(emptyAddress)) as Account
+    await (vm.stateManager as DefaultStateManager)['_trie'].put(
+      toBytes(emptyAddress),
+      emptyAccount.serialize()
+    )
     await vm.stateManager.putContractCode(contractAddress, hexToBytes(code)) // setup the contract code
     await vm.stateManager.putContractStorage(
       contractAddress,


### PR DESCRIPTION
This PR cleanups several instances where ts-ignore or ts-expect-errors was used, instead replacing them with less intrusive TypeScript solutions.

Notably, these TypeScript tags were very often used to ignore TS errors related to access of protected object properties. Instead, these properties can be accessed (without error) by the string literal. 

Here's an example:
```
 TS error:
if (this._eciesSession._gotEIP8Auth) {

No TS error:
if (this._eciesSession['_gotEIP8Auth']) {
 ```