### PR TITLE
RPC: implement debug_getRaw...  methods  

### DIFF
--- a/packages/client/src/rpc/modules/debug.ts
+++ b/packages/client/src/rpc/modules/debug.ts
@@ -116,6 +116,11 @@ export class Debug {
       1,
       [[validators.blockOption]]
     )
+    this.getRawHeader = middleware(
+      callWithStackTrace(this.getRawHeader.bind(this), this._rpcDebug),
+      1,
+      [[validators.blockOption]]
+    )
   }
 
   /**
@@ -353,5 +358,15 @@ export class Debug {
     const [blockOpt] = params
     const block = await getBlockByOption(blockOpt, this.chain)
     return bytesToHex(block.serialize())
+  }
+  /**
+   * Returns an RLP-encoded block header
+   * @param blockOpt Block number or tag
+   * @returns
+   */
+  async getRawHeader(params: [string]) {
+    const [blockOpt] = params
+    const block = await getBlockByOption(blockOpt, this.chain)
+    return bytesToHex(block.header.serialize())
   }
 }

--- a/packages/client/src/rpc/modules/debug.ts
+++ b/packages/client/src/rpc/modules/debug.ts
@@ -111,6 +111,11 @@ export class Debug {
         [validators.unsignedInteger],
       ]
     )
+    this.getRawBlock = middleware(
+      callWithStackTrace(this.getRawBlock.bind(this), this._rpcDebug),
+      1,
+      [[validators.blockOption]]
+    )
   }
 
   /**
@@ -339,5 +344,14 @@ export class Debug {
       BigInt(startKey),
       limit
     )
+  }
+  /**
+   * Returns an RLP-encoded block
+   * @param blockOpt Block number or tag
+   */
+  async getRawBlock(params: [string]) {
+    const [blockOpt] = params
+    const block = await getBlockByOption(blockOpt, this.chain)
+    return bytesToHex(block.serialize())
   }
 }

