### PR TITLE
Use node hash as db key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12293,9 +12293,9 @@
       }
     },
     "node_modules/verkle-cryptography-wasm": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/verkle-cryptography-wasm/-/verkle-cryptography-wasm-0.4.4.tgz",
-      "integrity": "sha512-ijAqsbnkoCYm6TS1qUxCq0BkSC+6bFE2UxSfwNRWeIJxdvvEHZxPGifdXsqC4NnOA1JVWeloNuxGuIwTo3HlSw==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/verkle-cryptography-wasm/-/verkle-cryptography-wasm-0.4.5.tgz",
+      "integrity": "sha512-CG0hRG0QuVoLnmwPiBpgWWzgJCoF81/w6S3ASeoew6tQp52HsN+e8yrachGh2bFIZLRDUQA2cX+0xr2VM60ywA==",
       "dependencies": {
         "@scure/base": "^1.1.5"
       },
@@ -13438,7 +13438,7 @@
         "level": "^8.0.0",
         "memory-level": "^1.0.0",
         "prom-client": "^15.1.0",
-        "verkle-cryptography-wasm": "^0.4.2",
+        "verkle-cryptography-wasm": "^0.4.5",
         "winston": "^3.3.3",
         "winston-daily-rotate-file": "^4.5.5",
         "yargs": "^17.7.1"
@@ -13669,7 +13669,7 @@
         "@ethereumjs/genesis": "^0.2.2",
         "@types/debug": "^4.1.9",
         "rustbn-wasm": "^0.4.0",
-        "verkle-cryptography-wasm": "^0.4.2"
+        "verkle-cryptography-wasm": "^0.4.5"
       }
     },
     "packages/trie": {
@@ -13747,7 +13747,7 @@
         "@ethereumjs/util": "^9.0.3",
         "debug": "^4.3.4",
         "lru-cache": "10.1.0",
-        "verkle-cryptography-wasm": "^0.4.4"
+        "verkle-cryptography-wasm": "^0.4.5"
       },
       "engines": {
         "node": ">=18"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -87,7 +87,7 @@
     "level": "^8.0.0",
     "memory-level": "^1.0.0",
     "prom-client": "^15.1.0",
-    "verkle-cryptography-wasm": "^0.4.2",
+    "verkle-cryptography-wasm": "^0.4.5",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.5.5",
     "yargs": "^17.7.1"

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -63,6 +63,6 @@
     "@ethereumjs/genesis": "^0.2.2",
     "@types/debug": "^4.1.9",
     "rustbn-wasm": "^0.4.0",
-    "verkle-cryptography-wasm": "^0.4.2"
+    "verkle-cryptography-wasm": "^0.4.5"
   }
 }

