### PR TITLE
Add `trie.del`

### DIFF
--- a/packages/verkle/src/node/leafNode.ts
+++ b/packages/verkle/src/node/leafNode.ts
@@ -125,8 +125,10 @@ export class LeafNode extends BaseVerkleNode<VerkleNodeType.Leaf> {
     const value = this.values[index]
     switch (value) {
       case VerkleLeafNodeValue.Untouched:
-      case VerkleLeafNodeValue.Deleted:
         return undefined
+      case VerkleLeafNodeValue.Deleted:
+        // Return zeroes if a value is "deleted" (i.e. overwitten with zeroes)
+        return new Uint8Array(32)
       default:
         return value
     }

--- a/packages/verkle/src/node/leafNode.ts
+++ b/packages/verkle/src/node/leafNode.ts
@@ -1,15 +1,13 @@
 import { equalsBytes, intToBytes, setLengthLeft, setLengthRight } from '@ethereumjs/util'
 
 import { BaseVerkleNode } from './baseVerkleNode.js'
+import { NODE_WIDTH, VerkleLeafNodeValue, VerkleNodeType } from './types.js'
 import {
-  NODE_WIDTH,
-  VerkleLeafNodeValue,
-  VerkleNodeType,
+  createCValues,
   createDefaultLeafValues,
   createDeletedLeafValue,
   createUntouchedLeafValue,
-} from './types.js'
-import { createCValues } from './util.js'
+} from './util.js'
 
 import type { VerkleNodeOptions } from './types.js'
 import type { VerkleCrypto } from '@ethereumjs/util'

--- a/packages/verkle/src/node/types.ts
+++ b/packages/verkle/src/node/types.ts
@@ -51,15 +51,3 @@ export interface VerkleNodeOptions {
 }
 
 export const NODE_WIDTH = 256
-
-export const createUntouchedLeafValue = () => new Uint8Array(32)
-
-export const createDeletedLeafValue = () => {
-  const bytes = new Uint8Array(32)
-  // Set the 129th bit to 1 directly by setting the 17th byte (index 16) to 0x80
-  bytes[16] = 0x80
-
-  return bytes
-}
-
-export const createDefaultLeafValues = () => new Array(256).fill(0)

--- a/packages/verkle/src/node/util.ts
+++ b/packages/verkle/src/node/util.ts
@@ -82,13 +82,14 @@ export const createCValues = (values: (Uint8Array | VerkleLeafNodeValue)[]) => {
         break
       case VerkleLeafNodeValue.Deleted: // Leaf value that has been written with zeros (either zeroes or a deleted value)
         val = createDeletedLeafValue()
-
         break
       default:
         val = retrievedValue
         break
     }
     // We add 16 trailing zeros to each value since all commitments are padded to an array of 32 byte values
+    // TODO: Determine whether we need to apply the leaf marker (i.e. set 129th bit) for all written values
+    // regardless of whether the value stored is zero or not
     expandedValues[x * 2] = setLengthRight(val.slice(0, 16), 32)
     expandedValues[x * 2 + 1] = setLengthRight(val.slice(16), 32)
   }

--- a/packages/verkle/src/node/util.ts
+++ b/packages/verkle/src/node/util.ts
@@ -1,5 +1,5 @@
 import { RLP } from '@ethereumjs/rlp'
-import { bigIntToBytes, bytesToBigInt, setLengthRight } from '@ethereumjs/util'
+import { setLengthRight } from '@ethereumjs/util'
 
 import { InternalNode } from './internalNode.js'
 import { LeafNode } from './leafNode.js'

--- a/packages/verkle/src/node/util.ts
+++ b/packages/verkle/src/node/util.ts
@@ -3,13 +3,7 @@ import { bigIntToBytes, bytesToBigInt, setLengthRight } from '@ethereumjs/util'
 
 import { InternalNode } from './internalNode.js'
 import { LeafNode } from './leafNode.js'
-import {
-  VerkleLeafNodeValue,
-  type VerkleNode,
-  VerkleNodeType,
-  createDeletedLeafValue,
-  createUntouchedLeafValue,
-} from './types.js'
+import { VerkleLeafNodeValue, type VerkleNode, VerkleNodeType } from './types.js'
 
 import type { VerkleCrypto } from '@ethereumjs/util'
 
@@ -37,19 +31,46 @@ export function isRawNode(node: Uint8Array | Uint8Array[]): node is Uint8Array[]
   return Array.isArray(node) && !(node instanceof Uint8Array)
 }
 