--- a/packages/client/test/rpc/debug/getRawBlock.spec.ts
+++ b/packages/client/test/rpc/debug/getRawBlock.spec.ts
@@ -1,0 +1,146 @@
+import { Block, BlockHeader } from '@ethereumjs/block'
+import { Common } from '@ethereumjs/common'
+import { BlobEIP4844Transaction, LegacyTransaction } from '@ethereumjs/tx'
+import { Address, bytesToHex, hexToBytes } from '@ethereumjs/util'
+import { loadKZG } from 'kzg-wasm'
+import { assert, describe, it } from 'vitest'
+
+import { INVALID_PARAMS } from '../../../src/rpc/error-code.js'
+import { createClient, createManager, dummy, getRpcClient, startRPC } from '../helpers.js'
+
+const kzg = await loadKZG()
+
+const common = Common.custom({ chainId: 1 }, { customCrypto: { kzg } })
+
+common.setHardfork('cancun')
+const mockedTx1 = LegacyTransaction.fromTxData({}).sign(dummy.privKey)
+const mockedTx2 = LegacyTransaction.fromTxData({ nonce: 1 }).sign(dummy.privKey)
+const mockedBlobTx3 = BlobEIP4844Transaction.fromTxData(
+  { nonce: 2, blobsData: ['0x1234'], to: Address.zero() },
+  { common }
+).sign(dummy.privKey)
+const blockHash = hexToBytes('0xdcf93da321b27bca12087d6526d2c10540a4c8dc29db1b36610c3004e0e5d2d5')
+const transactions = [mockedTx1]
+const transactions2 = [mockedTx2]
+
+const block = {
+  hash: () => blockHash,
+  header: {
+    number: BigInt(1),
+    hash: () => blockHash,
+    serialize: () => BlockHeader.fromHeaderData({ number: 1 }).serialize(),
+  },
+  toJSON: () => ({
+    ...Block.fromBlockData({ header: { number: 1 } }).toJSON(),
+    transactions: transactions2,
+  }),
+  serialize: () =>
+    Block.fromBlockData({ header: { number: 1 }, transactions: transactions2 }).serialize(),
+  transactions: transactions2,
+  uncleHeaders: [],
+}
+
+const genesisBlockHash = hexToBytes(
+  '0xdcf93da321b27bca12087d6526d2c10540a4c8dc29db1b36610c3004e0e5d2d5'
+)
+const genesisBlock = {
+  hash: () => genesisBlockHash,
+  header: {
+    number: BigInt(0),
+  },
+  toJSON: () => ({ ...Block.fromBlockData({ header: { number: 0 } }).toJSON(), transactions }),
+  serialize: () => Block.fromBlockData({ header: { number: 0 }, transactions }).serialize(),
+  transactions,
+  uncleHeaders: [],
+}
+function createChain(headBlock = block) {
+  const block = headBlock
+  return {
+    blocks: { latest: block },
+    getBlock: () => genesisBlock,
+    getCanonicalHeadBlock: () => block,
+    getCanonicalHeadHeader: () => block.header,
+    getTd: () => BigInt(0),
+  }
+}
+
+const method = 'debug_getRawBlock'
+
+describe(method, async () => {
+  it('call with valid arguments', async () => {
+    const manager = createManager(await createClient({ chain: createChain() }))
+    const rpc = getRpcClient(startRPC(manager.getMethods()))
+
+    const res = await rpc.request(method, ['0x0'])
+    assert.equal(res.result, bytesToHex(genesisBlock.serialize()), 'should return a valid block')
+  })
+
+  it('call with earliest param', async () => {
+    const manager = createManager(await createClient({ chain: createChain() }))
+    const rpc = getRpcClient(startRPC(manager.getMethods()))
+
+    const res = await rpc.request(method, ['earliest'])
+    assert.equal(
+      res.result,
+      bytesToHex(genesisBlock.serialize()),
+      'should return the genesis block as earliest'
+    )
+  })
+
+  it('call with latest param', async () => {
+    const manager = createManager(await createClient({ chain: createChain() }))
+    const rpc = getRpcClient(startRPC(manager.getMethods()))
+
+    const res = await rpc.request(method, ['latest'])
+    assert.equal(res.result, bytesToHex(block.serialize()), 'should return block 1 RLP')
+  })
+
+  it('call with unimplemented pending param', async () => {
+    const manager = createManager(await createClient({ chain: createChain() }))
+    const rpc = getRpcClient(startRPC(manager.getMethods()))
+    const res = await rpc.request(method, ['pending'])
+    assert.equal(res.error.code, INVALID_PARAMS)
+    assert.ok(res.error.message.includes('"pending" is not yet supported'))
+  })
+
+  it('call with non-string block number', async () => {
+    const manager = createManager(await createClient({ chain: createChain() }))
+    const rpc = getRpcClient(startRPC(manager.getMethods()))
+    const res = await rpc.request(method, [10])
+    assert.equal(res.error.code, INVALID_PARAMS)
+    assert.ok(res.error.message.includes('invalid argument 0: argument must be a string'))
+  })
+
+  it('call with invalid block number', async () => {
+    const manager = createManager(await createClient({ chain: createChain() }))
+    const rpc = getRpcClient(startRPC(manager.getMethods()))
+    const res = await rpc.request(method, ['WRONG BLOCK NUMBER'])
+    assert.equal(res.error.code, INVALID_PARAMS)
+    assert.ok(
+      res.error.message.includes(
+        'invalid argument 0: block option must be a valid 0x-prefixed block hash or hex integer, or "latest", "earliest" or "pending"'
+      )
+    )
+  })
+})
+describe('call with block with blob txs', () => {
+  it('retrieves a block with a blob tx in it', async () => {
+    const genesisBlock = Block.fromBlockData({ header: { number: 0 } })
+    const block1 = Block.fromBlockData(
+      {
+        header: { number: 1, parentHash: genesisBlock.header.hash() },
+        transactions: [mockedBlobTx3],
+      },
+      { common }
+    )
+    const manager = createManager(await createClient({ chain: createChain(block1 as any) }))
+    const rpc = getRpcClient(startRPC(manager.getMethods()))
+    const res = await rpc.request(method, ['latest'])
+
+    assert.equal(
+      res.result,
+      bytesToHex(block1.serialize()),
+      'block body contains a transaction with the blobVersionedHashes field'
+    )
+  })
+})

