### PR TITLE
Common: Simplify EIP and Hardfork Config Structure

### DIFF
--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -422,7 +422,7 @@ export const EIPs: EIPsDict = {
     },
   },
   /**
-   * Description : Execution layer triggered consolidations (experimental)
+   * Description : Increase the MAX_EFFECTIVE_BALANCE -> Execution layer triggered consolidations (experimental)
    * URL         : https://eips.ethereum.org/EIPS/eip-7251
    * Status      : Draft
    */

--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -6,18 +6,13 @@ type EIPsDict = {
   [key: string]: EIPConfig
 }
 
-enum Status {
-  Stagnant = 'stagnant',
-  Draft = 'draft',
-  Review = 'review',
-  Final = 'final',
-}
-
 export const EIPs: EIPsDict = {
+  /**
+   * Description : Transient storage opcodes
+   * URL         : https://eips.ethereum.org/EIPS/eip-1153
+   * Status      : Final
+   */
   1153: {
-    comment: 'Transient storage opcodes',
-    url: 'https://eips.ethereum.org/EIPS/eip-1153',
-    status: Status.Review,
     minimumHardfork: Hardfork.Chainstart,
     requiredEIPs: [],
     gasPrices: {
@@ -25,10 +20,12 @@ export const EIPs: EIPsDict = {
       tload: 100, // Base fee of the TLOAD opcode
     },
   },
+  /**
+   * Description : Fee market change for ETH 1.0 chain
+   * URL         : https://eips.ethereum.org/EIPS/eip-1559
+   * Status      : Final
+   */
   1559: {
-    comment: 'Fee market change for ETH 1.0 chain',
-    url: 'https://eips.ethereum.org/EIPS/eip-1559',
-    status: Status.Final,
     minimumHardfork: Hardfork.Berlin,
     requiredEIPs: [2930],
     gasConfig: {
@@ -37,20 +34,24 @@ export const EIPs: EIPsDict = {
       initialBaseFee: 1000000000, // Initial base fee on first EIP1559 block
     },
   },
+  /**
+   * Description : ModExp gas cost
+   * URL         : https://eips.ethereum.org/EIPS/eip-2565
+   * Status      : Final
+   */
   2565: {
-    comment: 'ModExp gas cost',
-    url: 'https://eips.ethereum.org/EIPS/eip-2565',
-    status: Status.Final,
     minimumHardfork: Hardfork.Byzantium,
     requiredEIPs: [],
     gasPrices: {
       modexpGquaddivisor: 3, // Gquaddivisor from modexp precompile for gas calculation
     },
   },
+  /**
+   * Description : BLS12-381 precompiles
+   * URL         : https://eips.ethereum.org/EIPS/eip-2537
+   * Status      : Review
+   */
   2537: {
-    comment: 'BLS12-381 precompiles',
-    url: 'https://eips.ethereum.org/EIPS/eip-2537',
-    status: 'Draft',
     minimumHardfork: Hardfork.Chainstart,
     requiredEIPs: [],
     gasConfig: {},
@@ -67,17 +68,21 @@ export const EIPs: EIPsDict = {
     vm: {},
     pow: {},
   },
+  /**
+   * Description : Typed Transaction Envelope
+   * URL         : https://eips.ethereum.org/EIPS/eip-2718
+   * Status      : Final
+   */
   2718: {
-    comment: 'Typed Transaction Envelope',
-    url: 'https://eips.ethereum.org/EIPS/eip-2718',
-    status: Status.Final,
     minimumHardfork: Hardfork.Chainstart,
     requiredEIPs: [],
   },
+  /**
+   * Description : Gas cost increases for state access opcodes
+   * URL         : https://eips.ethereum.org/EIPS/eip-2929
+   * Status      : Final
+   */
   2929: {
-    comment: 'Gas cost increases for state access opcodes',
-    url: 'https://eips.ethereum.org/EIPS/eip-2929',
-    status: Status.Final,
     minimumHardfork: Hardfork.Chainstart,
     requiredEIPs: [],
     gasPrices: {
@@ -101,10 +106,12 @@ export const EIPs: EIPsDict = {
       sstore: 0, // Base fee of the SSTORE opcode
     },
   },
+  /**
+   * Description : Optional access lists
+   * URL         : https://eips.ethereum.org/EIPS/eip-2930
+   * Status      : Final
+   */
   2930: {
-    comment: 'Optional access lists',
-    url: 'https://eips.ethereum.org/EIPS/eip-2930',
-    status: Status.Final,
     minimumHardfork: Hardfork.Istanbul,
     requiredEIPs: [2718, 2929],
     gasPrices: {
@@ -112,10 +119,12 @@ export const EIPs: EIPsDict = {
       accessListAddressCost: 2400, // Gas cost per storage key in an Access List transaction
     },
   },
+  /**
+   * Description : Save historical block hashes in state (Verkle related usage, UNSTABLE)
+   * URL         : https://github.com/gballet/EIPs/pull/3/commits/2e9ac09a142b0d9fb4db0b8d4609f92e5d9990c5
+   * Status      : Draft
+   */
   2935: {
-    comment: 'Save historical block hashes in state (Verkle related usage, UNSTABLE)',
-    url: 'https://github.com/gballet/EIPs/pull/3/commits/2e9ac09a142b0d9fb4db0b8d4609f92e5d9990c5',
-    status: Status.Draft,
     minimumHardfork: Hardfork.Chainstart,
     requiredEIPs: [],
     vm: {
@@ -123,10 +132,12 @@ export const EIPs: EIPsDict = {
       historyServeWindow: BigInt(8192), // The amount of blocks to be served by the historical blockhash contract
     },
   },
+  /**
+   * Description : AUTH and AUTHCALL opcodes
+   * URL         : https://github.com/ethereum/EIPs/commit/eca4416ff3c025fcb6ec8cd4eac481e74e108481
+   * Status      : Review
+   */
   3074: {
-    comment: 'AUTH and AUTHCALL opcodes',
-    url: 'https://github.com/ethereum/EIPs/commit/eca4416ff3c025fcb6ec8cd4eac481e74e108481',
-    status: Status.Review,
     minimumHardfork: Hardfork.London,
     requiredEIPs: [],
     gasPrices: {
@@ -135,20 +146,24 @@ export const EIPs: EIPsDict = {
       authcallValueTransfer: 6700, // Paid for CALL when the value transfer is non-zero
     },
   },
+  /**
+   * Description : BASEFEE opcode
+   * URL         : https://eips.ethereum.org/EIPS/eip-3198
+   * Status      : Final
+   */
   3198: {
-    comment: 'BASEFEE opcode',
-    url: 'https://eips.ethereum.org/EIPS/eip-3198',
-    status: Status.Final,
     minimumHardfork: Hardfork.London,
     requiredEIPs: [],
     gasPrices: {
       basefee: 2, // Gas cost of the BASEFEE opcode
     },
   },
+  /**
+   * Description : Reduction in refunds
+   * URL         : https://eips.ethereum.org/EIPS/eip-3529
+   * Status      : Final
+   */
   3529: {
-    comment: 'Reduction in refunds',
-    url: 'https://eips.ethereum.org/EIPS/eip-3529',
-    status: Status.Final,
     minimumHardfork: Hardfork.Berlin,
     requiredEIPs: [2929],
     gasConfig: {
@@ -159,76 +174,90 @@ export const EIPs: EIPsDict = {
       sstoreClearRefundEIP2200: 4800, // Once per SSTORE operation for clearing an originally existing storage slot
     },
   },
+  /**
+   * Description : EVM Object Format (EOF) v1
+   * URL         : https://eips.ethereum.org/EIPS/eip-3540
+   * Status      : Review
+   */
   3540: {
-    comment: 'EVM Object Format (EOF) v1',
-    url: 'https://eips.ethereum.org/EIPS/eip-3540',
-    status: Status.Review,
     minimumHardfork: Hardfork.London,
     requiredEIPs: [3541],
   },
+  /**
+   * Description : Reject new contracts starting with the 0xEF byte
+   * URL         : https://eips.ethereum.org/EIPS/eip-3541
+   * Status      : Final
+   */
   3541: {
-    comment: 'Reject new contracts starting with the 0xEF byte',
-    url: 'https://eips.ethereum.org/EIPS/eip-3541',
-    status: Status.Final,
     minimumHardfork: Hardfork.Berlin,
     requiredEIPs: [],
   },
+  /**
+   * Description : Difficulty Bomb Delay to December 1st 2021
+   * URL         : https://eips.ethereum.org/EIPS/eip-3554
+   * Status      : Final
+   */
   3554: {
-    comment: 'Difficulty Bomb Delay to December 1st 2021',
-    url: 'https://eips.ethereum.org/EIPS/eip-3554',
-    status: Status.Final,
     minimumHardfork: Hardfork.MuirGlacier,
     requiredEIPs: [],
     pow: {
       difficultyBombDelay: 9500000, // the amount of blocks to delay the difficulty bomb with
     },
   },
+  /**
+   * Description : Reject transactions from senders with deployed code
+   * URL         : https://eips.ethereum.org/EIPS/eip-3607
+   * Status      : Final
+   */
   3607: {
-    comment: 'Reject transactions from senders with deployed code',
-    url: 'https://eips.ethereum.org/EIPS/eip-3607',
-    status: Status.Final,
     minimumHardfork: Hardfork.Chainstart,
     requiredEIPs: [],
   },
+  /**
+   * Description : Warm COINBASE
+   * URL         : https://eips.ethereum.org/EIPS/eip-3651
+   * Status      : Final
+   */
   3651: {
-    comment: 'Warm COINBASE',
-    url: 'https://eips.ethereum.org/EIPS/eip-3651',
-    status: Status.Review,
     minimumHardfork: Hardfork.London,
     requiredEIPs: [2929],
   },
+  /**
+   * Description : EOF - Code Validation
+   * URL         : https://eips.ethereum.org/EIPS/eip-3670
+   * Status      : Review
+   */
   3670: {
-    comment: 'EOF - Code Validation',
-    url: 'https://eips.ethereum.org/EIPS/eip-3670',
-    status: 'Review',
     minimumHardfork: Hardfork.London,
     requiredEIPs: [3540],
-    gasConfig: {},
-    gasPrices: {},
-    vm: {},
-    pow: {},
   },
+  /**
+   * Description : Upgrade consensus to Proof-of-Stake
+   * URL         : https://eips.ethereum.org/EIPS/eip-3675
+   * Status      : Final
+   */
   3675: {
-    comment: 'Upgrade consensus to Proof-of-Stake',
-    url: 'https://eips.ethereum.org/EIPS/eip-3675',
-    status: Status.Final,
     minimumHardfork: Hardfork.London,
     requiredEIPs: [],
   },
+  /**
+   * Description : PUSH0 instruction
+   * URL         : https://eips.ethereum.org/EIPS/eip-3855
+   * Status      : Final
+   */
   3855: {
-    comment: 'PUSH0 instruction',
-    url: 'https://eips.ethereum.org/EIPS/eip-3855',
-    status: Status.Review,
     minimumHardfork: Hardfork.Chainstart,
     requiredEIPs: [],
     gasPrices: {
       push0: 2, // Base fee of the PUSH0 opcode
     },
   },
+  /**
+   * Description : Limit and meter initcode
+   * URL         : https://eips.ethereum.org/EIPS/eip-3860
+   * Status      : Final
+   */
   3860: {
-    comment: 'Limit and meter initcode',
-    url: 'https://eips.ethereum.org/EIPS/eip-3860',
-    status: Status.Review,
     minimumHardfork: Hardfork.SpuriousDragon,
     requiredEIPs: [],
     gasPrices: {
@@ -238,30 +267,36 @@ export const EIPs: EIPsDict = {
       maxInitCodeSize: 49152, // Maximum length of initialization code when creating a contract
     },
   },
+  /**
+   * Description : Difficulty Bomb Delay to June 2022
+   * URL         : https://eips.ethereum.org/EIPS/eip-4345
+   * Status      : Final
+   */
   4345: {
-    comment: 'Difficulty Bomb Delay to June 2022',
-    url: 'https://eips.ethereum.org/EIPS/eip-4345',
-    status: Status.Final,
     minimumHardfork: Hardfork.London,
     requiredEIPs: [],
     pow: {
       difficultyBombDelay: 10700000, // the amount of blocks to delay the difficulty bomb with
     },
   },
+  /**
+   * Description : Supplant DIFFICULTY opcode with PREVRANDAO
+   * URL         : https://eips.ethereum.org/EIPS/eip-4399
+   * Status      : Final
+   */
   4399: {
-    comment: 'Supplant DIFFICULTY opcode with PREVRANDAO',
-    url: 'https://eips.ethereum.org/EIPS/eip-4399',
-    status: Status.Review,
     minimumHardfork: Hardfork.London,
     requiredEIPs: [],
     gasPrices: {
       prevrandao: 2, // Base fee of the PREVRANDAO opcode (previously DIFFICULTY)
     },
   },
+  /**
+   * Description : Beacon block root in the EVM
+   * URL         : https://eips.ethereum.org/EIPS/eip-4788
+   * Status      : Final
+   */
   4788: {
-    comment: 'Beacon block root in the EVM',
-    url: 'https://eips.ethereum.org/EIPS/eip-4788',
-    status: Status.Draft,
     minimumHardfork: Hardfork.Cancun,
     requiredEIPs: [],
     gasPrices: {},
@@ -269,10 +304,12 @@ export const EIPs: EIPsDict = {
       historicalRootsLength: 8191, // The modulo parameter of the beaconroot ring buffer in the beaconroot statefull precompile
     },
   },
+  /**
+   * Description : Shard Blob Transactions
+   * URL         : https://eips.ethereum.org/EIPS/eip-4844
+   * Status      : Final
+   */
   4844: {
-    comment: 'Shard Blob Transactions',
-    url: 'https://eips.ethereum.org/EIPS/eip-4844',
-    status: Status.Draft,
     minimumHardfork: Hardfork.Paris,
     requiredEIPs: [1559, 2718, 2930, 4895],
     gasConfig: {
@@ -292,51 +329,63 @@ export const EIPs: EIPsDict = {
       fieldElementsPerBlob: 4096, // The number of field elements allowed per blob
     },
   },
+  /**
+   * Description : Beacon chain push withdrawals as operations
+   * URL         : https://eips.ethereum.org/EIPS/eip-4895
+   * Status      : Final
+   */
   4895: {
-    comment: 'Beacon chain push withdrawals as operations',
-    url: 'https://eips.ethereum.org/EIPS/eip-4895',
-    status: Status.Review,
     minimumHardfork: Hardfork.Paris,
     requiredEIPs: [],
   },
+  /**
+   * Description : Delaying Difficulty Bomb to mid-September 2022
+   * URL         : https://eips.ethereum.org/EIPS/eip-5133
+   * Status      : Final
+   */
   5133: {
-    comment: 'Delaying Difficulty Bomb to mid-September 2022',
-    url: 'https://eips.ethereum.org/EIPS/eip-5133',
-    status: Status.Draft,
     minimumHardfork: Hardfork.GrayGlacier,
     requiredEIPs: [],
     pow: {
       difficultyBombDelay: 11400000, // the amount of blocks to delay the difficulty bomb with
     },
   },
+  /**
+   * Description : MCOPY - Memory copying instruction
+   * URL         : https://eips.ethereum.org/EIPS/eip-5656
+   * Status      : Final
+   */
   5656: {
-    comment: 'MCOPY - Memory copying instruction',
-    url: 'https://eips.ethereum.org/EIPS/eip-5656',
-    status: Status.Draft,
     minimumHardfork: Hardfork.Shanghai,
     requiredEIPs: [],
     gasPrices: {
       mcopy: 3, // Base fee of the MCOPY opcode
     },
   },
+  /**
+   * Description : Supply validator deposits on chain
+   * URL         : https://eips.ethereum.org/EIPS/eip-6110
+   * Status      : Review
+   */
   6110: {
-    comment: 'Supply validator deposits on chain',
-    url: 'https://eips.ethereum.org/EIPS/eip-6110',
-    status: Status.Draft,
     minimumHardfork: Hardfork.Cancun,
     requiredEIPs: [7685],
   },
+  /**
+   * Description : SELFDESTRUCT only in same transaction
+   * URL         : https://eips.ethereum.org/EIPS/eip-6780
+   * Status      : Final
+   */
   6780: {
-    comment: 'SELFDESTRUCT only in same transaction',
-    url: 'https://eips.ethereum.org/EIPS/eip-6780',
-    status: Status.Draft,
     minimumHardfork: Hardfork.London,
     requiredEIPs: [],
   },
+  /**
+   * Description : Ethereum state using a unified verkle tree (experimental)
+   * URL         : https://github.com/ethereum/EIPs/pull/6800
+   * Status      : Draft
+   */
   6800: {
-    comment: 'Ethereum state using a unified verkle tree (experimental)',
-    url: 'https://github.com/ethereum/EIPs/pull/6800',
-    status: Status.Draft,
     minimumHardfork: Hardfork.London,
     requiredEIPs: [],
     gasPrices: {
@@ -349,10 +398,12 @@ export const EIPs: EIPsDict = {
       historyStorageAddress: BigInt('0xfffffffffffffffffffffffffffffffffffffffe'), // The address where the historical blockhashes are stored
     },
   },
+  /**
+   * Description : Execution layer triggerable withdrawals (experimental)
+   * URL         : https://github.com/ethereum/EIPs/blob/3b5fcad6b35782f8aaeba7d4ac26004e8fbd720f/EIPS/eip-7002.md
+   * Status      : Review
+   */
   7002: {
-    comment: 'Execution layer triggerable withdrawals (experimental)',
-    url: 'https://github.com/ethereum/EIPs/blob/3b5fcad6b35782f8aaeba7d4ac26004e8fbd720f/EIPS/eip-7002.md',
-    status: Status.Draft,
     minimumHardfork: Hardfork.Paris,
     requiredEIPs: [7685],
     vm: {
@@ -370,10 +421,12 @@ export const EIPs: EIPsDict = {
       withdrawalRequestPredeployAddress: BigInt('0x00A3ca265EBcb825B45F985A16CEFB49958cE017'), // Address of the validator excess address
     },
   },
+  /**
+   * Description : Execution layer triggered consolidations (experimental)
+   * URL         : https://eips.ethereum.org/EIPS/eip-7251
+   * Status      : Draft
+   */
   7251: {
-    comment: 'Execution layer triggered consolidations (experimental)',
-    url: 'https://eips.ethereum.org/EIPS/eip-7251',
-    status: Status.Draft,
     minimumHardfork: Hardfork.Paris,
     requiredEIPs: [7685],
     vm: {
@@ -382,29 +435,35 @@ export const EIPs: EIPsDict = {
       consolidationRequestPredeployAddress: BigInt('0x00b42dbF2194e931E80326D950320f7d9Dbeac02'), // Address of the consolidations contract
     },
   },
+  /**
+   * Description : BLOBBASEFEE opcode
+   * URL         : https://eips.ethereum.org/EIPS/eip-7516
+   * Status      : Final
+   */
   7516: {
-    comment: 'BLOBBASEFEE opcode',
-    url: 'https://eips.ethereum.org/EIPS/eip-7516',
-    status: Status.Draft,
     minimumHardfork: Hardfork.Paris,
     requiredEIPs: [4844],
     gasPrices: {
       blobbasefee: 2, // Gas cost of the BLOBBASEFEE opcode
     },
   },
+  /**
+   * Description : General purpose execution layer requests
+   * URL         : https://eips.ethereum.org/EIPS/eip-7685
+   * Status      : Review
+   */
   7685: {
-    comment: 'General purpose execution layer requests',
-    url: 'https://eips.ethereum.org/EIPS/eip-7685',
-    status: Status.Draft,
     // TODO: Set correct minimum hardfork
     minimumHardfork: Hardfork.Cancun,
     requiredEIPs: [3675],
     gasPrices: {},
   },
+  /**
+   * Description : Set EOA account code for one transaction
+   * URL         : https://github.com/ethereum/EIPs/blob/62419ca3f45375db00b04a368ea37c0bfb05386a/EIPS/eip-7702.md
+   * Status      : Review
+   */
   7702: {
-    comment: 'Set EOA account code for one transaction',
-    url: 'https://github.com/ethereum/EIPs/blob/62419ca3f45375db00b04a368ea37c0bfb05386a/EIPS/eip-7702.md',
-    status: Status.Review,
     // TODO: Set correct minimum hardfork
     minimumHardfork: Hardfork.Cancun,
     requiredEIPs: [2718, 2929, 2930],
@@ -412,10 +471,12 @@ export const EIPs: EIPsDict = {
       perAuthBaseCost: 2500, // Gas cost of each authority item
     },
   },
+  /**
+   * Description : Use historical block hashes saved in state for BLOCKHASH
+   * URL         : https://eips.ethereum.org/EIPS/eip-7709
+   * Status      : Final
+   */
   7709: {
-    comment: 'Use historical block hashes saved in state for BLOCKHASH',
-    url: 'https://eips.ethereum.org/EIPS/eip-7709',
-    status: Status.Draft,
     minimumHardfork: Hardfork.Chainstart,
     requiredEIPs: [2935],
   },

--- a/packages/common/src/hardforks.ts
+++ b/packages/common/src/hardforks.ts
@@ -1,17 +1,13 @@
 import type { HardforksDict } from './types.js'
 
-export enum Status {
-  Draft = 'draft',
-  Review = 'review',
-  Final = 'final',
-}
-
 export const hardforks: HardforksDict = {
+  /**
+   * Description: Start of the Ethereum main chain
+   * URL        : -
+   * Status     : Final
+   */
   chainstart: {
     name: 'chainstart',
-    comment: 'Start of the Ethereum main chain',
-    url: '',
-    status: Status.Final,
     gasConfig: {
       minGasLimit: 5000, // Minimum the gas limit may ever be
       gasLimitBoundDivisor: 1024, // The bound divisor of the gas limit, used in update calculations
@@ -126,26 +122,32 @@ export const hardforks: HardforksDict = {
       difficultyBombDelay: 0, // the amount of blocks to delay the difficulty bomb with
     },
   },
+  /**
+   * Description: Homestead hardfork with protocol and network changes
+   * URL        : https://eips.ethereum.org/EIPS/eip-606
+   * Status     : Final
+   */
   homestead: {
     name: 'homestead',
-    comment: 'Homestead hardfork with protocol and network changes',
-    url: 'https://eips.ethereum.org/EIPS/eip-606',
-    status: Status.Final,
     gasPrices: {
       delegatecall: 40, // Base fee of the DELEGATECALL opcode
     },
   },
+  /**
+   * Description: DAO rescue hardfork
+   * URL        : https://eips.ethereum.org/EIPS/eip-779
+   * Status     : Final
+   */
   dao: {
     name: 'dao',
-    comment: 'DAO rescue hardfork',
-    url: 'https://eips.ethereum.org/EIPS/eip-779',
-    status: Status.Final,
   },
+  /**
+   * Description: Hardfork with gas cost changes for IO-heavy operations
+   * URL        : https://eips.ethereum.org/EIPS/eip-608
+   * Status     : Final
+   */
   tangerineWhistle: {
     name: 'tangerineWhistle',
-    comment: 'Hardfork with gas cost changes for IO-heavy operations',
-    url: 'https://eips.ethereum.org/EIPS/eip-608',
-    status: Status.Final,
     gasPrices: {
       sload: 200, // Once per SLOAD operation
       call: 700, // Once per CALL operation & message call transaction
@@ -157,12 +159,13 @@ export const hardforks: HardforksDict = {
       selfdestruct: 5000, // Base fee of the SELFDESTRUCT opcode
     },
   },
+  /**
+   * Description: HF with EIPs for simple replay attack protection, EXP cost increase, state trie clearing, contract code size limit
+   * URL        : https://eips.ethereum.org/EIPS/eip-607
+   * Status     : Final
+   */
   spuriousDragon: {
     name: 'spuriousDragon',
-    comment:
-      'HF with EIPs for simple replay attack protection, EXP cost increase, state trie clearing, contract code size limit',
-    url: 'https://eips.ethereum.org/EIPS/eip-607',
-    status: Status.Final,
     gasPrices: {
       expByte: 50, // Times ceil(log256(exponent)) for the EXP instruction
     },
@@ -170,11 +173,13 @@ export const hardforks: HardforksDict = {
       maxCodeSize: 24576, // Maximum length of contract code
     },
   },
+  /**
+   * Description: Hardfork with new precompiles, instructions and other protocol changes
+   * URL        : https://eips.ethereum.org/EIPS/eip-609
+   * Status     : Final
+   */
   byzantium: {
     name: 'byzantium',
-    comment: 'Hardfork with new precompiles, instructions and other protocol changes',
-    url: 'https://eips.ethereum.org/EIPS/eip-609',
-    status: Status.Final,
     gasPrices: {
       modexpGquaddivisor: 20, // Gquaddivisor from modexp precompile for gas calculation
       ecAdd: 500, // Gas costs for curve addition precompile
@@ -191,11 +196,13 @@ export const hardforks: HardforksDict = {
       difficultyBombDelay: 3000000, // the amount of blocks to delay the difficulty bomb with
     },
   },
+  /**
+   * Description: Postponed hardfork including EIP-1283 (SSTORE gas metering changes)
+   * URL        : https://eips.ethereum.org/EIPS/eip-1013
+   * Status     : Final
+   */
   constantinople: {
     name: 'constantinople',
-    comment: 'Postponed hardfork including EIP-1283 (SSTORE gas metering changes)',
-    url: 'https://eips.ethereum.org/EIPS/eip-1013',
-    status: Status.Final,
     gasPrices: {
       netSstoreNoopGas: 200, // Once per SSTORE operation if the value doesn't change
       netSstoreInitGas: 20000, // Once per SSTORE operation from clean zero
@@ -215,12 +222,13 @@ export const hardforks: HardforksDict = {
       difficultyBombDelay: 5000000, // the amount of blocks to delay the difficulty bomb with
     },
   },
+  /**
+   * Description: Aka constantinopleFix, removes EIP-1283, activate together with or after constantinople
+   * URL        : https://eips.ethereum.org/EIPS/eip-1716
+   * Status     : Final
+   */
   petersburg: {
     name: 'petersburg',
-    comment:
-      'Aka constantinopleFix, removes EIP-1283, activate together with or after constantinople',
-    url: 'https://eips.ethereum.org/EIPS/eip-1716',
-    status: Status.Final,
     gasPrices: {
       netSstoreNoopGas: null, // Removed along EIP-1283
       netSstoreInitGas: null, // Removed along EIP-1283
@@ -231,11 +239,13 @@ export const hardforks: HardforksDict = {
       netSstoreResetClearRefund: null, // Removed along EIP-1283
     },
   },
+  /**
+   * Description: HF targeted for December 2019 following the Constantinople/Petersburg HF
+   * URL        : https://eips.ethereum.org/EIPS/eip-1679
+   * Status     : Final
+   */
   istanbul: {
     name: 'istanbul',
-    comment: 'HF targeted for December 2019 following the Constantinople/Petersburg HF',
-    url: 'https://eips.ethereum.org/EIPS/eip-1679',
-    status: Status.Final,
     gasConfig: {},
     gasPrices: {
       blake2Round: 1, // Gas cost per round for the Blake2 F precompile
@@ -259,48 +269,60 @@ export const hardforks: HardforksDict = {
       sload: 800, // Base fee of the SLOAD opcode
     },
   },
+  /**
+   * Description: HF to delay the difficulty bomb
+   * URL        : https://eips.ethereum.org/EIPS/eip-2384
+   * Status     : Final
+   */
   muirGlacier: {
     name: 'muirGlacier',
-    comment: 'HF to delay the difficulty bomb',
-    url: 'https://eips.ethereum.org/EIPS/eip-2384',
-    status: Status.Final,
     pow: {
       difficultyBombDelay: 9000000, // the amount of blocks to delay the difficulty bomb with
     },
   },
+  /**
+   * Description: HF targeted for July 2020 following the Muir Glacier HF
+   * URL        : https://eips.ethereum.org/EIPS/eip-2070
+   * Status     : Final
+   */
   berlin: {
     name: 'berlin',
-    comment: 'HF targeted for July 2020 following the Muir Glacier HF',
-    url: 'https://eips.ethereum.org/EIPS/eip-2070',
-    status: Status.Final,
     eips: [2565, 2929, 2718, 2930],
   },
+  /**
+   * Description: HF targeted for July 2021 following the Berlin fork
+   * URL        : https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/london.md
+   * Status     : Final
+   */
   london: {
     name: 'london',
-    comment: 'HF targeted for July 2021 following the Berlin fork',
-    url: 'https://github.com/ethereum/eth1.0-specs/blob/master/network-upgrades/mainnet-upgrades/london.md',
-    status: Status.Final,
     eips: [1559, 3198, 3529, 3541],
   },
+  /**
+   * Description: HF to delay the difficulty bomb
+   * URL        : https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/arrow-glacier.md
+   * Status     : Final
+   */
   arrowGlacier: {
     name: 'arrowGlacier',
-    comment: 'HF to delay the difficulty bomb',
-    url: 'https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/arrow-glacier.md',
-    status: Status.Final,
     eips: [4345],
   },
+  /**
+   * Description: Delaying the difficulty bomb to Mid September 2022
+   * URL        : https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/gray-glacier.md
+   * Status     : Final
+   */
   grayGlacier: {
     name: 'grayGlacier',
-    comment: 'Delaying the difficulty bomb to Mid September 2022',
-    url: 'https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/gray-glacier.md',
-    status: Status.Final,
     eips: [5133],
   },
+  /**
+   * Description: Hardfork to upgrade the consensus mechanism to Proof-of-Stake
+   * URL        : https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/merge.md
+   * Status     : Final
+   */
   paris: {
     name: 'paris',
-    comment: 'Hardfork to upgrade the consensus mechanism to Proof-of-Stake',
-    url: 'https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/merge.md',
-    status: Status.Final,
     consensus: {
       type: 'pos',
       algorithm: 'casper',
@@ -308,43 +330,51 @@ export const hardforks: HardforksDict = {
     },
     eips: [3675, 4399],
   },
+  /**
+   * Description: Pre-merge hardfork to fork off non-upgraded clients
+   * URL        : https://eips.ethereum.org/EIPS/eip-3675
+   * Status     : Final
+   */
   mergeForkIdTransition: {
     name: 'mergeForkIdTransition',
-    comment: 'Pre-merge hardfork to fork off non-upgraded clients',
-    url: 'https://eips.ethereum.org/EIPS/eip-3675',
-    status: Status.Final,
     eips: [],
   },
+  /**
+   * Description: Next feature hardfork after the merge hardfork having withdrawals, warm coinbase, push0, limit/meter initcode
+   * URL        : https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md
+   * Status     : Final
+   */
   shanghai: {
     name: 'shanghai',
-    comment:
-      'Next feature hardfork after the merge hardfork having withdrawals, warm coinbase, push0, limit/meter initcode',
-    url: 'https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md',
-    status: Status.Final,
     eips: [3651, 3855, 3860, 4895],
   },
+  /**
+   * Description: Next feature hardfork after shanghai, includes proto-danksharding EIP 4844 blobs
+   * (still WIP hence not for production use), transient storage opcodes, parent beacon block root
+   * availability in EVM, selfdestruct only in same transaction, and blob base fee opcode
+   * URL        : https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md
+   * Status     : Final
+   */
   cancun: {
     name: 'cancun',
-    comment:
-      'Next feature hardfork after shanghai, includes proto-danksharding EIP 4844 blobs (still WIP hence not for production use), transient storage opcodes, parent beacon block root availability in EVM, selfdestruct only in same transaction, and blob base fee opcode',
-    url: 'https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/cancun.md',
-    status: Status.Final,
     eips: [1153, 4844, 4788, 5656, 6780, 7516],
   },
+  /**
+   * Description: Next feature hardfork after cancun, internally used for pectra testing/implementation (incomplete/experimental)
+   * URL        : https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/prague.md
+   * Status     : Final
+   */
   prague: {
     name: 'prague',
-    comment:
-      'Next feature hardfork after cancun, internally used for pectra testing/implementation (incomplete/experimental)',
-    url: 'https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/prague.md',
-    status: Status.Draft,
     eips: [2537, 2935, 6110, 7002, 7251, 7685, 7702],
   },
+  /**
+   * Description: Next feature hardfork after prague, internally used for verkle testing/implementation (incomplete/experimental)
+   * URL        : https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/osaka.md
+   * Status     : Final
+   */
   osaka: {
     name: 'osaka',
-    comment:
-      'Next feature hardfork after prague, internally used for verkle testing/implementation (incomplete/experimental)',
-    url: 'https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/osaka.md',
-    status: Status.Draft,
     eips: [2935, 6800],
   },
 }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -165,9 +165,6 @@ export interface HardforkByOpts {
 }
 
 export type EIPOrHFConfig = {
-  comment: string
-  url: string
-  status: string
   gasConfig?: {
     [key: string]: number | bigint | null
   }

--- a/packages/common/test/customChains.spec.ts
+++ b/packages/common/test/customChains.spec.ts
@@ -1,7 +1,6 @@
 import { BIGINT_0 } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Status } from '../src/hardforks.js'
 import {
   Chain,
   Common,
@@ -182,11 +181,9 @@ describe('[Common]: Custom chains', () => {
   it('customHardforks parameter: initialization and transition tests', () => {
     const c = createCustomCommon({
       customHardforks: {
+        // Hardfork to test EIP 2935
         testEIP2935Hardfork: {
           name: 'testEIP2935Hardfork',
-          comment: 'Hardfork to test EIP 2935',
-          url: '',
-          status: Status.Final,
           eips: [2935],
         },
       },
@@ -234,11 +231,9 @@ describe('[Common]: Custom chains', () => {
   it('customHardforks: override params', () => {
     const c = createCustomCommon({
       customHardforks: {
+        // Hardfork which changes the gas of STOP from 0 to 10
         stop10Gas: {
           name: 'stop10Gas',
-          comment: 'Hardfork which changes the gas of STOP from 0 to 10',
-          url: '',
-          status: Status.Final,
           eips: [2935],
           vm: {
             stop: BigInt(10),


### PR DESCRIPTION
Small PR to move the `comment`, `url` and `status` properties of the Common EIP and hardfork configuration files over to the code docs, since there is no active programmatical use and this unnecessarily increases bundle sizes (as discussed in #3488).