### PR TITLE
common: update eip 2935 as per latest devnet1 spec and add related eip 7709

### DIFF
--- a/packages/block/src/from-beacon-payload.ts
+++ b/packages/block/src/from-beacon-payload.ts
@@ -20,7 +20,7 @@ type BeaconDepositRequest = {
 
 type BeaconWithdrawalRequest = {
   source_address: PrefixedHexString
-  validator_pub_key: PrefixedHexString
+  validator_pubkey: PrefixedHexString
   amount: PrefixedHexString
 }
 
@@ -160,7 +160,7 @@ export function executionPayloadFromBeaconPayload(payload: BeaconPayloadJson): E
   if (payload.withdrawal_requests !== undefined && payload.withdrawal_requests !== null) {
     executionPayload.withdrawalRequests = payload.withdrawal_requests.map((breq) => ({
       sourceAddress: breq.source_address,
-      validatorPubkey: breq.validator_pub_key,
+      validatorPubkey: breq.validator_pubkey,
       amount: breq.amount,
     }))
   }

--- a/packages/client/test/rpc/engine/newPayloadV4.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV4.spec.ts
@@ -50,7 +50,10 @@ describe(`${method}: call with executionPayloadV4`, () => {
     const { pragueJson, pragueTime } = readyPragueGenesis(genesisJSON)
     const { service, server } = await setupChain(pragueJson, 'post-merge', { engine: true })
     const rpc = getRpcClient(server)
-    // const res1 = await rpc.request(`eth_getBlockByNumber`, ["0x0",false])
+    let res
+
+    res = await rpc.request(`eth_getBlockByNumber`, ['0x0', false])
+    assert.equal(res.result.hash, validForkChoiceState.headBlockHash)
 
     const validBlock = {
       ...blockData,
@@ -64,7 +67,6 @@ describe(`${method}: call with executionPayloadV4`, () => {
       stateRoot: '0xd207043769091b6cdc91621f12bf2800b0b4643aeff09118fca52543c7a8ff03',
       blockHash: '0xf9b4285204630ca183fec0a9a282cb68021af1aa9f3ab5f10d6b9ea8a7a3d4b6',
     }
-    let res
 
     const oldMethods = ['engine_newPayloadV1', 'engine_newPayloadV2', 'engine_newPayloadV3']
     const expectedErrors = [

--- a/packages/client/test/rpc/engine/newPayloadV4.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV4.spec.ts
@@ -50,8 +50,7 @@ describe(`${method}: call with executionPayloadV4`, () => {
     const { pragueJson, pragueTime } = readyPragueGenesis(genesisJSON)
     const { service, server } = await setupChain(pragueJson, 'post-merge', { engine: true })
     const rpc = getRpcClient(server)
-    const res1 = await rpc.request(`eth_getBlockByNumber`, ["0x0",false])
-    console.log({res1})
+    // const res1 = await rpc.request(`eth_getBlockByNumber`, ["0x0",false])
 
     const validBlock = {
       ...blockData,

--- a/packages/client/test/rpc/engine/newPayloadV4.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV4.spec.ts
@@ -12,9 +12,9 @@ const [blockData] = blocks
 
 const parentBeaconBlockRoot = '0x42942949c4ed512cd85c2cb54ca88591338cbb0564d3a2bea7961a639ef29d64'
 const validForkChoiceState = {
-  headBlockHash: '0x586b459d3fa589fa0e30477ef0e9d11794629b8b914e00b2703c0615a33ab9ed',
-  safeBlockHash: '0x586b459d3fa589fa0e30477ef0e9d11794629b8b914e00b2703c0615a33ab9ed',
-  finalizedBlockHash: '0x586b459d3fa589fa0e30477ef0e9d11794629b8b914e00b2703c0615a33ab9ed',
+  headBlockHash: '0x3ff9144b3f0818580798b0a9ff5cedc1350ff62f46ec99b098344e2864be1e47',
+  safeBlockHash: '0x3ff9144b3f0818580798b0a9ff5cedc1350ff62f46ec99b098344e2864be1e47',
+  finalizedBlockHash: '0x3ff9144b3f0818580798b0a9ff5cedc1350ff62f46ec99b098344e2864be1e47',
 }
 const validPayloadAttributes = {
   timestamp: '0x64ba84fd',
@@ -50,6 +50,9 @@ describe(`${method}: call with executionPayloadV4`, () => {
     const { pragueJson, pragueTime } = readyPragueGenesis(genesisJSON)
     const { service, server } = await setupChain(pragueJson, 'post-merge', { engine: true })
     const rpc = getRpcClient(server)
+    const res1 = await rpc.request(`eth_getBlockByNumber`, ["0x0",false])
+    console.log({res1})
+
     const validBlock = {
       ...blockData,
       timestamp: bigIntToHex(BigInt(pragueTime)),
@@ -58,9 +61,9 @@ describe(`${method}: call with executionPayloadV4`, () => {
       excessBlobGas: '0x0',
       depositRequests: [],
       withdrawalRequests: [],
-      parentHash: '0x586b459d3fa589fa0e30477ef0e9d11794629b8b914e00b2703c0615a33ab9ed',
-      stateRoot: '0x76869ec89f1bc786e10a03ecf4a3f9815ec9dddecb372bd0eff51fe75d0d921e',
-      blockHash: '0x34ec8335d47f4ba04a4c1f75f414b85b5e5200d60a6a639b6fc71ce90bcaaee2',
+      parentHash: '0x3ff9144b3f0818580798b0a9ff5cedc1350ff62f46ec99b098344e2864be1e47',
+      stateRoot: '0xd207043769091b6cdc91621f12bf2800b0b4643aeff09118fca52543c7a8ff03',
+      blockHash: '0xf9b4285204630ca183fec0a9a282cb68021af1aa9f3ab5f10d6b9ea8a7a3d4b6',
     }
     let res
 
@@ -129,10 +132,10 @@ describe(`${method}: call with executionPayloadV4`, () => {
 const electraGenesisContracts = {
   // sender corresponding to the priv key 0x9c9996335451aab4fc4eac58e31a8c300e095cdbcee532d53d09280e83360355
   '0x610adc49ecd66cbf176a8247ebd59096c031bd9f': { balance: '0x6d6172697573766477000000' },
-  '0x25a219378dad9b3503c8268c9ca836a52427a4fb': {
+  '0x0aae40965e6800cd9b1f4b05ff21581047e3f91e': {
     balance: '0',
     nonce: '1',
-    code: '0x60203611603157600143035f35116029575f356120000143116029576120005f3506545f5260205ff35b5f5f5260205ff35b5f5ffd00',
+    code: '0x3373fffffffffffffffffffffffffffffffffffffffe1460575767ffffffffffffffff5f3511605357600143035f3511604b575f35612000014311604b57611fff5f3516545f5260205ff35b5f5f5260205ff35b5f5ffd5b5f35611fff60014303165500',
   },
   '0x00A3ca265EBcb825B45F985A16CEFB49958cE017': {
     balance: '0',

--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -624,7 +624,7 @@ export const EIPs: EIPsDict = {
     gasPrices: {},
   },
   7709: {
-    comment: 'Use historical block hashes saved in stte for BLOCKHASH',
+    comment: 'Use historical block hashes saved in state for BLOCKHASH',
     url: 'https://eips.ethereum.org/EIPS/eip-7709',
     status: Status.Draft,
     minimumHardfork: Hardfork.Chainstart,

--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -222,7 +222,7 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     vm: {
       historyStorageAddress: {
-        v: BigInt('0x25a219378dad9b3503c8268c9ca836a52427a4fb'),
+        v: BigInt('0x0aae40965e6800cd9b1f4b05ff21581047e3f91e'),
         d: 'The address where the historical blockhashes are stored',
       },
       historyServeWindow: {
@@ -622,5 +622,12 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.Cancun,
     requiredEIPs: [3675],
     gasPrices: {},
+  },
+  7709: {
+    comment: 'Use historical block hashes saved in stte for BLOCKHASH',
+    url: 'https://eips.ethereum.org/EIPS/eip-7709',
+    status: Status.Draft,
+    minimumHardfork: Hardfork.Chainstart,
+    requiredEIPs: [2935],
   },
 }

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -211,6 +211,7 @@ export class EVM implements EVMInterface {
     const supportedEIPs = [
       1153, 1559, 2537, 2565, 2718, 2929, 2930, 2935, 3074, 3198, 3529, 3540, 3541, 3607, 3651,
       3670, 3855, 3860, 4399, 4895, 4788, 4844, 5133, 5656, 6110, 6780, 6800, 7002, 7516, 7685,
+      7709,
     ]
 
     for (const eip of this.common.eips()) {

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -608,16 +608,16 @@ export const handlers: Map<number, OpHandler> = new Map([
     async function (runState, common) {
       const number = runState.stack.pop()
 
-      if (common.isActivatedEIP(2935)) {
+      if (common.isActivatedEIP(7709)) {
         if (number >= runState.interpreter.getBlockNumber()) {
           runState.stack.push(BIGINT_0)
           return
         }
 
         const diff = runState.interpreter.getBlockNumber() - number
-        const historyServeWindow = common.param('vm', 'historyServeWindow')
-        // block lookups must be within the `historyServeWindow`
-        if (diff > historyServeWindow || diff <= BIGINT_0) {
+        // block lookups must be within the original window even if historyStorageAddress's
+        // historyServeWindow is much greater than 256
+        if (diff > BIGINT_256 || diff <= BIGINT_0) {
           runState.stack.push(BIGINT_0)
           return
         }
@@ -625,6 +625,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         const historyAddress = new Address(
           bigIntToAddressBytes(common.param('vm', 'historyStorageAddress'))
         )
+        const historyServeWindow = common.param('vm', 'historyServeWindow')
         const key = setLengthLeft(bigIntToBytes(number % historyServeWindow), 32)
 
         if (common.isActivatedEIP(6800)) {


### PR DESCRIPTION
for devnet 1 of prague (spec: https://notes.ethereum.org/@ethpandaops/pectra-devnet-1)

eip 2935 got added with `set` leading to bytecode change as well as got broken down into two parts with `BLOCKHASH` reading from state moved to 7709 to be activated in verkle (without changing the BLOCKHASH window)


- https://eips.ethereum.org/EIPS/eip-7709
- https://eips.ethereum.org/EIPS/eip-2935