### PR TITLE
Monorepo: Add missing Import File Extensions / debug Import Fixes (v8 port)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16704,7 +16704,6 @@
         "@types/connect": "^3.4.35",
         "@types/cors": "^2.8.17",
         "@types/fs-extra": "^11.0.4",
-        "@types/node": "^20.14.10",
         "@types/ws": "^8.5.10",
         "@types/yargs": "^17.0.24",
         "eventsource": "^2.0.2",
@@ -16717,15 +16716,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "packages/client/node_modules/@types/node": {
-      "version": "20.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
       }
     },
     "packages/client/node_modules/cliui": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16704,6 +16704,7 @@
         "@types/connect": "^3.4.35",
         "@types/cors": "^2.8.17",
         "@types/fs-extra": "^11.0.4",
+        "@types/node": "^20.14.10",
         "@types/ws": "^8.5.10",
         "@types/yargs": "^17.0.24",
         "eventsource": "^2.0.2",
@@ -16716,6 +16717,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/client/node_modules/@types/node": {
+      "version": "20.14.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
+      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
       }
     },
     "packages/client/node_modules/cliui": {

--- a/packages/blockchain/src/consensus/clique.ts
+++ b/packages/blockchain/src/consensus/clique.ts
@@ -18,9 +18,8 @@ import type { Blockchain } from '../index.js'
 import type { Consensus, ConsensusOptions } from '../types.js'
 import type { Block, BlockHeader } from '@ethereumjs/block'
 import type { CliqueConfig } from '@ethereumjs/common'
-const { debug: createDebugLogger } = debugDefault
 
-const debug = createDebugLogger('blockchain:clique')
+const debug = debugDefault('blockchain:clique')
 
 // Magic nonce number to vote on adding a new signer
 export const CLIQUE_NONCE_AUTH = hexToBytes('0xffffffffffffffff')

--- a/packages/blockchain/src/consensus/ethash.ts
+++ b/packages/blockchain/src/consensus/ethash.ts
@@ -44,7 +44,7 @@ export class EthashConsensus implements Consensus {
   public async genesisInit(): Promise<void> {}
   public async setup({ blockchain }: ConsensusOptions): Promise<void> {
     this.blockchain = blockchain
-    this._ethash = new Ethash(this.blockchain.db as any)
+    this._ethash = new Ethash(this.blockchain!.db as any)
   }
   public async newBlock(): Promise<void> {}
 }

--- a/packages/blockchain/src/types.ts
+++ b/packages/blockchain/src/types.ts
@@ -1,4 +1,4 @@
-import type { Blockchain } from '.'
+import type { Blockchain } from './index.js'
 import type { Block, BlockHeader } from '@ethereumjs/block'
 import type { Common, ConsensusAlgorithm } from '@ethereumjs/common'
 import type { AsyncEventEmitter, DB, DBObject, GenesisState } from '@ethereumjs/util'

--- a/packages/blockchain/tsconfig.json
+++ b/packages/blockchain/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../config/tsconfig.json",
   "include": ["src/**/*.ts", "src/**/*.json", "test/**/*.ts"],
   "compilerOptions": {
-    "types": ["node"],
     "typeRoots": ["node_modules/@types"]
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -98,6 +98,7 @@
     "@types/connect": "^3.4.35",
     "@types/cors": "^2.8.17",
     "@types/fs-extra": "^11.0.4",
+    "@types/node": "^20.14.10",
     "@types/ws": "^8.5.10",
     "@types/yargs": "^17.0.24",
     "eventsource": "^2.0.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -98,7 +98,6 @@
     "@types/connect": "^3.4.35",
     "@types/cors": "^2.8.17",
     "@types/fs-extra": "^11.0.4",
-    "@types/node": "^20.14.10",
     "@types/ws": "^8.5.10",
     "@types/yargs": "^17.0.24",
     "eventsource": "^2.0.2",

--- a/packages/client/src/sync/fetcher/accountfetcher.ts
+++ b/packages/client/src/sync/fetcher/accountfetcher.ts
@@ -34,7 +34,6 @@ import type { FetcherOptions } from './fetcher.js'
 import type { StorageRequest } from './storagefetcher.js'
 import type { Job, SnapFetcherDoneFlags } from './types.js'
 import type { Debugger } from 'debug'
-const { debug: createDebugLogger } = debugDefault
 
 type AccountDataResponse = AccountData[] & { completed?: boolean }
 
@@ -99,7 +98,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
     this.stateManager = options.stateManager ?? new DefaultStateManager()
     this.accountTrie = this.stateManager['_getAccountTrie']()
 
-    this.debug = createDebugLogger('client:AccountFetcher')
+    this.debug = debugDefault('client:AccountFetcher')
 
     this.storageFetcher = new StorageFetcher({
       config: this.config,

--- a/packages/client/src/sync/fetcher/bytecodefetcher.ts
+++ b/packages/client/src/sync/fetcher/bytecodefetcher.ts
@@ -6,7 +6,7 @@ import {
   concatBytes,
   equalsBytes,
 } from '@ethereumjs/util'
-import debugDefault from 'debug'
+import debug from 'debug'
 import { keccak256 } from 'ethereum-cryptography/keccak'
 
 import { Fetcher } from './fetcher.js'
@@ -17,7 +17,6 @@ import type { FetcherOptions } from './fetcher.js'
 import type { Job, SnapFetcherDoneFlags } from './types.js'
 import type { BatchDBOp, DB } from '@ethereumjs/util'
 import type { Debugger } from 'debug'
-const { debug: createDebugLogger } = debugDefault
 
 type ByteCodeDataResponse = Uint8Array[] & { completed?: boolean }
 
@@ -62,7 +61,7 @@ export class ByteCodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
 
     this.keccakFunction = this.config.chainCommon.customCrypto.keccak256 ?? keccak256
 
-    this.debug = createDebugLogger('client:ByteCodeFetcher')
+    this.debug = debug('client:ByteCodeFetcher')
     if (this.hashes.length > 0) {
       const fullJob = { task: { hashes: this.hashes } } as Job<JobTask, Uint8Array[], Uint8Array>
       this.debug(

--- a/packages/client/src/sync/fetcher/fetcher.ts
+++ b/packages/client/src/sync/fetcher/fetcher.ts
@@ -1,4 +1,4 @@
-import debugDefault from 'debug'
+import debug from 'debug'
 import { Readable, Writable } from 'stream'
 
 import { Heap } from '../../ext/qheap.js'
@@ -11,8 +11,6 @@ import type { PeerPool } from '../../net/peerpool.js'
 import type { JobTask as BlockFetcherJobTask } from './blockfetcherbase.js'
 import type { Job } from './types.js'
 import type { Debugger } from 'debug'
-
-const { debug: createDebugLogger } = debugDefault
 
 export interface FetcherOptions {
   /* Common chain config*/
@@ -80,7 +78,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
     super({ ...options, objectMode: true })
 
     this.config = options.config
-    this.debug = createDebugLogger('client:fetcher')
+    this.debug = debug('client:fetcher')
 
     this.pool = options.pool
     this.timeout = options.timeout ?? 8000

--- a/packages/client/src/sync/fetcher/storagefetcher.ts
+++ b/packages/client/src/sync/fetcher/storagefetcher.ts
@@ -24,7 +24,6 @@ import type { StorageData } from '../../net/protocol/snapprotocol.js'
 import type { FetcherOptions } from './fetcher.js'
 import type { Job, SnapFetcherDoneFlags } from './types.js'
 import type { Debugger } from 'debug'
-const { debug: createDebugLogger } = debugDefault
 
 const TOTAL_RANGE_END = BIGINT_2 ** BIGINT_256 - BIGINT_1
 
@@ -95,7 +94,7 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
     this.fetcherDoneFlags.storageFetcher.count = BigInt(this.storageRequests.length)
 
     this.accountToHighestKnownHash = new Map<String, Uint8Array>()
-    this.debug = createDebugLogger('client:StorageFetcher')
+    this.debug = debugDefault('client:StorageFetcher')
     if (this.storageRequests.length > 0) {
       const fullJob = {
         task: { storageRequests: this.storageRequests },

--- a/packages/client/src/sync/fetcher/trienodefetcher.ts
+++ b/packages/client/src/sync/fetcher/trienodefetcher.ts
@@ -15,7 +15,7 @@ import {
   KECCAK256_RLP,
   unprefixedHexToBytes,
 } from '@ethereumjs/util'
-import debugPkg from 'debug'
+import debug from 'debug'
 import { keccak256 } from 'ethereum-cryptography/keccak.js'
 import { bytesToHex, equalsBytes, hexToBytes } from 'ethereum-cryptography/utils'
 import { OrderedMap } from 'js-sdsl'
@@ -28,7 +28,6 @@ import type { FetcherOptions } from './fetcher.js'
 import type { Job, SnapFetcherDoneFlags } from './types.js'
 import type { BatchDBOp, DB } from '@ethereumjs/util'
 import type { Debugger } from 'debug'
-const { debug: createDebugLogger } = debugPkg
 
 type TrieNodesResponse = Uint8Array[] & { completed?: boolean }
 
@@ -111,7 +110,7 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
     this.codeDB = this.stateManager['_getCodeDB']()
 
     this.nodeCount = 0
-    this.debug = createDebugLogger('client:TrieNodeFetcher')
+    this.debug = debug('client:TrieNodeFetcher')
 
     this.keccakFunction = this.config.chainCommon.customCrypto.keccak256 ?? keccak256
 

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["bin", "src", "test", "package.json"],
   "compilerOptions": {
     "typeRoots": ["node_modules/@types", "src/@types"],
-    "moduleResolution": "Node16"
+    "allowSyntheticDefaultImports": true
   }
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -3,6 +3,6 @@
   "include": ["bin", "src", "test", "package.json"],
   "compilerOptions": {
     "typeRoots": ["node_modules/@types", "src/@types"],
-    "allowSyntheticDefaultImports": true
+    "moduleResolution": "Node16"
   }
 }

--- a/packages/devp2p/src/dns/dns.ts
+++ b/packages/devp2p/src/dns/dns.ts
@@ -5,9 +5,8 @@ import { ENR } from './enr.js'
 
 import type { DNSOptions, PeerInfo } from '../types.js'
 import type { Common } from '@ethereumjs/common'
-const { debug: createDebugLogger } = debugDefault
 
-const debug = createDebugLogger('devp2p:dns:dns')
+const debug = debugDefault('devp2p:dns:dns')
 
 type SearchContext = {
   domain: string

--- a/packages/devp2p/src/dpt/ban-list.ts
+++ b/packages/devp2p/src/dpt/ban-list.ts
@@ -6,10 +6,9 @@ import { formatLogId } from '../util.js'
 import { KBucket } from './kbucket.js'
 
 import type { PeerInfo } from '../types.js'
-const { debug: createDebugLogger } = debugDefault
 
-const debug = createDebugLogger('devp2p:dpt:ban-list')
-const verbose = createDebugLogger('verbose').enabled
+const debug = debugDefault('devp2p:dpt:ban-list')
+const verbose = debugDefault('verbose').enabled
 
 export class BanList {
   private _lru: LRUCache<string, boolean>

--- a/packages/devp2p/src/dpt/message.ts
+++ b/packages/devp2p/src/dpt/message.ts
@@ -8,9 +8,8 @@ import { assertEq, ipToBytes, ipToString, isV4Format, isV6Format, unstrictDecode
 
 import type { PeerInfo } from '../types.js'
 import type { Common } from '@ethereumjs/common'
-const { debug: createDebugLogger } = debugDefault
 
-const debug = createDebugLogger('devp2p:dpt:server')
+const debug = debugDefault('devp2p:dpt:server')
 
 function getTimestamp() {
   return (Date.now() / 1000) | 0

--- a/packages/devp2p/src/dpt/server.ts
+++ b/packages/devp2p/src/dpt/server.ts
@@ -13,10 +13,9 @@ import type { DPT } from './dpt.js'
 import type { Common } from '@ethereumjs/common'
 import type { Debugger } from 'debug'
 import type { Socket as DgramSocket, RemoteInfo } from 'dgram'
-const { debug: createDebugLogger } = debugDefault
 
 const DEBUG_BASE_NAME = 'dpt:server'
-const verbose = createDebugLogger('verbose').enabled
+const verbose = debugDefault('verbose').enabled
 
 const VERSION = 0x04
 

--- a/packages/devp2p/src/protocol/protocol.ts
+++ b/packages/devp2p/src/protocol/protocol.ts
@@ -7,7 +7,6 @@ import { devp2pDebug } from '../util.js'
 import type { Peer } from '../rlpx/peer.js'
 import type { SendMethod } from '../types.js'
 import type { Debugger } from 'debug'
-const { debug: createDebugLogger } = debugDefault
 
 type MessageCodes = { [key: number | string]: number | string }
 
@@ -50,7 +49,7 @@ export abstract class Protocol {
         : undefined
 
     this._debug = devp2pDebug.extend(protocol)
-    this._verbose = createDebugLogger('verbose').enabled
+    this._verbose = debugDefault('verbose').enabled
     this.initMsgDebuggers(protocol)
   }
 

--- a/packages/devp2p/src/rlpx/ecies.ts
+++ b/packages/devp2p/src/rlpx/ecies.ts
@@ -12,10 +12,9 @@ import { assertEq, genPrivateKey, id2pk, pk2id, unstrictDecode, xor, zfill } fro
 import { MAC } from './mac.js'
 
 import type { Common } from '@ethereumjs/common'
-const { debug: createDebugLogger } = debugDefault
 type Decipher = crypto.Decipher
 
-const debug = createDebugLogger('devp2p:rlpx:peer')
+const debug = debugDefault('devp2p:rlpx:peer')
 
 function ecdhX(publicKey: Uint8Array, privateKey: Uint8Array) {
   // return (publicKey * privateKey).x

--- a/packages/devp2p/src/rlpx/peer.ts
+++ b/packages/devp2p/src/rlpx/peer.ts
@@ -23,10 +23,9 @@ import type { Capabilities, PeerOptions } from '../types.js'
 import type { Common } from '@ethereumjs/common'
 import type { Debugger } from 'debug'
 import type { Socket } from 'net'
-const { debug: createDebugLogger } = debugDefault
 
 const DEBUG_BASE_NAME = 'rlpx:peer'
-const verbose = createDebugLogger('verbose').enabled
+const verbose = debugDefault('verbose').enabled
 
 const BASE_PROTOCOL_VERSION = 5
 const BASE_PROTOCOL_LENGTH = 16

--- a/packages/devp2p/src/rlpx/rlpx.ts
+++ b/packages/devp2p/src/rlpx/rlpx.ts
@@ -22,12 +22,11 @@ import type { DPT } from '../dpt/index.js'
 import type { Capabilities, PeerInfo, RLPxOptions } from '../types.js'
 import type { Common } from '@ethereumjs/common'
 import type { Debugger } from 'debug'
-const { debug: createDebugLogger } = debugDefault
 
 // note: relative path only valid in .js file in dist
 
 const DEBUG_BASE_NAME = 'rlpx'
-const verbose = createDebugLogger('verbose').enabled
+const verbose = debugDefault('verbose').enabled
 
 export class RLPx {
   public events: EventEmitter

--- a/packages/devp2p/src/types.ts
+++ b/packages/devp2p/src/types.ts
@@ -1,5 +1,5 @@
-import type { DPT } from './dpt'
-import type { Protocol } from './protocol/protocol'
+import type { DPT } from './dpt/index.js'
+import type { Protocol } from './protocol/protocol.js'
 import type { Common } from '@ethereumjs/common'
 import type { Socket } from 'net'
 

--- a/packages/devp2p/src/util.ts
+++ b/packages/devp2p/src/util.ts
@@ -1,14 +1,13 @@
 import { RLP } from '@ethereumjs/rlp'
 import { bytesToHex, bytesToUnprefixedHex, concatBytes, equalsBytes } from '@ethereumjs/util'
-import debugDefault from 'debug'
+import debug from 'debug'
 import { publicKeyConvert } from 'ethereum-cryptography/secp256k1-compat.js'
 import { secp256k1 } from 'ethereum-cryptography/secp256k1.js'
 
 import type { ETH } from './protocol/eth.js'
 import type { LES } from './protocol/les.js'
-const { debug: createDebugLogger } = debugDefault
 
-export const devp2pDebug = createDebugLogger('devp2p')
+export const devp2pDebug = debug('devp2p')
 
 export function genPrivateKey(): Uint8Array {
   const privateKey = secp256k1.utils.randomPrivateKey()

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -52,11 +52,10 @@ import type {
   bn128,
 } from './types.js'
 import type { EVMStateManagerInterface } from '@ethereumjs/common'
-const { debug: createDebugLogger } = debugDefault
 
-const debug = createDebugLogger('evm:evm')
-const debugGas = createDebugLogger('evm:gas')
-const debugPrecompiles = createDebugLogger('evm:precompiles')
+const debug = debugDefault('evm:evm')
+const debugGas = debugDefault('evm:gas')
+const debugPrecompiles = debugDefault('evm:precompiles')
 
 let initializedRustBN: bn128 | undefined = undefined
 

--- a/packages/evm/src/index.ts
+++ b/packages/evm/src/index.ts
@@ -21,6 +21,7 @@ import type {
   Log,
   bn128,
 } from './types.js'
+export * from './logger.js'
 
 export type {
   bn128,

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -25,9 +25,8 @@ import type { AsyncOpHandler, Opcode, OpcodeMapEntry } from './opcodes/index.js'
 import type { Block, Blockchain, EVMProfilerOpts, EVMResult, Log } from './types.js'
 import type { AccessWitnessInterface, Common, EVMStateManagerInterface } from '@ethereumjs/common'
 import type { Address, PrefixedHexString } from '@ethereumjs/util'
-const { debug: createDebugLogger } = debugDefault
 
-const debugGas = createDebugLogger('evm:gas')
+const debugGas = debugDefault('evm:gas')
 
 export interface InterpreterOpts {
   pc?: number
@@ -435,7 +434,7 @@ export class Interpreter {
       }
 
       if (!(name in this.opDebuggers)) {
-        this.opDebuggers[name] = createDebugLogger(`evm:ops:${name}`)
+        this.opDebuggers[name] = debugDefault(`evm:ops:${name}`)
       }
       this.opDebuggers[name](JSON.stringify(opTrace))
     }

--- a/packages/evm/src/journal.ts
+++ b/packages/evm/src/journal.ts
@@ -13,7 +13,6 @@ import { hexToBytes } from 'ethereum-cryptography/utils'
 import type { Common, EVMStateManagerInterface } from '@ethereumjs/common'
 import type { Account, PrefixedHexString } from '@ethereumjs/util'
 import type { Debugger } from 'debug'
-const { debug: createDebugLogger } = debugDefault
 
 type AddressString = string
 type SlotString = string
@@ -54,7 +53,7 @@ export class Journal {
     this.DEBUG =
       typeof window === 'undefined' ? process?.env?.DEBUG?.includes('ethjs') ?? false : false
 
-    this._debug = createDebugLogger('statemanager:statemanager')
+    this._debug = debugDefault('statemanager:statemanager')
 
     // TODO maybe call into this.clearJournal
     this.cleanJournal()

--- a/packages/evm/src/precompiles/bls12_381/noble.ts
+++ b/packages/evm/src/precompiles/bls12_381/noble.ts
@@ -21,7 +21,7 @@ import {
 } from './constants.js'
 
 import type { EVMBLSInterface } from '../../types.js'
-import type { AffinePoint, ProjPointType } from '@noble/curves/abstract/weierstrass.js'
+import type { AffinePoint, ProjPointType } from '@noble/curves/abstract/weierstrass'
 
 // Copied from @noble/curves/bls12-381 (only local declaration)
 type Fp2 = {

--- a/packages/evm/src/precompiles/bls12_381/util.ts
+++ b/packages/evm/src/precompiles/bls12_381/util.ts
@@ -2,7 +2,7 @@ import { equalsBytes, short } from '@ethereumjs/util'
 
 import { BLS_GAS_DISCOUNT_PAIRS } from './constants.js'
 
-import type { PrecompileInput } from '../types'
+import type { PrecompileInput } from '../types.js'
 
 const ZERO_BYTES_16 = new Uint8Array(16)
 

--- a/packages/statemanager/src/accessWitness.ts
+++ b/packages/statemanager/src/accessWitness.ts
@@ -22,8 +22,7 @@ import debugDefault from 'debug'
 import type { AccessEventFlags, AccessWitnessInterface } from '@ethereumjs/common'
 import type { Address, PrefixedHexString, VerkleCrypto } from '@ethereumjs/util'
 
-const { debug: createDebugLogger } = debugDefault
-const debug = createDebugLogger('statemanager:verkle:aw')
+const debug = debugDefault('statemanager:verkle:aw')
 
 /**
  * Tree key constants.

--- a/packages/statemanager/src/cache/account.ts
+++ b/packages/statemanager/src/cache/account.ts
@@ -8,7 +8,6 @@ import { CacheType } from './types.js'
 
 import type { CacheOpts } from './types.js'
 import type { Account, Address } from '@ethereumjs/util'
-const { debug: createDebugLogger } = debugDefault
 
 /**
  * account: undefined
@@ -45,7 +44,7 @@ export class AccountCache extends Cache {
     }
 
     this._diffCache.push(new Map<string, AccountCacheElement | undefined>())
-    this._debug = createDebugLogger('statemanager:cache:account')
+    this._debug = debugDefault('statemanager:cache:account')
   }
 
   _saveCachePreState(cacheKeyHex: string) {

--- a/packages/statemanager/src/cache/cache.ts
+++ b/packages/statemanager/src/cache/cache.ts
@@ -1,7 +1,6 @@
 import debugDefault from 'debug'
 
 import type { Debugger } from 'debug'
-const { debug: createDebugLogger } = debugDefault
 
 export class Cache {
   _debug: Debugger
@@ -32,6 +31,6 @@ export class Cache {
     this.DEBUG =
       typeof window === 'undefined' ? process?.env?.DEBUG?.includes('ethjs') ?? false : false
 
-    this._debug = createDebugLogger('statemanager:cache')
+    this._debug = debugDefault('statemanager:cache')
   }
 }

--- a/packages/statemanager/src/cache/code.ts
+++ b/packages/statemanager/src/cache/code.ts
@@ -9,8 +9,6 @@ import { CacheType } from './types.js'
 import type { CacheOpts } from './types.js'
 import type { Address } from '@ethereumjs/util'
 
-const { debug: createDebugLogger } = debugDefault
-
 /**
  * Represents a cached code element.
  */
@@ -45,7 +43,7 @@ export class CodeCache extends Cache {
     }
 
     this._diffCache.push(new Map<string, CodeCacheElement | undefined>())
-    this._debug = createDebugLogger('statemanager:cache:code')
+    this._debug = debugDefault('statemanager:cache:code')
   }
 
   /**

--- a/packages/statemanager/src/cache/storage.ts
+++ b/packages/statemanager/src/cache/storage.ts
@@ -8,7 +8,6 @@ import { CacheType } from './types.js'
 
 import type { CacheOpts } from './types.js'
 import type { Address } from '@ethereumjs/util'
-const { debug: createDebugLogger } = debugDefault
 
 /**
  * key -> storage mapping
@@ -47,7 +46,7 @@ export class StorageCache extends Cache {
     this._diffCache.push(new Map())
 
     if (this.DEBUG) {
-      this._debug = createDebugLogger('statemanager:cache:storage')
+      this._debug = debugDefault('statemanager:cache:storage')
     }
   }
 

--- a/packages/statemanager/src/rpcStateManager.ts
+++ b/packages/statemanager/src/rpcStateManager.ts
@@ -25,7 +25,6 @@ import type {
 } from '@ethereumjs/common'
 import type { Address, PrefixedHexString } from '@ethereumjs/util'
 import type { Debugger } from 'debug'
-const { debug: createDebugLogger } = debugDefault
 
 export interface RPCStateManagerOpts {
   provider: string
@@ -57,7 +56,7 @@ export class RPCStateManager implements EVMStateManagerInterface {
     this.DEBUG =
       typeof window === 'undefined' ? process?.env?.DEBUG?.includes('ethjs') ?? false : false
 
-    this._debug = createDebugLogger('statemanager:rpcStateManager')
+    this._debug = debugDefault('statemanager:rpcStateManager')
     if (typeof opts.provider === 'string' && opts.provider.startsWith('http')) {
       this._provider = opts.provider
     } else {

--- a/packages/statemanager/src/stateManager.ts
+++ b/packages/statemanager/src/stateManager.ts
@@ -36,7 +36,6 @@ import type {
 } from '@ethereumjs/common'
 import type { DB, PrefixedHexString } from '@ethereumjs/util'
 import type { Debugger } from 'debug'
-const { debug: createDebugLogger } = debugDefault
 
 export type StorageProof = {
   key: PrefixedHexString
@@ -199,7 +198,7 @@ export class DefaultStateManager implements EVMStateManagerInterface {
     this.DEBUG =
       typeof window === 'undefined' ? process?.env?.DEBUG?.includes('ethjs') ?? false : false
 
-    this._debug = createDebugLogger('statemanager:statemanager')
+    this._debug = debugDefault('statemanager:statemanager')
 
     this.common = opts.common ?? new Common({ chain: Chain.Mainnet })
 

--- a/packages/statemanager/src/stateManager.ts
+++ b/packages/statemanager/src/stateManager.ts
@@ -28,8 +28,12 @@ import { keccak256 } from 'ethereum-cryptography/keccak.js'
 import { AccountCache, CacheType, CodeCache, StorageCache } from './cache/index.js'
 import { OriginalStorageCache } from './cache/originalStorageCache.js'
 
-import type { AccountFields, EVMStateManagerInterface, StorageDump } from '@ethereumjs/common'
-import type { StorageRange } from '@ethereumjs/common/src'
+import type {
+  AccountFields,
+  EVMStateManagerInterface,
+  StorageDump,
+  StorageRange,
+} from '@ethereumjs/common'
 import type { DB, PrefixedHexString } from '@ethereumjs/util'
 import type { Debugger } from 'debug'
 const { debug: createDebugLogger } = debugDefault

--- a/packages/statemanager/src/statelessVerkleStateManager.ts
+++ b/packages/statemanager/src/statelessVerkleStateManager.ts
@@ -44,9 +44,7 @@ import type {
   VerkleProof,
 } from '@ethereumjs/util'
 
-const { debug: createDebugLogger } = debugDefault
-
-const debug = createDebugLogger('statemanager:verkle')
+const debug = debugDefault('statemanager:verkle')
 
 export interface VerkleState {
   [key: PrefixedHexString]: PrefixedHexString | null

--- a/packages/vm/src/requests.ts
+++ b/packages/vm/src/requests.ts
@@ -13,7 +13,7 @@ import {
   unpadBytes,
 } from '@ethereumjs/util'
 
-import type { RunTxResult } from './types.ts'
+import type { RunTxResult } from './types.js'
 import type { VM } from './vm.js'
 import type { CLRequest, CLRequestType } from '@ethereumjs/util'
 

--- a/packages/vm/src/requests.ts
+++ b/packages/vm/src/requests.ts
@@ -13,7 +13,7 @@ import {
   unpadBytes,
 } from '@ethereumjs/util'
 
-import type { RunTxResult } from './types'
+import type { RunTxResult } from './types.ts'
 import type { VM } from './vm.js'
 import type { CLRequest, CLRequestType } from '@ethereumjs/util'
 

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -44,9 +44,7 @@ import type { Common } from '@ethereumjs/common'
 import type { EVM, EVMInterface } from '@ethereumjs/evm'
 import type { CLRequest, CLRequestType, PrefixedHexString } from '@ethereumjs/util'
 
-const { debug: createDebugLogger } = debugDefault
-
-const debug = createDebugLogger('vm:block')
+const debug = debugDefault('vm:block')
 
 const parentBeaconBlockRootAddress = Address.fromString(
   '0x000F3df6D732807Ef1319fB7B8bB8522d0Beac02'

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -43,10 +43,9 @@ import type {
   LegacyTransaction,
   TypedTransaction,
 } from '@ethereumjs/tx'
-const { debug: createDebugLogger } = debugDefault
 
-const debug = createDebugLogger('vm:tx')
-const debugGas = createDebugLogger('vm:tx:gas')
+const debug = debugDefault('vm:tx')
+const debugGas = debugDefault('vm:tx:gas')
 
 let enableProfiler = false
 const initLabel = 'EVM journal init, address/slot warming, fee validation'

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -20,8 +20,7 @@ import type {
 } from './types.js'
 import type { BlockchainInterface } from '@ethereumjs/blockchain'
 import type { EVMStateManagerInterface } from '@ethereumjs/common'
-import type { EVMInterface } from '@ethereumjs/evm'
-import type { EVMPerformanceLogOutput } from '@ethereumjs/evm/dist/cjs/logger.js'
+import type { EVMInterface, EVMPerformanceLogOutput } from '@ethereumjs/evm'
 import type { BigIntLike } from '@ethereumjs/util'
 
 /**

--- a/packages/vm/test/tester/runners/GeneralStateTestsRunner.ts
+++ b/packages/vm/test/tester/runners/GeneralStateTestsRunner.ts
@@ -5,8 +5,8 @@ import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { Trie } from '@ethereumjs/trie'
 import { Account, Address, bytesToHex, equalsBytes, toBytes } from '@ethereumjs/util'
 
-import { VM } from '../../../src/vm'
-import { makeBlockFromEnv, makeTx, setupPreConditions } from '../../util'
+import { VM } from '../../../src/index.js'
+import { makeBlockFromEnv, makeTx, setupPreConditions } from '../../util.js'
 
 import type * as tape from 'tape'
 


### PR DESCRIPTION
This PR ports over the generic fixes for import file extensions and `debug` package imports from #3494 to the `maintenance-v8` branch.

Might be good if @acolytec3 could review, since I took over changes from his commits and reverted *some* of the changes (configuration), but wasn't fully sure on everything. So, Andrew, maybe you can also directly push if you spot something and otherwise merge.