### PR TITLE
Integrated-portal-client

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -86,6 +86,7 @@
     "kzg-wasm": "^0.4.0",
     "level": "^8.0.0",
     "memory-level": "^1.0.0",
+    "portalnetwork": "^0.0.2-rc2",
     "prom-client": "^15.1.0",
     "qheap": "^1.4.0",
     "winston": "^3.3.3",

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -126,6 +126,9 @@ export class EthereumClient {
     if (this.opened) {
       return false
     }
+    if (this.config.portalNetworkConfig) {
+      this.portal = await PortalNetwork.create(this.config.portalNetworkConfig)
+    }
     const name = this.config.chainCommon.chainName()
     const chainId = this.config.chainCommon.chainId()
     const packageJson = JSON.parse(
@@ -162,6 +165,9 @@ export class EthereumClient {
     this.config.logger.info('Setup networking and services.')
 
     await Promise.all(this.services.map((s) => s.start()))
+    if (this.portal) {
+      await this.portal.start()
+    }
     this.config.server && (await this.config.server.start())
     // Only call bootstrap if servers are actually started
     this.config.server && this.config.server.started && (await this.config.server.bootstrap())

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'fs'
+import { PortalNetwork } from 'portalnetwork'
 
 import { Chain } from './blockchain/index.js'
 import { SyncMode } from './config.js'
@@ -70,6 +71,7 @@ export class EthereumClient {
   public config: Config
   public chain: Chain
   public services: (FullEthereumService | LightEthereumService)[] = []
+  public portal?: PortalNetwork
 
   public opened: boolean
   public started: boolean

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -13,6 +13,7 @@ import type { EventBusType, MultiaddrLike, PrometheusMetrics } from './types.js'
 import type { BlockHeader } from '@ethereumjs/block'
 import type { VM, VMProfilerOpts } from '@ethereumjs/vm'
 import type { Multiaddr } from '@multiformats/multiaddr'
+import type { PortalNetworkOpts } from 'portalnetwork'
 
 export enum DataDirectory {
   Chain = 'chain',
@@ -344,6 +345,11 @@ export interface ConfigOptions {
    * Enables Prometheus Metrics that can be collected for monitoring client health
    */
   prometheusMetrics?: PrometheusMetrics
+
+  /**
+   * Configuration for integrated portal network client
+   */
+  portalNetworkConfig?: Partial<PortalNetworkOpts>
 }
 
 export class Config {
@@ -470,6 +476,8 @@ export class Config {
 
   public readonly metrics: PrometheusMetrics | undefined
 
+  public readonly portalNetworkConfig?: Partial<PortalNetworkOpts>
+
   constructor(options: ConfigOptions = {}) {
     this.events = new EventBus() as EventBusType
 
@@ -578,6 +586,7 @@ export class Config {
     this.events.once(Event.CLIENT_SHUTDOWN, () => {
       this.shutdown = true
     })
+    this.portalNetworkConfig = options.portalNetworkConfig
   }
 
   /**


### PR DESCRIPTION
This is an experiment towards integrating `ultralight` directly into the ethjs `client`.

ultralight is imported as `portalnetwork` in the client dependencies.

optional `portalNetworkConfig` is added to client `Config`

optional `this.portal` attribute is added to client class.

client will create `PortalNetwork` instance during `client.open()`, and start the portal client along with the other `services`