### PR TITLE
vm: fix the gathering of stateroot only after requests have been accumulated

### DIFF
--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -304,7 +304,6 @@ export class BlockBuilder {
     }
     await this.processWithdrawals()
 
-    const stateRoot = await this.vm.stateManager.getStateRoot()
     const transactionsTrie = await this.transactionsTrie()
     const withdrawalsRoot = this.withdrawals
       ? await Block.genWithdrawalsTrieRoot(this.withdrawals, new Trie({ common: this.vm.common }))
@@ -328,6 +327,8 @@ export class BlockBuilder {
       // Do other validations per request type
     }
 
+    // get stateRoot after all the accumulateRequests etc have been done
+    const stateRoot = await this.vm.stateManager.getStateRoot()
     const headerData = {
       ...this.headerData,
       stateRoot,


### PR DESCRIPTION
stateRoot was collected before requests were accumulated which actually changes the state. so the build blocks would have the wrong stateroot

this pr fixes the same


tested on electra with lodestar integration