### PR TITLE
Fix EIP2537 fixtures

### DIFF
--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -74,7 +74,7 @@ export const EIPs: EIPsDict = {
     gasConfig: {},
     gasPrices: {
       Bls12381G1AddGas: {
-        v: 600,
+        v: 500,
         d: 'Gas cost of a single BLS12-381 G1 addition precompile-call',
       },
       Bls12381G1MulGas: {
@@ -82,11 +82,11 @@ export const EIPs: EIPsDict = {
         d: 'Gas cost of a single BLS12-381 G1 multiplication precompile-call',
       },
       Bls12381G2AddGas: {
-        v: 4500,
+        v: 800,
         d: 'Gas cost of a single BLS12-381 G2 addition precompile-call',
       },
       Bls12381G2MulGas: {
-        v: 55000,
+        v: 45000,
         d: 'Gas cost of a single BLS12-381 G2 multiplication precompile-call',
       },
       Bls12381PairingBaseGas: {
@@ -102,7 +102,7 @@ export const EIPs: EIPsDict = {
         d: 'Gas cost of BLS12-381 map field element to G1',
       },
       Bls12381MapG2Gas: {
-        v: 110000,
+        v: 75000,
         d: 'Gas cost of BLS12-381 map field element to G2',
       },
     },


### PR DESCRIPTION
This PR fixes the EIP 2537 fixtures from https://github.com/ethereum/execution-spec-tests/files/15099569/fixtures_develop.tar.gz

To run, see https://github.com/ethereumjs/ethereumjs-monorepo/pull/3387

Before, 164 failing tests.

After the "fixed gas schedule" there are only 10 failing tests which correspond to:

```
tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py::test_valid[fork_Prague-blockchain_test-bls_g1add_g1_wrong_order+g1-]
tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py::test_valid[fork_Prague-blockchain_test-not_in_subgroup_1-]
tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g1add.py::test_valid[fork_Prague-blockchain_test-not_in_subgroup_2-]
tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2add.py::test_valid[fork_Prague-blockchain_test-bls_g2add_g2_wrong_order+g2-]
tests/prague/eip2537_bls_12_381_precompiles/test_bls12_g2add.py::test_valid[fork_Prague-blockchain_test-not_in_subgroup-]
```

These individual tests can be fixed by disabling these checks in `./packages/evm/src/precompiles/util/bls12_381.ts`:

```typescript
  if (G1.isValidOrder() === false) {
    throw new EvmError(ERROR.BLS_12_381_POINT_NOT_ON_CURVE)
  }

  // Check if these coordinates are actually on the curve.
  if (G1.isValid() === false) {
    throw new EvmError(ERROR.BLS_12_381_POINT_NOT_ON_CURVE)
  }
```

and

```typescript
  if (mclPoint.isValidOrder() === false) {
    throw new EvmError(ERROR.BLS_12_381_POINT_NOT_ON_CURVE)
  }

  if (mclPoint.isValid() === false) {
    throw new EvmError(ERROR.BLS_12_381_POINT_NOT_ON_CURVE)
  }
```

(In the `BLS12_381_ToG1Point` and `BLS12_381_ToG2Point` methods)

However, disabling those now fails other tests, so not sure how to proceed here.