### PR TITLE
Remove unnecessary boolean comparisons when using isActivatedEIP

### DIFF
--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -559,7 +559,7 @@ export class Block {
     // eslint-disable-next-line prefer-const
     for (let [i, tx] of this.transactions.entries()) {
       const errs = tx.getValidationErrors()
-      if (this.common.isActivatedEIP(1559) === true) {
+      if (this.common.isActivatedEIP(1559)) {
         if (tx.supports(Capability.EIP1559FeeMarket)) {
           tx = tx as FeeMarketEIP1559Transaction
           if (tx.maxFeePerGas < this.header.baseFeePerGas!) {
@@ -572,7 +572,7 @@ export class Block {
           }
         }
       }
-      if (this.common.isActivatedEIP(4844) === true) {
+      if (this.common.isActivatedEIP(4844)) {
         if (tx instanceof BlobEIP4844Transaction) {
           blobGasUsed += BigInt(tx.numBlobs()) * blobGasPerBlob
           if (blobGasUsed > blobGasLimit) {
@@ -587,7 +587,7 @@ export class Block {
       }
     }
 
-    if (this.common.isActivatedEIP(4844) === true) {
+    if (this.common.isActivatedEIP(4844)) {
       if (blobGasUsed !== this.header.blobGasUsed) {
         errors.push(`invalid blobGasUsed expected=${this.header.blobGasUsed} actual=${blobGasUsed}`)
       }

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -76,7 +76,7 @@ export class BlockHeader {
    * EIP-4399: After merge to PoS, `mixHash` supplanted as `prevRandao`
    */
   get prevRandao() {
-    if (this.common.isActivatedEIP(4399) === false) {
+    if (!this.common.isActivatedEIP(4399)) {
       const msg = this._errorMsg(
         'The prevRandao parameter can only be accessed when EIP-4399 is activated'
       )
@@ -361,7 +361,7 @@ export class BlockHeader {
     }
 
     // Validation for EIP-1559 blocks
-    if (this.common.isActivatedEIP(1559) === true) {
+    if (this.common.isActivatedEIP(1559)) {
       if (typeof this.baseFeePerGas !== 'bigint') {
         const msg = this._errorMsg('EIP1559 block has no base fee field')
         throw new Error(msg)
@@ -380,7 +380,7 @@ export class BlockHeader {
       }
     }
 
-    if (this.common.isActivatedEIP(4895) === true) {
+    if (this.common.isActivatedEIP(4895)) {
       if (this.withdrawalsRoot === undefined) {
         const msg = this._errorMsg('EIP4895 block has no withdrawalsRoot field')
         throw new Error(msg)
@@ -393,7 +393,7 @@ export class BlockHeader {
       }
     }
 
-    if (this.common.isActivatedEIP(4788) === true) {
+    if (this.common.isActivatedEIP(4788)) {
       if (this.parentBeaconBlockRoot === undefined) {
         const msg = this._errorMsg('EIP4788 block has no parentBeaconBlockRoot field')
         throw new Error(msg)
@@ -550,7 +550,7 @@ export class BlockHeader {
    * Calculates the base fee for a potential next block
    */
   public calcNextBaseFee(): bigint {
-    if (this.common.isActivatedEIP(1559) === false) {
+    if (!this.common.isActivatedEIP(1559)) {
       const msg = this._errorMsg(
         'calcNextBaseFee() can only be called with EIP1559 being activated'
       )
@@ -671,26 +671,26 @@ export class BlockHeader {
       this.nonce,
     ]
 
-    if (this.common.isActivatedEIP(1559) === true) {
+    if (this.common.isActivatedEIP(1559)) {
       rawItems.push(bigIntToUnpaddedBytes(this.baseFeePerGas!))
     }
 
-    if (this.common.isActivatedEIP(4895) === true) {
+    if (this.common.isActivatedEIP(4895)) {
       rawItems.push(this.withdrawalsRoot!)
     }
 
     // in kaunstinen 2 verkle is scheduled after withdrawals, will eventually be post deneb hopefully
-    if (this.common.isActivatedEIP(6800) === true) {
+    if (this.common.isActivatedEIP(6800)) {
       // execution witness is not mandatory part of the the block so nothing to push here
       // but keep this comment segment for clarity regarding the same and move it according as per the
       // HF sequence eventually planned
     }
 
-    if (this.common.isActivatedEIP(4844) === true) {
+    if (this.common.isActivatedEIP(4844)) {
       rawItems.push(bigIntToUnpaddedBytes(this.blobGasUsed!))
       rawItems.push(bigIntToUnpaddedBytes(this.excessBlobGas!))
     }
-    if (this.common.isActivatedEIP(4788) === true) {
+    if (this.common.isActivatedEIP(4788)) {
       rawItems.push(this.parentBeaconBlockRoot!)
     }
 
@@ -950,14 +950,14 @@ export class BlockHeader {
       mixHash: bytesToHex(this.mixHash),
       nonce: bytesToHex(this.nonce),
     }
-    if (this.common.isActivatedEIP(1559) === true) {
+    if (this.common.isActivatedEIP(1559)) {
       jsonDict.baseFeePerGas = bigIntToHex(this.baseFeePerGas!)
     }
-    if (this.common.isActivatedEIP(4844) === true) {
+    if (this.common.isActivatedEIP(4844)) {
       jsonDict.blobGasUsed = bigIntToHex(this.blobGasUsed!)
       jsonDict.excessBlobGas = bigIntToHex(this.excessBlobGas!)
     }
-    if (this.common.isActivatedEIP(4788) === true) {
+    if (this.common.isActivatedEIP(4788)) {
       jsonDict.parentBeaconBlockRoot = bytesToHex(this.parentBeaconBlockRoot!)
     }
     return jsonDict

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -662,7 +662,7 @@ export class Blockchain implements BlockchainInterface {
     }
 
     // check blockchain dependent EIP1559 values
-    if (header.common.isActivatedEIP(1559) === true) {
+    if (header.common.isActivatedEIP(1559)) {
       // check if the base fee is correct
       let expectedBaseFee
       const londonHfBlock = this.common.hardforkBlock(Hardfork.London)
@@ -678,7 +678,7 @@ export class Blockchain implements BlockchainInterface {
       }
     }
 
-    if (header.common.isActivatedEIP(4844) === true) {
+    if (header.common.isActivatedEIP(4844)) {
       const expectedExcessBlobGas = parentHeader.calcNextExcessBlobGas()
       if (header.excessBlobGas !== expectedExcessBlobGas) {
         throw new Error(`expected blob gas: ${expectedExcessBlobGas}, got: ${header.excessBlobGas}`)

--- a/packages/client/src/miner/miner.ts
+++ b/packages/client/src/miner/miner.ts
@@ -264,7 +264,7 @@ export class Miner {
         this.config.chainCommon.paramByEIP('gasConfig', 'initialBaseFee', 1559) ?? BIGINT_0
       // Set initial EIP1559 block gas limit to 2x parent gas limit per logic in `block.validateGasLimit`
       gasLimit = gasLimit * BIGINT_2
-    } else if (this.config.chainCommon.isActivatedEIP(1559) === true) {
+    } else if (this.config.chainCommon.isActivatedEIP(1559)) {
       baseFeePerGas = parentBlock.header.calcNextBaseFee()
     }
 

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -589,7 +589,7 @@ export class EVM implements EVMInterface {
     // fee for size of the return value
     let totalGas = result.executionGasUsed
     let returnFee = BIGINT_0
-    if (!result.exceptionError && this.common.isActivatedEIP(6800) === false) {
+    if (!result.exceptionError && !this.common.isActivatedEIP(6800)) {
       returnFee =
         BigInt(result.returnValue.length) * BigInt(this.common.param('gasPrices', 'createData'))
       totalGas = totalGas + returnFee
@@ -905,7 +905,7 @@ export class EVM implements EVMInterface {
 
     await this._emit('beforeMessage', message)
 
-    if (!message.to && this.common.isActivatedEIP(2929) === true) {
+    if (!message.to && this.common.isActivatedEIP(2929)) {
       message.code = message.data
       this.journal.addWarmedAddress((await this._generateAddress(message)).bytes)
     }

--- a/packages/evm/src/opcodes/EIP2929.ts
+++ b/packages/evm/src/opcodes/EIP2929.ts
@@ -20,7 +20,7 @@ export function accessAddressEIP2929(
   chargeGas = true,
   isSelfdestructOrAuthcall = false
 ): bigint {
-  if (common.isActivatedEIP(2929) === false) return BIGINT_0
+  if (!common.isActivatedEIP(2929)) return BIGINT_0
 
   // Cold
   if (!runState.interpreter.journal.isWarmedAddress(address)) {
@@ -29,7 +29,7 @@ export function accessAddressEIP2929(
     // CREATE, CREATE2 opcodes have the address warmed for free.
     // selfdestruct beneficiary address reads are charged an *additional* cold access
     // if verkle not activated
-    if (chargeGas && common.isActivatedEIP(6800) === false) {
+    if (chargeGas && !common.isActivatedEIP(6800)) {
       return common.param('gasPrices', 'coldaccountaccess')
     }
     // Warm: (selfdestruct beneficiary address reads are not charged when warm)
@@ -54,7 +54,7 @@ export function accessStorageEIP2929(
   common: Common,
   chargeGas = true
 ): bigint {
-  if (common.isActivatedEIP(2929) === false) return BIGINT_0
+  if (!common.isActivatedEIP(2929)) return BIGINT_0
 
   const address = runState.interpreter.getAddress().bytes
   const slotIsCold = !runState.interpreter.journal.isWarmedStorage(address, key)
@@ -62,10 +62,10 @@ export function accessStorageEIP2929(
   // Cold (SLOAD and SSTORE)
   if (slotIsCold) {
     runState.interpreter.journal.addWarmedStorage(address, key)
-    if (chargeGas && common.isActivatedEIP(6800) === false) {
+    if (chargeGas && !common.isActivatedEIP(6800)) {
       return common.param('gasPrices', 'coldsload')
     }
-  } else if (chargeGas && (!isSstore || common.isActivatedEIP(6800) === true)) {
+  } else if (chargeGas && (!isSstore || common.isActivatedEIP(6800))) {
     return common.param('gasPrices', 'warmstorageread')
   }
   return BIGINT_0
@@ -88,7 +88,7 @@ export function adjustSstoreGasEIP2929(
   costName: string,
   common: Common
 ): bigint {
-  if (common.isActivatedEIP(2929) === false) return defaultCost
+  if (!common.isActivatedEIP(2929)) return defaultCost
 
   const address = runState.interpreter.getAddress().bytes
   const warmRead = common.param('gasPrices', 'warmstorageread')

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -627,7 +627,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         )
         const key = setLengthLeft(bigIntToBytes(number % historyServeWindow), 32)
 
-        if (common.isActivatedEIP(6800) === true) {
+        if (common.isActivatedEIP(6800)) {
           const { treeIndex, subIndex } = getTreeIndexesForStorageSlot(number)
           // create witnesses and charge gas
           const statelessGas = runState.env.accessWitness!.touchAddressOnReadAndComputeGas(

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -91,7 +91,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       async function (runState, gas, common): Promise<bigint> {
         const address = addresstoBytes(runState.stack.peek()[0])
         let charge2929Gas = true
-        if (common.isActivatedEIP(6800) === true) {
+        if (common.isActivatedEIP(6800)) {
           const balanceAddress = new Address(address)
           const coldAccessGas = runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
             balanceAddress,
@@ -103,7 +103,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           charge2929Gas = coldAccessGas === BIGINT_0
         }
 
-        if (common.isActivatedEIP(2929) === true) {
+        if (common.isActivatedEIP(2929)) {
           gas += accessAddressEIP2929(runState, address, common, charge2929Gas)
         }
 
@@ -160,7 +160,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         let charge2929Gas = true
         if (
-          common.isActivatedEIP(6800) === true &&
+          common.isActivatedEIP(6800) &&
           runState.interpreter._evm.getPrecompile(address) === undefined
         ) {
           let coldAccessGas = BIGINT_0
@@ -180,7 +180,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           charge2929Gas = coldAccessGas === BIGINT_0
         }
 
-        if (common.isActivatedEIP(2929) === true) {
+        if (common.isActivatedEIP(2929)) {
           gas += accessAddressEIP2929(runState, addressBytes, common, charge2929Gas)
         }
 
@@ -199,7 +199,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         let charge2929Gas = true
         if (
-          common.isActivatedEIP(6800) === true &&
+          common.isActivatedEIP(6800) &&
           runState.interpreter._evm.getPrecompile(address) === undefined
         ) {
           let coldAccessGas = BIGINT_0
@@ -219,7 +219,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           charge2929Gas = coldAccessGas === BIGINT_0
         }
 
-        if (common.isActivatedEIP(2929) === true) {
+        if (common.isActivatedEIP(2929)) {
           gas += accessAddressEIP2929(runState, addressBytes, common, charge2929Gas)
         }
 
@@ -268,7 +268,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         const address = addresstoBytes(runState.stack.peek()[0])
         let charge2929Gas = true
 
-        if (common.isActivatedEIP(6800) === true) {
+        if (common.isActivatedEIP(6800)) {
           const codeAddress = new Address(address)
 
           let coldAccessGas = BIGINT_0
@@ -282,7 +282,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           charge2929Gas = coldAccessGas === BIGINT_0
         }
 
-        if (common.isActivatedEIP(2929) === true) {
+        if (common.isActivatedEIP(2929)) {
           gas += accessAddressEIP2929(runState, address, common, charge2929Gas)
         }
 
@@ -324,7 +324,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
 
         let charge2929Gas = true
-        if (common.isActivatedEIP(6800) === true) {
+        if (common.isActivatedEIP(6800)) {
           const address = runState.interpreter.getAddress()
           const { treeIndex, subIndex } = getTreeIndexesForStorageSlot(key)
           const coldAccessGas = runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
@@ -337,7 +337,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           charge2929Gas = coldAccessGas === BIGINT_0
         }
 
-        if (common.isActivatedEIP(2929) === true) {
+        if (common.isActivatedEIP(2929)) {
           gas += accessStorageEIP2929(runState, keyBuf, false, common, charge2929Gas)
         }
 
@@ -377,7 +377,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
             common
           )
         } else if (common.gteHardfork(Hardfork.Istanbul)) {
-          if (common.isActivatedEIP(6800) === false) {
+          if (!common.isActivatedEIP(6800)) {
             gas += updateSstoreGasEIP2200(
               runState,
               currentStorage,
@@ -392,7 +392,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         }
 
         let charge2929Gas = true
-        if (common.isActivatedEIP(6800) === true) {
+        if (common.isActivatedEIP(6800)) {
           const contract = runState.interpreter.getAddress()
           const { treeIndex, subIndex } = getTreeIndexesForStorageSlot(key)
           const coldAccessGas = runState.env.accessWitness!.touchAddressOnWriteAndComputeGas(
@@ -405,7 +405,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           charge2929Gas = coldAccessGas === BIGINT_0
         }
 
-        if (common.isActivatedEIP(2929) === true) {
+        if (common.isActivatedEIP(2929)) {
           // We have to do this after the Istanbul (EIP2200) checks.
           // Otherwise, we might run out of gas, due to "sentry check" of 2300 gas,
           // if we deduct extra gas first.
@@ -459,7 +459,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         }
         const [_value, offset, length] = runState.stack.peek(3)
 
-        if (common.isActivatedEIP(2929) === true) {
+        if (common.isActivatedEIP(2929)) {
           gas += accessAddressEIP2929(
             runState,
             runState.interpreter.getAddress().bytes,
@@ -468,7 +468,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           )
         }
 
-        if (common.isActivatedEIP(3860) === true) {
+        if (common.isActivatedEIP(3860)) {
           gas += ((length + BIGINT_31) / BIGINT_32) * common.param('gasPrices', 'initCodeWordCost')
         }
 
@@ -514,11 +514,11 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           charge2929Gas = coldAccessGas === BIGINT_0
         }
 
-        if (common.isActivatedEIP(2929) === true) {
+        if (common.isActivatedEIP(2929)) {
           gas += accessAddressEIP2929(runState, toAddress.bytes, common, charge2929Gas)
         }
 
-        if (value !== BIGINT_0 && common.isActivatedEIP(6800) === false) {
+        if (value !== BIGINT_0 && !common.isActivatedEIP(6800)) {
           gas += common.param('gasPrices', 'callValueTransfer')
         }
 
@@ -583,7 +583,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           charge2929Gas = coldAccessGas === BIGINT_0
         }
 
-        if (common.isActivatedEIP(2929) === true) {
+        if (common.isActivatedEIP(2929)) {
           gas += accessAddressEIP2929(runState, addresstoBytes(toAddr), common, charge2929Gas)
         }
 
@@ -639,7 +639,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           charge2929Gas = coldAccessGas === BIGINT_0
         }
 
-        if (common.isActivatedEIP(2929) === true) {
+        if (common.isActivatedEIP(2929)) {
           gas += accessAddressEIP2929(runState, addresstoBytes(toAddr), common, charge2929Gas)
         }
 
@@ -671,7 +671,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         gas += subMemUsage(runState, offset, length, common)
 
-        if (common.isActivatedEIP(2929) === true) {
+        if (common.isActivatedEIP(2929)) {
           gas += accessAddressEIP2929(
             runState,
             runState.interpreter.getAddress().bytes,
@@ -680,7 +680,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           )
         }
 
-        if (common.isActivatedEIP(3860) === true) {
+        if (common.isActivatedEIP(3860)) {
           gas += ((length + BIGINT_31) / BIGINT_32) * common.param('gasPrices', 'initCodeWordCost')
         }
 
@@ -783,7 +783,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           charge2929Gas = coldAccessGas === BIGINT_0
         }
 
-        if (common.isActivatedEIP(2929) === true) {
+        if (common.isActivatedEIP(2929)) {
           gas += accessAddressEIP2929(runState, addresstoBytes(toAddr), common, charge2929Gas)
         }
 
@@ -844,7 +844,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         }
 
         let selfDestructToCharge2929Gas = true
-        if (common.isActivatedEIP(6800) === true) {
+        if (common.isActivatedEIP(6800)) {
           // read accesses for version and code size
           if (runState.interpreter._evm.getPrecompile(contractAddress) === undefined) {
             gas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
@@ -891,7 +891,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           selfDestructToCharge2929Gas = selfDestructToColdAccessGas === BIGINT_0
         }
 
-        if (common.isActivatedEIP(2929) === true) {
+        if (common.isActivatedEIP(2929)) {
           gas += accessAddressEIP2929(
             runState,
             selfdestructToAddress.bytes,

--- a/packages/tx/src/eip1559Transaction.ts
+++ b/packages/tx/src/eip1559Transaction.ts
@@ -154,7 +154,7 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<TransactionType
     this.common = this._getCommon(opts.common, chainId)
     this.chainId = this.common.chainId()
 
-    if (this.common.isActivatedEIP(1559) === false) {
+    if (!this.common.isActivatedEIP(1559)) {
       throw new Error('EIP-1559 not enabled on Common')
     }
     this.activeCapabilities = this.activeCapabilities.concat([1559, 2718, 2930])

--- a/packages/tx/src/eip4844Transaction.ts
+++ b/packages/tx/src/eip4844Transaction.ts
@@ -109,11 +109,11 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
     this.common = this._getCommon(opts.common, chainId)
     this.chainId = this.common.chainId()
 
-    if (this.common.isActivatedEIP(1559) === false) {
+    if (!this.common.isActivatedEIP(1559)) {
       throw new Error('EIP-1559 not enabled on Common')
     }
 
-    if (this.common.isActivatedEIP(4844) === false) {
+    if (!this.common.isActivatedEIP(4844)) {
       throw new Error('EIP-4844 not enabled on Common')
     }
     this.activeCapabilities = this.activeCapabilities.concat([1559, 2718, 2930])

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -87,7 +87,7 @@ export class BlockBuilder {
     this.withdrawals = opts.withdrawals?.map(Withdrawal.fromWithdrawalData)
 
     if (
-      this.vm.common.isActivatedEIP(1559) === true &&
+      this.vm.common.isActivatedEIP(1559) &&
       typeof this.headerData.baseFeePerGas === 'undefined'
     ) {
       if (this.headerData.number === vm.common.hardforkBlock(Hardfork.London)) {
@@ -106,7 +106,7 @@ export class BlockBuilder {
     }
 
     if (
-      this.vm.common.isActivatedEIP(4844) === true &&
+      this.vm.common.isActivatedEIP(4844) &&
       typeof this.headerData.excessBlobGas === 'undefined'
     ) {
       this.headerData.excessBlobGas = opts.parentBlock.header.calcNextExcessBlobGas()
@@ -224,7 +224,7 @@ export class BlockBuilder {
     }
     let blobGasUsed = undefined
     if (tx instanceof BlobEIP4844Transaction) {
-      if (this.blockOpts.common?.isActivatedEIP(4844) !== true) {
+      if (!this.blockOpts.common?.isActivatedEIP(4844)) {
         throw Error('eip4844 not activated yet for adding a blob transaction')
       }
       const blobTx = tx as BlobEIP4844Transaction
@@ -312,7 +312,7 @@ export class BlockBuilder {
     const timestamp = this.headerData.timestamp ?? BIGINT_0
 
     let blobGasUsed = undefined
-    if (this.vm.common.isActivatedEIP(4844) === true) {
+    if (this.vm.common.isActivatedEIP(4844)) {
       blobGasUsed = this.blobGasUsed
     }
 

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -224,7 +224,7 @@ export class BlockBuilder {
     }
     let blobGasUsed = undefined
     if (tx instanceof BlobEIP4844Transaction) {
-      if (!this.blockOpts.common?.isActivatedEIP(4844)) {
+      if (this.blockOpts.common?.isActivatedEIP(4844) === false) {
         throw Error('eip4844 not activated yet for adding a blob transaction')
       }
       const blobTx = tx as BlobEIP4844Transaction

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -696,7 +696,7 @@ export async function rewardAccount(
 ): Promise<Account> {
   let account = await evm.stateManager.getAccount(address)
   if (account === undefined) {
-    if (common?.isActivatedEIP(6800) === false) {
+    if (common?.isActivatedEIP(6800) === true) {
       ;(
         evm.stateManager as StatelessVerkleStateManager
       ).accessWitness!.touchAndChargeProofOfAbsence(address)
@@ -706,7 +706,7 @@ export async function rewardAccount(
   account.balance += reward
   await evm.journal.putAccount(address, account)
 
-  if (common?.isActivatedEIP(6800) === false) {
+  if (common?.isActivatedEIP(6800) === true) {
     // use this utility to build access but the computed gas is not charged and hence free
     ;(evm.stateManager as StatelessVerkleStateManager).accessWitness!.touchTxTargetAndComputeGas(
       address,

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -696,7 +696,7 @@ export async function rewardAccount(
 ): Promise<Account> {
   let account = await evm.stateManager.getAccount(address)
   if (account === undefined) {
-    if (common?.isActivatedEIP(6800)) {
+    if (common?.isActivatedEIP(6800) === false) {
       ;(
         evm.stateManager as StatelessVerkleStateManager
       ).accessWitness!.touchAndChargeProofOfAbsence(address)
@@ -706,7 +706,7 @@ export async function rewardAccount(
   account.balance += reward
   await evm.journal.putAccount(address, account)
 
-  if (common?.isActivatedEIP(6800)) {
+  if (common?.isActivatedEIP(6800) === false) {
     // use this utility to build access but the computed gas is not charged and hence free
     ;(evm.stateManager as StatelessVerkleStateManager).accessWitness!.touchTxTargetAndComputeGas(
       address,

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -214,7 +214,7 @@ export async function runBlock(this: VM, opts: RunBlockOpts): Promise<RunBlockRe
       header: { ...block.header, ...generatedFields },
     }
     block = Block.fromBlockData(blockData, { common: this.common })
-  } else if (this.common.isActivatedEIP(6800) === false) {
+  } else if (!this.common.isActivatedEIP(6800)) {
     // Only validate the following headers if verkle blocks aren't activated
     if (equalsBytes(result.receiptsRoot, block.header.receiptTrie) === false) {
       if (this.DEBUG) {
@@ -262,7 +262,7 @@ export async function runBlock(this: VM, opts: RunBlockOpts): Promise<RunBlockRe
       )
       throw new Error(msg)
     }
-  } else if (this.common.isActivatedEIP(6800) === true) {
+  } else if (this.common.isActivatedEIP(6800)) {
     // If verkle is activated, only validate the post-state
     if ((this._opts.stateManager as StatelessVerkleStateManager).verifyPostState() === false) {
       throw new Error(`Verkle post state verification failed on block ${block.header.number}`)
@@ -467,7 +467,7 @@ export async function accumulateParentBlockHash(
     const ringKey = number % historyServeWindow
 
     // generate access witness
-    if (vm.common.isActivatedEIP(6800) === true) {
+    if (vm.common.isActivatedEIP(6800)) {
       const { treeIndex, subIndex } = getTreeIndexesForStorageSlot(ringKey)
       // just create access witnesses without charging for the gas
       ;(
@@ -569,7 +569,7 @@ async function applyTransactions(this: VM, block: Block, opts: RunBlockOpts) {
     const tx = block.transactions[txIdx]
 
     let maxGasLimit
-    if (this.common.isActivatedEIP(1559) === true) {
+    if (this.common.isActivatedEIP(1559)) {
       maxGasLimit = block.header.gasLimit * this.common.param('gasConfig', 'elasticityMultiplier')
     } else {
       maxGasLimit = block.header.gasLimit
@@ -696,7 +696,7 @@ export async function rewardAccount(
 ): Promise<Account> {
   let account = await evm.stateManager.getAccount(address)
   if (account === undefined) {
-    if (common?.isActivatedEIP(6800) === true) {
+    if (common?.isActivatedEIP(6800)) {
       ;(
         evm.stateManager as StatelessVerkleStateManager
       ).accessWitness!.touchAndChargeProofOfAbsence(address)
@@ -706,7 +706,7 @@ export async function rewardAccount(
   account.balance += reward
   await evm.journal.putAccount(address, account)
 
-  if (common?.isActivatedEIP(6800) === true) {
+  if (common?.isActivatedEIP(6800)) {
     // use this utility to build access but the computed gas is not charged and hence free
     ;(evm.stateManager as StatelessVerkleStateManager).accessWitness!.touchTxTargetAndComputeGas(
       address,

--- a/packages/vm/test/api/runTx.spec.ts
+++ b/packages/vm/test/api/runTx.spec.ts
@@ -254,10 +254,9 @@ describe('runTx() -> successful API parameter usage', async () => {
             ? tx.maxPriorityFeePerGas
             : tx.maxFeePerGas - baseFee
           : tx.gasPrice - baseFee
-      const expectedCoinbaseBalance =
-        common.isActivatedEIP(1559) === true
-          ? result.totalGasSpent * inclusionFeePerGas
-          : result.amountSpent
+      const expectedCoinbaseBalance = common.isActivatedEIP(1559)
+        ? result.totalGasSpent * inclusionFeePerGas
+        : result.amountSpent
 
       assert.equal(
         coinbaseAccount!.balance,


### PR DESCRIPTION
This change removes some unnecessary explicit boolean comparisons where `isActivatedEIP` is called in order to make the code cleaner and more consistent.