### PR TITLE
Common: replace static methods

### DIFF
--- a/packages/block/test/eip4844block.spec.ts
+++ b/packages/block/test/eip4844block.spec.ts
@@ -1,4 +1,4 @@
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
 import {
   blobsToCommitments,
@@ -24,7 +24,7 @@ describe('EIP4844 header tests', () => {
   beforeAll(async () => {
     const kzg = await loadKZG()
 
-    common = Common.fromGethGenesis(gethGenesis, {
+    common = createCommonFromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
       customCrypto: { kzg },
@@ -102,7 +102,7 @@ describe('blob gas tests', () => {
   let blobGasPerBlob: bigint
   beforeAll(async () => {
     const kzg = await loadKZG()
-    common = Common.fromGethGenesis(gethGenesis, {
+    common = createCommonFromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
       customCrypto: { kzg },
@@ -159,7 +159,7 @@ describe('transaction validation tests', () => {
   let blobGasPerBlob: bigint
   beforeAll(async () => {
     kzg = await loadKZG()
-    common = Common.fromGethGenesis(gethGenesis, {
+    common = createCommonFromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
       customCrypto: { kzg },

--- a/packages/block/test/from-beacon-payload.spec.ts
+++ b/packages/block/test/from-beacon-payload.spec.ts
@@ -1,4 +1,4 @@
-import { Common, Hardfork } from '@ethereumjs/common'
+import { Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import { loadKZG } from 'kzg-wasm'
 import { assert, beforeAll, describe, it } from 'vitest'
 
@@ -12,6 +12,7 @@ import * as payload87475 from './testdata/payload-slot-87475.json'
 import * as testnetVerkleKaustinen from './testdata/testnetVerkleKaustinen.json'
 
 import type { BeaconPayloadJson } from '../src/index.js'
+import type { Common } from '@ethereumjs/common'
 import type { VerkleExecutionWitness } from '@ethereumjs/util'
 
 describe('[fromExecutionPayloadJson]: 4844 devnet 5', () => {
@@ -22,7 +23,7 @@ describe('[fromExecutionPayloadJson]: 4844 devnet 5', () => {
     const commonJson = { ...shardingJson }
     commonJson.config = { ...commonJson.config, chainId: 4844001005 }
     const network = 'sharding'
-    common = Common.fromGethGenesis(commonJson, { chain: network, customCrypto: { kzg } })
+    common = createCommonFromGethGenesis(commonJson, { chain: network, customCrypto: { kzg } })
     // safely change chainId without modifying undelying json
 
     common.setHardfork(Hardfork.Cancun)
@@ -87,7 +88,7 @@ describe('[fromExecutionPayloadJson]: kaustinen', () => {
   const network = 'kaustinen'
 
   // safely change chainId without modifying undelying json
-  const common = Common.fromGethGenesis(testnetVerkleKaustinen, {
+  const common = createCommonFromGethGenesis(testnetVerkleKaustinen, {
     chain: network,
     eips: [6800],
   })

--- a/packages/blockchain/examples/gethGenesis.ts
+++ b/packages/blockchain/examples/gethGenesis.ts
@@ -1,11 +1,11 @@
 import { createBlockchain } from '@ethereumjs/blockchain'
-import { Common, parseGethGenesis } from '@ethereumjs/common'
+import { Common, createCommonFromGethGenesis, parseGethGenesis } from '@ethereumjs/common'
 import { bytesToHex, parseGethGenesisState } from '@ethereumjs/util'
 import gethGenesisJson from './genesisData/post-merge.json'
 
 const main = async () => {
   // Load geth genesis json file into lets say `gethGenesisJson`
-  const common = Common.fromGethGenesis(gethGenesisJson, { chain: 'customChain' })
+  const common = createCommonFromGethGenesis(gethGenesisJson, { chain: 'customChain' })
   const genesisState = parseGethGenesisState(gethGenesisJson)
   const blockchain = await createBlockchain({
     genesisState,

--- a/packages/blockchain/test/clique.spec.ts
+++ b/packages/blockchain/test/clique.spec.ts
@@ -1,5 +1,12 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Chain, Common, ConsensusAlgorithm, ConsensusType, Hardfork } from '@ethereumjs/common'
+import {
+  Chain,
+  Common,
+  ConsensusAlgorithm,
+  ConsensusType,
+  Hardfork,
+  createCustomCommon,
+} from '@ethereumjs/common'
 import { Address, concatBytes, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
@@ -608,7 +615,7 @@ describe('Clique: Initialization', () => {
   })
 
   it('Clique Voting: Epoch transitions reset all votes to allow chain checkpointing', async () => {
-    const common = Common.custom(
+    const common = createCustomCommon(
       {
         consensus: {
           type: ConsensusType.ProofOfAuthority,
@@ -664,7 +671,7 @@ describe('Clique: Initialization', () => {
   })
 
   it('Clique Voting: Recent signatures should not reset on checkpoint blocks imported in a batch', async () => {
-    const common = Common.custom(
+    const common = createCustomCommon(
       {
         consensus: {
           type: ConsensusType.ProofOfAuthority,
@@ -811,7 +818,7 @@ describe('clique: reorgs', () => {
   it(
     'Two signers, voting to add one other signer, epoch transition, then reorg and revoke this addition',
     async (st) => {
-      const common = Common.custom(
+      const common = createCustomCommon(
         {
           consensus: {
             type: ConsensusType.ProofOfAuthority,

--- a/packages/blockchain/test/utils.spec.ts
+++ b/packages/blockchain/test/utils.spec.ts
@@ -1,4 +1,4 @@
-import { Common } from '@ethereumjs/common'
+import { createCommonFromGethGenesis } from '@ethereumjs/common'
 import { genesisStateRoot } from '@ethereumjs/trie'
 import { bytesToHex, parseGethGenesisState } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
@@ -11,7 +11,7 @@ import gethGenesisKilnJSON from './testdata/geth-genesis-kiln.json'
 import type { Blockchain } from '../src/blockchain.js'
 
 async function getBlockchain(gethGenesis: any): Promise<Blockchain> {
-  const common = Common.fromGethGenesis(gethGenesis, { chain: 'kiln' })
+  const common = createCommonFromGethGenesis(gethGenesis, { chain: 'kiln' })
   const genesisState = parseGethGenesisState(gethGenesis)
   const blockchain = await createBlockchain({
     genesisState,

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -2,7 +2,14 @@
 
 import { createBlockFromValuesArray } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
-import { Chain, Common, ConsensusAlgorithm, Hardfork } from '@ethereumjs/common'
+import {
+  Chain,
+  Common,
+  ConsensusAlgorithm,
+  Hardfork,
+  createCommonFromGethGenesis,
+  getInitializedChains,
+} from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import {
   Address,
@@ -63,7 +70,7 @@ import type { Server as RPCServer } from 'jayson/promise/index.js'
 
 type Account = [address: Address, privateKey: Uint8Array]
 
-const networks = Object.entries(Common.getInitializedChains().names)
+const networks = Object.entries(getInitializedChains().names)
 
 let logger: Logger
 
@@ -768,7 +775,10 @@ async function setupDevnet(prefundAddress: Address) {
     extraData,
     alloc: { [addr]: { balance: '0x10000000000000000000' } },
   }
-  const common = Common.fromGethGenesis(chainData, { chain: 'devnet', hardfork: Hardfork.London })
+  const common = createCommonFromGethGenesis(chainData, {
+    chain: 'devnet',
+    hardfork: Hardfork.London,
+  })
   const customGenesisState = parseGethGenesisState(chainData)
   return { common, customGenesisState }
 }
@@ -1003,7 +1013,7 @@ async function run() {
     // Use geth genesis parameters file if specified
     const genesisFile = JSON.parse(readFileSync(args.gethGenesis, 'utf-8'))
     const chainName = path.parse(args.gethGenesis).base.split('.')[0]
-    common = Common.fromGethGenesis(genesisFile, {
+    common = createCommonFromGethGenesis(genesisFile, {
       chain: chainName,
       mergeForkIdPostMerge: args.mergeForkIdPostMerge,
     })

--- a/packages/client/devnets/4844-interop/tools/txGenerator.ts
+++ b/packages/client/devnets/4844-interop/tools/txGenerator.ts
@@ -29,7 +29,7 @@ async function getNonce(client: Client, account: string) {
 async function run(data: any) {
   const kzg = await loadKZG()
 
-  const common = Common.fromGethGenesis(genesisJson, {
+  const common = createCommonFromGethGenesis(genesisJson, {
     chain: genesisJson.ChainName ?? 'devnet',
     hardfork: Hardfork.Cancun,
     customCrypto: { kzg },

--- a/packages/client/test/integration/beaconsync.spec.ts
+++ b/packages/client/test/integration/beaconsync.spec.ts
@@ -1,5 +1,5 @@
 import { BlockHeader } from '@ethereumjs/block'
-import { Common } from '@ethereumjs/common'
+import { createCommonFromGethGenesis } from '@ethereumjs/common'
 import { assert, describe, it, vi } from 'vitest'
 
 import { Event } from '../../src/types.js'
@@ -7,7 +7,7 @@ import genesisJSON from '../testdata/geth-genesis/post-merge.json'
 
 import { destroy, setup, wait } from './util.js'
 
-const common = Common.fromGethGenesis(genesisJSON, { chain: 'post-merge' })
+const common = createCommonFromGethGenesis(genesisJSON, { chain: 'post-merge' })
 common.setHardforkBy({ blockNumber: BigInt(0), td: BigInt(0) })
 
 describe('should sync blocks', async () => {

--- a/packages/client/test/integration/merge.spec.ts
+++ b/packages/client/test/integration/merge.spec.ts
@@ -2,10 +2,10 @@ import { BlockHeader } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
 import {
   Chain as ChainCommon,
-  Common,
   ConsensusAlgorithm,
   ConsensusType,
   Hardfork,
+  createCustomCommon,
 } from '@ethereumjs/common'
 import { Address, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
@@ -19,8 +19,9 @@ import { MockServer } from './mocks/mockserver.js'
 import { destroy, setup } from './util.js'
 
 import type { CliqueConsensus } from '@ethereumjs/blockchain'
+import type { Common } from '@ethereumjs/common'
 
-const commonPoA = Common.custom(
+const commonPoA = createCustomCommon(
   {
     consensus: {
       type: ConsensusType.ProofOfAuthority,
@@ -43,7 +44,7 @@ const commonPoA = Common.custom(
   },
   { baseChain: ChainCommon.Goerli, hardfork: Hardfork.London }
 )
-const commonPoW = Common.custom(
+const commonPoW = createCustomCommon(
   {
     genesis: {
       gasLimit: 16777216,

--- a/packages/client/test/integration/miner.spec.ts
+++ b/packages/client/test/integration/miner.spec.ts
@@ -5,6 +5,7 @@ import {
   ConsensusAlgorithm,
   ConsensusType,
   Hardfork,
+  createCustomCommon,
 } from '@ethereumjs/common'
 import { Address, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
@@ -27,7 +28,7 @@ const hardforks = new Common({ chain: ChainCommon.Goerli })
       ? { ...h, block: 0, timestamp: undefined }
       : { ...h, timestamp: undefined }
   )
-const common = Common.custom(
+const common = createCustomCommon(
   {
     hardforks,
     consensus: {

--- a/packages/client/test/integration/pow.spec.ts
+++ b/packages/client/test/integration/pow.spec.ts
@@ -1,4 +1,4 @@
-import { Common, Hardfork } from '@ethereumjs/common'
+import { Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import { Address, hexToBytes, parseGethGenesisState } from '@ethereumjs/util'
 import { rmSync } from 'fs'
 import { assert, describe, it } from 'vitest'
@@ -49,7 +49,10 @@ async function setupPowDevnet(prefundAddress: Address, cleanStart: boolean) {
     extraData,
     alloc: { [addr]: { balance: '0x10000000000000000000' } },
   }
-  const common = Common.fromGethGenesis(chainData, { chain: 'devnet', hardfork: Hardfork.London })
+  const common = createCommonFromGethGenesis(chainData, {
+    chain: 'devnet',
+    hardfork: Hardfork.London,
+  })
   const customGenesisState = parseGethGenesisState(chainData)
 
   const config = new Config({

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -1,5 +1,11 @@
 import { BlockHeader, createBlockFromBlockData } from '@ethereumjs/block'
-import { Common, Chain as CommonChain, Hardfork } from '@ethereumjs/common'
+import {
+  Common,
+  Chain as CommonChain,
+  Hardfork,
+  createCommonFromGethGenesis,
+  createCustomCommon,
+} from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { FeeMarketEIP1559Transaction, LegacyTransaction } from '@ethereumjs/tx'
 import { Address, equalsBytes, hexToBytes } from '@ethereumjs/util'
@@ -130,7 +136,7 @@ const chainData = {
   extraData,
   alloc: { [addr]: { balance: '0x10000000000000000000' } },
 }
-const customCommon = Common.fromGethGenesis(chainData, {
+const customCommon = createCommonFromGethGenesis(chainData, {
   chain: 'devnet',
   hardfork: Hardfork.Berlin,
 })
@@ -407,7 +413,7 @@ describe('assembleBlocks() -> with saveReceipts', async () => {
 
 describe('assembleBlocks() -> should not include tx under the baseFee', async () => {
   const customChainParams = { hardforks: [{ name: 'london', block: 0 }] }
-  const common = Common.custom(customChainParams, {
+  const common = createCustomCommon(customChainParams, {
     baseChain: CommonChain.Goerli,
     hardfork: Hardfork.London,
   })
@@ -588,7 +594,7 @@ describe.skip('should handle mining over the london hardfork block', async () =>
       { name: 'london', block: 3 },
     ],
   }
-  const common = Common.custom(customChainParams, { baseChain: CommonChain.Goerli })
+  const common = createCustomCommon(customChainParams, { baseChain: CommonChain.Goerli })
   common.setHardforkBy({ blockNumber: 0 })
   const config = new Config({
     accountCache: 10000,
@@ -696,7 +702,7 @@ describe.skip('should handle mining ethash PoW', async () => {
     extraData,
     alloc: { [addr]: { balance: '0x10000000000000000000' } },
   }
-  const common = Common.fromGethGenesis(chainData, {
+  const common = createCommonFromGethGenesis(chainData, {
     chain: 'devnet',
     hardfork: Hardfork.London,
   })

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -1,5 +1,10 @@
 import { Block, BlockHeader } from '@ethereumjs/block'
-import { Common, Chain as CommonChain, Hardfork } from '@ethereumjs/common'
+import {
+  Common,
+  Chain as CommonChain,
+  Hardfork,
+  createCommonFromGethGenesis,
+} from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import {
   BlobEIP4844Transaction,
@@ -356,7 +361,7 @@ describe('[PendingBlock]', async () => {
 
   it('construct blob bundles', async () => {
     const kzg = await loadKZG()
-    const common = Common.fromGethGenesis(gethGenesis, {
+    const common = createCommonFromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
       customCrypto: {
@@ -437,7 +442,7 @@ describe('[PendingBlock]', async () => {
     const gethGenesis = await import('../../../block/test/testdata/4844-hardfork.json')
     const kzg = await loadKZG()
 
-    const common = Common.fromGethGenesis(gethGenesis, {
+    const common = createCommonFromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
       customCrypto: { kzg },

--- a/packages/client/test/rpc/debug/getRawBlock.spec.ts
+++ b/packages/client/test/rpc/debug/getRawBlock.spec.ts
@@ -1,5 +1,5 @@
 import { BlockHeader, createBlockFromBlockData } from '@ethereumjs/block'
-import { Common } from '@ethereumjs/common'
+import { createCustomCommon } from '@ethereumjs/common'
 import { BlobEIP4844Transaction, LegacyTransaction } from '@ethereumjs/tx'
 import { Address, bytesToHex, hexToBytes } from '@ethereumjs/util'
 import { loadKZG } from 'kzg-wasm'
@@ -10,7 +10,7 @@ import { createClient, createManager, dummy, getRpcClient, startRPC } from '../h
 
 const kzg = await loadKZG()
 
-const common = Common.custom({ chainId: 1 }, { customCrypto: { kzg } })
+const common = createCustomCommon({ chainId: 1 }, { customCrypto: { kzg } })
 
 common.setHardfork('cancun')
 const mockedTx1 = LegacyTransaction.fromTxData({}).sign(dummy.privKey)

--- a/packages/client/test/rpc/debug/getRawHeader.spec.ts
+++ b/packages/client/test/rpc/debug/getRawHeader.spec.ts
@@ -1,5 +1,5 @@
 import { BlockHeader, createBlockFromBlockData } from '@ethereumjs/block'
-import { Common } from '@ethereumjs/common'
+import { createCustomCommon } from '@ethereumjs/common'
 import { BlobEIP4844Transaction, LegacyTransaction } from '@ethereumjs/tx'
 import { Address, bytesToHex, hexToBytes } from '@ethereumjs/util'
 import { loadKZG } from 'kzg-wasm'
@@ -10,7 +10,7 @@ import { createClient, createManager, dummy, getRpcClient, startRPC } from '../h
 
 const kzg = await loadKZG()
 
-const common = Common.custom({ chainId: 1 }, { customCrypto: { kzg } })
+const common = createCustomCommon({ chainId: 1 }, { customCrypto: { kzg } })
 
 common.setHardfork('cancun')
 const mockedTx1 = LegacyTransaction.fromTxData({}).sign(dummy.privKey)

--- a/packages/client/test/rpc/debug/getRawReceipts.spec.ts
+++ b/packages/client/test/rpc/debug/getRawReceipts.spec.ts
@@ -1,4 +1,4 @@
-import { Common, Hardfork } from '@ethereumjs/common'
+import { Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import {
   BlobEIP4844Transaction,
   FeeMarketEIP1559Transaction,
@@ -108,7 +108,7 @@ describe(method, () => {
 
       const kzg = await loadKZG()
 
-      const common = Common.fromGethGenesis(gethGenesis, {
+      const common = createCommonFromGethGenesis(gethGenesis, {
         chain: 'customChain',
         hardfork: Hardfork.Cancun,
         customCrypto: {

--- a/packages/client/test/rpc/eth/estimateGas.spec.ts
+++ b/packages/client/test/rpc/eth/estimateGas.spec.ts
@@ -1,6 +1,6 @@
 import { BlockHeader, createBlockFromBlockData } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
-import { Common } from '@ethereumjs/common'
+import { createCommonFromGethGenesis } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
 import { LegacyTransaction } from '@ethereumjs/tx'
 import { Address, bigIntToHex } from '@ethereumjs/util'
@@ -21,7 +21,10 @@ describe(
     it('call with valid arguments', async () => {
       // Use custom genesis so we can test EIP1559 txs more easily
       const genesisJson = await import('../../testdata/geth-genesis/rpctestnet.json')
-      const common = Common.fromGethGenesis(genesisJson, { chain: 'testnet', hardfork: 'berlin' })
+      const common = createCommonFromGethGenesis(genesisJson, {
+        chain: 'testnet',
+        hardfork: 'berlin',
+      })
       const blockchain = await createBlockchain({
         common,
         validateBlocks: false,

--- a/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
+++ b/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Common } from '@ethereumjs/common'
+import { createCustomCommon } from '@ethereumjs/common'
 import { BlobEIP4844Transaction, LegacyTransaction } from '@ethereumjs/tx'
 import { Address, hexToBytes } from '@ethereumjs/util'
 import { loadKZG } from 'kzg-wasm'
@@ -10,7 +10,7 @@ import { createClient, createManager, dummy, getRpcClient, startRPC } from '../h
 
 const kzg = await loadKZG()
 
-const common = Common.custom({ chainId: 1 }, { customCrypto: { kzg } })
+const common = createCustomCommon({ chainId: 1 }, { customCrypto: { kzg } })
 
 common.setHardfork('cancun')
 const mockedTx1 = LegacyTransaction.fromTxData({}).sign(dummy.privKey)

--- a/packages/client/test/rpc/eth/getBlockReceipts.spec.ts
+++ b/packages/client/test/rpc/eth/getBlockReceipts.spec.ts
@@ -1,4 +1,4 @@
-import { Common, Hardfork } from '@ethereumjs/common'
+import { Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import {
   BlobEIP4844Transaction,
   FeeMarketEIP1559Transaction,
@@ -111,7 +111,7 @@ describe(method, () => {
 
       const kzg = await loadKZG()
 
-      const common = Common.fromGethGenesis(gethGenesis, {
+      const common = createCommonFromGethGenesis(gethGenesis, {
         chain: 'customChain',
         hardfork: Hardfork.Cancun,
         customCrypto: {

--- a/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
@@ -1,4 +1,4 @@
-import { Common, Hardfork } from '@ethereumjs/common'
+import { Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import {
   BlobEIP4844Transaction,
   FeeMarketEIP1559Transaction,
@@ -91,7 +91,7 @@ describe(method, () => {
 
       const kzg = await loadKZG()
 
-      const common = Common.fromGethGenesis(gethGenesis, {
+      const common = createCommonFromGethGenesis(gethGenesis, {
         chain: 'customChain',
         hardfork: Hardfork.Cancun,
         customCrypto: {

--- a/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
+++ b/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
@@ -1,5 +1,5 @@
 import { BlockHeader } from '@ethereumjs/block'
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import {
   BlobEIP4844Transaction,
@@ -221,7 +221,7 @@ describe(method, () => {
 
     const kzg = await loadKZG()
 
-    const common = Common.fromGethGenesis(gethGenesis, {
+    const common = createCommonFromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
       customCrypto: { kzg },

--- a/packages/client/test/service/fullethereumservice.spec.ts
+++ b/packages/client/test/service/fullethereumservice.spec.ts
@@ -1,4 +1,4 @@
-import { Common, Hardfork } from '@ethereumjs/common'
+import { Common, Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import { TransactionFactory, TransactionType } from '@ethereumjs/tx'
 import { equalsBytes, hexToBytes, randomBytes } from '@ethereumjs/util'
 import { assert, describe, expect, it, vi } from 'vitest'
@@ -390,7 +390,7 @@ describe.skip('should handle structuring NewPooledTransactionHashes with eth/68 
 })
 
 describe('should start on beacon sync when past merge', async () => {
-  const common = Common.fromGethGenesis(genesisJSON, { chain: 'post-merge' })
+  const common = createCommonFromGethGenesis(genesisJSON, { chain: 'post-merge' })
   common.setHardforkBy({ blockNumber: BigInt(0), td: BigInt(0) })
   const config = new Config({ accountCache: 10000, storageCache: 1000, common })
   const chain = await Chain.create({ config })

--- a/packages/client/test/sim/4844-blobpost.spec.ts
+++ b/packages/client/test/sim/4844-blobpost.spec.ts
@@ -1,4 +1,4 @@
-import { Common } from '@ethereumjs/common'
+import { createCommonFromGethGenesis } from '@ethereumjs/common'
 import { bytesToHex, hexToBytes, privateToAddress } from '@ethereumjs/util'
 import { Client } from 'jayson/promise'
 import { randomBytes } from 'node:crypto'
@@ -39,7 +39,7 @@ const shardingJson = require(`./configs/${network}.json`)
 // safely change chainId without modifying undelying json
 const commonJson = { ...shardingJson }
 commonJson.config = { ...commonJson.config, chainId }
-const common = Common.fromGethGenesis(commonJson, { chain: network })
+const common = createCommonFromGethGenesis(commonJson, { chain: network })
 
 export async function runTx(data: PrefixedHexString, to?: PrefixedHexString, value?: bigint) {
   return runTxHelper({ client, common, sender, pkey }, data, to, value)

--- a/packages/client/test/sim/4844-devnet.spec.ts
+++ b/packages/client/test/sim/4844-devnet.spec.ts
@@ -1,4 +1,4 @@
-import { Common } from '@ethereumjs/common'
+import { createCommonFromGethGenesis } from '@ethereumjs/common'
 import { TransactionFactory } from '@ethereumjs/tx'
 import { bytesToHex, hexToBytes, privateToAddress } from '@ethereumjs/util'
 import { Client } from 'jayson/promise'
@@ -24,7 +24,7 @@ const client = Client.http({ port: 8545 })
 
 const network = '4844-devnet'
 const shardingJson = require(`./configs/${network}.json`)
-const common = Common.fromGethGenesis(shardingJson, { chain: network })
+const common = createCommonFromGethGenesis(shardingJson, { chain: network })
 
 export async function runTx(data: PrefixedHexString, to?: PrefixedHexString, value?: bigint) {
   return runTxHelper({ client, common, sender, pkey }, data, to, value)

--- a/packages/client/test/sim/beaconsync.spec.ts
+++ b/packages/client/test/sim/beaconsync.spec.ts
@@ -1,4 +1,4 @@
-import { Common } from '@ethereumjs/common'
+import { createCommonFromGethGenesis } from '@ethereumjs/common'
 import { bytesToHex, hexToBytes, parseGethGenesisState, privateToAddress } from '@ethereumjs/util'
 import debug from 'debug'
 import { Client } from 'jayson/promise'
@@ -26,7 +26,7 @@ const client = Client.http({ port: 8545 })
 
 const network = 'mainnet'
 const networkJson = require(`./configs/${network}.json`)
-const common = Common.fromGethGenesis(networkJson, { chain: network })
+const common = createCommonFromGethGenesis(networkJson, { chain: network })
 const customGenesisState = parseGethGenesisState(networkJson)
 
 const pkey = hexToBytes('0xae557af4ceefda559c924516cabf029bedc36b68109bf8d6183fe96e04121f4e')

--- a/packages/client/test/sim/eof.spec.ts
+++ b/packages/client/test/sim/eof.spec.ts
@@ -1,4 +1,4 @@
-import { Common } from '@ethereumjs/common'
+import { createCommonFromGethGenesis } from '@ethereumjs/common'
 import { bytesToHex, hexToBytes, privateToAddress } from '@ethereumjs/util'
 import { Client } from 'jayson/promise'
 import { assert, describe, it } from 'vitest'
@@ -19,7 +19,7 @@ const client = Client.http({ port: 8545 })
 
 const network = 'eof'
 const eofJson = require(`./configs/${network}.json`)
-const common = Common.fromGethGenesis(eofJson, { chain: network })
+const common = createCommonFromGethGenesis(eofJson, { chain: network })
 
 export async function runTx(data: PrefixedHexString | '', to?: PrefixedHexString, value?: bigint) {
   return runTxHelper({ client, common, sender, pkey }, data, to, value)

--- a/packages/client/test/sim/mainnet.spec.ts
+++ b/packages/client/test/sim/mainnet.spec.ts
@@ -1,4 +1,4 @@
-import { Common } from '@ethereumjs/common'
+import { createCommonFromGethGenesis } from '@ethereumjs/common'
 import { bytesToHex, hexToBytes, privateToAddress } from '@ethereumjs/util'
 import { Client } from 'jayson/promise'
 import { assert, describe, it } from 'vitest'
@@ -20,7 +20,7 @@ const client = Client.http({ port: 8545 })
 
 const network = 'mainnet'
 const eofJson = require(`./configs/${network}.json`)
-const common = Common.fromGethGenesis(eofJson, { chain: network })
+const common = createCommonFromGethGenesis(eofJson, { chain: network })
 
 export async function runTx(data: PrefixedHexString | '', to?: PrefixedHexString, value?: bigint) {
   return runTxHelper({ client, common, sender, pkey }, data, to, value)

--- a/packages/client/test/sim/snapsync.spec.ts
+++ b/packages/client/test/sim/snapsync.spec.ts
@@ -1,4 +1,4 @@
-import { Common } from '@ethereumjs/common'
+import { createCommonFromGethGenesis } from '@ethereumjs/common'
 import {
   Address,
   bytesToHex,
@@ -32,7 +32,7 @@ const client = Client.http({ port: 8545 })
 
 const network = 'mainnet'
 const networkJson = require(`./configs/${network}.json`)
-const common = Common.fromGethGenesis(networkJson, { chain: network })
+const common = createCommonFromGethGenesis(networkJson, { chain: network })
 const customGenesisState = parseGethGenesisState(networkJson)
 
 const pkey = hexToBytes('0xae557af4ceefda559c924516cabf029bedc36b68109bf8d6183fe96e04121f4e')

--- a/packages/client/test/sync/skeleton.spec.ts
+++ b/packages/client/test/sync/skeleton.spec.ts
@@ -1,5 +1,5 @@
 import { BlockHeader, createBlockFromBlockData } from '@ethereumjs/block'
-import { Common } from '@ethereumjs/common'
+import { Common, createCommonFromGethGenesis } from '@ethereumjs/common'
 import { equalsBytes, utf8ToBytes } from '@ethereumjs/util'
 import { MemoryLevel } from 'memory-level'
 import { assert, describe, it, vi } from 'vitest'
@@ -416,7 +416,7 @@ describe('[Skeleton] / setHead', async () => {
       extraData: '0x00000000000000000',
       difficulty: '0x1',
     }
-    const common = Common.fromGethGenesis(genesis, { chain: 'merge-not-set' })
+    const common = createCommonFromGethGenesis(genesis, { chain: 'merge-not-set' })
     const config = new Config({ common })
     const chain = await Chain.create({ config })
     ;(chain.blockchain as any)._validateBlocks = false
@@ -824,7 +824,7 @@ describe('[Skeleton] / setHead', async () => {
       extraData: '0x00000000000000000',
       difficulty: '0x1',
     }
-    const common = Common.fromGethGenesis(genesis, { chain: 'post-merge' })
+    const common = createCommonFromGethGenesis(genesis, { chain: 'post-merge' })
     common.setHardforkBy({ blockNumber: BigInt(0), td: BigInt(0) })
     const config = new Config({
       common,
@@ -928,7 +928,7 @@ describe('[Skeleton] / setHead', async () => {
       extraData: '0x00000000000000000',
       difficulty: '0x1',
     }
-    const common = Common.fromGethGenesis(genesis, { chain: 'post-merge' })
+    const common = createCommonFromGethGenesis(genesis, { chain: 'post-merge' })
     common.setHardforkBy({ blockNumber: BigInt(0), td: BigInt(0) })
     const config = new Config({
       common,
@@ -988,7 +988,7 @@ describe('[Skeleton] / setHead', async () => {
       },
       difficulty: '0x1',
     }
-    const common = Common.fromGethGenesis(genesis, { chain: 'post-merge' })
+    const common = createCommonFromGethGenesis(genesis, { chain: 'post-merge' })
     common.setHardforkBy({ blockNumber: BigInt(0), td: BigInt(0) })
     const config = new Config({
       common,

--- a/packages/common/examples/common.ts
+++ b/packages/common/examples/common.ts
@@ -1,4 +1,4 @@
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, createCustomCommon, Hardfork } from '@ethereumjs/common'
 
 // With enums:
 const commonWithEnums = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
@@ -23,5 +23,5 @@ c = new Common({ chain: Chain.Mainnet, eips: [4844] })
 console.log(`EIP 4844 is active -- ${c.isActivatedEIP(4844)}`)
 
 // Instantiate common with custom chainID
-const commonWithCustomChainId = Common.custom({ chainId: 1234 })
+const commonWithCustomChainId = createCustomCommon({ chainId: 1234 })
 console.log(`The current chain ID is ${commonWithCustomChainId.chainId}`)

--- a/packages/common/examples/fromGeth.ts
+++ b/packages/common/examples/fromGeth.ts
@@ -1,11 +1,11 @@
-import { Common } from '@ethereumjs/common'
+import { Common, createCommonFromGethGenesis } from '@ethereumjs/common'
 import { hexToBytes } from '@ethereumjs/util'
 
 import genesisJson from './genesisData/post-merge.json'
 
 const genesisHash = hexToBytes('0x3b8fb240d288781d4aac94d3fd16809ee413bc99294a085798a589dae51ddd4a')
 // Load geth genesis json file into lets say `genesisJson` and optional `chain` and `genesisHash`
-const common = Common.fromGethGenesis(genesisJson, { chain: 'customChain', genesisHash })
+const common = createCommonFromGethGenesis(genesisJson, { chain: 'customChain', genesisHash })
 // If you don't have `genesisHash` while initiating common, you can later configure common (for e.g.
 // after calculating it via `blockchain`)
 common.setForkHashes(genesisHash)

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -9,29 +9,25 @@ import {
 } from '@ethereumjs/util'
 import { EventEmitter } from 'events'
 
-import { chains as CHAIN_SPECS } from './chains.js'
 import { crc32 } from './crc.js'
 import { EIPs } from './eips.js'
-import { Chain, CustomChain, Hardfork } from './enums.js'
+import { Hardfork } from './enums.js'
 import { hardforks as HARDFORK_SPECS } from './hardforks.js'
-import { parseGethGenesis } from './utils.js'
 
-import type { ConsensusAlgorithm, ConsensusType } from './enums.js'
+import { _getChainParams } from './index.js'
+
+import type { Chain, ConsensusAlgorithm, ConsensusType } from './enums.js'
 import type {
   BootstrapNodeConfig,
   CasperConfig,
   ChainConfig,
-  ChainName,
-  ChainsConfig,
   CliqueConfig,
   CommonOpts,
-  CustomCommonOpts,
   CustomCrypto,
   EIPConfig,
   EIPOrHFConfig,
   EthashConfig,
   GenesisBlockConfig,
-  GethConfigOpts,
   HardforkByOpts,
   HardforkConfig,
   HardforkTransitionConfig,
@@ -68,171 +64,6 @@ export class Common {
 
   public events: EventEmitter
 
-  /**
-   * Creates a {@link Common} object for a custom chain, based on a standard one.
-   *
-   * It uses all the {@link Chain} parameters from the {@link baseChain} option except the ones overridden
-   * in a provided {@link chainParamsOrName} dictionary. Some usage example:
-   *
-   * ```javascript
-   * Common.custom({chainId: 123})
-   * ```
-   *
-   * There are also selected supported custom chains which can be initialized by using one of the
-   * {@link CustomChains} for {@link chainParamsOrName}, e.g.:
-   *
-   * ```javascript
-   * Common.custom(CustomChains.MaticMumbai)
-   * ```
-   *
-   * Note that these supported custom chains only provide some base parameters (usually the chain and
-   * network ID and a name) and can only be used for selected use cases (e.g. sending a tx with
-   * the `@ethereumjs/tx` library to a Layer-2 chain).
-   *
-   * @param chainParamsOrName Custom parameter dict (`name` will default to `custom-chain`) or string with name of a supported custom chain
-   * @param opts Custom chain options to set the {@link CustomCommonOpts.baseChain}, selected {@link CustomCommonOpts.hardfork} and others
-   */
-  static custom(
-    chainParamsOrName: Partial<ChainConfig> | CustomChain,
-    opts: CustomCommonOpts = {}
-  ): Common {
-    const baseChain = opts.baseChain ?? 'mainnet'
-    const standardChainParams = { ...Common._getChainParams(baseChain) }
-    standardChainParams['name'] = 'custom-chain'
-
-    if (typeof chainParamsOrName !== 'string') {
-      return new Common({
-        chain: {
-          ...standardChainParams,
-          ...chainParamsOrName,
-        },
-        ...opts,
-      })
-    } else {
-      if (chainParamsOrName === CustomChain.PolygonMainnet) {
-        return Common.custom(
-          {
-            name: CustomChain.PolygonMainnet,
-            chainId: 137,
-            networkId: 137,
-          },
-          opts
-        )
-      }
-      if (chainParamsOrName === CustomChain.PolygonMumbai) {
-        return Common.custom(
-          {
-            name: CustomChain.PolygonMumbai,
-            chainId: 80001,
-            networkId: 80001,
-          },
-          opts
-        )
-      }
-      if (chainParamsOrName === CustomChain.ArbitrumOne) {
-        return Common.custom(
-          {
-            name: CustomChain.ArbitrumOne,
-            chainId: 42161,
-            networkId: 42161,
-          },
-          opts
-        )
-      }
-      if (chainParamsOrName === CustomChain.xDaiChain) {
-        return Common.custom(
-          {
-            name: CustomChain.xDaiChain,
-            chainId: 100,
-            networkId: 100,
-          },
-          opts
-        )
-      }
-
-      if (chainParamsOrName === CustomChain.OptimisticKovan) {
-        return Common.custom(
-          {
-            name: CustomChain.OptimisticKovan,
-            chainId: 69,
-            networkId: 69,
-          },
-          opts
-        )
-      }
-
-      if (chainParamsOrName === CustomChain.OptimisticEthereum) {
-        return Common.custom(
-          {
-            name: CustomChain.OptimisticEthereum,
-            chainId: 10,
-            networkId: 10,
-          },
-          // Optimism has not implemented the London hardfork yet (targeting Q1.22)
-          { hardfork: Hardfork.Berlin, ...opts }
-        )
-      }
-      throw new Error(`Custom chain ${chainParamsOrName} not supported`)
-    }
-  }
-
-  /**
-   * Static method to load and set common from a geth genesis json
-   * @param genesisJson json of geth configuration
-   * @param { chain, eips, genesisHash, hardfork, mergeForkIdPostMerge } to further configure the common instance
-   * @returns Common
-   */
-  static fromGethGenesis(
-    genesisJson: any,
-    { chain, eips, genesisHash, hardfork, mergeForkIdPostMerge, customCrypto }: GethConfigOpts
-  ): Common {
-    const genesisParams = parseGethGenesis(genesisJson, chain, mergeForkIdPostMerge)
-    const common = new Common({
-      chain: genesisParams.name ?? 'custom',
-      customChains: [genesisParams],
-      eips,
-      hardfork: hardfork ?? genesisParams.hardfork,
-      customCrypto,
-    })
-    if (genesisHash !== undefined) {
-      common.setForkHashes(genesisHash)
-    }
-    return common
-  }
-
-  /**
-   * Static method to determine if a {@link chainId} is supported as a standard chain
-   * @param chainId bigint id (`1`) of a standard chain
-   * @returns boolean
-   */
-  static isSupportedChainId(chainId: bigint): boolean {
-    const initializedChains = this.getInitializedChains()
-    return Boolean((initializedChains['names'] as ChainName)[chainId.toString()])
-  }
-
-  protected static _getChainParams(
-    chain: string | number | Chain | bigint,
-    customChains?: ChainConfig[]
-  ): ChainConfig {
-    const initializedChains = this.getInitializedChains(customChains)
-    if (typeof chain === 'number' || typeof chain === 'bigint') {
-      chain = chain.toString()
-
-      if ((initializedChains['names'] as ChainName)[chain]) {
-        const name: string = (initializedChains['names'] as ChainName)[chain]
-        return initializedChains[name] as ChainConfig
-      }
-
-      throw new Error(`Chain with ID ${chain} not supported`)
-    }
-
-    if (initializedChains[chain] !== undefined) {
-      return initializedChains[chain] as ChainConfig
-    }
-
-    throw new Error(`Chain with name ${chain} not supported`)
-  }
-
   constructor(opts: CommonOpts) {
     this.events = new EventEmitter()
 
@@ -268,7 +99,7 @@ export class Common {
    */
   setChain(chain: string | number | Chain | bigint | object): ChainConfig {
     if (typeof chain === 'number' || typeof chain === 'bigint' || typeof chain === 'string') {
-      this._chainParams = Common._getChainParams(chain, this._customChains)
+      this._chainParams = _getChainParams(chain, this._customChains)
     } else if (typeof chain === 'object') {
       if (this._customChains.length > 0) {
         throw new Error(
@@ -1103,22 +934,5 @@ export class Common {
     const copy = Object.assign(Object.create(Object.getPrototypeOf(this)), this)
     copy.events = new EventEmitter()
     return copy
-  }
-
-  static getInitializedChains(customChains?: ChainConfig[]): ChainsConfig {
-    const names: ChainName = {}
-    for (const [name, id] of Object.entries(Chain)) {
-      names[id] = name.toLowerCase()
-    }
-    const chains = { ...CHAIN_SPECS } as ChainsConfig
-    if (customChains) {
-      for (const chain of customChains) {
-        const { name } = chain
-        names[chain.chainId.toString()] = name
-        chains[name] = chain
-      }
-    }
-    chains.names = names
-    return chains
   }
 }

--- a/packages/common/src/constructors.ts
+++ b/packages/common/src/constructors.ts
@@ -1,0 +1,135 @@
+import { Common, CustomChain, Hardfork, _getChainParams, parseGethGenesis } from './index.js'
+
+import type { ChainConfig, CustomCommonOpts, GethConfigOpts } from './index.js'
+
+/**
+ * Creates a {@link Common} object for a custom chain, based on a standard one.
+ *
+ * It uses all the {@link Chain} parameters from the {@link baseChain} option except the ones overridden
+ * in a provided {@link chainParamsOrName} dictionary. Some usage example:
+ *
+ * ```javascript
+ * createCustomCommon({chainId: 123})
+ * ```
+ *
+ * There are also selected supported custom chains which can be initialized by using one of the
+ * {@link CustomChains} for {@link chainParamsOrName}, e.g.:
+ *
+ * ```javascript
+ * createCustomCommon(CustomChains.MaticMumbai)
+ * ```
+ *
+ * Note that these supported custom chains only provide some base parameters (usually the chain and
+ * network ID and a name) and can only be used for selected use cases (e.g. sending a tx with
+ * the `@ethereumjs/tx` library to a Layer-2 chain).
+ *
+ * @param chainParamsOrName Custom parameter dict (`name` will default to `custom-chain`) or string with name of a supported custom chain
+ * @param opts Custom chain options to set the {@link CustomCommonOpts.baseChain}, selected {@link CustomCommonOpts.hardfork} and others
+ */
+export function createCustomCommon(
+  chainParamsOrName: Partial<ChainConfig> | CustomChain,
+  opts: CustomCommonOpts = {}
+): Common {
+  const baseChain = opts.baseChain ?? 'mainnet'
+  const standardChainParams = { ..._getChainParams(baseChain) }
+  standardChainParams['name'] = 'custom-chain'
+
+  if (typeof chainParamsOrName !== 'string') {
+    return new Common({
+      chain: {
+        ...standardChainParams,
+        ...chainParamsOrName,
+      },
+      ...opts,
+    })
+  } else {
+    if (chainParamsOrName === CustomChain.PolygonMainnet) {
+      return createCustomCommon(
+        {
+          name: CustomChain.PolygonMainnet,
+          chainId: 137,
+          networkId: 137,
+        },
+        opts
+      )
+    }
+    if (chainParamsOrName === CustomChain.PolygonMumbai) {
+      return createCustomCommon(
+        {
+          name: CustomChain.PolygonMumbai,
+          chainId: 80001,
+          networkId: 80001,
+        },
+        opts
+      )
+    }
+    if (chainParamsOrName === CustomChain.ArbitrumOne) {
+      return createCustomCommon(
+        {
+          name: CustomChain.ArbitrumOne,
+          chainId: 42161,
+          networkId: 42161,
+        },
+        opts
+      )
+    }
+    if (chainParamsOrName === CustomChain.xDaiChain) {
+      return createCustomCommon(
+        {
+          name: CustomChain.xDaiChain,
+          chainId: 100,
+          networkId: 100,
+        },
+        opts
+      )
+    }
+
+    if (chainParamsOrName === CustomChain.OptimisticKovan) {
+      return createCustomCommon(
+        {
+          name: CustomChain.OptimisticKovan,
+          chainId: 69,
+          networkId: 69,
+        },
+        opts
+      )
+    }
+
+    if (chainParamsOrName === CustomChain.OptimisticEthereum) {
+      return createCustomCommon(
+        {
+          name: CustomChain.OptimisticEthereum,
+          chainId: 10,
+          networkId: 10,
+        },
+        // Optimism has not implemented the London hardfork yet (targeting Q1.22)
+        { hardfork: Hardfork.Berlin, ...opts }
+      )
+    }
+    throw new Error(`Custom chain ${chainParamsOrName} not supported`)
+  }
+}
+
+/**
+ * Static method to load and set common from a geth genesis json
+ * @param genesisJson json of geth configuration
+ * @param { chain, eips, genesisHash, hardfork, mergeForkIdPostMerge } to further configure the common instance
+ * @returns Common
+ */
+export function createCommonFromGethGenesis(
+  genesisJson: any,
+  { chain, eips, genesisHash, hardfork, mergeForkIdPostMerge, customCrypto }: GethConfigOpts
+): Common {
+  const genesisParams = parseGethGenesis(genesisJson, chain, mergeForkIdPostMerge)
+  const common = new Common({
+    chain: genesisParams.name ?? 'custom',
+    customChains: [genesisParams],
+    eips,
+    hardfork: hardfork ?? genesisParams.hardfork,
+    customCrypto,
+  })
+  if (genesisHash !== undefined) {
+    common.setForkHashes(genesisHash)
+  }
+  return common
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,4 +1,5 @@
 export * from './common.js'
+export * from './constructors.js'
 export * from './enums.js'
 export * from './interfaces.js'
 export * from './types.js'

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,7 +1,9 @@
 import { intToHex, isHexString, stripHexPrefix } from '@ethereumjs/util'
 
-import { Hardfork } from './enums.js'
+import { chains as CHAIN_SPECS } from './chains.js'
+import { Chain, Hardfork } from './enums.js'
 
+import type { ChainConfig, ChainName, ChainsConfig } from './index.js'
 import type { PrefixedHexString } from '@ethereumjs/util'
 
 type ConfigHardfork =
@@ -235,4 +237,54 @@ export function parseGethGenesis(json: any, name?: string, mergeForkIdPostMerge?
   } catch (e: any) {
     throw new Error(`Error parsing parameters file: ${e.message}`)
   }
+}
+
+export function getInitializedChains(customChains?: ChainConfig[]): ChainsConfig {
+  const names: ChainName = {}
+  for (const [name, id] of Object.entries(Chain)) {
+    names[id] = name.toLowerCase()
+  }
+  const chains = { ...CHAIN_SPECS } as ChainsConfig
+  if (customChains) {
+    for (const chain of customChains) {
+      const { name } = chain
+      names[chain.chainId.toString()] = name
+      chains[name] = chain
+    }
+  }
+  chains.names = names
+  return chains
+}
+
+/**
+ * Determine if a {@link chainId} is supported as a standard chain
+ * @param chainId bigint id (`1`) of a standard chain
+ * @returns boolean
+ */
+export function isSupportedChainId(chainId: bigint): boolean {
+  const initializedChains = getInitializedChains()
+  return Boolean((initializedChains['names'] as ChainName)[chainId.toString()])
+}
+
+export function _getChainParams(
+  chain: string | number | Chain | bigint,
+  customChains?: ChainConfig[]
+): ChainConfig {
+  const initializedChains = getInitializedChains(customChains)
+  if (typeof chain === 'number' || typeof chain === 'bigint') {
+    chain = chain.toString()
+
+    if ((initializedChains['names'] as ChainName)[chain]) {
+      const name: string = (initializedChains['names'] as ChainName)[chain]
+      return initializedChains[name] as ChainConfig
+    }
+
+    throw new Error(`Chain with ID ${chain} not supported`)
+  }
+
+  if (initializedChains[chain] !== undefined) {
+    return initializedChains[chain] as ChainConfig
+  }
+
+  throw new Error(`Chain with name ${chain} not supported`)
 }

--- a/packages/common/test/chains.spec.ts
+++ b/packages/common/test/chains.spec.ts
@@ -1,6 +1,13 @@
 import { assert, describe, it } from 'vitest'
 
-import { Chain, Common, ConsensusAlgorithm, ConsensusType, Hardfork } from '../src/index.js'
+import {
+  Chain,
+  Common,
+  ConsensusAlgorithm,
+  ConsensusType,
+  Hardfork,
+  isSupportedChainId,
+} from '../src/index.js'
 
 describe('[Common/Chains]: Initialization / Chain params', () => {
   it('Should initialize with chain provided', () => {
@@ -126,11 +133,11 @@ describe('[Common/Chains]: Initialization / Chain params', () => {
 
 describe('[Common]: isSupportedChainId static method', () => {
   it('Should return true for supported chainId', () => {
-    assert.equal(Common.isSupportedChainId(BigInt(1)), true, 'returns true')
+    assert.equal(isSupportedChainId(BigInt(1)), true, 'returns true')
   })
 
   it('Should return false for unsupported chainId', () => {
-    assert.equal(Common.isSupportedChainId(BigInt(0)), false, 'returns false')
+    assert.equal(isSupportedChainId(BigInt(0)), false, 'returns false')
   })
 })
 

--- a/packages/common/test/customChains.spec.ts
+++ b/packages/common/test/customChains.spec.ts
@@ -1,7 +1,14 @@
 import { assert, describe, it } from 'vitest'
 
 import { Status } from '../src/hardforks.js'
-import { Chain, Common, ConsensusType, CustomChain, Hardfork } from '../src/index.js'
+import {
+  Chain,
+  Common,
+  ConsensusType,
+  CustomChain,
+  Hardfork,
+  createCustomCommon,
+} from '../src/index.js'
 
 import * as testnet from './data/testnet.json'
 import * as testnet2 from './data/testnet2.json'
@@ -36,7 +43,9 @@ describe('[Common]: Custom chains', () => {
     const mainnetCommon = new Common({ chain: Chain.Mainnet })
 
     const customChainParams = { name: 'custom', chainId: 123, networkId: 678 }
-    const customChainCommon = Common.custom(customChainParams, { hardfork: Hardfork.Byzantium })
+    const customChainCommon = createCustomCommon(customChainParams, {
+      hardfork: Hardfork.Byzantium,
+    })
 
     // From custom chain params
     assert.equal(customChainCommon.chainName(), customChainParams.name)
@@ -53,18 +62,18 @@ describe('[Common]: Custom chains', () => {
   })
 
   it('custom() -> behavior', () => {
-    let common = Common.custom({ chainId: 123 })
+    let common = createCustomCommon({ chainId: 123 })
     assert.deepEqual(common.networkId(), BigInt(1), 'should default to mainnet base chain')
     assert.equal(common.chainName(), 'custom-chain', 'should set default custom chain name')
 
-    common = Common.custom(CustomChain.PolygonMumbai)
+    common = createCustomCommon(CustomChain.PolygonMumbai)
     assert.deepEqual(
       common.networkId(),
       BigInt(80001),
       'supported chain -> should initialize with correct chain ID'
     )
     for (const customChain of Object.values(CustomChain)) {
-      common = Common.custom(customChain)
+      common = createCustomCommon(customChain)
       assert.equal(
         common.chainName(),
         customChain,
@@ -72,14 +81,14 @@ describe('[Common]: Custom chains', () => {
       )
     }
 
-    common = Common.custom(CustomChain.PolygonMumbai)
+    common = createCustomCommon(CustomChain.PolygonMumbai)
     assert.equal(
       common.hardfork(),
       common.DEFAULT_HARDFORK,
       'uses default hardfork when no options are present'
     )
 
-    common = Common.custom(CustomChain.OptimisticEthereum, { hardfork: Hardfork.Byzantium })
+    common = createCustomCommon(CustomChain.OptimisticEthereum, { hardfork: Hardfork.Byzantium })
     assert.equal(
       common.hardfork(),
       Hardfork.Byzantium,
@@ -88,7 +97,7 @@ describe('[Common]: Custom chains', () => {
 
     try {
       //@ts-ignore TypeScript complains, nevertheless do the test for JS behavior
-      Common.custom('this-chain-is-not-supported')
+      createCustomCommon('this-chain-is-not-supported')
       assert.fail('test should fail')
     } catch (e: any) {
       assert.ok(
@@ -152,7 +161,9 @@ describe('[Common]: Custom chains', () => {
       networkId: 678,
       depositContractAddress: '0x4242424242424242424242424242424242424242',
     }
-    const customChainCommon = Common.custom(customChainParams, { hardfork: Hardfork.Byzantium })
+    const customChainCommon = createCustomCommon(customChainParams, {
+      hardfork: Hardfork.Byzantium,
+    })
 
     assert.equal(
       customChainCommon['_chainParams'].depositContractAddress,
@@ -168,7 +179,7 @@ describe('[Common]: Custom chains', () => {
   })
 
   it('customHardforks parameter: initialization and transition tests', () => {
-    const c = Common.custom({
+    const c = createCustomCommon({
       customHardforks: {
         testEIP2935Hardfork: {
           name: 'testEIP2935Hardfork',
@@ -233,7 +244,7 @@ describe('custom chain setup with hardforks with undefined/null block numbers', 
     ]
 
     assert.throws(
-      () => Common.custom({ hardforks: undefinedHardforks as HardforkTransitionConfig[] }),
+      () => createCustomCommon({ hardforks: undefinedHardforks as HardforkTransitionConfig[] }),
       undefined,
       undefined,
       'throws when a hardfork with an undefined block number is passed'
@@ -248,7 +259,7 @@ describe('custom chain setup with hardforks with undefined/null block numbers', 
       { name: 'tangerineWhistle', block: 10 },
     ]
 
-    const common = Common.custom({ hardforks: nullHardforks })
+    const common = createCustomCommon({ hardforks: nullHardforks })
     common.setHardforkBy({ blockNumber: 10n })
     assert.equal('tangerineWhistle', common.hardfork(), 'set correct hardfork')
     common.setHardforkBy({ blockNumber: 3n })

--- a/packages/common/test/customCrypto.spec.ts
+++ b/packages/common/test/customCrypto.spec.ts
@@ -1,7 +1,7 @@
 import { concatBytes, randomBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Chain, Common } from '../src/index.js'
+import { Chain, Common, createCustomCommon } from '../src/index.js'
 
 import type { ECDSASignature } from '@ethereumjs/util'
 
@@ -42,7 +42,7 @@ describe('[Common]: Custom Crypto', () => {
     assert.deepEqual(c.copy().customCrypto.keccak256!(value), new Uint8Array([2, 1]), msg)
 
     const customChainParams = { name: 'custom', chainId: 123, networkId: 678 }
-    c = Common.custom(customChainParams, { customCrypto })
+    c = createCustomCommon(customChainParams, { customCrypto })
     msg = 'Should initialize with custom keccak256 function and use properly (custom() constructor)'
     assert.deepEqual(c.customCrypto.keccak256!(value), new Uint8Array([2, 1]), msg)
   })

--- a/packages/common/test/hardforks.spec.ts
+++ b/packages/common/test/hardforks.spec.ts
@@ -1,7 +1,15 @@
 import { hexToBytes, zeros } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Chain, Common, ConsensusAlgorithm, ConsensusType, Hardfork } from '../src/index.js'
+import {
+  Chain,
+  Common,
+  ConsensusAlgorithm,
+  ConsensusType,
+  Hardfork,
+  createCommonFromGethGenesis,
+  createCustomCommon,
+} from '../src/index.js'
 
 import * as gethGenesisKilnJSON from './data/geth-genesis/geth-genesis-kiln.json'
 
@@ -77,7 +85,7 @@ describe('[Common]: Hardfork logic', () => {
       },
     ]
 
-    const c = Common.custom({ hardforks }, { baseChain: Chain.Sepolia })
+    const c = createCustomCommon({ hardforks }, { baseChain: Chain.Sepolia })
     const f = () => {
       c.getHardforkBy({ blockNumber: 0n })
     }
@@ -314,7 +322,7 @@ describe('[Common]: Hardfork logic', () => {
       mergeForkIdPostMerge: true,
     }
     const genesisHash = zeros(32)
-    const zeroCommon = Common.fromGethGenesis(defaultConfig, gethConfig)
+    const zeroCommon = createCommonFromGethGenesis(defaultConfig, gethConfig)
 
     const zeroCommonShanghaiFork = zeroCommon.forkHash(Hardfork.Shanghai, genesisHash)
     const zeroCommonCancunFork = zeroCommon.forkHash(Hardfork.Shanghai, genesisHash)
@@ -414,7 +422,7 @@ describe('[Common]: Hardfork logic', () => {
     )
 
     // For kiln MergeForkIdTransition happens BEFORE Merge
-    c = Common.fromGethGenesis(gethGenesisKilnJSON, {
+    c = createCommonFromGethGenesis(gethGenesisKilnJSON, {
       chain: 'kiln',
       mergeForkIdPostMerge: false,
     })

--- a/packages/common/test/mergePOS.spec.ts
+++ b/packages/common/test/mergePOS.spec.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from 'vitest'
 
-import { Chain, Common, Hardfork } from '../src/index.js'
+import { Chain, Common, Hardfork, createCommonFromGethGenesis } from '../src/index.js'
 
 import * as postMergeJSON from './data/geth-genesis/post-merge.json'
 import * as testnetMerge from './data/merge/testnetMerge.json'
@@ -175,7 +175,7 @@ describe('[Common]: Merge/POS specific logic', () => {
   })
 
   it('should get the correct merge hardfork at genesis', async () => {
-    const c = Common.fromGethGenesis(postMergeJSON, { chain: 'post-merge' })
+    const c = createCommonFromGethGenesis(postMergeJSON, { chain: 'post-merge' })
     const msg = 'should get HF correctly'
     assert.equal(c.getHardforkBy({ blockNumber: 0n }), Hardfork.London, msg)
     assert.equal(c.getHardforkBy({ blockNumber: 0n, td: 0n }), Hardfork.Paris, msg)

--- a/packages/common/test/timestamp.spec.ts
+++ b/packages/common/test/timestamp.spec.ts
@@ -1,13 +1,19 @@
 import { hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Chain, Common, Hardfork } from '../src/index.js'
+import {
+  Chain,
+  Common,
+  Hardfork,
+  createCommonFromGethGenesis,
+  createCustomCommon,
+} from '../src/index.js'
 
 import * as timestampJson from './data/shanghai-time.json'
 
 describe('[Common]: Timestamp Hardfork logic', () => {
   it('shanghai-time', () => {
-    const c = Common.fromGethGenesis(timestampJson, {
+    const c = createCommonFromGethGenesis(timestampJson, {
       chain: 'withdrawals',
     })
     assert.equal(
@@ -32,7 +38,7 @@ describe('[Common]: Timestamp Hardfork logic', () => {
       cancunTime: timestampJson.config.shanghaiTime,
     })
     const modifiedJson = Object.assign({}, timestampJson, { config })
-    const c = Common.fromGethGenesis(modifiedJson, {
+    const c = createCommonFromGethGenesis(modifiedJson, {
       chain: 'modified',
     })
     assert.equal(
@@ -52,7 +58,7 @@ describe('[Common]: Timestamp Hardfork logic', () => {
       cancunTime: timestampJson.config.shanghaiTime + 1000,
     })
     const modifiedJson = Object.assign({}, timestampJson, { config })
-    const c = Common.fromGethGenesis(modifiedJson, {
+    const c = createCommonFromGethGenesis(modifiedJson, {
       chain: 'modified',
     })
     assert.equal(
@@ -93,7 +99,7 @@ describe('[Common]: Timestamp Hardfork logic', () => {
       },
     ])
 
-    const c = Common.custom({ hardforks }, { baseChain: Chain.Mainnet })
+    const c = createCustomCommon({ hardforks }, { baseChain: Chain.Mainnet })
     const mainnetGenesisHash = hexToBytes(
       '0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3'
     )
@@ -134,7 +140,7 @@ describe('[Common]: Timestamp Hardfork logic', () => {
       },
     ])
 
-    const c = Common.custom({ hardforks }, { baseChain: Chain.Mainnet })
+    const c = createCustomCommon({ hardforks }, { baseChain: Chain.Mainnet })
     const mainnetGenesisHash = hexToBytes(
       '0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3'
     )

--- a/packages/common/test/utils.spec.ts
+++ b/packages/common/test/utils.spec.ts
@@ -1,9 +1,9 @@
 import { hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Common } from '../src/common.js'
+import { createCommonFromGethGenesis } from '../src/constructors.js'
 import { Hardfork } from '../src/enums.js'
-import { parseGethGenesis } from '../src/utils.js'
+import { getInitializedChains, parseGethGenesis } from '../src/utils.js'
 
 import * as gethGenesisKilnJSON from './data/geth-genesis/geth-genesis-kiln.json'
 import * as invalidSpuriousDragonJSON from './data/geth-genesis/invalid-spurious-dragon.json'
@@ -57,7 +57,7 @@ describe('[Utils/Parse]', () => {
   })
 
   it('should successfully parse kiln genesis and set forkhash', async () => {
-    const common = Common.fromGethGenesis(gethGenesisKilnJSON, {
+    const common = createCommonFromGethGenesis(gethGenesisKilnJSON, {
       chain: 'customChain',
       genesisHash: hexToBytes('0x51c7fe41be669f69c45c33a56982cbde405313342d9e2b00d7c91a7b284dd4f8'),
       mergeForkIdPostMerge: false,
@@ -91,7 +91,7 @@ describe('[Utils/Parse]', () => {
     // genesis if even mergeForkIdTransition is not confirmed to be post merge
     // This will also check if the forks are being correctly sorted based on block
     Object.assign(gethGenesisKilnJSON.config, { shanghaiTime: Math.floor(Date.now() / 1000) })
-    const common1 = Common.fromGethGenesis(gethGenesisKilnJSON, {
+    const common1 = createCommonFromGethGenesis(gethGenesisKilnJSON, {
       chain: 'customChain',
     })
     // merge hardfork is now scheduled just after shanghai even if mergeForkIdTransition is not confirmed
@@ -120,7 +120,7 @@ describe('[Utils/Parse]', () => {
   })
 
   it('should successfully parse genesis with hardfork scheduled post merge', async () => {
-    const common = Common.fromGethGenesis(postMergeHardforkJSON, {
+    const common = createCommonFromGethGenesis(postMergeHardforkJSON, {
       chain: 'customChain',
     })
     assert.deepEqual(
@@ -175,16 +175,16 @@ describe('[Utils/Parse]', () => {
   })
 
   it('should successfully assign mainnet deposit contract address when none provided', async () => {
-    const common = Common.fromGethGenesis(postMergeHardforkJSON, {
+    const common = createCommonFromGethGenesis(postMergeHardforkJSON, {
       chain: 'customChain',
     })
     const depositContractAddress =
       common['_chainParams'].depositContractAddress ??
-      Common.getInitializedChains().mainnet.depositContractAddress
+      getInitializedChains().mainnet.depositContractAddress
 
     assert.equal(
       depositContractAddress,
-      Common.getInitializedChains().mainnet.depositContractAddress,
+      getInitializedChains().mainnet.depositContractAddress,
       'should assign mainnet deposit contract'
     )
   })
@@ -196,12 +196,12 @@ describe('[Utils/Parse]', () => {
       depositContractAddress: '0x4242424242424242424242424242424242424242',
     })
 
-    const common = Common.fromGethGenesis(customJson, {
+    const common = createCommonFromGethGenesis(customJson, {
       chain: 'customChain',
     })
     const depositContractAddress =
       common['_chainParams'].depositContractAddress ??
-      Common.getInitializedChains().mainnet.depositContractAddress
+      getInitializedChains().mainnet.depositContractAddress
 
     assert.equal(
       depositContractAddress,

--- a/packages/evm/test/blobVersionedHashes.spec.ts
+++ b/packages/evm/test/blobVersionedHashes.spec.ts
@@ -1,4 +1,4 @@
-import { Common, Hardfork } from '@ethereumjs/common'
+import { Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import { Account, Address, bytesToHex, hexToBytes, unpadBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
@@ -11,7 +11,7 @@ describe('BLOBHASH / access blobVersionedHashes in calldata', () => {
   it('should work', async () => {
     // setup the evm
     const genesisJSON = await import('../../client/test/testdata/geth-genesis/eip4844.json')
-    const common = Common.fromGethGenesis(genesisJSON, {
+    const common = createCommonFromGethGenesis(genesisJSON, {
       chain: 'custom',
       hardfork: Hardfork.Cancun,
     })
@@ -41,7 +41,7 @@ describe(`BLOBHASH: access blobVersionedHashes within contract calls`, () => {
   it('should work', async () => {
     // setup the evm
     const genesisJSON = await import('../../client/test/testdata/geth-genesis/eip4844.json')
-    const common = Common.fromGethGenesis(genesisJSON, {
+    const common = createCommonFromGethGenesis(genesisJSON, {
       chain: 'custom',
       hardfork: Hardfork.Cancun,
     })
@@ -91,7 +91,7 @@ describe(`BLOBHASH: access blobVersionedHashes in a CREATE/CREATE2 frame`, () =>
   it('should work', async () => {
     // setup the evm
     const genesisJSON = await import('../../client/test/testdata/geth-genesis/eip4844.json')
-    const common = Common.fromGethGenesis(genesisJSON, {
+    const common = createCommonFromGethGenesis(genesisJSON, {
       chain: 'custom',
       hardfork: Hardfork.Cancun,
     })

--- a/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
+++ b/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
@@ -1,4 +1,4 @@
-import { Common, Hardfork } from '@ethereumjs/common'
+import { Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import {
   bytesToBigInt,
   computeVersionedHash,
@@ -23,7 +23,7 @@ describe('Precompiles: point evaluation', () => {
 
     const kzg = await loadKZG()
 
-    const common = Common.fromGethGenesis(genesisJSON, {
+    const common = createCommonFromGethGenesis(genesisJSON, {
       chain: 'custom',
       hardfork: Hardfork.Cancun,
       customCrypto: { kzg },

--- a/packages/evm/test/runCall.spec.ts
+++ b/packages/evm/test/runCall.spec.ts
@@ -1,4 +1,4 @@
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import {
   Account,
   Address,
@@ -541,7 +541,7 @@ describe('RunCall tests', () => {
   })
   it('runCall() => use BLOBHASH opcode from EIP 4844', async () => {
     // setup the evm
-    const common = Common.fromGethGenesis(genesisJSON, {
+    const common = createCommonFromGethGenesis(genesisJSON, {
       chain: 'custom',
       hardfork: Hardfork.Cancun,
     })
@@ -578,7 +578,7 @@ describe('RunCall tests', () => {
 
   it('runCall() => use BLOBBASEFEE opcode from EIP 7516', async () => {
     // setup the evm
-    const common = Common.fromGethGenesis(genesisJSON, {
+    const common = createCommonFromGethGenesis(genesisJSON, {
       chain: 'custom',
       hardfork: Hardfork.Cancun,
     })

--- a/packages/statemanager/test/statelessVerkleStateManager.spec.ts
+++ b/packages/statemanager/test/statelessVerkleStateManager.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Common } from '@ethereumjs/common'
+import { createCommonFromGethGenesis } from '@ethereumjs/common'
 import { TransactionFactory } from '@ethereumjs/tx'
 import {
   Account,
@@ -28,7 +28,7 @@ describe('StatelessVerkleStateManager: Kaustinen Verkle Block', () => {
   beforeAll(async () => {
     verkleCrypto = await loadVerkleCrypto()
   })
-  const common = Common.fromGethGenesis(testnetVerkleKaustinen, {
+  const common = createCommonFromGethGenesis(testnetVerkleKaustinen, {
     chain: 'customChain',
     eips: [2935, 4895, 6800],
   })

--- a/packages/tx/examples/custom-chain-id-tx.ts
+++ b/packages/tx/examples/custom-chain-id-tx.ts
@@ -1,12 +1,12 @@
 import { LegacyTransaction } from '../dist/cjs'
 import { toBytes } from '@ethereumjs/util'
-import { Common, Hardfork } from '@ethereumjs/common'
+import { Common, createCustomCommon, Hardfork } from '@ethereumjs/common'
 
 const txData = toBytes(
   '0xf9010b82930284d09dc30083419ce0942d18de92e0f9aee1a29770c3b15c6cf8ac5498e580b8a42f43f4fb0000000000000000000000000000000000000000000000000000016b78998da900000000000000000000000000000000000000000000000000000000000cb1b70000000000000000000000000000000000000000000000000000000000000fa00000000000000000000000000000000000000000000000000000000001363e4f00000000000000000000000000000000000000000000000000000000000186a029a0fac36e66d329af0e831b2e61179b3ec8d7c7a8a2179e303cfed3364aff2bc3e4a07cb73d56e561ccbd838818dd3dea5fa0b5158577ffc61c0e6ec1f0ed55716891'
 )
 
-const common = Common.custom({ chainId: 3 })
+const common = createCustomCommon({ chainId: 3 })
 common.setHardfork(Hardfork.Petersburg)
 const tx = LegacyTransaction.fromSerializedTx(txData, { common })
 

--- a/packages/tx/examples/custom-chain-tx.ts
+++ b/packages/tx/examples/custom-chain-tx.ts
@@ -1,5 +1,5 @@
 import { Address } from '@ethereumjs/util'
-import { Common } from '@ethereumjs/common'
+import { Common, createCustomCommon } from '@ethereumjs/common'
 import { LegacyTransaction } from '../dist/cjs/index'
 import { hexToBytes } from '@ethereumjs/util'
 
@@ -8,7 +8,7 @@ import { hexToBytes } from '@ethereumjs/util'
 // This custom network has the same params as mainnet,
 // except for name, chainId, and networkId,
 // so we use the `Common.custom` method.
-const customCommon = Common.custom(
+const customCommon = createCustomCommon(
   {
     name: 'my-network',
     networkId: 123,

--- a/packages/tx/examples/l2tx.ts
+++ b/packages/tx/examples/l2tx.ts
@@ -1,10 +1,10 @@
-import { Common, CustomChain } from '@ethereumjs/common'
+import { Common, createCustomCommon, CustomChain } from '@ethereumjs/common'
 import { LegacyTransaction } from '@ethereumjs/tx'
 import { Address, bytesToHex, hexToBytes } from '@ethereumjs/util'
 
 const pk = hexToBytes('0x076247989df60a82f6e86e58104368676096f84e60972282ee00d4673a2bc9b9')
 const to = Address.fromString('0x256e8f0ba532ad83a0debde7501669511a41a1f3')
-const common = Common.custom(CustomChain.xDaiChain)
+const common = createCustomCommon(CustomChain.xDaiChain)
 
 const txData = {
   nonce: 0,

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -1,4 +1,4 @@
-import { Chain, Common } from '@ethereumjs/common'
+import { Chain, Common, createCustomCommon, isSupportedChainId } from '@ethereumjs/common'
 import {
   Address,
   BIGINT_0,
@@ -388,14 +388,14 @@ export abstract class BaseTransaction<T extends TransactionType>
         // -> Return provided Common
         return common.copy()
       } else {
-        if (Common.isSupportedChainId(chainIdBigInt)) {
+        if (isSupportedChainId(chainIdBigInt)) {
           // No Common, chain ID supported by Common
           // -> Instantiate Common with chain ID
           return new Common({ chain: chainIdBigInt })
         } else {
           // No Common, chain ID not supported by Common
           // -> Instantiate custom Common derived from DEFAULT_CHAIN
-          return Common.custom(
+          return createCustomCommon(
             {
               name: 'custom-chain',
               networkId: chainIdBigInt,

--- a/packages/tx/test/eip1559.spec.ts
+++ b/packages/tx/test/eip1559.spec.ts
@@ -1,4 +1,4 @@
-import { Common, Hardfork } from '@ethereumjs/common'
+import { Hardfork, createCustomCommon } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import { TWO_POW256, ecsign, equalsBytes, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
@@ -10,7 +10,7 @@ import testdata from './json/eip1559.json' // Source: Besu
 import type { FeeMarketEIP1559TxData, JsonTx } from '../src/index.js'
 import type { PrefixedHexString } from '@ethereumjs/util'
 
-const common = Common.custom({ chainId: 4 })
+const common = createCustomCommon({ chainId: 4 })
 common.setHardfork(Hardfork.London)
 
 const validAddress = hexToBytes(`0x${'01'.repeat(20)}`)
@@ -197,7 +197,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
       freeze: false,
     })
 
-    const newCommon = Common.custom({ chainId: 4 })
+    const newCommon = createCustomCommon({ chainId: 4 })
     newCommon.setHardfork(Hardfork.Paris)
 
     assert.notDeepEqual(newCommon, common, 'new common is different than original common')

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -1,4 +1,4 @@
-import { Common, Hardfork } from '@ethereumjs/common'
+import { Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import {
   Address,
   blobsToCommitments,
@@ -21,6 +21,7 @@ import { BlobEIP4844Transaction, TransactionFactory } from '../src/index.js'
 import blobTx from './json/serialized4844tx.json'
 
 import type { BlobEIP4844TxData } from '../src/index.js'
+import type { Common } from '@ethereumjs/common'
 import type { Kzg, PrefixedHexString } from '@ethereumjs/util'
 
 const pk = randomBytes(32)
@@ -28,7 +29,7 @@ describe('EIP4844 addSignature tests', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await loadKZG()
-    common = Common.fromGethGenesis(gethGenesis, {
+    common = createCommonFromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
       customCrypto: { kzg },
@@ -92,7 +93,7 @@ describe('EIP4844 constructor tests - valid scenarios', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await loadKZG()
-    common = Common.fromGethGenesis(gethGenesis, {
+    common = createCommonFromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
       customCrypto: { kzg },
@@ -130,7 +131,7 @@ describe('fromTxData using from a json', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await loadKZG()
-    common = Common.fromGethGenesis(gethGenesis, {
+    common = createCommonFromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
       customCrypto: { kzg },
@@ -202,7 +203,7 @@ describe('EIP4844 constructor tests - invalid scenarios', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await loadKZG()
-    common = Common.fromGethGenesis(gethGenesis, {
+    common = createCommonFromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
       customCrypto: { kzg },
@@ -259,7 +260,7 @@ describe('Network wrapper tests', () => {
   let common: Common
   beforeAll(async () => {
     kzg = await loadKZG()
-    common = Common.fromGethGenesis(gethGenesis, {
+    common = createCommonFromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
       customCrypto: { kzg },
@@ -531,7 +532,7 @@ describe('hash() and signature verification', () => {
   let common: Common
   beforeAll(async () => {
     const kzg = await loadKZG()
-    common = Common.fromGethGenesis(gethGenesis, {
+    common = createCommonFromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
       customCrypto: { kzg },
@@ -579,7 +580,7 @@ describe('hash() and signature verification', () => {
 
 it('getEffectivePriorityFee()', async () => {
   const kzg = await loadKZG()
-  const common = Common.fromGethGenesis(gethGenesis, {
+  const common = createCommonFromGethGenesis(gethGenesis, {
     chain: 'customChain',
     hardfork: Hardfork.Cancun,
     customCrypto: { kzg },
@@ -607,7 +608,7 @@ describe('Network wrapper deserialization test', () => {
   let common: Common
   beforeAll(async () => {
     kzg = await loadKZG()
-    common = Common.fromGethGenesis(gethGenesis, {
+    common = createCommonFromGethGenesis(gethGenesis, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
       customCrypto: {

--- a/packages/tx/test/legacy.spec.ts
+++ b/packages/tx/test/legacy.spec.ts
@@ -1,4 +1,4 @@
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, Hardfork, createCustomCommon } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import {
   bytesToBigInt,
@@ -399,7 +399,7 @@ describe('[Transaction]', () => {
     const privateKey = hexToBytes(
       '0xDE3128752F183E8930D7F00A2AAA302DCB5E700B2CBA2D8CA5795660F07DEFD5'
     )
-    const common = Common.custom({ chainId: 3 })
+    const common = createCustomCommon({ chainId: 3 })
     const tx = LegacyTransaction.fromValuesArray(
       txRaw.map((rawTxData) => hexToBytes(rawTxData as PrefixedHexString)),
       { common }

--- a/packages/tx/test/typedTxsAndEIP2930.spec.ts
+++ b/packages/tx/test/typedTxsAndEIP2930.spec.ts
@@ -1,4 +1,4 @@
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, Hardfork, createCustomCommon } from '@ethereumjs/common'
 import {
   Address,
   MAX_INTEGER,
@@ -605,7 +605,7 @@ describe('[AccessListEIP2930Transaction] -> Class Specific Tests', () => {
       chainId: txData.chainId,
       eips: [2718, 2929, 2930],
     }
-    const usedCommon = Common.custom(customChainParams, {
+    const usedCommon = createCustomCommon(customChainParams, {
       baseChain: Chain.Mainnet,
       hardfork: Hardfork.Berlin,
     })

--- a/packages/vm/src/requests.ts
+++ b/packages/vm/src/requests.ts
@@ -1,4 +1,4 @@
-import { Common } from '@ethereumjs/common'
+import { getInitializedChains } from '@ethereumjs/common'
 import {
   Address,
   ConsolidationRequest,
@@ -33,7 +33,7 @@ export const accumulateRequests = async (
   if (common.isActivatedEIP(6110)) {
     const depositContractAddress =
       vm.common['_chainParams'].depositContractAddress ??
-      Common.getInitializedChains().mainnet.depositContractAddress
+      getInitializedChains().mainnet.depositContractAddress
     if (depositContractAddress === undefined)
       throw new Error('deposit contract address required with EIP 6110')
     await accumulateDeposits(depositContractAddress, txResults, requests)

--- a/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts
@@ -1,6 +1,6 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
-import { Common, Hardfork } from '@ethereumjs/common'
+import { Hardfork, createCustomCommon } from '@ethereumjs/common'
 import { LegacyTransaction } from '@ethereumjs/tx'
 import {
   Account,
@@ -17,9 +17,9 @@ import {
 import { hexToBytes } from 'ethereum-cryptography/utils'
 import { assert, describe, it } from 'vitest'
 
-import { bytesToBigInt } from '../../../../util/src/bytes'
-import { BIGINT_0 } from '../../../../util/src/constants'
-import { VM } from '../../../src/vm'
+import { bytesToBigInt } from '../../../../util/src/bytes.js'
+import { BIGINT_0 } from '../../../../util/src/constants.js'
+import { VM } from '../../../src/vm.js'
 
 import type { Block } from '@ethereumjs/block'
 
@@ -56,7 +56,7 @@ function eip2935ActiveAtCommon(timestamp: number) {
     block: null,
     timestamp,
   })
-  const c = Common.custom({
+  const c = createCustomCommon({
     customHardforks: {
       testEIP2935Hardfork: {
         name: 'testEIP2935Hardfork',

--- a/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
@@ -1,6 +1,6 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
-import { Common, Hardfork } from '@ethereumjs/common'
+import { Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
 import {
   Address,
@@ -17,8 +17,8 @@ import { loadKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
 
 import * as genesisJSON from '../../../../client/test/testdata/geth-genesis/eip4844.json'
-import { VM } from '../../../src/vm'
-import { setBalance } from '../utils'
+import { VM } from '../../../src/vm.js'
+import { setBalance } from '../utils.js'
 
 const pk = hexToBytes(`0x${'20'.repeat(32)}`)
 const sender = bytesToHex(privateToAddress(pk))
@@ -27,7 +27,7 @@ describe('EIP4844 tests', () => {
   it('should build a block correctly with blobs', async () => {
     const kzg = await loadKZG()
 
-    const common = Common.fromGethGenesis(genesisJSON, {
+    const common = createCommonFromGethGenesis(genesisJSON, {
       chain: 'eip4844',
       hardfork: Hardfork.Cancun,
       customCrypto: { kzg },

--- a/packages/vm/test/api/EIPs/eip-4895-withdrawals.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-4895-withdrawals.spec.ts
@@ -1,6 +1,6 @@
 import { createBlockFromBlockData, genWithdrawalsTrieRoot } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import { decode } from '@ethereumjs/rlp'
 import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
 import {
@@ -191,7 +191,7 @@ describe('EIP4895 tests', () => {
   })
 
   it('should build a block correctly with withdrawals', async () => {
-    const common = Common.fromGethGenesis(genesisJSON, { chain: 'custom' })
+    const common = createCommonFromGethGenesis(genesisJSON, { chain: 'custom' })
     common.setHardfork(Hardfork.Shanghai)
     const genesisState = parseGethGenesisState(genesisJSON)
     const blockchain = await createBlockchain({

--- a/packages/vm/test/api/EIPs/eip-6110.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-6110.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, Hardfork, getInitializedChains } from '@ethereumjs/common'
 import { TransactionFactory } from '@ethereumjs/tx'
 import { Account, Address, bytesToHex, hexToBytes, randomBytes } from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak.js'
@@ -22,7 +22,7 @@ common['_activatedEIPsCache'] = [
   2565, 2929, 2718, 2930, 1559, 3198, 3529, 3541, 4345, 5133, 3675, 4399, 3651, 3855, 3860, 4895,
   1153, 4844, 4788, 5656, 6780, 7516, 2537, 3074, 6110, 7685,
 ]
-const DEPOSIT_CONTRACT_ADDRESS = Common.getInitializedChains().mainnet
+const DEPOSIT_CONTRACT_ADDRESS = getInitializedChains().mainnet
   .depositContractAddress! as PrefixedHexString
 
 const pubkey =

--- a/packages/vm/test/api/EIPs/eip-6800-verkle.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-6800-verkle.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Common, Hardfork } from '@ethereumjs/common'
+import { Hardfork, createCustomCommon } from '@ethereumjs/common'
 import { EVM } from '@ethereumjs/evm'
 import { StatelessVerkleStateManager } from '@ethereumjs/statemanager'
 import { TransactionFactory } from '@ethereumjs/tx'
@@ -14,7 +14,7 @@ import type { BlockData } from '@ethereumjs/block'
 import type { PrefixedHexString } from '@ethereumjs/util'
 
 const customChainParams = { name: 'custom', chainId: 69420, networkId: 678 }
-const common = Common.custom(customChainParams, {
+const common = createCustomCommon(customChainParams, {
   hardfork: Hardfork.Cancun,
   eips: [2935, 4895, 6800],
 })

--- a/packages/vm/test/api/buildBlock.spec.ts
+++ b/packages/vm/test/api/buildBlock.spec.ts
@@ -1,6 +1,6 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import { FeeMarketEIP1559Transaction, LegacyTransaction } from '@ethereumjs/tx'
 import { Account, Address, concatBytes, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
@@ -166,7 +166,7 @@ describe('BlockBuilder', () => {
       extraData: extraData2,
       alloc: { [addr]: { balance: '0x10000000000000000000' } },
     }
-    const common = Common.fromGethGenesis(chainData, {
+    const common = createCommonFromGethGenesis(chainData, {
       chain: 'devnet',
       hardfork: Hardfork.Istanbul,
     })

--- a/packages/vm/test/api/index.spec.ts
+++ b/packages/vm/test/api/index.spec.ts
@@ -1,4 +1,4 @@
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, Hardfork, createCustomCommon } from '@ethereumjs/common'
 import { EVM } from '@ethereumjs/evm'
 import { Account, Address, KECCAK256_RLP, hexToBytes } from '@ethereumjs/util'
 import * as util from 'util' // eslint-disable-line @typescript-eslint/no-unused-vars
@@ -153,7 +153,7 @@ describe('VM -> common (chain, HFs, EIPs)', () => {
 
   it('should only accept valid chain and fork', async () => {
     // let common = new Common({ chain: Chain.Ropsten, hardfork: Hardfork.Byzantium })
-    let common = Common.custom({ chainId: 3 })
+    let common = createCustomCommon({ chainId: 3 })
     common.setHardfork(Hardfork.Byzantium)
     let vm = await VM.create({ common })
     assert.equal(vm.common.param('gasPrices', 'ecAdd'), BigInt(500))
@@ -181,9 +181,9 @@ describe('VM -> common (chain, HFs, EIPs)', () => {
     }
   })
 
-  it('should accept a custom chain config (Common.custom() static constructor)', async () => {
+  it('should accept a custom chain config (createCustomCommon() static constructor)', async () => {
     const customChainParams = { name: 'custom', chainId: 123, networkId: 678 }
-    const common = Common.custom(customChainParams, {
+    const common = createCustomCommon(customChainParams, {
       baseChain: 'mainnet',
       hardfork: 'byzantium',
     })

--- a/packages/vm/test/api/runBlock.spec.ts
+++ b/packages/vm/test/api/runBlock.spec.ts
@@ -3,7 +3,7 @@ import {
   createBlockFromRLPSerializedBlock,
   createBlockFromValuesArray,
 } from '@ethereumjs/block'
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, Hardfork, createCustomCommon } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import {
   AccessListEIP2930Transaction,
@@ -138,9 +138,12 @@ describe('runBlock() -> successful API parameter usage', async () => {
     await uncleRun(vm)
   })
 
-  it('PoW block, Common custom chain (Common.custom() static constructor)', async () => {
+  it('PoW block, Common custom chain (createCustomCommon() static constructor)', async () => {
     const customChainParams = { name: 'custom', chainId: 123, networkId: 678 }
-    const common = Common.custom(customChainParams, { baseChain: 'mainnet', hardfork: 'berlin' })
+    const common = createCustomCommon(customChainParams, {
+      baseChain: 'mainnet',
+      hardfork: 'berlin',
+    })
     const vm = await setupVM({ common })
     await simpleRun(vm)
   })

--- a/packages/vm/test/api/runTx.spec.ts
+++ b/packages/vm/test/api/runTx.spec.ts
@@ -1,6 +1,6 @@
 import { BlockHeader, createBlockFromBlockData } from '@ethereumjs/block'
 import { Blockchain, createBlockchain } from '@ethereumjs/blockchain'
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import {
   BlobEIP4844Transaction,
   FeeMarketEIP1559Transaction,
@@ -881,7 +881,7 @@ describe('EIP 4844 transaction tests', () => {
     const kzg = await loadKZG()
 
     const genesisJson = await import('../../../block/test/testdata/4844-hardfork.json')
-    const common = Common.fromGethGenesis(genesisJson, {
+    const common = createCommonFromGethGenesis(genesisJson, {
       chain: 'customChain',
       hardfork: Hardfork.Cancun,
       customCrypto: { kzg },

--- a/packages/vm/test/tester/config.ts
+++ b/packages/vm/test/tester/config.ts
@@ -1,4 +1,4 @@
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, Hardfork, createCustomCommon } from '@ethereumjs/common'
 import * as path from 'path'
 
 import type { Kzg } from '@ethereumjs/util'
@@ -265,7 +265,7 @@ function setupCommonWithNetworks(network: string, ttd?: number, timestamp?: numb
       }
     }
   }
-  const common = Common.custom(
+  const common = createCustomCommon(
     {
       hardforks: testHardforks,
       defaultHardfork: hfName,
@@ -349,7 +349,7 @@ export function getCommon(network: string, kzg?: Kzg): Common {
         })
       }
     }
-    const common = Common.custom(
+    const common = createCustomCommon(
       {
         hardforks: testHardforks,
       },

--- a/packages/vm/test/util.ts
+++ b/packages/vm/test/util.ts
@@ -1,5 +1,5 @@
 import { Block, BlockHeader } from '@ethereumjs/block'
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, Hardfork, createCustomCommon } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import {
   AccessListEIP2930Transaction,
@@ -413,7 +413,7 @@ export function getDAOCommon(activationBlock: number) {
       editedForks.push(fork)
     }
   }
-  const DAOCommon = Common.custom(
+  const DAOCommon = createCustomCommon(
     {
       hardforks: editedForks,
     },


### PR DESCRIPTION
Works on #3487 tree shaking optimizations.

Relates to #3489 and #3491

Replaces static methods in `Common` class with separately defined functions.

### constructors:

- Common.custom
- Common.fromGethGenesis

move to `common/src/constructors` and renamed:

- createCustomCommon
- createCommonFromGethGenesis

### other static methods: 

- Common.isSupportedChainId
- Common._getChainParams
- Common.getInitializedChains

move to `common/src/utils.ts` and renamed

- isSupportedChainId
- _getChainParams
- .getInitializedChains
