### PR TITLE
Add support for Cancun -> Prague transition

### DIFF
--- a/packages/vm/test/tester/config.ts
+++ b/packages/vm/test/tester/config.ts
@@ -302,6 +302,8 @@ export function getCommon(network: string, kzg?: Kzg): Common {
     return setupCommonWithNetworks(startNetwork, TTD, undefined, kzg)
   } else if (networkLowercase === 'shanghaitocancunattime15k') {
     return setupCommonWithNetworks('Shanghai', undefined, 15000, kzg)
+  } else if (networkLowercase === 'cancuntopragueattime15k') {
+    return setupCommonWithNetworks('Cancun', undefined, 15000, kzg)
   } else {
     // Case 3: this is not a "default fork" network, but it is a "transition" network. Test the VM if it transitions the right way
     const transitionForks =


### PR DESCRIPTION
- Download the devnet0 fixtures https://github.com/ethereum/execution-spec-tests/files/15202215/fixtures_develop.tar.gz
- Put this inside the ethereum-tests folder, for instance in the Devnet0 folder
- Now run the EIP2935 transition tests:
- `npm run test:blockchain -- --fork=CancunToPragueAtTime15k --dir=../Devnet0/blockchain_tests/prague/eip2935_historical_block_hashes_from_state`

Note: this PR is a placeholder for any bugfixes which might arise if we find those via the tests.