-/***
- * Converts 128 32byte values of a leaf node into 16 byte values for generating a commitment for half of a
- * leaf node's values
- * @param values - an array of Uint8Arrays representing the first or second set of 128 values stored by the verkle trie leaf node
- * @param deletedValues - an array of booleans where a value of true at a given position indicates a value
- * that is being deleted - should always be false if generating C2 values
- * Returns an array of 256 16byte UintArrays with the leaf marker set for each value that is deleted
+export function isLeafNode(node: VerkleNode): node is LeafNode {
+  return node.type === VerkleNodeType.Leaf
+}
+
+export function isInternalNode(node: VerkleNode): node is InternalNode {
+  return node.type === VerkleNodeType.Internal
+}
+
+export const createUntouchedLeafValue = () => new Uint8Array(32)
+
+/**
+ * Generates a 32 byte array of zeroes and sets the 129th bit to 1, which the EIP
+ * refers to as the leaf marker to indicate a leaf value that has been touched previously
+ * and contains only zeroes
+ *
+ * Note: this value should only used in the commitment update process
+ *
+ * @returns a 32 byte array of zeroes with the 129th bit set to 1
  */
-export const createCValues = (
-  values: (Uint8Array | VerkleLeafNodeValue)[],
-  deletedValues = new Array(128).fill(false)
-) => {
-  if (values.length !== 128 || deletedValues.length !== 128)
+export const createDeletedLeafValue = () => {
+  const bytes = new Uint8Array(32)
+  // Set the 129th bit to 1 directly by setting the 17th byte (index 16) to 0x80
+  bytes[16] = 0x80
+
+  return bytes
+}
+
+export const createDefaultLeafValues = () => new Array(256).fill(0)
+
+/***
+ * Converts 128 32byte values of a leaf node into an array of 256 32 byte values representing
+ * the first and second 16 bytes of each value right padded with zeroes for generating a
+ * commitment for half of a leaf node's values
+ * @param values - an array of Uint8Arrays representing the first or second set of 128 values
+ * stored by the verkle trie leaf node
+ * Returns an array of 256 32 byte UintArrays with the leaf marker set for each value that is
+ * deleted
+ */
+export const createCValues = (values: (Uint8Array | VerkleLeafNodeValue)[]) => {
+  if (values.length !== 128)
     throw new Error(`got wrong number of values, expected 128, got ${values.length}`)
   const expandedValues: Uint8Array[] = new Array(256)
   for (let x = 0; x < 128; x++) {
@@ -59,7 +80,7 @@ export const createCValues = (
       case VerkleLeafNodeValue.Untouched: // Leaf value that has never been written before
         val = createUntouchedLeafValue()
         break
-      case VerkleLeafNodeValue.Deleted: // Leaf value that has been overwritten with zeros (i.e. a deleted value)
+      case VerkleLeafNodeValue.Deleted: // Leaf value that has been written with zeros (either zeroes or a deleted value)
         val = createDeletedLeafValue()
 
         break
@@ -68,21 +89,8 @@ export const createCValues = (
         break
     }
     // We add 16 trailing zeros to each value since all commitments are padded to an array of 32 byte values
-    expandedValues[x * 2] = setLengthRight(
-      deletedValues[x] === true
-        ? bigIntToBytes(bytesToBigInt(val.subarray(0, 16)) + BigInt(2 ** 128))
-        : val.slice(0, 16),
-      32
-    )
-    // TODO: Decide if we should use slice or subarray here (i.e. do we need to copy these slices or not)
+    expandedValues[x * 2] = setLengthRight(val.slice(0, 16), 32)
     expandedValues[x * 2 + 1] = setLengthRight(val.slice(16), 32)
   }
   return expandedValues
-}
-export function isLeafNode(node: VerkleNode): node is LeafNode {
-  return node.type === VerkleNodeType.Leaf
-}
-
-export function isInternalNode(node: VerkleNode): node is InternalNode {
-  return node.type === VerkleNodeType.Internal
 }

--- a/packages/verkle/src/verkleTree.ts
+++ b/packages/verkle/src/verkleTree.ts
@@ -14,8 +14,8 @@ import { loadVerkleCrypto } from 'verkle-cryptography-wasm'
 import { CheckpointDB } from './db/checkpoint.js'
 import { InternalNode } from './node/internalNode.js'
 import { LeafNode } from './node/leafNode.js'
-import { VerkleLeafNodeValue, type VerkleNode, createDeletedLeafValue } from './node/types.js'
-import { decodeNode, isLeafNode } from './node/util.js'
+import { VerkleLeafNodeValue, type VerkleNode } from './node/types.js'
+import { createDeletedLeafValue, decodeNode, isLeafNode } from './node/util.js'
 import {
   type Proof,
   ROOT_DB_KEY,
@@ -256,16 +256,12 @@ export class VerkleTree {
     }
     // Update value in leaf node and push to putStack
     if (equalsBytes(value, createDeletedLeafValue())) {
-      // Special case for when the deleted leaf value is passed to `put`
+      // Special case for when the deleted leaf value or zeroes is passed to `put`
       // Writing the deleted leaf value to the suffix indicated in the key
-      this.DEBUG &&
-        this.debug(
-          `Deleting value at suffix: ${suffix} in leaf node with stem: ${bytesToHex(stem)}`,
-          ['DEL']
-        )
       leafNode.setValue(suffix, VerkleLeafNodeValue.Deleted)
+    } else {
+      leafNode.setValue(suffix, value)
     }
-    leafNode.setValue(suffix, value)
     this.DEBUG &&
       this.debug(
         `Updating value for suffix: ${suffix} at leaf node with stem: ${bytesToHex(stem)}`,

--- a/packages/verkle/src/verkleTree.ts
+++ b/packages/verkle/src/verkleTree.ts
@@ -250,13 +250,6 @@ export class VerkleTree {
         )
       }
     } else {
-      if (equalsBytes(value, createDeletedLeafValue())) {
-        // Special case for when the deleted leaf value is passed to `put`
-        // You can't delete a value on a leaf node that doesn't exist
-        this.DEBUG &&
-          this.debug(`Leaf node with stem: ${bytesToHex(stem)} not found in trie`, ['DEL'])
-        return
-      }
       // Leaf node doesn't exist, create a new one
       leafNode = await LeafNode.create(stem, this.verkleCrypto)
       this.DEBUG && this.debug(`Creating new leaf node at stem: ${bytesToHex(stem)}`, ['PUT'])

--- a/packages/verkle/test/leafNode.spec.ts
+++ b/packages/verkle/test/leafNode.spec.ts
@@ -58,7 +58,7 @@ describe('verkle node - leaf', () => {
     node.setValue(0, setLengthLeft(Uint8Array.from([5]), 32))
     assert.deepEqual(node.getValue(0), setLengthLeft(Uint8Array.from([5]), 32))
     node.setValue(0, VerkleLeafNodeValue.Deleted)
-    assert.equal(node.getValue(0), undefined)
+    assert.deepEqual(node.getValue(0), new Uint8Array(32))
   })
 
   it('should update a commitment when setting a value', async () => {

--- a/packages/verkle/test/verkle.spec.ts
+++ b/packages/verkle/test/verkle.spec.ts
@@ -5,6 +5,7 @@ import { assert, beforeAll, describe, it } from 'vitest'
 import {
   InternalNode,
   LeafNode,
+  VerkleLeafNodeValue,
   VerkleNodeType,
   decodeNode,
   matchingBytesLength,
@@ -247,5 +248,23 @@ describe('Verkle tree', () => {
 
     await trie.put(hexToBytes(keys[0]), hexToBytes(values[0]))
     assert.deepEqual(await trie.get(hexToBytes(keys[0])), hexToBytes(values[0]))
+  })
+  it('should put zeros in leaf node when del called with stem  that was not in the trie before', async () => {
+    const keys = ['0x318dea512b6f3237a2d4763cf49bf26de3b617fb0cabe38a97807a5549df4d01']
+
+    const trie = await VerkleTree.create({
+      verkleCrypto,
+      db: new MapDB<Uint8Array, Uint8Array>(),
+    })
+
+    await trie['_createRootNode']()
+    assert.deepEqual(await trie.get(hexToBytes(keys[0])), undefined)
+    await trie.del(hexToBytes(keys[0]))
+    const res = await trie.findPath(hexToBytes(keys[0]).slice(0, 31))
+    assert.ok(res.node !== null)
+    assert.deepEqual(
+      (res.node as LeafNode).values[hexToBytes(keys[0])[31]],
+      VerkleLeafNodeValue.Deleted
+    )
   })
 })

--- a/packages/verkle/test/verkle.spec.ts
+++ b/packages/verkle/test/verkle.spec.ts
@@ -244,7 +244,7 @@ describe('Verkle tree', () => {
     assert.deepEqual(await trie.get(hexToBytes(keys[3])), hexToBytes(values[3]))
 
     await trie.del(hexToBytes(keys[0]))
-    assert.deepEqual(await trie.get(hexToBytes(keys[0])), undefined)
+    assert.deepEqual(await trie.get(hexToBytes(keys[0])), new Uint8Array(32))
 
     await trie.put(hexToBytes(keys[0]), hexToBytes(values[0]))
     assert.deepEqual(await trie.get(hexToBytes(keys[0])), hexToBytes(values[0]))

--- a/packages/verkle/test/verkle.spec.ts
+++ b/packages/verkle/test/verkle.spec.ts
@@ -6,7 +6,6 @@ import {
   InternalNode,
   LeafNode,
   VerkleNodeType,
-  createDeletedLeafValue,
   decodeNode,
   matchingBytesLength,
 } from '../src/index.js'

--- a/packages/verkle/test/verkle.spec.ts
+++ b/packages/verkle/test/verkle.spec.ts
@@ -211,7 +211,7 @@ describe('Verkle tree', () => {
     assert.deepEqual(val2, hexToBytes(values[2]), 'confirm values[2] can be retrieved from trie')
   })
 
-  it('should put, find, delete, and the put values (again)', async () => {
+  it('should sequentially put->find->delete->put values', async () => {
     const keys = [
       // Two keys with the same stem but different suffixes
       '0x318dea512b6f3237a2d4763cf49bf26de3b617fb0cabe38a97807a5549df4d01',

--- a/packages/verkle/test/verkle.spec.ts
+++ b/packages/verkle/test/verkle.spec.ts
@@ -211,7 +211,7 @@ describe('Verkle tree', () => {
     assert.deepEqual(val2, hexToBytes(values[2]), 'confirm values[2] can be retrieved from trie')
   })
 
-  it('should put, find, and delete values', async () => {
+  it('should put, find, delete, and the put values (again)', async () => {
     const keys = [
       // Two keys with the same stem but different suffixes
       '0x318dea512b6f3237a2d4763cf49bf26de3b617fb0cabe38a97807a5549df4d01',
@@ -244,5 +244,8 @@ describe('Verkle tree', () => {
 
     await trie.del(hexToBytes(keys[0]))
     assert.deepEqual(await trie.get(hexToBytes(keys[0])), undefined)
+
+    await trie.put(hexToBytes(keys[0]), hexToBytes(values[0]))
+    assert.deepEqual(await trie.get(hexToBytes(keys[0])), hexToBytes(values[0]))
   })
 })

--- a/packages/verkle/test/verkle.spec.ts
+++ b/packages/verkle/test/verkle.spec.ts
@@ -249,7 +249,7 @@ describe('Verkle tree', () => {
     await trie.put(hexToBytes(keys[0]), hexToBytes(values[0]))
     assert.deepEqual(await trie.get(hexToBytes(keys[0])), hexToBytes(values[0]))
   })
-  it('should put zeros in leaf node when del called with stem  that was not in the trie before', async () => {
+  it('should put zeros in leaf node when del called with stem that was not in the trie before', async () => {
     const keys = ['0x318dea512b6f3237a2d4763cf49bf26de3b617fb0cabe38a97807a5549df4d01']
 
     const trie = await VerkleTree.create({

--- a/packages/verkle/test/verkle.spec.ts
+++ b/packages/verkle/test/verkle.spec.ts
@@ -6,6 +6,7 @@ import {
   InternalNode,
   LeafNode,
   VerkleNodeType,
+  createDeletedLeafValue,
   decodeNode,
   matchingBytesLength,
 } from '../src/index.js'
@@ -211,7 +212,7 @@ describe('Verkle tree', () => {
     assert.deepEqual(val2, hexToBytes(values[2]), 'confirm values[2] can be retrieved from trie')
   })
 
-  it('should put values and find them', async () => {
+  it('should put, find, and delete values', async () => {
     const keys = [
       // Two keys with the same stem but different suffixes
       '0x318dea512b6f3237a2d4763cf49bf26de3b617fb0cabe38a97807a5549df4d01',
@@ -241,5 +242,8 @@ describe('Verkle tree', () => {
     assert.deepEqual(await trie.get(hexToBytes(keys[0])), hexToBytes(values[0]))
     assert.deepEqual(await trie.get(hexToBytes(keys[2])), hexToBytes(values[2]))
     assert.deepEqual(await trie.get(hexToBytes(keys[3])), hexToBytes(values[3]))
+
+    await trie.del(hexToBytes(keys[0]))
+    assert.deepEqual(await trie.get(hexToBytes(keys[0])), undefined)
   })
 })


### PR DESCRIPTION
Adds `trie.del` as a simple extension of `trie.put`

- Adds a new `trie.del` function which wraps `trie.put`
- Add special handling in `trie.put` for the deleted leaf value
  1. If no leaf node exists at the specified key (i.e. `findPath` returns no leaf node), return early (since you can't delete a value in a leaf node that doesn't exist)
  2. Writes the special `VerkleLeafNodeValues.Deleted` when inserting the value into the leaf node.