### PR TITLE
refactor: restrict PrefixedHexString types

### DIFF
--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -203,15 +203,14 @@ export interface JsonHeader {
 /*
  * Based on https://ethereum.org/en/developers/docs/apis/json-rpc/
  */
-// TODO: Either we should we add null to the types, or remove it from the comments
 export interface JsonRpcBlock {
-  number: PrefixedHexString // the block number. null when pending block.
-  hash: PrefixedHexString // hash of the block. null when pending block.
+  number: PrefixedHexString // the block number.
+  hash: PrefixedHexString // hash of the block.
   parentHash: PrefixedHexString // hash of the parent block.
   mixHash?: PrefixedHexString // bit hash which proves combined with the nonce that a sufficient amount of computation has been carried out on this block.
-  nonce: PrefixedHexString // hash of the generated proof-of-work. null when pending block.
+  nonce: PrefixedHexString // hash of the generated proof-of-work.
   sha3Uncles: PrefixedHexString // SHA3 of the uncles data in the block.
-  logsBloom: PrefixedHexString // the bloom filter for the logs of the block. null when pending block.
+  logsBloom: PrefixedHexString // the bloom filter for the logs of the block.
   transactionsRoot: PrefixedHexString // the root of the transaction trie of the block.
   stateRoot: PrefixedHexString // the root of the final state trie of the block.
   receiptsRoot: PrefixedHexString // the root of the receipts trie of the block.
@@ -224,7 +223,7 @@ export interface JsonRpcBlock {
   gasUsed: PrefixedHexString // the total used gas by all transactions in this block.
   timestamp: PrefixedHexString // the unix timestamp for when the block was collated.
   transactions: Array<JsonRpcTx | PrefixedHexString> // Array of transaction objects, or 32 Bytes transaction hashes depending on the last given parameter.
-  uncles: PrefixedHexString[][] // Array of uncle hashes
+  uncles: PrefixedHexString[] // Array of uncle hashes
   baseFeePerGas?: PrefixedHexString // If EIP-1559 is enabled for this block, returns the base fee per gas
   withdrawals?: Array<JsonRpcWithdrawal> // If EIP-4895 is enabled for this block, array of withdrawals
   withdrawalsRoot?: PrefixedHexString // If EIP-4895 is enabled for this block, the root of the withdrawal trie of the block.

--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -83,29 +83,28 @@ export interface BlockOptions {
 /**
  * A block header's data.
  */
-// TODO: Deprecate the string type and only keep BytesLike/AddressLike/BigIntLike
 export interface HeaderData {
-  parentHash?: BytesLike | string
-  uncleHash?: BytesLike | string
-  coinbase?: AddressLike | string
-  stateRoot?: BytesLike | string
-  transactionsTrie?: BytesLike | string
-  receiptTrie?: BytesLike | string
-  logsBloom?: BytesLike | string
-  difficulty?: BigIntLike | string
-  number?: BigIntLike | string
-  gasLimit?: BigIntLike | string
-  gasUsed?: BigIntLike | string
-  timestamp?: BigIntLike | string
-  extraData?: BytesLike | string
-  mixHash?: BytesLike | string
-  nonce?: BytesLike | string
-  baseFeePerGas?: BigIntLike | string
-  withdrawalsRoot?: BytesLike | string
-  blobGasUsed?: BigIntLike | string
-  excessBlobGas?: BigIntLike | string
-  parentBeaconBlockRoot?: BytesLike | string
-  requestsRoot?: BytesLike | string
+  parentHash?: BytesLike
+  uncleHash?: BytesLike
+  coinbase?: AddressLike
+  stateRoot?: BytesLike
+  transactionsTrie?: BytesLike
+  receiptTrie?: BytesLike
+  logsBloom?: BytesLike
+  difficulty?: BigIntLike
+  number?: BigIntLike
+  gasLimit?: BigIntLike
+  gasUsed?: BigIntLike
+  timestamp?: BigIntLike
+  extraData?: BytesLike
+  mixHash?: BytesLike
+  nonce?: BytesLike
+  baseFeePerGas?: BigIntLike
+  withdrawalsRoot?: BytesLike
+  blobGasUsed?: BigIntLike
+  excessBlobGas?: BigIntLike
+  parentBeaconBlockRoot?: BytesLike
+  requestsRoot?: BytesLike
 }
 
 /**
@@ -177,65 +176,64 @@ export interface JsonBlock {
 /**
  * An object with the block header's data represented as 0x-prefixed hex strings.
  */
-// TODO: Remove the string type and only keep PrefixedHexString
 export interface JsonHeader {
-  parentHash?: PrefixedHexString | string
-  uncleHash?: PrefixedHexString | string
-  coinbase?: PrefixedHexString | string
-  stateRoot?: PrefixedHexString | string
-  transactionsTrie?: PrefixedHexString | string
-  receiptTrie?: PrefixedHexString | string
-  logsBloom?: PrefixedHexString | string
-  difficulty?: PrefixedHexString | string
-  number?: PrefixedHexString | string
-  gasLimit?: PrefixedHexString | string
-  gasUsed?: PrefixedHexString | string
-  timestamp?: PrefixedHexString | string
-  extraData?: PrefixedHexString | string
-  mixHash?: PrefixedHexString | string
-  nonce?: PrefixedHexString | string
-  baseFeePerGas?: PrefixedHexString | string
-  withdrawalsRoot?: PrefixedHexString | string
-  blobGasUsed?: PrefixedHexString | string
-  excessBlobGas?: PrefixedHexString | string
-  parentBeaconBlockRoot?: PrefixedHexString | string
-  requestsRoot?: PrefixedHexString | string
+  parentHash?: PrefixedHexString
+  uncleHash?: PrefixedHexString
+  coinbase?: PrefixedHexString
+  stateRoot?: PrefixedHexString
+  transactionsTrie?: PrefixedHexString
+  receiptTrie?: PrefixedHexString
+  logsBloom?: PrefixedHexString
+  difficulty?: PrefixedHexString
+  number?: PrefixedHexString
+  gasLimit?: PrefixedHexString
+  gasUsed?: PrefixedHexString
+  timestamp?: PrefixedHexString
+  extraData?: PrefixedHexString
+  mixHash?: PrefixedHexString
+  nonce?: PrefixedHexString
+  baseFeePerGas?: PrefixedHexString
+  withdrawalsRoot?: PrefixedHexString
+  blobGasUsed?: PrefixedHexString
+  excessBlobGas?: PrefixedHexString
+  parentBeaconBlockRoot?: PrefixedHexString
+  requestsRoot?: PrefixedHexString
 }
 
 /*
  * Based on https://ethereum.org/en/developers/docs/apis/json-rpc/
  */
-// TODO: Remove the string type and only keep PrefixedHexString
+// TODO: Either we should we add null to the types, or remove it from the comments
 export interface JsonRpcBlock {
-  number: PrefixedHexString | string // the block number. null when pending block.
-  hash: PrefixedHexString | string // hash of the block. null when pending block.
-  parentHash: PrefixedHexString | string // hash of the parent block.
-  mixHash?: PrefixedHexString | string // bit hash which proves combined with the nonce that a sufficient amount of computation has been carried out on this block.
-  nonce: PrefixedHexString | string // hash of the generated proof-of-work. null when pending block.
-  sha3Uncles: PrefixedHexString | string // SHA3 of the uncles data in the block.
-  logsBloom: PrefixedHexString | string // the bloom filter for the logs of the block. null when pending block.
-  transactionsRoot: PrefixedHexString | string // the root of the transaction trie of the block.
-  stateRoot: PrefixedHexString | string // the root of the final state trie of the block.
-  receiptsRoot: PrefixedHexString | string // the root of the receipts trie of the block.
-  miner: PrefixedHexString | string // the address of the beneficiary to whom the mining rewards were given.
-  difficulty: PrefixedHexString | string // integer of the difficulty for this block.
-  totalDifficulty: PrefixedHexString | string // integer of the total difficulty of the chain until this block.
-  extraData: PrefixedHexString | string // the “extra data” field of this block.
-  size: PrefixedHexString | string // integer the size of this block in bytes.
-  gasLimit: PrefixedHexString | string // the maximum gas allowed in this block.
-  gasUsed: PrefixedHexString | string // the total used gas by all transactions in this block.
-  timestamp: PrefixedHexString | string // the unix timestamp for when the block was collated.
-  transactions: Array<JsonRpcTx | PrefixedHexString | string> // Array of transaction objects, or 32 Bytes transaction hashes depending on the last given parameter.
-  uncles: PrefixedHexString[] | string[] // Array of uncle hashes
-  baseFeePerGas?: PrefixedHexString | string // If EIP-1559 is enabled for this block, returns the base fee per gas
+  number: PrefixedHexString // the block number. null when pending block.
+  hash: PrefixedHexString // hash of the block. null when pending block.
+  parentHash: PrefixedHexString // hash of the parent block.
+  mixHash?: PrefixedHexString // bit hash which proves combined with the nonce that a sufficient amount of computation has been carried out on this block.
+  nonce: PrefixedHexString // hash of the generated proof-of-work. null when pending block.
+  sha3Uncles: PrefixedHexString // SHA3 of the uncles data in the block.
+  logsBloom: PrefixedHexString // the bloom filter for the logs of the block. null when pending block.
+  transactionsRoot: PrefixedHexString // the root of the transaction trie of the block.
+  stateRoot: PrefixedHexString // the root of the final state trie of the block.
+  receiptsRoot: PrefixedHexString // the root of the receipts trie of the block.
+  miner: PrefixedHexString // the address of the beneficiary to whom the mining rewards were given.
+  difficulty: PrefixedHexString // integer of the difficulty for this block.
+  totalDifficulty: PrefixedHexString // integer of the total difficulty of the chain until this block.
+  extraData: PrefixedHexString // the “extra data” field of this block.
+  size: PrefixedHexString // integer the size of this block in bytes.
+  gasLimit: PrefixedHexString // the maximum gas allowed in this block.
+  gasUsed: PrefixedHexString // the total used gas by all transactions in this block.
+  timestamp: PrefixedHexString // the unix timestamp for when the block was collated.
+  transactions: Array<JsonRpcTx | PrefixedHexString> // Array of transaction objects, or 32 Bytes transaction hashes depending on the last given parameter.
+  uncles: PrefixedHexString[][] // Array of uncle hashes
+  baseFeePerGas?: PrefixedHexString // If EIP-1559 is enabled for this block, returns the base fee per gas
   withdrawals?: Array<JsonRpcWithdrawal> // If EIP-4895 is enabled for this block, array of withdrawals
-  withdrawalsRoot?: PrefixedHexString | string // If EIP-4895 is enabled for this block, the root of the withdrawal trie of the block.
-  blobGasUsed?: PrefixedHexString | string // If EIP-4844 is enabled for this block, returns the blob gas used for the block
-  excessBlobGas?: PrefixedHexString | string // If EIP-4844 is enabled for this block, returns the excess blob gas for the block
-  parentBeaconBlockRoot?: PrefixedHexString | string // If EIP-4788 is enabled for this block, returns parent beacon block root
+  withdrawalsRoot?: PrefixedHexString // If EIP-4895 is enabled for this block, the root of the withdrawal trie of the block.
+  blobGasUsed?: PrefixedHexString // If EIP-4844 is enabled for this block, returns the blob gas used for the block
+  excessBlobGas?: PrefixedHexString // If EIP-4844 is enabled for this block, returns the excess blob gas for the block
+  parentBeaconBlockRoot?: PrefixedHexString // If EIP-4788 is enabled for this block, returns parent beacon block root
   executionWitness?: VerkleExecutionWitness | null // If Verkle is enabled for this block
-  requestsRoot?: PrefixedHexString | string // If EIP-7685 is enabled for this block, returns the requests root
-  requests?: Array<PrefixedHexString | string> // If EIP-7685 is enabled for this block, array of serialized CL requests
+  requestsRoot?: PrefixedHexString // If EIP-7685 is enabled for this block, returns the requests root
+  requests?: Array<PrefixedHexString> // If EIP-7685 is enabled for this block, array of serialized CL requests
 }
 
 export type WithdrawalV1 = {
@@ -246,26 +244,25 @@ export type WithdrawalV1 = {
 }
 
 // Note: all these strings are 0x-prefixed
-// TODO: Remove the string type and only keep PrefixedHexString
 export type ExecutionPayload = {
-  parentHash: PrefixedHexString | string // DATA, 32 Bytes
-  feeRecipient: PrefixedHexString | string // DATA, 20 Bytes
-  stateRoot: PrefixedHexString | string // DATA, 32 Bytes
-  receiptsRoot: PrefixedHexString | string // DATA, 32 bytes
-  logsBloom: PrefixedHexString | string // DATA, 256 Bytes
-  prevRandao: PrefixedHexString | string // DATA, 32 Bytes
-  blockNumber: PrefixedHexString | string // QUANTITY, 64 Bits
-  gasLimit: PrefixedHexString | string // QUANTITY, 64 Bits
-  gasUsed: PrefixedHexString | string // QUANTITY, 64 Bits
-  timestamp: PrefixedHexString | string // QUANTITY, 64 Bits
-  extraData: PrefixedHexString | string // DATA, 0 to 32 Bytes
-  baseFeePerGas: PrefixedHexString | string // QUANTITY, 256 Bits
-  blockHash: PrefixedHexString | string // DATA, 32 Bytes
-  transactions: PrefixedHexString[] | string[] // Array of DATA - Array of transaction rlp strings,
+  parentHash: PrefixedHexString // DATA, 32 Bytes
+  feeRecipient: PrefixedHexString // DATA, 20 Bytes
+  stateRoot: PrefixedHexString // DATA, 32 Bytes
+  receiptsRoot: PrefixedHexString // DATA, 32 bytes
+  logsBloom: PrefixedHexString // DATA, 256 Bytes
+  prevRandao: PrefixedHexString // DATA, 32 Bytes
+  blockNumber: PrefixedHexString // QUANTITY, 64 Bits
+  gasLimit: PrefixedHexString // QUANTITY, 64 Bits
+  gasUsed: PrefixedHexString // QUANTITY, 64 Bits
+  timestamp: PrefixedHexString // QUANTITY, 64 Bits
+  extraData: PrefixedHexString // DATA, 0 to 32 Bytes
+  baseFeePerGas: PrefixedHexString // QUANTITY, 256 Bits
+  blockHash: PrefixedHexString // DATA, 32 Bytes
+  transactions: PrefixedHexString[] // Array of DATA - Array of transaction rlp strings,
   withdrawals?: WithdrawalV1[] // Array of withdrawal objects
-  blobGasUsed?: PrefixedHexString | string // QUANTITY, 64 Bits
-  excessBlobGas?: PrefixedHexString | string // QUANTITY, 64 Bits
-  parentBeaconBlockRoot?: PrefixedHexString | string // QUANTITY, 64 Bits
+  blobGasUsed?: PrefixedHexString // QUANTITY, 64 Bits
+  excessBlobGas?: PrefixedHexString // QUANTITY, 64 Bits
+  parentBeaconBlockRoot?: PrefixedHexString // QUANTITY, 64 Bits
   // VerkleExecutionWitness is already a hex serialized object
   executionWitness?: VerkleExecutionWitness | null // QUANTITY, 64 Bits, null implies not available
   depositRequests?: DepositRequestV1[] // Array of 6110 deposit requests

--- a/packages/client/src/rpc/modules/debug.ts
+++ b/packages/client/src/rpc/modules/debug.ts
@@ -398,7 +398,7 @@ export class Debug {
    * Returns the bytes of the transaction.
    * @param blockOpt Block number or tag
    */
-  async getRawTransaction(params: [string]) {
+  async getRawTransaction(params: [PrefixedHexString]) {
     const [txHash] = params
     if (!this.service.execution.receiptsManager) throw new Error('missing receiptsManager')
     const result = await this.service.execution.receiptsManager.getReceiptByTxHash(

--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -14,6 +14,7 @@ import {
   equalsBytes,
   hexToBytes,
   intToHex,
+  isHexString,
   setLengthLeft,
   toType,
 } from '@ethereumjs/util'
@@ -918,7 +919,7 @@ export class Eth {
     const [blockOpt] = params
     let block: Block
     try {
-      if (blockOpt.length === 66) {
+      if (isHexString(blockOpt, 64)) {
         block = await this._chain.getBlock(hexToBytes(blockOpt))
       } else {
         block = await getBlockByOption(blockOpt, this._chain)

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -41,15 +41,14 @@ export interface ChainConfig {
   depositContractAddress?: PrefixedHexString
 }
 
-// TODO: Remove the string type and only keep PrefixedHexString
 export interface GenesisBlockConfig {
-  timestamp?: PrefixedHexString | string
-  gasLimit: number | PrefixedHexString | string
-  difficulty: number | PrefixedHexString | string
-  nonce: PrefixedHexString | string
-  extraData: PrefixedHexString | string
-  baseFeePerGas?: PrefixedHexString | string
-  excessBlobGas?: PrefixedHexString | string
+  timestamp?: PrefixedHexString
+  gasLimit: number | PrefixedHexString
+  difficulty: number | PrefixedHexString
+  nonce: PrefixedHexString
+  extraData: PrefixedHexString
+  baseFeePerGas?: PrefixedHexString
+  excessBlobGas?: PrefixedHexString
 }
 
 export interface HardforkTransitionConfig {
@@ -159,11 +158,10 @@ export interface GethConfigOpts extends BaseOpts {
   mergeForkIdPostMerge?: boolean
 }
 
-// TODO: Deprecate the string type and only keep BigIntLike
 export interface HardforkByOpts {
-  blockNumber?: BigIntLike | string
-  timestamp?: BigIntLike | string
-  td?: BigIntLike | string
+  blockNumber?: BigIntLike
+  timestamp?: BigIntLike
+  td?: BigIntLike
 }
 
 export type EIPOrHFConfig = {

--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -107,14 +107,13 @@ export const bytesToInt = (bytes: Uint8Array): number => {
   return res
 }
 
-// TODO: Restrict the input type to only PrefixedHexString
 /**
  * Converts a {@link PrefixedHexString} to a {@link Uint8Array}
- * @param {PrefixedHexString | string} hex The 0x-prefixed hex string to convert
+ * @param {PrefixedHexString} hex The 0x-prefixed hex string to convert
  * @returns {Uint8Array} The converted bytes
  * @throws If the input is not a valid 0x-prefixed hex string
  */
-export const hexToBytes = (hex: PrefixedHexString | string): Uint8Array => {
+export const hexToBytes = (hex: PrefixedHexString): Uint8Array => {
   if (typeof hex !== 'string') {
     throw new Error(`hex argument type ${typeof hex} must be of type string`)
   }
@@ -257,21 +256,18 @@ export const unpadArray = (a: number[]): number[] => {
   return stripZeros(a)
 }
 
-// TODO: Restrict the input type to only PrefixedHexString
 /**
  * Trims leading zeros from a `PrefixedHexString`.
- * @param {PrefixedHexString | string} a
+ * @param {PrefixedHexString} a
  * @return {PrefixedHexString}
  */
-export const unpadHex = (a: PrefixedHexString | string): PrefixedHexString => {
+export const unpadHex = (a: PrefixedHexString): PrefixedHexString => {
   assertIsHexString(a)
   return `0x${stripZeros(stripHexPrefix(a))}`
 }
 
-// TODO: remove the string type from this function (only keep PrefixedHexString)
 export type ToBytesInputTypes =
   | PrefixedHexString
-  | string
   | number
   | bigint
   | Uint8Array
@@ -552,7 +548,6 @@ export function bigInt64ToBytes(value: bigint, littleEndian: boolean = false): U
 // eslint-disable-next-line no-restricted-imports
 export { bytesToUtf8, equalsBytes, utf8ToBytes } from 'ethereum-cryptography/utils.js'
 
-// TODO: Restrict the input type to only PrefixedHexString
-export function hexToBigInt(input: PrefixedHexString | string): bigint {
+export function hexToBigInt(input: PrefixedHexString): bigint {
   return bytesToBigInt(hexToBytes(isHexString(input) ? input : `0x${input}`))
 }


### PR DESCRIPTION
This PR addresses one of the points from #3216, namely:

- Go through the bytes module, and related functions that accept both PrefixedHexString | string as types, and restrict the type to only accept PrefixedHexString.
