### PR TITLE
Fix Prague test runner

### DIFF
--- a/packages/common/src/hardforks.ts
+++ b/packages/common/src/hardforks.ts
@@ -841,7 +841,7 @@ export const hardforks: HardforksDict = {
       'Next feature hardfork after cancun, internally used for pectra testing/implementation (incomplete/experimental)',
     url: 'https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/prague.md',
     status: Status.Draft,
-    eips: [2537, 2935, 3074, 6110, 7002, 7251, 7685],
+    eips: [2537, 2935, 6110, 7002, 7251, 7685, 7702],
   },
   osaka: {
     name: 'osaka',

--- a/packages/vm/src/requests.ts
+++ b/packages/vm/src/requests.ts
@@ -78,7 +78,7 @@ const accumulateEIP7002Requests = async (
   const systemAddressBytes = bigIntToAddressBytes(vm.common.param('vm', 'systemAddress'))
   const systemAddress = Address.fromString(bytesToHex(systemAddressBytes))
 
-  const addrIsEmpty = (await vm.stateManager.getAccount(systemAddress)) === undefined
+  const originalAccount = await vm.stateManager.getAccount(systemAddress)
 
   const results = await vm.evm.runCall({
     caller: systemAddress,
@@ -98,8 +98,11 @@ const accumulateEIP7002Requests = async (
     }
   }
 
-  if (addrIsEmpty) {
+  if (originalAccount === undefined) {
     await vm.stateManager.deleteAccount(systemAddress)
+  } else {
+    // Restore the original account (the `runCall` updates the nonce)
+    await vm.stateManager.putAccount(systemAddress, originalAccount)
   }
 }
 
@@ -125,7 +128,7 @@ const accumulateEIP7251Requests = async (
   const systemAddressBytes = bigIntToAddressBytes(vm.common.param('vm', 'systemAddress'))
   const systemAddress = Address.fromString(bytesToHex(systemAddressBytes))
 
-  const addrIsEmpty = (await vm.stateManager.getAccount(systemAddress)) === undefined
+  const originalAccount = await vm.stateManager.getAccount(systemAddress)
 
   const results = await vm.evm.runCall({
     caller: systemAddress,
@@ -147,8 +150,11 @@ const accumulateEIP7251Requests = async (
     }
   }
 
-  if (addrIsEmpty) {
+  if (originalAccount === undefined) {
     await vm.stateManager.deleteAccount(systemAddress)
+  } else {
+    // Restore the original account (the `runCall` updates the nonce)
+    await vm.stateManager.putAccount(systemAddress, originalAccount)
   }
 }
 

--- a/packages/vm/test/util.ts
+++ b/packages/vm/test/util.ts
@@ -4,6 +4,7 @@ import { RLP } from '@ethereumjs/rlp'
 import {
   AccessListEIP2930Transaction,
   BlobEIP4844Transaction,
+  EOACodeEIP7702Transaction,
   FeeMarketEIP1559Transaction,
   LegacyTransaction,
 } from '@ethereumjs/tx'
@@ -18,12 +19,13 @@ import {
   isHexString,
   setLengthLeft,
   toBytes,
+  unpadBytes,
 } from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak'
 
 import type { BlockOptions } from '@ethereumjs/block'
 import type { EVMStateManagerInterface } from '@ethereumjs/common'
-import { EOACodeEIP7702Transaction, TxOptions } from '@ethereumjs/tx'
+import type { TxOptions } from '@ethereumjs/tx'
 import type * as tape from 'tape'
 
 export function dumpState(state: any, cb: Function) {
@@ -126,7 +128,7 @@ export function makeTx(
     // Convert `v` keys to `yParity`
     for (const signature of txData.authorizationList) {
       if (signature.v !== undefined) {
-        signature.yParity = signature.v
+        signature.yParity = bytesToHex(unpadBytes(hexToBytes(signature.v)))
       }
       if (signature.nonce !== undefined && signature.nonce[0] === '0x00') {
         signature.nonce[0] = '0x'


### PR DESCRIPTION
This PR solves some bugs in https://github.com/ethereum/execution-spec-tests/releases/tag/devnet-1%40v1.3.0

Note: some bugs were in the state runner itself, others were in the VM, mainly the one in `requests.ts`.

A question we might have to answer here is if our 7702 txs are too strict on loading values, for instance an `yParity` of `0x00` will not be accepted (leading zeros in the hex string) and neither will a `v` value (old alias for `yParity`).

This solves both the state and blockchain tests.

Note: also ensures the correct EIPs are on Prague's common