### PR TITLE
common: move description string from being an object field to a comment

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -414,7 +414,7 @@ export class Common {
       (this._paramsCache as any)[topic] !== undefined &&
       (this._paramsCache as any)[topic][name] !== undefined
     ) {
-      value = (this._paramsCache as any)[topic][name].v
+      value = (this._paramsCache as any)[topic][name]
     }
     return BigInt(value ?? 0)
   }
@@ -442,7 +442,7 @@ export class Common {
           (hfChanges[1] as any)[topic] !== undefined &&
           (hfChanges[1] as any)[topic][name] !== undefined
         ) {
-          value = (hfChanges[1] as any)[topic][name].v
+          value = (hfChanges[1] as any)[topic][name]
         }
       }
       if (hfChanges[0] === hardfork) break
@@ -469,7 +469,7 @@ export class Common {
     if (eipParams[topic][name] === undefined) {
       return undefined
     }
-    const value = eipParams[topic][name].v
+    const value = eipParams[topic][name]
     return BigInt(value)
   }
 

--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -22,12 +22,10 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     gasPrices: {
       tstore: {
-        v: 100,
-        d: 'Base fee of the TSTORE opcode',
+        v: 100, // Base fee of the TSTORE opcode
       },
       tload: {
-        v: 100,
-        d: 'Base fee of the TLOAD opcode',
+        v: 100, // Base fee of the TLOAD opcode
       },
     },
   },
@@ -39,16 +37,13 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [2930],
     gasConfig: {
       baseFeeMaxChangeDenominator: {
-        v: 8,
-        d: 'Maximum base fee change denominator',
+        v: 8, // Maximum base fee change denominator
       },
       elasticityMultiplier: {
-        v: 2,
-        d: 'Maximum block gas target elasticity',
+        v: 2, // Maximum block gas target elasticity
       },
       initialBaseFee: {
-        v: 1000000000,
-        d: 'Initial base fee on first EIP1559 block',
+        v: 1000000000, // Initial base fee on first EIP1559 block
       },
     },
   },
@@ -60,8 +55,7 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     gasPrices: {
       modexpGquaddivisor: {
-        v: 3,
-        d: 'Gquaddivisor from modexp precompile for gas calculation',
+        v: 3, // Gquaddivisor from modexp precompile for gas calculation
       },
     },
   },
@@ -74,36 +68,28 @@ export const EIPs: EIPsDict = {
     gasConfig: {},
     gasPrices: {
       Bls12381G1AddGas: {
-        v: 500,
-        d: 'Gas cost of a single BLS12-381 G1 addition precompile-call',
+        v: 500, // Gas cost of a single BLS12-381 G1 addition precompile-call
       },
       Bls12381G1MulGas: {
-        v: 12000,
-        d: 'Gas cost of a single BLS12-381 G1 multiplication precompile-call',
+        v: 12000, // Gas cost of a single BLS12-381 G1 multiplication precompile-call
       },
       Bls12381G2AddGas: {
-        v: 800,
-        d: 'Gas cost of a single BLS12-381 G2 addition precompile-call',
+        v: 800, // Gas cost of a single BLS12-381 G2 addition precompile-call
       },
       Bls12381G2MulGas: {
-        v: 45000,
-        d: 'Gas cost of a single BLS12-381 G2 multiplication precompile-call',
+        v: 45000, // Gas cost of a single BLS12-381 G2 multiplication precompile-call
       },
       Bls12381PairingBaseGas: {
-        v: 65000,
-        d: 'Base gas cost of BLS12-381 pairing check',
+        v: 65000, // Base gas cost of BLS12-381 pairing check
       },
       Bls12381PairingPerPairGas: {
-        v: 43000,
-        d: 'Per-pair gas cost of BLS12-381 pairing check',
+        v: 43000, // Per-pair gas cost of BLS12-381 pairing check
       },
       Bls12381MapG1Gas: {
-        v: 5500,
-        d: 'Gas cost of BLS12-381 map field element to G1',
+        v: 5500, // Gas cost of BLS12-381 map field element to G1
       },
       Bls12381MapG2Gas: {
-        v: 75000,
-        d: 'Gas cost of BLS12-381 map field element to G2',
+        v: 75000, // Gas cost of BLS12-381 map field element to G2
       },
     },
     vm: {},
@@ -124,76 +110,58 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     gasPrices: {
       coldsload: {
-        v: 2100,
-        d: 'Gas cost of the first read of storage from a given location (per transaction)',
+        v: 2100, // Gas cost of the first read of storage from a given location (per transaction)
       },
       coldaccountaccess: {
-        v: 2600,
-        d: 'Gas cost of the first read of a given address (per transaction)',
+        v: 2600, // Gas cost of the first read of a given address (per transaction)
       },
       warmstorageread: {
-        v: 100,
-        d: "Gas cost of reading storage locations which have already loaded 'cold'",
+        v: 100, // Gas cost of reading storage locations which have already loaded 'cold'
       },
       sstoreCleanGasEIP2200: {
-        v: 2900,
-        d: 'Once per SSTORE operation from clean non-zero to something else',
+        v: 2900, // Once per SSTORE operation from clean non-zero to something else
       },
       sstoreNoopGasEIP2200: {
-        v: 100,
-        d: "Once per SSTORE operation if the value doesn't change",
+        v: 100, // Once per SSTORE operation if the value doesn't change
       },
       sstoreDirtyGasEIP2200: {
-        v: 100,
-        d: 'Once per SSTORE operation if a dirty value is changed',
+        v: 100, // Once per SSTORE operation if a dirty value is changed
       },
       sstoreInitRefundEIP2200: {
-        v: 19900,
-        d: 'Once per SSTORE operation for resetting to the original zero value',
+        v: 19900, // Once per SSTORE operation for resetting to the original zero value
       },
       sstoreCleanRefundEIP2200: {
-        v: 4900,
-        d: 'Once per SSTORE operation for resetting to the original non-zero value',
+        v: 4900, // Once per SSTORE operation for resetting to the original non-zero value
       },
       call: {
-        v: 0,
-        d: 'Base fee of the CALL opcode',
+        v: 0, // Base fee of the CALL opcode
       },
       callcode: {
-        v: 0,
-        d: 'Base fee of the CALLCODE opcode',
+        v: 0, // Base fee of the CALLCODE opcode
       },
       delegatecall: {
-        v: 0,
-        d: 'Base fee of the DELEGATECALL opcode',
+        v: 0, // Base fee of the DELEGATECALL opcode
       },
       staticcall: {
-        v: 0,
-        d: 'Base fee of the STATICCALL opcode',
+        v: 0, // Base fee of the STATICCALL opcode
       },
       balance: {
-        v: 0,
-        d: 'Base fee of the BALANCE opcode',
+        v: 0, // Base fee of the BALANCE opcode
       },
       extcodesize: {
-        v: 0,
-        d: 'Base fee of the EXTCODESIZE opcode',
+        v: 0, // Base fee of the EXTCODESIZE opcode
       },
       extcodecopy: {
-        v: 0,
-        d: 'Base fee of the EXTCODECOPY opcode',
+        v: 0, // Base fee of the EXTCODECOPY opcode
       },
       extcodehash: {
-        v: 0,
-        d: 'Base fee of the EXTCODEHASH opcode',
+        v: 0, // Base fee of the EXTCODEHASH opcode
       },
       sload: {
-        v: 0,
-        d: 'Base fee of the SLOAD opcode',
+        v: 0, // Base fee of the SLOAD opcode
       },
       sstore: {
-        v: 0,
-        d: 'Base fee of the SSTORE opcode',
+        v: 0, // Base fee of the SSTORE opcode
       },
     },
   },
@@ -205,12 +173,10 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [2718, 2929],
     gasPrices: {
       accessListStorageKeyCost: {
-        v: 1900,
-        d: 'Gas cost per storage key in an Access List transaction',
+        v: 1900, // Gas cost per storage key in an Access List transaction
       },
       accessListAddressCost: {
-        v: 2400,
-        d: 'Gas cost per storage key in an Access List transaction',
+        v: 2400, // Gas cost per storage key in an Access List transaction
       },
     },
   },
@@ -222,12 +188,10 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     vm: {
       historyStorageAddress: {
-        v: BigInt('0x0aae40965e6800cd9b1f4b05ff21581047e3f91e'),
-        d: 'The address where the historical blockhashes are stored',
+        v: BigInt('0x0aae40965e6800cd9b1f4b05ff21581047e3f91e'), // The address where the historical blockhashes are stored
       },
       historyServeWindow: {
-        v: BigInt(8192),
-        d: 'The amount of blocks to be served by the historical blockhash contract',
+        v: BigInt(8192), // The amount of blocks to be served by the historical blockhash contract
       },
     },
   },
@@ -239,16 +203,13 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     gasPrices: {
       auth: {
-        v: 3100,
-        d: 'Gas cost of the AUTH opcode',
+        v: 3100, // Gas cost of the AUTH opcode
       },
       authcall: {
-        v: 0,
-        d: 'Gas cost of the AUTHCALL opcode',
+        v: 0, // Gas cost of the AUTHCALL opcode
       },
       authcallValueTransfer: {
-        v: 6700,
-        d: 'Paid for CALL when the value transfer is non-zero',
+        v: 6700, // Paid for CALL when the value transfer is non-zero
       },
     },
   },
@@ -260,8 +221,7 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     gasPrices: {
       basefee: {
-        v: 2,
-        d: 'Gas cost of the BASEFEE opcode',
+        v: 2, // Gas cost of the BASEFEE opcode
       },
     },
   },
@@ -273,18 +233,15 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [2929],
     gasConfig: {
       maxRefundQuotient: {
-        v: 5,
-        d: 'Maximum refund quotient; max tx refund is min(tx.gasUsed/maxRefundQuotient, tx.gasRefund)',
+        v: 5, // Maximum refund quotient; max tx refund is min(tx.gasUsed/maxRefundQuotient, tx.gasRefund)
       },
     },
     gasPrices: {
       selfdestructRefund: {
-        v: 0,
-        d: 'Refunded following a selfdestruct operation',
+        v: 0, // Refunded following a selfdestruct operation
       },
       sstoreClearRefundEIP2200: {
-        v: 4800,
-        d: 'Once per SSTORE operation for clearing an originally existing storage slot',
+        v: 4800, // Once per SSTORE operation for clearing an originally existing storage slot
       },
     },
   },
@@ -310,8 +267,7 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     pow: {
       difficultyBombDelay: {
-        v: 9500000,
-        d: 'the amount of blocks to delay the difficulty bomb with',
+        v: 9500000, // the amount of blocks to delay the difficulty bomb with
       },
     },
   },
@@ -355,8 +311,7 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     gasPrices: {
       push0: {
-        v: 2,
-        d: 'Base fee of the PUSH0 opcode',
+        v: 2, // Base fee of the PUSH0 opcode
       },
     },
   },
@@ -368,14 +323,12 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     gasPrices: {
       initCodeWordCost: {
-        v: 2,
-        d: 'Gas to pay for each word (32 bytes) of initcode when creating a contract',
+        v: 2, // Gas to pay for each word (32 bytes) of initcode when creating a contract
       },
     },
     vm: {
       maxInitCodeSize: {
-        v: 49152,
-        d: 'Maximum length of initialization code when creating a contract',
+        v: 49152, // Maximum length of initialization code when creating a contract
       },
     },
   },
@@ -387,8 +340,7 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     pow: {
       difficultyBombDelay: {
-        v: 10700000,
-        d: 'the amount of blocks to delay the difficulty bomb with',
+        v: 10700000, // the amount of blocks to delay the difficulty bomb with
       },
     },
   },
@@ -400,8 +352,7 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     gasPrices: {
       prevrandao: {
-        v: 2,
-        d: 'Base fee of the PREVRANDAO opcode (previously DIFFICULTY)',
+        v: 2, // Base fee of the PREVRANDAO opcode (previously DIFFICULTY)
       },
     },
   },
@@ -414,8 +365,7 @@ export const EIPs: EIPsDict = {
     gasPrices: {},
     vm: {
       historicalRootsLength: {
-        v: 8191,
-        d: 'The modulo parameter of the beaconroot ring buffer in the beaconroot statefull precompile',
+        v: 8191, // The modulo parameter of the beaconroot ring buffer in the beaconroot statefull precompile
       },
     },
   },
