### PR TITLE
Fix tx status in `eth_getTransactionReceipt`

### DIFF
--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -201,7 +201,7 @@ const jsonRpcReceipt = async (
       ? bytesToHex((receipt as PreByzantiumTxReceipt).stateRoot)
       : undefined,
   status:
-    ((receipt as PostByzantiumTxReceipt).status as unknown) instanceof Uint8Array
+    (receipt as PostByzantiumTxReceipt).status !== undefined
       ? intToHex((receipt as PostByzantiumTxReceipt).status)
       : undefined,
   blobGasUsed: blobGasUsed !== undefined ? bigIntToHex(blobGasUsed) : undefined,

--- a/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
@@ -69,6 +69,7 @@ describe(method, () => {
     const res = await rpc.request(method, [bytesToHex(tx.hash())])
 
     assert.equal(res.result.transactionHash, bytesToHex(tx.hash()), 'should return the correct tx')
+    assert.equal(res.result.status, '0x1', 'transaction result is 1 since succeeded')
   })
 
   it('call with unknown tx hash', async () => {


### PR DESCRIPTION
While running `assertoor` tests in kurtosis, we identified a bug in our code where we were not returning a `status` field as part of the response from `eth_getTransactionReceipt`.  This PR brings our code into line with the [spec](https://ethereum.github.io/execution-apis/api-documentation/)