--- a/packages/client/test/rpc/debug/getRawHeader.spec.ts
+++ b/packages/client/test/rpc/debug/getRawHeader.spec.ts
@@ -1,0 +1,151 @@
+import { Block, BlockHeader } from '@ethereumjs/block'
+import { Common } from '@ethereumjs/common'
+import { BlobEIP4844Transaction, LegacyTransaction } from '@ethereumjs/tx'
+import { Address, bytesToHex, hexToBytes } from '@ethereumjs/util'
+import { loadKZG } from 'kzg-wasm'
+import { assert, describe, it } from 'vitest'
+
+import { INVALID_PARAMS } from '../../../src/rpc/error-code.js'
+import { createClient, createManager, dummy, getRpcClient, startRPC } from '../helpers.js'
+
+const kzg = await loadKZG()
+
+const common = Common.custom({ chainId: 1 }, { customCrypto: { kzg } })
+
+common.setHardfork('cancun')
+const mockedTx1 = LegacyTransaction.fromTxData({}).sign(dummy.privKey)
+const mockedTx2 = LegacyTransaction.fromTxData({ nonce: 1 }).sign(dummy.privKey)
+const mockedBlobTx3 = BlobEIP4844Transaction.fromTxData(
+  { nonce: 2, blobsData: ['0x1234'], to: Address.zero() },
+  { common }
+).sign(dummy.privKey)
+const blockHash = hexToBytes('0xdcf93da321b27bca12087d6526d2c10540a4c8dc29db1b36610c3004e0e5d2d5')
+const transactions = [mockedTx1]
+const transactions2 = [mockedTx2]
+
+const block = {
+  hash: () => blockHash,
+  header: {
+    number: BigInt(1),
+    hash: () => blockHash,
+    serialize: () => BlockHeader.fromHeaderData({ number: 1 }).serialize(),
+  },
+  toJSON: () => ({
+    ...Block.fromBlockData({ header: { number: 1 } }).toJSON(),
+    transactions: transactions2,
+  }),
+  serialize: () =>
+    Block.fromBlockData({ header: { number: 1 }, transactions: transactions2 }).serialize(),
+  transactions: transactions2,
+  uncleHeaders: [],
+}
+
+const genesisBlockHash = hexToBytes(
+  '0xdcf93da321b27bca12087d6526d2c10540a4c8dc29db1b36610c3004e0e5d2d5'
+)
+const genesisBlock = {
+  hash: () => genesisBlockHash,
+  header: {
+    number: BigInt(0),
+    serialize: () => BlockHeader.fromHeaderData({ number: 0 }).serialize(),
+  },
+  toJSON: () => ({ ...Block.fromBlockData({ header: { number: 0 } }).toJSON(), transactions }),
+  serialize: () => Block.fromBlockData({ header: { number: 0 }, transactions }).serialize(),
+  transactions,
+  uncleHeaders: [],
+}
+function createChain(headBlock = block) {
+  const block = headBlock
+  return {
+    blocks: { latest: block },
+    getBlock: () => genesisBlock,
+    getCanonicalHeadBlock: () => block,
+    getCanonicalHeadHeader: () => block.header,
+    getTd: () => BigInt(0),
+  }
+}
+
+const method = 'debug_getRawHeader'
+
+describe(method, async () => {
+  it('call with valid arguments', async () => {
+    const manager = createManager(await createClient({ chain: createChain() }))
+    const rpc = getRpcClient(startRPC(manager.getMethods()))
+
+    const res = await rpc.request(method, ['0x0'])
+    assert.equal(
+      res.result,
+      bytesToHex(genesisBlock.header.serialize()),
+      'should return a valid block'
+    )
+  })
+
+  it('call with earliest param', async () => {
+    const manager = createManager(await createClient({ chain: createChain() }))
+    const rpc = getRpcClient(startRPC(manager.getMethods()))
+
+    const res = await rpc.request(method, ['earliest'])
+    assert.equal(
+      res.result,
+      bytesToHex(genesisBlock.header.serialize()),
+      'should return the genesis block as earliest'
+    )
+  })
+
+  it('call with latest param', async () => {
+    const manager = createManager(await createClient({ chain: createChain() }))
+    const rpc = getRpcClient(startRPC(manager.getMethods()))
+
+    const res = await rpc.request(method, ['latest'])
+    assert.equal(res.result, bytesToHex(block.header.serialize()), 'should return block 1 RLP')
+  })
+
+  it('call with unimplemented pending param', async () => {
+    const manager = createManager(await createClient({ chain: createChain() }))
+    const rpc = getRpcClient(startRPC(manager.getMethods()))
+    const res = await rpc.request(method, ['pending'])
+    assert.equal(res.error.code, INVALID_PARAMS)
+    assert.ok(res.error.message.includes('"pending" is not yet supported'))
+  })
+
+  it('call with non-string block number', async () => {
+    const manager = createManager(await createClient({ chain: createChain() }))
+    const rpc = getRpcClient(startRPC(manager.getMethods()))
+    const res = await rpc.request(method, [10])
+    assert.equal(res.error.code, INVALID_PARAMS)
+    assert.ok(res.error.message.includes('invalid argument 0: argument must be a string'))
+  })
+
+  it('call with invalid block number', async () => {
+    const manager = createManager(await createClient({ chain: createChain() }))
+    const rpc = getRpcClient(startRPC(manager.getMethods()))
+    const res = await rpc.request(method, ['WRONG BLOCK NUMBER'])
+    assert.equal(res.error.code, INVALID_PARAMS)
+    assert.ok(
+      res.error.message.includes(
+        'invalid argument 0: block option must be a valid 0x-prefixed block hash or hex integer, or "latest", "earliest" or "pending"'
+      )
+    )
+  })
+})
+describe('call with block with blob txs', () => {
+  it('retrieves a block with a blob tx in it', async () => {
+    const genesisBlock = Block.fromBlockData({ header: { number: 0 } })
+    const block1 = Block.fromBlockData(
+      {
+        header: { number: 1, parentHash: genesisBlock.header.hash() },
+        transactions: [mockedBlobTx3],
+      },
+      { common }
+    )
+    const manager = createManager(await createClient({ chain: createChain(block1 as any) }))
+    const rpc = getRpcClient(startRPC(manager.getMethods()))
+    const res = await rpc.request(method, ['latest'])
+
+    assert.equal(
+      res.result,
+      bytesToHex(block1.header.serialize()),
+      'block body contains a transaction with the blobVersionedHashes field'
+    )
+  })
+})