@@ -427,48 +377,38 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [1559, 2718, 2930, 4895],
     gasConfig: {
       blobGasPerBlob: {
-        v: 131072,
-        d: 'The base fee for blob gas per blob',
+        v: 131072, // The base fee for blob gas per blob
       },
       targetBlobGasPerBlock: {
-        v: 393216,
-        d: 'The target blob gas consumed per block',
+        v: 393216, // The target blob gas consumed per block
       },
       maxblobGasPerBlock: {
-        v: 786432,
-        d: 'The max blob gas allowable per block',
+        v: 786432, // The max blob gas allowable per block
       },
       blobGasPriceUpdateFraction: {
-        v: 3338477,
-        d: 'The denominator used in the exponential when calculating a blob gas price',
+        v: 3338477, // The denominator used in the exponential when calculating a blob gas price
       },
     },
     gasPrices: {
       simpleGasPerBlob: {
-        v: 12000,
-        d: 'The basic gas fee for each blob',
+        v: 12000, // The basic gas fee for each blob
       },
       minBlobGasPrice: {
-        v: 1,
-        d: 'The minimum fee per blob gas',
+        v: 1, // The minimum fee per blob gas
       },
       kzgPointEvaluationGasPrecompilePrice: {
-        v: 50000,
-        d: 'The fee associated with the point evaluation precompile',
+        v: 50000, // The fee associated with the point evaluation precompile
       },
       blobhash: {
-        v: 3,
-        d: 'Base fee of the BLOBHASH opcode',
+        v: 3, // Base fee of the BLOBHASH opcode
       },
     },
     sharding: {
       blobCommitmentVersionKzg: {
-        v: 1,
-        d: 'The number indicated a versioned hash is a KZG commitment',
+        v: 1, // The number indicated a versioned hash is a KZG commitment
       },
       fieldElementsPerBlob: {
-        v: 4096,
-        d: 'The number of field elements allowed per blob',
+        v: 4096, // The number of field elements allowed per blob
       },
     },
   },
@@ -487,8 +427,7 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     pow: {
       difficultyBombDelay: {
-        v: 11400000,
-        d: 'the amount of blocks to delay the difficulty bomb with',
+        v: 11400000, // the amount of blocks to delay the difficulty bomb with
       },
     },
   },
@@ -500,8 +439,7 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     gasPrices: {
       mcopy: {
-        v: 3,
-        d: 'Base fee of the MCOPY opcode',
+        v: 3, // Base fee of the MCOPY opcode
       },
     },
   },
@@ -527,20 +465,17 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     gasPrices: {
       create: {
-        v: 1000,
-        d: 'Base fee of the CREATE opcode',
+        v: 1000, // Base fee of the CREATE opcode
       },
       coldsload: {
-        v: 0,
-        d: 'Gas cost of the first read of storage from a given location (per transaction)',
+        v: 0, // Gas cost of the first read of storage from a given location (per transaction)
       },
     },
     vm: {
       // kaustinen 6 current uses this address, however this will be updated to correct address
       // in next iteration
       historyStorageAddress: {
-        v: BigInt('0xfffffffffffffffffffffffffffffffffffffffe'),
-        d: 'The address where the historical blockhashes are stored',
+        v: BigInt('0xfffffffffffffffffffffffffffffffffffffffe'), // The address where the historical blockhashes are stored
       },
     },
   },
@@ -552,52 +487,40 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [7685],
     vm: {
       withdrawalRequestType: {
-        v: BigInt(0x01),
-        d: 'The withdrawal request type for EIP-7685',
+        v: BigInt(0x01), // The withdrawal request type for EIP-7685
       },
       excessWithdrawalsRequestStorageSlot: {
-        v: BigInt(0),
-        d: 'The storage slot of the excess withdrawals',
+        v: BigInt(0), // The storage slot of the excess withdrawals
       },
       withdrawalsRequestCountStorage: {
-        v: BigInt(1),
-        d: 'The storage slot of the withdrawal request count',
+        v: BigInt(1), // The storage slot of the withdrawal request count
       },
       withdrawalsRequestQueueHeadStorageSlot: {
-        v: BigInt(2),
-        d: 'The storage slot of the withdrawal request head of the queue',
+        v: BigInt(2), // The storage slot of the withdrawal request head of the queue
       },
       withdrawalsRequestTailHeadStorageSlot: {
-        v: BigInt(3),
-        d: 'The storage slot of the withdrawal request tail of the queue',
+        v: BigInt(3), // The storage slot of the withdrawal request tail of the queue
       },
       withdrawalsRequestQueueStorageOffset: {
-        v: BigInt(4),
-        d: 'The storage slot of the withdrawal request queue offset',
+        v: BigInt(4), // The storage slot of the withdrawal request queue offset
       },
       maxWithdrawalRequestsPerBlock: {
-        v: BigInt(16),
-        d: 'The max withdrawal requests per block',
+        v: BigInt(16), // The max withdrawal requests per block
       },
       targetWithdrawalRequestsPerBlock: {
-        v: BigInt(2),
-        d: 'The target withdrawal requests per block',
+        v: BigInt(2), // The target withdrawal requests per block
       },
       minWithdrawalRequestFee: {
-        v: BigInt(1),
-        d: 'The minimum withdrawal request fee (in wei)',
+        v: BigInt(1), // The minimum withdrawal request fee (in wei)
       },
       withdrawalRequestFeeUpdateFraction: {
-        v: BigInt(17),
-        d: 'The withdrawal request fee update fraction (used in the fake exponential)',
+        v: BigInt(17), // The withdrawal request fee update fraction (used in the fake exponential)
       },
       systemAddress: {
-        v: BigInt('0xfffffffffffffffffffffffffffffffffffffffe'),
-        d: 'The system address to perform operations on the withdrawal requests predeploy address',
+        v: BigInt('0xfffffffffffffffffffffffffffffffffffffffe'), // The system address to perform operations on the withdrawal requests predeploy address
       },
       withdrawalRequestPredeployAddress: {
-        v: BigInt('0x00A3ca265EBcb825B45F985A16CEFB49958cE017'),
-        d: 'Address of the validator excess address',
+        v: BigInt('0x00A3ca265EBcb825B45F985A16CEFB49958cE017'), // Address of the validator excess address
       },
     },
   },
@@ -609,16 +532,13 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [7685],
     vm: {
       consolidationRequestType: {
-        v: BigInt(0x02),
-        d: 'The withdrawal request type for EIP-7685',
+        v: BigInt(0x02), // The withdrawal request type for EIP-7685
       },
       systemAddress: {
-        v: BigInt('0xfffffffffffffffffffffffffffffffffffffffe'),
-        d: 'The system address to perform operations on the consolidation requests predeploy address',
+        v: BigInt('0xfffffffffffffffffffffffffffffffffffffffe'), // The system address to perform operations on the consolidation requests predeploy address
       },
       consolidationRequestPredeployAddress: {
-        v: BigInt('0x00b42dbF2194e931E80326D950320f7d9Dbeac02'),
-        d: 'Address of the consolidations contract',
+        v: BigInt('0x00b42dbF2194e931E80326D950320f7d9Dbeac02'), // Address of the consolidations contract
       },
     },
   },
@@ -630,8 +550,7 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [4844],
     gasPrices: {
       blobbasefee: {
-        v: 2,
-        d: 'Gas cost of the BLOBBASEFEE opcode',
+        v: 2, // Gas cost of the BLOBBASEFEE opcode
       },
     },
   },
@@ -653,8 +572,7 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [2718, 2929, 2930],
     gasPrices: {
       perAuthBaseCost: {
-        v: 2500,
-        d: 'Gas cost of each authority item',
+        v: 2500, // Gas cost of each authority item
       },
     },
   },

