### PR TITLE
common: add spec test for 2935 contract code and update history storage address

### DIFF
--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -222,7 +222,7 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     vm: {
       historyStorageAddress: {
-        v: BigInt('0xfffffffffffffffffffffffffffffffffffffffe'),
+        v: BigInt('0x25a219378dad9b3503c8268c9ca836a52427a4fb'),
         d: 'The address where the historical blockhashes are stored',
       },
       historyServeWindow: {

--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -534,6 +534,12 @@ export const EIPs: EIPsDict = {
         v: 0,
         d: 'Gas cost of the first read of storage from a given location (per transaction)',
       },
+      // kaustinen 6 current uses this address, however this will be updated to correct address
+      // in next iteration
+      historyStorageAddress: {
+        v: BigInt('0xfffffffffffffffffffffffffffffffffffffffe'),
+        d: 'The address where the historical blockhashes are stored',
+      },
     },
   },
   7002: {

--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -534,6 +534,8 @@ export const EIPs: EIPsDict = {
         v: 0,
         d: 'Gas cost of the first read of storage from a given location (per transaction)',
       },
+    },
+    vm: {
       // kaustinen 6 current uses this address, however this will be updated to correct address
       // in next iteration
       historyStorageAddress: {

--- a/packages/common/src/hardforks.ts
+++ b/packages/common/src/hardforks.ts
@@ -849,6 +849,6 @@ export const hardforks: HardforksDict = {
       'Next feature hardfork after prague, internally used for verkle testing/implementation (incomplete/experimental)',
     url: 'https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/osaka.md',
     status: Status.Draft,
-    eips: [6800, 2935],
+    eips: [2935, 6800],
   },
 }


### PR DESCRIPTION
test the 2935 contract code as per the eip
 - https://eips.ethereum.org/EIPS/eip-2935
 
and update history save address, however old address is till overriden for kaustine6 (tested and verified) 

its likely that the code and hence address will be modified at which point the address and the code for testing will be updated