--- a/packages/client/test/rpc/debug/getRawReceipts.spec.ts
+++ b/packages/client/test/rpc/debug/getRawReceipts.spec.ts
@@ -1,0 +1,167 @@
+import { Common, Hardfork } from '@ethereumjs/common'
+import {
+  BlobEIP4844Transaction,
+  FeeMarketEIP1559Transaction,
+  LegacyTransaction,
+} from '@ethereumjs/tx'
+import {
+  bigIntToHex,
+  blobsToCommitments,
+  bytesToHex,
+  commitmentsToVersionedHashes,
+  getBlobs,
+  hexToBytes,
+  randomBytes,
+} from '@ethereumjs/util'
+import { encodeReceipt } from '@ethereumjs/vm'
+import { loadKZG } from 'kzg-wasm'
+import { assert, describe, it } from 'vitest'
+
+import pow from '../../testdata/geth-genesis/pow.json'
+import {
+  dummy,
+  getRpcClient,
+  gethGenesisStartLondon,
+  runBlockWithTxs,
+  setupChain,
+} from '../helpers.js'
+
+import type { TxReceipt } from '@ethereumjs/vm'
+
+const method = 'eth_getTransactionReceipt'
+const method2 = 'debug_getRawReceipts'
+
+describe(method, () => {
+  it('call with legacy tx', async () => {
+    const { chain, common, execution, server } = await setupChain(pow, 'pow')
+    const rpc = getRpcClient(server)
+    // construct tx
+    const tx = LegacyTransaction.fromTxData(
+      {
+        gasLimit: 2000000,
+        gasPrice: 100,
+        to: '0x0000000000000000000000000000000000000000',
+      },
+      { common }
+    ).sign(dummy.privKey)
+    const block = await runBlockWithTxs(chain, execution, [tx])
+    const res0 = await rpc.request(method, [bytesToHex(tx.hash())])
+    const rec: TxReceipt = {
+      cumulativeBlockGasUsed: BigInt(res0.result.cumulativeGasUsed),
+      logs: [],
+      stateRoot: hexToBytes(res0.result.root),
+      bitvector: hexToBytes(res0.result.logsBloom),
+    }
+    const receipt = bytesToHex(encodeReceipt(rec, 0))
+    const res2 = await rpc.request(method2, [bigIntToHex(block.header.number)])
+    assert.deepEqual(res2.result, [receipt])
+  })
+
+  it('call with 1559 tx', async () => {
+    const { chain, common, execution, server } = await setupChain(
+      gethGenesisStartLondon(pow),
+      'powLondon'
+    )
+    const rpc = getRpcClient(server)
+    // construct tx
+    const tx = FeeMarketEIP1559Transaction.fromTxData(
+      {
+        gasLimit: 2000000,
+        maxFeePerGas: 975000000,
+        maxPriorityFeePerGas: 10,
+        to: '0x1230000000000000000000000000000000000321',
+      },
+      { common }
+    ).sign(dummy.privKey)
+
+    const block = await runBlockWithTxs(chain, execution, [tx])
+
+    // get the tx
+    const res0 = await rpc.request(method, [bytesToHex(tx.hash())])
+    const rec: TxReceipt = {
+      cumulativeBlockGasUsed: BigInt(res0.result.cumulativeGasUsed),
+      logs: [],
+      bitvector: hexToBytes(res0.result.logsBloom),
+      status: 1,
+    }
+    const receipt = bytesToHex(encodeReceipt(rec, 2))
+    const res1 = await rpc.request(method2, [bigIntToHex(block.header.number)])
+    assert.equal(res1.result, receipt, 'transaction result is 1 since succeeded')
+  })
+
+  it('call with unknown block hash', async () => {
+    const { server } = await setupChain(pow, 'pow')
+    const rpc = getRpcClient(server)
+    // get a random tx hash
+    const res = await rpc.request(method, [
+      '0x89ea5b54111befb936851660a72b686a21bc2fc4889a9a308196ff99d08925a0',
+    ])
+    assert.equal(res.result, null, 'should return null')
+  })
+
+  it('get blobGasUsed/blobGasPrice in blob tx receipt', async () => {
+    const isBrowser = new Function('try {return this===window;}catch(e){ return false;}')
+    if (isBrowser() === true) {
+      assert.ok(true)
+    } else {
+      const gethGenesis = await import('../../../../block/test/testdata/4844-hardfork.json')
+
+      const kzg = await loadKZG()
+
+      const common = Common.fromGethGenesis(gethGenesis, {
+        chain: 'customChain',
+        hardfork: Hardfork.Cancun,
+        customCrypto: {
+          kzg,
+        },
+      })
+      const { chain, execution, server } = await setupChain(gethGenesis, 'customChain', {
+        customCrypto: { kzg },
+      })
+      common.setHardfork(Hardfork.Cancun)
+      const rpc = getRpcClient(server)
+
+      const blobs = getBlobs('hello world')
+      const commitments = blobsToCommitments(kzg, blobs)
+      const blobVersionedHashes = commitmentsToVersionedHashes(commitments)
+      const proofs = blobs.map((blob, ctx) => kzg.computeBlobKzgProof(blob, commitments[ctx]))
+      const tx = BlobEIP4844Transaction.fromTxData(
+        {
+          blobVersionedHashes,
+          blobs,
+          kzgCommitments: commitments,
+          kzgProofs: proofs,
+          maxFeePerBlobGas: 1000000n,
+          gasLimit: 0xffffn,
+          maxFeePerGas: 10000000n,
+          maxPriorityFeePerGas: 1000000n,
+          to: randomBytes(20),
+          nonce: 0n,
+        },
+        { common }
+      ).sign(dummy.privKey)
+
+      const block = await runBlockWithTxs(chain, execution, [tx], true)
+
+      const res = await rpc.request(method, [bytesToHex(tx.hash())])
+
+      assert.equal(res.result.blobGasUsed, '0x20000', 'receipt has correct blob gas usage')
+      assert.equal(res.result.blobGasPrice, '0x1', 'receipt has correct blob gas price')
+
+      const rec: TxReceipt = {
+        cumulativeBlockGasUsed: BigInt(res.result.cumulativeGasUsed),
+        logs: [],
+        bitvector: hexToBytes(res.result.logsBloom),
+        blobGasPrice: BigInt(res.result.blobGasPrice),
+        blobGasUsed: BigInt(res.result.blobGasUsed),
+        status: 1,
+      }
+
+      const receipt = bytesToHex(encodeReceipt(rec, tx.type))
+
+      const res2 = await rpc.request(method2, [bigIntToHex(block.header.number)])
+
+      assert.equal(res2.result, receipt)
+    }
+  })
+})

