### PR TITLE
Common: allow overriding params

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -371,6 +371,9 @@ export class Common {
       } else {
         this._mergeWithParamsCache(hfChanges[1])
       }
+      if (hfChanges[1].vm) {
+        this._mergeWithParamsCache(hfChanges[1])
+      }
       if (hfChanges[0] === hardfork) break
     }
     // Iterate through all additionally activated EIPs

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -371,7 +371,13 @@ export class Common {
       } else {
         this._mergeWithParamsCache(hfChanges[1])
       }
-      if (hfChanges[1].vm) {
+      if (
+        hfChanges[1].vm ||
+        hfChanges[1].gasConfig ||
+        hfChanges[1].gasPrices ||
+        hfChanges[1].pow ||
+        hfChanges[1].sharding
+      ) {
         this._mergeWithParamsCache(hfChanges[1])
       }
       if (hfChanges[0] === hardfork) break

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -39,6 +39,11 @@ export interface ChainConfig {
   dnsNetworks?: string[]
   consensus: ConsensusConfig
   depositContractAddress?: PrefixedHexString
+  params?: {
+    [topic: string]: {
+      [param: string]: number | bigint
+    }
+  }
 }
 
 // TODO: Remove the string type and only keep PrefixedHexString
@@ -201,6 +206,22 @@ export type HardforkConfig = {
   name: string
   eips?: number[]
   consensus?: ConsensusConfig
+  // Type to optionally override params
+  vm?: {
+    [param: string]: ParamDict
+  }
+  gasPrices?: {
+    [param: string]: ParamDict
+  }
+  gasConfig?: {
+    [param: string]: ParamDict
+  }
+  pow?: {
+    [param: string]: ParamDict
+  }
+  sharding?: {
+    [param: string]: ParamDict
+  }
 } & EIPOrHFConfig
 
 export type HardforksDict = {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -202,20 +202,20 @@ export type HardforkConfig = {
   eips?: number[]
   consensus?: ConsensusConfig
   // Type to optionally override params
-  vm?: {
-    [param: string]: ParamDict
+  gasConfig?: {
+    [key: string]: number | bigint | null
   }
   gasPrices?: {
-    [param: string]: ParamDict
-  }
-  gasConfig?: {
-    [param: string]: ParamDict
+    [key: string]: number | bigint | null
   }
   pow?: {
-    [param: string]: ParamDict
+    [key: string]: number | bigint | null
   }
   sharding?: {
-    [param: string]: ParamDict
+    [key: string]: number | bigint | null
+  }
+  vm?: {
+    [key: string]: number | bigint | null
   }
 } & EIPOrHFConfig
 

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -39,11 +39,6 @@ export interface ChainConfig {
   dnsNetworks?: string[]
   consensus: ConsensusConfig
   depositContractAddress?: PrefixedHexString
-  params?: {
-    [topic: string]: {
-      [param: string]: number | bigint
-    }
-  }
 }
 
 // TODO: Remove the string type and only keep PrefixedHexString

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -201,22 +201,6 @@ export type HardforkConfig = {
   name: string
   eips?: number[]
   consensus?: ConsensusConfig
-  // Type to optionally override params
-  gasConfig?: {
-    [key: string]: number | bigint | null
-  }
-  gasPrices?: {
-    [key: string]: number | bigint | null
-  }
-  pow?: {
-    [key: string]: number | bigint | null
-  }
-  sharding?: {
-    [key: string]: number | bigint | null
-  }
-  vm?: {
-    [key: string]: number | bigint | null
-  }
 } & EIPOrHFConfig
 
 export type HardforksDict = {

--- a/packages/common/test/customChains.spec.ts
+++ b/packages/common/test/customChains.spec.ts
@@ -1,3 +1,4 @@
+import { BIGINT_0 } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
 import { Status } from '../src/hardforks.js'
@@ -228,6 +229,42 @@ describe('[Common]: Custom chains', () => {
     })
     assert.equal(c.hardfork(), 'testEIP2935Hardfork')
     assert.ok(c.isActivatedEIP(2935))
+  })
+
+  it('customHardforks: override params', () => {
+    const c = createCustomCommon({
+      customHardforks: {
+        stop10Gas: {
+          name: 'stop10Gas',
+          comment: 'Hardfork which changes the gas of STOP from 0 to 10',
+          url: '',
+          status: Status.Final,
+          eips: [2935],
+          vm: {
+            stop: BigInt(10),
+          },
+        },
+      },
+      hardforks: [
+        {
+          name: 'chainstart',
+          block: 0,
+        },
+        {
+          name: 'stop10Gas',
+          block: null,
+          timestamp: 1000,
+        },
+      ],
+    })
+    c.setHardfork(Hardfork.Chainstart)
+    assert.equal(c.param('vm', 'stop'), BIGINT_0)
+    c.setHardforkBy({
+      blockNumber: 1,
+      timestamp: 1000,
+    })
+    assert.equal(c.hardfork(), 'stop10Gas')
+    assert.equal(c.param('vm', 'stop'), BigInt(10))
   })
 })
 

