### PR TITLE
evm: fix eip3074 AUTH check

### DIFF
--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -1157,9 +1157,16 @@ export const handlers: Map<number, OpHandler> = new Map([
       }
 
       const expectedAddress = new Address(setLengthLeft(bigIntToBytes(authority), 20).slice(-20))
-      const accountNonce = (
-        (await runState.stateManager.getAccount(expectedAddress)) ?? new Account()
-      ).nonce
+      const account = (await runState.stateManager.getAccount(expectedAddress)) ?? new Account()
+
+      if (account.isContract()) {
+        // EXTCODESIZE > 0
+        runState.stack.push(BIGINT_0)
+        runState.auth = undefined
+        return
+      }
+
+      const accountNonce = account.nonce
 
       const invokedAddress = setLengthLeft(runState.interpreter._env.address.bytes, 32)
       const chainId = setLengthLeft(bigIntToBytes(runState.interpreter.getChainId()), 32)


### PR DESCRIPTION
We did not have the extcodesize > 0 check in AUTH which should invalidate the signer.

To test: download https://github.com/ethereum/execution-spec-tests/files/15330588/fixtures_develop.tar.gz

Untar the blockchain tests into `ethereum-tests` for instance in a Devnet0 dir.

Then from VM:

`npm run test:blockchain -- --fork=Prague --dir=../Devnet0`