### PR TITLE
Blockchain: More Modern and Flexible Consensus Layout / Tree Shaking Optimization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16638,7 +16638,6 @@
       "dependencies": {
         "@ethereumjs/block": "^5.2.0",
         "@ethereumjs/common": "^4.3.0",
-        "@ethereumjs/ethash": "^3.0.3",
         "@ethereumjs/rlp": "^5.0.2",
         "@ethereumjs/trie": "^6.2.0",
         "@ethereumjs/tx": "^5.3.0",
@@ -16647,7 +16646,9 @@
         "ethereum-cryptography": "^2.2.1",
         "lru-cache": "10.1.0"
       },
-      "devDependencies": {},
+      "devDependencies": {
+        "@ethereumjs/ethash": "^3.0.3"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -17026,6 +17027,7 @@
         "ethereum-cryptography": "^2.2.1"
       },
       "devDependencies": {
+        "@ethereumjs/ethash": "^3.0.3",
         "@ethersproject/abi": "^5.0.12",
         "@types/benchmark": "^1.0.33",
         "@types/core-js": "^2.5.0",

--- a/packages/blockchain/examples/clique.ts
+++ b/packages/blockchain/examples/clique.ts
@@ -1,0 +1,14 @@
+import { createBlockchain, CliqueConsensus, ConsensusDict } from '@ethereumjs/blockchain'
+import { Chain, Common, ConsensusAlgorithm, Hardfork } from '@ethereumjs/common'
+
+const common = new Common({ chain: Chain.Goerli, hardfork: Hardfork.London })
+
+const consensusDict: ConsensusDict = {}
+consensusDict[ConsensusAlgorithm.Clique] = new CliqueConsensus()
+const blockchain = await createBlockchain({
+  consensusDict: {
+    clique: new CliqueConsensus(),
+  },
+  common,
+})
+console.log(`Created blockchain with ${blockchain.consensus.algorithm} consensus algorithm`)

--- a/packages/blockchain/examples/clique.ts
+++ b/packages/blockchain/examples/clique.ts
@@ -6,9 +6,7 @@ const common = new Common({ chain: Chain.Goerli, hardfork: Hardfork.London })
 const consensusDict: ConsensusDict = {}
 consensusDict[ConsensusAlgorithm.Clique] = new CliqueConsensus()
 const blockchain = await createBlockchain({
-  consensusDict: {
-    clique: new CliqueConsensus(),
-  },
+  consensusDict,
   common,
 })
 console.log(`Created blockchain with ${blockchain.consensus.algorithm} consensus algorithm`)

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -49,7 +49,6 @@
   "dependencies": {
     "@ethereumjs/block": "^5.2.0",
     "@ethereumjs/common": "^4.3.0",
-    "@ethereumjs/ethash": "^3.0.3",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/trie": "^6.2.0",
     "@ethereumjs/tx": "^5.3.0",
@@ -58,7 +57,9 @@
     "ethereum-cryptography": "^2.2.1",
     "lru-cache": "10.1.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@ethereumjs/ethash": "^3.0.3"
+  },
   "engines": {
     "node": ">=18"
   }

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -380,7 +380,7 @@ export class Blockchain implements BlockchainInterface {
         }
 
         if (this._validateConsensus) {
-          if (!(this.common.consensusAlgorithm() in this._consensusDict)) {
+          if (this.consensus === undefined) {
             throw new Error(
               `Consensus object for ${this.common.consensusAlgorithm()} consensus not available in (see consensusDict option)`
             )

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -77,6 +77,7 @@ export class Blockchain implements BlockchainInterface {
   public readonly common: Common
   private _hardforkByHeadBlockNumber: boolean
   private readonly _validateBlocks: boolean
+  private readonly _validateConsensus: boolean
   private _consensusDict: ConsensusDict
 
   /**
@@ -110,6 +111,7 @@ export class Blockchain implements BlockchainInterface {
 
     this._hardforkByHeadBlockNumber = opts.hardforkByHeadBlockNumber ?? false
     this._validateBlocks = opts.validateBlocks ?? true
+    this._validateConsensus = opts.validateConsensus ?? true
     this._customGenesisState = opts.genesisState
 
     this.db = opts.db !== undefined ? opts.db : new MapDB()
@@ -375,7 +377,9 @@ export class Blockchain implements BlockchainInterface {
           await this.validateBlock(block)
         }
 
-        await this.consensus?.validateConsensus(block)
+        if (this._validateConsensus) {
+          await this.consensus?.validateConsensus(block)
+        }
 
         // set total difficulty in the current context scope
         if (this._headHeaderHash) {

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -14,7 +14,6 @@ import {
   equalsBytes,
 } from '@ethereumjs/util'
 
-import { CasperConsensus } from './consensus/index.js'
 import {
   DBOp,
   DBSaveLookups,
@@ -120,7 +119,6 @@ export class Blockchain implements BlockchainInterface {
     this.events = new AsyncEventEmitter()
 
     this._consensusDict = {}
-    this._consensusDict[ConsensusAlgorithm.Casper] = new CasperConsensus()
 
     if (opts.consensusDict !== undefined) {
       this._consensusDict = { ...this._consensusDict, ...opts.consensusDict }
@@ -140,12 +138,6 @@ export class Blockchain implements BlockchainInterface {
    * or undefined if non available
    */
   get consensus(): Consensus | undefined {
-    if (!(this.common.consensusAlgorithm() in this._consensusDict)) {
-      throw new Error(
-        `No consensus implementation provided for the Common consensus algorithm set (${this.common.consensusAlgorithm()})`
-      )
-    }
-
     return this._consensusDict[this.common.consensusAlgorithm()]
   }
 

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -127,6 +127,7 @@ export class Blockchain implements BlockchainInterface {
     if (opts.consensusDict !== undefined) {
       this._consensusDict = { ...this._consensusDict, ...opts.consensusDict }
     }
+    this._consensusCheck()
 
     this._heads = {}
 
@@ -134,6 +135,14 @@ export class Blockchain implements BlockchainInterface {
 
     if (opts.genesisBlock && !opts.genesisBlock.isGenesis()) {
       throw 'supplied block is not a genesis block'
+    }
+  }
+
+  private _consensusCheck() {
+    if (this._validateConsensus && this.consensus === undefined) {
+      throw new Error(
+        `Consensus object for ${this.common.consensusAlgorithm()} must be passed (see consensusDict option) if consensus validation is activated`
+      )
     }
   }
 
@@ -380,12 +389,6 @@ export class Blockchain implements BlockchainInterface {
         }
 
         if (this._validateConsensus) {
-          if (this.consensus === undefined) {
-            throw new Error(
-              `Consensus object for ${this.common.consensusAlgorithm()} consensus not available in (see consensusDict option)`
-            )
-          }
-
           await this.consensus!.validateConsensus(block)
         }
 
@@ -1217,6 +1220,7 @@ export class Blockchain implements BlockchainInterface {
       timestamp,
     })
 
+    this._consensusCheck()
     await this.consensus?.setup({ blockchain: this })
     await this.consensus?.genesisInit(this.genesisBlock)
   }

--- a/packages/blockchain/src/consensus/casper.ts
+++ b/packages/blockchain/src/consensus/casper.ts
@@ -1,6 +1,8 @@
 import { ConsensusAlgorithm } from '@ethereumjs/common'
+import { BIGINT_0 } from '@ethereumjs/util'
 
 import type { Consensus } from '../types.js'
+import type { BlockHeader } from '@ethereumjs/block'
 
 /**
  * This class encapsulates Casper-related consensus functionality when used with the Blockchain class.
@@ -18,6 +20,14 @@ export class CasperConsensus implements Consensus {
 
   public async validateConsensus(): Promise<void> {}
 
-  public async validateDifficulty(): Promise<void> {}
+  public async validateDifficulty(header: BlockHeader): Promise<void> {
+    // TODO: This is not really part of consensus validation and it should be analyzed
+    // if it is possible to replace by a more generic hardfork check between block and
+    // blockchain along adding new blocks or headers
+    if (header.difficulty !== BIGINT_0) {
+      const msg = 'invalid difficulty.  PoS blocks must have difficulty 0'
+      throw new Error(`${msg} ${header.errorStr()}`)
+    }
+  }
   public async newBlock(): Promise<void> {}
 }

--- a/packages/blockchain/src/consensus/casper.ts
+++ b/packages/blockchain/src/consensus/casper.ts
@@ -1,8 +1,6 @@
 import { ConsensusAlgorithm } from '@ethereumjs/common'
-import { BIGINT_0 } from '@ethereumjs/util'
 
 import type { Consensus } from '../types.js'
-import type { BlockHeader } from '@ethereumjs/block'
 
 /**
  * This class encapsulates Casper-related consensus functionality when used with the Blockchain class.
@@ -20,11 +18,6 @@ export class CasperConsensus implements Consensus {
 
   public async validateConsensus(): Promise<void> {}
 
-  public async validateDifficulty(header: BlockHeader): Promise<void> {
-    if (header.difficulty !== BIGINT_0) {
-      const msg = 'invalid difficulty.  PoS blocks must have difficulty 0'
-      throw new Error(`${msg} ${header.errorStr()}`)
-    }
-  }
+  public async validateDifficulty(): Promise<void> {}
   public async newBlock(): Promise<void> {}
 }

--- a/packages/blockchain/src/consensus/ethash.ts
+++ b/packages/blockchain/src/consensus/ethash.ts
@@ -1,9 +1,13 @@
 import { ConsensusAlgorithm } from '@ethereumjs/common'
-import { Ethash } from '@ethereumjs/ethash'
 
 import type { Blockchain } from '../index.js'
 import type { Consensus, ConsensusOptions } from '../types.js'
 import type { Block, BlockHeader } from '@ethereumjs/block'
+
+type MinimalEthashInterface = {
+  dbOpts: Object
+  verifyPOW(block: Block): Promise<boolean>
+}
 
 /**
  * This class encapsulates Ethash-related consensus functionality when used with the Blockchain class.
@@ -11,16 +15,14 @@ import type { Block, BlockHeader } from '@ethereumjs/block'
 export class EthashConsensus implements Consensus {
   blockchain: Blockchain | undefined
   algorithm: ConsensusAlgorithm
-  _ethash: Ethash | undefined
+  _ethash: MinimalEthashInterface
 
-  constructor() {
+  constructor(ethash: MinimalEthashInterface) {
     this.algorithm = ConsensusAlgorithm.Ethash
+    this._ethash = ethash
   }
 
   async validateConsensus(block: Block): Promise<void> {
-    if (!this._ethash) {
-      throw new Error('blockchain not provided')
-    }
     const valid = await this._ethash.verifyPOW(block)
     if (!valid) {
       throw new Error('invalid POW')
@@ -44,7 +46,7 @@ export class EthashConsensus implements Consensus {
   public async genesisInit(): Promise<void> {}
   public async setup({ blockchain }: ConsensusOptions): Promise<void> {
     this.blockchain = blockchain
-    this._ethash = new Ethash(this.blockchain!.db as any)
+    this._ethash.dbOpts = this.blockchain!.db as any
   }
   public async newBlock(): Promise<void> {}
 }

--- a/packages/blockchain/src/consensus/ethash.ts
+++ b/packages/blockchain/src/consensus/ethash.ts
@@ -5,7 +5,7 @@ import type { Consensus, ConsensusOptions } from '../types.js'
 import type { Block, BlockHeader } from '@ethereumjs/block'
 
 type MinimalEthashInterface = {
-  cacheDB: Object
+  cacheDB?: any
   verifyPOW(block: Block): Promise<boolean>
 }
 

--- a/packages/blockchain/src/consensus/ethash.ts
+++ b/packages/blockchain/src/consensus/ethash.ts
@@ -5,7 +5,7 @@ import type { Consensus, ConsensusOptions } from '../types.js'
 import type { Block, BlockHeader } from '@ethereumjs/block'
 
 type MinimalEthashInterface = {
-  dbOpts: Object
+  cacheDB: Object
   verifyPOW(block: Block): Promise<boolean>
 }
 
@@ -46,7 +46,7 @@ export class EthashConsensus implements Consensus {
   public async genesisInit(): Promise<void> {}
   public async setup({ blockchain }: ConsensusOptions): Promise<void> {
     this.blockchain = blockchain
-    this._ethash.dbOpts = this.blockchain!.db as any
+    this._ethash.cacheDB = this.blockchain!.db as any
   }
   public async newBlock(): Promise<void> {}
 }

--- a/packages/blockchain/src/consensus/index.ts
+++ b/packages/blockchain/src/consensus/index.ts
@@ -1,5 +1,4 @@
-import { CasperConsensus } from './casper.js'
 import { CliqueConsensus } from './clique.js'
 import { EthashConsensus } from './ethash.js'
 
-export { CasperConsensus, CliqueConsensus, EthashConsensus }
+export { CliqueConsensus, EthashConsensus }

--- a/packages/blockchain/src/consensus/index.ts
+++ b/packages/blockchain/src/consensus/index.ts
@@ -1,4 +1,5 @@
+import { CasperConsensus } from './casper.js'
 import { CliqueConsensus } from './clique.js'
 import { EthashConsensus } from './ethash.js'
 
-export { CliqueConsensus, EthashConsensus }
+export { CasperConsensus, CliqueConsensus, EthashConsensus }

--- a/packages/blockchain/src/constructors.ts
+++ b/packages/blockchain/src/constructors.ts
@@ -17,7 +17,7 @@ import type { Chain } from '@ethereumjs/common'
 export async function createBlockchain(opts: BlockchainOptions = {}) {
   const blockchain = new Blockchain(opts)
 
-  await blockchain.consensus.setup({ blockchain })
+  await blockchain.consensus?.setup({ blockchain })
 
   let stateRoot = opts.genesisBlock?.header.stateRoot ?? opts.genesisStateRoot
   if (stateRoot === undefined) {
@@ -56,7 +56,7 @@ export async function createBlockchain(opts: BlockchainOptions = {}) {
     DBSetBlockOrHeader(genesisBlock).map((op) => dbOps.push(op))
     DBSaveLookups(genesisHash, BIGINT_0).map((op) => dbOps.push(op))
     await blockchain.dbManager.batch(dbOps)
-    await blockchain.consensus.genesisInit(genesisBlock)
+    await blockchain.consensus?.genesisInit(genesisBlock)
   }
 
   // At this point, we can safely set the genesis:

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -1,5 +1,5 @@
 export { Blockchain } from './blockchain.js'
-export { CliqueConsensus, EthashConsensus } from './consensus/index.js'
+export { CasperConsensus, CliqueConsensus, EthashConsensus } from './consensus/index.js'
 export * from './constructors.js'
 export {
   DBOp,

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -1,5 +1,5 @@
 export { Blockchain } from './blockchain.js'
-export { CasperConsensus, CliqueConsensus, EthashConsensus } from './consensus/index.js'
+export { CliqueConsensus, EthashConsensus } from './consensus/index.js'
 export * from './constructors.js'
 export {
   DBOp,

--- a/packages/blockchain/src/types.ts
+++ b/packages/blockchain/src/types.ts
@@ -132,6 +132,10 @@ export interface GenesisOptions {
   genesisStateRoot?: Uint8Array
 }
 
+export type ConsensusDict = {
+  [consensusAlgorithm: ConsensusAlgorithm | string]: Consensus
+}
+
 /**
  * This are the options that the Blockchain constructor can receive.
  */
@@ -181,9 +185,20 @@ export interface BlockchainOptions extends GenesisOptions {
   validateBlocks?: boolean
 
   /**
-   * Optional custom consensus that implements the {@link Consensus} class
+   * Optional dictionary with custom consensus implementations adhering to the
+   * {@link Consensus} interface.
+   *
+   * By default a blockchain object is initialized with a `CasperConsensus` implementation
+   * for PoS, so this consensus implementation does not need to be provided anymore.
+   * `EthashConsensus` and `CliqueConsensus` implementations are provided with the package
+   * and need to be passed via this option if an `ConsensusAlgorithm.Ethash` or
+   * `ConsensusAlgorithm.Clique` consensus blockchain should be used.
+   *
+   * Additionally it is possible to provide a fully custom consensus implementation.
+   * Note that this needs a custom `Common` object passed to the blockchain where
+   * the `ConsensusAlgorithm` string matches the string used here.
    */
-  consensus?: Consensus
+  consensusDict?: ConsensusDict
 }
 
 /**

--- a/packages/blockchain/src/types.ts
+++ b/packages/blockchain/src/types.ts
@@ -174,13 +174,14 @@ export interface BlockchainOptions extends GenesisOptions {
   validateBlocks?: boolean
 
   /**
-   * Validate the consensus if a respective consensus implementation is passed
-   * to `consensusDict` (see respective option).
+   * Validate the consensus with the respective consensus implementation passed
+   * to `consensusDict` (see respective option) `CapserConsensus` (which effectively
+   * does nothing) is available by default.
    *
    * For the build-in validation classes the following validations take place.
    * - 'pow' with 'ethash' algorithm (validates the proof-of-work)
    * - 'poa' with 'clique' algorithm (verifies the block signatures)
-   * Default: `true`.
+   * Default: `false`.
    */
   validateConsensus?: boolean
 

--- a/packages/blockchain/src/types.ts
+++ b/packages/blockchain/src/types.ts
@@ -195,11 +195,11 @@ export interface BlockchainOptions extends GenesisOptions {
    * respective consensus validation objects `EthashConsensus` or `CliqueConsensus`.
    *
    * ```ts
-   * import { EthashConsensus, createBlockchain } from '../src/index.js'
-   * import type { ConsensusDict } from '../src/index.js'
+   * import { CliqueConsensus, createBlockchain } from '@ethereumjs/blockchain'
+   * import type { ConsensusDict } from '@ethereumjs/blockchain'
    *
    * const consensusDict: ConsensusDict = {}
-   * consensusDict[ConsensusAlgorithm.Ethash] = new EthashConsensus()
+   * consensusDict[ConsensusAlgorithm.Clique] = new CliqueConsensus()
    * const blockchain = await createBlockchain({ common, consensusDict })
    * ```
    *

--- a/packages/blockchain/src/types.ts
+++ b/packages/blockchain/src/types.ts
@@ -166,17 +166,6 @@ export interface BlockchainOptions extends GenesisOptions {
   db?: DB<Uint8Array | string | number, Uint8Array | string | DBObject>
 
   /**
-   * This flags indicates if a block should be validated along the consensus algorithm
-   * or protocol used by the chain, e.g. by verifying the PoW on the block.
-   *
-   * Supported consensus types and algorithms (taken from the `Common` instance):
-   * - 'pow' with 'ethash' algorithm (validates the proof-of-work)
-   * - 'poa' with 'clique' algorithm (verifies the block signatures)
-   * Default: `true`.
-   */
-  validateConsensus?: boolean
-
-  /**
    * This flag indicates if protocol-given consistency checks on
    * block headers and included uncles and transactions should be performed,
    * see Block#validate for details.
@@ -192,6 +181,15 @@ export interface BlockchainOptions extends GenesisOptions {
    * consensus is not validated by default. For `ConsensusAlgorithm.Ethash` and
    * `ConsensusAlgorith.Clique` consensus validation can be activated by passing in the
    * respective consensus validation objects `EthashConsensus` or `CliqueConsensus`.
+   *
+   * ```ts
+   * import { EthashConsensus, createBlockchain } from '../src/index.js'
+   * import type { ConsensusDict } from '../src/index.js'
+   *
+   * const consensusDict: ConsensusDict = {}
+   * consensusDict[ConsensusAlgorithm.Ethash] = new EthashConsensus()
+   * const blockchain = await createBlockchain({ common, consensusDict })
+   * ```
    *
    * Additionally it is possible to provide a fully custom consensus implementation.
    * Note that this needs a custom `Common` object passed to the blockchain where

--- a/packages/blockchain/src/types.ts
+++ b/packages/blockchain/src/types.ts
@@ -174,6 +174,17 @@ export interface BlockchainOptions extends GenesisOptions {
   validateBlocks?: boolean
 
   /**
+   * Validate the consensus if a respective consensus implementation is passed
+   * to `consensusDict` (see respective option).
+   *
+   * For the build-in validation classes the following validations take place.
+   * - 'pow' with 'ethash' algorithm (validates the proof-of-work)
+   * - 'poa' with 'clique' algorithm (verifies the block signatures)
+   * Default: `true`.
+   */
+  validateConsensus?: boolean
+
+  /**
    * Optional dictionary with consensus objects (adhering to the {@link Consensus} interface)
    * if consensus validation is wished for certain consensus algorithms.
    *

--- a/packages/blockchain/src/types.ts
+++ b/packages/blockchain/src/types.ts
@@ -10,7 +10,7 @@ export type BlockchainEvents = {
 }
 
 export interface BlockchainInterface {
-  consensus: Consensus
+  consensus: Consensus | undefined
   /**
    * Adds a block to the blockchain.
    *
@@ -185,14 +185,13 @@ export interface BlockchainOptions extends GenesisOptions {
   validateBlocks?: boolean
 
   /**
-   * Optional dictionary with custom consensus implementations adhering to the
-   * {@link Consensus} interface.
+   * Optional dictionary with consensus objects (adhering to the {@link Consensus} interface)
+   * if consensus validation is wished for certain consensus algorithms.
    *
-   * By default a blockchain object is initialized with a `CasperConsensus` implementation
-   * for PoS, so this consensus implementation does not need to be provided anymore.
-   * `EthashConsensus` and `CliqueConsensus` implementations are provided with the package
-   * and need to be passed via this option if an `ConsensusAlgorithm.Ethash` or
-   * `ConsensusAlgorithm.Clique` consensus blockchain should be used.
+   * Since consensus validation moved to the Ethereum consensus layer with Proof-of-Stake
+   * consensus is not validated by default. For `ConsensusAlgorithm.Ethash` and
+   * `ConsensusAlgorith.Clique` consensus validation can be activated by passing in the
+   * respective consensus validation objects `EthashConsensus` or `CliqueConsensus`.
    *
    * Additionally it is possible to provide a fully custom consensus implementation.
    * Note that this needs a custom `Common` object passed to the blockchain where

--- a/packages/blockchain/test/blockValidation.spec.ts
+++ b/packages/blockchain/test/blockValidation.spec.ts
@@ -1,13 +1,15 @@
 import { BlockHeader, createBlockFromBlockData } from '@ethereumjs/block'
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, ConsensusAlgorithm, Hardfork } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import { KECCAK256_RLP, bytesToHex, randomBytes } from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak.js'
 import { assert, describe, expect, it } from 'vitest'
 
-import { createBlockchain } from '../src/index.js'
+import { EthashConsensus, createBlockchain } from '../src/index.js'
 
 import { createBlock } from './util.js'
+
+import type { ConsensusDict } from '../src/index.js'
 
 describe('[Blockchain]: Block validation tests', () => {
   it('should throw if an uncle is included before', async () => {
@@ -119,13 +121,11 @@ describe('[Blockchain]: Block validation tests', () => {
     }
   })
 
-  // TODO: See if we can skip this test setup since it is hard to recreate
-  // (combination of Ethash difficulty validation: yes, PoW validation: no not possible any more)
-  /*it('should throw if the uncle header is invalid', async () => {
+  it('should throw if the uncle header is invalid', async () => {
     const consensusDict: ConsensusDict = {}
     consensusDict[ConsensusAlgorithm.Ethash] = new EthashConsensus()
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await createBlockchain({ common, consensusDict })
+    const blockchain = await createBlockchain({ common, validateConsensus: false, consensusDict })
 
     const genesis = blockchain.genesisBlock
 
@@ -155,7 +155,7 @@ describe('[Blockchain]: Block validation tests', () => {
         'block throws when uncle header is invalid'
       )
     }
-  })*/
+  })
 
   it('throws if uncle is a canonical block', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })

--- a/packages/blockchain/test/blockValidation.spec.ts
+++ b/packages/blockchain/test/blockValidation.spec.ts
@@ -12,7 +12,7 @@ import { createBlock } from './util.js'
 describe('[Blockchain]: Block validation tests', () => {
   it('should throw if an uncle is included before', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await createBlockchain({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common })
 
     const genesis = blockchain.genesisBlock
 
@@ -39,7 +39,7 @@ describe('[Blockchain]: Block validation tests', () => {
 
   it('should throw if the uncle parent block is not part of the canonical chain', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await createBlockchain({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common })
 
     const genesis = blockchain.genesisBlock
 
@@ -66,7 +66,7 @@ describe('[Blockchain]: Block validation tests', () => {
 
   it('should throw if the uncle is too old', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await createBlockchain({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common })
 
     const genesis = blockchain.genesisBlock
 
@@ -99,7 +99,7 @@ describe('[Blockchain]: Block validation tests', () => {
 
   it('should throw if uncle is too young', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await createBlockchain({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common })
 
     const genesis = blockchain.genesisBlock
 
@@ -119,9 +119,13 @@ describe('[Blockchain]: Block validation tests', () => {
     }
   })
 
-  it('should throw if the uncle header is invalid', async () => {
+  // TODO: See if we can skip this test setup since it is hard to recreate
+  // (combination of Ethash difficulty validation: yes, PoW validation: no not possible any more)
+  /*it('should throw if the uncle header is invalid', async () => {
+    const consensusDict: ConsensusDict = {}
+    consensusDict[ConsensusAlgorithm.Ethash] = new EthashConsensus()
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await createBlockchain({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common, consensusDict })
 
     const genesis = blockchain.genesisBlock
 
@@ -151,11 +155,11 @@ describe('[Blockchain]: Block validation tests', () => {
         'block throws when uncle header is invalid'
       )
     }
-  })
+  })*/
 
   it('throws if uncle is a canonical block', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await createBlockchain({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common })
 
     const genesis = blockchain.genesisBlock
 
@@ -178,7 +182,7 @@ describe('[Blockchain]: Block validation tests', () => {
 
   it('successfully validates uncles', async () => {
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await createBlockchain({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common })
 
     const genesis = blockchain.genesisBlock
 
@@ -204,7 +208,7 @@ describe('[Blockchain]: Block validation tests', () => {
       hardfork: Hardfork.London,
     })
 
-    const blockchain = await createBlockchain({ common, validateConsensus: false })
+    const blockchain = await createBlockchain({ common })
     const genesis = blockchain.genesisBlock
 
     // Small hack to hack in the activation block number
@@ -300,7 +304,6 @@ describe('[Blockchain]: Block validation tests', () => {
 
     const blockchain = await createBlockchain({
       common,
-      validateConsensus: false,
       validateBlocks: false,
     })
 
@@ -389,7 +392,6 @@ describe('EIP 7685: requests field validation tests', () => {
     })
     const blockchain = await createBlockchain({
       common,
-      validateConsensus: false,
     })
     const block = createBlockFromBlockData(
       {

--- a/packages/blockchain/test/blockValidation.spec.ts
+++ b/packages/blockchain/test/blockValidation.spec.ts
@@ -1,5 +1,6 @@
 import { BlockHeader, createBlockFromBlockData } from '@ethereumjs/block'
 import { Chain, Common, ConsensusAlgorithm, Hardfork } from '@ethereumjs/common'
+import { Ethash } from '@ethereumjs/ethash'
 import { RLP } from '@ethereumjs/rlp'
 import { KECCAK256_RLP, bytesToHex, randomBytes } from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak.js'
@@ -123,7 +124,7 @@ describe('[Blockchain]: Block validation tests', () => {
 
   it('should throw if the uncle header is invalid', async () => {
     const consensusDict: ConsensusDict = {}
-    consensusDict[ConsensusAlgorithm.Ethash] = new EthashConsensus()
+    consensusDict[ConsensusAlgorithm.Ethash] = new EthashConsensus(new Ethash())
     const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Chainstart })
     const blockchain = await createBlockchain({ common, validateConsensus: false, consensusDict })
 

--- a/packages/blockchain/test/clique.spec.ts
+++ b/packages/blockchain/test/clique.spec.ts
@@ -10,11 +10,10 @@ import {
 import { Address, concatBytes, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { CLIQUE_NONCE_AUTH, CLIQUE_NONCE_DROP } from '../src/consensus/clique.js'
+import { CLIQUE_NONCE_AUTH, CLIQUE_NONCE_DROP, CliqueConsensus } from '../src/consensus/clique.js'
 import { createBlockchain } from '../src/index.js'
 
-import type { CliqueConsensus } from '../src/consensus/clique.js'
-import type { Blockchain } from '../src/index.js'
+import type { Blockchain, ConsensusDict } from '../src/index.js'
 import type { Block } from '@ethereumjs/block'
 import type { CliqueConfig } from '@ethereumjs/common'
 
@@ -91,9 +90,12 @@ const initWithSigners = async (signers: Signer[], common?: Common) => {
   )
   blocks.push(genesisBlock)
 
+  const consensusDict: ConsensusDict = {}
+  consensusDict[ConsensusAlgorithm.Clique] = new CliqueConsensus()
+
   const blockchain = await createBlockchain({
     validateBlocks: true,
-    validateConsensus: true,
+    consensusDict,
     genesisBlock,
     common,
   })
@@ -191,7 +193,9 @@ const addNextBlock = async (
 describe('Clique: Initialization', () => {
   it('should initialize a clique blockchain', async () => {
     const common = new Common({ chain: Chain.Goerli, hardfork: Hardfork.Chainstart })
-    const blockchain = await createBlockchain({ common })
+    const consensusDict: ConsensusDict = {}
+    consensusDict[ConsensusAlgorithm.Clique] = new CliqueConsensus()
+    const blockchain = await createBlockchain({ common, consensusDict })
 
     const head = await blockchain.getIteratorHead()
     assert.deepEqual(head.hash(), blockchain.genesisBlock.hash(), 'correct genesis hash')

--- a/packages/blockchain/test/clique.spec.ts
+++ b/packages/blockchain/test/clique.spec.ts
@@ -95,6 +95,7 @@ const initWithSigners = async (signers: Signer[], common?: Common) => {
 
   const blockchain = await createBlockchain({
     validateBlocks: true,
+    validateConsensus: true,
     consensusDict,
     genesisBlock,
     common,

--- a/packages/blockchain/test/customConsensus.spec.ts
+++ b/packages/blockchain/test/customConsensus.spec.ts
@@ -3,9 +3,11 @@ import { Common, Hardfork } from '@ethereumjs/common'
 import { bytesToHex } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { EthashConsensus, createBlockchain } from '../src/index.js'
+import { createBlockchain } from '../src/index.js'
 
-import type { Consensus } from '../src/index.js'
+import * as testnet from './testdata/testnet.json'
+
+import type { Consensus, ConsensusDict } from '../src/index.js'
 import type { Block, BlockHeader } from '@ethereumjs/block'
 
 class fibonacciConsensus implements Consensus {
@@ -41,12 +43,15 @@ class fibonacciConsensus implements Consensus {
   }
 }
 
+testnet.default.consensus.algorithm = 'fibonacci'
+const consensusDict: ConsensusDict = {}
+consensusDict['fibonacci'] = new fibonacciConsensus()
+
 describe('Optional consensus parameter in blockchain constructor', () => {
   it('blockchain constructor should work with custom consensus', async () => {
-    const common = new Common({ chain: 'mainnet', hardfork: Hardfork.Chainstart })
-    const consensus = new fibonacciConsensus()
+    const common = new Common({ chain: testnet, hardfork: Hardfork.Chainstart })
     try {
-      const blockchain = await createBlockchain({ common, consensus })
+      const blockchain = await createBlockchain({ common, consensusDict })
       assert.equal(
         (blockchain.consensus as fibonacciConsensus).algorithm,
         'fibonacciConsensus',
@@ -60,9 +65,8 @@ describe('Optional consensus parameter in blockchain constructor', () => {
 
 describe('Custom consensus validation rules', () => {
   it('should validat custom consensus rules', async () => {
-    const common = new Common({ chain: 'mainnet', hardfork: Hardfork.Chainstart })
-    const consensus = new fibonacciConsensus()
-    const blockchain = await createBlockchain({ common, consensus })
+    const common = new Common({ chain: testnet, hardfork: Hardfork.Chainstart })
+    const blockchain = await createBlockchain({ common, consensusDict })
     const block = createBlockFromBlockData(
       {
         header: {
@@ -138,9 +142,8 @@ describe('Custom consensus validation rules', () => {
 
 describe('consensus transition checks', () => {
   it('should transition correctly', async () => {
-    const common = new Common({ chain: 'mainnet', hardfork: Hardfork.Chainstart })
-    const consensus = new fibonacciConsensus()
-    const blockchain = await createBlockchain({ common, consensus })
+    const common = new Common({ chain: testnet, hardfork: Hardfork.Chainstart })
+    const blockchain = await createBlockchain({ common, consensusDict })
 
     try {
       await blockchain.checkAndTransitionHardForkByNumber(5n)
@@ -148,22 +151,6 @@ describe('consensus transition checks', () => {
     } catch (err: any) {
       assert.fail(
         `checkAndTransitionHardForkByNumber should not throw with custom consensus, error=${err.message}`
-      )
-    }
-
-    blockchain.consensus = new EthashConsensus()
-    blockchain.common.consensusAlgorithm = () => 'fibonacci'
-
-    try {
-      await blockchain.checkAndTransitionHardForkByNumber(5n)
-      assert.fail(
-        'checkAndTransitionHardForkByNumber should throw when using standard consensus (ethash, clique, casper) but consensus algorithm defined in common is different'
-      )
-    } catch (err: any) {
-      assert.equal(
-        err.message,
-        'consensus algorithm fibonacci not supported',
-        `checkAndTransitionHardForkByNumber correctly throws when using standard consensus (ethash, clique, casper) but consensus algorithm defined in common is different, error=${err.message}`
       )
     }
   })

--- a/packages/blockchain/test/customConsensus.spec.ts
+++ b/packages/blockchain/test/customConsensus.spec.ts
@@ -51,7 +51,7 @@ describe('Optional consensus parameter in blockchain constructor', () => {
   it('blockchain constructor should work with custom consensus', async () => {
     const common = new Common({ chain: testnet, hardfork: Hardfork.Chainstart })
     try {
-      const blockchain = await createBlockchain({ common, consensusDict })
+      const blockchain = await createBlockchain({ common, validateConsensus: true, consensusDict })
       assert.equal(
         (blockchain.consensus as fibonacciConsensus).algorithm,
         'fibonacciConsensus',
@@ -66,7 +66,7 @@ describe('Optional consensus parameter in blockchain constructor', () => {
 describe('Custom consensus validation rules', () => {
   it('should validat custom consensus rules', async () => {
     const common = new Common({ chain: testnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await createBlockchain({ common, consensusDict })
+    const blockchain = await createBlockchain({ common, validateConsensus: true, consensusDict })
     const block = createBlockFromBlockData(
       {
         header: {
@@ -143,7 +143,7 @@ describe('Custom consensus validation rules', () => {
 describe('consensus transition checks', () => {
   it('should transition correctly', async () => {
     const common = new Common({ chain: testnet, hardfork: Hardfork.Chainstart })
-    const blockchain = await createBlockchain({ common, consensusDict })
+    const blockchain = await createBlockchain({ common, validateConsensus: true, consensusDict })
 
     try {
       await blockchain.checkAndTransitionHardForkByNumber(5n)

--- a/packages/blockchain/test/customConsensus.spec.ts
+++ b/packages/blockchain/test/customConsensus.spec.ts
@@ -153,5 +153,16 @@ describe('consensus transition checks', () => {
         `checkAndTransitionHardForkByNumber should not throw with custom consensus, error=${err.message}`
       )
     }
+
+    blockchain.common.consensusAlgorithm = () => 'ethash'
+
+    try {
+      await blockchain.checkAndTransitionHardForkByNumber(5n)
+      assert.fail(
+        'checkAndTransitionHardForkByNumber should throw when using standard consensus (ethash, clique, casper) but consensus algorithm defined in common is different'
+      )
+    } catch (err: any) {
+      assert.ok(err.message.includes('Consensus object for ethash must be passed'))
+    }
   })
 })

--- a/packages/blockchain/test/pos.spec.ts
+++ b/packages/blockchain/test/pos.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
 import { bytesToHex } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
@@ -88,6 +88,29 @@ describe('Proof of Stake - inserting blocks into blockchain', () => {
         BigInt(1313601),
         'should have calculated the correct post-Merge total difficulty'
       )
+
+      const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
+      const powBlock = createBlockFromBlockData(
+        {
+          header: {
+            number: 16,
+            difficulty: BigInt(1),
+            parentHash: latestHeader.hash(),
+            timestamp: latestHeader.timestamp + BigInt(1),
+            gasLimit: BigInt(10000),
+          },
+        },
+        { common }
+      )
+      try {
+        await blockchain.putBlock(powBlock)
+        assert.fail('should throw when inserting PoW block')
+      } catch (err: any) {
+        assert.ok(
+          err.message.includes('invalid difficulty'),
+          'should throw with invalid difficulty message'
+        )
+      }
     })
   }
 })

--- a/packages/blockchain/test/pos.spec.ts
+++ b/packages/blockchain/test/pos.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Common, Hardfork } from '@ethereumjs/common'
 import { bytesToHex } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
@@ -63,7 +63,6 @@ describe('Proof of Stake - inserting blocks into blockchain', () => {
     it('should pass', async () => {
       const blockchain = await createBlockchain({
         validateBlocks: true,
-        validateConsensus: false,
         common: s.common,
         hardforkByHeadBlockNumber: true,
       })
@@ -89,29 +88,6 @@ describe('Proof of Stake - inserting blocks into blockchain', () => {
         BigInt(1313601),
         'should have calculated the correct post-Merge total difficulty'
       )
-
-      const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.London })
-      const powBlock = createBlockFromBlockData(
-        {
-          header: {
-            number: 16,
-            difficulty: BigInt(1),
-            parentHash: latestHeader.hash(),
-            timestamp: latestHeader.timestamp + BigInt(1),
-            gasLimit: BigInt(10000),
-          },
-        },
-        { common }
-      )
-      try {
-        await blockchain.putBlock(powBlock)
-        assert.fail('should throw when inserting PoW block')
-      } catch (err: any) {
-        assert.ok(
-          err.message.includes('invalid difficulty'),
-          'should throw with invalid difficulty message'
-        )
-      }
     })
   }
 })

--- a/packages/blockchain/test/reorg.spec.ts
+++ b/packages/blockchain/test/reorg.spec.ts
@@ -1,14 +1,14 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Chain, Common, ConsensusAlgorithm, Hardfork } from '@ethereumjs/common'
 import { Address, equalsBytes, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { CLIQUE_NONCE_AUTH } from '../src/consensus/clique.js'
+import { CLIQUE_NONCE_AUTH, CliqueConsensus } from '../src/consensus/clique.js'
 import { createBlockchain } from '../src/index.js'
 
 import { generateConsecutiveBlock } from './util.js'
 
-import type { CliqueConsensus } from '../src/consensus/clique.js'
+import type { ConsensusDict } from '../src/index.js'
 import type { Block } from '@ethereumjs/block'
 
 describe('reorg tests', () => {
@@ -71,9 +71,13 @@ describe('reorg tests', () => {
       { header: { extraData: new Uint8Array(97) } },
       { common }
     )
+
+    const consensusDict: ConsensusDict = {}
+    consensusDict[ConsensusAlgorithm.Clique] = new CliqueConsensus()
     const blockchain = await createBlockchain({
       validateBlocks: false,
       validateConsensus: false,
+      consensusDict,
       common,
       genesisBlock,
     })

--- a/packages/blockchain/test/util.ts
+++ b/packages/blockchain/test/util.ts
@@ -53,7 +53,6 @@ export const generateBlockchain = async (numberOfBlocks: number, genesis?: Block
 
   const blockchain = await createBlockchain({
     validateBlocks: true,
-    validateConsensus: false,
     genesisBlock: genesis ?? blocks[0],
   })
   try {

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { createBlockFromValuesArray } from '@ethereumjs/block'
-import { createBlockchain } from '@ethereumjs/blockchain'
+import { CliqueConsensus, createBlockchain } from '@ethereumjs/blockchain'
 import {
   Chain,
   Common,
@@ -63,6 +63,7 @@ import type { FullEthereumService } from '../src/service/index.js'
 import type { ClientOpts } from '../src/types.js'
 import type { RPCArgs } from './startRpc.js'
 import type { Block, BlockBytes } from '@ethereumjs/block'
+import type { ConsensusDict } from '@ethereumjs/blockchain'
 import type { CustomCrypto } from '@ethereumjs/common'
 import type { GenesisState, PrefixedHexString } from '@ethereumjs/util'
 import type { AbstractLevel } from 'abstract-level'
@@ -636,14 +637,21 @@ async function startClient(
 
   let blockchain
   if (genesisMeta.genesisState !== undefined || genesisMeta.genesisStateRoot !== undefined) {
-    const validateConsensus = config.chainCommon.consensusAlgorithm() === ConsensusAlgorithm.Clique
+    let validateConsensus = false
+    const consensusDict: ConsensusDict = {}
+    if (config.chainCommon.consensusAlgorithm() === ConsensusAlgorithm.Clique) {
+      consensusDict[ConsensusAlgorithm.Clique] = new CliqueConsensus()
+      validateConsensus = true
+    }
+
     blockchain = await createBlockchain({
       db: new LevelDB(dbs.chainDB),
       ...genesisMeta,
       common: config.chainCommon,
       hardforkByHeadBlockNumber: true,
-      validateConsensus,
       validateBlocks: true,
+      validateConsensus,
+      consensusDict,
       genesisState: genesisMeta.genesisState,
       genesisStateRoot: genesisMeta.genesisStateRoot,
     })

--- a/packages/client/src/blockchain/chain.ts
+++ b/packages/client/src/blockchain/chain.ts
@@ -1,5 +1,5 @@
 import { BlockHeader, createBlockFromValuesArray } from '@ethereumjs/block'
-import { createBlockchain } from '@ethereumjs/blockchain'
+import { CliqueConsensus, createBlockchain } from '@ethereumjs/blockchain'
 import { ConsensusAlgorithm, Hardfork } from '@ethereumjs/common'
 import { BIGINT_0, BIGINT_1, equalsBytes } from '@ethereumjs/util'
 
@@ -8,7 +8,7 @@ import { Event } from '../types.js'
 
 import type { Config } from '../config.js'
 import type { Block } from '@ethereumjs/block'
-import type { Blockchain } from '@ethereumjs/blockchain'
+import type { Blockchain, ConsensusDict } from '@ethereumjs/blockchain'
 import type { DB, DBObject, GenesisState } from '@ethereumjs/util'
 import type { AbstractLevel } from 'abstract-level'
 
@@ -158,7 +158,9 @@ export class Chain {
    */
   public static async create(options: ChainOptions) {
     let validateConsensus = false
+    const consensusDict: ConsensusDict = {}
     if (options.config.chainCommon.consensusAlgorithm() === ConsensusAlgorithm.Clique) {
+      consensusDict[ConsensusAlgorithm.Clique] = new CliqueConsensus()
       validateConsensus = true
     }
 
@@ -170,6 +172,7 @@ export class Chain {
         hardforkByHeadBlockNumber: true,
         validateBlocks: true,
         validateConsensus,
+        consensusDict,
         genesisState: options.genesisState,
         genesisStateRoot: options.genesisStateRoot,
       }))
@@ -448,7 +451,7 @@ export class Chain {
           td,
           b.header.timestamp
         )
-        await this.blockchain.consensus.setup({ blockchain: this.blockchain })
+        await this.blockchain.consensus?.setup({ blockchain: this.blockchain })
       }
 
       const block = createBlockFromValuesArray(b.raw(), {

--- a/packages/client/test/integration/merge.spec.ts
+++ b/packages/client/test/integration/merge.spec.ts
@@ -1,5 +1,5 @@
 import { BlockHeader } from '@ethereumjs/block'
-import { createBlockchain } from '@ethereumjs/blockchain'
+import { CliqueConsensus, EthashConsensus, createBlockchain } from '@ethereumjs/blockchain'
 import {
   Chain as ChainCommon,
   ConsensusAlgorithm,
@@ -18,7 +18,7 @@ import { Event } from '../../src/types.js'
 import { MockServer } from './mocks/mockserver.js'
 import { destroy, setup } from './util.js'
 
-import type { CliqueConsensus } from '@ethereumjs/blockchain'
+import type { ConsensusDict } from '@ethereumjs/blockchain'
 import type { Common } from '@ethereumjs/common'
 
 const commonPoA = createCustomCommon(
@@ -74,10 +74,14 @@ const accounts: [Address, Uint8Array][] = [
 async function minerSetup(common: Common): Promise<[MockServer, FullEthereumService]> {
   const config = new Config({ common, accountCache: 10000, storageCache: 1000 })
   const server = new MockServer({ config }) as any
+  const consensusDict: ConsensusDict = {}
+  consensusDict[ConsensusAlgorithm.Clique] = new CliqueConsensus()
+  consensusDict[ConsensusAlgorithm.Ethash] = new EthashConsensus()
   const blockchain = await createBlockchain({
     common,
     validateBlocks: false,
     validateConsensus: false,
+    consensusDict,
   })
   ;(blockchain.consensus as CliqueConsensus).cliqueActiveSigners = () => [accounts[0][0]] // stub
   const serviceConfig = new Config({

--- a/packages/client/test/integration/merge.spec.ts
+++ b/packages/client/test/integration/merge.spec.ts
@@ -7,6 +7,7 @@ import {
   Hardfork,
   createCustomCommon,
 } from '@ethereumjs/common'
+import { Ethash } from '@ethereumjs/ethash'
 import { Address, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
@@ -76,7 +77,7 @@ async function minerSetup(common: Common): Promise<[MockServer, FullEthereumServ
   const server = new MockServer({ config }) as any
   const consensusDict: ConsensusDict = {}
   consensusDict[ConsensusAlgorithm.Clique] = new CliqueConsensus()
-  consensusDict[ConsensusAlgorithm.Ethash] = new EthashConsensus()
+  consensusDict[ConsensusAlgorithm.Ethash] = new EthashConsensus(new Ethash())
   const blockchain = await createBlockchain({
     common,
     validateBlocks: false,

--- a/packages/client/test/integration/miner.spec.ts
+++ b/packages/client/test/integration/miner.spec.ts
@@ -1,4 +1,4 @@
-import { createBlockchain } from '@ethereumjs/blockchain'
+import { CliqueConsensus, createBlockchain } from '@ethereumjs/blockchain'
 import {
   Chain as ChainCommon,
   Common,
@@ -18,7 +18,7 @@ import { Event } from '../../src/types.js'
 import { MockServer } from './mocks/mockserver.js'
 import { destroy, setup } from './util.js'
 
-import type { CliqueConsensus } from '@ethereumjs/blockchain'
+import type { ConsensusDict } from '@ethereumjs/blockchain'
 
 // Schedule london at 0 and also unset any past scheduled timestamp hardforks that might collide with test
 const hardforks = new Common({ chain: ChainCommon.Goerli })
@@ -52,10 +52,13 @@ async function minerSetup(): Promise<[MockServer, FullEthereumService]> {
   const config = new Config({ common, accountCache: 10000, storageCache: 1000 })
   const server = new MockServer({ config }) as any
 
+  const consensusDict: ConsensusDict = {}
+  consensusDict[ConsensusAlgorithm.Clique] = new CliqueConsensus()
   const blockchain = await createBlockchain({
     common,
     validateBlocks: false,
     validateConsensus: false,
+    consensusDict,
   })
   ;(blockchain.consensus as CliqueConsensus).cliqueActiveSigners = () => [accounts[0][0]] // stub
   const chain = await Chain.create({ config, blockchain })

--- a/packages/client/test/integration/util.ts
+++ b/packages/client/test/integration/util.ts
@@ -1,4 +1,5 @@
-import { createBlockchain } from '@ethereumjs/blockchain'
+import { CliqueConsensus, createBlockchain } from '@ethereumjs/blockchain'
+import { type Common, ConsensusAlgorithm } from '@ethereumjs/common'
 import { MemoryLevel } from 'memory-level'
 
 import { Config } from '../../src/config.js'
@@ -9,7 +10,7 @@ import { MockChain } from './mocks/mockchain.js'
 import { MockServer } from './mocks/mockserver.js'
 
 import type { SyncMode } from '../../src/config.js'
-import type { Common } from '@ethereumjs/common'
+import type { ConsensusDict } from '@ethereumjs/blockchain'
 
 interface SetupOptions {
   location?: string
@@ -39,9 +40,12 @@ export async function setup(
   })
 
   const server = new MockServer({ config, location }) as any
+  const consensusDict: ConsensusDict = {}
+  consensusDict[ConsensusAlgorithm.Clique] = new CliqueConsensus()
   const blockchain = await createBlockchain({
     validateBlocks: false,
     validateConsensus: false,
+    consensusDict,
     common,
   })
 

--- a/packages/vm/examples/run-blockchain.ts
+++ b/packages/vm/examples/run-blockchain.ts
@@ -12,8 +12,14 @@ import {
   createBlockFromBlockData,
   createBlockFromRLPSerializedBlock,
 } from '@ethereumjs/block'
-import { Blockchain, createBlockchain } from '@ethereumjs/blockchain'
-import { Common, ConsensusType } from '@ethereumjs/common'
+import {
+  Blockchain,
+  ConsensusDict,
+  createBlockchain,
+  EthashConsensus,
+} from '@ethereumjs/blockchain'
+import { Common, ConsensusAlgorithm, ConsensusType } from '@ethereumjs/common'
+import { Ethash } from '@ethereumjs/ethash'
 import { VM } from '@ethereumjs/vm'
 
 import testData from './helpers/blockchain-mock-data.json'
@@ -25,10 +31,13 @@ async function main() {
 
   const genesisBlock = createBlockFromBlockData({ header: testData.genesisBlockHeader }, { common })
 
+  const consensusDict: ConsensusDict = {}
+  consensusDict[ConsensusAlgorithm.Ethash] = new EthashConsensus(new Ethash())
   const blockchain = await createBlockchain({
     common,
-    validateConsensus: validatePow,
     validateBlocks,
+    validateConsensus: validatePow,
+    consensusDict,
     genesisBlock,
   })
 

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -77,6 +77,7 @@
     "ethereum-cryptography": "^2.2.1"
   },
   "devDependencies": {
+    "@ethereumjs/ethash": "^3.0.3",
     "@ethersproject/abi": "^5.0.12",
     "@types/benchmark": "^1.0.33",
     "@types/core-js": "^2.5.0",

--- a/packages/vm/test/api/buildBlock.spec.ts
+++ b/packages/vm/test/api/buildBlock.spec.ts
@@ -7,6 +7,7 @@ import {
   Hardfork,
   createCommonFromGethGenesis,
 } from '@ethereumjs/common'
+import { Ethash } from '@ethereumjs/ethash'
 import { FeeMarketEIP1559Transaction, LegacyTransaction } from '@ethereumjs/tx'
 import { Account, Address, concatBytes, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
@@ -91,7 +92,7 @@ describe('BlockBuilder', () => {
     const genesisBlock = createBlockFromBlockData({ header: { gasLimit: 50000 } }, { common })
 
     const consensusDict: ConsensusDict = {}
-    consensusDict[ConsensusAlgorithm.Ethash] = new EthashConsensus()
+    consensusDict[ConsensusAlgorithm.Ethash] = new EthashConsensus(new Ethash())
     const blockchain = await createBlockchain({
       genesisBlock,
       common,

--- a/packages/vm/test/api/buildBlock.spec.ts
+++ b/packages/vm/test/api/buildBlock.spec.ts
@@ -1,5 +1,5 @@
 import { createBlockFromBlockData } from '@ethereumjs/block'
-import { CliqueConsensus, EthashConsensus, createBlockchain } from '@ethereumjs/blockchain'
+import { EthashConsensus, createBlockchain } from '@ethereumjs/blockchain'
 import {
   Chain,
   Common,

--- a/packages/vm/test/tester/runners/BlockchainTestsRunner.ts
+++ b/packages/vm/test/tester/runners/BlockchainTestsRunner.ts
@@ -1,6 +1,7 @@
 import { createBlockFromBlockData, createBlockFromRLPSerializedBlock } from '@ethereumjs/block'
-import { createBlockchain } from '@ethereumjs/blockchain'
+import { EthashConsensus, createBlockchain } from '@ethereumjs/blockchain'
 import { ConsensusAlgorithm } from '@ethereumjs/common'
+import { Ethash } from '@ethereumjs/ethash'
 import { RLP } from '@ethereumjs/rlp'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { Trie } from '@ethereumjs/trie'
@@ -15,11 +16,11 @@ import {
   toBytes,
 } from '@ethereumjs/util'
 
-import { VM } from '../../../src/vm'
-import { setupPreConditions, verifyPostConditions } from '../../util'
+import { VM } from '../../../src/vm.js'
+import { setupPreConditions, verifyPostConditions } from '../../util.js'
 
 import type { Block } from '@ethereumjs/block'
-import type { EthashConsensus } from '@ethereumjs/blockchain'
+import type { ConsensusDict } from '@ethereumjs/blockchain'
 import type { Common } from '@ethereumjs/common'
 import type { PrefixedHexString } from '@ethereumjs/util'
 import type * as tape from 'tape'
@@ -73,10 +74,13 @@ export async function runBlockchainTest(options: any, testData: any, t: tape.Tes
     t.deepEquals(genesisBlock.serialize(), rlp, 'correct genesis RLP')
   }
 
+  const consensusDict: ConsensusDict = {}
+  consensusDict[ConsensusAlgorithm.Ethash] = new EthashConsensus(new Ethash())
   let blockchain = await createBlockchain({
     common,
     validateBlocks: true,
     validateConsensus: validatePow,
+    consensusDict,
     genesisBlock,
   })
 


### PR DESCRIPTION
This PR moves to a more flexible consensus layout for blockchain allowing for an optional `consensusDict` to be passed in where all consensus objects which should be used for consensus validation must be present.

This basic setup allows for full tree shaking regarding Clique and Etash code and it will - step 2 - also allow to remove the Ethash dependency.

Since we are now in a Proof-of-Stake world where consensus validation is the exception the PR also moves to having consensus validation deactivated by default. Semantics of the `consensusValidation` flag is "merged" with the `consensusDict` object ("consensus" and "consensus validation" is basically the same), this allows for a substantial simplification on otherwise useless "combinations" (this and that object passed, but `consensusValidation` set to `false`) and also have a lot cleaner deactivated-by-default structure.

Deactivated-by-default also allows for removing a lot of `consensusValidation: false` passing, which we lately did more and more on tests since we just didn't want to have/do any more.

Consensus transitions - if wished - still fully work, as a side note (even more flexible than before).

WIP, several tests failing. But on the way.