--- a/packages/verkle/package.json
+++ b/packages/verkle/package.json
@@ -54,7 +54,7 @@
   "dependencies": {
     "debug": "^4.3.4",
     "lru-cache": "10.1.0",
-    "verkle-cryptography-wasm": "^0.4.4",
+    "verkle-cryptography-wasm": "^0.4.5",
     "@ethereumjs/block": "^5.2.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/util": "^9.0.3"

--- a/packages/verkle/src/node/baseVerkleNode.ts
+++ b/packages/verkle/src/node/baseVerkleNode.ts
@@ -2,7 +2,7 @@ import { RLP } from '@ethereumjs/rlp'
 
 import { type VerkleNodeInterface, type VerkleNodeOptions, type VerkleNodeType } from './types.js'
 
-import type { VerkleCrypto } from 'verkle-cryptography-wasm'
+import type { VerkleCrypto } from '@ethereumjs/util'
 
 export abstract class BaseVerkleNode<T extends VerkleNodeType> implements VerkleNodeInterface {
   public commitment: Uint8Array

--- a/packages/verkle/src/node/types.ts
+++ b/packages/verkle/src/node/types.ts
@@ -1,6 +1,6 @@
 import type { InternalNode } from './internalNode.js'
 import type { LeafNode } from './leafNode.js'
-import type { VerkleCrypto } from 'verkle-cryptography-wasm'
+import type { VerkleCrypto } from '@ethereumjs/util'
 
 export enum VerkleNodeType {
   Internal,

--- a/packages/verkle/test/verkle.spec.ts
+++ b/packages/verkle/test/verkle.spec.ts
@@ -185,6 +185,9 @@ describe('findPath validation', () => {
     // Put a second leaf node in the tree with a partially matching stem
     putStack = []
     const stem2 = hexToBytes(keys[2]).slice(0, 31)
+
+    // Find path to closest node in tree
+    const foundPath = await trie.findPath(stem2)
     const leafNode2 = await LeafNode.create(
       stem2,
       new Array(256).fill(new Uint8Array(32)),

--- a/packages/verkle/test/verkle.spec.ts
+++ b/packages/verkle/test/verkle.spec.ts
@@ -5,7 +5,6 @@ import { assert, beforeAll, describe, it } from 'vitest'
 import {
   InternalNode,
   LeafNode,
-  ROOT_DB_KEY,
   VerkleNodeType,
   decodeNode,
   matchingBytesLength,

--- a/packages/verkle/test/verkle.spec.ts
+++ b/packages/verkle/test/verkle.spec.ts
@@ -163,16 +163,16 @@ describe('findPath validation', () => {
     leafNode1.setValue(hexToBytes(keys[0])[31], hexToBytes(values[0]))
     leafNode1.setValue(hexToBytes(keys[1])[31], hexToBytes(values[1]))
 
-    putStack.push([stem1, leafNode1])
+    putStack.push([leafNode1.hash(), leafNode1])
 
     // Pull root node from DB
-    const rawNode = await trie['_db'].get(ROOT_DB_KEY)
+    const rawNode = await trie['_db'].get(trie.root())
     const rootNode = decodeNode(rawNode!, verkleCrypto) as InternalNode
     // Update root node with commitment from leaf node
     rootNode.setChild(stem1[0], { commitment: leafNode1.commitment, path: stem1 })
-    putStack.push([ROOT_DB_KEY, rootNode])
-    await trie.saveStack(putStack)
     trie.root(verkleCrypto.serializeCommitment(rootNode.commitment))
+    putStack.push([trie.root(), rootNode])
+    await trie.saveStack(putStack)
 
     // Verify that path to leaf node can be found from stem
     const res = await trie.findPath(stem1)
@@ -191,7 +191,7 @@ describe('findPath validation', () => {
       verkleCrypto
     )
     leafNode2.setValue(hexToBytes(keys[2])[31], hexToBytes(values[2]))
-    putStack.push([stem2, leafNode2])
+    putStack.push([leafNode2.hash(), leafNode2])
 
     // Create new internal node
     const internalNode1 = InternalNode.create(verkleCrypto)
@@ -211,15 +211,15 @@ describe('findPath validation', () => {
       path: stem2,
     })
 
-    putStack.push([internalNode1Path, internalNode1])
+    putStack.push([internalNode1.hash(), internalNode1])
     // Update rootNode child reference for internal node 1
     rootNode.setChild(internalNode1Path[0], {
       commitment: internalNode1.commitment,
       path: internalNode1Path,
     })
-    putStack.push([ROOT_DB_KEY, rootNode])
-    await trie.saveStack(putStack)
     trie.root(verkleCrypto.serializeCommitment(rootNode.commitment))
+    putStack.push([trie.root(), rootNode])
+    await trie.saveStack(putStack)
     let res2 = await trie.findPath(stem1)
 
     assert.equal(res2.remaining.length, 0, 'confirm full path was found')


### PR DESCRIPTION
This makes several small updates to `verkle` preparing for implementation of `trie.push`

- Update `VerkleTrie` class to use output from `verkleCrypto.serializeCommitment` as db key for root node instead of `ROOT_DB_KEY` (serialized commitment is needed for the verkle state root when we start creating block execution proofs)
- Update `findPath` test to use `verklenode.hash` instead of the partial path as the db key (to ensure that we can find nodes from previous state roots and not overwrite them everytime a node at a given partial path changes)
- Update `findPath` test to use result from `findPath` when inserting a new node into the trie.  This gives a cleaner example of how `trie.put` should work 
- Updates `verkle-cryptography-wasm` to v0.4.5