### PR TITLE
Add support for `pending` in `getTransactionCount`

### DIFF
--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -770,7 +770,9 @@ export class Eth {
    */
   async getTransactionCount(params: [string, string]) {
     const [addressHex, blockOpt] = params
-    const block = await getBlockByOption(blockOpt, this._chain)
+    let block
+    if (blockOpt !== 'pending') block = await getBlockByOption(blockOpt, this._chain)
+    else block = await getBlockByOption('latest', this._chain)
 
     if (this._vm === undefined) {
       throw new Error('missing vm')
@@ -784,7 +786,17 @@ export class Eth {
     if (account === undefined) {
       return '0x0'
     }
-    return bigIntToHex(account.nonce)
+
+    let pendingTxsCount = BIGINT_0
+
+    // Add pending txns to nonce if blockOpt is 'pending'
+    if (blockOpt === 'pending') {
+      pendingTxsCount = BigInt(
+        (this.client.service('eth') as FullEthereumService).txPool.pool.get(addressHex.slice(2))
+          ?.length ?? 0
+      )
+    }
+    return bigIntToHex(account.nonce + pendingTxsCount)
   }
 
   /**

--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -792,8 +792,7 @@ export class Eth {
     // Add pending txns to nonce if blockOpt is 'pending'
     if (blockOpt === 'pending') {
       pendingTxsCount = BigInt(
-        (this.client.service('eth') as FullEthereumService).txPool.pool.get(addressHex.slice(2))
-          ?.length ?? 0
+        (this.service as FullEthereumService).txPool.pool.get(addressHex.slice(2))?.length ?? 0
       )
     }
     return bigIntToHex(account.nonce + pendingTxsCount)

--- a/packages/client/test/rpc/eth/getTransactionCount.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionCount.spec.ts
@@ -3,10 +3,9 @@ import { Blockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
 import { LegacyTransaction, TransactionFactory } from '@ethereumjs/tx'
-import { Account, Address, bytesToHex, hexToBytes, randomBytes } from '@ethereumjs/util'
+import { Account, Address, hexToBytes, randomBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { INVALID_PARAMS } from '../../../src/rpc/error-code.js'
 import { createClient, createManager, getRpcClient, startRPC } from '../helpers.js'
 
 import type { FullEthereumService } from '../../../src/service/index.js'

--- a/packages/client/test/rpc/eth/getTransactionCount.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionCount.spec.ts
@@ -2,8 +2,8 @@ import { Block } from '@ethereumjs/block'
 import { Blockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
-import { LegacyTransaction } from '@ethereumjs/tx'
-import { Address } from '@ethereumjs/util'
+import { LegacyTransaction, TransactionFactory } from '@ethereumjs/tx'
+import { Account, Address, bytesToHex, hexToBytes, randomBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
 import { INVALID_PARAMS } from '../../../src/rpc/error-code.js'
@@ -74,15 +74,34 @@ describe(method, () => {
     assert.equal(res.result, `0x0`, 'should return 0x0 for nonexistent account')
   }, 40000)
 
-  it('call with unsupported block argument', async () => {
+  it('call with pending block argument', async () => {
     const blockchain = await Blockchain.create()
 
     const client = await createClient({ blockchain, includeVM: true })
     const manager = createManager(client)
+    const service = client.services.find((s) => s.name === 'eth') as FullEthereumService
     const rpc = getRpcClient(startRPC(manager.getMethods()))
 
-    const res = await rpc.request(method, ['0xccfd725760a68823ff1e062f4cc97e1360e8d997', 'pending'])
-    assert.equal(res.error.code, INVALID_PARAMS)
-    assert.ok(res.error.message.includes('"pending" is not yet supported'))
+    const pk = hexToBytes('0x266682876da8fd86410d001ec33c7c281515aeeb640d175693534062e2599238')
+    const address = Address.fromPrivateKey(pk)
+    await service.execution.vm.stateManager.putAccount(address, new Account())
+    const account = await service.execution.vm.stateManager.getAccount(address)
+    account!.balance = 0xffffffffffffffn
+    await service.execution.vm.stateManager.putAccount(address, account!)
+    const tx = TransactionFactory.fromTxData({
+      to: randomBytes(20),
+      value: 1,
+      maxFeePerGas: 0xffffff,
+    }).sign(pk)
+
+    // Set stubs so getTxCount won't validate txns or mess up state root
+    service.txPool['validate'] = () => Promise.resolve(undefined)
+    service.execution.vm.stateManager.setStateRoot = () => Promise.resolve(undefined)
+    service.execution.vm.shallowCopy = () => Promise.resolve(service.execution.vm)
+
+    await service.txPool.add(tx, true)
+
+    const res = await rpc.request(method, [address.toString(), 'pending'])
+    assert.equal(res.result, '0x1')
   }, 40000)
 })


### PR DESCRIPTION
This updates the response handler for `eth_getTransactionCount` to support the `pending` block option.  This includes pending transactions currently in the local transaction pool in the transaction count.

This is needed to allow our client to work with the [tx fuzzer](https://github.com/MariusVanDerWijden/tx-fuzz/) 