### PR TITLE
VM: EVM Opts Chaining for better DevEx

### DIFF
--- a/packages/vm/src/types.ts
+++ b/packages/vm/src/types.ts
@@ -2,7 +2,7 @@ import type { Bloom } from './bloom/index.js'
 import type { Block, BlockOptions, HeaderData } from '@ethereumjs/block'
 import type { BlockchainInterface } from '@ethereumjs/blockchain'
 import type { Common, EVMStateManagerInterface } from '@ethereumjs/common'
-import type { EVMInterface, EVMResult, Log } from '@ethereumjs/evm'
+import type { EVMInterface, EVMOpts, EVMResult, Log } from '@ethereumjs/evm'
 import type { AccessList, TypedTransaction } from '@ethereumjs/tx'
 import type {
   BigIntLike,
@@ -158,6 +158,14 @@ export interface VMOpts {
    * Use a custom EVM to run Messages on. If this is not present, use the default EVM.
    */
   evm?: EVMInterface
+
+  /**
+   * Often there is no need to provide a full custom EVM but only a few options need to be
+   * adopted. This option allows to provide a custom set of EVM options to be passed.
+   *
+   * Note: This option will throw if used in conjunction with a full custom EVM passed.
+   */
+  evmOpts?: EVMOpts
 
   profilerOpts?: VMProfilerOpts
 }

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -123,13 +123,13 @@ export class VM {
       }
       const evmOpts = opts.evmOpts ?? {}
       opts.evm = await EVM.create({
-        ...evmOpts,
-        common: opts.evmOpts?.common ?? opts.common,
-        stateManager: opts.evmOpts?.stateManager ?? opts.stateManager,
-        blockchain: opts.evmOpts?.blockchain ?? opts.blockchain,
-        profiler: opts.evmOpts?.profiler ?? {
+        common: opts.common,
+        stateManager: opts.stateManager,
+        blockchain: opts.blockchain,
+        profiler: {
           enabled: enableProfiler,
         },
+        ...evmOpts,
       })
     }
 

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -241,18 +241,15 @@ export class VM {
    * @param downlevelCaches Downlevel (so: adopted for short-term usage) associated state caches (default: true)
    */
   async shallowCopy(downlevelCaches = true): Promise<VM> {
-    const common = this._opts.evmOpts?.common?.copy() ?? this.common.copy()
+    const common = this.common.copy()
     common.setHardfork(this.common.hardfork())
-    const blockchain =
-      this._opts.evmOpts?.blockchain?.shallowCopy() ?? this.blockchain.shallowCopy()
-    const stateManager =
-      this._opts.evmOpts?.stateManager?.shallowCopy(downlevelCaches) ??
-      this.stateManager.shallowCopy(downlevelCaches)
+    const blockchain = this.blockchain.shallowCopy()
+    const stateManager = this.stateManager.shallowCopy(downlevelCaches)
     const evmOpts = {
       ...(this.evm as any)._optsCached,
-      common,
-      blockchain,
-      stateManager,
+      common: this._opts.evmOpts?.common?.copy() ?? common,
+      blockchain: this._opts.evmOpts?.blockchain?.shallowCopy() ?? blockchain,
+      stateManager: this._opts.evmOpts?.stateManager?.shallowCopy(downlevelCaches) ?? stateManager,
     }
     const evmCopy = await EVM.create(evmOpts) // TODO fixme (should copy the EVMInterface, not default EVM)
     return VM.create({

--- a/packages/vm/test/api/index.spec.ts
+++ b/packages/vm/test/api/index.spec.ts
@@ -52,7 +52,7 @@ describe('VM -> basic instantiation / boolean switches', () => {
   })
 })
 
-describe('VM -> Custom EVM Opts', () => {
+describe('VM -> Default EVM / Custom EVM Opts', () => {
   it('Default EVM should have correct default EVM opts', async () => {
     const vm = await VM.create()
     assert.isFalse((vm.evm as EVM).allowUnlimitedContractSize, 'allowUnlimitedContractSize=false')
@@ -70,6 +70,37 @@ describe('VM -> Custom EVM Opts', () => {
   it('Default EVM should use custom EVM opts', async () => {
     const vm = await VM.create({ evmOpts: { allowUnlimitedContractSize: true } })
     assert.isTrue((vm.evm as EVM).allowUnlimitedContractSize, 'allowUnlimitedContractSize=true')
+    const copiedVM = await vm.shallowCopy()
+    assert.isTrue(
+      (copiedVM.evm as EVM).allowUnlimitedContractSize,
+      'allowUnlimitedContractSize=true (for shallowCopied VM)'
+    )
+  })
+
+  it('Default EVM should use VM common', async () => {
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium })
+    const vm = await VM.create({ common })
+    assert.equal((vm.evm as EVM).common.hardfork(), 'byzantium', 'use modfied HF from VM common')
+
+    const copiedVM = await vm.shallowCopy()
+    assert.equal(
+      (copiedVM.evm as EVM).common.hardfork(),
+      'byzantium',
+      'use modfied HF from VM common (for shallowCopied VM)'
+    )
+  })
+
+  it('Default EVM should prefer common from evmOpts if provided (same logic for blockchain, statemanager)', async () => {
+    const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Byzantium })
+    const vm = await VM.create({ evmOpts: { common } })
+    assert.equal((vm.evm as EVM).common.hardfork(), 'byzantium', 'use modfied HF from evmOpts')
+
+    const copiedVM = await vm.shallowCopy()
+    assert.equal(
+      (copiedVM.evm as EVM).common.hardfork(),
+      'byzantium',
+      'use modfied HF from evmOpts (for shallowCopied VM)'
+    )
   })
 })
 

--- a/packages/vm/test/api/index.spec.ts
+++ b/packages/vm/test/api/index.spec.ts
@@ -52,6 +52,27 @@ describe('VM -> basic instantiation / boolean switches', () => {
   })
 })
 
+describe('VM -> Custom EVM Opts', () => {
+  it('Default EVM should have correct default EVM opts', async () => {
+    const vm = await VM.create()
+    assert.isFalse((vm.evm as EVM).allowUnlimitedContractSize, 'allowUnlimitedContractSize=false')
+  })
+
+  it('should throw if evm and evmOpts are both used', async () => {
+    try {
+      await VM.create({ evmOpts: {}, evm: await EVM.create() })
+      assert.fail('should throw')
+    } catch (e: any) {
+      assert.ok('correctly thrown')
+    }
+  })
+
+  it('Default EVM should use custom EVM opts', async () => {
+    const vm = await VM.create({ evmOpts: { allowUnlimitedContractSize: true } })
+    assert.isTrue((vm.evm as EVM).allowUnlimitedContractSize, 'allowUnlimitedContractSize=true')
+  })
+})
+
 describe('VM -> supportedHardforks', () => {
   it('should throw when common is set to an unsupported hardfork', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Shanghai })


### PR DESCRIPTION
I was a bit shocked when I wanted to integrate the new `bls` EVM option into the client [here](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/client/src/execution/vmexecution.ts#L180) (e.g.) that we still have got this ugly DevEx in place that a full fledged EVM needs to be passed over to the VM, even if only a tiny setting or boolean flag should be adjusted (so this then draws this need in to re-provide a full round set of statemanager, blockchain, common,... to align with the VM).

This PR solves this, by just chaining over the EVM options. Should have no side effects, I thought through (and provided with tests) a couple of scenarios, especially regarding blockchain, statemanager, common.

So, if these three *are* provided to `evmOpts` (for whatever reasons), one would assume that the calling user has some reason for it and knows what he/she is doing, so then these three take precendence (note that the whole scenario is rather theoretical, this is just "solved for completeness").

Otherwise SM, blockchain, common from the normal VM options take precedense, so behavior from before.

Should be ready to be merged, this should ease the life of other users as well.