### PR TITLE
util,block: rename deposit receipt to deposit request

### DIFF
--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -423,7 +423,7 @@ export class Block {
       transactions,
       withdrawals: withdrawalsData,
       requestsRoot,
-      depositReceipts,
+      depositRequests,
       withdrawalRequests,
       executionWitness,
     } = payload
@@ -464,13 +464,13 @@ export class Block {
       requestsRoot: reqRoot,
     }
 
-    const hasDepositRequests = depositReceipts !== undefined && depositReceipts !== null
+    const hasDepositRequests = depositRequests !== undefined && depositRequests !== null
     const hasWithdrawalRequests = withdrawalRequests !== undefined && withdrawalRequests !== null
     const requests =
       hasDepositRequests || hasWithdrawalRequests ? ([] as CLRequest<CLRequestType>[]) : undefined
 
-    if (depositReceipts !== undefined && depositReceipts !== null) {
-      for (const dJson of depositReceipts) {
+    if (depositRequests !== undefined && depositRequests !== null) {
+      for (const dJson of depositRequests) {
         requests!.push(DepositRequest.fromJSON(dJson))
       }
     }
@@ -1001,7 +1001,7 @@ export class Block {
       executionWitness: this.executionWitness,
 
       // lets add the  request fields first and then iterate over requests to fill them up
-      depositReceipts: this.common.isActivatedEIP(6110) ? [] : undefined,
+      depositRequests: this.common.isActivatedEIP(6110) ? [] : undefined,
       withdrawalRequests: this.common.isActivatedEIP(7002) ? [] : undefined,
     }
 
@@ -1009,7 +1009,7 @@ export class Block {
       for (const request of this.requests) {
         switch (request.type) {
           case CLRequestType.Deposit:
-            executionPayload.depositReceipts!.push((request as DepositRequest).toJSON())
+            executionPayload.depositRequests!.push((request as DepositRequest).toJSON())
             continue
 
           case CLRequestType.Withdrawal:
@@ -1018,7 +1018,7 @@ export class Block {
         }
       }
     } else if (
-      executionPayload.depositReceipts !== undefined ||
+      executionPayload.depositRequests !== undefined ||
       executionPayload.withdrawalRequests !== undefined
     ) {
       throw Error(`Undefined requests for activated deposit or withdrawal requests`)

--- a/packages/block/src/from-beacon-payload.ts
+++ b/packages/block/src/from-beacon-payload.ts
@@ -149,7 +149,7 @@ export function executionPayloadFromBeaconPayload(payload: BeaconPayloadJson): E
 
   // requests
   if (payload.deposit_receipts !== undefined && payload.deposit_receipts !== null) {
-    executionPayload.depositReceipts = payload.deposit_receipts.map((breq) => ({
+    executionPayload.depositRequests = payload.deposit_receipts.map((breq) => ({
       pubkey: breq.pubkey,
       withdrawalCredentials: breq.withdrawal_credentials,
       amount: breq.amount,

--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -7,7 +7,7 @@ import type {
   BytesLike,
   CLRequest,
   CLRequestType,
-  DepositReceiptV1,
+  DepositRequestV1,
   JsonRpcWithdrawal,
   PrefixedHexString,
   RequestBytes,
@@ -306,6 +306,6 @@ export type ExecutionPayload = {
   // VerkleExecutionWitness is already a hex serialized object
   executionWitness?: VerkleExecutionWitness | null // QUANTITY, 64 Bits, null implies not available
   requestsRoot?: PrefixedHexString | string | null // DATA, 32 bytes, null implies EIP 7685 not active yet
-  depositReceipts?: DepositReceiptV1[] // Array of 6110 deposit requests
+  depositRequests?: DepositRequestV1[] // Array of 6110 deposit requests
   withdrawalRequests?: WithdrawalRequestV1[] // Array of 7002 withdrawal requests
 }

--- a/packages/client/src/rpc/modules/engine/types.ts
+++ b/packages/client/src/rpc/modules/engine/types.ts
@@ -2,7 +2,7 @@ import { UNKNOWN_PAYLOAD } from '../../error-code.js'
 
 import type { Skeleton } from '../../../service/index.js'
 import type { Block, ExecutionPayload } from '@ethereumjs/block'
-import type { DepositReceiptV1, PrefixedHexString, WithdrawalRequestV1 } from '@ethereumjs/util'
+import type { DepositRequestV1, PrefixedHexString, WithdrawalRequestV1 } from '@ethereumjs/util'
 
 export enum Status {
   ACCEPTED = 'ACCEPTED',
@@ -29,7 +29,7 @@ export type ExecutionPayloadV2 = ExecutionPayloadV1 & { withdrawals: WithdrawalV
 // parentBeaconBlockRoot comes separate in new payloads and needs to be added to payload data
 export type ExecutionPayloadV3 = ExecutionPayloadV2 & { excessBlobGas: Uint64; blobGasUsed: Uint64 }
 export type ExecutionPayloadV4 = ExecutionPayloadV3 & {
-  depositReceipts: DepositReceiptV1[]
+  depositRequests: DepositRequestV1[]
   withdrawalRequests: WithdrawalRequestV1[]
 }
 

--- a/packages/client/src/rpc/modules/engine/validators.ts
+++ b/packages/client/src/rpc/modules/engine/validators.ts
@@ -28,7 +28,7 @@ export const executionPayloadV3FieldValidators = {
 
 export const executionPayloadV4FieldValidators = {
   ...executionPayloadV3FieldValidators,
-  depositReceipts: validators.array(validators.depositReceipt()),
+  depositRequests: validators.array(validators.depositRequest()),
   withdrawalRequests: validators.array(validators.withdrawalRequest()),
 }
 

--- a/packages/client/src/rpc/validation.ts
+++ b/packages/client/src/rpc/validation.ts
@@ -428,7 +428,7 @@ export const validators = {
     }
   },
 
-  get depositReceipt() {
+  get depositRequest() {
     return (
       requiredFields: string[] = ['pubkey', 'withdrawalCredentials', 'amount', 'signature', 'index']
     ) => {

--- a/packages/client/test/rpc/engine/newPayloadV4.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV4.spec.ts
@@ -28,7 +28,7 @@ describe(`${method}: call with executionPayloadV4`, () => {
       withdrawals: [],
       blobGasUsed: '0x0',
       excessBlobGas: '0x0',
-      depositReceipts: [],
+      depositRequests: [],
       withdrawalRequests: [],
       blockHash: '0x87994ea69d14924d908ed979bf2aadd91f0954f95792c3fcf442d2513af957c4',
       stateRoot: '0xca3149fa9e37db08d1cd49c9061db1002ef1cd58db2210f2115c8c989b2bdf45',

--- a/packages/util/src/requests.ts
+++ b/packages/util/src/requests.ts
@@ -20,7 +20,7 @@ export enum CLRequestType {
   Withdrawal = 0x01,
 }
 
-export type DepositReceiptV1 = {
+export type DepositRequestV1 = {
   pubkey: PrefixedHexString // DATA 48 bytes
   withdrawalCredentials: PrefixedHexString // DATA 32 bytes
   amount: PrefixedHexString // QUANTITY 8 bytes in gwei
@@ -35,7 +35,7 @@ export type WithdrawalRequestV1 = {
 }
 
 export interface RequestJSON {
-  [CLRequestType.Deposit]: DepositReceiptV1
+  [CLRequestType.Deposit]: DepositRequestV1
   [CLRequestType.Withdrawal]: WithdrawalRequestV1
 }
 
@@ -91,7 +91,7 @@ export class DepositRequest extends CLRequest<CLRequestType.Deposit> {
     return new DepositRequest(pubkey, withdrawalCredentials, amount, signature, index)
   }
 
-  public static fromJSON(jsonData: DepositReceiptV1): DepositRequest {
+  public static fromJSON(jsonData: DepositRequestV1): DepositRequest {
     const { pubkey, withdrawalCredentials, amount, signature, index } = jsonData
     return this.fromRequestData({
       pubkey: hexToBytes(pubkey),
@@ -113,7 +113,7 @@ export class DepositRequest extends CLRequest<CLRequestType.Deposit> {
     )
   }
 
-  toJSON(): DepositReceiptV1 {
+  toJSON(): DepositRequestV1 {
     return {
       pubkey: bytesToHex(this.pubkey),
       withdrawalCredentials: bytesToHex(this.withdrawalCredentials),


### PR DESCRIPTION
it has been decided to not accept this engine api change:
 - https://github.com/ethereum/execution-apis/pull/544
 
so the CLs have to rename the field from receipts to request now even for devnet0