### PR TITLE
Client: Better --execution Flag Guard

### DIFF
--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -590,7 +590,7 @@ export class VMExecution extends Execution {
    * @returns number of blocks executed
    */
   async run(loop = true, runOnlybatched = false): Promise<number> {
-    if (this.running || !this.started || this.config.shutdown) return 0
+    if (this.running || !this.started || !this.config.execution || this.config.shutdown) return 0
 
     return this.runWithLock<number>(async () => {
       try {


### PR DESCRIPTION
When I just tested the client on the ESM build with `npm run client:start -- --execution=false` I realized that the execution flag is ignored and execution started nevertheless.

This is likely since we have various execution entrypoints atm and it is likely that at least one gets triggered in an non-expected context.

This small PR adds a better guard in the execution `run()` method directly to avoid this kind of scenarios. Should be safe to merge since the `--execution` flag is used with very much a clear intention and so this cannot have side effects on beacon sync or whatsoever on normal runs.