--- a/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts
@@ -23,7 +23,7 @@ import { VM } from '../../../src/vm.js'
 
 import type { Block } from '@ethereumjs/block'
 
-function eip2935ActiveAtCommon(timestamp: number) {
+function eip2935ActiveAtCommon(timestamp: number, address: BigInt) {
   const hfs = [
     Hardfork.Chainstart,
     Hardfork.Homestead,
@@ -64,6 +64,12 @@ function eip2935ActiveAtCommon(timestamp: number) {
         url: '',
         status: 'final',
         eips: [2935, 7709],
+        vm: {
+          historyStorageAddress: {
+            v: address,
+            d: 'The address where the historical blockhashes are stored',
+          },
+        },
       },
     },
     hardforks,
@@ -127,6 +133,7 @@ describe('EIP 2935: historical block hashes', () => {
     ] = deploymentConfig
 
     const historyAddress = Address.fromString(deployedToAddress)
+    const historyAddressBigInt = bytesToBigInt(historyAddress.bytes)
     const contract2935Code = hexToBytes(contract2935CodeHex)
 
     // eslint-disable-next-line no-inner-declarations
@@ -179,7 +186,7 @@ describe('EIP 2935: historical block hashes', () => {
     })
 
     it('should save genesis block hash to the history block hash contract', async () => {
-      const commonGenesis = eip2935ActiveAtCommon(1)
+      const commonGenesis = eip2935ActiveAtCommon(1, historyAddressBigInt)
       const blockchain = await createBlockchain({
         common: commonGenesis,
         validateBlocks: false,
@@ -189,10 +196,6 @@ describe('EIP 2935: historical block hashes', () => {
       commonGenesis.setHardforkBy({
         timestamp: 1,
       })
-      commonGenesis['_paramsCache']['vm']['historyStorageAddress'].v = bytesToBigInt(
-        historyAddress.bytes
-      )
-
       const genesis = await vm.blockchain.getBlock(0)
       const block = await (
         await vm.buildBlock({
@@ -216,9 +219,9 @@ describe('EIP 2935: historical block hashes', () => {
       const blocksActivation = 256 // This ensures that only block 255 gets stored into the hash contract
       // More than blocks activation to build, so we can ensure that we can also retrieve block 0 or block 1 hash at block 300
       const blocksToBuild = 500
-      const commonGetHistoryServeWindow = eip2935ActiveAtCommon(0)
+      const commonGetHistoryServeWindow = eip2935ActiveAtCommon(0, historyAddressBigInt)
       commonGetHistoryServeWindow.setEIPs([2935])
-      const common = eip2935ActiveAtCommon(blocksActivation)
+      const common = eip2935ActiveAtCommon(blocksActivation, historyAddressBigInt)
       const historyServeWindow = commonGetHistoryServeWindow.param('vm', 'historyServeWindow')
 
       const blockchain = await createBlockchain({


### PR DESCRIPTION
Closes https://github.com/ethereumjs/ethereumjs-monorepo/issues/3505

This PR expands the types in Common such that one can override params in hardforks.

An example is given in the 2935 test on how to use it.