### PR TITLE
update tests to v14

### DIFF
--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -7,6 +7,7 @@ import {
   BIGINT_0,
   BIGINT_1,
   KECCAK256_NULL,
+  KECCAK256_RLP,
   MAX_INTEGER,
   bigIntToBytes,
   bytesToUnprefixedHex,
@@ -490,7 +491,9 @@ export class EVM implements EVMInterface {
     // Check for collision
     if (
       (toAccount.nonce && toAccount.nonce > BIGINT_0) ||
-      !(equalsBytes(toAccount.codeHash, KECCAK256_NULL) === true)
+      !(equalsBytes(toAccount.codeHash, KECCAK256_NULL) === true) ||
+      // See EIP 7610 and the discussion `https://ethereum-magicians.org/t/eip-7610-revert-creation-in-case-of-non-empty-storage`
+      !(equalsBytes(toAccount.storageRoot, KECCAK256_RLP) === true)
     ) {
       if (this.DEBUG) {
         debug(`Returning on address collision`)

--- a/packages/vm/test/tester/config.ts
+++ b/packages/vm/test/tester/config.ts
@@ -165,17 +165,18 @@ const testLegacy = {
   byzantium: true,
   constantinople: true,
   petersburg: true,
-  istanbul: false,
-  muirGlacier: false,
-  berlin: false,
-  london: false,
-  paris: false,
-  ByzantiumToConstantinopleFixAt5: false,
-  EIP158ToByzantiumAt5: false,
-  FrontierToHomesteadAt5: false,
-  HomesteadToDaoAt5: false,
-  HomesteadToEIP150At5: false,
-  BerlinToLondonAt5: false,
+  istanbul: true,
+  muirGlacier: true,
+  berlin: true,
+  london: true,
+  paris: true,
+  shanghai: true,
+  ByzantiumToConstantinopleFixAt5: true,
+  EIP158ToByzantiumAt5: true,
+  FrontierToHomesteadAt5: true,
+  HomesteadToDaoAt5: true,
+  HomesteadToEIP150At5: true,
+  BerlinToLondonAt5: true,
 }
 
 /**
@@ -190,9 +191,12 @@ export function getTestDirs(network: string, testType: string) {
       key.toLowerCase() === network.toLowerCase() &&
       testLegacy[key as keyof typeof testLegacy] === true
     ) {
-      // Tests for HFs before Istanbul have been moved under `LegacyTests/Constantinople`:
+      // Tests snapshots have moved in `LegacyTests/Constantinople`:
       // https://github.com/ethereum/tests/releases/tag/v7.0.0-beta.1
+      // Also tests have moved in `LegacyTests/Cancun`:
+      // https://github.com/ethereum/tests/releases/tag/v14.0
       testDirs.push('LegacyTests/Constantinople/' + testType)
+      testDirs.push('LegacyTests/Cancun/' + testType)
       break
     }
   }

--- a/packages/vm/test/tester/config.ts
+++ b/packages/vm/test/tester/config.ts
@@ -24,6 +24,11 @@ export const SKIP_BROKEN = [
   'blockChainFrontierWithLargerTDvsHomesteadBlockchain2_FrontierToHomesteadAt5',
   'blockChainFrontierWithLargerTDvsHomesteadBlockchain_FrontierToHomesteadAt5',
   'HomesteadOverrideFrontier_FrontierToHomesteadAt5',
+
+  // Test skipped in ethereum-tests v14, this is an internal test for retesteth to throw an error if the test self is wrong
+  // This test is thus not supposed to pass
+  // TODO: remove me once this test is removed from the releases
+  'filling_unexpectedException',
 ]
 
 /**


### PR DESCRIPTION
This PR

- Updates `ethereum-tests` to https://github.com/ethereum/tests/releases/tag/v14.0
- This includes a back-and-forth conversation with Dimitry about some tests (one should not be in the release and we skip them now)
- Implements and adds https://eips.ethereum.org/EIPS/eip-7610 (note, have not added this to Common since this is always allowed by default - the situation has not happened on mainnet so we can safely allow it always from Chainstart)