### PR TITLE
EVM/VM: Update mcl-wasm Dependency (Esbuild Issue)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8888,9 +8888,9 @@
       }
     },
     "node_modules/mcl-wasm": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-1.4.0.tgz",
-      "integrity": "sha512-90Tvmg2NXwnKMgTafA01PRELsYNNRb/F2bj3nzdByTLLMUmgkgL8H/oeWcjZtVVffnBJyNjDcYxY7cdOE/WoHg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-1.5.0.tgz",
+      "integrity": "sha512-+Bnefweg0PWhQ//pVAawNkZAC+TH/mMZVsxmEyHvw8Ujhwu3cxUe9WITFK74dfgPRB09Zkmf6aUFXnW23OnVUw==",
       "dependencies": {
         "@types/node": "^20.2.5"
       },
@@ -13463,7 +13463,7 @@
         "@types/debug": "^4.1.9",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.1.3",
-        "mcl-wasm": "^1.4.0",
+        "mcl-wasm": "^1.5.0",
         "rustbn-wasm": "^0.4.0"
       },
       "devDependencies": {
@@ -13633,7 +13633,7 @@
         "@ethereumjs/verkle": "^0.0.2",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.1.3",
-        "mcl-wasm": "^1.4.0"
+        "mcl-wasm": "^1.5.0"
       },
       "devDependencies": {
         "@ethersproject/abi": "^5.0.12",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -61,7 +61,7 @@
     "@types/debug": "^4.1.9",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.1.3",
-    "mcl-wasm": "^1.4.0",
+    "mcl-wasm": "^1.5.0",
     "rustbn-wasm": "^0.4.0"
   },
   "devDependencies": {

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -75,7 +75,7 @@
     "@ethereumjs/verkle": "^0.0.2",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.1.3",
-    "mcl-wasm": "^1.4.0"
+    "mcl-wasm": "^1.5.0"
   },
   "devDependencies": {
     "@ethersproject/abi": "^5.0.12",


### PR DESCRIPTION
This updates the `mcl-wasm` dependency from 1.4.0 to 1.5.0 to adress a browser build issue due an included Node.js native `crypto` import as also described here https://github.com/herumi/mcl-wasm/issues/35.

Ready to be merged if tests pass!