--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -21,12 +21,8 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.Chainstart,
     requiredEIPs: [],
     gasPrices: {
-      tstore: {
-        v: 100, // Base fee of the TSTORE opcode
-      },
-      tload: {
-        v: 100, // Base fee of the TLOAD opcode
-      },
+      tstore: 100, // Base fee of the TSTORE opcode
+      tload: 100, // Base fee of the TLOAD opcode
     },
   },
   1559: {
@@ -36,15 +32,9 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.Berlin,
     requiredEIPs: [2930],
     gasConfig: {
-      baseFeeMaxChangeDenominator: {
-        v: 8, // Maximum base fee change denominator
-      },
-      elasticityMultiplier: {
-        v: 2, // Maximum block gas target elasticity
-      },
-      initialBaseFee: {
-        v: 1000000000, // Initial base fee on first EIP1559 block
-      },
+      baseFeeMaxChangeDenominator: 8, // Maximum base fee change denominator
+      elasticityMultiplier: 2, // Maximum block gas target elasticity
+      initialBaseFee: 1000000000, // Initial base fee on first EIP1559 block
     },
   },
   2565: {
@@ -54,9 +44,7 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.Byzantium,
     requiredEIPs: [],
     gasPrices: {
-      modexpGquaddivisor: {
-        v: 3, // Gquaddivisor from modexp precompile for gas calculation
-      },
+      modexpGquaddivisor: 3, // Gquaddivisor from modexp precompile for gas calculation
     },
   },
   2537: {
@@ -67,30 +55,14 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     gasConfig: {},
     gasPrices: {
-      Bls12381G1AddGas: {
-        v: 500, // Gas cost of a single BLS12-381 G1 addition precompile-call
-      },
-      Bls12381G1MulGas: {
-        v: 12000, // Gas cost of a single BLS12-381 G1 multiplication precompile-call
-      },
-      Bls12381G2AddGas: {
-        v: 800, // Gas cost of a single BLS12-381 G2 addition precompile-call
-      },
-      Bls12381G2MulGas: {
-        v: 45000, // Gas cost of a single BLS12-381 G2 multiplication precompile-call
-      },
-      Bls12381PairingBaseGas: {
-        v: 65000, // Base gas cost of BLS12-381 pairing check
-      },
-      Bls12381PairingPerPairGas: {
-        v: 43000, // Per-pair gas cost of BLS12-381 pairing check
-      },
-      Bls12381MapG1Gas: {
-        v: 5500, // Gas cost of BLS12-381 map field element to G1
-      },
-      Bls12381MapG2Gas: {
-        v: 75000, // Gas cost of BLS12-381 map field element to G2
-      },
+      Bls12381G1AddGas: 500, // Gas cost of a single BLS12-381 G1 addition precompile-call
+      Bls12381G1MulGas: 12000, // Gas cost of a single BLS12-381 G1 multiplication precompile-call
+      Bls12381G2AddGas: 800, // Gas cost of a single BLS12-381 G2 addition precompile-call
+      Bls12381G2MulGas: 45000, // Gas cost of a single BLS12-381 G2 multiplication precompile-call
+      Bls12381PairingBaseGas: 65000, // Base gas cost of BLS12-381 pairing check
+      Bls12381PairingPerPairGas: 43000, // Per-pair gas cost of BLS12-381 pairing check
+      Bls12381MapG1Gas: 5500, // Gas cost of BLS12-381 map field element to G1
+      Bls12381MapG2Gas: 75000, // Gas cost of BLS12-381 map field element to G2
     },
     vm: {},
     pow: {},
@@ -109,60 +81,24 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.Chainstart,
     requiredEIPs: [],
     gasPrices: {
-      coldsload: {
-        v: 2100, // Gas cost of the first read of storage from a given location (per transaction)
-      },
-      coldaccountaccess: {
-        v: 2600, // Gas cost of the first read of a given address (per transaction)
-      },
-      warmstorageread: {
-        v: 100, // Gas cost of reading storage locations which have already loaded 'cold'
-      },
-      sstoreCleanGasEIP2200: {
-        v: 2900, // Once per SSTORE operation from clean non-zero to something else
-      },
-      sstoreNoopGasEIP2200: {
-        v: 100, // Once per SSTORE operation if the value doesn't change
-      },
-      sstoreDirtyGasEIP2200: {
-        v: 100, // Once per SSTORE operation if a dirty value is changed
-      },
-      sstoreInitRefundEIP2200: {
-        v: 19900, // Once per SSTORE operation for resetting to the original zero value
-      },
-      sstoreCleanRefundEIP2200: {
-        v: 4900, // Once per SSTORE operation for resetting to the original non-zero value
-      },
-      call: {
-        v: 0, // Base fee of the CALL opcode
-      },
-      callcode: {
-        v: 0, // Base fee of the CALLCODE opcode
-      },
-      delegatecall: {
-        v: 0, // Base fee of the DELEGATECALL opcode
-      },
-      staticcall: {
-        v: 0, // Base fee of the STATICCALL opcode
-      },
-      balance: {
-        v: 0, // Base fee of the BALANCE opcode
-      },
-      extcodesize: {
-        v: 0, // Base fee of the EXTCODESIZE opcode
-      },
-      extcodecopy: {
-        v: 0, // Base fee of the EXTCODECOPY opcode
-      },
-      extcodehash: {
-        v: 0, // Base fee of the EXTCODEHASH opcode
-      },
-      sload: {
-        v: 0, // Base fee of the SLOAD opcode
-      },
-      sstore: {
-        v: 0, // Base fee of the SSTORE opcode
-      },
+      coldsload: 2100, // Gas cost of the first read of storage from a given location (per transaction)
+      coldaccountaccess: 2600, // Gas cost of the first read of a given address (per transaction)
+      warmstorageread: 100, // Gas cost of reading storage locations which have already loaded 'cold'
+      sstoreCleanGasEIP2200: 2900, // Once per SSTORE operation from clean non-zero to something else
+      sstoreNoopGasEIP2200: 100, // Once per SSTORE operation if the value doesn't change
+      sstoreDirtyGasEIP2200: 100, // Once per SSTORE operation if a dirty value is changed
+      sstoreInitRefundEIP2200: 19900, // Once per SSTORE operation for resetting to the original zero value
+      sstoreCleanRefundEIP2200: 4900, // Once per SSTORE operation for resetting to the original non-zero value
+      call: 0, // Base fee of the CALL opcode
+      callcode: 0, // Base fee of the CALLCODE opcode
+      delegatecall: 0, // Base fee of the DELEGATECALL opcode
+      staticcall: 0, // Base fee of the STATICCALL opcode
+      balance: 0, // Base fee of the BALANCE opcode
+      extcodesize: 0, // Base fee of the EXTCODESIZE opcode
+      extcodecopy: 0, // Base fee of the EXTCODECOPY opcode
+      extcodehash: 0, // Base fee of the EXTCODEHASH opcode
+      sload: 0, // Base fee of the SLOAD opcode
+      sstore: 0, // Base fee of the SSTORE opcode
     },
   },
   2930: {
@@ -172,12 +108,8 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.Istanbul,
     requiredEIPs: [2718, 2929],
     gasPrices: {
-      accessListStorageKeyCost: {
-        v: 1900, // Gas cost per storage key in an Access List transaction
-      },
-      accessListAddressCost: {
-        v: 2400, // Gas cost per storage key in an Access List transaction
-      },
+      accessListStorageKeyCost: 1900, // Gas cost per storage key in an Access List transaction
+      accessListAddressCost: 2400, // Gas cost per storage key in an Access List transaction
     },
   },
   2935: {
@@ -187,12 +119,8 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.Chainstart,
     requiredEIPs: [],
     vm: {
-      historyStorageAddress: {
-        v: BigInt('0x0aae40965e6800cd9b1f4b05ff21581047e3f91e'), // The address where the historical blockhashes are stored
-      },
-      historyServeWindow: {
-        v: BigInt(8192), // The amount of blocks to be served by the historical blockhash contract
-      },
+      historyStorageAddress: BigInt('0x0aae40965e6800cd9b1f4b05ff21581047e3f91e'), // The address where the historical blockhashes are stored
+      historyServeWindow: BigInt(8192), // The amount of blocks to be served by the historical blockhash contract
     },
   },
   3074: {
@@ -202,15 +130,9 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.London,
     requiredEIPs: [],
     gasPrices: {
-      auth: {
-        v: 3100, // Gas cost of the AUTH opcode
-      },
-      authcall: {
-        v: 0, // Gas cost of the AUTHCALL opcode
-      },
-      authcallValueTransfer: {
-        v: 6700, // Paid for CALL when the value transfer is non-zero
-      },
+      auth: 3100, // Gas cost of the AUTH opcode
+      authcall: 0, // Gas cost of the AUTHCALL opcode
+      authcallValueTransfer: 6700, // Paid for CALL when the value transfer is non-zero
     },
   },
   3198: {
@@ -220,9 +142,7 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.London,
     requiredEIPs: [],
     gasPrices: {
-      basefee: {
-        v: 2, // Gas cost of the BASEFEE opcode
-      },
+      basefee: 2, // Gas cost of the BASEFEE opcode
     },
   },
   3529: {
@@ -232,17 +152,11 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.Berlin,
     requiredEIPs: [2929],
     gasConfig: {
-      maxRefundQuotient: {
-        v: 5, // Maximum refund quotient; max tx refund is min(tx.gasUsed/maxRefundQuotient, tx.gasRefund)
-      },
+      maxRefundQuotient: 5, // Maximum refund quotient; max tx refund is min(tx.gasUsed/maxRefundQuotient, tx.gasRefund)
     },
     gasPrices: {
-      selfdestructRefund: {
-        v: 0, // Refunded following a selfdestruct operation
-      },
-      sstoreClearRefundEIP2200: {
-        v: 4800, // Once per SSTORE operation for clearing an originally existing storage slot
-      },
+      selfdestructRefund: 0, // Refunded following a selfdestruct operation
+      sstoreClearRefundEIP2200: 4800, // Once per SSTORE operation for clearing an originally existing storage slot
     },
   },
   3540: {
@@ -266,9 +180,7 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.MuirGlacier,
     requiredEIPs: [],
     pow: {
-      difficultyBombDelay: {
-        v: 9500000, // the amount of blocks to delay the difficulty bomb with
-      },
+      difficultyBombDelay: 9500000, // the amount of blocks to delay the difficulty bomb with
     },
   },
   3607: {
@@ -310,9 +222,7 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.Chainstart,
     requiredEIPs: [],
     gasPrices: {
-      push0: {
-        v: 2, // Base fee of the PUSH0 opcode
-      },
+      push0: 2, // Base fee of the PUSH0 opcode
     },
   },
   3860: {
@@ -322,14 +232,10 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.SpuriousDragon,
     requiredEIPs: [],
     gasPrices: {
-      initCodeWordCost: {
-        v: 2, // Gas to pay for each word (32 bytes) of initcode when creating a contract
-      },
+      initCodeWordCost: 2, // Gas to pay for each word (32 bytes) of initcode when creating a contract
     },
     vm: {
-      maxInitCodeSize: {
-        v: 49152, // Maximum length of initialization code when creating a contract
-      },
+      maxInitCodeSize: 49152, // Maximum length of initialization code when creating a contract
     },
   },
   4345: {
@@ -339,9 +245,7 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.London,
     requiredEIPs: [],
     pow: {
-      difficultyBombDelay: {
-        v: 10700000, // the amount of blocks to delay the difficulty bomb with
-      },
+      difficultyBombDelay: 10700000, // the amount of blocks to delay the difficulty bomb with
     },
   },
   4399: {
@@ -351,9 +255,7 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.London,
     requiredEIPs: [],
     gasPrices: {
-      prevrandao: {
-        v: 2, // Base fee of the PREVRANDAO opcode (previously DIFFICULTY)
-      },
+      prevrandao: 2, // Base fee of the PREVRANDAO opcode (previously DIFFICULTY)
     },
   },
   4788: {
@@ -364,9 +266,7 @@ export const EIPs: EIPsDict = {
     requiredEIPs: [],
     gasPrices: {},
     vm: {
-      historicalRootsLength: {
-        v: 8191, // The modulo parameter of the beaconroot ring buffer in the beaconroot statefull precompile
-      },
+      historicalRootsLength: 8191, // The modulo parameter of the beaconroot ring buffer in the beaconroot statefull precompile
     },
   },
   4844: {
@@ -376,40 +276,20 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.Paris,
     requiredEIPs: [1559, 2718, 2930, 4895],
     gasConfig: {
-      blobGasPerBlob: {
-        v: 131072, // The base fee for blob gas per blob
-      },
-      targetBlobGasPerBlock: {
-        v: 393216, // The target blob gas consumed per block
-      },
-      maxblobGasPerBlock: {
-        v: 786432, // The max blob gas allowable per block
-      },
-      blobGasPriceUpdateFraction: {
-        v: 3338477, // The denominator used in the exponential when calculating a blob gas price
-      },
+      blobGasPerBlob: 131072, // The base fee for blob gas per blob
+      targetBlobGasPerBlock: 393216, // The target blob gas consumed per block
+      maxblobGasPerBlock: 786432, // The max blob gas allowable per block
+      blobGasPriceUpdateFraction: 3338477, // The denominator used in the exponential when calculating a blob gas price
     },
     gasPrices: {
-      simpleGasPerBlob: {
-        v: 12000, // The basic gas fee for each blob
-      },
-      minBlobGasPrice: {
-        v: 1, // The minimum fee per blob gas
-      },
-      kzgPointEvaluationGasPrecompilePrice: {
-        v: 50000, // The fee associated with the point evaluation precompile
-      },
-      blobhash: {
-        v: 3, // Base fee of the BLOBHASH opcode
-      },
+      simpleGasPerBlob: 12000, // The basic gas fee for each blob
+      minBlobGasPrice: 1, // The minimum fee per blob gas
+      kzgPointEvaluationGasPrecompilePrice: 50000, // The fee associated with the point evaluation precompile
+      blobhash: 3, // Base fee of the BLOBHASH opcode
     },
     sharding: {
-      blobCommitmentVersionKzg: {
-        v: 1, // The number indicated a versioned hash is a KZG commitment
-      },
-      fieldElementsPerBlob: {
-        v: 4096, // The number of field elements allowed per blob
-      },
+      blobCommitmentVersionKzg: 1, // The number indicated a versioned hash is a KZG commitment
+      fieldElementsPerBlob: 4096, // The number of field elements allowed per blob
     },
   },
   4895: {
@@ -426,9 +306,7 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.GrayGlacier,
     requiredEIPs: [],
     pow: {
-      difficultyBombDelay: {
-        v: 11400000, // the amount of blocks to delay the difficulty bomb with
-      },
+      difficultyBombDelay: 11400000, // the amount of blocks to delay the difficulty bomb with
     },
   },
   5656: {
@@ -438,9 +316,7 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.Shanghai,
     requiredEIPs: [],
     gasPrices: {
-      mcopy: {
-        v: 3, // Base fee of the MCOPY opcode
-      },
+      mcopy: 3, // Base fee of the MCOPY opcode
     },
   },
   6110: {
@@ -464,19 +340,13 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.London,
     requiredEIPs: [],
     gasPrices: {
-      create: {
-        v: 1000, // Base fee of the CREATE opcode
-      },
-      coldsload: {
-        v: 0, // Gas cost of the first read of storage from a given location (per transaction)
-      },
+      create: 1000, // Base fee of the CREATE opcode
+      coldsload: 0, // Gas cost of the first read of storage from a given location (per transaction)
     },
     vm: {
       // kaustinen 6 current uses this address, however this will be updated to correct address
       // in next iteration
-      historyStorageAddress: {
-        v: BigInt('0xfffffffffffffffffffffffffffffffffffffffe'), // The address where the historical blockhashes are stored
-      },
+      historyStorageAddress: BigInt('0xfffffffffffffffffffffffffffffffffffffffe'), // The address where the historical blockhashes are stored
     },
   },
   7002: {
@@ -486,42 +356,18 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.Paris,
     requiredEIPs: [7685],
     vm: {
-      withdrawalRequestType: {
-        v: BigInt(0x01), // The withdrawal request type for EIP-7685
-      },
-      excessWithdrawalsRequestStorageSlot: {
-        v: BigInt(0), // The storage slot of the excess withdrawals
-      },
-      withdrawalsRequestCountStorage: {
-        v: BigInt(1), // The storage slot of the withdrawal request count
-      },
-      withdrawalsRequestQueueHeadStorageSlot: {
-        v: BigInt(2), // The storage slot of the withdrawal request head of the queue
-      },
-      withdrawalsRequestTailHeadStorageSlot: {
-        v: BigInt(3), // The storage slot of the withdrawal request tail of the queue
-      },
-      withdrawalsRequestQueueStorageOffset: {
-        v: BigInt(4), // The storage slot of the withdrawal request queue offset
-      },
-      maxWithdrawalRequestsPerBlock: {
-        v: BigInt(16), // The max withdrawal requests per block
-      },
-      targetWithdrawalRequestsPerBlock: {
-        v: BigInt(2), // The target withdrawal requests per block
-      },
-      minWithdrawalRequestFee: {
-        v: BigInt(1), // The minimum withdrawal request fee (in wei)
-      },
-      withdrawalRequestFeeUpdateFraction: {
-        v: BigInt(17), // The withdrawal request fee update fraction (used in the fake exponential)
-      },
-      systemAddress: {
-        v: BigInt('0xfffffffffffffffffffffffffffffffffffffffe'), // The system address to perform operations on the withdrawal requests predeploy address
-      },
-      withdrawalRequestPredeployAddress: {
-        v: BigInt('0x00A3ca265EBcb825B45F985A16CEFB49958cE017'), // Address of the validator excess address
-      },
+      withdrawalRequestType: BigInt(0x01), // The withdrawal request type for EIP-7685
+      excessWithdrawalsRequestStorageSlot: BigInt(0), // The storage slot of the excess withdrawals
+      withdrawalsRequestCountStorage: BigInt(1), // The storage slot of the withdrawal request count
+      withdrawalsRequestQueueHeadStorageSlot: BigInt(2), // The storage slot of the withdrawal request head of the queue
+      withdrawalsRequestTailHeadStorageSlot: BigInt(3), // The storage slot of the withdrawal request tail of the queue
+      withdrawalsRequestQueueStorageOffset: BigInt(4), // The storage slot of the withdrawal request queue offset
+      maxWithdrawalRequestsPerBlock: BigInt(16), // The max withdrawal requests per block
+      targetWithdrawalRequestsPerBlock: BigInt(2), // The target withdrawal requests per block
+      minWithdrawalRequestFee: BigInt(1), // The minimum withdrawal request fee (in wei)
+      withdrawalRequestFeeUpdateFraction: BigInt(17), // The withdrawal request fee update fraction (used in the fake exponential)
+      systemAddress: BigInt('0xfffffffffffffffffffffffffffffffffffffffe'), // The system address to perform operations on the withdrawal requests predeploy address
+      withdrawalRequestPredeployAddress: BigInt('0x00A3ca265EBcb825B45F985A16CEFB49958cE017'), // Address of the validator excess address
     },
   },
   7251: {
@@ -531,15 +377,9 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.Paris,
     requiredEIPs: [7685],
     vm: {
-      consolidationRequestType: {
-        v: BigInt(0x02), // The withdrawal request type for EIP-7685
-      },
-      systemAddress: {
-        v: BigInt('0xfffffffffffffffffffffffffffffffffffffffe'), // The system address to perform operations on the consolidation requests predeploy address
-      },
-      consolidationRequestPredeployAddress: {
-        v: BigInt('0x00b42dbF2194e931E80326D950320f7d9Dbeac02'), // Address of the consolidations contract
-      },
+      consolidationRequestType: BigInt(0x02), // The withdrawal request type for EIP-7685
+      systemAddress: BigInt('0xfffffffffffffffffffffffffffffffffffffffe'), // The system address to perform operations on the consolidation requests predeploy address
+      consolidationRequestPredeployAddress: BigInt('0x00b42dbF2194e931E80326D950320f7d9Dbeac02'), // Address of the consolidations contract
     },
   },
   7516: {
@@ -549,9 +389,7 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.Paris,
     requiredEIPs: [4844],
     gasPrices: {
-      blobbasefee: {
-        v: 2, // Gas cost of the BLOBBASEFEE opcode
-      },
+      blobbasefee: 2, // Gas cost of the BLOBBASEFEE opcode
     },
   },
   7685: {
@@ -571,9 +409,7 @@ export const EIPs: EIPsDict = {
     minimumHardfork: Hardfork.Cancun,
     requiredEIPs: [2718, 2929, 2930],
     gasPrices: {
-      perAuthBaseCost: {
-        v: 2500, // Gas cost of each authority item
-      },
+      perAuthBaseCost: 2500, // Gas cost of each authority item
     },
   },
   7709: {

--- a/packages/common/src/hardforks.ts
+++ b/packages/common/src/hardforks.ts
@@ -14,430 +14,325 @@ export const hardforks: HardforksDict = {
     status: Status.Final,
     gasConfig: {
       minGasLimit: {
-        v: 5000,
-        d: 'Minimum the gas limit may ever be',
+        v: 5000, // Minimum the gas limit may ever be
       },
       gasLimitBoundDivisor: {
-        v: 1024,
-        d: 'The bound divisor of the gas limit, used in update calculations',
+        v: 1024, // The bound divisor of the gas limit, used in update calculations
       },
       maxRefundQuotient: {
-        v: 2,
-        d: 'Maximum refund quotient; max tx refund is min(tx.gasUsed/maxRefundQuotient, tx.gasRefund)',
+        v: 2, // Maximum refund quotient; max tx refund is min(tx.gasUsed/maxRefundQuotient, tx.gasRefund)
       },
     },
     gasPrices: {
       base: {
-        v: 2,
-        d: 'Gas base cost, used e.g. for ChainID opcode (Istanbul)',
+        v: 2, // Gas base cost, used e.g. for ChainID opcode (Istanbul)
       },
       exp: {
-        v: 10,
-        d: 'Base fee of the EXP opcode',
+        v: 10, // Base fee of the EXP opcode
       },
       expByte: {
-        v: 10,
-        d: 'Times ceil(log256(exponent)) for the EXP instruction',
+        v: 10, // Times ceil(log256(exponent)) for the EXP instruction
       },
       keccak256: {
-        v: 30,
-        d: 'Base fee of the SHA3 opcode',
+        v: 30, // Base fee of the SHA3 opcode
       },
       keccak256Word: {
-        v: 6,
-        d: "Once per word of the SHA3 operation's data",
+        v: 6, // Once per word of the SHA3 operation's data
       },
       sload: {
-        v: 50,
-        d: 'Base fee of the SLOAD opcode',
+        v: 50, // Base fee of the SLOAD opcode
       },
       sstoreSet: {
-        v: 20000,
-        d: 'Once per SSTORE operation if the zeroness changes from zero',
+        v: 20000, // Once per SSTORE operation if the zeroness changes from zero
       },
       sstoreReset: {
-        v: 5000,
-        d: 'Once per SSTORE operation if the zeroness does not change from zero',
+        v: 5000, // Once per SSTORE operation if the zeroness does not change from zero
       },
       sstoreRefund: {
-        v: 15000,
-        d: 'Once per SSTORE operation if the zeroness changes to zero',
+        v: 15000, // Once per SSTORE operation if the zeroness changes to zero
       },
       jumpdest: {
-        v: 1,
-        d: 'Base fee of the JUMPDEST opcode',
+        v: 1, // Base fee of the JUMPDEST opcode
       },
       log: {
-        v: 375,
-        d: 'Base fee of the LOG opcode',
+        v: 375, // Base fee of the LOG opcode
       },
       logData: {
-        v: 8,
-        d: "Per byte in a LOG* operation's data",
+        v: 8, // Per byte in a LOG* operation's data
       },
       logTopic: {
-        v: 375,
-        d: 'Multiplied by the * of the LOG*, per LOG transaction. e.g. LOG0 incurs 0 * c_txLogTopicGas, LOG4 incurs 4 * c_txLogTopicGas',
+        v: 375, // Multiplied by the * of the LOG*, per LOG transaction. e.g. LOG0 incurs 0 * c_txLogTopicGas, LOG4 incurs 4 * c_txLogTopicGas
       },
       create: {
-        v: 32000,
-        d: 'Base fee of the CREATE opcode',
+        v: 32000, // Base fee of the CREATE opcode
       },
       call: {
-        v: 40,
-        d: 'Base fee of the CALL opcode',
+        v: 40, // Base fee of the CALL opcode
       },
       callStipend: {
-        v: 2300,
-        d: 'Free gas given at beginning of call',
+        v: 2300, // Free gas given at beginning of call
       },
       callValueTransfer: {
-        v: 9000,
-        d: 'Paid for CALL when the value transfor is non-zero',
+        v: 9000, // Paid for CALL when the value transfor is non-zero
       },
       callNewAccount: {
-        v: 25000,
-        d: "Paid for CALL when the destination address didn't exist prior",
+        v: 25000, // Paid for CALL when the destination address didn't exist prior
       },
       selfdestructRefund: {
-        v: 24000,
-        d: 'Refunded following a selfdestruct operation',
+        v: 24000, // Refunded following a selfdestruct operation
       },
       memory: {
-        v: 3,
-        d: 'Times the address of the (highest referenced byte in memory + 1). NOTE: referencing happens on read, write and in instructions such as RETURN and CALL',
+        v: 3, // Times the address of the (highest referenced byte in memory + 1). NOTE: referencing happens on read, write and in instructions such as RETURN and CALL
       },
       quadCoeffDiv: {
-        v: 512,
-        d: 'Divisor for the quadratic particle of the memory cost equation',
+        v: 512, // Divisor for the quadratic particle of the memory cost equation
       },
       createData: {
-        v: 200,
-        d: '',
+        v: 200, //
       },
       tx: {
-        v: 21000,
-        d: 'Per transaction. NOTE: Not payable on data of calls between transactions',
+        v: 21000, // Per transaction. NOTE: Not payable on data of calls between transactions
       },
       txCreation: {
-        v: 32000,
-        d: 'The cost of creating a contract via tx',
+        v: 32000, // The cost of creating a contract via tx
       },
       txDataZero: {
-        v: 4,
-        d: 'Per byte of data attached to a transaction that equals zero. NOTE: Not payable on data of calls between transactions',
+        v: 4, // Per byte of data attached to a transaction that equals zero. NOTE: Not payable on data of calls between transactions
       },
       txDataNonZero: {
-        v: 68,
-        d: 'Per byte of data attached to a transaction that is not equal to zero. NOTE: Not payable on data of calls between transactions',
+        v: 68, // Per byte of data attached to a transaction that is not equal to zero. NOTE: Not payable on data of calls between transactions
       },
       copy: {
-        v: 3,
-        d: 'Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added',
+        v: 3, // Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added
       },
       ecRecover: {
         v: 3000,
-        d: '',
       },
       sha256: {
         v: 60,
-        d: '',
       },
       sha256Word: {
         v: 12,
-        d: '',
       },
       ripemd160: {
         v: 600,
-        d: '',
       },
       ripemd160Word: {
         v: 120,
-        d: '',
       },
       identity: {
         v: 15,
-        d: '',
       },
       identityWord: {
         v: 3,
-        d: '',
       },
       stop: {
-        v: 0,
-        d: 'Base fee of the STOP opcode',
+        v: 0, // Base fee of the STOP opcode
       },
       add: {
-        v: 3,
-        d: 'Base fee of the ADD opcode',
+        v: 3, // Base fee of the ADD opcode
       },
       mul: {
-        v: 5,
-        d: 'Base fee of the MUL opcode',
+        v: 5, // Base fee of the MUL opcode
       },
       sub: {
-        v: 3,
-        d: 'Base fee of the SUB opcode',
+        v: 3, // Base fee of the SUB opcode
       },
       div: {
-        v: 5,
-        d: 'Base fee of the DIV opcode',
+        v: 5, // Base fee of the DIV opcode
       },
       sdiv: {
-        v: 5,
-        d: 'Base fee of the SDIV opcode',
+        v: 5, // Base fee of the SDIV opcode
       },
       mod: {
-        v: 5,
-        d: 'Base fee of the MOD opcode',
+        v: 5, // Base fee of the MOD opcode
       },
       smod: {
-        v: 5,
-        d: 'Base fee of the SMOD opcode',
+        v: 5, // Base fee of the SMOD opcode
       },
       addmod: {
-        v: 8,
-        d: 'Base fee of the ADDMOD opcode',
+        v: 8, // Base fee of the ADDMOD opcode
       },
       mulmod: {
-        v: 8,
-        d: 'Base fee of the MULMOD opcode',
+        v: 8, // Base fee of the MULMOD opcode
       },
       signextend: {
-        v: 5,
-        d: 'Base fee of the SIGNEXTEND opcode',
+        v: 5, // Base fee of the SIGNEXTEND opcode
       },
       lt: {
-        v: 3,
-        d: 'Base fee of the LT opcode',
+        v: 3, // Base fee of the LT opcode
       },
       gt: {
-        v: 3,
-        d: 'Base fee of the GT opcode',
+        v: 3, // Base fee of the GT opcode
       },
       slt: {
-        v: 3,
-        d: 'Base fee of the SLT opcode',
+        v: 3, // Base fee of the SLT opcode
       },
       sgt: {
-        v: 3,
-        d: 'Base fee of the SGT opcode',
+        v: 3, // Base fee of the SGT opcode
       },
       eq: {
-        v: 3,
-        d: 'Base fee of the EQ opcode',
+        v: 3, // Base fee of the EQ opcode
       },
       iszero: {
-        v: 3,
-        d: 'Base fee of the ISZERO opcode',
+        v: 3, // Base fee of the ISZERO opcode
       },
       and: {
-        v: 3,
-        d: 'Base fee of the AND opcode',
+        v: 3, // Base fee of the AND opcode
       },
       or: {
-        v: 3,
-        d: 'Base fee of the OR opcode',
+        v: 3, // Base fee of the OR opcode
       },
       xor: {
-        v: 3,
-        d: 'Base fee of the XOR opcode',
+        v: 3, // Base fee of the XOR opcode
       },
       not: {
-        v: 3,
-        d: 'Base fee of the NOT opcode',
+        v: 3, // Base fee of the NOT opcode
       },
       byte: {
-        v: 3,
-        d: 'Base fee of the BYTE opcode',
+        v: 3, // Base fee of the BYTE opcode
       },
       address: {
-        v: 2,
-        d: 'Base fee of the ADDRESS opcode',
+        v: 2, // Base fee of the ADDRESS opcode
       },
       balance: {
-        v: 20,
-        d: 'Base fee of the BALANCE opcode',
+        v: 20, // Base fee of the BALANCE opcode
       },
       origin: {
-        v: 2,
-        d: 'Base fee of the ORIGIN opcode',
+        v: 2, // Base fee of the ORIGIN opcode
       },
       caller: {
-        v: 2,
-        d: 'Base fee of the CALLER opcode',
+        v: 2, // Base fee of the CALLER opcode
       },
       callvalue: {
-        v: 2,
-        d: 'Base fee of the CALLVALUE opcode',
+        v: 2, // Base fee of the CALLVALUE opcode
       },
       calldataload: {
-        v: 3,
-        d: 'Base fee of the CALLDATALOAD opcode',
+        v: 3, // Base fee of the CALLDATALOAD opcode
       },
       calldatasize: {
-        v: 2,
-        d: 'Base fee of the CALLDATASIZE opcode',
+        v: 2, // Base fee of the CALLDATASIZE opcode
       },
       calldatacopy: {
-        v: 3,
-        d: 'Base fee of the CALLDATACOPY opcode',
+        v: 3, // Base fee of the CALLDATACOPY opcode
       },
       codesize: {
-        v: 2,
-        d: 'Base fee of the CODESIZE opcode',
+        v: 2, // Base fee of the CODESIZE opcode
       },
       codecopy: {
-        v: 3,
-        d: 'Base fee of the CODECOPY opcode',
+        v: 3, // Base fee of the CODECOPY opcode
       },
       gasprice: {
-        v: 2,
-        d: 'Base fee of the GASPRICE opcode',
+        v: 2, // Base fee of the GASPRICE opcode
       },
       extcodesize: {
-        v: 20,
-        d: 'Base fee of the EXTCODESIZE opcode',
+        v: 20, // Base fee of the EXTCODESIZE opcode
       },
       extcodecopy: {
-        v: 20,
-        d: 'Base fee of the EXTCODECOPY opcode',
+        v: 20, // Base fee of the EXTCODECOPY opcode
       },
       blockhash: {
-        v: 20,
-        d: 'Base fee of the BLOCKHASH opcode',
+        v: 20, // Base fee of the BLOCKHASH opcode
       },
       coinbase: {
-        v: 2,
-        d: 'Base fee of the COINBASE opcode',
+        v: 2, // Base fee of the COINBASE opcode
       },
       timestamp: {
-        v: 2,
-        d: 'Base fee of the TIMESTAMP opcode',
+        v: 2, // Base fee of the TIMESTAMP opcode
       },
       number: {
-        v: 2,
-        d: 'Base fee of the NUMBER opcode',
+        v: 2, // Base fee of the NUMBER opcode
       },
       difficulty: {
-        v: 2,
-        d: 'Base fee of the DIFFICULTY opcode',
+        v: 2, // Base fee of the DIFFICULTY opcode
       },
       gaslimit: {
-        v: 2,
-        d: 'Base fee of the GASLIMIT opcode',
+        v: 2, // Base fee of the GASLIMIT opcode
       },
       pop: {
-        v: 2,
-        d: 'Base fee of the POP opcode',
+        v: 2, // Base fee of the POP opcode
       },
       mload: {
-        v: 3,
-        d: 'Base fee of the MLOAD opcode',
+        v: 3, // Base fee of the MLOAD opcode
       },
       mstore: {
-        v: 3,
-        d: 'Base fee of the MSTORE opcode',
+        v: 3, // Base fee of the MSTORE opcode
       },
       mstore8: {
-        v: 3,
-        d: 'Base fee of the MSTORE8 opcode',
+        v: 3, // Base fee of the MSTORE8 opcode
       },
       sstore: {
-        v: 0,
-        d: 'Base fee of the SSTORE opcode',
+        v: 0, // Base fee of the SSTORE opcode
       },
       jump: {
-        v: 8,
-        d: 'Base fee of the JUMP opcode',
+        v: 8, // Base fee of the JUMP opcode
       },
       jumpi: {
-        v: 10,
-        d: 'Base fee of the JUMPI opcode',
+        v: 10, // Base fee of the JUMPI opcode
       },
       pc: {
-        v: 2,
-        d: 'Base fee of the PC opcode',
+        v: 2, // Base fee of the PC opcode
       },
       msize: {
-        v: 2,
-        d: 'Base fee of the MSIZE opcode',
+        v: 2, // Base fee of the MSIZE opcode
       },
       gas: {
-        v: 2,
-        d: 'Base fee of the GAS opcode',
+        v: 2, // Base fee of the GAS opcode
       },
       push: {
-        v: 3,
-        d: 'Base fee of the PUSH opcode',
+        v: 3, // Base fee of the PUSH opcode
       },
       dup: {
-        v: 3,
-        d: 'Base fee of the DUP opcode',
+        v: 3, // Base fee of the DUP opcode
       },
       swap: {
-        v: 3,
-        d: 'Base fee of the SWAP opcode',
+        v: 3, // Base fee of the SWAP opcode
       },
       callcode: {
-        v: 40,
-        d: 'Base fee of the CALLCODE opcode',
+        v: 40, // Base fee of the CALLCODE opcode
       },
       return: {
-        v: 0,
-        d: 'Base fee of the RETURN opcode',
+        v: 0, // Base fee of the RETURN opcode
       },
       invalid: {
-        v: 0,
-        d: 'Base fee of the INVALID opcode',
+        v: 0, // Base fee of the INVALID opcode
       },
       selfdestruct: {
-        v: 0,
-        d: 'Base fee of the SELFDESTRUCT opcode',
+        v: 0, // Base fee of the SELFDESTRUCT opcode
       },
     },
     vm: {
       stackLimit: {
-        v: 1024,
-        d: 'Maximum size of VM stack allowed',
+        v: 1024, // Maximum size of VM stack allowed
       },
       callCreateDepth: {
-        v: 1024,
-        d: 'Maximum depth of call/create stack',
+        v: 1024, // Maximum depth of call/create stack
       },
       maxExtraDataSize: {
-        v: 32,
-        d: 'Maximum size extra data may be after Genesis',
+        v: 32, // Maximum size extra data may be after Genesis
       },
     },
     pow: {
       minimumDifficulty: {
-        v: 131072,
-        d: 'The minimum that the difficulty may ever be',
+        v: 131072, // The minimum that the difficulty may ever be
       },
       difficultyBoundDivisor: {
-        v: 2048,
-        d: 'The bound divisor of the difficulty, used in the update calculations',
+        v: 2048, // The bound divisor of the difficulty, used in the update calculations
       },
       durationLimit: {
-        v: 13,
-        d: 'The decision boundary on the blocktime duration used to determine whether difficulty should go up or not',
+        v: 13, // The decision boundary on the blocktime duration used to determine whether difficulty should go up or not
       },
       epochDuration: {
-        v: 30000,
-        d: 'Duration between proof-of-work epochs',
+        v: 30000, // Duration between proof-of-work epochs
       },
       timebombPeriod: {
-        v: 100000,
-        d: 'Exponential difficulty timebomb period',
+        v: 100000, // Exponential difficulty timebomb period
       },
       minerReward: {
-        v: BigInt('5000000000000000000'),
-        d: 'the amount a miner get rewarded for mining a block',
+        v: BigInt('5000000000000000000'), // the amount a miner get rewarded for mining a block
       },
       difficultyBombDelay: {
-        v: 0,
-        d: 'the amount of blocks to delay the difficulty bomb with',
+        v: 0, // the amount of blocks to delay the difficulty bomb with
       },
     },
   },
@@ -448,8 +343,7 @@ export const hardforks: HardforksDict = {
     status: Status.Final,
     gasPrices: {
       delegatecall: {
-        v: 40,
-        d: 'Base fee of the DELEGATECALL opcode',
+        v: 40, // Base fee of the DELEGATECALL opcode
       },
     },
   },
@@ -466,36 +360,28 @@ export const hardforks: HardforksDict = {
     status: Status.Final,
     gasPrices: {
       sload: {
-        v: 200,
-        d: 'Once per SLOAD operation',
+        v: 200, // Once per SLOAD operation
       },
       call: {
-        v: 700,
-        d: 'Once per CALL operation & message call transaction',
+        v: 700, // Once per CALL operation & message call transaction
       },
       extcodesize: {
-        v: 700,
-        d: 'Base fee of the EXTCODESIZE opcode',
+        v: 700, // Base fee of the EXTCODESIZE opcode
       },
       extcodecopy: {
-        v: 700,
-        d: 'Base fee of the EXTCODECOPY opcode',
+        v: 700, // Base fee of the EXTCODECOPY opcode
       },
       balance: {
-        v: 400,
-        d: 'Base fee of the BALANCE opcode',
+        v: 400, // Base fee of the BALANCE opcode
       },
       delegatecall: {
-        v: 700,
-        d: 'Base fee of the DELEGATECALL opcode',
+        v: 700, // Base fee of the DELEGATECALL opcode
       },
       callcode: {
-        v: 700,
-        d: 'Base fee of the CALLCODE opcode',
+        v: 700, // Base fee of the CALLCODE opcode
       },
       selfdestruct: {
-        v: 5000,
-        d: 'Base fee of the SELFDESTRUCT opcode',
+        v: 5000, // Base fee of the SELFDESTRUCT opcode
       },
     },
   },
@@ -507,14 +393,12 @@ export const hardforks: HardforksDict = {
     status: Status.Final,
     gasPrices: {
       expByte: {
-        v: 50,
-        d: 'Times ceil(log256(exponent)) for the EXP instruction',
+        v: 50, // Times ceil(log256(exponent)) for the EXP instruction
       },
     },
     vm: {
       maxCodeSize: {
-        v: 24576,
-        d: 'Maximum length of contract code',
+        v: 24576, // Maximum length of contract code
       },
     },
   },
@@ -525,50 +409,39 @@ export const hardforks: HardforksDict = {
     status: Status.Final,
     gasPrices: {
       modexpGquaddivisor: {
-        v: 20,
-        d: 'Gquaddivisor from modexp precompile for gas calculation',
+        v: 20, // Gquaddivisor from modexp precompile for gas calculation
       },
       ecAdd: {
-        v: 500,
-        d: 'Gas costs for curve addition precompile',
+        v: 500, // Gas costs for curve addition precompile
       },
       ecMul: {
-        v: 40000,
-        d: 'Gas costs for curve multiplication precompile',
+        v: 40000, // Gas costs for curve multiplication precompile
       },
       ecPairing: {
-        v: 100000,
-        d: 'Base gas costs for curve pairing precompile',
+        v: 100000, // Base gas costs for curve pairing precompile
       },
       ecPairingWord: {
-        v: 80000,
-        d: 'Gas costs regarding curve pairing precompile input length',
+        v: 80000, // Gas costs regarding curve pairing precompile input length
       },
       revert: {
-        v: 0,
-        d: 'Base fee of the REVERT opcode',
+        v: 0, // Base fee of the REVERT opcode
       },
       staticcall: {
-        v: 700,
-        d: 'Base fee of the STATICCALL opcode',
+        v: 700, // Base fee of the STATICCALL opcode
       },
       returndatasize: {
-        v: 2,
-        d: 'Base fee of the RETURNDATASIZE opcode',
+        v: 2, // Base fee of the RETURNDATASIZE opcode
       },
       returndatacopy: {
-        v: 3,
-        d: 'Base fee of the RETURNDATACOPY opcode',
+        v: 3, // Base fee of the RETURNDATACOPY opcode
       },
     },
     pow: {
       minerReward: {
-        v: BigInt('3000000000000000000'),
-        d: 'the amount a miner get rewarded for mining a block',
+        v: BigInt('3000000000000000000'), // the amount a miner get rewarded for mining a block
       },
       difficultyBombDelay: {
-        v: 3000000,
-        d: 'the amount of blocks to delay the difficulty bomb with',
+        v: 3000000, // the amount of blocks to delay the difficulty bomb with
       },
     },
   },
@@ -579,62 +452,48 @@ export const hardforks: HardforksDict = {
     status: Status.Final,
     gasPrices: {
       netSstoreNoopGas: {
-        v: 200,
-        d: "Once per SSTORE operation if the value doesn't change",
+        v: 200, // Once per SSTORE operation if the value doesn't change
       },
       netSstoreInitGas: {
-        v: 20000,
-        d: 'Once per SSTORE operation from clean zero',
+        v: 20000, // Once per SSTORE operation from clean zero
       },
       netSstoreCleanGas: {
-        v: 5000,
-        d: 'Once per SSTORE operation from clean non-zero',
+        v: 5000, // Once per SSTORE operation from clean non-zero
       },
       netSstoreDirtyGas: {
-        v: 200,
-        d: 'Once per SSTORE operation from dirty',
+        v: 200, // Once per SSTORE operation from dirty
       },
       netSstoreClearRefund: {
-        v: 15000,
-        d: 'Once per SSTORE operation for clearing an originally existing storage slot',
+        v: 15000, // Once per SSTORE operation for clearing an originally existing storage slot
       },
       netSstoreResetRefund: {
-        v: 4800,
-        d: 'Once per SSTORE operation for resetting to the original non-zero value',
+        v: 4800, // Once per SSTORE operation for resetting to the original non-zero value
       },
       netSstoreResetClearRefund: {
-        v: 19800,
-        d: 'Once per SSTORE operation for resetting to the original zero value',
+        v: 19800, // Once per SSTORE operation for resetting to the original zero value
       },
       shl: {
-        v: 3,
-        d: 'Base fee of the SHL opcode',
+        v: 3, // Base fee of the SHL opcode
       },
       shr: {
-        v: 3,
-        d: 'Base fee of the SHR opcode',
+        v: 3, // Base fee of the SHR opcode
       },
       sar: {
-        v: 3,
-        d: 'Base fee of the SAR opcode',
+        v: 3, // Base fee of the SAR opcode
       },
       extcodehash: {
-        v: 400,
-        d: 'Base fee of the EXTCODEHASH opcode',
+        v: 400, // Base fee of the EXTCODEHASH opcode
       },
       create2: {
-        v: 32000,
-        d: 'Base fee of the CREATE2 opcode',
+        v: 32000, // Base fee of the CREATE2 opcode
       },
     },
     pow: {
       minerReward: {
-        v: BigInt('2000000000000000000'),
-        d: 'The amount a miner gets rewarded for mining a block',
+        v: BigInt('2000000000000000000'), // The amount a miner gets rewarded for mining a block
       },
       difficultyBombDelay: {
-        v: 5000000,
-        d: 'the amount of blocks to delay the difficulty bomb with',
+        v: 5000000, // the amount of blocks to delay the difficulty bomb with
       },
     },
   },
@@ -646,32 +505,25 @@ export const hardforks: HardforksDict = {
     status: Status.Final,
     gasPrices: {
       netSstoreNoopGas: {
-        v: null,
-        d: 'Removed along EIP-1283',
+        v: null, // Removed along EIP-1283
       },
       netSstoreInitGas: {
-        v: null,
-        d: 'Removed along EIP-1283',
+        v: null, // Removed along EIP-1283
       },
       netSstoreCleanGas: {
-        v: null,
-        d: 'Removed along EIP-1283',
+        v: null, // Removed along EIP-1283
       },
       netSstoreDirtyGas: {
-        v: null,
-        d: 'Removed along EIP-1283',
+        v: null, // Removed along EIP-1283
       },
       netSstoreClearRefund: {
-        v: null,
-        d: 'Removed along EIP-1283',
+        v: null, // Removed along EIP-1283
       },
       netSstoreResetRefund: {
-        v: null,
-        d: 'Removed along EIP-1283',
+        v: null, // Removed along EIP-1283
       },
       netSstoreResetClearRefund: {
-        v: null,
-        d: 'Removed along EIP-1283',
+        v: null, // Removed along EIP-1283
       },
     },
   },
@@ -683,80 +535,61 @@ export const hardforks: HardforksDict = {
     gasConfig: {},
     gasPrices: {
       blake2Round: {
-        v: 1,
-        d: 'Gas cost per round for the Blake2 F precompile',
+        v: 1, // Gas cost per round for the Blake2 F precompile
       },
       ecAdd: {
-        v: 150,
-        d: 'Gas costs for curve addition precompile',
+        v: 150, // Gas costs for curve addition precompile
       },
       ecMul: {
-        v: 6000,
-        d: 'Gas costs for curve multiplication precompile',
+        v: 6000, // Gas costs for curve multiplication precompile
       },
       ecPairing: {
-        v: 45000,
-        d: 'Base gas costs for curve pairing precompile',
+        v: 45000, // Base gas costs for curve pairing precompile
       },
       ecPairingWord: {
-        v: 34000,
-        d: 'Gas costs regarding curve pairing precompile input length',
+        v: 34000, // Gas costs regarding curve pairing precompile input length
       },
       txDataNonZero: {
-        v: 16,
-        d: 'Per byte of data attached to a transaction that is not equal to zero. NOTE: Not payable on data of calls between transactions',
+        v: 16, // Per byte of data attached to a transaction that is not equal to zero. NOTE: Not payable on data of calls between transactions
       },
       sstoreSentryGasEIP2200: {
-        v: 2300,
-        d: 'Minimum gas required to be present for an SSTORE call, not consumed',
+        v: 2300, // Minimum gas required to be present for an SSTORE call, not consumed
       },
       sstoreNoopGasEIP2200: {
-        v: 800,
-        d: "Once per SSTORE operation if the value doesn't change",
+        v: 800, // Once per SSTORE operation if the value doesn't change
       },
       sstoreDirtyGasEIP2200: {
-        v: 800,
-        d: 'Once per SSTORE operation if a dirty value is changed',
+        v: 800, // Once per SSTORE operation if a dirty value is changed
       },
       sstoreInitGasEIP2200: {
-        v: 20000,
-        d: 'Once per SSTORE operation from clean zero to non-zero',
+        v: 20000, // Once per SSTORE operation from clean zero to non-zero
       },
       sstoreInitRefundEIP2200: {
-        v: 19200,
-        d: 'Once per SSTORE operation for resetting to the original zero value',
+        v: 19200, // Once per SSTORE operation for resetting to the original zero value
       },
       sstoreCleanGasEIP2200: {
-        v: 5000,
-        d: 'Once per SSTORE operation from clean non-zero to something else',
+        v: 5000, // Once per SSTORE operation from clean non-zero to something else
       },
       sstoreCleanRefundEIP2200: {
-        v: 4200,
-        d: 'Once per SSTORE operation for resetting to the original non-zero value',
+        v: 4200, // Once per SSTORE operation for resetting to the original non-zero value
       },
       sstoreClearRefundEIP2200: {
-        v: 15000,
-        d: 'Once per SSTORE operation for clearing an originally existing storage slot',
+        v: 15000, // Once per SSTORE operation for clearing an originally existing storage slot
       },
       balance: {
-        v: 700,
-        d: 'Base fee of the BALANCE opcode',
+        v: 700, // Base fee of the BALANCE opcode
       },
       extcodehash: {
-        v: 700,
-        d: 'Base fee of the EXTCODEHASH opcode',
+        v: 700, // Base fee of the EXTCODEHASH opcode
       },
       chainid: {
-        v: 2,
-        d: 'Base fee of the CHAINID opcode',
+        v: 2, // Base fee of the CHAINID opcode
       },
       selfbalance: {
-        v: 5,
-        d: 'Base fee of the SELFBALANCE opcode',
+        v: 5, // Base fee of the SELFBALANCE opcode
       },
       sload: {
-        v: 800,
-        d: 'Base fee of the SLOAD opcode',
+        v: 800, // Base fee of the SLOAD opcode
       },
     },
   },
@@ -767,8 +600,7 @@ export const hardforks: HardforksDict = {
     status: Status.Final,
     pow: {
       difficultyBombDelay: {
-        v: 9000000,
-        d: 'the amount of blocks to delay the difficulty bomb with',
+        v: 9000000, // the amount of blocks to delay the difficulty bomb with
       },
     },
   },

--- a/packages/common/src/hardforks.ts
+++ b/packages/common/src/hardforks.ts
@@ -13,327 +13,117 @@ export const hardforks: HardforksDict = {
     url: '',
     status: Status.Final,
     gasConfig: {
-      minGasLimit: {
-        v: 5000, // Minimum the gas limit may ever be
-      },
-      gasLimitBoundDivisor: {
-        v: 1024, // The bound divisor of the gas limit, used in update calculations
-      },
-      maxRefundQuotient: {
-        v: 2, // Maximum refund quotient; max tx refund is min(tx.gasUsed/maxRefundQuotient, tx.gasRefund)
-      },
+      minGasLimit: 5000, // Minimum the gas limit may ever be
+      gasLimitBoundDivisor: 1024, // The bound divisor of the gas limit, used in update calculations
+      maxRefundQuotient: 2, // Maximum refund quotient; max tx refund is min(tx.gasUsed/maxRefundQuotient, tx.gasRefund)
     },
     gasPrices: {
-      base: {
-        v: 2, // Gas base cost, used e.g. for ChainID opcode (Istanbul)
-      },
-      exp: {
-        v: 10, // Base fee of the EXP opcode
-      },
-      expByte: {
-        v: 10, // Times ceil(log256(exponent)) for the EXP instruction
-      },
-      keccak256: {
-        v: 30, // Base fee of the SHA3 opcode
-      },
-      keccak256Word: {
-        v: 6, // Once per word of the SHA3 operation's data
-      },
-      sload: {
-        v: 50, // Base fee of the SLOAD opcode
-      },
-      sstoreSet: {
-        v: 20000, // Once per SSTORE operation if the zeroness changes from zero
-      },
-      sstoreReset: {
-        v: 5000, // Once per SSTORE operation if the zeroness does not change from zero
-      },
-      sstoreRefund: {
-        v: 15000, // Once per SSTORE operation if the zeroness changes to zero
-      },
-      jumpdest: {
-        v: 1, // Base fee of the JUMPDEST opcode
-      },
-      log: {
-        v: 375, // Base fee of the LOG opcode
-      },
-      logData: {
-        v: 8, // Per byte in a LOG* operation's data
-      },
-      logTopic: {
-        v: 375, // Multiplied by the * of the LOG*, per LOG transaction. e.g. LOG0 incurs 0 * c_txLogTopicGas, LOG4 incurs 4 * c_txLogTopicGas
-      },
-      create: {
-        v: 32000, // Base fee of the CREATE opcode
-      },
-      call: {
-        v: 40, // Base fee of the CALL opcode
-      },
-      callStipend: {
-        v: 2300, // Free gas given at beginning of call
-      },
-      callValueTransfer: {
-        v: 9000, // Paid for CALL when the value transfor is non-zero
-      },
-      callNewAccount: {
-        v: 25000, // Paid for CALL when the destination address didn't exist prior
-      },
-      selfdestructRefund: {
-        v: 24000, // Refunded following a selfdestruct operation
-      },
-      memory: {
-        v: 3, // Times the address of the (highest referenced byte in memory + 1). NOTE: referencing happens on read, write and in instructions such as RETURN and CALL
-      },
-      quadCoeffDiv: {
-        v: 512, // Divisor for the quadratic particle of the memory cost equation
-      },
-      createData: {
-        v: 200, //
-      },
-      tx: {
-        v: 21000, // Per transaction. NOTE: Not payable on data of calls between transactions
-      },
-      txCreation: {
-        v: 32000, // The cost of creating a contract via tx
-      },
-      txDataZero: {
-        v: 4, // Per byte of data attached to a transaction that equals zero. NOTE: Not payable on data of calls between transactions
-      },
-      txDataNonZero: {
-        v: 68, // Per byte of data attached to a transaction that is not equal to zero. NOTE: Not payable on data of calls between transactions
-      },
-      copy: {
-        v: 3, // Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added
-      },
-      ecRecover: {
-        v: 3000,
-      },
-      sha256: {
-        v: 60,
-      },
-      sha256Word: {
-        v: 12,
-      },
-      ripemd160: {
-        v: 600,
-      },
-      ripemd160Word: {
-        v: 120,
-      },
-      identity: {
-        v: 15,
-      },
-      identityWord: {
-        v: 3,
-      },
-      stop: {
-        v: 0, // Base fee of the STOP opcode
-      },
-      add: {
-        v: 3, // Base fee of the ADD opcode
-      },
-      mul: {
-        v: 5, // Base fee of the MUL opcode
-      },
-      sub: {
-        v: 3, // Base fee of the SUB opcode
-      },
-      div: {
-        v: 5, // Base fee of the DIV opcode
-      },
-      sdiv: {
-        v: 5, // Base fee of the SDIV opcode
-      },
-      mod: {
-        v: 5, // Base fee of the MOD opcode
-      },
-      smod: {
-        v: 5, // Base fee of the SMOD opcode
-      },
-      addmod: {
-        v: 8, // Base fee of the ADDMOD opcode
-      },
-      mulmod: {
-        v: 8, // Base fee of the MULMOD opcode
-      },
-      signextend: {
-        v: 5, // Base fee of the SIGNEXTEND opcode
-      },
-      lt: {
-        v: 3, // Base fee of the LT opcode
-      },
-      gt: {
-        v: 3, // Base fee of the GT opcode
-      },
-      slt: {
-        v: 3, // Base fee of the SLT opcode
-      },
-      sgt: {
-        v: 3, // Base fee of the SGT opcode
-      },
-      eq: {
-        v: 3, // Base fee of the EQ opcode
-      },
-      iszero: {
-        v: 3, // Base fee of the ISZERO opcode
-      },
-      and: {
-        v: 3, // Base fee of the AND opcode
-      },
-      or: {
-        v: 3, // Base fee of the OR opcode
-      },
-      xor: {
-        v: 3, // Base fee of the XOR opcode
-      },
-      not: {
-        v: 3, // Base fee of the NOT opcode
-      },
-      byte: {
-        v: 3, // Base fee of the BYTE opcode
-      },
-      address: {
-        v: 2, // Base fee of the ADDRESS opcode
-      },
-      balance: {
-        v: 20, // Base fee of the BALANCE opcode
-      },
-      origin: {
-        v: 2, // Base fee of the ORIGIN opcode
-      },
-      caller: {
-        v: 2, // Base fee of the CALLER opcode
-      },
-      callvalue: {
-        v: 2, // Base fee of the CALLVALUE opcode
-      },
-      calldataload: {
-        v: 3, // Base fee of the CALLDATALOAD opcode
-      },
-      calldatasize: {
-        v: 2, // Base fee of the CALLDATASIZE opcode
-      },
-      calldatacopy: {
-        v: 3, // Base fee of the CALLDATACOPY opcode
-      },
-      codesize: {
-        v: 2, // Base fee of the CODESIZE opcode
-      },
-      codecopy: {
-        v: 3, // Base fee of the CODECOPY opcode
-      },
-      gasprice: {
-        v: 2, // Base fee of the GASPRICE opcode
-      },
-      extcodesize: {
-        v: 20, // Base fee of the EXTCODESIZE opcode
-      },
-      extcodecopy: {
-        v: 20, // Base fee of the EXTCODECOPY opcode
-      },
-      blockhash: {
-        v: 20, // Base fee of the BLOCKHASH opcode
-      },
-      coinbase: {
-        v: 2, // Base fee of the COINBASE opcode
-      },
-      timestamp: {
-        v: 2, // Base fee of the TIMESTAMP opcode
-      },
-      number: {
-        v: 2, // Base fee of the NUMBER opcode
-      },
-      difficulty: {
-        v: 2, // Base fee of the DIFFICULTY opcode
-      },
-      gaslimit: {
-        v: 2, // Base fee of the GASLIMIT opcode
-      },
-      pop: {
-        v: 2, // Base fee of the POP opcode
-      },
-      mload: {
-        v: 3, // Base fee of the MLOAD opcode
-      },
-      mstore: {
-        v: 3, // Base fee of the MSTORE opcode
-      },
-      mstore8: {
-        v: 3, // Base fee of the MSTORE8 opcode
-      },
-      sstore: {
-        v: 0, // Base fee of the SSTORE opcode
-      },
-      jump: {
-        v: 8, // Base fee of the JUMP opcode
-      },
-      jumpi: {
-        v: 10, // Base fee of the JUMPI opcode
-      },
-      pc: {
-        v: 2, // Base fee of the PC opcode
-      },
-      msize: {
-        v: 2, // Base fee of the MSIZE opcode
-      },
-      gas: {
-        v: 2, // Base fee of the GAS opcode
-      },
-      push: {
-        v: 3, // Base fee of the PUSH opcode
-      },
-      dup: {
-        v: 3, // Base fee of the DUP opcode
-      },
-      swap: {
-        v: 3, // Base fee of the SWAP opcode
-      },
-      callcode: {
-        v: 40, // Base fee of the CALLCODE opcode
-      },
-      return: {
-        v: 0, // Base fee of the RETURN opcode
-      },
-      invalid: {
-        v: 0, // Base fee of the INVALID opcode
-      },
-      selfdestruct: {
-        v: 0, // Base fee of the SELFDESTRUCT opcode
-      },
+      base: 2, // Gas base cost, used e.g. for ChainID opcode (Istanbul)
+      exp: 10, // Base fee of the EXP opcode
+      expByte: 10, // Times ceil(log256(exponent)) for the EXP instruction
+      keccak256: 30, // Base fee of the SHA3 opcode
+      keccak256Word: 6, // Once per word of the SHA3 operation's data
+      sload: 50, // Base fee of the SLOAD opcode
+      sstoreSet: 20000, // Once per SSTORE operation if the zeroness changes from zero
+      sstoreReset: 5000, // Once per SSTORE operation if the zeroness does not change from zero
+      sstoreRefund: 15000, // Once per SSTORE operation if the zeroness changes to zero
+      jumpdest: 1, // Base fee of the JUMPDEST opcode
+      log: 375, // Base fee of the LOG opcode
+      logData: 8, // Per byte in a LOG* operation's data
+      logTopic: 375, // Multiplied by the * of the LOG*, per LOG transaction. e.g. LOG0 incurs 0 * c_txLogTopicGas, LOG4 incurs 4 * c_txLogTopicGas
+      create: 32000, // Base fee of the CREATE opcode
+      call: 40, // Base fee of the CALL opcode
+      callStipend: 2300, // Free gas given at beginning of call
+      callValueTransfer: 9000, // Paid for CALL when the value transfor is non-zero
+      callNewAccount: 25000, // Paid for CALL when the destination address didn't exist prior
+      selfdestructRefund: 24000, // Refunded following a selfdestruct operation
+      memory: 3, // Times the address of the (highest referenced byte in memory + 1). NOTE: referencing happens on read, write and in instructions such as RETURN and CALL
+      quadCoeffDiv: 512, // Divisor for the quadratic particle of the memory cost equation
+      createData: 200, //
+      tx: 21000, // Per transaction. NOTE: Not payable on data of calls between transactions
+      txCreation: 32000, // The cost of creating a contract via tx
+      txDataZero: 4, // Per byte of data attached to a transaction that equals zero. NOTE: Not payable on data of calls between transactions
+      txDataNonZero: 68, // Per byte of data attached to a transaction that is not equal to zero. NOTE: Not payable on data of calls between transactions
+      copy: 3, // Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added
+      ecRecover: 3000,
+      sha256: 60,
+      sha256Word: 12,
+      ripemd160: 600,
+      ripemd160Word: 120,
+      identity: 15,
+      identityWord: 3,
+      stop: 0, // Base fee of the STOP opcode
+      add: 3, // Base fee of the ADD opcode
+      mul: 5, // Base fee of the MUL opcode
+      sub: 3, // Base fee of the SUB opcode
+      div: 5, // Base fee of the DIV opcode
+      sdiv: 5, // Base fee of the SDIV opcode
+      mod: 5, // Base fee of the MOD opcode
+      smod: 5, // Base fee of the SMOD opcode
+      addmod: 8, // Base fee of the ADDMOD opcode
+      mulmod: 8, // Base fee of the MULMOD opcode
+      signextend: 5, // Base fee of the SIGNEXTEND opcode
+      lt: 3, // Base fee of the LT opcode
+      gt: 3, // Base fee of the GT opcode
+      slt: 3, // Base fee of the SLT opcode
+      sgt: 3, // Base fee of the SGT opcode
+      eq: 3, // Base fee of the EQ opcode
+      iszero: 3, // Base fee of the ISZERO opcode
+      and: 3, // Base fee of the AND opcode
+      or: 3, // Base fee of the OR opcode
+      xor: 3, // Base fee of the XOR opcode
+      not: 3, // Base fee of the NOT opcode
+      byte: 3, // Base fee of the BYTE opcode
+      address: 2, // Base fee of the ADDRESS opcode
+      balance: 20, // Base fee of the BALANCE opcode
+      origin: 2, // Base fee of the ORIGIN opcode
+      caller: 2, // Base fee of the CALLER opcode
+      callvalue: 2, // Base fee of the CALLVALUE opcode
+      calldataload: 3, // Base fee of the CALLDATALOAD opcode
+      calldatasize: 2, // Base fee of the CALLDATASIZE opcode
+      calldatacopy: 3, // Base fee of the CALLDATACOPY opcode
+      codesize: 2, // Base fee of the CODESIZE opcode
+      codecopy: 3, // Base fee of the CODECOPY opcode
+      gasprice: 2, // Base fee of the GASPRICE opcode
+      extcodesize: 20, // Base fee of the EXTCODESIZE opcode
+      extcodecopy: 20, // Base fee of the EXTCODECOPY opcode
+      blockhash: 20, // Base fee of the BLOCKHASH opcode
+      coinbase: 2, // Base fee of the COINBASE opcode
+      timestamp: 2, // Base fee of the TIMESTAMP opcode
+      number: 2, // Base fee of the NUMBER opcode
+      difficulty: 2, // Base fee of the DIFFICULTY opcode
+      gaslimit: 2, // Base fee of the GASLIMIT opcode
+      pop: 2, // Base fee of the POP opcode
+      mload: 3, // Base fee of the MLOAD opcode
+      mstore: 3, // Base fee of the MSTORE opcode
+      mstore8: 3, // Base fee of the MSTORE8 opcode
+      sstore: 0, // Base fee of the SSTORE opcode
+      jump: 8, // Base fee of the JUMP opcode
+      jumpi: 10, // Base fee of the JUMPI opcode
+      pc: 2, // Base fee of the PC opcode
+      msize: 2, // Base fee of the MSIZE opcode
+      gas: 2, // Base fee of the GAS opcode
+      push: 3, // Base fee of the PUSH opcode
+      dup: 3, // Base fee of the DUP opcode
+      swap: 3, // Base fee of the SWAP opcode
+      callcode: 40, // Base fee of the CALLCODE opcode
+      return: 0, // Base fee of the RETURN opcode
+      invalid: 0, // Base fee of the INVALID opcode
+      selfdestruct: 0, // Base fee of the SELFDESTRUCT opcode
     },
     vm: {
-      stackLimit: {
-        v: 1024, // Maximum size of VM stack allowed
-      },
-      callCreateDepth: {
-        v: 1024, // Maximum depth of call/create stack
-      },
-      maxExtraDataSize: {
-        v: 32, // Maximum size extra data may be after Genesis
-      },
+      stackLimit: 1024, // Maximum size of VM stack allowed
+      callCreateDepth: 1024, // Maximum depth of call/create stack
+      maxExtraDataSize: 32, // Maximum size extra data may be after Genesis
     },
     pow: {
-      minimumDifficulty: {
-        v: 131072, // The minimum that the difficulty may ever be
-      },
-      difficultyBoundDivisor: {
-        v: 2048, // The bound divisor of the difficulty, used in the update calculations
-      },
-      durationLimit: {
-        v: 13, // The decision boundary on the blocktime duration used to determine whether difficulty should go up or not
-      },
-      epochDuration: {
-        v: 30000, // Duration between proof-of-work epochs
-      },
-      timebombPeriod: {
-        v: 100000, // Exponential difficulty timebomb period
-      },
-      minerReward: {
-        v: BigInt('5000000000000000000'), // the amount a miner get rewarded for mining a block
-      },
-      difficultyBombDelay: {
-        v: 0, // the amount of blocks to delay the difficulty bomb with
-      },
+      minimumDifficulty: 131072, // The minimum that the difficulty may ever be
+      difficultyBoundDivisor: 2048, // The bound divisor of the difficulty, used in the update calculations
+      durationLimit: 13, // The decision boundary on the blocktime duration used to determine whether difficulty should go up or not
+      epochDuration: 30000, // Duration between proof-of-work epochs
+      timebombPeriod: 100000, // Exponential difficulty timebomb period
+      minerReward: BigInt('5000000000000000000'), // the amount a miner get rewarded for mining a block
+      difficultyBombDelay: 0, // the amount of blocks to delay the difficulty bomb with
     },
   },
   homestead: {
@@ -342,9 +132,7 @@ export const hardforks: HardforksDict = {
     url: 'https://eips.ethereum.org/EIPS/eip-606',
     status: Status.Final,
     gasPrices: {
-      delegatecall: {
-        v: 40, // Base fee of the DELEGATECALL opcode
-      },
+      delegatecall: 40, // Base fee of the DELEGATECALL opcode
     },
   },
   dao: {
@@ -359,30 +147,14 @@ export const hardforks: HardforksDict = {
     url: 'https://eips.ethereum.org/EIPS/eip-608',
     status: Status.Final,
     gasPrices: {
-      sload: {
-        v: 200, // Once per SLOAD operation
-      },
-      call: {
-        v: 700, // Once per CALL operation & message call transaction
-      },
-      extcodesize: {
-        v: 700, // Base fee of the EXTCODESIZE opcode
-      },
-      extcodecopy: {
-        v: 700, // Base fee of the EXTCODECOPY opcode
-      },
-      balance: {
-        v: 400, // Base fee of the BALANCE opcode
-      },
-      delegatecall: {
-        v: 700, // Base fee of the DELEGATECALL opcode
-      },
-      callcode: {
-        v: 700, // Base fee of the CALLCODE opcode
-      },
-      selfdestruct: {
-        v: 5000, // Base fee of the SELFDESTRUCT opcode
-      },
+      sload: 200, // Once per SLOAD operation
+      call: 700, // Once per CALL operation & message call transaction
+      extcodesize: 700, // Base fee of the EXTCODESIZE opcode
+      extcodecopy: 700, // Base fee of the EXTCODECOPY opcode
+      balance: 400, // Base fee of the BALANCE opcode
+      delegatecall: 700, // Base fee of the DELEGATECALL opcode
+      callcode: 700, // Base fee of the CALLCODE opcode
+      selfdestruct: 5000, // Base fee of the SELFDESTRUCT opcode
     },
   },
   spuriousDragon: {
@@ -392,14 +164,10 @@ export const hardforks: HardforksDict = {
     url: 'https://eips.ethereum.org/EIPS/eip-607',
     status: Status.Final,
     gasPrices: {
-      expByte: {
-        v: 50, // Times ceil(log256(exponent)) for the EXP instruction
-      },
+      expByte: 50, // Times ceil(log256(exponent)) for the EXP instruction
     },
     vm: {
-      maxCodeSize: {
-        v: 24576, // Maximum length of contract code
-      },
+      maxCodeSize: 24576, // Maximum length of contract code
     },
   },
   byzantium: {
@@ -408,41 +176,19 @@ export const hardforks: HardforksDict = {
     url: 'https://eips.ethereum.org/EIPS/eip-609',
     status: Status.Final,
     gasPrices: {
-      modexpGquaddivisor: {
-        v: 20, // Gquaddivisor from modexp precompile for gas calculation
-      },
-      ecAdd: {
-        v: 500, // Gas costs for curve addition precompile
-      },
-      ecMul: {
-        v: 40000, // Gas costs for curve multiplication precompile
-      },
-      ecPairing: {
-        v: 100000, // Base gas costs for curve pairing precompile
-      },
-      ecPairingWord: {
-        v: 80000, // Gas costs regarding curve pairing precompile input length
-      },
-      revert: {
-        v: 0, // Base fee of the REVERT opcode
-      },
-      staticcall: {
-        v: 700, // Base fee of the STATICCALL opcode
-      },
-      returndatasize: {
-        v: 2, // Base fee of the RETURNDATASIZE opcode
-      },
-      returndatacopy: {
-        v: 3, // Base fee of the RETURNDATACOPY opcode
-      },
+      modexpGquaddivisor: 20, // Gquaddivisor from modexp precompile for gas calculation
+      ecAdd: 500, // Gas costs for curve addition precompile
+      ecMul: 40000, // Gas costs for curve multiplication precompile
+      ecPairing: 100000, // Base gas costs for curve pairing precompile
+      ecPairingWord: 80000, // Gas costs regarding curve pairing precompile input length
+      revert: 0, // Base fee of the REVERT opcode
+      staticcall: 700, // Base fee of the STATICCALL opcode
+      returndatasize: 2, // Base fee of the RETURNDATASIZE opcode
+      returndatacopy: 3, // Base fee of the RETURNDATACOPY opcode
     },
     pow: {
-      minerReward: {
-        v: BigInt('3000000000000000000'), // the amount a miner get rewarded for mining a block
-      },
-      difficultyBombDelay: {
-        v: 3000000, // the amount of blocks to delay the difficulty bomb with
-      },
+      minerReward: BigInt('3000000000000000000'), // the amount a miner get rewarded for mining a block
+      difficultyBombDelay: 3000000, // the amount of blocks to delay the difficulty bomb with
     },
   },
   constantinople: {
@@ -451,50 +197,22 @@ export const hardforks: HardforksDict = {
     url: 'https://eips.ethereum.org/EIPS/eip-1013',
     status: Status.Final,
     gasPrices: {
-      netSstoreNoopGas: {
-        v: 200, // Once per SSTORE operation if the value doesn't change
-      },
-      netSstoreInitGas: {
-        v: 20000, // Once per SSTORE operation from clean zero
-      },
-      netSstoreCleanGas: {
-        v: 5000, // Once per SSTORE operation from clean non-zero
-      },
-      netSstoreDirtyGas: {
-        v: 200, // Once per SSTORE operation from dirty
-      },
-      netSstoreClearRefund: {
-        v: 15000, // Once per SSTORE operation for clearing an originally existing storage slot
-      },
-      netSstoreResetRefund: {
-        v: 4800, // Once per SSTORE operation for resetting to the original non-zero value
-      },
-      netSstoreResetClearRefund: {
-        v: 19800, // Once per SSTORE operation for resetting to the original zero value
-      },
-      shl: {
-        v: 3, // Base fee of the SHL opcode
-      },
-      shr: {
-        v: 3, // Base fee of the SHR opcode
-      },
-      sar: {
-        v: 3, // Base fee of the SAR opcode
-      },
-      extcodehash: {
-        v: 400, // Base fee of the EXTCODEHASH opcode
-      },
-      create2: {
-        v: 32000, // Base fee of the CREATE2 opcode
-      },
+      netSstoreNoopGas: 200, // Once per SSTORE operation if the value doesn't change
+      netSstoreInitGas: 20000, // Once per SSTORE operation from clean zero
+      netSstoreCleanGas: 5000, // Once per SSTORE operation from clean non-zero
+      netSstoreDirtyGas: 200, // Once per SSTORE operation from dirty
+      netSstoreClearRefund: 15000, // Once per SSTORE operation for clearing an originally existing storage slot
+      netSstoreResetRefund: 4800, // Once per SSTORE operation for resetting to the original non-zero value
+      netSstoreResetClearRefund: 19800, // Once per SSTORE operation for resetting to the original zero value
+      shl: 3, // Base fee of the SHL opcode
+      shr: 3, // Base fee of the SHR opcode
+      sar: 3, // Base fee of the SAR opcode
+      extcodehash: 400, // Base fee of the EXTCODEHASH opcode
+      create2: 32000, // Base fee of the CREATE2 opcode
     },
     pow: {
-      minerReward: {
-        v: BigInt('2000000000000000000'), // The amount a miner gets rewarded for mining a block
-      },
-      difficultyBombDelay: {
-        v: 5000000, // the amount of blocks to delay the difficulty bomb with
-      },
+      minerReward: BigInt('2000000000000000000'), // The amount a miner gets rewarded for mining a block
+      difficultyBombDelay: 5000000, // the amount of blocks to delay the difficulty bomb with
     },
   },
   petersburg: {
@@ -504,27 +222,13 @@ export const hardforks: HardforksDict = {
     url: 'https://eips.ethereum.org/EIPS/eip-1716',
     status: Status.Final,
     gasPrices: {
-      netSstoreNoopGas: {
-        v: null, // Removed along EIP-1283
-      },
-      netSstoreInitGas: {
-        v: null, // Removed along EIP-1283
-      },
-      netSstoreCleanGas: {
-        v: null, // Removed along EIP-1283
-      },
-      netSstoreDirtyGas: {
-        v: null, // Removed along EIP-1283
-      },
-      netSstoreClearRefund: {
-        v: null, // Removed along EIP-1283
-      },
-      netSstoreResetRefund: {
-        v: null, // Removed along EIP-1283
-      },
-      netSstoreResetClearRefund: {
-        v: null, // Removed along EIP-1283
-      },
+      netSstoreNoopGas: null, // Removed along EIP-1283
+      netSstoreInitGas: null, // Removed along EIP-1283
+      netSstoreCleanGas: null, // Removed along EIP-1283
+      netSstoreDirtyGas: null, // Removed along EIP-1283
+      netSstoreClearRefund: null, // Removed along EIP-1283
+      netSstoreResetRefund: null, // Removed along EIP-1283
+      netSstoreResetClearRefund: null, // Removed along EIP-1283
     },
   },
   istanbul: {
@@ -534,63 +238,25 @@ export const hardforks: HardforksDict = {
     status: Status.Final,
     gasConfig: {},
     gasPrices: {
-      blake2Round: {
-        v: 1, // Gas cost per round for the Blake2 F precompile
-      },
-      ecAdd: {
-        v: 150, // Gas costs for curve addition precompile
-      },
-      ecMul: {
-        v: 6000, // Gas costs for curve multiplication precompile
-      },
-      ecPairing: {
-        v: 45000, // Base gas costs for curve pairing precompile
-      },
-      ecPairingWord: {
-        v: 34000, // Gas costs regarding curve pairing precompile input length
-      },
-      txDataNonZero: {
-        v: 16, // Per byte of data attached to a transaction that is not equal to zero. NOTE: Not payable on data of calls between transactions
-      },
-      sstoreSentryGasEIP2200: {
-        v: 2300, // Minimum gas required to be present for an SSTORE call, not consumed
-      },
-      sstoreNoopGasEIP2200: {
-        v: 800, // Once per SSTORE operation if the value doesn't change
-      },
-      sstoreDirtyGasEIP2200: {
-        v: 800, // Once per SSTORE operation if a dirty value is changed
-      },
-      sstoreInitGasEIP2200: {
-        v: 20000, // Once per SSTORE operation from clean zero to non-zero
-      },
-      sstoreInitRefundEIP2200: {
-        v: 19200, // Once per SSTORE operation for resetting to the original zero value
-      },
-      sstoreCleanGasEIP2200: {
-        v: 5000, // Once per SSTORE operation from clean non-zero to something else
-      },
-      sstoreCleanRefundEIP2200: {
-        v: 4200, // Once per SSTORE operation for resetting to the original non-zero value
-      },
-      sstoreClearRefundEIP2200: {
-        v: 15000, // Once per SSTORE operation for clearing an originally existing storage slot
-      },
-      balance: {
-        v: 700, // Base fee of the BALANCE opcode
-      },
-      extcodehash: {
-        v: 700, // Base fee of the EXTCODEHASH opcode
-      },
-      chainid: {
-        v: 2, // Base fee of the CHAINID opcode
-      },
-      selfbalance: {
-        v: 5, // Base fee of the SELFBALANCE opcode
-      },
-      sload: {
-        v: 800, // Base fee of the SLOAD opcode
-      },
+      blake2Round: 1, // Gas cost per round for the Blake2 F precompile
+      ecAdd: 150, // Gas costs for curve addition precompile
+      ecMul: 6000, // Gas costs for curve multiplication precompile
+      ecPairing: 45000, // Base gas costs for curve pairing precompile
+      ecPairingWord: 34000, // Gas costs regarding curve pairing precompile input length
+      txDataNonZero: 16, // Per byte of data attached to a transaction that is not equal to zero. NOTE: Not payable on data of calls between transactions
+      sstoreSentryGasEIP2200: 2300, // Minimum gas required to be present for an SSTORE call, not consumed
+      sstoreNoopGasEIP2200: 800, // Once per SSTORE operation if the value doesn't change
+      sstoreDirtyGasEIP2200: 800, // Once per SSTORE operation if a dirty value is changed
+      sstoreInitGasEIP2200: 20000, // Once per SSTORE operation from clean zero to non-zero
+      sstoreInitRefundEIP2200: 19200, // Once per SSTORE operation for resetting to the original zero value
+      sstoreCleanGasEIP2200: 5000, // Once per SSTORE operation from clean non-zero to something else
+      sstoreCleanRefundEIP2200: 4200, // Once per SSTORE operation for resetting to the original non-zero value
+      sstoreClearRefundEIP2200: 15000, // Once per SSTORE operation for clearing an originally existing storage slot
+      balance: 700, // Base fee of the BALANCE opcode
+      extcodehash: 700, // Base fee of the EXTCODEHASH opcode
+      chainid: 2, // Base fee of the CHAINID opcode
+      selfbalance: 5, // Base fee of the SELFBALANCE opcode
+      sload: 800, // Base fee of the SLOAD opcode
     },
   },
   muirGlacier: {
@@ -599,9 +265,7 @@ export const hardforks: HardforksDict = {
     url: 'https://eips.ethereum.org/EIPS/eip-2384',
     status: Status.Final,
     pow: {
-      difficultyBombDelay: {
-        v: 9000000, // the amount of blocks to delay the difficulty bomb with
-      },
+      difficultyBombDelay: 9000000, // the amount of blocks to delay the difficulty bomb with
     },
   },
   berlin: {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -168,7 +168,6 @@ export interface HardforkByOpts {
 
 type ParamDict = {
   v: number | bigint | null
-  d: string
 }
 
 export type EIPOrHFConfig = {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -166,28 +166,24 @@ export interface HardforkByOpts {
   td?: BigIntLike | string
 }
 
-type ParamDict = {
-  v: number | bigint | null
-}
-
 export type EIPOrHFConfig = {
   comment: string
   url: string
   status: string
   gasConfig?: {
-    [key: string]: ParamDict
+    [key: string]: number | bigint | null
   }
   gasPrices?: {
-    [key: string]: ParamDict
+    [key: string]: number | bigint | null
   }
   pow?: {
-    [key: string]: ParamDict
+    [key: string]: number | bigint | null
   }
   sharding?: {
-    [key: string]: ParamDict
+    [key: string]: number | bigint | null
   }
   vm?: {
-    [key: string]: ParamDict
+    [key: string]: number | bigint | null
   }
 }
 

--- a/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts
@@ -85,21 +85,6 @@ const PREBALANCE = BigInt(10000000)
 
 // array of different deployment configurations
 const deploymentConfigs = [
-  // original configuration
-  [
-    // contract code
-    '0x60203611603157600143035f35116029575f356120000143116029576120005f3506545f5260205ff35b5f5f5260205ff35b5f5ffd00',
-    // deployment tx input
-    '0x60368060095f395ff360203611603157600143035f35116029575f356120000143116029576120005f3506545f5260205ff35b5f5f5260205ff35b5f5ffd00',
-    // v r s
-    ['0x1b', '0x539', '0x1b9b6eb1f0'],
-    // sender, hash, deployed address
-    [
-      '0xa4690f0ed0d089faa1e0ad94c8f1b4a2fd4b0734',
-      '0x7ba81426bfa88a2cf4ea5c9abbbe83619505acd1173bc8450f93cf17cde3784b',
-      '0x25a219378dad9b3503c8268c9ca836a52427a4fb',
-    ],
-  ],
   // may 25 configuration with set on the lines of 4788
   [
     // contract code

--- a/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts
@@ -189,7 +189,7 @@ describe('EIP 2935: historical block hashes', () => {
       commonGenesis.setHardforkBy({
         timestamp: 1,
       })
-      commonGenesis['_paramsCache']['vm']['historyStorageAddress'].v = bytesToBigInt(
+      commonGenesis['_paramsCache']['vm']['historyStorageAddress'] = bytesToBigInt(
         historyAddress.bytes
       )
 


### PR DESCRIPTION
This change is inspired by #3448 and refactors the following files by removing any description string fields and instead including them as comments to reduce code size:
* `eips.ts`
* `hardforks.ts`