### PR TITLE
Add support for multiple sources of rlp blocks

### DIFF
--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -166,7 +166,7 @@ export interface ClientOpts {
   isSingleNode?: boolean
   vmProfileBlocks?: boolean
   vmProfileTxs?: boolean
-  loadBlocksFromRlp?: string
+  loadBlocksFromRlp?: string[]
   pruneEngineCache?: boolean
   savePreimages?: boolean
   verkleGenesisStateRoot?: Uint8Array


### PR DESCRIPTION
This PR allows multiple files to be passed in as an input for the `--loadBlocksFromRlp` CLI parameter in the `client` which will allow the hive `consensus` tests to be run.