### PR TITLE
common: parse deposit contract address from geth genesis for chain config

### DIFF
--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -38,7 +38,7 @@ export interface ChainConfig {
   bootstrapNodes: BootstrapNodeConfig[]
   dnsNetworks?: string[]
   consensus: ConsensusConfig
-  depositContractAddress?: string
+  depositContractAddress?: PrefixedHexString
 }
 
 // TODO: Remove the string type and only keep PrefixedHexString

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -57,7 +57,10 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
     timestamp: string
   } = json
   const genesisTimestamp = Number(unparsedTimestamp)
-  const { chainId }: { chainId: number } = config
+  const {
+    chainId,
+    depositContractAddress,
+  }: { chainId: number; depositContractAddress: PrefixedHexString } = config
 
   // geth is not strictly putting empty fields with a 0x prefix
   const extraData: PrefixedHexString =
@@ -84,6 +87,7 @@ function parseGethParams(json: any, mergeForkIdPostMerge: boolean = true) {
     name,
     chainId,
     networkId: chainId,
+    depositContractAddress,
     genesis: {
       timestamp,
       gasLimit,

--- a/packages/common/test/utils.spec.ts
+++ b/packages/common/test/utils.spec.ts
@@ -173,6 +173,42 @@ describe('[Utils/Parse]', () => {
     )
     assert.equal(common.hardfork(), Hardfork.Shanghai, 'should correctly infer common hardfork')
   })
+
+  it('should successfully assign mainnet deposit contract address when none provided', async () => {
+    const common = Common.fromGethGenesis(postMergeHardforkJSON, {
+      chain: 'customChain',
+    })
+    const depositContractAddress =
+      common['_chainParams'].depositContractAddress ??
+      Common.getInitializedChains().mainnet.depositContractAddress
+
+    assert.equal(
+      depositContractAddress,
+      Common.getInitializedChains().mainnet.depositContractAddress,
+      'should assign mainnet deposit contract'
+    )
+  })
+
+  it('should correctly parse deposit contract adddress', async () => {
+    // clone json out to not have side effects
+    const customJson = JSON.parse(JSON.stringify(postMergeHardforkJSON))
+    Object.assign(customJson.config, {
+      depositContractAddress: '0x4242424242424242424242424242424242424242',
+    })
+
+    const common = Common.fromGethGenesis(customJson, {
+      chain: 'customChain',
+    })
+    const depositContractAddress =
+      common['_chainParams'].depositContractAddress ??
+      Common.getInitializedChains().mainnet.depositContractAddress
+
+    assert.equal(
+      depositContractAddress,
+      '0x4242424242424242424242424242424242424242',
+      'should parse correct address'
+    )
+  })
 })
 
 const kilnForkHashes: any = {


### PR DESCRIPTION
pick deposit contract address from genesis.json config which is specified in this way:
```json
{
  "config": {
    "chainId": 3151908,
    "homesteadBlock": 0,
    "eip150Block": 0,
    "eip155Block": 0,
    "eip158Block": 0,
    "byzantiumBlock": 0,
    "constantinopleBlock": 0,
    "petersburgBlock": 0,
    "istanbulBlock": 0,
    "berlinBlock": 0,
    "londonBlock": 0,
    "mergeNetsplitBlock": 0,
    "terminalTotalDifficulty": 0,
    "terminalTotalDifficultyPassed": true,
    "shanghaiTime": 0,
    "cancunTime": 0,
    "depositContractAddress": "0x4242424242424242424242424242424242424242",
    "pragueTime": 1715694670
  }
}
```