### PR TITLE
Monorepo: Set sideEffects to false for all Packages

### DIFF
--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -17,6 +17,7 @@
   "license": "MPL-2.0",
   "author": "mjbecze (mb@ethdev.com)",
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -17,6 +17,7 @@
   "license": "MPL-2.0",
   "author": "mjbecze <mjbecze@gmail.com>",
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -27,6 +27,7 @@
     }
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -30,6 +30,7 @@
     "Holger Drewes <holger.drewes@gmail.com>"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -18,6 +18,7 @@
   "license": "MPL-2.0",
   "author": "mjbecze <mjbecze@gmail.com>",
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -22,6 +22,7 @@
     "Alex Beregszaszi <alex@rtfs.hu>"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/genesis/package.json
+++ b/packages/genesis/package.json
@@ -17,6 +17,7 @@
   "license": "MIT",
   "author": "g11tech <gajinder@g11.in>",
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/rlp/package.json
+++ b/packages/rlp/package.json
@@ -25,6 +25,7 @@
     "Paul Miller <pkg@paulmillr.com>"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -20,6 +20,7 @@
     "g11tech <gajinder@g11.in>"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -22,6 +22,7 @@
     "Aaron Kumavis <http://aaron.kumavis.me/> (https://github.com/kumavis)"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -28,6 +28,7 @@
     }
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -62,6 +62,7 @@
     }
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/verkle/package.json
+++ b/packages/verkle/package.json
@@ -25,6 +25,7 @@
     }
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -20,6 +20,7 @@
     "Alex Beregszaszi <alex@rtfs.hu>"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "author": "Alex Beregszaszi <alex@rtfs.hu>",
   "type": "module",
+  "sideEffects": false,
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "exports": {


### PR DESCRIPTION
I've now read a bit on side effects [here](https://sgom.es/posts/2020-06-15-everything-you-never-wanted-to-know-about-side-effects/) and have gotten some base feeling for potential situations.

My overall stance here is that it is...

## a) generally unlikely that we have side effects in our libraries.

Putting something in the global scope which then constitutes the state for some other library is generally a pattern we try to fully avoid. And if something is passed on via an object (`Common` being the most prominent one), this is then no problem again. The one thing which might came closest is this global KZG initialization we had before we discoverd ourself that this bad (also for other reasons) and where we switched to this `Common.customCrypto`-encapsuled way of passing things around. If I understand side effects correctly I would also think that the `debug` usage does not apply here. It's not that we re-use a `debug` object e.g. in `statemanager` which we before globally instantiated in `util` (or whatever).

## b) chances are high that we discover over time.

Other thing is: we will now have quite some time playing around with the libraries and the changes. No production releases in sight. We we also do alpha/dev releases where people can test things. So for the unlikely chance that we'll get a hidden side effect missed it is pretty likely that this will be discovered along the way.

I will nevertheless go one-by-one library here. Not necessarily by pushing, but at least along switching and give every library some quick thought if there might be mechanisms/code parts in which could be sensitive regarding introducing some side effect risk.

### RLP

Generally do not think so. Might the `bin` folder need some thought here?

### Util

Looked once over the modules we have there, do not think so.

### Common

Full no. All encapsulated in the `Common` main class.

### Tx

Again a no. Tx classes or TxFactory class.

### Trie

No. Trie class.

### Block

Noddeldy noodeldy no. Block/header class.

### Blockchain

No. Blockchain class.

### Verkle

No.

### StateManager

No.

### Wallet

No, Wallet class.

### Genesis

Would not think so.

### Devp2p

A bit more complex, but also would not think so.

### Ethash

No. Ethash object/class.

### EVM

Also here: all in EVM I would say.

### VM

No.

### Client

I will leave client out for now. Not in a library mode for now. We might want to switch on later on.

Ok, that's actually it. 🙂 

Will now push with all the above enabled.

Guess we can merge if CI passes!
