### PR TITLE
verkle: rename code keccak

### DIFF
--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -12,7 +12,7 @@ import {
 } from '@ethereumjs/util'
 import {
   BALANCE_LEAF_KEY,
-  CODE_KECCAK_LEAF_KEY,
+  CODE_HASH_LEAF_KEY,
   CODE_SIZE_LEAF_KEY,
   VERSION_LEAF_KEY,
   getTreeIndexesForStorageSlot,
@@ -275,7 +275,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           coldAccessGas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
             codeAddress,
             0,
-            CODE_KECCAK_LEAF_KEY
+            CODE_HASH_LEAF_KEY
           )
 
           gas += coldAccessGas

--- a/packages/statemanager/docs/README.md
+++ b/packages/statemanager/docs/README.md
@@ -40,7 +40,7 @@
 
 - [BALANCE\_LEAF\_KEY](README.md#balance_leaf_key)
 - [CODEHASH\_PREFIX](README.md#codehash_prefix)
-- [CODE\_KECCAK\_LEAF\_KEY](README.md#code_keccak_leaf_key)
+- [CODE\_KECCAK\_LEAF\_KEY](README.md#CODE_HASH_leaf_key)
 - [CODE\_OFFSET](README.md#code_offset)
 - [CODE\_SIZE\_LEAF\_KEY](README.md#code_size_leaf_key)
 - [HEADER\_STORAGE\_OFFSET](README.md#header_storage_offset)

--- a/packages/statemanager/src/accessWitness.ts
+++ b/packages/statemanager/src/accessWitness.ts
@@ -1,7 +1,7 @@
 import { BIGINT_0, bytesToBigInt, bytesToHex, hexToBytes, intToBytes } from '@ethereumjs/util'
 import {
   BALANCE_LEAF_KEY,
-  CODE_KECCAK_LEAF_KEY,
+  CODE_HASH_LEAF_KEY,
   CODE_OFFSET,
   CODE_SIZE_LEAF_KEY,
   HEADER_STORAGE_OFFSET,
@@ -97,7 +97,7 @@ export class AccessWitness {
     gas += this.touchAddressOnReadAndComputeGas(address, 0, VERSION_LEAF_KEY)
     gas += this.touchAddressOnReadAndComputeGas(address, 0, BALANCE_LEAF_KEY)
     gas += this.touchAddressOnReadAndComputeGas(address, 0, CODE_SIZE_LEAF_KEY)
-    gas += this.touchAddressOnReadAndComputeGas(address, 0, CODE_KECCAK_LEAF_KEY)
+    gas += this.touchAddressOnReadAndComputeGas(address, 0, CODE_HASH_LEAF_KEY)
     gas += this.touchAddressOnReadAndComputeGas(address, 0, NONCE_LEAF_KEY)
 
     return gas
@@ -136,7 +136,7 @@ export class AccessWitness {
     gas += this.touchAddressOnWriteAndComputeGas(address, 0, VERSION_LEAF_KEY)
     gas += this.touchAddressOnWriteAndComputeGas(address, 0, BALANCE_LEAF_KEY)
     gas += this.touchAddressOnWriteAndComputeGas(address, 0, CODE_SIZE_LEAF_KEY)
-    gas += this.touchAddressOnWriteAndComputeGas(address, 0, CODE_KECCAK_LEAF_KEY)
+    gas += this.touchAddressOnWriteAndComputeGas(address, 0, CODE_HASH_LEAF_KEY)
     gas += this.touchAddressOnWriteAndComputeGas(address, 0, NONCE_LEAF_KEY)
 
     return gas
@@ -147,7 +147,7 @@ export class AccessWitness {
 
     gas += this.touchAddressOnReadAndComputeGas(origin, 0, VERSION_LEAF_KEY)
     gas += this.touchAddressOnReadAndComputeGas(origin, 0, CODE_SIZE_LEAF_KEY)
-    gas += this.touchAddressOnReadAndComputeGas(origin, 0, CODE_KECCAK_LEAF_KEY)
+    gas += this.touchAddressOnReadAndComputeGas(origin, 0, CODE_HASH_LEAF_KEY)
 
     gas += this.touchAddressOnWriteAndComputeGas(origin, 0, NONCE_LEAF_KEY)
     gas += this.touchAddressOnWriteAndComputeGas(origin, 0, BALANCE_LEAF_KEY)
@@ -160,7 +160,7 @@ export class AccessWitness {
 
     gas += this.touchAddressOnReadAndComputeGas(target, 0, VERSION_LEAF_KEY)
     gas += this.touchAddressOnReadAndComputeGas(target, 0, CODE_SIZE_LEAF_KEY)
-    gas += this.touchAddressOnReadAndComputeGas(target, 0, CODE_KECCAK_LEAF_KEY)
+    gas += this.touchAddressOnReadAndComputeGas(target, 0, CODE_HASH_LEAF_KEY)
     gas += this.touchAddressOnReadAndComputeGas(target, 0, NONCE_LEAF_KEY)
 
     if (sendsValue === true) {

--- a/packages/statemanager/src/statelessVerkleStateManager.ts
+++ b/packages/statemanager/src/statelessVerkleStateManager.ts
@@ -501,7 +501,7 @@ export class StatelessVerkleStateManager implements EVMStateManagerInterface {
    */
   async clearContractStorage(address: Address): Promise<void> {
     const stem = getStem(this.verkleCrypto, address, 0)
-    const codeHashKey = getKey(stem, LeafType.CodeKeccak)
+    const codeHashKey = getKey(stem, LeafType.CodeHash)
     this._storageCache?.clearContractStorage(address)
     // Update codeHash to `c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`
     this._state[bytesToHex(codeHashKey)] = KECCAK256_NULL_S
@@ -521,7 +521,7 @@ export class StatelessVerkleStateManager implements EVMStateManagerInterface {
     const versionKey = getKey(stem, LeafType.Version)
     const balanceKey = getKey(stem, LeafType.Balance)
     const nonceKey = getKey(stem, LeafType.Nonce)
-    const codeHashKey = getKey(stem, LeafType.CodeKeccak)
+    const codeHashKey = getKey(stem, LeafType.CodeHash)
     const codeSizeKey = getKey(stem, LeafType.CodeSize)
 
     const versionRaw = this._state[bytesToHex(versionKey)]
@@ -607,7 +607,7 @@ export class StatelessVerkleStateManager implements EVMStateManagerInterface {
       const stem = getStem(this.verkleCrypto, address, 0)
       const balanceKey = getKey(stem, LeafType.Balance)
       const nonceKey = getKey(stem, LeafType.Nonce)
-      const codeHashKey = getKey(stem, LeafType.CodeKeccak)
+      const codeHashKey = getKey(stem, LeafType.CodeHash)
 
       const balanceBuf = setLengthRight(bigIntToBytes(account.balance, true), 32)
       const nonceBuf = setLengthRight(bigIntToBytes(account.nonce, true), 32)

--- a/packages/statemanager/test/statelessVerkleStateManager.spec.ts
+++ b/packages/statemanager/test/statelessVerkleStateManager.spec.ts
@@ -118,7 +118,7 @@ describe('StatelessVerkleStateManager: Kaustinen Verkle Block', () => {
 
     const balanceKey = getKey(stem, LeafType.Balance)
     const nonceKey = getKey(stem, LeafType.Nonce)
-    const codeHashKey = getKey(stem, LeafType.CodeKeccak)
+    const codeHashKey = getKey(stem, LeafType.CodeHash)
 
     const balanceRaw = stateManager['_state'][bytesToHex(balanceKey)]
     const nonceRaw = stateManager['_state'][bytesToHex(nonceKey)]

--- a/packages/verkle/src/types.ts
+++ b/packages/verkle/src/types.ts
@@ -135,7 +135,7 @@ export enum LeafType {
 export const VERSION_LEAF_KEY = intToBytes(LeafType.Version)
 export const BALANCE_LEAF_KEY = intToBytes(LeafType.Balance)
 export const NONCE_LEAF_KEY = intToBytes(LeafType.Nonce)
-export const CODE_KECCAK_LEAF_KEY = intToBytes(LeafType.CodeHash)
+export const CODE_HASH_LEAF_KEY = intToBytes(LeafType.CodeHash)
 export const CODE_SIZE_LEAF_KEY = intToBytes(LeafType.CodeSize)
 
 export const HEADER_STORAGE_OFFSET = 64

--- a/packages/verkle/src/types.ts
+++ b/packages/verkle/src/types.ts
@@ -128,14 +128,14 @@ export enum LeafType {
   Version = 0,
   Balance = 1,
   Nonce = 2,
-  CodeKeccak = 3,
+  CodeHash = 3,
   CodeSize = 4,
 }
 
 export const VERSION_LEAF_KEY = intToBytes(LeafType.Version)
 export const BALANCE_LEAF_KEY = intToBytes(LeafType.Balance)
 export const NONCE_LEAF_KEY = intToBytes(LeafType.Nonce)
-export const CODE_KECCAK_LEAF_KEY = intToBytes(LeafType.CodeKeccak)
+export const CODE_KECCAK_LEAF_KEY = intToBytes(LeafType.CodeHash)
 export const CODE_SIZE_LEAF_KEY = intToBytes(LeafType.CodeSize)
 
 export const HEADER_STORAGE_OFFSET = 64

--- a/packages/verkle/src/util/keys.ts
+++ b/packages/verkle/src/util/keys.ts
@@ -34,7 +34,7 @@ export const getKey = (stem: Uint8Array, leaf: LeafType | Uint8Array) => {
       return concatBytes(stem, BALANCE_LEAF_KEY)
     case LeafType.Nonce:
       return concatBytes(stem, NONCE_LEAF_KEY)
-    case LeafType.CodeKeccak:
+    case LeafType.CodeHash:
       return concatBytes(stem, CODE_KECCAK_LEAF_KEY)
     case LeafType.CodeSize:
       return concatBytes(stem, CODE_SIZE_LEAF_KEY)

--- a/packages/verkle/src/util/keys.ts
+++ b/packages/verkle/src/util/keys.ts
@@ -2,7 +2,7 @@ import { concatBytes, setLengthRight, toBytes } from '@ethereumjs/util'
 
 import {
   BALANCE_LEAF_KEY,
-  CODE_KECCAK_LEAF_KEY,
+  CODE_HASH_LEAF_KEY,
   CODE_OFFSET,
   CODE_SIZE_LEAF_KEY,
   HEADER_STORAGE_OFFSET,
@@ -35,7 +35,7 @@ export const getKey = (stem: Uint8Array, leaf: LeafType | Uint8Array) => {
     case LeafType.Nonce:
       return concatBytes(stem, NONCE_LEAF_KEY)
     case LeafType.CodeHash:
-      return concatBytes(stem, CODE_KECCAK_LEAF_KEY)
+      return concatBytes(stem, CODE_HASH_LEAF_KEY)
     case LeafType.CodeSize:
       return concatBytes(stem, CODE_SIZE_LEAF_KEY)
     default:

--- a/packages/verkle/test/keys.spec.ts
+++ b/packages/verkle/test/keys.spec.ts
@@ -10,7 +10,7 @@ describe('should generate valid tree keys', () => {
       LeafType.Version,
       LeafType.Balance,
       LeafType.Nonce,
-      LeafType.CodeKeccak,
+      LeafType.CodeHash,
       LeafType.CodeSize,
     ]) {
       const key = getKey(stem, leaf)


### PR DESCRIPTION
This PR renames code keccak to codehash as suggested by @acolytec3 