### PR TITLE
New Minor Releases (Prague Outlook, Bundle Fixes, Bugfixes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16614,14 +16614,14 @@
     },
     "packages/block": {
       "name": "@ethereumjs/block",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/common": "^4.3.0",
+        "@ethereumjs/common": "^4.4.0",
         "@ethereumjs/rlp": "^5.0.2",
-        "@ethereumjs/trie": "^6.2.0",
-        "@ethereumjs/tx": "^5.3.0",
-        "@ethereumjs/util": "^9.0.3",
+        "@ethereumjs/trie": "^6.2.1",
+        "@ethereumjs/tx": "^5.4.0",
+        "@ethereumjs/util": "^9.1.0",
         "ethereum-cryptography": "^2.2.1"
       },
       "devDependencies": {
@@ -16633,16 +16633,16 @@
     },
     "packages/blockchain": {
       "name": "@ethereumjs/blockchain",
-      "version": "7.2.0",
+      "version": "7.3.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/block": "^5.2.0",
-        "@ethereumjs/common": "^4.3.0",
-        "@ethereumjs/ethash": "^3.0.3",
+        "@ethereumjs/block": "^5.3.0",
+        "@ethereumjs/common": "^4.4.0",
+        "@ethereumjs/ethash": "^3.0.4",
         "@ethereumjs/rlp": "^5.0.2",
-        "@ethereumjs/trie": "^6.2.0",
-        "@ethereumjs/tx": "^5.3.0",
-        "@ethereumjs/util": "^9.0.3",
+        "@ethereumjs/trie": "^6.2.1",
+        "@ethereumjs/tx": "^5.4.0",
+        "@ethereumjs/util": "^9.1.0",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.2.1",
         "lru-cache": "10.1.0"
@@ -16654,24 +16654,24 @@
     },
     "packages/client": {
       "name": "@ethereumjs/client",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/block": "5.2.0",
-        "@ethereumjs/blockchain": "7.2.0",
-        "@ethereumjs/common": "4.3.0",
-        "@ethereumjs/devp2p": "6.1.2",
-        "@ethereumjs/ethash": "3.0.3",
-        "@ethereumjs/evm": "3.0.0",
-        "@ethereumjs/genesis": "0.2.2",
+        "@ethereumjs/block": "5.3.0",
+        "@ethereumjs/blockchain": "7.3.0",
+        "@ethereumjs/common": "4.4.0",
+        "@ethereumjs/devp2p": "6.1.3",
+        "@ethereumjs/ethash": "3.0.4",
+        "@ethereumjs/evm": "3.1.0",
+        "@ethereumjs/genesis": "0.2.3",
         "@ethereumjs/rlp": "5.0.2",
-        "@ethereumjs/statemanager": "2.3.0",
-        "@ethereumjs/trie": "6.2.0",
-        "@ethereumjs/tx": "5.3.0",
-        "@ethereumjs/util": "9.0.3",
-        "@ethereumjs/verkle": "^0.0.2",
-        "@ethereumjs/vm": "8.0.0",
+        "@ethereumjs/statemanager": "2.4.0",
+        "@ethereumjs/trie": "6.2.1",
+        "@ethereumjs/tx": "5.4.0",
+        "@ethereumjs/util": "9.1.0",
+        "@ethereumjs/verkle": "^0.1.0",
+        "@ethereumjs/vm": "8.1.0",
         "@multiformats/multiaddr": "^12.2.1",
         "@polkadot/util": "^12.6.2",
         "@polkadot/wasm-crypto": "^7.3.2",
@@ -16784,10 +16784,10 @@
     },
     "packages/common": {
       "name": "@ethereumjs/common",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "license": "MIT",
       "dependencies": {
-        "@ethereumjs/util": "^9.0.3"
+        "@ethereumjs/util": "^9.1.0"
       },
       "devDependencies": {
         "@polkadot/util": "^12.6.2",
@@ -16796,12 +16796,12 @@
     },
     "packages/devp2p": {
       "name": "@ethereumjs/devp2p",
-      "version": "6.1.2",
+      "version": "6.1.3",
       "license": "MIT",
       "dependencies": {
-        "@ethereumjs/common": "^4.3.0",
+        "@ethereumjs/common": "^4.4.0",
         "@ethereumjs/rlp": "^5.0.2",
-        "@ethereumjs/util": "^9.0.3",
+        "@ethereumjs/util": "^9.1.0",
         "@scure/base": "^1.1.7",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.2.1",
@@ -16810,8 +16810,8 @@
         "snappyjs": "^0.6.1"
       },
       "devDependencies": {
-        "@ethereumjs/block": "^5.2.0",
-        "@ethereumjs/tx": "^5.3.0",
+        "@ethereumjs/block": "^5.3.0",
+        "@ethereumjs/tx": "^5.4.0",
         "@types/debug": "^4.1.9",
         "@types/k-bucket": "^5.0.0",
         "chalk": "^4.1.2",
@@ -16823,17 +16823,17 @@
     },
     "packages/ethash": {
       "name": "@ethereumjs/ethash",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/block": "^5.2.0",
+        "@ethereumjs/block": "^5.3.0",
         "@ethereumjs/rlp": "^5.0.2",
-        "@ethereumjs/util": "^9.0.3",
+        "@ethereumjs/util": "^9.1.0",
         "bigint-crypto-utils": "^3.2.2",
         "ethereum-cryptography": "^2.2.1"
       },
       "devDependencies": {
-        "@ethereumjs/common": "^4.3.0"
+        "@ethereumjs/common": "^4.4.0"
       },
       "engines": {
         "node": ">=18"
@@ -16841,13 +16841,13 @@
     },
     "packages/evm": {
       "name": "@ethereumjs/evm",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/common": "^4.3.0",
-        "@ethereumjs/statemanager": "^2.3.0",
-        "@ethereumjs/tx": "^5.3.0",
-        "@ethereumjs/util": "^9.0.3",
+        "@ethereumjs/common": "^4.4.0",
+        "@ethereumjs/statemanager": "^2.4.0",
+        "@ethereumjs/tx": "^5.4.0",
+        "@ethereumjs/util": "^9.1.0",
         "@noble/curves": "^1.4.2",
         "@types/debug": "^4.1.9",
         "debug": "^4.3.3",
@@ -16877,14 +16877,14 @@
     },
     "packages/genesis": {
       "name": "@ethereumjs/genesis",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
-        "@ethereumjs/common": "^4.3.0",
-        "@ethereumjs/util": "^9.0.3"
+        "@ethereumjs/common": "^4.4.0",
+        "@ethereumjs/util": "^9.1.0"
       },
       "devDependencies": {
-        "@ethereumjs/trie": "^6.2.0"
+        "@ethereumjs/trie": "^6.2.1"
       },
       "engines": {
         "node": ">=18"
@@ -16906,21 +16906,21 @@
     },
     "packages/statemanager": {
       "name": "@ethereumjs/statemanager",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/common": "^4.3.0",
+        "@ethereumjs/common": "^4.4.0",
         "@ethereumjs/rlp": "^5.0.2",
-        "@ethereumjs/trie": "^6.2.0",
-        "@ethereumjs/util": "^9.0.3",
+        "@ethereumjs/trie": "^6.2.1",
+        "@ethereumjs/util": "^9.1.0",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.2.1",
         "js-sdsl": "^4.1.4",
         "lru-cache": "10.1.0"
       },
       "devDependencies": {
-        "@ethereumjs/block": "^5.2.0",
-        "@ethereumjs/genesis": "^0.2.2",
+        "@ethereumjs/block": "^5.3.0",
+        "@ethereumjs/genesis": "^0.2.3",
         "@types/debug": "^4.1.9",
         "rustbn-wasm": "^0.4.0",
         "verkle-cryptography-wasm": "^0.4.5"
@@ -16928,11 +16928,11 @@
     },
     "packages/trie": {
       "name": "@ethereumjs/trie",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
-        "@ethereumjs/util": "^9.0.3",
+        "@ethereumjs/util": "^9.1.0",
         "@types/readable-stream": "^2.3.13",
         "debug": "^4.3.4",
         "ethereum-cryptography": "^2.2.1",
@@ -16940,7 +16940,7 @@
         "readable-stream": "^3.6.0"
       },
       "devDependencies": {
-        "@ethereumjs/genesis": "^0.2.2",
+        "@ethereumjs/genesis": "^0.2.3",
         "@types/benchmark": "^1.0.33",
         "abstract-level": "^1.0.3",
         "level": "^8.0.0",
@@ -16957,12 +16957,12 @@
     },
     "packages/tx": {
       "name": "@ethereumjs/tx",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/common": "^4.3.0",
+        "@ethereumjs/common": "^4.4.0",
         "@ethereumjs/rlp": "^5.0.2",
-        "@ethereumjs/util": "^9.0.3",
+        "@ethereumjs/util": "^9.1.0",
         "ethereum-cryptography": "^2.2.1"
       },
       "devDependencies": {
@@ -16978,7 +16978,7 @@
     },
     "packages/util": {
       "name": "@ethereumjs/util",
-      "version": "9.0.3",
+      "version": "9.1.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
@@ -16993,12 +16993,12 @@
     },
     "packages/verkle": {
       "name": "@ethereumjs/verkle",
-      "version": "0.0.2",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@ethereumjs/block": "^5.2.0",
+        "@ethereumjs/block": "^5.3.0",
         "@ethereumjs/rlp": "^5.0.2",
-        "@ethereumjs/util": "^9.0.3",
+        "@ethereumjs/util": "^9.1.0",
         "debug": "^4.3.4",
         "lru-cache": "10.1.0",
         "verkle-cryptography-wasm": "^0.4.5"
@@ -17009,18 +17009,18 @@
     },
     "packages/vm": {
       "name": "@ethereumjs/vm",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ethereumjs/block": "^5.2.0",
-        "@ethereumjs/blockchain": "^7.2.0",
-        "@ethereumjs/common": "^4.3.0",
-        "@ethereumjs/evm": "^3.0.0",
+        "@ethereumjs/block": "^5.3.0",
+        "@ethereumjs/blockchain": "^7.3.0",
+        "@ethereumjs/common": "^4.4.0",
+        "@ethereumjs/evm": "^3.1.0",
         "@ethereumjs/rlp": "^5.0.2",
-        "@ethereumjs/statemanager": "^2.3.0",
-        "@ethereumjs/trie": "^6.2.0",
-        "@ethereumjs/tx": "^5.3.0",
-        "@ethereumjs/util": "^9.0.3",
+        "@ethereumjs/statemanager": "^2.4.0",
+        "@ethereumjs/trie": "^6.2.1",
+        "@ethereumjs/tx": "^5.4.0",
+        "@ethereumjs/util": "^9.1.0",
         "debug": "^4.3.3",
         "ethereum-cryptography": "^2.2.1"
       },
@@ -17044,10 +17044,10 @@
     },
     "packages/wallet": {
       "name": "@ethereumjs/wallet",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "dependencies": {
-        "@ethereumjs/util": "^9.0.3",
+        "@ethereumjs/util": "^9.1.0",
         "@scure/base": "^1.1.7",
         "ethereum-cryptography": "^2.2.1",
         "js-md5": "^0.8.3",

--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -177,7 +177,7 @@ Have a look at the EIP for some guidance on how to use and fill in the various d
 
 ### Other Features
 
-- New `Block.toExecutionPayload()` method to map to the execution payload structore from the beacon chain, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+- New `Block.toExecutionPayload()` method to map to the execution payload structure from the beacon chain, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 - Stricter prefixed hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes removed in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
 ### Other Changes

--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## - 2024-07-23
+## 5.3.0 - 2024-07-23
+
+### Verkle Updates
+
+- Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+
+### Features
+
+- New `Block.toExecutionPayload()` method to map to the execution payload structore from the beacon chain, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 
 ## 5.2.0 - 2024-03-18
 

--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 5.2.0 - 2024-03-05
+## 5.2.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness
 

--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## - 2024-07-23
+
 ## 5.2.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness

--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -114,12 +114,66 @@ main()
 
 Have a look at the EIP for some guidance on how to use and fill in the various withdrawal request parameters.
 
+#### EIP-7251 Consolidation Requests
+
+[EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) introduces consolidation requests allowing staked ETH from more than one validator on the beacon chain to be consolidated into one validator, triggered from the execution layer, see PR [#3477](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3477). Starting with this release this library supports consolidation requests and a containing block can be instantiated as follows:
+
+```ts
+// ./examples/7251Requests.ts
+
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Block } from '@ethereumjs/block'
+import {
+  bytesToBigInt,
+  ConsolidationRequest,
+  randomBytes,
+  type CLRequest,
+  type CLRequestType,
+} from '@ethereumjs/util'
+
+const main = async () => {
+  const common = new Common({
+    chain: Chain.Mainnet,
+    hardfork: Hardfork.Prague,
+  })
+
+  const consolidationRequestData = {
+    sourceAddress: randomBytes(20),
+    sourcePubkey: randomBytes(48),
+    targetPubkey: randomBytes(48),
+  }
+  const request = ConsolidationRequest.fromRequestData(
+    consolidationRequestData
+  ) as CLRequest<CLRequestType>
+  const requests = [request]
+  const requestsRoot = await Block.genRequestsTrieRoot(requests)
+
+  const block = Block.fromBlockData(
+    {
+      requests,
+      header: { requestsRoot },
+    },
+    { common }
+  )
+  console.log(
+    `Instantiated block with ${
+      block.requests?.length
+    } consolidation request, requestTrieValid=${await block.requestsTrieIsValid()}`
+  )
+}
+
+main()
+```
+
+Have a look at the EIP for some guidance on how to use and fill in the various deposit request parameters.
+
 ### Verkle Updates
 
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 - Update `kzg-wasm` to `0.4.0`, PR [#3358](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3358)
 - Shift Verkle to `osaka` hardfork, PR [#3371](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3371)
 - Fix the block body parsing as well as save/load from blockchain, PR [#3392](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3392)
+- Verkle type/interface refactoring (moved to Common package), PR [#3462](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3462)
 
 ### Other Features
 
@@ -131,6 +185,7 @@ Have a look at the EIP for some guidance on how to use and fill in the various w
 - Make EIP-4895 withdrawals trie check consistent with tx trie, PR [#3338](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3338)
 - Rename deposit receipt to deposit request, PR [#3408](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3408)
 - Enhances typing of CL requests, PR [#3398](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3398)
+- Rename withdrawal request's `validatorPublicKey` to `validatorPubkey`, PR [#3474](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3474)
 
 ## 5.2.0 - 2024-03-18
 

--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -10,11 +10,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Blocks with EIP-7685 Consensus Layer Requests
 
-Starting with this release this library supports requests to the consensus layer (see PR [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372)) which have been introduce with [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) and will come into play for deposit and withdrawal requests along the upcoming [Prague](https://eips.ethereum.org/EIPS/eip-7600) hardfork.
+Starting with this release this library supports requests to the consensus layer (see PRs [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372) and [#3393](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3393)) which have been introduce with [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) and will come into play for deposit and withdrawal requests along the upcoming [Prague](https://eips.ethereum.org/EIPS/eip-7600) hardfork.
 
 #### EIP-6110 Deposit Requests
 
-[EIP-6110](https://eips.ethereum.org/EIPS/eip-6110) introduces deposit requests allowing beacon chain deposits being triggered from the execution layer, see PR [#3390](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3390). Starting with this release this library supports deposit requests and a containing block can be instantiated as follows:
+[EIP-6110](https://eips.ethereum.org/EIPS/eip-6110) introduces deposit requests allowing beacon chain deposits being triggered from the execution layer, see PRs [#3390](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3390) and [#3397](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3397). Starting with this release this library supports deposit requests and a containing block can be instantiated as follows:
 
 ```ts
 import { Chain, Common, Hardfork } from '@ethereumjs/common'
@@ -118,15 +118,19 @@ Have a look at the EIP for some guidance on how to use and fill in the various w
 
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 - Update `kzg-wasm` to `0.4.0`, PR [#3358](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3358)
+- Shift Verkle to `osaka` hardfork, PR [#3371](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3371)
+- Fix the block body parsing as well as save/load from blockchain, PR [#3392](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3392)
 
 ### Other Features
 
 - New `Block.toExecutionPayload()` method to map to the execution payload structore from the beacon chain, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
-- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+- Stricter prefixe hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
 ### Other Changes
 
 - Make EIP-4895 withdrawals trie check consistent with tx trie, PR [#3338](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3338)
+- Rename deposit receipt to deposit request, PR [#3408](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3408)
+- Enhances typing of CL requests, PR [#3398](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3398)
 
 ## 5.2.0 - 2024-03-18
 

--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -124,6 +124,10 @@ Have a look at the EIP for some guidance on how to use and fill in the various w
 - New `Block.toExecutionPayload()` method to map to the execution payload structore from the beacon chain, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 - Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
+### Other Changes
+
+- Make EIP-4895 withdrawals trie check consistent with tx trie, PR [#3338](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3338)
+
 ## 5.2.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness

--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 5.3.0 - 2024-07-23
+## 5.3.0 - 2024-08-15
 
 ### Blocks with EIP-7685 Consensus Layer Requests
 

--- a/packages/block/CHANGELOG.md
+++ b/packages/block/CHANGELOG.md
@@ -12,9 +12,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 
-### Features
+### Other Features
 
 - New `Block.toExecutionPayload()` method to map to the execution payload structore from the beacon chain, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
 ## 5.2.0 - 2024-03-18
 

--- a/packages/block/README.md
+++ b/packages/block/README.md
@@ -321,6 +321,59 @@ main()
 
 Have a look at the EIP for some guidance on how to use and fill in the various withdrawal request parameters.
 
+#### EIP-7251 Consolidation Requests
+
+[EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) introduces consolidation requests allowing staked ETH from more than one validator on the beacon chain to be consolidated into one validator, triggered from the execution layer. Starting with v5.3.0 this library supports consolidation requests and a containing block can be instantiated as follows:
+
+```ts
+// ./examples/7251Requests.ts
+
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Block } from '@ethereumjs/block'
+import {
+  bytesToBigInt,
+  ConsolidationRequest,
+  randomBytes,
+  type CLRequest,
+  type CLRequestType,
+} from '@ethereumjs/util'
+
+const main = async () => {
+  const common = new Common({
+    chain: Chain.Mainnet,
+    hardfork: Hardfork.Prague,
+  })
+
+  const consolidationRequestData = {
+    sourceAddress: randomBytes(20),
+    sourcePubkey: randomBytes(48),
+    targetPubkey: randomBytes(48),
+  }
+  const request = ConsolidationRequest.fromRequestData(
+    consolidationRequestData
+  ) as CLRequest<CLRequestType>
+  const requests = [request]
+  const requestsRoot = await Block.genRequestsTrieRoot(requests)
+
+  const block = Block.fromBlockData(
+    {
+      requests,
+      header: { requestsRoot },
+    },
+    { common }
+  )
+  console.log(
+    `Instantiated block with ${
+      block.requests?.length
+    } consolidation request, requestTrieValid=${await block.requestsTrieIsValid()}`
+  )
+}
+
+main()
+```
+
+Have a look at the EIP for some guidance on how to use and fill in the various deposit request parameters.
+
 ### Consensus Types
 
 The block library supports the creation as well as consensus format validation of PoW `ethash` and PoA `clique` blocks (so e.g. do specific `extraData` checks on Clique/PoA blocks).

--- a/packages/block/README.md
+++ b/packages/block/README.md
@@ -212,6 +212,115 @@ main()
 
 **Note:** Working with blob transactions needs a manual KZG library installation and global initialization, see [KZG Setup](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/tx/README.md#kzg-setup) for instructions.
 
+### Blocks with EIP-7685 Consensus Layer Requests
+
+Starting with v5.3.0 this library supports requests to the consensus layer which have been introduce with [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) and will come into play for deposit and withdrawal requests along the upcoming [Prague](https://eips.ethereum.org/EIPS/eip-7600) hardfork.
+
+#### EIP-6110 Deposit Requests
+
+[EIP-6110](https://eips.ethereum.org/EIPS/eip-6110) introduces deposit requests allowing beacon chain deposits being triggered from the execution layer. Starting with v5.3.0 this library supports deposit requests and a containing block can be instantiated as follows:
+
+```ts
+// ./examples/6110Requests.ts
+
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Block } from '@ethereumjs/block'
+import {
+  bytesToBigInt,
+  DepositRequest,
+  randomBytes,
+  type CLRequest,
+  type CLRequestType,
+} from '@ethereumjs/util'
+
+const main = async () => {
+  const common = new Common({
+    chain: Chain.Mainnet,
+    hardfork: Hardfork.Cancun,
+    eips: [7685, 4788],
+  })
+
+  const depositRequestData = {
+    pubkey: randomBytes(48),
+    withdrawalCredentials: randomBytes(32),
+    amount: bytesToBigInt(randomBytes(8)),
+    signature: randomBytes(96),
+    index: bytesToBigInt(randomBytes(8)),
+  }
+  const request = DepositRequest.fromRequestData(depositRequestData) as CLRequest<CLRequestType>
+  const requests = [request]
+  const requestsRoot = await Block.genRequestsTrieRoot(requests)
+
+  const block = Block.fromBlockData(
+    {
+      requests,
+      header: { requestsRoot },
+    },
+    { common }
+  )
+  console.log(
+    `Instantiated block with ${
+      block.requests?.length
+    } request, requestTrieValid=${await block.requestsTrieIsValid()}`
+  )
+}
+
+main()
+```
+
+Have a look at the EIP for some guidance on how to use and fill in the various deposit request parameters.
+
+#### EIP-7002 Withdrawal Requests
+
+[EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) introduces the possibility for validators to trigger exits and partial withdrawals via the execution layer. Starting with v5.3.0 this library supports withdrawal requests and a containing block can be instantiated as follows:
+
+```ts
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Block } from '@ethereumjs/block'
+import {
+  bytesToBigInt,
+  randomBytes,
+  WithdrawalRequest,
+  type CLRequest,
+  type CLRequestType,
+} from '@ethereumjs/util'
+
+const main = async () => {
+  const common = new Common({
+    chain: Chain.Mainnet,
+    hardfork: Hardfork.Prague,
+  })
+
+  const withdrawalRequestData = {
+    sourceAddress: randomBytes(20),
+    validatorPubkey: randomBytes(48),
+    amount: bytesToBigInt(randomBytes(8)),
+  }
+  const request = WithdrawalRequest.fromRequestData(
+    withdrawalRequestData
+  ) as CLRequest<CLRequestType>
+  const requests = [request]
+  const requestsRoot = await Block.genRequestsTrieRoot(requests)
+
+  const block = Block.fromBlockData(
+    {
+      requests,
+      header: { requestsRoot },
+    },
+    { common }
+  )
+  console.log(
+    `Instantiated block with ${
+      block.requests?.length
+    } withdrawal request, requestTrieValid=${await block.requestsTrieIsValid()}`
+  )
+}
+
+main()
+```
+
+Have a look at the EIP for some guidance on how to use and fill in the various withdrawal request parameters.
+
 ### Consensus Types
 
 The block library supports the creation as well as consensus format validation of PoW `ethash` and PoA `clique` blocks (so e.g. do specific `extraData` checks on Clique/PoA blocks).

--- a/packages/block/examples/6110Requests.ts
+++ b/packages/block/examples/6110Requests.ts
@@ -1,0 +1,42 @@
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Block } from '@ethereumjs/block'
+import {
+  bytesToBigInt,
+  DepositRequest,
+  randomBytes,
+  type CLRequest,
+  type CLRequestType,
+} from '@ethereumjs/util'
+
+const main = async () => {
+  const common = new Common({
+    chain: Chain.Mainnet,
+    hardfork: Hardfork.Prague,
+  })
+
+  const depositRequestData = {
+    pubkey: randomBytes(48),
+    withdrawalCredentials: randomBytes(32),
+    amount: bytesToBigInt(randomBytes(8)),
+    signature: randomBytes(96),
+    index: bytesToBigInt(randomBytes(8)),
+  }
+  const request = DepositRequest.fromRequestData(depositRequestData) as CLRequest<CLRequestType>
+  const requests = [request]
+  const requestsRoot = await Block.genRequestsTrieRoot(requests)
+
+  const block = Block.fromBlockData(
+    {
+      requests,
+      header: { requestsRoot },
+    },
+    { common }
+  )
+  console.log(
+    `Instantiated block with ${
+      block.requests?.length
+    } deposit request, requestTrieValid=${await block.requestsTrieIsValid()}`
+  )
+}
+
+main()

--- a/packages/block/examples/7002Requests.ts
+++ b/packages/block/examples/7002Requests.ts
@@ -1,0 +1,42 @@
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Block } from '@ethereumjs/block'
+import {
+  bytesToBigInt,
+  randomBytes,
+  WithdrawalRequest,
+  type CLRequest,
+  type CLRequestType,
+} from '@ethereumjs/util'
+
+const main = async () => {
+  const common = new Common({
+    chain: Chain.Mainnet,
+    hardfork: Hardfork.Prague,
+  })
+
+  const withdrawalRequestData = {
+    sourceAddress: randomBytes(20),
+    validatorPubkey: randomBytes(48),
+    amount: bytesToBigInt(randomBytes(8)),
+  }
+  const request = WithdrawalRequest.fromRequestData(
+    withdrawalRequestData
+  ) as CLRequest<CLRequestType>
+  const requests = [request]
+  const requestsRoot = await Block.genRequestsTrieRoot(requests)
+
+  const block = Block.fromBlockData(
+    {
+      requests,
+      header: { requestsRoot },
+    },
+    { common }
+  )
+  console.log(
+    `Instantiated block with ${
+      block.requests?.length
+    } withdrawal request, requestTrieValid=${await block.requestsTrieIsValid()}`
+  )
+}
+
+main()

--- a/packages/block/examples/7251Requests.ts
+++ b/packages/block/examples/7251Requests.ts
@@ -1,0 +1,42 @@
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { Block } from '@ethereumjs/block'
+import {
+  bytesToBigInt,
+  ConsolidationRequest,
+  randomBytes,
+  type CLRequest,
+  type CLRequestType,
+} from '@ethereumjs/util'
+
+const main = async () => {
+  const common = new Common({
+    chain: Chain.Mainnet,
+    hardfork: Hardfork.Prague,
+  })
+
+  const consolidationRequestData = {
+    sourceAddress: randomBytes(20),
+    sourcePubkey: randomBytes(48),
+    targetPubkey: randomBytes(48),
+  }
+  const request = ConsolidationRequest.fromRequestData(
+    consolidationRequestData
+  ) as CLRequest<CLRequestType>
+  const requests = [request]
+  const requestsRoot = await Block.genRequestsTrieRoot(requests)
+
+  const block = Block.fromBlockData(
+    {
+      requests,
+      header: { requestsRoot },
+    },
+    { common }
+  )
+  console.log(
+    `Instantiated block with ${
+      block.requests?.length
+    } consolidation request, requestTrieValid=${await block.requestsTrieIsValid()}`
+  )
+}
+
+main()

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -49,7 +49,7 @@
     "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/trie": "^6.2.1",
-    "@ethereumjs/tx": "^5.3.0",
+    "@ethereumjs/tx": "^5.4.0",
     "@ethereumjs/util": "^9.1.0",
     "ethereum-cryptography": "^2.2.1"
   },

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/block",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "Provides Block serialization and help functions",
   "keywords": [
     "ethereum",

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -50,7 +50,7 @@
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/trie": "^6.2.0",
     "@ethereumjs/tx": "^5.3.0",
-    "@ethereumjs/util": "^9.0.3",
+    "@ethereumjs/util": "^9.1.0",
     "ethereum-cryptography": "^2.2.1"
   },
   "devDependencies": {

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -46,7 +46,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/common": "^4.3.0",
+    "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/trie": "^6.2.0",
     "@ethereumjs/tx": "^5.3.0",

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/rlp": "^5.0.2",
-    "@ethereumjs/trie": "^6.2.0",
+    "@ethereumjs/trie": "^6.2.1",
     "@ethereumjs/tx": "^5.3.0",
     "@ethereumjs/util": "^9.1.0",
     "ethereum-cryptography": "^2.2.1"

--- a/packages/block/src/block.ts
+++ b/packages/block/src/block.ts
@@ -988,6 +988,12 @@ export class Block {
     }
   }
 
+  /**
+   * Maps the block properties to the execution payload structore from the beacon chain,
+   * see https://github.com/ethereum/consensus-specs/blob/dev/specs/bellatrix/beacon-chain.md#ExecutionPayload
+   *
+   * @returns dict with the execution payload parameters with camel case naming
+   */
   toExecutionPayload(): ExecutionPayload {
     const blockJson = this.toJSON()
     const header = blockJson.header!

--- a/packages/block/test/eip7685block.spec.ts
+++ b/packages/block/test/eip7685block.spec.ts
@@ -26,7 +26,7 @@ function getRandomDepositRequest(): CLRequest<CLRequestType> {
 function getRandomWithdrawalRequest(): CLRequest<CLRequestType> {
   const withdrawalRequestData = {
     sourceAddress: randomBytes(20),
-    validatorPublicKey: randomBytes(48),
+    validatorPubkey: randomBytes(48),
     amount: bytesToBigInt(randomBytes(8)),
   }
   return WithdrawalRequest.fromRequestData(withdrawalRequestData) as CLRequest<CLRequestType>

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -8,8 +8,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## - 2024-07-23
 
+### EIP-6110 (Deposit Requests) / EIP-7002 (Withdrawal Requests) Support
+
+This library now supports running blocks including `EIP-6110` deposit requests, see PR [#3390](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3390) and `EIP-7002` withdrawal requests, see PR [#3385](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3385).
+
+These new request types will be activated with the `Prague` hardfork, see [@ethereumjs/block](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/block) README for detailed documentation.
+
 ### Other Features
 
+- Support for EIP-7685 blocks containing withdrawal and/or deposit requests (see @ethereumjs/block for main documentation), PR [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372)
 - Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
 ## 7.2.0 - 2024-03-18

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 7.2.0 - 2024-03-05
+## 7.2.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness
 

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -14,10 +14,15 @@ This library now supports running blocks including `EIP-6110` deposit requests, 
 
 These new request types will be activated with the `Prague` hardfork, see [@ethereumjs/block](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/block) README for detailed documentation.
 
+### Verkle Updates
+
+- Fix the block body parsing as well as save/load from blockchain, PR [#3392](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3392)
+- Handle nil block bodies for backwards compatibility, PR [#3394](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3394)
+
 ### Other Features
 
 - Support for EIP-7685 blocks containing withdrawal and/or deposit requests (see @ethereumjs/block for main documentation), PR [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372)
-- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+- Stricter prefixe hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
 ## 7.2.0 - 2024-03-18
 

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## - 2024-07-23
+
 ## 7.2.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## - 2024-07-23
+## 7.3.0 - 2024-07-23
 
 ### EIP-6110 (Deposit Requests) / EIP-7002 (Withdrawal Requests) Support
 

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## - 2024-07-23
 
+### Other Features
+
+- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+
 ## 7.2.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 7.3.0 - 2024-08-15
 
-### EIP-6110 (Deposit Requests) / EIP-7002 (Withdrawal Requests) Support
+### EIP-7685 Requests: EIP-6110 (Deposits) / EIP-7002 (Withdrawals) / EIP-7251 (Consolidations)
 
-This library now supports running blocks including `EIP-6110` deposit requests, see PR [#3390](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3390) and `EIP-7002` withdrawal requests, see PR [#3385](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3385).
+This library now supports `EIP-6110` deposit requests, see PR [#3390](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3390), `EIP-7002` withdrawal requests, see PR [#3385](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3385) and `EIP-7251` consolidation requests, see PR [#3477](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3477) as well as the underlying generic execution layer request logic introduced with `EIP-7685` (PR [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372)).
 
 These new request types will be activated with the `Prague` hardfork, see [@ethereumjs/block](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/block) README for detailed documentation.
 

--- a/packages/blockchain/CHANGELOG.md
+++ b/packages/blockchain/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 7.3.0 - 2024-07-23
+## 7.3.0 - 2024-08-15
 
 ### EIP-6110 (Deposit Requests) / EIP-7002 (Withdrawal Requests) Support
 

--- a/packages/blockchain/README.md
+++ b/packages/blockchain/README.md
@@ -180,6 +180,10 @@ The blockchain library now allows for blob transactions to be validated and incl
 
 **Note:** Working with blob transactions needs a manual KZG library installation and global initialization, see [KZG Setup](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/tx/README.md#kzg-setup) for instructions.
 
+### EIP-6110/EIP-7002 Requests Support
+
+This libary supports blocks including `EIP-6110` deposit requests as well as `EIP-7002` withdrawal requests starting with `v7.3.0`.
+
 ## Browser
 
 With the breaking release round in Summer 2023 we have added hybrid ESM/CJS builds for all our libraries (see section below) and have eliminated many of the caveats which had previously prevented a frictionless browser usage.

--- a/packages/blockchain/README.md
+++ b/packages/blockchain/README.md
@@ -180,9 +180,13 @@ The blockchain library now allows for blob transactions to be validated and incl
 
 **Note:** Working with blob transactions needs a manual KZG library installation and global initialization, see [KZG Setup](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/tx/README.md#kzg-setup) for instructions.
 
-### EIP-6110/EIP-7002 Requests Support
+### EIP-7685 Requests Support
 
-This libary supports blocks including `EIP-6110` deposit requests as well as `EIP-7002` withdrawal requests starting with `v7.3.0`.
+This libary supports blocks including the following [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) requests:
+
+- [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110) - Deposit Requests (`v7.3.0`+)
+- [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Withdrawal Requests (`v7.3.0`+)
+- [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) - Consolidation Requests (`v7.3.0`+)
 
 ## Browser
 

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/blockchain",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "description": "A module to store and interact with blocks",
   "keywords": [
     "ethereum",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -46,7 +46,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/block": "^5.2.0",
+    "@ethereumjs/block": "^5.3.0",
     "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/ethash": "^3.0.4",
     "@ethereumjs/rlp": "^5.0.2",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -50,7 +50,7 @@
     "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/ethash": "^3.0.3",
     "@ethereumjs/rlp": "^5.0.2",
-    "@ethereumjs/trie": "^6.2.0",
+    "@ethereumjs/trie": "^6.2.1",
     "@ethereumjs/tx": "^5.3.0",
     "@ethereumjs/util": "^9.1.0",
     "debug": "^4.3.3",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@ethereumjs/block": "^5.2.0",
     "@ethereumjs/common": "^4.4.0",
-    "@ethereumjs/ethash": "^3.0.3",
+    "@ethereumjs/ethash": "^3.0.4",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/trie": "^6.2.1",
     "@ethereumjs/tx": "^5.4.0",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@ethereumjs/block": "^5.2.0",
-    "@ethereumjs/common": "^4.3.0",
+    "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/ethash": "^3.0.3",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/trie": "^6.2.0",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -51,7 +51,7 @@
     "@ethereumjs/ethash": "^3.0.3",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/trie": "^6.2.1",
-    "@ethereumjs/tx": "^5.3.0",
+    "@ethereumjs/tx": "^5.4.0",
     "@ethereumjs/util": "^9.1.0",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.2.1",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -52,7 +52,7 @@
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/trie": "^6.2.0",
     "@ethereumjs/tx": "^5.3.0",
-    "@ethereumjs/util": "^9.0.3",
+    "@ethereumjs/util": "^9.1.0",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.2.1",
     "lru-cache": "10.1.0"

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -11,7 +11,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Verkle Updates
 
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+- Kaustinen5 related fixes, PR [#3343](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3343)
 - CLI option `--ignoreStatelessInvalidExecs` for Verkle debugging, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+- Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
 - Update `kzg-wasm` to `0.4.0`, PR [#3358](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3358)
 
 ### Other Features

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Other Changes
 
+- Integrates support for [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
 - Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348)
 
 ## 0.10.1 - 2024-03-18

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -18,12 +18,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Shift Verkle to `osaka` hardfork, PR [#3371](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3371)
 - Simplify `--ignoreStatelessInvalidExecs` to just a boolean flag, PR [#3395](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3395)
 - Add verkle execution support to `executeBlocks()`, PR [#3406](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3406)
+- Verkle decoupling in underlying libraries, PR [#3462](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3462)
 
 ### Other Features
 
 - Integrates support for [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
 - New `--startExectionFrom` and `--startExecution` CLI options, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+- Add `eth_blobBaseFee` RPC endpoint, PR [#3436](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3436)
 - Add support for `pending` in `eth_getTransactionCount` RPC method, PR [#3415](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3415)
+- Add support for multiple sources of rlp blocks when loading with `--loadBlocksFromRlp`, PR [#3442](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3442)
 - Basic Prometheus metrics support (not many metrics yet), PR [#3287](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3287)
 
 ### Other Changes
@@ -33,6 +36,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - New mechanism to keep latest block from peers updated, PR [#3354](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3354)
 - Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348)
 - Update `multiaddress` dependency, PR [#3384](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3384)
+- Internalize `QHeap` dependency, PR [#3451](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3451)
+- Internalize `jwt-simple` dependency, PR [#3458](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3458)
 
 ### Bugfixes
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -15,15 +15,29 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - CLI option `--ignoreStatelessInvalidExecs` for Verkle debugging, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 - Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
 - Update `kzg-wasm` to `0.4.0`, PR [#3358](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3358)
+- Shift Verkle to `osaka` hardfork, PR [#3371](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3371)
+- Simplify `--ignoreStatelessInvalidExecs` to just a boolean flag, PR [#3395](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3395)
+- Add verkle execution support to `executeBlocks()`, PR [#3406](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3406)
 
 ### Other Features
 
+- Integrates support for [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
 - New `--startExectionFrom` and `--startExecution` CLI options, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+- Add support for `pending` in `eth_getTransactionCount` RPC method, PR [#3415](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3415)
+- Basic Prometheus metrics support (not many metrics yet), PR [#3287](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3287)
 
 ### Other Changes
 
-- Integrates support for [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
+- ESM-only client build, PRs [#3359](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3359) and [#3414](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3414)
+- Add execution api v4 handling to engine, PR [#3399](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3399)
+- New mechanism to keep latest block from peers updated, PR [#3354](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3354)
 - Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348)
+- Update `multiaddress` dependency, PR [#3384](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3384)
+
+### Bugfixes
+
+- Fixes for the `eth_estimateGas` RPC endpoint, PR [#3416](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3416)
+- Fixes the "block to payload" serialization for getpayload V4, PR [#3409](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3409)
 
 ## 0.10.1 - 2024-03-18
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## - 2024-07-23
 
+### Verkle Updates
+
+- Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+- CLI option `--ignoreStatelessInvalidExecs` for Verkle debugging, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+
+### Features
+
+- New `--startExectionFrom` and `--startExecution` CLI options, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+
 ## 0.10.1 - 2024-03-18
 
 This is mainly a maintenance release coming with a few internal changes and minor bug fixes, single user-focused addition is the support for the `eth_feeHistory` RPC call.

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 - CLI option `--ignoreStatelessInvalidExecs` for Verkle debugging, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+- Update `kzg-wasm` to `0.4.0`, PR [#3358](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3358)
 
 ### Other Features
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 0.10.1 - 2024-03-05
+## 0.10.1 - 2024-03-18
 
 This is mainly a maintenance release coming with a few internal changes and minor bug fixes, single user-focused addition is the support for the `eth_feeHistory` RPC call.
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -24,7 +24,7 @@ This releases comes with some RPC improvements as well as various updates to cat
 
 ### Other Features
 
-- Integrates support for [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
+- Integrates support for [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (outdated) (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
 - New `--startExectionFrom` and `--startExecution` CLI options, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 - Add `eth_blobBaseFee` RPC endpoint, PR [#3436](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3436)
 - Add support for `pending` in `eth_getTransactionCount` RPC method, PR [#3415](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3415)

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## - 2024-07-23
+## 0.10.2 - 2024-07-23
+
+This releases comes with some RPC improvements as well as various updates to catch up for testnets preparing for the Prague hardfork as well as the Verkle tree integration. Note that for running/participating in the latest Prague and Verkle testnets it is still needed to join with a build from `master` since testnets are evolving so quickly that it is not practical to catch up with official client releases!
 
 ### Verkle Updates
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## - 2024-07-23
+
 ## 0.10.1 - 2024-03-18
 
 This is mainly a maintenance release coming with a few internal changes and minor bug fixes, single user-focused addition is the support for the `eth_feeHistory` RPC call.

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -13,9 +13,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 - CLI option `--ignoreStatelessInvalidExecs` for Verkle debugging, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 
-### Features
+### Other Features
 
 - New `--startExectionFrom` and `--startExecution` CLI options, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+
+### Other Changes
+
+- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348)
 
 ## 0.10.1 - 2024-03-18
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 0.10.2 - 2024-07-23
+## 0.10.2 - 2024-08-15
 
 This releases comes with some RPC improvements as well as various updates to catch up for testnets preparing for the Prague hardfork as well as the Verkle tree integration. Note that for running/participating in the latest Prague and Verkle testnets it is still needed to join with a build from `master` since testnets are evolving so quickly that it is not practical to catch up with official client releases!
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 0.10.2 - 2024-08-15
 
-This releases comes with some RPC improvements as well as various updates to catch up for testnets preparing for the Prague hardfork as well as the Verkle tree integration. Note that for running/participating in the latest Prague and Verkle testnets it is still needed to join with a build from `master` since testnets are evolving so quickly that it is not practical to catch up with official client releases!
+This release comes with some RPC improvements as well as various updates to catch up for testnets preparing for the Prague hardfork as well as the Verkle tree integration. Note that for running/participating in the latest Prague and Verkle testnets it is still needed to join with a build from `master` since testnets are evolving so quickly that it is not practical to catch up with official client releases!
 
 ### Verkle Updates
 

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - ESM-only client build, PRs [#3359](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3359) and [#3414](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3414)
 - Add execution api v4 handling to engine, PR [#3399](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3399)
 - New mechanism to keep latest block from peers updated, PR [#3354](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3354)
+- Better `--execution` flag guard, PR [#3363](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3363)
 - Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348)
 - Update `multiaddress` dependency, PR [#3384](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3384)
 - Internalize `QHeap` dependency, PR [#3451](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3451)
@@ -42,7 +43,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Bugfixes
 
 - Fixes for the `eth_estimateGas` RPC endpoint, PR [#3416](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3416)
+- Fixes tx status in `eth_getTransactionReceipt` RPC method, PR [#3435](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3435)
 - Fixes the "block to payload" serialization for getpayload V4, PR [#3409](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3409)
+- Fix the getpayloadv4 with a deposit tx and expected deposit requests, PR [#3410](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3410)
 
 ## 0.10.1 - 2024-03-18
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -307,7 +307,7 @@ dist/bin/cli.js --d
 
 ## Metrics
 
-The client can optionally collect metrics using the Prometheus metrics platform and expose them via an HTTP endpoint with the following CLI flags.  
+The client can optionally collect metrics using the [Prometheus](https://github.com/prometheus/prometheus) metrics platform and expose them via an HTTP endpoint with the following CLI flags.  
 The current metrics that are reported by the client can be found [here](./src/util//metrics.ts).
 
 ```sh

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -67,7 +67,7 @@
     "@ethereumjs/trie": "6.2.1",
     "@ethereumjs/tx": "5.3.0",
     "@ethereumjs/util": "9.1.0",
-    "@ethereumjs/verkle": "^0.0.2",
+    "@ethereumjs/verkle": "^0.1.0",
     "@ethereumjs/vm": "8.0.0",
     "@multiformats/multiaddr": "^12.2.1",
     "@polkadot/util": "^12.6.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -61,7 +61,7 @@
     "@ethereumjs/devp2p": "6.1.2",
     "@ethereumjs/ethash": "3.0.3",
     "@ethereumjs/evm": "3.0.0",
-    "@ethereumjs/genesis": "0.2.2",
+    "@ethereumjs/genesis": "0.2.3",
     "@ethereumjs/rlp": "5.0.2",
     "@ethereumjs/statemanager": "2.3.0",
     "@ethereumjs/trie": "6.2.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -55,7 +55,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/block": "5.2.0",
+    "@ethereumjs/block": "5.3.0",
     "@ethereumjs/blockchain": "7.2.0",
     "@ethereumjs/common": "4.4.0",
     "@ethereumjs/devp2p": "6.1.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@ethereumjs/block": "5.3.0",
-    "@ethereumjs/blockchain": "7.2.0",
+    "@ethereumjs/blockchain": "7.3.0",
     "@ethereumjs/common": "4.4.0",
     "@ethereumjs/devp2p": "6.1.3",
     "@ethereumjs/ethash": "3.0.4",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -60,7 +60,7 @@
     "@ethereumjs/common": "4.4.0",
     "@ethereumjs/devp2p": "6.1.3",
     "@ethereumjs/ethash": "3.0.4",
-    "@ethereumjs/evm": "3.0.0",
+    "@ethereumjs/evm": "3.1.0",
     "@ethereumjs/genesis": "0.2.3",
     "@ethereumjs/rlp": "5.0.2",
     "@ethereumjs/statemanager": "2.4.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -58,7 +58,7 @@
     "@ethereumjs/block": "5.2.0",
     "@ethereumjs/blockchain": "7.2.0",
     "@ethereumjs/common": "4.4.0",
-    "@ethereumjs/devp2p": "6.1.2",
+    "@ethereumjs/devp2p": "6.1.3",
     "@ethereumjs/ethash": "3.0.3",
     "@ethereumjs/evm": "3.0.0",
     "@ethereumjs/genesis": "0.2.3",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -66,7 +66,7 @@
     "@ethereumjs/statemanager": "2.3.0",
     "@ethereumjs/trie": "6.2.0",
     "@ethereumjs/tx": "5.3.0",
-    "@ethereumjs/util": "9.0.3",
+    "@ethereumjs/util": "9.1.0",
     "@ethereumjs/verkle": "^0.0.2",
     "@ethereumjs/vm": "8.0.0",
     "@multiformats/multiaddr": "^12.2.1",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -64,7 +64,7 @@
     "@ethereumjs/genesis": "0.2.2",
     "@ethereumjs/rlp": "5.0.2",
     "@ethereumjs/statemanager": "2.3.0",
-    "@ethereumjs/trie": "6.2.0",
+    "@ethereumjs/trie": "6.2.1",
     "@ethereumjs/tx": "5.3.0",
     "@ethereumjs/util": "9.1.0",
     "@ethereumjs/verkle": "^0.0.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -63,7 +63,7 @@
     "@ethereumjs/evm": "3.0.0",
     "@ethereumjs/genesis": "0.2.3",
     "@ethereumjs/rlp": "5.0.2",
-    "@ethereumjs/statemanager": "2.3.0",
+    "@ethereumjs/statemanager": "2.4.0",
     "@ethereumjs/trie": "6.2.1",
     "@ethereumjs/tx": "5.4.0",
     "@ethereumjs/util": "9.1.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@ethereumjs/block": "5.2.0",
     "@ethereumjs/blockchain": "7.2.0",
-    "@ethereumjs/common": "4.3.0",
+    "@ethereumjs/common": "4.4.0",
     "@ethereumjs/devp2p": "6.1.2",
     "@ethereumjs/ethash": "3.0.3",
     "@ethereumjs/evm": "3.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -65,7 +65,7 @@
     "@ethereumjs/rlp": "5.0.2",
     "@ethereumjs/statemanager": "2.3.0",
     "@ethereumjs/trie": "6.2.1",
-    "@ethereumjs/tx": "5.3.0",
+    "@ethereumjs/tx": "5.4.0",
     "@ethereumjs/util": "9.1.0",
     "@ethereumjs/verkle": "^0.1.0",
     "@ethereumjs/vm": "8.0.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/client",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "EthereumJS Execution Layer (EL) Client Implementation",
   "keywords": [
     "ethereum",
@@ -68,7 +68,7 @@
     "@ethereumjs/tx": "5.4.0",
     "@ethereumjs/util": "9.1.0",
     "@ethereumjs/verkle": "^0.1.0",
-    "@ethereumjs/vm": "8.0.0",
+    "@ethereumjs/vm": "8.1.0",
     "@multiformats/multiaddr": "^12.2.1",
     "@polkadot/util": "^12.6.2",
     "@polkadot/wasm-crypto": "^7.3.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -59,7 +59,7 @@
     "@ethereumjs/blockchain": "7.2.0",
     "@ethereumjs/common": "4.4.0",
     "@ethereumjs/devp2p": "6.1.3",
-    "@ethereumjs/ethash": "3.0.3",
+    "@ethereumjs/ethash": "3.0.4",
     "@ethereumjs/evm": "3.0.0",
     "@ethereumjs/genesis": "0.2.3",
     "@ethereumjs/rlp": "5.0.2",

--- a/packages/client/src/ext/jwt-simple.ts
+++ b/packages/client/src/ext/jwt-simple.ts
@@ -7,7 +7,7 @@
  * module dependencies
  */
 import { bytesToUtf8, utf8ToBytes } from '@ethereumjs/util'
-import { base64url } from '@scure/base'
+import { base64url, base64urlnopad } from '@scure/base'
 import crypto from 'crypto'
 
 /**
@@ -121,7 +121,7 @@ const decode = function jwt_decode(
 
   // base64 decode and parse JSON
   const header = JSON.parse(bytesToUtf8(base64url.decode(headerSeg)))
-  const payload = JSON.parse(bytesToUtf8(base64url.decode(payloadSeg)))
+  const payload = JSON.parse(bytesToUtf8(base64urlnopad.decode(payloadSeg)))
 
   if (!noVerify) {
     if (!algorithm && /BEGIN( RSA)? PUBLIC KEY/.test(key.toString())) {
@@ -193,7 +193,7 @@ const encode = function jwt_encode(
   // create segments, all segments should be base64 string
   const segments = []
   segments.push(base64url.encode(utf8ToBytes(JSON.stringify(header))))
-  segments.push(base64url.encode(utf8ToBytes(JSON.stringify(payload))))
+  segments.push(base64urlnopad.encode(utf8ToBytes(JSON.stringify(payload))))
   segments.push(sign(segments.join('.'), key, signingMethod, signingType))
 
   return segments.join('.')

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -23,6 +23,10 @@ These new request types will be activated with the `Prague` hardfork, see [@ethe
 - Adds support for [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
 - Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
+### Other Changes
+
+- Removes support for [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) simple subroutines for EVM (deprecated with an alternative version integrated into EOF), PR [#3342](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3342)
+
 ## 4.3.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 4.4.0 - 2024-07-23
+## 4.4.0 - 2024-08-15
 
 ### EIP-6110 (Deposit Requests) / EIP-7002 (Withdrawal Requests) / EIP-7251 (Consolidation Requests) Support
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -24,7 +24,7 @@ These new request types will be activated with the `Prague` hardfork, see [@ethe
 ### Other Features
 
 - Adds support for [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
-- Adds support for [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) Serve Historical Block Hashes from State (Prague) (see EVM for full docs), PR [#3475](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3475)
+- Adds support for [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) Serve Historical Block Hashes from State (Prague) (see EVM for full docs) as well as the related [EIP-7709](https://eips.ethereum.org/EIPS/eip-7709), PR [#3475](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3475)
 - Stricter prefixe hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
 ### Other Changes

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 4.3.0 - 2024-03-05
+## 4.3.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 4.4.0 - 2024-07-23
 
-### EIP-6110 (Deposit Requests) / EIP-7002 (Withdrawal Requests) Support
+### EIP-6110 (Deposit Requests) / EIP-7002 (Withdrawal Requests) / EIP-7251 (Consolidation Requests) Support
 
-This library now supports `EIP-6110` deposit requests, see PR [#3390](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3390) and `EIP-7002` withdrawal requests, see PR [#3385](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3385) as well as the underlying generic execution layer request logic introduced with `EIP-7685` (PR [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372)).
+This library now supports `EIP-6110` deposit requests, see PR [#3390](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3390), `EIP-7002` withdrawal requests, see PR [#3385](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3385) and `EIP-7251` consolidation requests, see PR [#3477](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3477) as well as the underlying generic execution layer request logic introduced with `EIP-7685` (PR [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372)).
 
 These new request types will be activated with the `Prague` hardfork, see [@ethereumjs/block](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/block) README for detailed documentation.
 
@@ -19,6 +19,7 @@ These new request types will be activated with the `Prague` hardfork, see [@ethe
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 - Kaustinen5 related fixes, PR [#3343](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3343)
 - Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
+- Verkle decoupling, PR [#3462](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3462)
 
 ### Other Features
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 4.4.0 - 2024-08-15
 
-### EIP-6110 (Deposit Requests) / EIP-7002 (Withdrawal Requests) / EIP-7251 (Consolidation Requests) Support
+### EIP-7685 Requests: EIP-6110 (Deposits) / EIP-7002 (Withdrawals) / EIP-7251 (Consolidations)
 
 This library now supports `EIP-6110` deposit requests, see PR [#3390](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3390), `EIP-7002` withdrawal requests, see PR [#3385](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3385) and `EIP-7251` consolidation requests, see PR [#3477](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3477) as well as the underlying generic execution layer request logic introduced with `EIP-7685` (PR [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372)).
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -23,7 +23,7 @@ These new request types will be activated with the `Prague` hardfork, see [@ethe
 
 ### Other Features
 
-- Adds support for [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
+- Adds support for [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (outdated) (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
 - Adds support for [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) Serve Historical Block Hashes from State (Prague) (see EVM for full docs) as well as the related [EIP-7709](https://eips.ethereum.org/EIPS/eip-7709), PR [#3475](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3475)
 - Stricter prefixe hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -24,6 +24,7 @@ These new request types will be activated with the `Prague` hardfork, see [@ethe
 ### Other Features
 
 - Adds support for [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
+- Adds support for [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) Serve Historical Block Hashes from State (Prague) (see EVM for full docs), PR [#3475](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3475)
 - Stricter prefixe hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
 ### Other Changes

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 4.4.0 - 2024-07-23
 
+### EIP-6110 (Deposit Requests) / EIP-7002 (Withdrawal Requests) Support
+
+This library now supports `EIP-6110` deposit requests, see PR [#3390](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3390) and `EIP-7002` withdrawal requests, see PR [#3385](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3385) as well as the underlying generic execution layer request logic introduced with `EIP-7685` (PR [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372)).
+
+These new request types will be activated with the `Prague` hardfork, see [@ethereumjs/block](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/block) README for detailed documentation.
+
 ### Verkle Updates
 
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -20,6 +20,7 @@ These new request types will be activated with the `Prague` hardfork, see [@ethe
 
 ### Other Features
 
+- Adds support for [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
 - Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
 ## 4.3.0 - 2024-03-18

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 
+### Other Features
+
+- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+
 ## 4.3.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## - 2024-07-23
+## 4.4.0 - 2024-07-23
+
+### Verkle Updates
+
+- Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 
 ## 4.3.0 - 2024-03-18
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## - 2024-07-23
+
 ## 4.3.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -23,11 +23,18 @@ These new request types will be activated with the `Prague` hardfork, see [@ethe
 ### Other Features
 
 - Adds support for [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
-- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+- Stricter prefixe hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
 ### Other Changes
 
 - Removes support for [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) simple subroutines for EVM (deprecated with an alternative version integrated into EOF), PR [#3342](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3342)
+- Clean up access to deposit address, PR [#3411](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3411)
+- Add spec test for 2935 contract code and update history storage address, PR [#3373](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3373)
+- Parse deposit contract address from geth genesis for chain config, PR [#3422](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3422)
+
+### Bugfixes
+
+- BLS gas prices fixes, PR [#3400](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3400)
 
 ## 4.3.0 - 2024-03-18
 

--- a/packages/common/CHANGELOG.md
+++ b/packages/common/CHANGELOG.md
@@ -17,6 +17,8 @@ These new request types will be activated with the `Prague` hardfork, see [@ethe
 ### Verkle Updates
 
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+- Kaustinen5 related fixes, PR [#3343](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3343)
+- Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
 
 ### Other Features
 

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -434,7 +434,7 @@ The following EIPs are currently supported:
 - [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) - SELFDESTRUCT only in same transaction (Cancun)
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
 - [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) - Execution layer triggerable validator consolidations (Prague)
-- [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague)
+- [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague) (`outdated`)
 - [EIP-7709](https://eips.ethereum.org/EIPS/eip-7709) - Read BLOCKHASH from storage and update cost (Osaka)
 - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
 - [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -435,6 +435,7 @@ The following EIPs are currently supported:
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
 - [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) - Execution layer triggerable validator consolidations (Prague)
 - [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague)
+- [EIP-7709](https://eips.ethereum.org/EIPS/eip-7709) - Read BLOCKHASH from storage and update cost (Osaka)
 - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
 - [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)
 

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -433,6 +433,7 @@ The following EIPs are currently supported:
 - [EIP-6110](https://eips.ethereum.org/EIPS/eip-5656) - Supply validator deposits on chain (Prague)
 - [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) - SELFDESTRUCT only in same transaction (Cancun)
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
+- [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) - Execution layer triggerable validator consolidations (Prague)
 - [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague)
 - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
 - [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -408,7 +408,7 @@ The following EIPs are currently supported:
 - [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) - BLS precompiles (removed in v4.0.0, see latest v3 release)
 - [EIP-2565](https://eips.ethereum.org/EIPS/eip-2565) - ModExp gas cost
 - [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) - Transaction Types
-- [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) - Save historical block hashes in state (`experimental`)
+- [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) - Serve historical block hashes from state (Prague)
 - [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929) - gas cost increases for state access opcodes
 - [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) - Optional access list tx type
 - [EIP-3074](https://eips.ethereum.org/EIPS/eip-3074) - AUTH and AUTHCALL opcodes

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -405,7 +405,6 @@ The following EIPs are currently supported:
 
 - [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153) - Transient storage opcodes (Cancun)
 - [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) - Fee market change for ETH 1.0 chain
-- [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) - Simple subroutines for the EVM (`outdated`)
 - [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) - BLS precompiles (removed in v4.0.0, see latest v3 release)
 - [EIP-2565](https://eips.ethereum.org/EIPS/eip-2565) - ModExp gas cost
 - [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) - Transaction Types
@@ -431,8 +430,11 @@ The following EIPs are currently supported:
 - [EIP-4895](https://eips.ethereum.org/EIPS/eip-4895) - Beacon chain push withdrawals as operations (Shanghai)
 - [EIP-5133](https://eips.ethereum.org/EIPS/eip-5133) - Delaying Difficulty Bomb to mid-September 2022 (Gray Glacier)
 - [EIP-5656](https://eips.ethereum.org/EIPS/eip-5656) - MCOPY - Memory copying instruction (Cancun)
+- [EIP-6110](https://eips.ethereum.org/EIPS/eip-5656) - Supply validator deposits on chain (Prague)
 - [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) - SELFDESTRUCT only in same transaction (Cancun)
+- [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
 - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
+- [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)
 
 ### Bootstrap Nodes
 

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -433,6 +433,7 @@ The following EIPs are currently supported:
 - [EIP-6110](https://eips.ethereum.org/EIPS/eip-5656) - Supply validator deposits on chain (Prague)
 - [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) - SELFDESTRUCT only in same transaction (Cancun)
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
+- [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague)
 - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
 - [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)
 

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -56,7 +56,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/util": "^9.0.3"
+    "@ethereumjs/util": "^9.1.0"
   },
   "devDependencies": {
     "@polkadot/util": "^12.6.2",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/common",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Resources common to all Ethereum implementations",
   "keywords": [
     "ethereum",

--- a/packages/devp2p/CHANGELOG.md
+++ b/packages/devp2p/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## - 2024-07-23
+## 6.1.3 - 2024-07-23
+
+Maintenance release with downstream dependency updates, see PR [#3527](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3527)
 
 ## 6.1.2 - 2024-03-18
 

--- a/packages/devp2p/CHANGELOG.md
+++ b/packages/devp2p/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## - 2024-07-23
+
 ## 6.1.2 - 2024-03-18
 
 - Fix a type error related to the `lru-cache` dependency, PR [#3285](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3285)

--- a/packages/devp2p/CHANGELOG.md
+++ b/packages/devp2p/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 6.1.2 - 2024-03-05
+## 6.1.2 - 2024-03-18
 
 - Fix a type error related to the `lru-cache` dependency, PR [#3285](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3285)
 - Downstream dependency updates, see PR [#3297](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3297)

--- a/packages/devp2p/CHANGELOG.md
+++ b/packages/devp2p/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 6.1.3 - 2024-07-23
+## 6.1.3 - 2024-08-15
 
 Maintenance release with downstream dependency updates, see PR [#3527](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3527)
 

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/devp2p",
-  "version": "6.1.2",
+  "version": "6.1.3",
   "description": "A JavaScript implementation of ÐΞVp2p",
   "keywords": [
     "ethereum",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -68,7 +68,7 @@
     "snappyjs": "^0.6.1"
   },
   "devDependencies": {
-    "@ethereumjs/block": "^5.2.0",
+    "@ethereumjs/block": "^5.3.0",
     "@ethereumjs/tx": "^5.4.0",
     "@types/debug": "^4.1.9",
     "@types/k-bucket": "^5.0.0",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -57,7 +57,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/common": "^4.3.0",
+    "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/util": "^9.1.0",
     "@scure/base": "^1.1.7",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@ethereumjs/block": "^5.2.0",
-    "@ethereumjs/tx": "^5.3.0",
+    "@ethereumjs/tx": "^5.4.0",
     "@types/debug": "^4.1.9",
     "@types/k-bucket": "^5.0.0",
     "chalk": "^4.1.2",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@ethereumjs/common": "^4.3.0",
     "@ethereumjs/rlp": "^5.0.2",
-    "@ethereumjs/util": "^9.0.3",
+    "@ethereumjs/util": "^9.1.0",
     "@scure/base": "^1.1.7",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.2.1",

--- a/packages/ethash/CHANGELOG.md
+++ b/packages/ethash/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## - 2024-07-23
+## 3.0.4 - 2024-07-23
+
+Maintenance release with downstream dependency updates, see PR [#3527](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3527)
 
 ## 3.0.3 - 2024-03-18
 

--- a/packages/ethash/CHANGELOG.md
+++ b/packages/ethash/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 3.0.3 - 2024-03-05
+## 3.0.3 - 2024-03-18
 
 Maintenance release with downstream dependency updates, see PR [#3297](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3297)
 

--- a/packages/ethash/CHANGELOG.md
+++ b/packages/ethash/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## - 2024-07-23
+
 ## 3.0.3 - 2024-03-18
 
 Maintenance release with downstream dependency updates, see PR [#3297](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3297)

--- a/packages/ethash/CHANGELOG.md
+++ b/packages/ethash/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 3.0.4 - 2024-07-23
+## 3.0.4 - 2024-08-15
 
 Maintenance release with downstream dependency updates, see PR [#3527](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3527)
 

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -52,7 +52,7 @@
     "ethereum-cryptography": "^2.2.1"
   },
   "devDependencies": {
-    "@ethereumjs/common": "^4.3.0"
+    "@ethereumjs/common": "^4.4.0"
   },
   "engines": {
     "node": ">=18"

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/ethash",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "An implementation of the Ethash consensus algorithm in JavaScript",
   "keywords": [
     "ethash",

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -45,7 +45,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/block": "^5.2.0",
+    "@ethereumjs/block": "^5.3.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/util": "^9.1.0",
     "bigint-crypto-utils": "^3.2.2",

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@ethereumjs/block": "^5.2.0",
     "@ethereumjs/rlp": "^5.0.2",
-    "@ethereumjs/util": "^9.0.3",
+    "@ethereumjs/util": "^9.1.0",
     "bigint-crypto-utils": "^3.2.2",
     "ethereum-cryptography": "^2.2.1"
   },

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Verkle Updates
 
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+- Update `kzg-wasm` to `0.4.0`, PR [#3358](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3358)
 
 ### Other Features
 

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -55,6 +55,7 @@ An update to this release is therefore strongly recommended even if other fixes 
 ### Bugfixes
 
 - BLS precompile fixes, PR [#3400](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3400)
+- Ignore precompile addresses for some target access events, PR [#3366](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3366)
 
 ## 3.0.0 - 2024-03-18
 

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -25,6 +25,7 @@ const evm = await EVM.create({ common, bls })
 
 ### Verkle Updates
 
+- Adds ability to run [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 - Update `kzg-wasm` to `0.4.0`, PR [#3358](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3358)
 

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -30,14 +30,20 @@ const evm = await EVM.create({ common, bls })
 - Kaustinen5 related fixes, PR [#3343](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3343)
 - Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
 - Update `kzg-wasm` to `0.4.0`, PR [#3358](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3358)
+- Shift Verkle to `osaka` hardfork, PR [#3371](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3371)
+- Fix `accessWitness` passing, PR [#3405](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3405)
 
 ### Other Features
 
-- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+- Stricter prefixe hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
 ### Other Changes
 
 - Removes support for [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) simple subroutines for EVM (deprecated with an alternative version integrated into EOF), PR [#3342](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3342)
+
+### Bugfixes
+
+- BLS precompile fixes, PR [#3400](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3400)
 
 ## 3.0.0 - 2024-03-18
 

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 3.0.0 - 2024-03-05
+## 3.0.0 - 2024-03-18
 
 ### New EVM.create() Async Static Constructor
 

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -23,6 +23,12 @@ const mclbls = new MCLBLS(mcl)
 const evm = await EVM.create({ common, bls })
 ```
 
+### Verkle Dependency Decoupling
+
+We have relatively light-heartedly added a new `@ethereumjs/verkle` main dependency to the VM/EVM stack in the `v7.2.1` release, which added an additional burden to the bundle size by several 100 KB and additionally draw in non-neceesary WASM code. Coupling with Verkle has been refactored in PR [#3462](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3462) and the directly dependency has been removed again.
+
+An update to this release is therefore strongly recommended even if other fixes or features are not that relevant for you right now.
+
 ### Verkle Updates
 
 - Adds ability to run [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
@@ -32,14 +38,18 @@ const evm = await EVM.create({ common, bls })
 - Update `kzg-wasm` to `0.4.0`, PR [#3358](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3358)
 - Shift Verkle to `osaka` hardfork, PR [#3371](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3371)
 - Fix `accessWitness` passing, PR [#3405](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3405)
+- Remove the hacks to prevent account cleanups of system contracts, PR [#3418](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3418)
+- Fix EIP-2935 address conversion issues, PR [#3447](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3447)
 
 ### Other Features
 
+- Adds bundle visualizer (to be used with `npm run visualize:bundle`), PR [#3463](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3463)
 - Stricter prefixe hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
 ### Other Changes
 
 - Removes support for [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) simple subroutines for EVM (deprecated with an alternative version integrated into EOF), PR [#3342](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3342)
+- Update `mcl-wasm` Dependency (Esbuild Issue), PR [#3461](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3461)
 
 ### Bugfixes
 

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## - 2024-07-23
+## 3.1.0 - 2024-07-23
+
+### Verkle Updates
+
+- Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 
 ## 3.0.0 - 2024-03-18
 

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 3.1.0 - 2024-07-23
 
+### EIP-2935 BLS Precompiles
+
+Starting with this release the EVM support the BLS precompiles introduced with [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). These precompiles run natively using the [@noble/curves](https://github.com/paulmillr/noble-curves) library (❤️ to `@paulmillr`!), see PRs [#3350](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3350) and [#3471](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3350).
+
+An alternative WASM implementation (using [bls-wasm](https://github.com/herumi/bls-wasm)) can be optionally used like this if needed for performance reasons:
+
+```ts
+import { EVM, MCLBLS } from '@ethereumjs/evm'
+
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Prague })
+await mcl.init(mcl.BLS12_381)
+const mclbls = new MCLBLS(mcl)
+const evm = await EVM.create({ common, bls })
+```
+
 ### Verkle Updates
 
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 3.1.0 - 2024-07-23
 
-### EIP-2537 BLS Precompiles
+### EIP-2537 BLS Precompiles (Prague)
 
 Starting with this release the EVM support the BLS precompiles introduced with [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). These precompiles run natively using the [@noble/curves](https://github.com/paulmillr/noble-curves) library (❤️ to `@paulmillr`!), see PRs [#3350](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3350) and [#3471](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3471).
 
@@ -22,6 +22,12 @@ await mcl.init(mcl.BLS12_381)
 const mclbls = new MCLBLS(mcl)
 const evm = await EVM.create({ common, bls })
 ```
+
+### EIP-2935 Serve Historical Block Hashes from State (Prague)
+
+Starting with this release the EVM supports [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) which replaces the assumption of block hashes being present (to be served in the `BLOCKHASH` opcode) in a client by a sync process with relying on a system contract where historical block hashes are stored, see PR [#3475](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3475) as the major integrational PR (while work on this has already been done in previous PRs).
+
+The window of 256 historical block hashes which can be served by the `BLOCKHASH` opcode remains unchanged. See [this associated test setup](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts) for inspiration on code setting up a respective environment.
 
 ### Verkle Dependency Decoupling
 

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -27,6 +27,8 @@ const evm = await EVM.create({ common, bls })
 
 - Adds ability to run [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation), see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470)
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+- Kaustinen5 related fixes, PR [#3343](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3343)
+- Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
 - Update `kzg-wasm` to `0.4.0`, PR [#3358](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3358)
 
 ### Other Features

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 
+### Other Features
+
+- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+
 ## 3.0.0 - 2024-03-18
 
 ### New EVM.create() Async Static Constructor

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -23,12 +23,6 @@ const mclbls = new MCLBLS(mcl)
 const evm = await EVM.create({ common, bls })
 ```
 
-### EIP-2935 Serve Historical Block Hashes from State (Prague)
-
-Starting with this release the EVM supports [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) which replaces the assumption of block hashes being present (to be served in the `BLOCKHASH` opcode) in a client by a sync process with relying on a system contract where historical block hashes are stored, see PR [#3475](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3475) as the major integrational PR (while work on this has already been done in previous PRs).
-
-The window of 256 historical block hashes which can be served by the `BLOCKHASH` opcode remains unchanged. See [this associated test setup](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts) for inspiration on code setting up a respective environment.
-
 ### Verkle Dependency Decoupling
 
 We have relatively light-heartedly added a new `@ethereumjs/verkle` main dependency to the VM/EVM stack in the `v7.2.1` release, which added an additional burden to the bundle size by several 100 KB and additionally draw in non-neceesary WASM code. Coupling with Verkle has been refactored in PR [#3462](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3462) and the directly dependency has been removed again.
@@ -49,6 +43,7 @@ An update to this release is therefore strongly recommended even if other fixes 
 
 ### Other Features
 
+- Add support for retroactive [EIP-7610](https://eips.ethereum.org/EIPS/eip-7610), PR [#3480](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3480)
 - Adds bundle visualizer (to be used with `npm run visualize:bundle`), PR [#3463](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3463)
 - Stricter prefixe hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## - 2024-07-23
+
 ## 3.0.0 - 2024-03-18
 
 ### New EVM.create() Async Static Constructor

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 3.1.0 - 2024-07-23
 
-### EIP-2935 BLS Precompiles
+### EIP-2537 BLS Precompiles
 
-Starting with this release the EVM support the BLS precompiles introduced with [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). These precompiles run natively using the [@noble/curves](https://github.com/paulmillr/noble-curves) library (❤️ to `@paulmillr`!), see PRs [#3350](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3350) and [#3471](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3350).
+Starting with this release the EVM support the BLS precompiles introduced with [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). These precompiles run natively using the [@noble/curves](https://github.com/paulmillr/noble-curves) library (❤️ to `@paulmillr`!), see PRs [#3350](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3350) and [#3471](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3471).
 
 An alternative WASM implementation (using [bls-wasm](https://github.com/herumi/bls-wasm)) can be optionally used like this if needed for performance reasons:
 
@@ -32,6 +32,10 @@ const evm = await EVM.create({ common, bls })
 ### Other Features
 
 - Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+
+### Other Changes
+
+- Removes support for [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) simple subroutines for EVM (deprecated with an alternative version integrated into EOF), PR [#3342](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3342)
 
 ## 3.0.0 - 2024-03-18
 

--- a/packages/evm/CHANGELOG.md
+++ b/packages/evm/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 3.1.0 - 2024-07-23
+## 3.1.0 - 2024-08-15
 
 ### EIP-2537 BLS Precompiles (Prague)
 

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -97,6 +97,59 @@ void main()
 Additionally this usage example shows the use of events to listen on the inner workings and procedural updates
 (`step` event) of the EVM.
 
+### Precompiles
+
+This library support all EVM precompiles up to the `Prague` hardfork.
+
+The following code allows to run precompiles in isolation, e.g. for testing purposes:
+
+```ts
+// ./examples/precompile.ts
+
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { EVM, getActivePrecompiles } from '@ethereumjs/evm'
+import { bytesToHex, hexToBytes } from '@ethereumjs/util'
+
+const main = async () => {
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Prague })
+
+  // Taken from test/eips/precompiles/bls/add_G1_bls.json
+  const data = hexToBytes(
+    '0x0000000000000000000000000000000017f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb0000000000000000000000000000000008b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e100000000000000000000000000000000112b98340eee2777cc3c14163dea3ec97977ac3dc5c70da32e6e87578f44912e902ccef9efe28d4a78b8999dfbca942600000000000000000000000000000000186b28d92356c4dfec4b5201ad099dbdede3781f8998ddf929b4cd7756192185ca7b8f4ef7088f813270ac3d48868a21'
+  )
+  const gasLimit = BigInt(5000000)
+
+  const evm = await EVM.create({ common })
+  const precompile = getActivePrecompiles(common).get('000000000000000000000000000000000000000b')!
+
+  const callData = {
+    data,
+    gasLimit,
+    common,
+    _EVM: evm,
+  }
+  const result = await precompile(callData)
+  console.log(`Precompile result:${bytesToHex(result.returnValue)}`)
+}
+
+main()
+```
+
+### EIP-2935 BLS Precompiles
+
+Starting with `v3.1.0` the EVM support the BLS precompiles introduced with [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). These precompiles run natively using the [@noble/curves](https://github.com/paulmillr/noble-curves) library (❤️ to `@paulmillr`!).
+
+An alternative WASM implementation (using [bls-wasm](https://github.com/herumi/bls-wasm)) can be optionally used like this if needed for performance reasons:
+
+```ts
+import { EVM, MCLBLS } from '@ethereumjs/evm'
+
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Prague })
+await mcl.init(mcl.BLS12_381)
+const mclbls = new MCLBLS(mcl)
+const evm = await EVM.create({ common, bls })
+```
+
 ## Examples
 
 This projects contain the following examples:

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -135,7 +135,7 @@ const main = async () => {
 main()
 ```
 
-### EIP-2537 BLS Precompiles
+### EIP-2537 BLS Precompiles (Prague)
 
 Starting with `v3.1.0` the EVM support the BLS precompiles introduced with [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). These precompiles run natively using the [@noble/curves](https://github.com/paulmillr/noble-curves) library (❤️ to `@paulmillr`!).
 
@@ -149,6 +149,12 @@ await mcl.init(mcl.BLS12_381)
 const mclbls = new MCLBLS(mcl)
 const evm = await EVM.create({ common, bls })
 ```
+
+### EIP-2935 Serve Historical Block Hashes from State (Prague)
+
+Starting with `v3.1.0` the EVM supports [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) which replaces the assumption of block hashes being present (to be served in the `BLOCKHASH` opcode) in a client by a sync process with relying on a system contract where historical block hashes are stored, see PR [#3475](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3475) as the major integrational PR (while work on this has already been done in previous PRs).
+
+The window of 256 historical block hashes which can be served by the `BLOCKHASH` opcode remains unchanged. See [this associated test setup](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts) for inspiration on code setting up a respective environment.
 
 ## Examples
 
@@ -274,7 +280,7 @@ Currently supported EIPs:
 - [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) - BLS precompiles (removed in v4.0.0, see latest v3 release)
 - [EIP-2565](https://eips.ethereum.org/EIPS/eip-2565) - ModExp gas cost
 - [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) - Transaction Types
-- [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) - Save historical block hashes in state (`experimental`)
+- [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) - Serve historical block hashes from state (Prague)
 - [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929) - gas cost increases for state access opcodes
 - [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) - Optional access list tx type
 - [EIP-3074](https://eips.ethereum.org/EIPS/eip-3074) - AUTH and AUTHCALL opcodes

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -300,7 +300,7 @@ Currently supported EIPs:
 - [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) - SELFDESTRUCT only in same transaction (Cancun)
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
 - [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) - Execution layer triggerable validator consolidations (Prague)
-- [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague)
+- [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague) (`outdated`)
 - [EIP-7709](https://eips.ethereum.org/EIPS/eip-7709) - Read BLOCKHASH from storage and update cost (Osaka)
 - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
 - [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)
@@ -329,10 +329,6 @@ EIP-4844 comes with a new opcode `BLOBHASH` (Attention! Renamed from `DATAHASH`)
 (moved from `0x14` at some point along spec updates).
 
 **Note:** Usage of the point evaluation precompile needs a manual KZG library installation and global initialization, see [KZG Setup](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/tx/README.md#kzg-setup) for instructions.
-
-### EIP-7702 EAO Code Transactions Support (experimental)
-
-This library support the execution of [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation) with `runTx()` or the wrapping `runBlock()` execution methods starting with `v3.1.0`, see [this test setup](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/vm/test/api/EIPs/eip-7702.spec.ts) for a more complete example setup on how to run code from an EOA.
 
 ### Tracing Events
 

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -299,6 +299,7 @@ Currently supported EIPs:
 - [EIP-6110](https://eips.ethereum.org/EIPS/eip-5656) - Supply validator deposits on chain (Prague)
 - [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) - SELFDESTRUCT only in same transaction (Cancun)
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
+- [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague)
 - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
 - [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)
 

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -135,7 +135,7 @@ const main = async () => {
 main()
 ```
 
-### EIP-2935 BLS Precompiles
+### EIP-2537 BLS Precompiles
 
 Starting with `v3.1.0` the EVM support the BLS precompiles introduced with [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537). These precompiles run natively using the [@noble/curves](https://github.com/paulmillr/noble-curves) library (❤️ to `@paulmillr`!).
 

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -327,6 +327,10 @@ EIP-4844 comes with a new opcode `BLOBHASH` (Attention! Renamed from `DATAHASH`)
 
 **Note:** Usage of the point evaluation precompile needs a manual KZG library installation and global initialization, see [KZG Setup](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/tx/README.md#kzg-setup) for instructions.
 
+### EIP-7702 EAO Code Transactions Support (experimental)
+
+This library support the execution of [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation) with `runTx()` or the wrapping `runBlock()` execution methods starting with `v3.1.0`, see [this test setup](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/vm/test/api/EIPs/eip-7702.spec.ts) for a more complete example setup on how to run code from an EOA.
+
 ### Tracing Events
 
 The EVM has a public property `events` which instantiates an [AsyncEventEmitter](https://github.com/ahultgren/async-eventemitter) and events are submitted along major execution steps which you can listen to.

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -218,7 +218,6 @@ Currently supported EIPs:
 
 - [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153) - Transient storage opcodes (Cancun)
 - [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) - Fee market change for ETH 1.0 chain
-- [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) - Simple subroutines for the EVM (`outdated`)
 - [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) - BLS precompiles (removed in v4.0.0, see latest v3 release)
 - [EIP-2565](https://eips.ethereum.org/EIPS/eip-2565) - ModExp gas cost
 - [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) - Transaction Types
@@ -244,8 +243,11 @@ Currently supported EIPs:
 - [EIP-4895](https://eips.ethereum.org/EIPS/eip-4895) - Beacon chain push withdrawals as operations (Shanghai)
 - [EIP-5133](https://eips.ethereum.org/EIPS/eip-5133) - Delaying Difficulty Bomb to mid-September 2022 (Gray Glacier)
 - [EIP-5656](https://eips.ethereum.org/EIPS/eip-5656) - MCOPY - Memory copying instruction (Cancun)
+- [EIP-6110](https://eips.ethereum.org/EIPS/eip-5656) - Supply validator deposits on chain (Prague)
 - [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) - SELFDESTRUCT only in same transaction (Cancun)
+- [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
 - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
+- [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)
 
 ### WASM Crypto Support
 

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -299,6 +299,7 @@ Currently supported EIPs:
 - [EIP-6110](https://eips.ethereum.org/EIPS/eip-5656) - Supply validator deposits on chain (Prague)
 - [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) - SELFDESTRUCT only in same transaction (Cancun)
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
+- [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) - Execution layer triggerable validator consolidations (Prague)
 - [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague)
 - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
 - [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -150,12 +150,6 @@ const mclbls = new MCLBLS(mcl)
 const evm = await EVM.create({ common, bls })
 ```
 
-### EIP-2935 Serve Historical Block Hashes from State (Prague)
-
-Starting with `v3.1.0` the EVM supports [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) which replaces the assumption of block hashes being present (to be served in the `BLOCKHASH` opcode) in a client by a sync process with relying on a system contract where historical block hashes are stored, see PR [#3475](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3475) as the major integrational PR (while work on this has already been done in previous PRs).
-
-The window of 256 historical block hashes which can be served by the `BLOCKHASH` opcode remains unchanged. See [this associated test setup](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts) for inspiration on code setting up a respective environment.
-
 ## Examples
 
 This projects contain the following examples:
@@ -307,6 +301,7 @@ Currently supported EIPs:
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
 - [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) - Execution layer triggerable validator consolidations (Prague)
 - [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague)
+- [EIP-7709](https://eips.ethereum.org/EIPS/eip-7709) - Read BLOCKHASH from storage and update cost (Osaka)
 - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
 - [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)
 

--- a/packages/evm/docs/interfaces/EVMOpts.md
+++ b/packages/evm/docs/interfaces/EVMOpts.md
@@ -95,6 +95,7 @@ Use a Common instance for EVM instantiation.
 - [EIP-6110](https://eips.ethereum.org/EIPS/eip-5656) - Supply validator deposits on chain (Prague)
 - [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) - SELFDESTRUCT only in same transaction (Cancun)
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
+- [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) - Execution layer triggerable validator consolidations (Prague)
 - [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague)
 - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
 - [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)

--- a/packages/evm/docs/interfaces/EVMOpts.md
+++ b/packages/evm/docs/interfaces/EVMOpts.md
@@ -96,7 +96,7 @@ Use a Common instance for EVM instantiation.
 - [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) - SELFDESTRUCT only in same transaction (Cancun)
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
 - [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) - Execution layer triggerable validator consolidations (Prague)
-- [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague)
+- [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague) (`outdated`)
 - [EIP-7709](https://eips.ethereum.org/EIPS/eip-7709) - Read BLOCKHASH from storage and update cost (Osaka)
 - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
 - [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)

--- a/packages/evm/docs/interfaces/EVMOpts.md
+++ b/packages/evm/docs/interfaces/EVMOpts.md
@@ -70,7 +70,7 @@ Use a Common instance for EVM instantiation.
 - [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) - BLS precompiles (removed in v4.0.0, see latest v3 release)
 - [EIP-2565](https://eips.ethereum.org/EIPS/eip-2565) - ModExp gas cost
 - [EIP-2718](https://eips.ethereum.org/EIPS/eip-2565) - Transaction Types
-- [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) - Save historical block hashes in state (`experimental`)
+- [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) - Serve historical block hashes from state (Prague)
 - [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929) - gas cost increases for state access opcodes
 - [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) - Optional access list tx type
 - [EIP-3074](https://eips.ethereum.org/EIPS/eip-3074) - AUTH and AUTHCALL opcodes

--- a/packages/evm/docs/interfaces/EVMOpts.md
+++ b/packages/evm/docs/interfaces/EVMOpts.md
@@ -67,7 +67,6 @@ Use a Common instance for EVM instantiation.
 
 - [EIP-1153](https://eips.ethereum.org/EIPS/eip-1153) - Transient storage opcodes (Cancun)
 - [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) - Fee market change for ETH 1.0 chain
-- [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) - Simple subroutines for the EVM (`outdated`)
 - [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) - BLS precompiles (removed in v4.0.0, see latest v3 release)
 - [EIP-2565](https://eips.ethereum.org/EIPS/eip-2565) - ModExp gas cost
 - [EIP-2718](https://eips.ethereum.org/EIPS/eip-2565) - Transaction Types
@@ -93,8 +92,11 @@ Use a Common instance for EVM instantiation.
 - [EIP-4895](https://eips.ethereum.org/EIPS/eip-4895) - Beacon chain push withdrawals as operations (Shanghai)
 - [EIP-5133](https://eips.ethereum.org/EIPS/eip-5133) - Delaying Difficulty Bomb to mid-September 2022 (Gray Glacier)
 - [EIP-5656](https://eips.ethereum.org/EIPS/eip-5656) - MCOPY - Memory copying instruction (Cancun)
+- [EIP-6110](https://eips.ethereum.org/EIPS/eip-5656) - Supply validator deposits on chain (Prague)
 - [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) - SELFDESTRUCT only in same transaction (Cancun)
+- [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
 - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
+- [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)
 
 *Annotations:*
 

--- a/packages/evm/docs/interfaces/EVMOpts.md
+++ b/packages/evm/docs/interfaces/EVMOpts.md
@@ -97,6 +97,7 @@ Use a Common instance for EVM instantiation.
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
 - [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) - Execution layer triggerable validator consolidations (Prague)
 - [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague)
+- [EIP-7709](https://eips.ethereum.org/EIPS/eip-7709) - Read BLOCKHASH from storage and update cost (Osaka)
 - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
 - [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)
 

--- a/packages/evm/docs/interfaces/EVMOpts.md
+++ b/packages/evm/docs/interfaces/EVMOpts.md
@@ -95,6 +95,7 @@ Use a Common instance for EVM instantiation.
 - [EIP-6110](https://eips.ethereum.org/EIPS/eip-5656) - Supply validator deposits on chain (Prague)
 - [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) - SELFDESTRUCT only in same transaction (Cancun)
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
+- [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague)
 - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
 - [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)
 

--- a/packages/evm/examples/precompile.ts
+++ b/packages/evm/examples/precompile.ts
@@ -1,0 +1,27 @@
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { EVM, getActivePrecompiles } from '@ethereumjs/evm'
+import { bytesToHex, hexToBytes } from '@ethereumjs/util'
+
+const main = async () => {
+  const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Prague })
+
+  // Taken from test/eips/precompiles/bls/add_G1_bls.json
+  const data = hexToBytes(
+    '0x0000000000000000000000000000000017f1d3a73197d7942695638c4fa9ac0fc3688c4f9774b905a14e3a3f171bac586c55e83ff97a1aeffb3af00adb22c6bb0000000000000000000000000000000008b3f481e3aaa0f1a09e30ed741d8ae4fcf5e095d5d00af600db18cb2c04b3edd03cc744a2888ae40caa232946c5e7e100000000000000000000000000000000112b98340eee2777cc3c14163dea3ec97977ac3dc5c70da32e6e87578f44912e902ccef9efe28d4a78b8999dfbca942600000000000000000000000000000000186b28d92356c4dfec4b5201ad099dbdede3781f8998ddf929b4cd7756192185ca7b8f4ef7088f813270ac3d48868a21'
+  )
+  const gasLimit = BigInt(5000000)
+
+  const evm = await EVM.create({ common })
+  const precompile = getActivePrecompiles(common).get('000000000000000000000000000000000000000b')!
+
+  const callData = {
+    data,
+    gasLimit,
+    common,
+    _EVM: evm,
+  }
+  const result = await precompile(callData)
+  console.log(`Precompile result:${bytesToHex(result.returnValue)}`)
+}
+
+main()

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@ethereumjs/common": "^4.4.0",
-    "@ethereumjs/statemanager": "^2.3.0",
+    "@ethereumjs/statemanager": "^2.4.0",
     "@ethereumjs/tx": "^5.4.0",
     "@ethereumjs/util": "^9.1.0",
     "@types/debug": "^4.1.9",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -54,7 +54,7 @@
     "visualize:bundle": "npx vite build --config=./vite.config.bundler.ts --emptyOutDir=false --outDir ."
   },
   "dependencies": {
-    "@ethereumjs/common": "^4.3.0",
+    "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/statemanager": "^2.3.0",
     "@ethereumjs/tx": "^5.3.0",
     "@ethereumjs/util": "^9.1.0",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/statemanager": "^2.3.0",
-    "@ethereumjs/tx": "^5.3.0",
+    "@ethereumjs/tx": "^5.4.0",
     "@ethereumjs/util": "^9.1.0",
     "@types/debug": "^4.1.9",
     "debug": "^4.3.3",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -57,7 +57,7 @@
     "@ethereumjs/common": "^4.3.0",
     "@ethereumjs/statemanager": "^2.3.0",
     "@ethereumjs/tx": "^5.3.0",
-    "@ethereumjs/util": "^9.0.3",
+    "@ethereumjs/util": "^9.1.0",
     "@types/debug": "^4.1.9",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.2.1",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/evm",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "JavaScript Ethereum Virtual Machine (EVM) implementation",
   "keywords": [
     "ethereum",

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -203,8 +203,11 @@ export interface EVMOpts {
    * - [EIP-4895](https://eips.ethereum.org/EIPS/eip-4895) - Beacon chain push withdrawals as operations (Shanghai)
    * - [EIP-5133](https://eips.ethereum.org/EIPS/eip-5133) - Delaying Difficulty Bomb to mid-September 2022 (Gray Glacier)
    * - [EIP-5656](https://eips.ethereum.org/EIPS/eip-5656) - MCOPY - Memory copying instruction (Cancun)
+   * - [EIP-6110](https://eips.ethereum.org/EIPS/eip-5656) - Supply validator deposits on chain (Prague)
    * - [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) - SELFDESTRUCT only in same transaction (Cancun)
+   * - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
    * - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
+   * - [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)
    *
    * *Annotations:*
    *

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -201,6 +201,7 @@ export interface EVMOpts {
    * - [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788) - Beacon block root in the EVM (Cancun)
    * - [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) - Shard Blob Transactions (Cancun)
    * - [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague)
+   * - [EIP-7709](https://eips.ethereum.org/EIPS/eip-7709) - Read BLOCKHASH from storage and update cost (Osaka)
    * - [EIP-4895](https://eips.ethereum.org/EIPS/eip-4895) - Beacon chain push withdrawals as operations (Shanghai)
    * - [EIP-5133](https://eips.ethereum.org/EIPS/eip-5133) - Delaying Difficulty Bomb to mid-September 2022 (Gray Glacier)
    * - [EIP-5656](https://eips.ethereum.org/EIPS/eip-5656) - MCOPY - Memory copying instruction (Cancun)

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -181,7 +181,7 @@ export interface EVMOpts {
    * - [EIP-2537](https://eips.ethereum.org/EIPS/eip-2537) - BLS precompiles (removed in v4.0.0, see latest v3 release)
    * - [EIP-2565](https://eips.ethereum.org/EIPS/eip-2565) - ModExp gas cost
    * - [EIP-2718](https://eips.ethereum.org/EIPS/eip-2565) - Transaction Types
-   * - [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) - Save historical block hashes in state (`experimental`)
+   * - [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) - Serve historical block hashes from state (Prague)
    * - [EIP-2929](https://eips.ethereum.org/EIPS/eip-2929) - gas cost increases for state access opcodes
    * - [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) - Optional access list tx type
    * - [EIP-3074](https://eips.ethereum.org/EIPS/eip-3074) - AUTH and AUTHCALL opcodes

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -261,7 +261,7 @@ export interface EVMOpts {
   customPrecompiles?: CustomPrecompile[]
 
   /**
-   * For the EIP-2935 BLS precompiles, the native JS `@noble/curves`
+   * For the EIP-2537 BLS Precompiles, the native JS `@noble/curves`
    * https://github.com/paulmillr/noble-curves BLS12-381 curve implementation
    * is used (see `noble.ts` file in the `precompiles` folder).
    *

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -207,6 +207,7 @@ export interface EVMOpts {
    * - [EIP-6110](https://eips.ethereum.org/EIPS/eip-5656) - Supply validator deposits on chain (Prague)
    * - [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) - SELFDESTRUCT only in same transaction (Cancun)
    * - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Execution layer triggerable withdrawals (Prague)
+   * - [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) - Execution layer triggerable validator consolidations (Prague)
    * - [EIP-7516](https://eips.ethereum.org/EIPS/eip-7516) - BLOBBASEFEE opcode (Cancun)
    * - [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) - General purpose execution layer requests (Prague)
    *

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -200,6 +200,7 @@ export interface EVMOpts {
    * - [EIP-4399](https://eips.ethereum.org/EIPS/eip-4399) - Supplant DIFFICULTY opcode with PREVRANDAO (Merge)
    * - [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788) - Beacon block root in the EVM (Cancun)
    * - [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) - Shard Blob Transactions (Cancun)
+   * - [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague)
    * - [EIP-4895](https://eips.ethereum.org/EIPS/eip-4895) - Beacon chain push withdrawals as operations (Shanghai)
    * - [EIP-5133](https://eips.ethereum.org/EIPS/eip-5133) - Delaying Difficulty Bomb to mid-September 2022 (Gray Glacier)
    * - [EIP-5656](https://eips.ethereum.org/EIPS/eip-5656) - MCOPY - Memory copying instruction (Cancun)

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -200,7 +200,7 @@ export interface EVMOpts {
    * - [EIP-4399](https://eips.ethereum.org/EIPS/eip-4399) - Supplant DIFFICULTY opcode with PREVRANDAO (Merge)
    * - [EIP-4788](https://eips.ethereum.org/EIPS/eip-4788) - Beacon block root in the EVM (Cancun)
    * - [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844) - Shard Blob Transactions (Cancun)
-   * - [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague)
+   * - [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) - EOA code transactions (Prague) (`outdated`)
    * - [EIP-7709](https://eips.ethereum.org/EIPS/eip-7709) - Read BLOCKHASH from storage and update cost (Osaka)
    * - [EIP-4895](https://eips.ethereum.org/EIPS/eip-4895) - Beacon chain push withdrawals as operations (Shanghai)
    * - [EIP-5133](https://eips.ethereum.org/EIPS/eip-5133) - Delaying Difficulty Bomb to mid-September 2022 (Gray Glacier)

--- a/packages/genesis/CHANGELOG.md
+++ b/packages/genesis/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## - 2024-07-23
+## 0.2.3 - 2024-07-23
+
+Maintenance release with downstream dependency updates, see PR [#3527](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3527)
 
 ## 0.2.2 - 2024-03-18
 

--- a/packages/genesis/CHANGELOG.md
+++ b/packages/genesis/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## - 2024-07-23
+
 ## 0.2.2 - 2024-03-18
 
 Maintenance release with downstream dependency updates, see PR [#3297](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3297)

--- a/packages/genesis/CHANGELOG.md
+++ b/packages/genesis/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 0.2.2 - 2024-03-05
+## 0.2.2 - 2024-03-18
 
 Maintenance release with downstream dependency updates, see PR [#3297](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3297)
 

--- a/packages/genesis/CHANGELOG.md
+++ b/packages/genesis/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 0.2.3 - 2024-07-23
+## 0.2.3 - 2024-08-15
 
 Maintenance release with downstream dependency updates, see PR [#3527](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3527)
 

--- a/packages/genesis/package.json
+++ b/packages/genesis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/genesis",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A module to provide genesis states of well known networks",
   "keywords": [
     "ethereum",

--- a/packages/genesis/package.json
+++ b/packages/genesis/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@ethereumjs/common": "^4.3.0",
-    "@ethereumjs/util": "^9.0.3"
+    "@ethereumjs/util": "^9.1.0"
   },
   "engines": {
     "node": ">=18"

--- a/packages/genesis/package.json
+++ b/packages/genesis/package.json
@@ -58,7 +58,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/common": "^4.3.0",
+    "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/util": "^9.1.0"
   },
   "engines": {

--- a/packages/genesis/package.json
+++ b/packages/genesis/package.json
@@ -65,6 +65,6 @@
     "node": ">=18"
   },
   "devDependencies": {
-    "@ethereumjs/trie": "^6.2.0"
+    "@ethereumjs/trie": "^6.2.1"
   }
 }

--- a/packages/statemanager/CHANGELOG.md
+++ b/packages/statemanager/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 2.3.0 - 2024-03-05
+## 2.3.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness
 

--- a/packages/statemanager/CHANGELOG.md
+++ b/packages/statemanager/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## - 2024-07-23
+
 ## 2.3.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness

--- a/packages/statemanager/CHANGELOG.md
+++ b/packages/statemanager/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## - 2024-07-23
+## 2.4.0 - 2024-07-23
+
+### Verkle Updates
+
+- Various fixes for Kaustinen4 support (partial account integration, `getContractCodeSize()`, other), PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 
 ## 2.3.0 - 2024-03-18
 

--- a/packages/statemanager/CHANGELOG.md
+++ b/packages/statemanager/CHANGELOG.md
@@ -13,10 +13,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Various fixes for Kaustinen4 support (partial account integration, `getContractCodeSize()`, other), PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 - Kaustinen5 related fixes, PR [#3343](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3343)
 - Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
+- Missing beaconroot account verkle fix, PR [#3421](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3421)
 
 ### Other Features
 
-- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+- Stricter prefixe hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
 ### Other Changes
 

--- a/packages/statemanager/CHANGELOG.md
+++ b/packages/statemanager/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Kaustinen5 related fixes, PR [#3343](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3343)
 - Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
 - Missing beaconroot account verkle fix, PR [#3421](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3421)
+- Verkle decoupling, PR [#3462](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3462)
 
 ### Other Features
 
@@ -22,6 +23,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Other Changes
 
 - Modify RPCStateManager `getAccount()`, PR [#3345](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3345)
+
+### Bugfixes
+
+- Fixes an issue where under certain deployment conditions wrong storage values could be provided, PR [#3434](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3434)
 
 ## 2.3.0 - 2024-03-18
 

--- a/packages/statemanager/CHANGELOG.md
+++ b/packages/statemanager/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Bugfixes
 
 - Fixes an issue where under certain deployment conditions wrong storage values could be provided, PR [#3434](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3434)
+- Fixes statemanager empty code bug, PR [#3483](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3483)
 
 ## 2.3.0 - 2024-03-18
 

--- a/packages/statemanager/CHANGELOG.md
+++ b/packages/statemanager/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - Various fixes for Kaustinen4 support (partial account integration, `getContractCodeSize()`, other), PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 
+### Other Features
+
+- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+
 ## 2.3.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness

--- a/packages/statemanager/CHANGELOG.md
+++ b/packages/statemanager/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 2.4.0 - 2024-07-23
+## 2.4.0 - 2024-08-15
 
 ### Verkle Updates
 

--- a/packages/statemanager/CHANGELOG.md
+++ b/packages/statemanager/CHANGELOG.md
@@ -11,10 +11,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Verkle Updates
 
 - Various fixes for Kaustinen4 support (partial account integration, `getContractCodeSize()`, other), PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+- Kaustinen5 related fixes, PR [#3343](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3343)
+- Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
 
 ### Other Features
 
 - Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+
+### Other Changes
+
+- Modify RPCStateManager `getAccount()`, PR [#3345](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3345)
 
 ## 2.3.0 - 2024-03-18
 

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -59,7 +59,7 @@
     "lru-cache": "10.1.0"
   },
   "devDependencies": {
-    "@ethereumjs/block": "^5.2.0",
+    "@ethereumjs/block": "^5.3.0",
     "@ethereumjs/genesis": "^0.2.3",
     "@types/debug": "^4.1.9",
     "rustbn-wasm": "^0.4.0",

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -49,7 +49,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/common": "^4.3.0",
+    "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/trie": "^6.2.0",
     "@ethereumjs/util": "^9.1.0",

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/statemanager",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "An Ethereum statemanager implementation",
   "keywords": [
     "ethereum",

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@ethereumjs/block": "^5.2.0",
-    "@ethereumjs/genesis": "^0.2.2",
+    "@ethereumjs/genesis": "^0.2.3",
     "@types/debug": "^4.1.9",
     "rustbn-wasm": "^0.4.0",
     "verkle-cryptography-wasm": "^0.4.5"

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -52,7 +52,7 @@
     "@ethereumjs/common": "^4.3.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/trie": "^6.2.0",
-    "@ethereumjs/util": "^9.0.3",
+    "@ethereumjs/util": "^9.1.0",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.2.1",
     "js-sdsl": "^4.1.4",

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/rlp": "^5.0.2",
-    "@ethereumjs/trie": "^6.2.0",
+    "@ethereumjs/trie": "^6.2.1",
     "@ethereumjs/util": "^9.1.0",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.2.1",

--- a/packages/trie/CHANGELOG.md
+++ b/packages/trie/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 6.2.0 - 2024-03-05
+## 6.2.0 - 2024-03-18
 
 In the hope that you do not have yet integrated: we needed to remove the new more modern async trie iteration with web streams functionality (new `createAsyncReadStream()` method) introduced with the `v6.1.0` release - see PR [#3231](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3231) for context - since the related Node.js web streams API import caused relatively severe problems for all upstream libraries when being used in the browser.
 

--- a/packages/trie/CHANGELOG.md
+++ b/packages/trie/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## - 2024-07-23
+## 6.2.1 - 2024-07-23
 
 ### Other Features
 

--- a/packages/trie/CHANGELOG.md
+++ b/packages/trie/CHANGELOG.md
@@ -10,7 +10,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Other Features
 
-- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+- Stricter prefixe hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+
+### Bugfixes
+
+- Fixes an issue in the delete operation used for unhashed tries and pruning activated which resulted in a wrong state root (bad!), PR [#3333](https://github.com/ethereumjs/ethereumjs-monorepo/issues/3333)
 
 ## 6.2.0 - 2024-03-18
 

--- a/packages/trie/CHANGELOG.md
+++ b/packages/trie/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## - 2024-07-23
 
+### Other Features
+
+- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+
 ## 6.2.0 - 2024-03-18
 
 In the hope that you do not have yet integrated: we needed to remove the new more modern async trie iteration with web streams functionality (new `createAsyncReadStream()` method) introduced with the `v6.1.0` release - see PR [#3231](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3231) for context - since the related Node.js web streams API import caused relatively severe problems for all upstream libraries when being used in the browser.

--- a/packages/trie/CHANGELOG.md
+++ b/packages/trie/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## - 2024-07-23
+
 ## 6.2.0 - 2024-03-18
 
 In the hope that you do not have yet integrated: we needed to remove the new more modern async trie iteration with web streams functionality (new `createAsyncReadStream()` method) introduced with the `v6.1.0` release - see PR [#3231](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3231) for context - since the related Node.js web streams API import caused relatively severe problems for all upstream libraries when being used in the browser.

--- a/packages/trie/CHANGELOG.md
+++ b/packages/trie/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 6.2.1 - 2024-07-23
+## 6.2.1 - 2024-08-15
 
 ### Other Features
 

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -62,7 +62,7 @@
     "readable-stream": "^3.6.0"
   },
   "devDependencies": {
-    "@ethereumjs/genesis": "^0.2.2",
+    "@ethereumjs/genesis": "^0.2.3",
     "@types/benchmark": "^1.0.33",
     "abstract-level": "^1.0.3",
     "level": "^8.0.0",

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/trie",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Implementation of the modified merkle patricia tree as specified in Ethereum's yellow paper.",
   "keywords": [
     "merkle",

--- a/packages/trie/package.json
+++ b/packages/trie/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@ethereumjs/rlp": "^5.0.2",
-    "@ethereumjs/util": "^9.0.3",
+    "@ethereumjs/util": "^9.1.0",
     "@types/readable-stream": "^2.3.13",
     "debug": "^4.3.4",
     "lru-cache": "10.1.0",

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## - 2024-07-23
+
 ## 5.3.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 #### EOA Code Transaction (EIP-7702) (experimental)
 
-This release introduces support for an experimental version of [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions. This tx type allows to run code in the context of an EOA and therefore extend the functionality which can be "reached" from respectively integrated into the scope of an otherwise limited EOA account.
+This release introduces support for an experimental version of [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions, see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470). This tx type allows to run code in the context of an EOA and therefore extend the functionality which can be "reached" from respectively integrated into the scope of an otherwise limited EOA account.
 
 The following is a simple example how to use an `EOACodeEIP7702Transaction` with one autorization list item:
 

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -6,9 +6,46 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## - 2024-07-23
+## 5.4.0 - 2024-07-23
 
-## 5.3.0 - 2024-03-18
+#### EOA Code Transaction (EIP-7702) (experimental)
+
+This release introduces support for an experimental version of [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions. This tx type allows to run code in the context of an EOA and therefore extend the functionality which can be "reached" from respectively integrated into the scope of an otherwise limited EOA account.
+
+The following is a simple example how to use an `EOACodeEIP7702Transaction` with one autorization list item:
+
+```ts
+// ./examples/EOACodeTx.ts
+
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { EOACodeEIP7702Transaction } from '@ethereumjs/tx'
+import type { PrefixedHexString } from '@ethereumjs/util'
+
+const ones32 = `0x${'01'.repeat(32)}` as PrefixedHexString
+
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Cancun, eips: [7702] })
+const tx = EOACodeEIP7702Transaction.fromTxData(
+  {
+    authorizationList: [
+      {
+        chainId: '0x1',
+        address: `0x${'20'.repeat(20)}`,
+        nonce: ['0x1'],
+        yParity: '0x1',
+        r: ones32,
+        s: ones32,
+      },
+    ],
+  },
+  { common }
+)
+
+console.log(
+  `EIP-7702 EOA code tx created with ${tx.authorizationList.length} authorization list item(s).`
+)
+```
+
+Note that the specification of this EIP is not yet stable and the API of this tx type might still change at any time.
 
 ### Verkle Updates
 
@@ -17,6 +54,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Other Features
 
 - Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+
+## 5.3.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness
 

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 5.3.0 - 2024-03-18
 
+### Other Features
+
+- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+
 ### Full 4844 Browser Readiness
 
 #### WASM KZG

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 5.4.0 - 2024-08-15
 
-#### EOA Code Transaction (EIP-7702) (experimental)
+#### EOA Code Transaction (EIP-7702) (outdated)
 
-This release introduces support for an experimental version of [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions, see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470). This tx type allows to run code in the context of an EOA and therefore extend the functionality which can be "reached" from respectively integrated into the scope of an otherwise limited EOA account.
+This release introduces support for a non-final version of [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions, see PR [#3470](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3470). This tx type allows to run code in the context of an EOA and therefore extend the functionality which can be "reached" from respectively integrated into the scope of an otherwise limited EOA account.
 
 The following is a simple example how to use an `EOACodeEIP7702Transaction` with one autorization list item:
 
@@ -45,7 +45,7 @@ console.log(
 )
 ```
 
-Note that the specification of this EIP is not yet stable and the API of this tx type might still change at any time.
+Note: Things move fast with `EIP-7702` and the released implementation is based on [this](https://github.com/ethereum/EIPs/blob/14400434e1199c57d912082127b1d22643788d11/EIPS/eip-7702.md) commit and therefore already outdated. An up-to-date version will be released along our breaking release round planned for early September 2024.
 
 ### Verkle Updates
 

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 5.3.0 - 2024-03-18
 
+### Verkle Updates
+
+- Update `kzg-wasm` to `0.4.0`, PR [#3358](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3358)
+
 ### Other Features
 
 - Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -50,10 +50,16 @@ Note that the specification of this EIP is not yet stable and the API of this tx
 ### Verkle Updates
 
 - Update `kzg-wasm` to `0.4.0`, PR [#3358](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3358)
+- Shift Verkle to `osaka` hardfork, PR [#3371](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3371)
 
 ### Other Features
 
-- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+- Extend `BlobEIP4844Transaction.networkWrapperToJson()` to also include the 4844 fields, PR [#3365](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3365)
+- Stricter prefixe hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+
+### Bugfixes
+
+- Fix bug in generic error message regarding chain ID reporting, PR [#3386](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3386)
 
 ## 5.3.0 - 2024-03-18
 

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 5.3.0 - 2024-03-05
+## 5.3.0 - 2024-03-18
 
 ### Full 4844 Browser Readiness
 

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 5.4.0 - 2024-07-23
+## 5.4.0 - 2024-08-15
 
 #### EOA Code Transaction (EIP-7702) (experimental)
 

--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -102,6 +102,7 @@ This library supports the following transaction types ([EIP-2718](https://eips.e
 
 - `BlobEIP4844Transaction` ([EIP-4844](https://eips.ethereum.org/EIPS/eip-4844), proto-danksharding)
 - `FeeMarketEIP1559Transaction` ([EIP-1559](https://eips.ethereum.org/EIPS/eip-1559), gas fee market)
+- `EOACodeEIP7702Transaction` (experimental) ([EIP-7702](https://eips.ethereum.org/EIPS/eip-7702), EOA code delegation)
 - `AccessListEIP2930Transaction` ([EIP-2930](https://eips.ethereum.org/EIPS/eip-2930), optional access lists)
 - `BlobEIP4844Transaction` ([EIP-4844](https://eips.ethereum.org/EIPS/eip-4844), blob transactions)
 - `LegacyTransaction`, the Ethereum standard tx up to `berlin`, now referred to as legacy txs with the introduction of tx types
@@ -205,6 +206,47 @@ const txData = {
 
 const tx = FeeMarketEIP1559Transaction.fromTxData(txData, { common })
 console.log(bytesToHex(tx.hash())) // 0x6f9ef69ccb1de1aea64e511efd6542541008ced321887937c95b03779358ec8a
+```
+
+#### EOA Code Transaction (EIP-7702) (experimental)
+
+- Class: `EOACodeEIP7702Transaction`
+- Activation: `prague` (or per EIP setting)
+- Type: `4`
+
+This library suppports an experimental version of [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) starting with `v5.4.0`. This tx type allows to run code in the context of an EOA and therefore extend the functionality which can be "reached" from respectively integrated into the scope of an otherwise limited EOA account.
+
+The following is a simple example how to use an `EOACodeEIP7702Transaction` with one autorization list item:
+
+```ts
+// ./examples/EOACodeTx.ts
+
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { EOACodeEIP7702Transaction } from '@ethereumjs/tx'
+import type { PrefixedHexString } from '@ethereumjs/util'
+
+const ones32 = `0x${'01'.repeat(32)}` as PrefixedHexString
+
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Cancun, eips: [7702] })
+const tx = EOACodeEIP7702Transaction.fromTxData(
+  {
+    authorizationList: [
+      {
+        chainId: '0x1',
+        address: `0x${'20'.repeat(20)}`,
+        nonce: ['0x1'],
+        yParity: '0x1',
+        r: ones32,
+        s: ones32,
+      },
+    ],
+  },
+  { common }
+)
+
+console.log(
+  `EIP-7702 EOA code tx created with ${tx.authorizationList.length} authorization list item(s).`
+)
 ```
 
 #### Access List Transactions (EIP-2930)

--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -208,13 +208,13 @@ const tx = FeeMarketEIP1559Transaction.fromTxData(txData, { common })
 console.log(bytesToHex(tx.hash())) // 0x6f9ef69ccb1de1aea64e511efd6542541008ced321887937c95b03779358ec8a
 ```
 
-#### EOA Code Transaction (EIP-7702) (experimental)
+#### EOA Code Transaction (EIP-7702) (outdated)
 
 - Class: `EOACodeEIP7702Transaction`
 - Activation: `prague` (or per EIP setting)
 - Type: `4`
 
-This library suppports an experimental version of [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) starting with `v5.4.0`. This tx type allows to run code in the context of an EOA and therefore extend the functionality which can be "reached" from respectively integrated into the scope of an otherwise limited EOA account.
+This library suppports a non-final version of [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) starting with `v5.4.0`. This tx type allows to run code in the context of an EOA and therefore extend the functionality which can be "reached" from respectively integrated into the scope of an otherwise limited EOA account.
 
 The following is a simple example how to use an `EOACodeEIP7702Transaction` with one autorization list item:
 
@@ -248,6 +248,8 @@ console.log(
   `EIP-7702 EOA code tx created with ${tx.authorizationList.length} authorization list item(s).`
 )
 ```
+
+Note: Things move fast with `EIP-7702` and the currently released implementation is based on [this](https://github.com/ethereum/EIPs/blob/14400434e1199c57d912082127b1d22643788d11/EIPS/eip-7702.md) commit and therefore already outdated. An up-to-date version will be released along our breaking release round planned for early September 2024.
 
 #### Access List Transactions (EIP-2930)
 

--- a/packages/tx/examples/EOACodeTx.ts
+++ b/packages/tx/examples/EOACodeTx.ts
@@ -1,0 +1,26 @@
+import { Chain, Common, Hardfork } from '@ethereumjs/common'
+import { EOACodeEIP7702Transaction } from '@ethereumjs/tx'
+import type { PrefixedHexString } from '@ethereumjs/util'
+
+const ones32 = `0x${'01'.repeat(32)}` as PrefixedHexString
+
+const common = new Common({ chain: Chain.Mainnet, hardfork: Hardfork.Cancun, eips: [7702] })
+const tx = EOACodeEIP7702Transaction.fromTxData(
+  {
+    authorizationList: [
+      {
+        chainId: '0x1',
+        address: `0x${'20'.repeat(20)}`,
+        nonce: ['0x1'],
+        yParity: '0x1',
+        r: ones32,
+        s: ones32,
+      },
+    ],
+  },
+  { common }
+)
+
+console.log(
+  `EIP-7702 EOA code tx created with ${tx.authorizationList.length} authorization list item(s).`
+)

--- a/packages/tx/examples/EOACodeTx.ts
+++ b/packages/tx/examples/EOACodeTx.ts
@@ -9,7 +9,7 @@ const tx = EOACodeEIP7702Transaction.fromTxData(
   {
     authorizationList: [
       {
-        chainId: '0x1',
+        chainId: '0x2',
         address: `0x${'20'.repeat(20)}`,
         nonce: ['0x1'],
         yParity: '0x1',

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -57,7 +57,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/common": "^4.3.0",
+    "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/util": "^9.1.0",
     "ethereum-cryptography": "^2.2.1"

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@ethereumjs/common": "^4.3.0",
     "@ethereumjs/rlp": "^5.0.2",
-    "@ethereumjs/util": "^9.0.3",
+    "@ethereumjs/util": "^9.1.0",
     "ethereum-cryptography": "^2.2.1"
   },
   "devDependencies": {

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/tx",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "Implementation of the various Ethereum Transaction Types",
   "keywords": [
     "ethereum",
@@ -20,11 +20,7 @@
     {
       "name": "Alex Beregszaszi",
       "email": "alex@rtfs.hu",
-      "url": "https://github.com/axic",
-      "additions": 27562,
-      "contributions": 22,
-      "deletions": 42613,
-      "hireable": true
+      "url": "https://github.com/axic"
     }
   ],
   "type": "commonjs",

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -24,7 +24,7 @@ console.log(`Partial account with nonce=${account.nonce} and balance=${account.b
 
 ### New `requests` Module
 
-This release introduces a new `requests` module (see PR [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372)) with various type and an abstract base class for [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) general purpose execution layer requests to the CL (Prague hardfork) as well as concrete implementations for the currently supported request types:
+This release introduces a new `requests` module (see PRs [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372), [#3393](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3393) and [#3398](, PR [#3398](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3398))) with various type and an abstract base class for [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) general purpose execution layer requests to the CL (Prague hardfork) as well as concrete implementations for the currently supported request types:
 
 - [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110): `DepositRequest` (Prague Harfork)
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002): `WithdrawawlRequest` (Prague Hardfork)
@@ -34,14 +34,18 @@ These request types are mainly used within the [@ethereumjs/block](https://githu
 ### Verkle Updates
 
 - Update `kzg-wasm` to `0.4.0`, PR [#3358](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3358)
+- Shift Verkle to `osaka` hardfork, PR [#3371](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3371)
 
 ### Other Features
 
-- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+- Stricter prefixe hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
 ### Other Changes
 
 - Adjust `Account.isContract()` (in Verkle context work), PR [#3343](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3343)
+- Rename deposit receipt to deposit request, PR [#3408](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3408)
+- Adjust `Account.isEmpty()` to also work for partial accounts, PR [#3405](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3405)
+- Enhances typing of CL requests, PR [#3398](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3398)
 
 ## 9.0.3 - 2024-03-18
 

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -22,6 +22,10 @@ const account = Account.fromPartialAccountData({
 console.log(`Partial account with nonce=${account.nonce} and balance=${account.balance} created`)
 ```
 
+### Other Features
+
+- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+
 ## 9.0.3 - 2024-03-18
 
 - Allow optional `trustedSetupPath` for the `initKZG()` method, PR [#3296](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3296)

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -22,6 +22,19 @@ const account = Account.fromPartialAccountData({
 console.log(`Partial account with nonce=${account.nonce} and balance=${account.balance} created`)
 ```
 
+### New `requests` Module
+
+This release introduces a new `requests` module (see PR [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372)) with various type and an abstract base class for [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) general purpose execution layer requests to the CL (Prague hardfork) as well as concrete implementations for the currently supported request types:
+
+- [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110): `DepositRequest` (Prague Harfork)
+- [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002): `WithdrawawlRequest` (Prague Hardfork)
+
+These request types are mainly used within the [@ethereumjs/block](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/block) library where applied usage instructions are provided in the README.
+
+### Verkle Updates
+
+- Update `kzg-wasm` to `0.4.0`, PR [#3358](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3358)
+
 ### Other Features
 
 - Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -24,10 +24,11 @@ console.log(`Partial account with nonce=${account.nonce} and balance=${account.b
 
 ### New `requests` Module
 
-This release introduces a new `requests` module (see PRs [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372), [#3393](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3393) and [#3398](, PR [#3398](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3398))) with various type and an abstract base class for [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) general purpose execution layer requests to the CL (Prague hardfork) as well as concrete implementations for the currently supported request types:
+This release introduces a new `requests` module (see PRs [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372), [#3393](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3393), [#3398](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3398) and [#3477](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3477)) with various type and an abstract base class for [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) general purpose execution layer requests to the CL (Prague hardfork) as well as concrete implementations for the currently supported request types:
 
 - [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110): `DepositRequest` (Prague Harfork)
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002): `WithdrawawlRequest` (Prague Hardfork)
+- [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251): `ConsolidationRequest` (Prague Hardfork)
 
 These request types are mainly used within the [@ethereumjs/block](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/block) library where applied usage instructions are provided in the README.
 
@@ -35,6 +36,8 @@ These request types are mainly used within the [@ethereumjs/block](https://githu
 
 - Update `kzg-wasm` to `0.4.0`, PR [#3358](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3358)
 - Shift Verkle to `osaka` hardfork, PR [#3371](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3371)
+- New `verkle` module with utility methods and interfaces, PR [#3462](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3462)
+- Rename verkle utils and refactor, PR [#3468](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3468)
 
 ### Other Features
 
@@ -46,6 +49,7 @@ These request types are mainly used within the [@ethereumjs/block](https://githu
 - Rename deposit receipt to deposit request, PR [#3408](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3408)
 - Adjust `Account.isEmpty()` to also work for partial accounts, PR [#3405](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3405)
 - Enhances typing of CL requests, PR [#3398](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3398)
+- Rename withdrawal request's `validatorPublicKey` to `validatorPubkey`, PR [#3474](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3474)
 
 ## 9.0.3 - 2024-03-18
 

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 9.0.3 - 2024-03-05
+## 9.0.3 - 2024-03-18
 
 - Allow optional `trustedSetupPath` for the `initKZG()` method, PR [#3296](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3296)
 

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 9.1.0 - 2024-07-23
+## 9.1.0 - 2024-08-15
 
 ### Support for Partial Accounts
 

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -39,6 +39,10 @@ These request types are mainly used within the [@ethereumjs/block](https://githu
 
 - Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
+### Other Changes
+
+- Adjust `Account.isContract()` (in Verkle context work), PR [#3343](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3343)
+
 ## 9.0.3 - 2024-03-18
 
 - Allow optional `trustedSetupPath` for the `initKZG()` method, PR [#3296](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3296)

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## - 2024-07-23
+
 ## 9.0.3 - 2024-03-18
 
 - Allow optional `trustedSetupPath` for the `initKZG()` method, PR [#3296](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3296)

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -6,7 +6,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## - 2024-07-23
+## 9.1.0 - 2024-07-23
+
+### Support for Partial Accounts
+
+For Verkle or other contexts it can be useful to create partial accounts not containing all the account parameters. This is now supported starting with this release, see PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269):
+
+```ts
+import { Account } from '@ethereumjs/util'
+
+const account = Account.fromPartialAccountData({
+  nonce: '0x02',
+  balance: '0x0384',
+})
+console.log(`Partial account with nonce=${account.nonce} and balance=${account.balance} created`)
+```
 
 ## 9.0.3 - 2024-03-18
 

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -45,6 +45,20 @@ const account = Account.fromAccountData({
 console.log(`Account with nonce=${account.nonce} and balance=${account.balance} created`)
 ```
 
+For Verkle or other contexts it can be useful to create partial accounts not containing all the account parameters. This is supported starting with v9.1.0:
+
+```ts
+// ./examples/accountPartial.ts
+
+import { Account } from '@ethereumjs/util'
+
+const account = Account.fromPartialAccountData({
+  nonce: '0x02',
+  balance: '0x0384',
+})
+console.log(`Partial account with nonce=${account.nonce} and balance=${account.balance} created`)
+```
+
 ### Module: [address](src/address.ts)
 
 Class representing an Ethereum `Address` with instantiation helpers and validation methods.

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -147,6 +147,7 @@ Module with various type and an abstract base class for [EIP-7685](https://eips.
 
 - [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110): `DepositRequest` (Prague Harfork)
 - [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002): `WithdrawawlRequest` (Prague Hardfork)
+- [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251): `ConsolidationRequest` (Prague Hardfork)
 
 These request types are mainly used within the [@ethereumjs/block](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/block) library where applied usage instructions are provided in the README.
 

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -141,6 +141,15 @@ KZG interface (used for 4844 blob txs), see [@ethereumjs/tx](https://github.com/
 
 Simple map DB implementation using the `DB` interface (see above).
 
+### Module: [requests](src/requests.ts)
+
+Module with various type and an abstract base class for [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) general purpose execution layer requests to the CL (Prague hardfork) as well as concrete implementations for the currently supported request types:
+
+- [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110): `DepositRequest` (Prague Harfork)
+- [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002): `WithdrawawlRequest` (Prague Hardfork)
+
+These request types are mainly used within the [@ethereumjs/block](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/block) library where applied usage instructions are provided in the README.
+
 ### Module: [signature](src/signature.ts)
 
 Functionality for signing, signature validation, conversion, recovery.

--- a/packages/util/examples/accountPartial.ts
+++ b/packages/util/examples/accountPartial.ts
@@ -1,0 +1,7 @@
+import { Account } from '@ethereumjs/util'
+
+const account = Account.fromPartialAccountData({
+  nonce: '0x02',
+  balance: '0x0384',
+})
+console.log(`Partial account with nonce=${account.nonce} and balance=${account.balance} created`)

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/util",
-  "version": "9.0.3",
+  "version": "9.1.0",
   "description": "A collection of utility functions for Ethereum",
   "keywords": [
     "ethereum",

--- a/packages/verkle/CHANGELOG.md
+++ b/packages/verkle/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 0.0.3 - 2024-07-23
+## 0.1.0 - 2024-07-23
+
+This is the first (still experimental) Verkle library release with some basic `put()` and `get()` functionality working! 🎉 Still highly moving and evolving parts, but early experiments and feedback welcome!
 
 - Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
 - Move tree key computation to verkle and simplify, PR [#3420](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3420)
@@ -14,6 +16,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Add tests for verkle bytes helper, PR [#3441](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3441)
 - Verkle decoupling, PR [#3462](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3462)
 - Rename verkle utils and refactor, PR [#3468](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3468)
+- Optimize storage of default values in VerkleNode, PR [#3476](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3476)
+- Build out trie processing, PR [#3430](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3430)
+- Implement `trie.put()`, PR [#3473](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3473)
+- Add `trie.del()`, PR [#3486](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3486)
 
 ## 0.0.2 - 2024-03-18
 

--- a/packages/verkle/CHANGELOG.md
+++ b/packages/verkle/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## - 2024-07-23
+## 0.0.3 - 2024-07-23
+
+- Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
 
 ## 0.0.2 - 2024-03-18
 

--- a/packages/verkle/CHANGELOG.md
+++ b/packages/verkle/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ## 0.0.3 - 2024-07-23
 
 - Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
+- Move tree key computation to verkle and simplify, PR [#3420](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3420)
+- Rename code keccak, PR [#3426](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3426)
 
 ## 0.0.2 - 2024-03-18
 

--- a/packages/verkle/CHANGELOG.md
+++ b/packages/verkle/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 0.1.0 - 2024-07-23
+## 0.1.0 - 2024-08-15
 
 This is the first (still experimental) Verkle library release with some basic `put()` and `get()` functionality working! 🎉 Still highly moving and evolving parts, but early experiments and feedback welcome!
 

--- a/packages/verkle/CHANGELOG.md
+++ b/packages/verkle/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
 - Move tree key computation to verkle and simplify, PR [#3420](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3420)
 - Rename code keccak, PR [#3426](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3426)
+- Add tests for verkle bytes helper, PR [#3441](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3441)
+- Verkle decoupling, PR [#3462](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3462)
+- Rename verkle utils and refactor, PR [#3468](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3468)
 
 ## 0.0.2 - 2024-03-18
 

--- a/packages/verkle/CHANGELOG.md
+++ b/packages/verkle/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 0.0.2 - 2024-03-05
+## 0.0.2 - 2024-03-18
 
 - Fix a type error related to the `lru-cache` dependency, PR [#3285](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3285)
 - Downstream dependency updates, see PR [#3297](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3297)

--- a/packages/verkle/CHANGELOG.md
+++ b/packages/verkle/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## - 2024-07-23
+
 ## 0.0.2 - 2024-03-18
 
 - Fix a type error related to the `lru-cache` dependency, PR [#3285](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3285)

--- a/packages/verkle/package.json
+++ b/packages/verkle/package.json
@@ -55,7 +55,7 @@
     "debug": "^4.3.4",
     "lru-cache": "10.1.0",
     "verkle-cryptography-wasm": "^0.4.5",
-    "@ethereumjs/block": "^5.2.0",
+    "@ethereumjs/block": "^5.3.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/util": "^9.1.0"
   },

--- a/packages/verkle/package.json
+++ b/packages/verkle/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/verkle",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Implementation of verkle trees as used in Ethereum.",
   "keywords": [
     "verkle",

--- a/packages/verkle/package.json
+++ b/packages/verkle/package.json
@@ -57,7 +57,7 @@
     "verkle-cryptography-wasm": "^0.4.5",
     "@ethereumjs/block": "^5.2.0",
     "@ethereumjs/rlp": "^5.0.2",
-    "@ethereumjs/util": "^9.0.3"
+    "@ethereumjs/util": "^9.1.0"
   },
   "engines": {
     "node": ">=18"

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 8.0.0 - 2024-03-05
+## 8.0.0 - 2024-03-18
 
 ### New EVM.create() Async Static Constructor / Mandatory VM.create() Constructor
 

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -8,11 +8,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 8.1.0 - 2024-07-23
 
-### EIP-6110 (Deposit Requests) / EIP-7002 (Withdrawal Requests) Support
+### EIP-6110 (Deposit Requests) / EIP-7002 (Withdrawal Requests) / EIP-7251 (Consolidation Requests) Support
 
-This library now supports both the execution as well as the building of blocks including `EIP-6110` deposit requests, see PR [#3390](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3390) and `EIP-7002` withdrawal requests, see PR [#3385](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3385).
+This library now supports `EIP-6110` deposit requests, see PR [#3390](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3390), `EIP-7002` withdrawal requests, see PR [#3385](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3385) and `EIP-7251` consolidation requests, see PR [#3477](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3477) as well as the underlying generic execution layer request logic introduced with `EIP-7685` (PR [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372)).
 
 These new request types will be activated with the `Prague` hardfork, see [@ethereumjs/block](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/block) README for detailed documentation.
+
+### Verkle Dependency Decoupling
+
+We have relatively light-heartedly added a new `@ethereumjs/verkle` main dependency to the VM/EVM stack in the `v7.2.1` release, which added an additional burden to the bundle size by several 100 KB and additionally draw in non-neceesary WASM code. Coupling with Verkle has been refactored in PR [#3462](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3462) and the directly dependency has been removed again.
+
+An update to this release is therefore strongly recommended even if other fixes or features are not that relevant for you right now.
 
 ### Verkle Updates
 
@@ -20,6 +26,10 @@ These new request types will be activated with the `Prague` hardfork, see [@ethe
 - Kaustinen5 related fixes, PR [#3343](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3343)
 - Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
 - Missing beaconroot account verkle fix, PR [#3421](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3421)
+- Remove the hacks to prevent account cleanups of system contracts, PR [#3418](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3418)
+- Updates EIP-2935 tests with the new proposed bytecode and corresponding config, PR [#3438](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3438)
+- Fix EIP-2935 address conversion issues, PR [#3447](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3447)
+- Remove backfill of block hashes on EIP-2935 activation, PR [#3478](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3478)
 
 ### Other Features
 
@@ -29,6 +39,7 @@ These new request types will be activated with the `Prague` hardfork, see [@ethe
 
 - Removes support for [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) simple subroutines for EVM (deprecated with an alternative version integrated into EOF), PR [#3342](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3342)
 - Small clean-up to `VM_emit()`, PR [#3396](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3396)
+- Update `mcl-wasm` Dependency (Esbuild Issue), PR [#3461](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3461)
 
 ### Bugfixes
 

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## - 2024-07-23
+## 8.1.0 - 2024-07-23
+
+### Verkle Updates
+
+- Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 
 ## 8.0.0 - 2024-03-18
 

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 8.1.0 - 2024-07-23
+## 8.1.0 - 2024-08-15
 
 ### EIP-6110 (Deposit Requests) / EIP-7002 (Withdrawal Requests) / EIP-7251 (Consolidation Requests) Support
 

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 8.1.0 - 2024-07-23
 
+### EIP-6110 (Deposit Requests) / EIP-7002 (Withdrawal Requests) Support
+
+This library now supports both the execution as well as the building of blocks including `EIP-6110` deposit requests, see PR [#3390](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3390) and `EIP-7002` withdrawal requests, see PR [#3385](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3385).
+
+These new request types will be activated with the `Prague` hardfork, see [@ethereumjs/block](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/block) README for detailed documentation.
+
 ### Verkle Updates
 
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -14,6 +14,12 @@ This library now supports `EIP-6110` deposit requests, see PR [#3390](https://gi
 
 These new request types will be activated with the `Prague` hardfork, see [@ethereumjs/block](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/block) README for detailed documentation.
 
+### EIP-2935 Serve Historical Block Hashes from State (Prague)
+
+Starting with this release the EVM supports [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) which replaces the assumption of block hashes being present (to be served in the `BLOCKHASH` opcode) in a client by a sync process with relying on a system contract where historical block hashes are stored, see PR [#3475](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3475) as the major integrational PR (while work on this has already been done in previous PRs).
+
+The window of 256 historical block hashes which can be served by the `BLOCKHASH` opcode remains unchanged. See [this associated test setup](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts) for inspiration on code setting up a respective environment.
+
 ### Verkle Dependency Decoupling
 
 We have relatively light-heartedly added a new `@ethereumjs/verkle` main dependency to the VM/EVM stack in the `v7.2.1` release, which added an additional burden to the bundle size by several 100 KB and additionally draw in non-neceesary WASM code. Coupling with Verkle has been refactored in PR [#3462](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3462) and the directly dependency has been removed again.

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 
+### Other Features
+
+- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+
 ## 8.0.0 - 2024-03-18
 
 ### New EVM.create() Async Static Constructor / Mandatory VM.create() Constructor

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -19,14 +19,21 @@ These new request types will be activated with the `Prague` hardfork, see [@ethe
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
 - Kaustinen5 related fixes, PR [#3343](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3343)
 - Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
+- Missing beaconroot account verkle fix, PR [#3421](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3421)
 
 ### Other Features
 
-- Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
+- Stricter prefixe hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
 ### Other Changes
 
 - Removes support for [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) simple subroutines for EVM (deprecated with an alternative version integrated into EOF), PR [#3342](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3342)
+- Small clean-up to `VM_emit()`, PR [#3396](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3396)
+
+### Bugfixes
+
+- Fix block building with blocks including CL requests, PR [#3413](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3413)
+- Ensure system address is not created if it is empty, PR [#3400](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3400)
 
 ## 8.0.0 - 2024-03-18
 

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## 8.1.0 - 2024-08-15
 
-### EIP-6110 (Deposit Requests) / EIP-7002 (Withdrawal Requests) / EIP-7251 (Consolidation Requests) Support
+### EIP-7685 Requests: EIP-6110 (Deposits) / EIP-7002 (Withdrawals) / EIP-7251 (Consolidations)
 
 This library now supports `EIP-6110` deposit requests, see PR [#3390](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3390), `EIP-7002` withdrawal requests, see PR [#3385](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3385) and `EIP-7251` consolidation requests, see PR [#3477](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3477) as well as the underlying generic execution layer request logic introduced with `EIP-7685` (PR [#3372](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3372)).
 

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## - 2024-07-23
+
 ## 8.0.0 - 2024-03-18
 
 ### New EVM.create() Async Static Constructor / Mandatory VM.create() Constructor

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -39,6 +39,7 @@ An update to this release is therefore strongly recommended even if other fixes 
 
 ### Other Features
 
+- Add `evmOpts` to the VM opts to allow for options chaining to the underlying EVM, PR [#3481](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3481)
 - Stricter prefixe hex typing, PRs [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348), [#3427](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3427) and [#3357](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3357) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
 ### Other Changes

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -22,6 +22,10 @@ These new request types will be activated with the `Prague` hardfork, see [@ethe
 
 - Stricter prefixe hex typing, PR [#3348](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3348) (some changes take back in PR [#3382](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3382) for backwards compatibility reasons, will be reintroduced along upcoming breaking releases)
 
+### Other Changes
+
+- Removes support for [EIP-2315](https://eips.ethereum.org/EIPS/eip-2315) simple subroutines for EVM (deprecated with an alternative version integrated into EOF), PR [#3342](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3342)
+
 ## 8.0.0 - 2024-03-18
 
 ### New EVM.create() Async Static Constructor / Mandatory VM.create() Constructor

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -16,9 +16,9 @@ These new request types will be activated with the `Prague` hardfork, see [@ethe
 
 ### EIP-2935 Serve Historical Block Hashes from State (Prague)
 
-Starting with this release the EVM supports [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) which replaces the assumption of block hashes being present (to be served in the `BLOCKHASH` opcode) in a client by a sync process with relying on a system contract where historical block hashes are stored, see PR [#3475](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3475) as the major integrational PR (while work on this has already been done in previous PRs).
+Starting with this release the VM supports [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) which stores the latest 256 block hashes in the storage of a system contract, see PR [#3475](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3475) as the major integrational PR (while work on this has already been done in previous PRs).
 
-The window of 256 historical block hashes which can be served by the `BLOCKHASH` opcode remains unchanged. See [this associated test setup](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/vm/test/api/EIPs/eip-2935-historical-block-hashes.spec.ts) for inspiration on code setting up a respective environment.
+This EIP will be activated along the Prague hardfork. Note that this EIP has no effect on the resolution of the `BLOCKHASH` opcode, which will be a separate activation taking place by the integration of [EIP-7709](https://eips.ethereum.org/EIPS/eip-7709) in the following Osaka hardfork.
 
 ### Verkle Dependency Decoupling
 

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -17,6 +17,8 @@ These new request types will be activated with the `Prague` hardfork, see [@ethe
 ### Verkle Updates
 
 - Fixes for Kaustinen4 support, PR [#3269](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3269)
+- Kaustinen5 related fixes, PR [#3343](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3343)
+- Kaustinen6 adjustments, `verkle-cryptography-wasm` migration, PRs [#3355](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3355) and [#3356](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3356)
 
 ### Other Features
 

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -318,6 +318,10 @@ For a list with supported EIPs see the [@ethereumjs/evm](https://github.com/ethe
 
 This library supports the blob transaction type introduced with [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844).
 
+### EIP-6110/EIP-7002 Requests Support
+
+This libary supports executing and building blocks including `EIP-6110` deposit requests as well as `EIP-7002` withdrawal requests starting with `v8.1.0`.
+
 #### Initialization
 
 To run VM/EVM related EIP-4844 functionality you have to activate the EIP in the associated `@ethereumjs/common` library:

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -334,7 +334,7 @@ This libary supports blocks including the following [EIP-7685](https://eips.ethe
 
 ### EIP-2935 Serve Historical Block Hashes from State (Prague)
 
-Starting with `v8.1.0` the VM supports [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) which stores the latest 256 block hashes in the storage of a system contract, see PR [#3475](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3475) as the major integrational PR (while work on this has already been done in previous PRs).
+Starting with `v8.1.0` the VM supports [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) which stores the latest 8192 block hashes in the storage of a system contract, see PR [#3475](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3475) as the major integrational PR (while work on this has already been done in previous PRs).
 
 This EIP will be activated along the Prague hardfork. Note that this EIP has no effect on the resolution of the `BLOCKHASH` opcode, which will be a separate activation taking place by the integration of [EIP-7709](https://eips.ethereum.org/EIPS/eip-7709) in the following Osaka hardfork.
 

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -318,6 +318,12 @@ For a list with supported EIPs see the [@ethereumjs/evm](https://github.com/ethe
 
 This library supports the blob transaction type introduced with [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844).
 
+### EIP-7702 EAO Code Transactions Support (outdated)
+
+This library support the execution of [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) EOA code transactions (see tx library for full documentation) with `runTx()` or the wrapping `runBlock()` execution methods starting with `v3.1.0`, see [this test setup](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/vm/test/api/EIPs/eip-7702.spec.ts) for a more complete example setup on how to run code from an EOA.
+
+Note: Things move fast with `EIP-7702` and the currently released implementation is based on [this](https://github.com/ethereum/EIPs/blob/14400434e1199c57d912082127b1d22643788d11/EIPS/eip-7702.md) commit and therefore already outdated. An up-to-date version will be released along our breaking release round planned for early September 2024.
+
 ### EIP-7685 Requests Support
 
 This libary supports blocks including the following [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) requests:

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -322,6 +322,12 @@ This library supports the blob transaction type introduced with [EIP-4844](https
 
 This libary supports executing and building blocks including `EIP-6110` deposit requests as well as `EIP-7002` withdrawal requests starting with `v8.1.0`.
 
+### EIP-2935 Serve Historical Block Hashes from State (Prague)
+
+Starting with `v8.1.0` the VM supports [EIP-2935](https://eips.ethereum.org/EIPS/eip-2935) which stores the latest 256 block hashes in the storage of a system contract, see PR [#3475](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3475) as the major integrational PR (while work on this has already been done in previous PRs).
+
+This EIP will be activated along the Prague hardfork. Note that this EIP has no effect on the resolution of the `BLOCKHASH` opcode, which will be a separate activation taking place by the integration of [EIP-7709](https://eips.ethereum.org/EIPS/eip-7709) in the following Osaka hardfork.
+
 #### Initialization
 
 To run VM/EVM related EIP-4844 functionality you have to activate the EIP in the associated `@ethereumjs/common` library:

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -318,9 +318,13 @@ For a list with supported EIPs see the [@ethereumjs/evm](https://github.com/ethe
 
 This library supports the blob transaction type introduced with [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844).
 
-### EIP-6110/EIP-7002 Requests Support
+### EIP-7685 Requests Support
 
-This libary supports executing and building blocks including `EIP-6110` deposit requests as well as `EIP-7002` withdrawal requests starting with `v8.1.0`.
+This libary supports blocks including the following [EIP-7685](https://eips.ethereum.org/EIPS/eip-7685) requests:
+
+- [EIP-6110](https://eips.ethereum.org/EIPS/eip-6110) - Deposit Requests (`v7.3.0`+)
+- [EIP-7002](https://eips.ethereum.org/EIPS/eip-7002) - Withdrawal Requests (`v7.3.0`+)
+- [EIP-7251](https://eips.ethereum.org/EIPS/eip-7251) - Consolidation Requests (`v7.3.0`+)
 
 ### EIP-2935 Serve Historical Block Hashes from State (Prague)
 

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/vm",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "An Ethereum VM implementation",
   "keywords": [
     "ethereum",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "@ethereumjs/block": "^5.3.0",
-    "@ethereumjs/blockchain": "^7.2.0",
+    "@ethereumjs/blockchain": "^7.3.0",
     "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/evm": "^3.0.0",
     "@ethereumjs/rlp": "^5.0.2",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -63,7 +63,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/block": "^5.2.0",
+    "@ethereumjs/block": "^5.3.0",
     "@ethereumjs/blockchain": "^7.2.0",
     "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/evm": "^3.0.0",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -66,7 +66,7 @@
     "@ethereumjs/block": "^5.3.0",
     "@ethereumjs/blockchain": "^7.3.0",
     "@ethereumjs/common": "^4.4.0",
-    "@ethereumjs/evm": "^3.0.0",
+    "@ethereumjs/evm": "^3.1.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/statemanager": "^2.4.0",
     "@ethereumjs/trie": "^6.2.1",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@ethereumjs/block": "^5.2.0",
     "@ethereumjs/blockchain": "^7.2.0",
-    "@ethereumjs/common": "^4.3.0",
+    "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/evm": "^3.0.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/statemanager": "^2.3.0",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -71,7 +71,7 @@
     "@ethereumjs/statemanager": "^2.3.0",
     "@ethereumjs/trie": "^6.2.0",
     "@ethereumjs/tx": "^5.3.0",
-    "@ethereumjs/util": "^9.0.3",
+    "@ethereumjs/util": "^9.1.0",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.2.1"
   },

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -70,7 +70,7 @@
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/statemanager": "^2.3.0",
     "@ethereumjs/trie": "^6.2.1",
-    "@ethereumjs/tx": "^5.3.0",
+    "@ethereumjs/tx": "^5.4.0",
     "@ethereumjs/util": "^9.1.0",
     "debug": "^4.3.3",
     "ethereum-cryptography": "^2.2.1"

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -69,7 +69,7 @@
     "@ethereumjs/evm": "^3.0.0",
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/statemanager": "^2.3.0",
-    "@ethereumjs/trie": "^6.2.0",
+    "@ethereumjs/trie": "^6.2.1",
     "@ethereumjs/tx": "^5.3.0",
     "@ethereumjs/util": "^9.1.0",
     "debug": "^4.3.3",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -68,7 +68,7 @@
     "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/evm": "^3.0.0",
     "@ethereumjs/rlp": "^5.0.2",
-    "@ethereumjs/statemanager": "^2.3.0",
+    "@ethereumjs/statemanager": "^2.4.0",
     "@ethereumjs/trie": "^6.2.1",
     "@ethereumjs/tx": "^5.4.0",
     "@ethereumjs/util": "^9.1.0",

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 2.0.4 - 2024-07-23
+## 2.0.4 - 2024-08-15
 
 Maintenance release with downstream dependency updates, see PR [#3527](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3527)
 

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## - 2024-07-23
+
 ## 2.0.3 - 2024-03-18
 
 Maintenance release with downstream dependency updates, see PR [#3297](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3297)

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## - 2024-07-23
+## 2.0.4 - 2024-07-23
+
+Maintenance release with downstream dependency updates, see PR [#3527](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3527)
 
 ## 2.0.3 - 2024-03-18
 

--- a/packages/wallet/CHANGELOG.md
+++ b/packages/wallet/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 2.0.3 - 2024-03-05
+## 2.0.3 - 2024-03-18
 
 Maintenance release with downstream dependency updates, see PR [#3297](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3297)
 

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -47,7 +47,7 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "@ethereumjs/util": "^9.0.3",
+    "@ethereumjs/util": "^9.1.0",
     "@scure/base": "^1.1.7",
     "ethereum-cryptography": "^2.2.1",
     "js-md5": "^0.8.3",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ethereumjs/wallet",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Utilities for handling Ethereum keys",
   "keywords": [
     "ethereum",


### PR DESCRIPTION
Follow-up on #3297 

This is the last planned release round on the v8 release series before the next breaking release round planned for autumn 2024, where work is already taking place on the `master` branch (this PR is targeted towards `maintenance-v8` but will be ported over to `master` after the releases to have the CHANGELOG and doc updates in there as well).

Focus of the releases is somewhat of a Prague outlook with shippment of mostly finalized versions of many Prague EIPs like EIP-6110 and EIP-7002 as well as significant bundle fixes for higher stack libaries like the EVM and various improvements and bugfixes during the last 3-4 months (quite some time since the last release round).

Releases are done on all libraries except `RLP` (15 libraries).