### PR TITLE
util: remove isHexString length arg

### DIFF
--- a/packages/util/src/internal.ts
+++ b/packages/util/src/internal.ts
@@ -27,15 +27,12 @@ import { bytesToUnprefixedHex, utf8ToBytes } from './bytes.js'
 import type { PrefixedHexString } from './types.js'
 
 /**
- * Returns a boolean on whether or not the the input starts with '0x' and matches the optional length
+ * Returns a boolean on whether or not the the input starts with '0x'
  * @param {string} value the string input value
- * @param {number|undefined} length the optional length of the hex string in bytes
- * @returns {boolean} Whether or not the string is a valid PrefixedHexString matching the optional length
+ * @returns {boolean} Whether or not the string is a valid PrefixedHexString
  */
-export function isHexString(value: string, length?: number): value is PrefixedHexString {
+export function isHexString(value: string): value is PrefixedHexString {
   if (typeof value !== 'string' || !value.match(/^0x[0-9A-Fa-f]*$/)) return false
-
-  if (typeof length !== 'undefined' && length > 0 && value.length !== 2 + 2 * length) return false
 
   return true
 }


### PR DESCRIPTION
This PR removes the isHexString length arg.

My reasons for removing: 

- It's usage is confusing because it expects bytes length, and not hex length. This is not obvious at all from the api, only realized through looking at the code
- It is not used anywhere in our repo
- It's in the internal folder, so I assume intended for internal usage.