### PR TITLE
Client: Fix Node 20 Nightly Test Runs

### DIFF
--- a/packages/client/test/integration/beaconsync.spec.ts
+++ b/packages/client/test/integration/beaconsync.spec.ts
@@ -38,7 +38,7 @@ describe('should sync blocks', async () => {
     await destroy(remoteServer, remoteService)
   })
   await localService.synchronizer!.start()
-})
+}, 30000)
 
 describe('should not sync with stale peers', async () => {
   const [remoteServer, remoteService] = await setup({ location: '127.0.0.2', height: 9, common })
@@ -57,7 +57,7 @@ describe('should not sync with stale peers', async () => {
   })
   await destroy(localServer, localService)
   await destroy(remoteServer, remoteService)
-})
+}, 30000)
 
 describe('should sync with best peer', async () => {
   const [remoteServer1, remoteService1] = await setup({
@@ -99,4 +99,4 @@ describe('should sync with best peer', async () => {
     await destroy(remoteServer2, remoteService2)
   })
   await localService.synchronizer!.start()
-})
+}, 30000)


### PR DESCRIPTION
Currently the nightly Node 20 tests are failing, see e.g. [here](https://github.com/ethereumjs/ethereumjs-monorepo/actions/runs/8776976521/job/24081258740), the beacon sync integration tests are timing out:

<img width="1023" alt="grafik" src="https://github.com/ethereumjs/ethereumjs-monorepo/assets/931137/2c0210c6-b84c-4c92-b60f-653ba475e3b4">

This is an attempt to fix, ready to be merged (I would not want to create an extra PR proof-of-success test setup, unreasonable effort).

There is a specific test case named in the failing test run, but since tests are async might not be directly attributable, so I just increased timeouts for all tests.