--- a/packages/client/test/rpc/debug/getRawTransaction.spec.ts
+++ b/packages/client/test/rpc/debug/getRawTransaction.spec.ts
@@ -1,0 +1,71 @@
+import { FeeMarketEIP1559Transaction, LegacyTransaction } from '@ethereumjs/tx'
+import { bytesToHex } from '@ethereumjs/util'
+import { assert, describe, it } from 'vitest'
+
+import pow from '../../testdata/geth-genesis/pow.json'
+import {
+  dummy,
+  getRpcClient,
+  gethGenesisStartLondon,
+  runBlockWithTxs,
+  setupChain,
+} from '../helpers.js'
+
+const method = 'debug_getRawTransaction'
+
+describe(method, () => {
+  it('call with legacy tx', async () => {
+    const { chain, common, execution, server } = await setupChain(pow, 'pow', { txLookupLimit: 1 })
+    const rpc = getRpcClient(server)
+    // construct tx
+    const tx = LegacyTransaction.fromTxData(
+      { gasLimit: 2000000, gasPrice: 100, to: '0x0000000000000000000000000000000000000000' },
+      { common }
+    ).sign(dummy.privKey)
+
+    await runBlockWithTxs(chain, execution, [tx])
+
+    // get the tx
+    const res1 = await rpc.request(method, [bytesToHex(tx.hash())])
+    assert.equal(res1.result, bytesToHex(tx.serialize()), 'should return the correct tx')
+
+    // run a block to ensure tx hash index is cleaned up when txLookupLimit=1
+    await runBlockWithTxs(chain, execution, [])
+    const res2 = await rpc.request(method, [bytesToHex(tx.hash())])
+    assert.equal(res2.result, null, 'should return null when past txLookupLimit')
+  })
+
+  it('call with 1559 tx', async () => {
+    const { chain, common, execution, server } = await setupChain(
+      gethGenesisStartLondon(pow),
+      'powLondon'
+    )
+    const rpc = getRpcClient(server)
+    // construct tx
+    const tx = FeeMarketEIP1559Transaction.fromTxData(
+      {
+        gasLimit: 2000000,
+        maxFeePerGas: 975000000,
+        maxPriorityFeePerGas: 10,
+        to: '0x0000000000000000000000000000000000000000',
+      },
+      { common }
+    ).sign(dummy.privKey)
+
+    await runBlockWithTxs(chain, execution, [tx])
+
+    // get the tx
+    const res1 = await rpc.request(method, [bytesToHex(tx.hash())])
+    assert.equal(res1.result, bytesToHex(tx.serialize()), 'should return the correct tx type')
+  })
+
+  it('call with unknown tx hash', async () => {
+    const { server } = await setupChain(pow, 'pow')
+    const rpc = getRpcClient(server)
+    // get a random tx hash
+    const res = await rpc.request(method, [
+      '0x89ea5b54111befb936851660a72b686a21bc2fc4889a9a308196ff99d08925a0',
+    ])
+    assert.equal(res.result, null, 'should return null')
+  })
+})

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -302,6 +302,7 @@ export async function runBlockWithTxs(
   // put block into chain and run execution
   await chain.putBlocks([block], fromEngine)
   await execution.run()
+  return block
 }
 
 /**


### PR DESCRIPTION
Implements 4 JSON-RPC methods in the `debug` namespace.

- debug.getRawBlock
  - returns an RLP-encoded block
- debug.getRawHeader
  - returns an RLP-encoded header
- debug.getRawReceipts
  - retuns an array of EIP-2718 binary-encoded receipts from a block
- debug.getRawTransaction
  - returns the bytes of a transaction
