### PR TITLE
Ensure EthJS and Grandine talk

### DIFF
--- a/packages/client/src/ext/jwt-simple.ts
+++ b/packages/client/src/ext/jwt-simple.ts
@@ -7,7 +7,7 @@
  * module dependencies
  */
 import { bytesToUtf8, utf8ToBytes } from '@ethereumjs/util'
-import { base64url } from '@scure/base'
+import { base64url, base64urlnopad } from '@scure/base'
 import crypto from 'crypto'
 
 /**
@@ -121,7 +121,7 @@ const decode = function jwt_decode(
 
   // base64 decode and parse JSON
   const header = JSON.parse(bytesToUtf8(base64url.decode(headerSeg)))
-  const payload = JSON.parse(bytesToUtf8(base64url.decode(payloadSeg)))
+  const payload = JSON.parse(bytesToUtf8(base64urlnopad.decode(payloadSeg)))
 
   if (!noVerify) {
     if (!algorithm && /BEGIN( RSA)? PUBLIC KEY/.test(key.toString())) {

--- a/packages/client/src/ext/jwt-simple.ts
+++ b/packages/client/src/ext/jwt-simple.ts
@@ -193,7 +193,7 @@ const encode = function jwt_encode(
   // create segments, all segments should be base64 string
   const segments = []
   segments.push(base64url.encode(utf8ToBytes(JSON.stringify(header))))
-  segments.push(base64url.encode(utf8ToBytes(JSON.stringify(payload))))
+  segments.push(base64urlnopad.encode(utf8ToBytes(JSON.stringify(payload))))
   segments.push(sign(segments.join('.'), key, signingMethod, signingType))
 
   return segments.join('.')


### PR DESCRIPTION
Closes https://github.com/ethereumjs/ethereumjs-monorepo/issues/3508

It seems we changed `jwt-simple` internally. `jwt-simple` is now edited (internally) to support decoding/encoding unpadded payload bytes. 

This fixes CL <-> EL communication with Grandine. I also tested this (before and after) on Prysm, and the communication works.