### PR TITLE
Extend EIP 4844 transaction toJson data to include additional fields

### DIFF
--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -32,6 +32,7 @@ import type {
   TxData as AllTypesTxData,
   TxValuesArray as AllTypesTxValuesArray,
   BlobEIP4844NetworkValuesArray,
+  ExtendedJsonTx,
   JsonTx,
   TxOptions,
 } from './types.js'
@@ -551,6 +552,26 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
    */
   public getSenderPublicKey(): Uint8Array {
     return Legacy.getSenderPublicKey(this)
+  }
+
+  public static networkWrapperToJson(serialized: Uint8Array, opts?: TxOptions): ExtendedJsonTx {
+    const tx = this.fromSerializedBlobTxNetworkWrapper(serialized, opts)
+
+    const accessListJSON = AccessLists.getAccessListJSON(tx.accessList)
+    const baseJson = tx.toJSON()
+
+    return {
+      ...baseJson,
+      chainId: bigIntToHex(tx.chainId),
+      maxPriorityFeePerGas: bigIntToHex(tx.maxPriorityFeePerGas),
+      maxFeePerGas: bigIntToHex(tx.maxFeePerGas),
+      accessList: accessListJSON,
+      maxFeePerBlobGas: bigIntToHex(tx.maxFeePerBlobGas),
+      blobVersionedHashes: tx.blobVersionedHashes.map((hash) => bytesToHex(hash)),
+      blobs: tx.blobs!.map((bytes) => bytesToHex(bytes)),
+      kzgCommitments: tx.kzgCommitments!.map((bytes) => bytesToHex(bytes)),
+      kzgProofs: tx.kzgProofs!.map((bytes) => bytesToHex(bytes)),
+    }
   }
 
   toJSON(): JsonTx {

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -366,7 +366,6 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
    * @param opts any TxOptions defined
    * @returns a BlobEIP4844Transaction
    */
-
   public static fromSerializedBlobTxNetworkWrapper(
     serialized: Uint8Array,
     opts?: TxOptions

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -461,6 +461,12 @@ export interface JsonTx {
   blobVersionedHashes?: PrefixedHexString[]
 }
 
+export type ExtendedJsonTx = JsonTx & {
+  blobs: PrefixedHexString[]
+  kzgCommitments: PrefixedHexString[]
+  kzgProofs: PrefixedHexString[]
+}
+
 /*
  * Based on https://ethereum.org/en/developers/docs/apis/json-rpc/
  */

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -285,6 +285,35 @@ describe('Network wrapper tests', () => {
     const signedTx = unsignedTx.sign(pk)
     const sender = signedTx.getSenderAddress().toString()
     const wrapper = signedTx.serializeNetworkWrapper()
+
+    const jsonData = BlobEIP4844Transaction.networkWrapperToJson(wrapper, { common })
+    assert.equal(jsonData.blobs?.length, blobs.length, 'contains the correct number of blobs')
+    for (let i = 0; i < jsonData.blobs.length; i++) {
+      const b1 = jsonData.blobs[i]
+      const b2 = bytesToHex(signedTx.blobs![i])
+      assert.equal(b1, b2, 'contains the same blobs')
+    }
+    assert.equal(
+      jsonData.kzgCommitments?.length,
+      signedTx.kzgCommitments!.length,
+      'contains the correct number of commitments'
+    )
+    for (let i = 0; i < jsonData.kzgCommitments.length; i++) {
+      const c1 = jsonData.kzgCommitments[i]
+      const c2 = bytesToHex(signedTx.kzgCommitments![i])
+      assert.equal(c1, c2, 'contains the same commitments')
+    }
+    assert.equal(
+      jsonData.kzgProofs?.length,
+      signedTx.kzgProofs!.length,
+      'contains the correct number of proofs'
+    )
+    for (let i = 0; i < jsonData.kzgProofs.length; i++) {
+      const p1 = jsonData.kzgProofs[i]
+      const p2 = bytesToHex(signedTx.kzgProofs![i])
+      assert.equal(p1, p2, 'contains the same proofs')
+    }
+
     const deserializedTx = BlobEIP4844Transaction.fromSerializedBlobTxNetworkWrapper(wrapper, {
       common,
     })


### PR DESCRIPTION
This change adds a new `networkWrapperToJson` function that extends the data already returned by the `toJson` function of the `BlobEIP4844Transaction` to also include blobs, commitments, and proofs as hexadecimal strings.