### PR TITLE
client: simplify --ignoreStatelessInvalidExecs to just a boolean flag

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -445,11 +445,8 @@ const args: ClientOpts = yargs
   })
   .option('ignoreStatelessInvalidExecs', {
     describe:
-      'Ignore stateless execution failures and keep moving the vm execution along using execution witnesses available in block (verkle). Sets/overrides --statelessVerkle=true and --engineNewpayloadMaxExecute=0 to prevent engine newPayload direct block execution where block execution faliures may stall the CL client. Useful for debugging the verkle. If provided a valid filename as arg, the invalid blocks will be stored there which one may use later for debugging',
-    coerce: (arg: string | boolean) =>
-      typeof arg === 'string' && arg !== 'true' && arg !== 'false'
-        ? path.resolve(arg)
-        : arg === true || arg === 'true',
+      'Ignore stateless execution failures and keep moving the vm execution along using execution witnesses available in block (verkle). Sets/overrides --statelessVerkle=true and --engineNewpayloadMaxExecute=0 to prevent engine newPayload direct block execution where block execution faliures may stall the CL client. Useful for debugging the verkle. The invalid blocks will be stored in dataDir/network/invalidPayloads which one may use later for debugging',
+    boolean: true,
     hidden: true,
   })
   .option('useJsCrypto', {
@@ -1018,6 +1015,11 @@ async function run() {
   mkdirSync(configDirectory, {
     recursive: true,
   })
+  const invalidPayloadsDir = `${networkDir}/invalidPayloads`
+  mkdirSync(invalidPayloadsDir, {
+    recursive: true,
+  })
+
   const key = await Config.getClientKey(datadir, common)
 
   // logFile is either filename or boolean true or false to enable (with default) or disable

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -337,7 +337,7 @@ export interface ConfigOptions {
    */
   statelessVerkle?: boolean
   startExecution?: boolean
-  ignoreStatelessInvalidExecs?: boolean | string
+  ignoreStatelessInvalidExecs?: boolean
 
   /**
    * Enables Prometheus Metrics that can be collected for monitoring client health
@@ -450,7 +450,7 @@ export class Config {
 
   public readonly statelessVerkle: boolean
   public readonly startExecution: boolean
-  public readonly ignoreStatelessInvalidExecs: boolean | string
+  public readonly ignoreStatelessInvalidExecs: boolean
 
   public synchronized: boolean
   public lastsyncronized?: boolean
@@ -644,6 +644,10 @@ export class Config {
   getNetworkDirectory(): string {
     const networkDirName = this.chainCommon.chainName()
     return `${this.datadir}/${networkDirName}`
+  }
+
+  getInvalidPayloadsDir(): string {
+    return `${this.getNetworkDirectory()}/invalidPayloads`
   }
 
   /**

--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -828,13 +828,10 @@ export class VMExecution extends Execution {
                   }
 
                   // headBlock should be parent of errorBlock and not undefined
-                  if (
-                    typeof this.config.ignoreStatelessInvalidExecs === 'string' &&
-                    headBlock !== undefined
-                  ) {
+                  if (headBlock !== undefined) {
                     // save the data in spec test compatible manner
                     const blockNumStr = `${errorBlock.header.number}`
-                    const file = `${this.config.ignoreStatelessInvalidExecs}/${blockNumStr}.json`
+                    const file = `${this.config.getInvalidPayloadsDir()}/${blockNumStr}.json`
                     const jsonDump = {
                       [blockNumStr]: {
                         parent: headBlock.toExecutionPayload(),
@@ -842,9 +839,7 @@ export class VMExecution extends Execution {
                       },
                     }
                     writeFileSync(file, JSON.stringify(jsonDump, null, 2))
-                    this.config.logger.warn(
-                      `${errorMsg}:\n${error} payload saved to=${this.config.ignoreStatelessInvalidExecs}`
-                    )
+                    this.config.logger.warn(`${errorMsg}:\n${error} payload saved to=${file}`)
                   } else {
                     this.config.logger.warn(`${errorMsg}:\n${error}`)
                   }

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -173,7 +173,7 @@ export interface ClientOpts {
   statelessVerkle?: boolean
   engineNewpayloadMaxExecute?: number
   skipEngineExec?: boolean
-  ignoreStatelessInvalidExecs?: string | boolean
+  ignoreStatelessInvalidExecs?: boolean
   useJsCrypto?: boolean
 }
 


### PR DESCRIPTION
now no need to specify a file path with `--ignoreStatelessInvalidExecs` to save invalid payloads, they will be automaitcally saved in datadir/networkname/invalidPayloads
![image](https://github.com/ethereumjs/ethereumjs-monorepo/assets/76567250/171de4fb-284d-45c5-8e88-92804b5543f1)
