### PR TITLE
Blockchain: replace static constructors

### DIFF
--- a/packages/blockchain/examples/gethGenesis.ts
+++ b/packages/blockchain/examples/gethGenesis.ts
@@ -1,4 +1,4 @@
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Common, parseGethGenesis } from '@ethereumjs/common'
 import { bytesToHex, parseGethGenesisState } from '@ethereumjs/util'
 import gethGenesisJson from './genesisData/post-merge.json'

--- a/packages/blockchain/examples/gethGenesis.ts
+++ b/packages/blockchain/examples/gethGenesis.ts
@@ -7,7 +7,7 @@ const main = async () => {
   // Load geth genesis json file into lets say `gethGenesisJson`
   const common = Common.fromGethGenesis(gethGenesisJson, { chain: 'customChain' })
   const genesisState = parseGethGenesisState(gethGenesisJson)
-  const blockchain = await Blockchain.create({
+  const blockchain = await createBlockchain({
     genesisState,
     common,
   })

--- a/packages/blockchain/examples/simple.ts
+++ b/packages/blockchain/examples/simple.ts
@@ -1,5 +1,5 @@
 import { Block, createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Common, Hardfork } from '@ethereumjs/common'
 import { bytesToHex } from '@ethereumjs/util'
 

--- a/packages/blockchain/examples/simple.ts
+++ b/packages/blockchain/examples/simple.ts
@@ -6,7 +6,7 @@ import { bytesToHex } from '@ethereumjs/util'
 const main = async () => {
   const common = new Common({ chain: 'mainnet', hardfork: Hardfork.London })
   // Use the safe static constructor which awaits the init method
-  const blockchain = await Blockchain.create({
+  const blockchain = await createBlockchain({
     validateBlocks: false, // Skipping validation so we can make a simple chain without having to provide complete blocks
     validateConsensus: false,
     common,

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -1,13 +1,5 @@
 import { Block, BlockHeader, createBlockFromBlockData } from '@ethereumjs/block'
-import {
-  Chain,
-  ChainGenesis,
-  Common,
-  ConsensusAlgorithm,
-  ConsensusType,
-  Hardfork,
-} from '@ethereumjs/common'
-import { genesisStateRoot as genMerkleGenesisStateRoot } from '@ethereumjs/trie'
+import { Chain, Common, ConsensusAlgorithm, ConsensusType, Hardfork } from '@ethereumjs/common'
 import {
   AsyncEventEmitter,
   BIGINT_0,
@@ -40,40 +32,9 @@ import type {
   Consensus,
   OnBlock,
 } from './types.js'
-import type { BlockData, HeaderData } from '@ethereumjs/block'
+import type { HeaderData } from '@ethereumjs/block'
 import type { CliqueConfig } from '@ethereumjs/common'
 import type { BigIntLike, DB, DBObject, GenesisState } from '@ethereumjs/util'
-
-/**
- * Verkle or Merkle genesis root
- * @param genesisState
- * @param common
- * @returns
- */
-async function genGenesisStateRoot(
-  genesisState: GenesisState,
-  common: Common
-): Promise<Uint8Array> {
-  const genCommon = common.copy()
-  genCommon.setHardforkBy({
-    blockNumber: 0,
-    td: BigInt(genCommon.genesis().difficulty),
-    timestamp: genCommon.genesis().timestamp,
-  })
-  if (genCommon.isActivatedEIP(6800)) {
-    throw Error(`Verkle tree state not yet supported`)
-  } else {
-    return genMerkleGenesisStateRoot(genesisState)
-  }
-}
-
-/**
- * Returns the genesis state root if chain is well known or an empty state's root otherwise
- */
-async function getGenesisStateRoot(chainId: Chain, common: Common): Promise<Uint8Array> {
-  const chainGenesis = ChainGenesis[chainId]
-  return chainGenesis !== undefined ? chainGenesis.stateRoot : genGenesisStateRoot({}, common)
-}
 
 /**
  * This class stores and interacts with blocks.
@@ -120,117 +81,16 @@ export class Blockchain implements BlockchainInterface {
   private _deletedBlocks: Block[] = []
 
   /**
-   * Safe creation of a new Blockchain object awaiting the initialization function,
-   * encouraged method to use when creating a blockchain object.
-   *
-   * @param opts Constructor options, see {@link BlockchainOptions}
-   */
-
-  public static async create(opts: BlockchainOptions = {}) {
-    const blockchain = new Blockchain(opts)
-
-    await blockchain.consensus.setup({ blockchain })
-
-    let stateRoot = opts.genesisBlock?.header.stateRoot ?? opts.genesisStateRoot
-    if (stateRoot === undefined) {
-      if (blockchain._customGenesisState !== undefined) {
-        stateRoot = await genGenesisStateRoot(blockchain._customGenesisState, blockchain.common)
-      } else {
-        stateRoot = await getGenesisStateRoot(
-          Number(blockchain.common.chainId()) as Chain,
-          blockchain.common
-        )
-      }
-    }
-
-    const genesisBlock = opts.genesisBlock ?? blockchain.createGenesisBlock(stateRoot)
-
-    let genesisHash = await blockchain.dbManager.numberToHash(BIGINT_0)
-
-    const dbGenesisBlock =
-      genesisHash !== undefined ? await blockchain.dbManager.getBlock(genesisHash) : undefined
-
-    // If the DB has a genesis block, then verify that the genesis block in the
-    // DB is indeed the Genesis block generated or assigned.
-    if (dbGenesisBlock !== undefined && !equalsBytes(genesisBlock.hash(), dbGenesisBlock.hash())) {
-      throw new Error(
-        'The genesis block in the DB has a different hash than the provided genesis block.'
-      )
-    }
-
-    genesisHash = genesisBlock.hash()
-
-    if (!dbGenesisBlock) {
-      // If there is no genesis block put the genesis block in the DB.
-      // For that TD, the BlockOrHeader, and the Lookups have to be saved.
-      const dbOps: DBOp[] = []
-      dbOps.push(DBSetTD(genesisBlock.header.difficulty, BIGINT_0, genesisHash))
-      DBSetBlockOrHeader(genesisBlock).map((op) => dbOps.push(op))
-      DBSaveLookups(genesisHash, BIGINT_0).map((op) => dbOps.push(op))
-      await blockchain.dbManager.batch(dbOps)
-      await blockchain.consensus.genesisInit(genesisBlock)
-    }
-
-    // At this point, we can safely set the genesis:
-    // it is either the one we put in the DB, or it is equal to the one
-    // which we read from the DB.
-    blockchain._genesisBlock = genesisBlock
-
-    // load verified iterator heads
-    const heads = await blockchain.dbManager.getHeads()
-    blockchain._heads = heads !== undefined ? heads : {}
-
-    // load headerchain head
-    let hash = await blockchain.dbManager.getHeadHeader()
-    blockchain._headHeaderHash = hash !== undefined ? hash : genesisHash
-
-    // load blockchain head
-    hash = await blockchain.dbManager.getHeadBlock()
-    blockchain._headBlockHash = hash !== undefined ? hash : genesisHash
-
-    if (blockchain._hardforkByHeadBlockNumber) {
-      const latestHeader = await blockchain._getHeader(blockchain._headHeaderHash)
-      const td = await blockchain.getParentTD(latestHeader)
-      await blockchain.checkAndTransitionHardForkByNumber(
-        latestHeader.number,
-        td,
-        latestHeader.timestamp
-      )
-    }
-
-    return blockchain
-  }
-
-  /**
-   * Creates a blockchain from a list of block objects,
-   * objects must be readable by {@link createBlockFromBlockData}
-   *
-   * @param blockData List of block objects
-   * @param opts Constructor options, see {@link BlockchainOptions}
-   */
-  public static async fromBlocksData(blocksData: BlockData[], opts: BlockchainOptions = {}) {
-    const blockchain = await Blockchain.create(opts)
-    for (const blockData of blocksData) {
-      const block = createBlockFromBlockData(blockData, {
-        common: blockchain.common,
-        setHardfork: true,
-      })
-      await blockchain.putBlock(block)
-    }
-    return blockchain
-  }
-
-  /**
    * Creates new Blockchain object.
    *
    * @deprecated The direct usage of this constructor is discouraged since
    * non-finalized async initialization might lead to side effects. Please
-   * use the async {@link Blockchain.create} constructor instead (same API).
+   * use the async {@link createBlockchain} constructor instead (same API).
    *
    * @param opts An object with the options that this constructor takes. See
    * {@link BlockchainOptions}.
    */
-  protected constructor(opts: BlockchainOptions = {}) {
+  constructor(opts: BlockchainOptions = {}) {
     if (opts.common) {
       this.common = opts.common
     } else {

--- a/packages/blockchain/src/constructors.ts
+++ b/packages/blockchain/src/constructors.ts
@@ -1,0 +1,112 @@
+import { createBlockFromBlockData } from '@ethereumjs/block'
+import { BIGINT_0, equalsBytes } from '@ethereumjs/util'
+
+import {
+  Blockchain,
+  DBSaveLookups,
+  DBSetBlockOrHeader,
+  DBSetTD,
+  genGenesisStateRoot,
+  getGenesisStateRoot,
+} from './index.js'
+
+import type { BlockchainOptions, DBOp } from './index.js'
+import type { BlockData } from '@ethereumjs/block'
+import type { Chain } from '@ethereumjs/common'
+
+export async function createBlockchain(opts: BlockchainOptions = {}) {
+  const blockchain = new Blockchain(opts)
+
+  await blockchain.consensus.setup({ blockchain })
+
+  let stateRoot = opts.genesisBlock?.header.stateRoot ?? opts.genesisStateRoot
+  if (stateRoot === undefined) {
+    if (blockchain['_customGenesisState'] !== undefined) {
+      stateRoot = await genGenesisStateRoot(blockchain['_customGenesisState'], blockchain.common)
+    } else {
+      stateRoot = await getGenesisStateRoot(
+        Number(blockchain.common.chainId()) as Chain,
+        blockchain.common
+      )
+    }
+  }
+
+  const genesisBlock = opts.genesisBlock ?? blockchain.createGenesisBlock(stateRoot)
+
+  let genesisHash = await blockchain.dbManager.numberToHash(BIGINT_0)
+
+  const dbGenesisBlock =
+    genesisHash !== undefined ? await blockchain.dbManager.getBlock(genesisHash) : undefined
+
+  // If the DB has a genesis block, then verify that the genesis block in the
+  // DB is indeed the Genesis block generated or assigned.
+  if (dbGenesisBlock !== undefined && !equalsBytes(genesisBlock.hash(), dbGenesisBlock.hash())) {
+    throw new Error(
+      'The genesis block in the DB has a different hash than the provided genesis block.'
+    )
+  }
+
+  genesisHash = genesisBlock.hash()
+
+  if (!dbGenesisBlock) {
+    // If there is no genesis block put the genesis block in the DB.
+    // For that TD, the BlockOrHeader, and the Lookups have to be saved.
+    const dbOps: DBOp[] = []
+    dbOps.push(DBSetTD(genesisBlock.header.difficulty, BIGINT_0, genesisHash))
+    DBSetBlockOrHeader(genesisBlock).map((op) => dbOps.push(op))
+    DBSaveLookups(genesisHash, BIGINT_0).map((op) => dbOps.push(op))
+    await blockchain.dbManager.batch(dbOps)
+    await blockchain.consensus.genesisInit(genesisBlock)
+  }
+
+  // At this point, we can safely set the genesis:
+  // it is either the one we put in the DB, or it is equal to the one
+  // which we read from the DB.
+  blockchain['_genesisBlock'] = genesisBlock
+
+  // load verified iterator heads
+  const heads = await blockchain.dbManager.getHeads()
+  blockchain['_heads'] = heads !== undefined ? heads : {}
+
+  // load headerchain head
+  let hash = await blockchain.dbManager.getHeadHeader()
+  blockchain['_headHeaderHash'] = hash !== undefined ? hash : genesisHash
+
+  // load blockchain head
+  hash = await blockchain.dbManager.getHeadBlock()
+  blockchain['_headBlockHash'] = hash !== undefined ? hash : genesisHash
+
+  if (blockchain['_hardforkByHeadBlockNumber']) {
+    const latestHeader = await blockchain['_getHeader'](blockchain['_headHeaderHash'])
+    const td = await blockchain.getParentTD(latestHeader)
+    await blockchain.checkAndTransitionHardForkByNumber(
+      latestHeader.number,
+      td,
+      latestHeader.timestamp
+    )
+  }
+
+  return blockchain
+}
+
+/**
+ * Creates a blockchain from a list of block objects,
+ * objects must be readable by {@link Block.fromBlockData}
+ *
+ * @param blockData List of block objects
+ * @param opts Constructor options, see {@link BlockchainOptions}
+ */
+export async function createBlockchainFromBlocksData(
+  blocksData: BlockData[],
+  opts: BlockchainOptions = {}
+) {
+  const blockchain = await createBlockchain(opts)
+  for (const blockData of blocksData) {
+    const block = createBlockFromBlockData(blockData, {
+      common: blockchain.common,
+      setHardfork: true,
+    })
+    await blockchain.putBlock(block)
+  }
+  return blockchain
+}

--- a/packages/blockchain/src/helpers.ts
+++ b/packages/blockchain/src/helpers.ts
@@ -1,4 +1,4 @@
-import { Block } from '@ethereumjs/block'
+import { createBlockFromBlockData } from '@ethereumjs/block'
 import { ChainGenesis } from '@ethereumjs/common'
 import { genesisStateRoot as genMerkleGenesisStateRoot } from '@ethereumjs/trie'
 import { BIGINT_0, equalsBytes } from '@ethereumjs/util'
@@ -136,7 +136,7 @@ export async function createBlockchainFromBlocksData(
 ) {
   const blockchain = await createBlockchain(opts)
   for (const blockData of blocksData) {
-    const block = Block.fromBlockData(blockData, {
+    const block = createBlockFromBlockData(blockData, {
       common: blockchain.common,
       setHardfork: true,
     })

--- a/packages/blockchain/src/helpers.ts
+++ b/packages/blockchain/src/helpers.ts
@@ -1,0 +1,146 @@
+import { Block } from '@ethereumjs/block'
+import { ChainGenesis } from '@ethereumjs/common'
+import { genesisStateRoot as genMerkleGenesisStateRoot } from '@ethereumjs/trie'
+import { BIGINT_0, equalsBytes } from '@ethereumjs/util'
+
+import { Blockchain, DBSaveLookups, DBSetBlockOrHeader, DBSetTD } from '.'
+
+import type { BlockchainOptions, DBOp } from '.'
+import type { BlockData } from '@ethereumjs/block'
+import type { Chain, Common } from '@ethereumjs/common'
+import type { GenesisState } from '@ethereumjs/util'
+
+/**
+ * Safe creation of a new Blockchain object awaiting the initialization function,
+ * encouraged method to use when creating a blockchain object.
+ *
+ * @param opts Constructor options, see {@link BlockchainOptions}
+ */
+
+/**
+ * Verkle or Merkle genesis root
+ * @param genesisState
+ * @param common
+ * @returns
+ */
+export async function genGenesisStateRoot(
+  genesisState: GenesisState,
+  common: Common
+): Promise<Uint8Array> {
+  const genCommon = common.copy()
+  genCommon.setHardforkBy({
+    blockNumber: 0,
+    td: BigInt(genCommon.genesis().difficulty),
+    timestamp: genCommon.genesis().timestamp,
+  })
+  if (genCommon.isActivatedEIP(6800)) {
+    throw Error(`Verkle tree state not yet supported`)
+  } else {
+    return genMerkleGenesisStateRoot(genesisState)
+  }
+}
+
+/**
+ * Returns the genesis state root if chain is well known or an empty state's root otherwise
+ */
+export async function getGenesisStateRoot(chainId: Chain, common: Common): Promise<Uint8Array> {
+  const chainGenesis = ChainGenesis[chainId]
+  return chainGenesis !== undefined ? chainGenesis.stateRoot : genGenesisStateRoot({}, common)
+}
+
+export async function createBlockchain(opts: BlockchainOptions = {}) {
+  const blockchain = new Blockchain(opts)
+
+  await blockchain.consensus.setup({ blockchain })
+
+  let stateRoot = opts.genesisBlock?.header.stateRoot ?? opts.genesisStateRoot
+  if (stateRoot === undefined) {
+    if (blockchain['_customGenesisState'] !== undefined) {
+      stateRoot = await genGenesisStateRoot(blockchain['_customGenesisState'], blockchain.common)
+    } else {
+      stateRoot = await getGenesisStateRoot(
+        Number(blockchain.common.chainId()) as Chain,
+        blockchain.common
+      )
+    }
+  }
+
+  const genesisBlock = opts.genesisBlock ?? blockchain.createGenesisBlock(stateRoot)
+
+  let genesisHash = await blockchain.dbManager.numberToHash(BIGINT_0)
+
+  const dbGenesisBlock =
+    genesisHash !== undefined ? await blockchain.dbManager.getBlock(genesisHash) : undefined
+
+  // If the DB has a genesis block, then verify that the genesis block in the
+  // DB is indeed the Genesis block generated or assigned.
+  if (dbGenesisBlock !== undefined && !equalsBytes(genesisBlock.hash(), dbGenesisBlock.hash())) {
+    throw new Error(
+      'The genesis block in the DB has a different hash than the provided genesis block.'
+    )
+  }
+
+  genesisHash = genesisBlock.hash()
+
+  if (!dbGenesisBlock) {
+    // If there is no genesis block put the genesis block in the DB.
+    // For that TD, the BlockOrHeader, and the Lookups have to be saved.
+    const dbOps: DBOp[] = []
+    dbOps.push(DBSetTD(genesisBlock.header.difficulty, BIGINT_0, genesisHash))
+    DBSetBlockOrHeader(genesisBlock).map((op) => dbOps.push(op))
+    DBSaveLookups(genesisHash, BIGINT_0).map((op) => dbOps.push(op))
+    await blockchain.dbManager.batch(dbOps)
+    await blockchain.consensus.genesisInit(genesisBlock)
+  }
+
+  // At this point, we can safely set the genesis:
+  // it is either the one we put in the DB, or it is equal to the one
+  // which we read from the DB.
+  blockchain['_genesisBlock'] = genesisBlock
+
+  // load verified iterator heads
+  const heads = await blockchain.dbManager.getHeads()
+  blockchain['_heads'] = heads !== undefined ? heads : {}
+
+  // load headerchain head
+  let hash = await blockchain.dbManager.getHeadHeader()
+  blockchain['_headHeaderHash'] = hash !== undefined ? hash : genesisHash
+
+  // load blockchain head
+  hash = await blockchain.dbManager.getHeadBlock()
+  blockchain['_headBlockHash'] = hash !== undefined ? hash : genesisHash
+
+  if (blockchain['_hardforkByHeadBlockNumber']) {
+    const latestHeader = await blockchain['_getHeader'](blockchain['_headHeaderHash'])
+    const td = await blockchain.getParentTD(latestHeader)
+    await blockchain.checkAndTransitionHardForkByNumber(
+      latestHeader.number,
+      td,
+      latestHeader.timestamp
+    )
+  }
+
+  return blockchain
+}
+
+/**
+ * Creates a blockchain from a list of block objects,
+ * objects must be readable by {@link Block.fromBlockData}
+ *
+ * @param blockData List of block objects
+ * @param opts Constructor options, see {@link BlockchainOptions}
+ */
+export async function createBlockchainFromBlocksData(
+  blocksData: BlockData[],
+  opts: BlockchainOptions = {}
+) {
+  const blockchain = await createBlockchain(opts)
+  for (const blockData of blocksData) {
+    const block = Block.fromBlockData(blockData, {
+      common: blockchain.common,
+      setHardfork: true,
+    })
+    await blockchain.putBlock(block)
+  }
+  return blockchain
+}

--- a/packages/blockchain/src/helpers.ts
+++ b/packages/blockchain/src/helpers.ts
@@ -1,12 +1,6 @@
-import { createBlockFromBlockData } from '@ethereumjs/block'
 import { ChainGenesis } from '@ethereumjs/common'
 import { genesisStateRoot as genMerkleGenesisStateRoot } from '@ethereumjs/trie'
-import { BIGINT_0, equalsBytes } from '@ethereumjs/util'
 
-import { Blockchain, DBSaveLookups, DBSetBlockOrHeader, DBSetTD } from './index.js'
-
-import type { BlockchainOptions, DBOp } from './index.js'
-import type { BlockData } from '@ethereumjs/block'
 import type { Chain, Common } from '@ethereumjs/common'
 import type { GenesisState } from '@ethereumjs/util'
 
@@ -46,101 +40,4 @@ export async function genGenesisStateRoot(
 export async function getGenesisStateRoot(chainId: Chain, common: Common): Promise<Uint8Array> {
   const chainGenesis = ChainGenesis[chainId]
   return chainGenesis !== undefined ? chainGenesis.stateRoot : genGenesisStateRoot({}, common)
-}
-
-export async function createBlockchain(opts: BlockchainOptions = {}) {
-  const blockchain = new Blockchain(opts)
-
-  await blockchain.consensus.setup({ blockchain })
-
-  let stateRoot = opts.genesisBlock?.header.stateRoot ?? opts.genesisStateRoot
-  if (stateRoot === undefined) {
-    if (blockchain['_customGenesisState'] !== undefined) {
-      stateRoot = await genGenesisStateRoot(blockchain['_customGenesisState'], blockchain.common)
-    } else {
-      stateRoot = await getGenesisStateRoot(
-        Number(blockchain.common.chainId()) as Chain,
-        blockchain.common
-      )
-    }
-  }
-
-  const genesisBlock = opts.genesisBlock ?? blockchain.createGenesisBlock(stateRoot)
-
-  let genesisHash = await blockchain.dbManager.numberToHash(BIGINT_0)
-
-  const dbGenesisBlock =
-    genesisHash !== undefined ? await blockchain.dbManager.getBlock(genesisHash) : undefined
-
-  // If the DB has a genesis block, then verify that the genesis block in the
-  // DB is indeed the Genesis block generated or assigned.
-  if (dbGenesisBlock !== undefined && !equalsBytes(genesisBlock.hash(), dbGenesisBlock.hash())) {
-    throw new Error(
-      'The genesis block in the DB has a different hash than the provided genesis block.'
-    )
-  }
-
-  genesisHash = genesisBlock.hash()
-
-  if (!dbGenesisBlock) {
-    // If there is no genesis block put the genesis block in the DB.
-    // For that TD, the BlockOrHeader, and the Lookups have to be saved.
-    const dbOps: DBOp[] = []
-    dbOps.push(DBSetTD(genesisBlock.header.difficulty, BIGINT_0, genesisHash))
-    DBSetBlockOrHeader(genesisBlock).map((op) => dbOps.push(op))
-    DBSaveLookups(genesisHash, BIGINT_0).map((op) => dbOps.push(op))
-    await blockchain.dbManager.batch(dbOps)
-    await blockchain.consensus.genesisInit(genesisBlock)
-  }
-
-  // At this point, we can safely set the genesis:
-  // it is either the one we put in the DB, or it is equal to the one
-  // which we read from the DB.
-  blockchain['_genesisBlock'] = genesisBlock
-
-  // load verified iterator heads
-  const heads = await blockchain.dbManager.getHeads()
-  blockchain['_heads'] = heads !== undefined ? heads : {}
-
-  // load headerchain head
-  let hash = await blockchain.dbManager.getHeadHeader()
-  blockchain['_headHeaderHash'] = hash !== undefined ? hash : genesisHash
-
-  // load blockchain head
-  hash = await blockchain.dbManager.getHeadBlock()
-  blockchain['_headBlockHash'] = hash !== undefined ? hash : genesisHash
-
-  if (blockchain['_hardforkByHeadBlockNumber']) {
-    const latestHeader = await blockchain['_getHeader'](blockchain['_headHeaderHash'])
-    const td = await blockchain.getParentTD(latestHeader)
-    await blockchain.checkAndTransitionHardForkByNumber(
-      latestHeader.number,
-      td,
-      latestHeader.timestamp
-    )
-  }
-
-  return blockchain
-}
-
-/**
- * Creates a blockchain from a list of block objects,
- * objects must be readable by {@link Block.fromBlockData}
- *
- * @param blockData List of block objects
- * @param opts Constructor options, see {@link BlockchainOptions}
- */
-export async function createBlockchainFromBlocksData(
-  blocksData: BlockData[],
-  opts: BlockchainOptions = {}
-) {
-  const blockchain = await createBlockchain(opts)
-  for (const blockData of blocksData) {
-    const block = createBlockFromBlockData(blockData, {
-      common: blockchain.common,
-      setHardfork: true,
-    })
-    await blockchain.putBlock(block)
-  }
-  return blockchain
 }

--- a/packages/blockchain/src/helpers.ts
+++ b/packages/blockchain/src/helpers.ts
@@ -3,9 +3,9 @@ import { ChainGenesis } from '@ethereumjs/common'
 import { genesisStateRoot as genMerkleGenesisStateRoot } from '@ethereumjs/trie'
 import { BIGINT_0, equalsBytes } from '@ethereumjs/util'
 
-import { Blockchain, DBSaveLookups, DBSetBlockOrHeader, DBSetTD } from '.'
+import { Blockchain, DBSaveLookups, DBSetBlockOrHeader, DBSetTD } from './index.js'
 
-import type { BlockchainOptions, DBOp } from '.'
+import type { BlockchainOptions, DBOp } from './index.js'
 import type { BlockData } from '@ethereumjs/block'
 import type { Chain, Common } from '@ethereumjs/common'
 import type { GenesisState } from '@ethereumjs/util'

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -1,5 +1,6 @@
 export { Blockchain } from './blockchain.js'
 export { CasperConsensus, CliqueConsensus, EthashConsensus } from './consensus/index.js'
+export * from './constructors.js'
 export {
   DBOp,
   DBSaveLookups,

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -7,4 +7,5 @@ export {
   DBSetHashToNumber,
   DBSetTD,
 } from './db/helpers.js'
+export * from './helpers.js'
 export * from './types.js'

--- a/packages/blockchain/test/blockValidation.spec.ts
+++ b/packages/blockchain/test/blockValidation.spec.ts
@@ -5,14 +5,14 @@ import { KECCAK256_RLP, bytesToHex, randomBytes } from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak.js'
 import { assert, describe, expect, it } from 'vitest'
 
-import { Blockchain } from '../src/index.js'
+import { createBlockchain } from '../src/index.js'
 
 import { createBlock } from './util.js'
 
 describe('[Blockchain]: Block validation tests', () => {
   it('should throw if an uncle is included before', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await Blockchain.create({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common, validateConsensus: false })
 
     const genesis = blockchain.genesisBlock
 
@@ -39,7 +39,7 @@ describe('[Blockchain]: Block validation tests', () => {
 
   it('should throw if the uncle parent block is not part of the canonical chain', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await Blockchain.create({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common, validateConsensus: false })
 
     const genesis = blockchain.genesisBlock
 
@@ -66,7 +66,7 @@ describe('[Blockchain]: Block validation tests', () => {
 
   it('should throw if the uncle is too old', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await Blockchain.create({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common, validateConsensus: false })
 
     const genesis = blockchain.genesisBlock
 
@@ -99,7 +99,7 @@ describe('[Blockchain]: Block validation tests', () => {
 
   it('should throw if uncle is too young', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await Blockchain.create({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common, validateConsensus: false })
 
     const genesis = blockchain.genesisBlock
 
@@ -121,7 +121,7 @@ describe('[Blockchain]: Block validation tests', () => {
 
   it('should throw if the uncle header is invalid', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await Blockchain.create({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common, validateConsensus: false })
 
     const genesis = blockchain.genesisBlock
 
@@ -155,7 +155,7 @@ describe('[Blockchain]: Block validation tests', () => {
 
   it('throws if uncle is a canonical block', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await Blockchain.create({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common, validateConsensus: false })
 
     const genesis = blockchain.genesisBlock
 
@@ -178,7 +178,7 @@ describe('[Blockchain]: Block validation tests', () => {
 
   it('successfully validates uncles', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await Blockchain.create({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common, validateConsensus: false })
 
     const genesis = blockchain.genesisBlock
 
@@ -204,7 +204,7 @@ describe('[Blockchain]: Block validation tests', () => {
       hardfork: Hardfork.London,
     })
 
-    const blockchain = await Blockchain.create({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common, validateConsensus: false })
     const genesis = blockchain.genesisBlock
 
     // Small hack to hack in the activation block number
@@ -298,7 +298,7 @@ describe('[Blockchain]: Block validation tests', () => {
       return BigInt(0)
     }
 
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       common,
       validateConsensus: false,
       validateBlocks: false,
@@ -387,7 +387,7 @@ describe('EIP 7685: requests field validation tests', () => {
       hardfork: Hardfork.Cancun,
       eips: [7685, 1559, 4895, 4844, 4788],
     })
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       common,
       validateConsensus: false,
     })

--- a/packages/blockchain/test/clique.spec.ts
+++ b/packages/blockchain/test/clique.spec.ts
@@ -4,9 +4,10 @@ import { Address, concatBytes, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
 import { CLIQUE_NONCE_AUTH, CLIQUE_NONCE_DROP } from '../src/consensus/clique.js'
-import { Blockchain } from '../src/index.js'
+import { createBlockchain } from '../src/index.js'
 
 import type { CliqueConsensus } from '../src/consensus/clique.js'
+import type { Blockchain } from '../src/index.js'
 import type { Block } from '@ethereumjs/block'
 import type { CliqueConfig } from '@ethereumjs/common'
 
@@ -83,7 +84,7 @@ const initWithSigners = async (signers: Signer[], common?: Common) => {
   )
   blocks.push(genesisBlock)
 
-  const blockchain = await Blockchain.create({
+  const blockchain = await createBlockchain({
     validateBlocks: true,
     validateConsensus: true,
     genesisBlock,
@@ -183,7 +184,7 @@ const addNextBlock = async (
 describe('Clique: Initialization', () => {
   it('should initialize a clique blockchain', async () => {
     const common = new Common({ chain: Chain.Goerli, hardfork: Hardfork.Chainstart })
-    const blockchain = await Blockchain.create({ common })
+    const blockchain = await createBlockchain({ common })
 
     const head = await blockchain.getIteratorHead()
     assert.deepEqual(head.hash(), blockchain.genesisBlock.hash(), 'correct genesis hash')

--- a/packages/blockchain/test/customConsensus.spec.ts
+++ b/packages/blockchain/test/customConsensus.spec.ts
@@ -3,7 +3,7 @@ import { Common, Hardfork } from '@ethereumjs/common'
 import { bytesToHex } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Blockchain, EthashConsensus } from '../src/index.js'
+import { EthashConsensus, createBlockchain } from '../src/index.js'
 
 import type { Consensus } from '../src/index.js'
 import type { Block, BlockHeader } from '@ethereumjs/block'
@@ -46,7 +46,7 @@ describe('Optional consensus parameter in blockchain constructor', () => {
     const common = new Common({ chain: 'mainnet', hardfork: Hardfork.Chainstart })
     const consensus = new fibonacciConsensus()
     try {
-      const blockchain = await Blockchain.create({ common, consensus })
+      const blockchain = await createBlockchain({ common, consensus })
       assert.equal(
         (blockchain.consensus as fibonacciConsensus).algorithm,
         'fibonacciConsensus',
@@ -62,7 +62,7 @@ describe('Custom consensus validation rules', () => {
   it('should validat custom consensus rules', async () => {
     const common = new Common({ chain: 'mainnet', hardfork: Hardfork.Chainstart })
     const consensus = new fibonacciConsensus()
-    const blockchain = await Blockchain.create({ common, consensus })
+    const blockchain = await createBlockchain({ common, consensus })
     const block = createBlockFromBlockData(
       {
         header: {
@@ -140,7 +140,7 @@ describe('consensus transition checks', () => {
   it('should transition correctly', async () => {
     const common = new Common({ chain: 'mainnet', hardfork: Hardfork.Chainstart })
     const consensus = new fibonacciConsensus()
-    const blockchain = await Blockchain.create({ common, consensus })
+    const blockchain = await createBlockchain({ common, consensus })
 
     try {
       await blockchain.checkAndTransitionHardForkByNumber(5n)

--- a/packages/blockchain/test/iterator.spec.ts
+++ b/packages/blockchain/test/iterator.spec.ts
@@ -1,7 +1,7 @@
 import { bytesToHex, equalsBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Blockchain } from '../src/index.js'
+import { createBlockchain } from '../src/index.js'
 
 import { createTestDB, generateBlockchain, generateConsecutiveBlock } from './util.js'
 
@@ -165,7 +165,7 @@ describe('blockchain test', () => {
   })
 
   it('should not call iterator function in an empty blockchain', async () => {
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       validateBlocks: true,
       validateConsensus: false,
     })
@@ -178,7 +178,7 @@ describe('blockchain test', () => {
 
   it('should get heads', async () => {
     const [db, genesis] = await createTestDB()
-    const blockchain = await Blockchain.create({ db, genesisBlock: genesis })
+    const blockchain = await createBlockchain({ db, genesisBlock: genesis })
     const head = await blockchain.getIteratorHead()
 
     if (typeof genesis !== 'undefined') {

--- a/packages/blockchain/test/pos.spec.ts
+++ b/packages/blockchain/test/pos.spec.ts
@@ -3,9 +3,11 @@ import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { bytesToHex } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Blockchain } from '../src/index.js'
+import { createBlockchain } from '../src/index.js'
 
 import * as testnet from './testdata/testnet.json'
+
+import type { Blockchain } from '../src/index.js'
 
 import type { Block } from '@ethereumjs/block'
 
@@ -60,7 +62,7 @@ describe('Proof of Stake - inserting blocks into blockchain', () => {
 
   for (const s of scenarios) {
     it('should pass', async () => {
-      const blockchain = await Blockchain.create({
+      const blockchain = await createBlockchain({
         validateBlocks: true,
         validateConsensus: false,
         common: s.common,

--- a/packages/blockchain/test/pos.spec.ts
+++ b/packages/blockchain/test/pos.spec.ts
@@ -8,7 +8,6 @@ import { createBlockchain } from '../src/index.js'
 import * as testnet from './testdata/testnet.json'
 
 import type { Blockchain } from '../src/index.js'
-
 import type { Block } from '@ethereumjs/block'
 
 const buildChain = async (blockchain: Blockchain, common: Common, height: number) => {

--- a/packages/blockchain/test/reorg.spec.ts
+++ b/packages/blockchain/test/reorg.spec.ts
@@ -4,7 +4,7 @@ import { Address, equalsBytes, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
 import { CLIQUE_NONCE_AUTH } from '../src/consensus/clique.js'
-import { Blockchain } from '../src/index.js'
+import { createBlockchain } from '../src/index.js'
 
 import { generateConsecutiveBlock } from './util.js'
 
@@ -71,7 +71,7 @@ describe('reorg tests', () => {
       { header: { extraData: new Uint8Array(97) } },
       { common }
     )
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       validateBlocks: false,
       validateConsensus: false,
       common,

--- a/packages/blockchain/test/util.ts
+++ b/packages/blockchain/test/util.ts
@@ -11,7 +11,7 @@ import {
 } from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak.js'
 
-import { Blockchain } from '../src/index.js'
+import { createBlockchain } from '../src/index.js'
 
 import type { DB } from '@ethereumjs/util'
 
@@ -51,7 +51,7 @@ export const generateBlockchain = async (numberOfBlocks: number, genesis?: Block
   const existingBlocks: Block[] = genesis ? [genesis] : []
   const blocks = generateBlocks(numberOfBlocks, existingBlocks)
 
-  const blockchain = await Blockchain.create({
+  const blockchain = await createBlockchain({
     validateBlocks: true,
     validateConsensus: false,
     genesisBlock: genesis ?? blocks[0],

--- a/packages/blockchain/test/utils.spec.ts
+++ b/packages/blockchain/test/utils.spec.ts
@@ -3,15 +3,17 @@ import { genesisStateRoot } from '@ethereumjs/trie'
 import { bytesToHex, parseGethGenesisState } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Blockchain } from '../src/blockchain.js'
-
 // kiln genesis with deposit contract storage set
+import { createBlockchain } from '../src/index.js'
+
 import gethGenesisKilnJSON from './testdata/geth-genesis-kiln.json'
+
+import type { Blockchain } from '../src/blockchain.js'
 
 async function getBlockchain(gethGenesis: any): Promise<Blockchain> {
   const common = Common.fromGethGenesis(gethGenesis, { chain: 'kiln' })
   const genesisState = parseGethGenesisState(gethGenesis)
-  const blockchain = await Blockchain.create({
+  const blockchain = await createBlockchain({
     genesisState,
     common,
   })

--- a/packages/client/archive/libp2p/index.ts
+++ b/packages/client/archive/libp2p/index.ts
@@ -75,7 +75,7 @@ export async function createClient(args: any) {
     `${datadir}/${common.chainName()}`
   )
 
-  const blockchain = await Blockchain.create({
+  const blockchain = await createBlockchain({
     db: new LevelDB(chainDB),
     common: config.chainCommon,
     hardforkByHeadBlockNumber: true,

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { createBlockFromValuesArray } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, ConsensusAlgorithm, Hardfork } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import {
@@ -630,7 +630,7 @@ async function startClient(
   let blockchain
   if (genesisMeta.genesisState !== undefined || genesisMeta.genesisStateRoot !== undefined) {
     const validateConsensus = config.chainCommon.consensusAlgorithm() === ConsensusAlgorithm.Clique
-    blockchain = await Blockchain.create({
+    blockchain = await createBlockchain({
       db: new LevelDB(dbs.chainDB),
       ...genesisMeta,
       common: config.chainCommon,

--- a/packages/client/src/blockchain/chain.ts
+++ b/packages/client/src/blockchain/chain.ts
@@ -1,5 +1,5 @@
 import { BlockHeader, createBlockFromValuesArray } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { ConsensusAlgorithm, Hardfork } from '@ethereumjs/common'
 import { BIGINT_0, BIGINT_1, equalsBytes } from '@ethereumjs/util'
 
@@ -7,6 +7,7 @@ import { LevelDB } from '../execution/level.js'
 import { Event } from '../types.js'
 
 import type { Config } from '../config.js'
+import type { Blockchain } from '@ethereumjs/blockchain'
 import type { Block } from '@ethereumjs/block'
 import type { DB, DBObject, GenesisState } from '@ethereumjs/util'
 import type { AbstractLevel } from 'abstract-level'
@@ -163,7 +164,7 @@ export class Chain {
 
     options.blockchain =
       options.blockchain ??
-      (await Blockchain.create({
+      (await createBlockchain({
         db: new LevelDB(options.chainDB),
         common: options.config.chainCommon,
         hardforkByHeadBlockNumber: true,

--- a/packages/client/src/blockchain/chain.ts
+++ b/packages/client/src/blockchain/chain.ts
@@ -7,8 +7,8 @@ import { LevelDB } from '../execution/level.js'
 import { Event } from '../types.js'
 
 import type { Config } from '../config.js'
-import type { Blockchain } from '@ethereumjs/blockchain'
 import type { Block } from '@ethereumjs/block'
+import type { Blockchain } from '@ethereumjs/blockchain'
 import type { DB, DBObject, GenesisState } from '@ethereumjs/util'
 import type { AbstractLevel } from 'abstract-level'
 

--- a/packages/client/src/util/debug.ts
+++ b/packages/client/src/util/debug.ts
@@ -51,7 +51,7 @@ const main = async () => {
 
 
   const chainDB = new Level('${execution.config.getDataDirectory(DataDirectory.Chain)}')
-  const blockchain = await Blockchain.create({
+  const blockchain = await createBlockchain({
     db: chainDB,
     common,
     validateBlocks: true,

--- a/packages/client/test/blockchain/chain.spec.ts
+++ b/packages/client/test/blockchain/chain.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { KeyEncoding, ValueEncoding, bytesToHex, equalsBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
@@ -49,7 +49,7 @@ describe('[Chain]', () => {
   })
 
   it('should detect unopened chain', async () => {
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       validateBlocks: false,
       validateConsensus: false,
     })
@@ -122,7 +122,7 @@ describe('[Chain]', () => {
 
   it('should add block to chain', async () => {
     // TODO: add test cases with activated block validation
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       validateBlocks: false,
       validateConsensus: false,
     })

--- a/packages/client/test/execution/vmexecution.spec.ts
+++ b/packages/client/test/execution/vmexecution.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromExecutionPayload } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain, createBlockchainFromBlocksData } from '@ethereumjs/blockchain'
 import { Chain as ChainEnum, Common, Hardfork } from '@ethereumjs/common'
 import { bytesToHex } from '@ethereumjs/util'
 import { VM } from '@ethereumjs/vm'
@@ -15,6 +15,7 @@ import testnet from '../testdata/common/testnet.json'
 import shanghaiJSON from '../testdata/geth-genesis/withdrawals.json'
 
 import type { BlockData, ExecutionPayload } from '@ethereumjs/block'
+import type { Blockchain } from '@ethereumjs/blockchain'
 import type { ChainConfig } from '@ethereumjs/common'
 
 const shanghaiPayload = {
@@ -104,7 +105,7 @@ describe('[VMExecution]', () => {
   }
 
   it('Block execution / Hardforks PoW (mainnet)', async () => {
-    let blockchain = await Blockchain.create({
+    let blockchain = await createBlockchain({
       validateBlocks: true,
       validateConsensus: false,
     })
@@ -114,7 +115,7 @@ describe('[VMExecution]', () => {
     let newHead = await exec.vm.blockchain.getIteratorHead!()
     assert.deepEqual(newHead.hash(), oldHead.hash(), 'should not modify blockchain on empty run')
 
-    blockchain = await Blockchain.fromBlocksData(blocksDataMainnet as BlockData[], {
+    blockchain = await createBlockchainFromBlocksData(blocksDataMainnet as BlockData[], {
       validateBlocks: true,
       validateConsensus: false,
     })
@@ -130,13 +131,13 @@ describe('[VMExecution]', () => {
   })
 
   it('Test block execution using executeBlocks function', async () => {
-    let blockchain = await Blockchain.create({
+    let blockchain = await createBlockchain({
       validateBlocks: true,
       validateConsensus: false,
     })
     let exec = await testSetup(blockchain)
 
-    blockchain = await Blockchain.fromBlocksData(blocksDataMainnet as BlockData[], {
+    blockchain = await createBlockchainFromBlocksData(blocksDataMainnet as BlockData[], {
       validateBlocks: true,
       validateConsensus: false,
     })
@@ -152,7 +153,7 @@ describe('[VMExecution]', () => {
   })
 
   it('Should fail opening if vmPromise already assigned', async () => {
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       validateBlocks: true,
       validateConsensus: false,
     })
@@ -174,7 +175,7 @@ describe('[VMExecution]', () => {
 
   it('Block execution / Hardforks PoA (goerli)', async () => {
     const common = new Common({ chain: ChainEnum.Goerli, hardfork: Hardfork.Chainstart })
-    let blockchain = await Blockchain.create({
+    let blockchain = await createBlockchain({
       validateBlocks: true,
       validateConsensus: false,
       common,
@@ -185,7 +186,7 @@ describe('[VMExecution]', () => {
     let newHead = await exec.vm.blockchain.getIteratorHead!()
     assert.deepEqual(newHead.hash(), oldHead.hash(), 'should not modify blockchain on empty run')
 
-    blockchain = await Blockchain.fromBlocksData(blocksDataGoerli as BlockData[], {
+    blockchain = await createBlockchainFromBlocksData(blocksDataGoerli as BlockData[], {
       validateBlocks: true,
       validateConsensus: false,
       common,

--- a/packages/client/test/integration/fullethereumservice.spec.ts
+++ b/packages/client/test/integration/fullethereumservice.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Hardfork } from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
@@ -26,7 +26,7 @@ DefaultStateManager.prototype.shallowCopy = function () {
 }
 async function setup(): Promise<[MockServer, FullEthereumService]> {
   const server = new MockServer({ config }) as any
-  const blockchain = await Blockchain.create({
+  const blockchain = await createBlockchain({
     common: config.chainCommon,
     validateBlocks: false,
     validateConsensus: false,

--- a/packages/client/test/integration/merge.spec.ts
+++ b/packages/client/test/integration/merge.spec.ts
@@ -1,5 +1,5 @@
 import { BlockHeader } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import {
   Chain as ChainCommon,
   Common,
@@ -73,7 +73,7 @@ const accounts: [Address, Uint8Array][] = [
 async function minerSetup(common: Common): Promise<[MockServer, FullEthereumService]> {
   const config = new Config({ common, accountCache: 10000, storageCache: 1000 })
   const server = new MockServer({ config }) as any
-  const blockchain = await Blockchain.create({
+  const blockchain = await createBlockchain({
     common,
     validateBlocks: false,
     validateConsensus: false,

--- a/packages/client/test/integration/miner.spec.ts
+++ b/packages/client/test/integration/miner.spec.ts
@@ -1,4 +1,4 @@
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import {
   Chain as ChainCommon,
   Common,
@@ -51,7 +51,7 @@ async function minerSetup(): Promise<[MockServer, FullEthereumService]> {
   const config = new Config({ common, accountCache: 10000, storageCache: 1000 })
   const server = new MockServer({ config }) as any
 
-  const blockchain = await Blockchain.create({
+  const blockchain = await createBlockchain({
     common,
     validateBlocks: false,
     validateConsensus: false,

--- a/packages/client/test/integration/peerpool.spec.ts
+++ b/packages/client/test/integration/peerpool.spec.ts
@@ -1,4 +1,4 @@
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { assert, describe, it } from 'vitest'
 
 import { Config } from '../../src/config.js'
@@ -65,7 +65,7 @@ describe('should ban peer', async () => {
 
 describe('should handle peer messages', async () => {
   const config = new Config({ accountCache: 10000, storageCache: 1000 })
-  const blockchain = await Blockchain.create({
+  const blockchain = await createBlockchain({
     validateBlocks: false,
     validateConsensus: false,
   })

--- a/packages/client/test/integration/util.ts
+++ b/packages/client/test/integration/util.ts
@@ -1,4 +1,4 @@
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { MemoryLevel } from 'memory-level'
 
 import { Config } from '../../src/config.js'
@@ -39,7 +39,7 @@ export async function setup(
   })
 
   const server = new MockServer({ config, location }) as any
-  const blockchain = await Blockchain.create({
+  const blockchain = await createBlockchain({
     validateBlocks: false,
     validateConsensus: false,
     common,

--- a/packages/client/test/rpc/eth/call.spec.ts
+++ b/packages/client/test/rpc/eth/call.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { LegacyTransaction } from '@ethereumjs/tx'
 import { Address, bigIntToHex, bytesToHex } from '@ethereumjs/util'
@@ -17,7 +17,7 @@ const method = 'eth_call'
 describe(method, () => {
   it('call with valid arguments', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       common,
       validateBlocks: false,
       validateConsensus: false,
@@ -123,7 +123,7 @@ describe(method, () => {
   })
 
   it('call with unsupported block argument', async () => {
-    const blockchain = await Blockchain.create()
+    const blockchain = await createBlockchain()
 
     const client = await createClient({ blockchain, includeVM: true })
     const manager = createManager(client)
@@ -149,7 +149,7 @@ describe(method, () => {
   })
 
   it('call with invalid hex params', async () => {
-    const blockchain = await Blockchain.create()
+    const blockchain = await createBlockchain()
 
     const client = await createClient({ blockchain, includeVM: true })
     const manager = createManager(client)

--- a/packages/client/test/rpc/eth/estimateGas.spec.ts
+++ b/packages/client/test/rpc/eth/estimateGas.spec.ts
@@ -1,5 +1,5 @@
 import { BlockHeader, createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Common } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
 import { LegacyTransaction } from '@ethereumjs/tx'
@@ -22,7 +22,7 @@ describe(
       // Use custom genesis so we can test EIP1559 txs more easily
       const genesisJson = await import('../../testdata/geth-genesis/rpctestnet.json')
       const common = Common.fromGethGenesis(genesisJson, { chain: 'testnet', hardfork: 'berlin' })
-      const blockchain = await Blockchain.create({
+      const blockchain = await createBlockchain({
         common,
         validateBlocks: false,
         validateConsensus: false,
@@ -186,7 +186,7 @@ describe(
     })
 
     it('call with unsupported block argument', async () => {
-      const blockchain = await Blockchain.create()
+      const blockchain = await createBlockchain()
 
       const client = await createClient({ blockchain, includeVM: true })
       const manager = createManager(client)

--- a/packages/client/test/rpc/eth/getBalance.spec.ts
+++ b/packages/client/test/rpc/eth/getBalance.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
 import { LegacyTransaction } from '@ethereumjs/tx'
@@ -18,7 +18,7 @@ describe(
   () => {
     it('ensure balance deducts after a tx', async () => {
       const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-      const blockchain = await Blockchain.create({ common })
+      const blockchain = await createBlockchain({ common })
 
       const client = await createClient({ blockchain, commonChain: common, includeVM: true })
       const manager = createManager(client)
@@ -93,7 +93,7 @@ describe(
     })
 
     it('call with unsupported block argument', async () => {
-      const blockchain = await Blockchain.create()
+      const blockchain = await createBlockchain()
 
       const client = await createClient({ blockchain, includeVM: true })
       const manager = createManager(client)

--- a/packages/client/test/rpc/eth/getBlockTransactionCountByNumber.spec.ts
+++ b/packages/client/test/rpc/eth/getBlockTransactionCountByNumber.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
 import { LegacyTransaction } from '@ethereumjs/tx'
@@ -18,7 +18,7 @@ const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart 
 
 describe(method, () => {
   it('call with valid arguments', async () => {
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       common,
       validateBlocks: false,
       validateConsensus: false,
@@ -65,7 +65,7 @@ describe(method, () => {
   })
 
   it('call with valid arguments (multiple transactions)', async () => {
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       common,
       validateBlocks: false,
       validateConsensus: false,
@@ -130,7 +130,7 @@ describe(method, () => {
   })
 
   it('call with unsupported block argument', async () => {
-    const blockchain = await Blockchain.create()
+    const blockchain = await createBlockchain()
 
     const client = await createClient({ blockchain, includeVM: true })
     const manager = createManager(client)

--- a/packages/client/test/rpc/eth/getCode.spec.ts
+++ b/packages/client/test/rpc/eth/getCode.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
 import { LegacyTransaction } from '@ethereumjs/tx'
@@ -18,7 +18,7 @@ const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart 
 
 describe(method, () => {
   it('call with valid arguments', async () => {
-    const blockchain = await Blockchain.create({ common })
+    const blockchain = await createBlockchain({ common })
 
     const client = await createClient({ blockchain, commonChain: common, includeVM: true })
     const manager = createManager(client)
@@ -38,7 +38,7 @@ describe(method, () => {
   })
 
   it('ensure returns correct code', async () => {
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       common,
       validateBlocks: false,
       validateConsensus: false,
@@ -99,7 +99,7 @@ describe(method, () => {
   })
 
   it('call with unsupported block argument', async () => {
-    const blockchain = await Blockchain.create()
+    const blockchain = await createBlockchain()
 
     const client = await createClient({ blockchain, includeVM: true })
     const manager = createManager(client)

--- a/packages/client/test/rpc/eth/getProof.spec.ts
+++ b/packages/client/test/rpc/eth/getProof.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Common } from '@ethereumjs/common'
 import { LegacyTransaction } from '@ethereumjs/tx'
 import { Address, bigIntToHex } from '@ethereumjs/util'
@@ -91,7 +91,7 @@ const common = new Common({ chain: 'testnet2', customChains: [testnetData] })
 
 describe(method, async () => {
   it('call with valid arguments', async () => {
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       common,
       validateBlocks: false,
       validateConsensus: false,

--- a/packages/client/test/rpc/eth/getTransactionCount.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionCount.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
 import { LegacyTransaction, TransactionFactory } from '@ethereumjs/tx'
@@ -17,7 +17,7 @@ const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart 
 
 describe(method, () => {
   it('call with valid arguments', async () => {
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       common,
       validateBlocks: false,
       validateConsensus: false,
@@ -75,7 +75,7 @@ describe(method, () => {
   }, 40000)
 
   it('call with pending block argument', async () => {
-    const blockchain = await Blockchain.create()
+    const blockchain = await createBlockchain()
 
     const client = await createClient({ blockchain, includeVM: true })
     const manager = createManager(client)

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -1,5 +1,5 @@
 import { BlockHeader } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain as ChainEnum, Common, Hardfork, parseGethGenesis } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
 import {
@@ -28,6 +28,7 @@ import { mockBlockchain } from './mockBlockchain.js'
 
 import type { EthereumClient } from '../../src/client.js'
 import type { FullEthereumService } from '../../src/service/index.js'
+import type { Blockchain } from '@ethereumjs/blockchain'
 import type { TypedTransaction } from '@ethereumjs/tx'
 import type { GenesisState } from '@ethereumjs/util'
 import type { IncomingMessage } from 'connect'
@@ -235,7 +236,7 @@ export async function setupChain(genesisFile: any, chainName = 'dev', clientOpts
   // use genesisStateRoot for blockchain init as well as to start of the stateless
   // client. else the stateroot could have been generated out of box
   const genesisMeta = common.gteHardfork(Hardfork.Osaka) ? { genesisStateRoot } : { genesisState }
-  const blockchain = await Blockchain.create({
+  const blockchain = await createBlockchain({
     common,
     validateBlocks: false,
     validateConsensus: false,

--- a/packages/client/test/rpc/txpool/content.spec.ts
+++ b/packages/client/test/rpc/txpool/content.spec.ts
@@ -1,5 +1,5 @@
 import { BlockHeader, createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
 import { TransactionFactory } from '@ethereumjs/tx'
@@ -16,7 +16,7 @@ const method = 'txpool_content'
 describe(method, () => {
   it('call with valid arguments', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       common,
       validateBlocks: false,
       validateConsensus: false,

--- a/packages/client/test/sim/simutils.ts
+++ b/packages/client/test/sim/simutils.ts
@@ -1,5 +1,5 @@
 import { executionPayloadFromBeaconPayload } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { BlobEIP4844Transaction, FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
 import {
   Address,
@@ -445,7 +445,7 @@ export async function createInlineClient(
     `${datadir}/${common.chainName()}/metaDB`
   )
 
-  const blockchain = await Blockchain.create({
+  const blockchain = await createBlockchain({
     db: new LevelDB(chainDB),
     genesisState: customGenesisState,
     common: config.chainCommon,

--- a/packages/evm/examples/runCode.ts
+++ b/packages/evm/examples/runCode.ts
@@ -1,11 +1,11 @@
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { EVM } from '@ethereumjs/evm'
 import { bytesToHex, hexToBytes } from '@ethereumjs/util'
 
 const main = async () => {
   const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
-  const blockchain = await Blockchain.create()
+  const blockchain = await createBlockchain()
 
   const evm = await EVM.create({
     common,

--- a/packages/evm/examples/withBlockchain.ts
+++ b/packages/evm/examples/withBlockchain.ts
@@ -1,4 +1,4 @@
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { EVM } from '@ethereumjs/evm'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
@@ -7,7 +7,7 @@ import { bytesToHex } from '@ethereumjs/util'
 const main = async () => {
   const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Shanghai })
   const stateManager = new DefaultStateManager()
-  const blockchain = await Blockchain.create()
+  const blockchain = await createBlockchain()
 
   const evm = await EVM.create({
     common,

--- a/packages/vm/examples/run-blockchain.ts
+++ b/packages/vm/examples/run-blockchain.ts
@@ -12,7 +12,7 @@ import {
   createBlockFromBlockData,
   createBlockFromRLPSerializedBlock,
 } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { Blockchain, createBlockchain } from '@ethereumjs/blockchain'
 import { Common, ConsensusType } from '@ethereumjs/common'
 import { VM } from '@ethereumjs/vm'
 
@@ -25,7 +25,7 @@ async function main() {
 
   const genesisBlock = createBlockFromBlockData({ header: testData.genesisBlockHeader }, { common })
 
-  const blockchain = await Blockchain.create({
+  const blockchain = await createBlockchain({
     common,
     validateConsensus: validatePow,
     validateBlocks,

--- a/packages/vm/examples/vmWithGenesisState.ts
+++ b/packages/vm/examples/vmWithGenesisState.ts
@@ -1,4 +1,4 @@
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
 import { Address } from '@ethereumjs/util'
@@ -7,7 +7,7 @@ import { VM } from '@ethereumjs/vm'
 const main = async () => {
   const genesisState = getGenesis(Chain.Mainnet)
 
-  const blockchain = await Blockchain.create({ genesisState })
+  const blockchain = await createBlockchain({ genesisState })
   const vm = await VM.create({ blockchain, genesisState })
   const account = await vm.stateManager.getAccount(
     Address.fromString('0x000d836201318ec6899a67540690382780743280')

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -1,4 +1,4 @@
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain, Common } from '@ethereumjs/common'
 import { EVM, getActivePrecompiles } from '@ethereumjs/evm'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
@@ -91,7 +91,7 @@ export class VM {
     }
 
     if (opts.blockchain === undefined) {
-      opts.blockchain = await Blockchain.create({ common: opts.common })
+      opts.blockchain = await createBlockchain({ common: opts.common })
     }
 
     const genesisState = opts.genesisState ?? {}

--- a/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Common, Hardfork } from '@ethereumjs/common'
 import { LegacyTransaction } from '@ethereumjs/tx'
 import {
@@ -180,7 +180,7 @@ describe('EIP 2935: historical block hashes', () => {
 
     it('should save genesis block hash to the history block hash contract', async () => {
       const commonGenesis = eip2935ActiveAtCommon(1)
-      const blockchain = await Blockchain.create({
+      const blockchain = await createBlockchain({
         common: commonGenesis,
         validateBlocks: false,
         validateConsensus: false,
@@ -221,7 +221,7 @@ describe('EIP 2935: historical block hashes', () => {
       const common = eip2935ActiveAtCommon(blocksActivation)
       const historyServeWindow = commonGetHistoryServeWindow.param('vm', 'historyServeWindow')
 
-      const blockchain = await Blockchain.create({
+      const blockchain = await createBlockchain({
         common,
         validateBlocks: false,
         validateConsensus: false,
@@ -251,7 +251,7 @@ describe('EIP 2935: historical block hashes', () => {
       }
 
       // swap out the blockchain to test from storage
-      const blockchainEmpty = await Blockchain.create({
+      const blockchainEmpty = await createBlockchain({
         common,
         validateBlocks: false,
         validateConsensus: false,

--- a/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Common, Hardfork } from '@ethereumjs/common'
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
 import {
@@ -36,7 +36,7 @@ describe('EIP4844 tests', () => {
       { header: { gasLimit: 50000, parentBeaconBlockRoot: zeros(32) } },
       { common }
     )
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       genesisBlock,
       common,
       validateBlocks: false,

--- a/packages/vm/test/api/EIPs/eip-4895-withdrawals.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-4895-withdrawals.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData, genWithdrawalsTrieRoot } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { decode } from '@ethereumjs/rlp'
 import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
@@ -194,7 +194,7 @@ describe('EIP4895 tests', () => {
     const common = Common.fromGethGenesis(genesisJSON, { chain: 'custom' })
     common.setHardfork(Hardfork.Shanghai)
     const genesisState = parseGethGenesisState(genesisJSON)
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       common,
       validateBlocks: false,
       validateConsensus: false,

--- a/packages/vm/test/api/EIPs/eip-7685.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-7685.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData, genRequestsTrieRoot } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import {
   DepositRequest,
@@ -92,7 +92,7 @@ describe('EIP 7685 buildBlock tests', () => {
       { header: { gasLimit: 50000, baseFeePerGas: 100 } },
       { common }
     )
-    const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
+    const blockchain = await createBlockchain({ genesisBlock, common, validateConsensus: false })
     const vm = await VM.create({ common, blockchain })
     const blockBuilder = await vm.buildBlock({
       parentBlock: genesisBlock,

--- a/packages/vm/test/api/buildBlock.spec.ts
+++ b/packages/vm/test/api/buildBlock.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { FeeMarketEIP1559Transaction, LegacyTransaction } from '@ethereumjs/tx'
 import { Account, Address, concatBytes, hexToBytes } from '@ethereumjs/util'
@@ -16,7 +16,7 @@ describe('BlockBuilder', () => {
   it('should build a valid block', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     const genesisBlock = createBlockFromBlockData({ header: { gasLimit: 50000 } }, { common })
-    const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
+    const blockchain = await createBlockchain({ genesisBlock, common, validateConsensus: false })
     const vm = await VM.create({ common, blockchain })
 
     await setBalance(vm, pKeyAddress)
@@ -81,7 +81,7 @@ describe('BlockBuilder', () => {
   it('should correctly seal a PoW block', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     const genesisBlock = createBlockFromBlockData({ header: { gasLimit: 50000 } }, { common })
-    const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
+    const blockchain = await createBlockchain({ genesisBlock, common, validateConsensus: false })
     const vm = await VM.create({ common, blockchain })
 
     await setBalance(vm, pKeyAddress)
@@ -178,7 +178,7 @@ describe('BlockBuilder', () => {
       { header: { gasLimit: 50000, extraData } },
       { common, cliqueSigner }
     )
-    const blockchain = await Blockchain.create({ genesisBlock, common })
+    const blockchain = await createBlockchain({ genesisBlock, common })
     const vm = await VM.create({ common, blockchain })
 
     // add balance for tx
@@ -211,7 +211,7 @@ describe('BlockBuilder', () => {
   it('should throw if block already built or reverted', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     const genesisBlock = createBlockFromBlockData({ header: { gasLimit: 50000 } }, { common })
-    const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
+    const blockchain = await createBlockchain({ genesisBlock, common, validateConsensus: false })
     const vm = await VM.create({ common, blockchain })
 
     await setBalance(vm, pKeyAddress)
@@ -265,7 +265,7 @@ describe('BlockBuilder', () => {
   it('should build a block without any txs', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Istanbul })
     const genesisBlock = createBlockFromBlockData({ header: { gasLimit: 50000 } }, { common })
-    const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
+    const blockchain = await createBlockchain({ genesisBlock, common, validateConsensus: false })
     const vm = await VM.create({ common, blockchain })
     const vmCopy = await vm.shallowCopy()
 
@@ -290,7 +290,7 @@ describe('BlockBuilder', () => {
       { header: { gasLimit: 50000, baseFeePerGas: 100 } },
       { common }
     )
-    const blockchain = await Blockchain.create({ genesisBlock, common, validateConsensus: false })
+    const blockchain = await createBlockchain({ genesisBlock, common, validateConsensus: false })
     const vm = await VM.create({ common, blockchain })
 
     await setBalance(vm, pKeyAddress)

--- a/packages/vm/test/api/customChain.spec.ts
+++ b/packages/vm/test/api/customChain.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Common, Hardfork } from '@ethereumjs/common'
 import { TransactionFactory } from '@ethereumjs/tx'
 import { Address, bytesToHex, hexToBytes } from '@ethereumjs/util'
@@ -63,7 +63,7 @@ const privateKey = hexToBytes('0xe331b6d69882b4cb4ea581d88e0b604039a3de5967688d3
 
 describe('VM initialized with custom state', () => {
   it('should transfer eth from already existent account', async () => {
-    const blockchain = await Blockchain.create({ common, genesisState })
+    const blockchain = await createBlockchain({ common, genesisState })
     const vm = await VM.create({ blockchain, common, genesisState })
 
     const to = '0x00000000000000000000000000000000000000ff'
@@ -90,7 +90,7 @@ describe('VM initialized with custom state', () => {
   })
 
   it('should retrieve value from storage', async () => {
-    const blockchain = await Blockchain.create({ common, genesisState })
+    const blockchain = await createBlockchain({ common, genesisState })
     common.setHardfork(Hardfork.London)
     const vm = await VM.create({ blockchain, common, genesisState })
     const sigHash = new Interface(['function retrieve()']).getSighash(

--- a/packages/vm/test/api/genesis.spec.ts
+++ b/packages/vm/test/api/genesis.spec.ts
@@ -1,4 +1,4 @@
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
 import { assert, describe, it } from 'vitest'
@@ -10,7 +10,7 @@ describe('genesis', () => {
     const f = async () => {
       const genesisState = getGenesis(Chain.Mainnet)
 
-      const blockchain = await Blockchain.create({ genesisState })
+      const blockchain = await createBlockchain({ genesisState })
       await VM.create({ blockchain, genesisState })
     }
 

--- a/packages/vm/test/api/runTx.spec.ts
+++ b/packages/vm/test/api/runTx.spec.ts
@@ -1,5 +1,5 @@
 import { BlockHeader, createBlockFromBlockData } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { Blockchain, createBlockchain } from '@ethereumjs/blockchain'
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import {
   BlobEIP4844Transaction,
@@ -74,7 +74,7 @@ describe('runTx() -> successful API parameter usage', async () => {
     common = new Common({ chain: Chain.Goerli, hardfork: Hardfork.London })
     vm = await VM.create({
       common,
-      blockchain: await Blockchain.create({ validateConsensus: false, validateBlocks: false }),
+      blockchain: await createBlockchain({ validateConsensus: false, validateBlocks: false }),
     })
     await simpleRun(vm, 'goerli (PoA), london HF, default SM - should run without errors')
   })
@@ -83,7 +83,7 @@ describe('runTx() -> successful API parameter usage', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
     const vm = await VM.create({
       common,
-      blockchain: await Blockchain.create({ validateConsensus: false, validateBlocks: false }),
+      blockchain: await createBlockchain({ validateConsensus: false, validateBlocks: false }),
     })
     const tx = getTransaction(vm.common, 0, true)
     const caller = tx.getSenderAddress()
@@ -98,7 +98,7 @@ describe('runTx() -> successful API parameter usage', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
     const vm = await VM.create({
       common,
-      blockchain: await Blockchain.create({ validateConsensus: false, validateBlocks: false }),
+      blockchain: await createBlockchain({ validateConsensus: false, validateBlocks: false }),
     })
     const tx = getTransaction(vm.common, 0, true)
     const caller = tx.getSenderAddress()
@@ -141,7 +141,7 @@ describe('runTx() -> successful API parameter usage', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Paris })
     const vm = await VM.create({
       common,
-      blockchain: await Blockchain.create({ validateConsensus: false, validateBlocks: false }),
+      blockchain: await createBlockchain({ validateConsensus: false, validateBlocks: false }),
     })
     const tx = getTransaction(vm.common, 0, true)
     const caller = tx.getSenderAddress()
@@ -912,7 +912,7 @@ describe('EIP 4844 transaction tests', () => {
         }
       )
     }
-    const blockchain = await Blockchain.create({
+    const blockchain = await createBlockchain({
       validateBlocks: false,
       validateConsensus: false,
     })

--- a/packages/vm/test/api/utils.ts
+++ b/packages/vm/test/api/utils.ts
@@ -1,4 +1,4 @@
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { TransactionFactory, TransactionType } from '@ethereumjs/tx'
 import {
   Account,
@@ -33,7 +33,7 @@ export async function setupVM(opts: VMOpts & { genesisBlock?: Block } = {}) {
   const db: any = new LevelDB(new MemoryLevel())
   const { common, genesisBlock } = opts
   if (opts.blockchain === undefined) {
-    opts.blockchain = await Blockchain.create({
+    opts.blockchain = await createBlockchain({
       db,
       validateBlocks: false,
       validateConsensus: false,

--- a/packages/vm/test/tester/runners/BlockchainTestsRunner.ts
+++ b/packages/vm/test/tester/runners/BlockchainTestsRunner.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData, createBlockFromRLPSerializedBlock } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { ConsensusAlgorithm } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
@@ -73,7 +73,7 @@ export async function runBlockchainTest(options: any, testData: any, t: tape.Tes
     t.deepEquals(genesisBlock.serialize(), rlp, 'correct genesis RLP')
   }
 
-  let blockchain = await Blockchain.create({
+  let blockchain = await createBlockchain({
     common,
     validateBlocks: true,
     validateConsensus: validatePow,

--- a/packages/vm/test/tester/runners/GeneralStateTestsRunner.ts
+++ b/packages/vm/test/tester/runners/GeneralStateTestsRunner.ts
@@ -1,5 +1,5 @@
 import { Block } from '@ethereumjs/block'
-import { Blockchain } from '@ethereumjs/blockchain'
+import { createBlockchain } from '@ethereumjs/blockchain'
 import { type InterpreterStep } from '@ethereumjs/evm'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { Trie } from '@ethereumjs/trie'
@@ -72,7 +72,7 @@ async function runTestCase(options: any, testData: any, t: tape.Test) {
   // Have to create a blockchain with empty block as genesisBlock for Merge
   // Otherwise mainnet genesis will throw since this has difficulty nonzero
   const genesisBlock = new Block(undefined, undefined, undefined, undefined, { common })
-  const blockchain = await Blockchain.create({ genesisBlock, common })
+  const blockchain = await createBlockchain({ genesisBlock, common })
   const state = new Trie({ useKeyHashing: true, common })
   const stateManager = new DefaultStateManager({
     trie: state,


### PR DESCRIPTION
Works on #3487

Relates to #3489

Replaces all static `Blockchain` class methods with independently defined functions.

Moves constructor functions  to `packages/blockchain/src/constructors.ts`

- `Blockchain.create(...)` > `createBlockchain(...)`
- `Blockchain.fromBlocksData(...)` > `createBlockchainFromBlocksData(...)

moves helper functions to `packages/blockchain/src/helpers.ts`
- `genGenesisStateRoot`
- `getGenesisStateRoot` 