### PR TITLE
Client: fix more hive RPC-Compat tests

### DIFF
--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -507,6 +507,7 @@ export class Eth {
       gasPrice: toType(gasPrice, TypeOutput.BigInt),
       value: toType(value, TypeOutput.BigInt),
       data: data !== undefined ? hexToBytes(data) : undefined,
+      block,
     }
     const { execResult } = await vm.evm.runCall(runCallOpts)
     return bytesToHex(execResult.returnValue)

--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -498,7 +498,9 @@ export class Eth {
     const vm = await this._vm.shallowCopy()
     await vm.stateManager.setStateRoot(block.header.stateRoot)
 
-    const { from, to, gas: gasLimit, gasPrice, value, data } = transaction
+    const { from, to, gas: gasLimit, gasPrice, value } = transaction
+
+    const data = transaction.data ?? transaction.input
 
     const runCallOpts = {
       caller: from !== undefined ? Address.fromString(from) : undefined,

--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -372,6 +372,12 @@ export class Eth {
       [[validators.hex, validators.blockHash], [validators.hex]]
     )
 
+    this.getTransactionByBlockNumberAndIndex = middleware(
+      callWithStackTrace(this.getTransactionByBlockNumberAndIndex.bind(this), this._rpcDebug),
+      2,
+      [[validators.hex, validators.blockOption], [validators.hex]]
+    )
+
     this.getTransactionByHash = middleware(
       callWithStackTrace(this.getTransactionByHash.bind(this), this._rpcDebug),
       1,
@@ -787,6 +793,31 @@ export class Eth {
       const [blockHash, txIndexHex] = params
       const txIndex = parseInt(txIndexHex, 16)
       const block = await this._chain.getBlock(hexToBytes(blockHash))
+      if (block.transactions.length <= txIndex) {
+        return null
+      }
+
+      const tx = block.transactions[txIndex]
+      return jsonRpcTx(tx, block, txIndex)
+    } catch (error: any) {
+      throw {
+        code: INVALID_PARAMS,
+        message: error.message.toString(),
+      }
+    }
+  }
+
+  /**
+   * Returns information about a transaction given a block hash and a transaction's index position.
+   * @param params An array of two parameter:
+   *   1. a block number
+   *   2. an integer of the transaction index position encoded as a hexadecimal.
+   */
+  async getTransactionByBlockNumberAndIndex(params: [PrefixedHexString, string]) {
+    try {
+      const [blockNumber, txIndexHex] = params
+      const txIndex = parseInt(txIndexHex, 16)
+      const block = await getBlockByOption(blockNumber, this._chain)
       if (block.transactions.length <= txIndex) {
         return null
       }

--- a/packages/client/src/rpc/types.ts
+++ b/packages/client/src/rpc/types.ts
@@ -7,6 +7,7 @@ export interface RpcTx {
   gasPrice?: PrefixedHexString
   value?: PrefixedHexString
   data?: PrefixedHexString
+  input?: PrefixedHexString // This is the "official" name of the property the client uses for "data" in the RPC spec
   maxPriorityFeePerGas?: PrefixedHexString
   maxFeePerGas?: PrefixedHexString
   type?: PrefixedHexString


### PR DESCRIPTION
To run, setup local hive with EthereumJS

1. Ensure in hive, `clients/ethereumjs` has a cloned `ethereumjs-monorepo`
2. Ensure that in `clients`, you rename `Dockerfile.local` to `Dockerfile`
3. To run: `./hive --sim ethereum/rpc --client ethereumjs --sim.limit rpc-compat`

Before: 16/90 failed, after: 13/90 failed

Side note: in order to run EthereumJS in hive with TS-node from the source, change `ethereumjs-local.sh`:

`ethereumjs="node /ethereumjs-monorepo/packages/client/dist/esm/bin/cli.js"`

To

`ethereumjs="tsx /ethereumjs-monorepo/packages/client/bin/cli.ts"`

And ensure that in `Dockerfile` (the renamed `Dockerfile.local`) you install `tsx`:

```
RUN npm i -g ts-node
RUN npm i -g tsx
```



**Failing tests overview**

- `eth_call/call-callenv` - the test expects us to return 0 on the `BASEFEE` opcode it seems, but this does not seem correct to me
- `eth_call/call-contract` - tests calls into a contract which loads the `CALLDATASIZE`, and if its nonzero it reverts (it seems to push some string on the stack). The test however expects us to return a completely different value (and I do not understand why)

I investigated the other tests but it is not clear why those fail to me (or they are simply too complex to implement, for instance decode the ABI revert data into human readable strings)