### PR TITLE
evm: move map -> array for opcodes/gas

### DIFF
--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -107,9 +107,9 @@ export class EVM implements EVMInterface {
   protected readonly _customOpcodes?: CustomOpcode[]
   protected readonly _customPrecompiles?: CustomPrecompile[]
 
-  protected _handlers!: Map<number, OpHandler>
+  protected _handlers!: OpHandler[]
 
-  protected _dynamicGasHandlers!: Map<number, AsyncDynamicGasHandler | SyncDynamicGasHandler>
+  protected _dynamicGasHandlers!: (AsyncDynamicGasHandler | SyncDynamicGasHandler)[]
 
   protected _opcodeMap!: OpcodeMap
 

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -69,1735 +69,1518 @@ export interface AsyncOpHandler {
 export type OpHandler = SyncOpHandler | AsyncOpHandler
 
 // the opcode functions
-export const handlers: Map<number, OpHandler> = new Map([
-  // 0x00: STOP
-  [
-    0x00,
-    function () {
-      trap(ERROR.STOP)
-    },
-  ],
-  // 0x01: ADD
-  [
-    0x01,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      const r = mod(a + b, TWO_POW256)
-      runState.stack.push(r)
-    },
-  ],
-  // 0x02: MUL
-  [
-    0x02,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      const r = mod(a * b, TWO_POW256)
-      runState.stack.push(r)
-    },
-  ],
-  // 0x03: SUB
-  [
-    0x03,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      const r = mod(a - b, TWO_POW256)
-      runState.stack.push(r)
-    },
-  ],
-  // 0x04: DIV
-  [
-    0x04,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      let r
-      if (b === BIGINT_0) {
-        r = BIGINT_0
-      } else {
-        r = mod(a / b, TWO_POW256)
-      }
-      runState.stack.push(r)
-    },
-  ],
-  // 0x05: SDIV
-  [
-    0x05,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      let r
-      if (b === BIGINT_0) {
-        r = BIGINT_0
-      } else {
-        r = toTwos(fromTwos(a) / fromTwos(b))
-      }
-      runState.stack.push(r)
-    },
-  ],
-  // 0x06: MOD
-  [
-    0x06,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      let r
-      if (b === BIGINT_0) {
-        r = b
-      } else {
-        r = mod(a, b)
-      }
-      runState.stack.push(r)
-    },
-  ],
-  // 0x07: SMOD
-  [
-    0x07,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      let r
-      if (b === BIGINT_0) {
-        r = b
-      } else {
-        r = fromTwos(a) % fromTwos(b)
-      }
-      runState.stack.push(toTwos(r))
-    },
-  ],
-  // 0x08: ADDMOD
-  [
-    0x08,
-    function (runState) {
-      const [a, b, c] = runState.stack.popN(3)
-      let r
-      if (c === BIGINT_0) {
-        r = BIGINT_0
-      } else {
-        r = mod(a + b, c)
-      }
-      runState.stack.push(r)
-    },
-  ],
-  // 0x09: MULMOD
-  [
-    0x09,
-    function (runState) {
-      const [a, b, c] = runState.stack.popN(3)
-      let r
-      if (c === BIGINT_0) {
-        r = BIGINT_0
-      } else {
-        r = mod(a * b, c)
-      }
-      runState.stack.push(r)
-    },
-  ],
-  // 0x0a: EXP
-  [
-    0x0a,
-    function (runState) {
-      const [base, exponent] = runState.stack.popN(2)
-      if (base === BIGINT_2) {
-        switch (exponent) {
-          case BIGINT_96:
-            runState.stack.push(BIGINT_2EXP96)
-            return
-          case BIGINT_160:
-            runState.stack.push(BIGINT_2EXP160)
-            return
-          case BIGINT_224:
-            runState.stack.push(BIGINT_2EXP224)
-            return
-        }
-      }
-      if (exponent === BIGINT_0) {
-        runState.stack.push(BIGINT_1)
+export const handlers: OpHandler[] = []
+
+// 0x00: STOP
+handlers[0x00] = function () {
+  trap(ERROR.STOP)
+}
+
+// 0x01: ADD
+handlers[0x01] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  const r = mod(a + b, TWO_POW256)
+  runState.stack.push(r)
+}
+
+// 0x02: MUL
+handlers[0x02] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  const r = mod(a * b, TWO_POW256)
+  runState.stack.push(r)
+}
+
+// 0x03: SUB
+handlers[0x03] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  const r = mod(a - b, TWO_POW256)
+  runState.stack.push(r)
+}
+
+// 0x04: DIV
+handlers[0x04] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  let r
+  if (b === BIGINT_0) {
+    r = BIGINT_0
+  } else {
+    r = mod(a / b, TWO_POW256)
+  }
+  runState.stack.push(r)
+}
+
+// 0x05: SDIV
+handlers[0x05] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  let r
+  if (b === BIGINT_0) {
+    r = BIGINT_0
+  } else {
+    r = toTwos(fromTwos(a) / fromTwos(b))
+  }
+  runState.stack.push(r)
+}
+
+// 0x06: MOD
+handlers[0x06] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  let r
+  if (b === BIGINT_0) {
+    r = b
+  } else {
+    r = mod(a, b)
+  }
+  runState.stack.push(r)
+}
+
+// 0x07: SMOD
+handlers[0x07] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  let r
+  if (b === BIGINT_0) {
+    r = b
+  } else {
+    r = fromTwos(a) % fromTwos(b)
+  }
+  runState.stack.push(toTwos(r))
+}
+
+// 0x08: ADDMOD
+handlers[0x08] = function (runState) {
+  const [a, b, c] = runState.stack.popN(3)
+  let r
+  if (c === BIGINT_0) {
+    r = BIGINT_0
+  } else {
+    r = mod(a + b, c)
+  }
+  runState.stack.push(r)
+}
+
+// 0x09: MULMOD
+handlers[0x09] = function (runState) {
+  const [a, b, c] = runState.stack.popN(3)
+  let r
+  if (c === BIGINT_0) {
+    r = BIGINT_0
+  } else {
+    r = mod(a * b, c)
+  }
+  runState.stack.push(r)
+}
+
+// 0x0a: EXP
+handlers[0x0a] = function (runState) {
+  const [base, exponent] = runState.stack.popN(2)
+  if (base === BIGINT_2) {
+    switch (exponent) {
+      case BIGINT_96:
+        runState.stack.push(BIGINT_2EXP96)
         return
-      }
-
-      if (base === BIGINT_0) {
-        runState.stack.push(base)
+      case BIGINT_160:
+        runState.stack.push(BIGINT_2EXP160)
         return
-      }
-      const r = exponentiation(base, exponent)
-      runState.stack.push(r)
-    },
-  ],
-  // 0x0b: SIGNEXTEND
-  [
-    0x0b,
-    function (runState) {
-      /* eslint-disable-next-line prefer-const */
-      let [k, val] = runState.stack.popN(2)
-      if (k < BIGINT_31) {
-        const signBit = k * BIGINT_8 + BIGINT_7
-        const mask = (BIGINT_1 << signBit) - BIGINT_1
-        if ((val >> signBit) & BIGINT_1) {
-          val = val | BigInt.asUintN(256, ~mask)
-        } else {
-          val = val & mask
-        }
-      }
-      runState.stack.push(val)
-    },
-  ],
-  // 0x10 range - bit ops
-  // 0x10: LT
-  [
-    0x10,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      const r = a < b ? BIGINT_1 : BIGINT_0
-      runState.stack.push(r)
-    },
-  ],
-  // 0x11: GT
-  [
-    0x11,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      const r = a > b ? BIGINT_1 : BIGINT_0
-      runState.stack.push(r)
-    },
-  ],
-  // 0x12: SLT
-  [
-    0x12,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      const r = fromTwos(a) < fromTwos(b) ? BIGINT_1 : BIGINT_0
-      runState.stack.push(r)
-    },
-  ],
-  // 0x13: SGT
-  [
-    0x13,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      const r = fromTwos(a) > fromTwos(b) ? BIGINT_1 : BIGINT_0
-      runState.stack.push(r)
-    },
-  ],
-  // 0x14: EQ
-  [
-    0x14,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      const r = a === b ? BIGINT_1 : BIGINT_0
-      runState.stack.push(r)
-    },
-  ],
-  // 0x15: ISZERO
-  [
-    0x15,
-    function (runState) {
-      const a = runState.stack.pop()
-      const r = a === BIGINT_0 ? BIGINT_1 : BIGINT_0
-      runState.stack.push(r)
-    },
-  ],
-  // 0x16: AND
-  [
-    0x16,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      const r = a & b
-      runState.stack.push(r)
-    },
-  ],
-  // 0x17: OR
-  [
-    0x17,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      const r = a | b
-      runState.stack.push(r)
-    },
-  ],
-  // 0x18: XOR
-  [
-    0x18,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      const r = a ^ b
-      runState.stack.push(r)
-    },
-  ],
-  // 0x19: NOT
-  [
-    0x19,
-    function (runState) {
-      const a = runState.stack.pop()
-      const r = BigInt.asUintN(256, ~a)
-      runState.stack.push(r)
-    },
-  ],
-  // 0x1a: BYTE
-  [
-    0x1a,
-    function (runState) {
-      const [pos, word] = runState.stack.popN(2)
-      if (pos > BIGINT_32) {
-        runState.stack.push(BIGINT_0)
+      case BIGINT_224:
+        runState.stack.push(BIGINT_2EXP224)
         return
-      }
+    }
+  }
+  if (exponent === BIGINT_0) {
+    runState.stack.push(BIGINT_1)
+    return
+  }
 
-      const r = (word >> ((BIGINT_31 - pos) * BIGINT_8)) & BIGINT_255
-      runState.stack.push(r)
-    },
-  ],
-  // 0x1b: SHL
-  [
-    0x1b,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      if (a > BIGINT_256) {
-        runState.stack.push(BIGINT_0)
-        return
-      }
+  if (base === BIGINT_0) {
+    runState.stack.push(base)
+    return
+  }
+  const r = exponentiation(base, exponent)
+  runState.stack.push(r)
+}
 
-      const r = (b << a) & MAX_INTEGER_BIGINT
-      runState.stack.push(r)
-    },
-  ],
-  // 0x1c: SHR
-  [
-    0x1c,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
-      if (a > 256) {
-        runState.stack.push(BIGINT_0)
-        return
-      }
+// 0x0b: SIGNEXTEND
+handlers[0x0b] = function (runState) {
+  /* eslint-disable-next-line prefer-const */
+  let [k, val] = runState.stack.popN(2)
+  if (k < BIGINT_31) {
+    const signBit = k * BIGINT_8 + BIGINT_7
+    const mask = (BIGINT_1 << signBit) - BIGINT_1
+    if ((val >> signBit) & BIGINT_1) {
+      val = val | BigInt.asUintN(256, ~mask)
+    } else {
+      val = val & mask
+    }
+  }
+  runState.stack.push(val)
+}
 
-      const r = b >> a
-      runState.stack.push(r)
-    },
-  ],
-  // 0x1d: SAR
-  [
-    0x1d,
-    function (runState) {
-      const [a, b] = runState.stack.popN(2)
+// 0x10 range - bit ops
+// 0x10: LT
+handlers[0x10] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  const r = a < b ? BIGINT_1 : BIGINT_0
+  runState.stack.push(r)
+}
 
-      let r
-      const bComp = BigInt.asIntN(256, b)
-      const isSigned = bComp < 0
-      if (a > 256) {
-        if (isSigned) {
-          r = MAX_INTEGER_BIGINT
-        } else {
-          r = BIGINT_0
-        }
-        runState.stack.push(r)
-        return
-      }
+// 0x11: GT
+handlers[0x11] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  const r = a > b ? BIGINT_1 : BIGINT_0
+  runState.stack.push(r)
+}
 
-      const c = b >> a
-      if (isSigned) {
-        const shiftedOutWidth = BIGINT_255 - a
-        const mask = (MAX_INTEGER_BIGINT >> shiftedOutWidth) << shiftedOutWidth
-        r = c | mask
-      } else {
-        r = c
-      }
-      runState.stack.push(r)
-    },
-  ],
-  // 0x20 range - crypto
-  // 0x20: KECCAK256
-  [
-    0x20,
-    function (runState, common) {
-      const [offset, length] = runState.stack.popN(2)
-      let data = new Uint8Array(0)
-      if (length !== BIGINT_0) {
-        data = runState.memory.read(Number(offset), Number(length))
-      }
-      const r = BigInt(bytesToHex((common.customCrypto.keccak256 ?? keccak256)(data)))
-      runState.stack.push(r)
-    },
-  ],
-  // 0x30 range - closure state
-  // 0x30: ADDRESS
-  [
-    0x30,
-    function (runState) {
-      const address = bytesToBigInt(runState.interpreter.getAddress().bytes)
-      runState.stack.push(address)
-    },
-  ],
-  // 0x31: BALANCE
-  [
-    0x31,
-    async function (runState) {
-      const addressBigInt = runState.stack.pop()
-      const address = new Address(addresstoBytes(addressBigInt))
-      const balance = await runState.interpreter.getExternalBalance(address)
-      runState.stack.push(balance)
-    },
-  ],
-  // 0x32: ORIGIN
-  [
-    0x32,
-    function (runState) {
-      runState.stack.push(runState.interpreter.getTxOrigin())
-    },
-  ],
-  // 0x33: CALLER
-  [
-    0x33,
-    function (runState) {
-      runState.stack.push(runState.interpreter.getCaller())
-    },
-  ],
-  // 0x34: CALLVALUE
-  [
-    0x34,
-    function (runState) {
-      runState.stack.push(runState.interpreter.getCallValue())
-    },
-  ],
-  // 0x35: CALLDATALOAD
-  [
-    0x35,
-    function (runState) {
-      const pos = runState.stack.pop()
-      if (pos > runState.interpreter.getCallDataSize()) {
-        runState.stack.push(BIGINT_0)
-        return
-      }
+// 0x12: SLT
+handlers[0x12] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  const r = fromTwos(a) < fromTwos(b) ? BIGINT_1 : BIGINT_0
+  runState.stack.push(r)
+}
 
-      const i = Number(pos)
-      let loaded = runState.interpreter.getCallData().subarray(i, i + 32)
-      loaded = loaded.length ? loaded : Uint8Array.from([0])
-      let r = bytesToBigInt(loaded)
-      if (loaded.length < 32) {
-        r = r << (BIGINT_8 * BigInt(32 - loaded.length))
-      }
-      runState.stack.push(r)
-    },
-  ],
-  // 0x36: CALLDATASIZE
-  [
-    0x36,
-    function (runState) {
-      const r = runState.interpreter.getCallDataSize()
-      runState.stack.push(r)
-    },
-  ],
-  // 0x37: CALLDATACOPY
-  [
-    0x37,
-    function (runState) {
-      const [memOffset, dataOffset, dataLength] = runState.stack.popN(3)
+// 0x13: SGT
+handlers[0x13] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  const r = fromTwos(a) > fromTwos(b) ? BIGINT_1 : BIGINT_0
+  runState.stack.push(r)
+}
 
-      if (dataLength !== BIGINT_0) {
-        const data = getDataSlice(runState.interpreter.getCallData(), dataOffset, dataLength)
-        const memOffsetNum = Number(memOffset)
-        const dataLengthNum = Number(dataLength)
-        runState.memory.write(memOffsetNum, dataLengthNum, data)
-      }
-    },
-  ],
-  // 0x38: CODESIZE
-  [
-    0x38,
-    function (runState) {
-      runState.stack.push(runState.interpreter.getCodeSize())
-    },
-  ],
-  // 0x39: CODECOPY
-  [
-    0x39,
-    function (runState) {
-      const [memOffset, codeOffset, dataLength] = runState.stack.popN(3)
+// 0x14: EQ
+handlers[0x14] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  const r = a === b ? BIGINT_1 : BIGINT_0
+  runState.stack.push(r)
+}
 
-      if (dataLength !== BIGINT_0) {
-        const data = getDataSlice(runState.interpreter.getCode(), codeOffset, dataLength)
-        const memOffsetNum = Number(memOffset)
-        const lengthNum = Number(dataLength)
-        runState.memory.write(memOffsetNum, lengthNum, data)
-      }
-    },
-  ],
-  // 0x3b: EXTCODESIZE
-  [
-    0x3b,
-    async function (runState) {
-      const addressBigInt = runState.stack.pop()
-      const address = new Address(addresstoBytes(addressBigInt))
-      // EOF check
-      const code = await runState.stateManager.getContractCode(address)
-      if (isEOF(code)) {
-        // In legacy code, the target code is treated as to be "EOFBYTES" code
-        runState.stack.push(BigInt(EOFBYTES.length))
-        return
-      }
+// 0x15: ISZERO
+handlers[0x15] = function (runState) {
+  const a = runState.stack.pop()
+  const r = a === BIGINT_0 ? BIGINT_1 : BIGINT_0
+  runState.stack.push(r)
+}
 
-      let size
-      if (typeof runState.stateManager.getContractCodeSize === 'function') {
-        size = BigInt(
-          await runState.stateManager.getContractCodeSize(
-            new Address(addresstoBytes(addressBigInt))
-          )
-        )
-      } else {
-        size = BigInt(
-          (await runState.stateManager.getContractCode(new Address(addresstoBytes(addressBigInt))))
-            .length
-        )
-      }
+// 0x16: AND
+handlers[0x16] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  const r = a & b
+  runState.stack.push(r)
+}
 
-      runState.stack.push(size)
-    },
-  ],
-  // 0x3c: EXTCODECOPY
-  [
-    0x3c,
-    async function (runState) {
-      const [addressBigInt, memOffset, codeOffset, dataLength] = runState.stack.popN(4)
+// 0x17: OR
+handlers[0x17] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  const r = a | b
+  runState.stack.push(r)
+}
 
-      if (dataLength !== BIGINT_0) {
-        let code = await runState.stateManager.getContractCode(
-          new Address(addresstoBytes(addressBigInt))
-        )
+// 0x18: XOR
+handlers[0x18] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  const r = a ^ b
+  runState.stack.push(r)
+}
 
-        if (isEOF(code)) {
-          // In legacy code, the target code is treated as to be "EOFBYTES" code
-          code = EOFBYTES
-        }
+// 0x19: NOT
+handlers[0x19] = function (runState) {
+  const a = runState.stack.pop()
+  const r = BigInt.asUintN(256, ~a)
+  runState.stack.push(r)
+}
 
-        const data = getDataSlice(code, codeOffset, dataLength)
-        const memOffsetNum = Number(memOffset)
-        const lengthNum = Number(dataLength)
-        runState.memory.write(memOffsetNum, lengthNum, data)
-      }
-    },
-  ],
-  // 0x3f: EXTCODEHASH
-  [
-    0x3f,
-    async function (runState) {
-      const addressBigInt = runState.stack.pop()
-      const address = new Address(addresstoBytes(addressBigInt))
+// 0x1a: BYTE
+handlers[0x1a] = function (runState) {
+  const [pos, word] = runState.stack.popN(2)
+  if (pos > BIGINT_32) {
+    runState.stack.push(BIGINT_0)
+    return
+  }
 
-      // EOF check
-      const code = await runState.stateManager.getContractCode(address)
-      if (isEOF(code)) {
-        // In legacy code, the target code is treated as to be "EOFBYTES" code
-        // Therefore, push the hash of EOFBYTES to the stack
-        runState.stack.push(bytesToBigInt(EOFHASH))
-        return
-      }
+  const r = (word >> ((BIGINT_31 - pos) * BIGINT_8)) & BIGINT_255
+  runState.stack.push(r)
+}
 
-      const account = await runState.stateManager.getAccount(address)
-      if (!account || account.isEmpty()) {
-        runState.stack.push(BIGINT_0)
-        return
-      }
+// 0x1b: SHL
+handlers[0x1b] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  if (a > BIGINT_256) {
+    runState.stack.push(BIGINT_0)
+    return
+  }
 
-      runState.stack.push(BigInt(bytesToHex(account.codeHash)))
-    },
-  ],
-  // 0x3d: RETURNDATASIZE
-  [
-    0x3d,
-    function (runState) {
-      runState.stack.push(runState.interpreter.getReturnDataSize())
-    },
-  ],
-  // 0x3e: RETURNDATACOPY
-  [
-    0x3e,
-    function (runState) {
-      const [memOffset, returnDataOffset, dataLength] = runState.stack.popN(3)
+  const r = (b << a) & MAX_INTEGER_BIGINT
+  runState.stack.push(r)
+}
 
-      if (dataLength !== BIGINT_0) {
-        const data = getDataSlice(
-          runState.interpreter.getReturnData(),
-          returnDataOffset,
-          dataLength
-        )
-        const memOffsetNum = Number(memOffset)
-        const lengthNum = Number(dataLength)
-        runState.memory.write(memOffsetNum, lengthNum, data)
-      }
-    },
-  ],
-  // 0x3a: GASPRICE
-  [
-    0x3a,
-    function (runState) {
-      runState.stack.push(runState.interpreter.getTxGasPrice())
-    },
-  ],
-  // '0x40' range - block operations
-  // 0x40: BLOCKHASH
-  [
-    0x40,
-    async function (runState, common) {
-      const number = runState.stack.pop()
+// 0x1c: SHR
+handlers[0x1c] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
+  if (a > 256) {
+    runState.stack.push(BIGINT_0)
+    return
+  }
 
-      if (common.isActivatedEIP(7709)) {
-        if (number >= runState.interpreter.getBlockNumber()) {
-          runState.stack.push(BIGINT_0)
-          return
-        }
+  const r = b >> a
+  runState.stack.push(r)
+}
 
-        const diff = runState.interpreter.getBlockNumber() - number
-        // block lookups must be within the original window even if historyStorageAddress's
-        // historyServeWindow is much greater than 256
-        if (diff > BIGINT_256 || diff <= BIGINT_0) {
-          runState.stack.push(BIGINT_0)
-          return
-        }
+// 0x1d: SAR
+handlers[0x1d] = function (runState) {
+  const [a, b] = runState.stack.popN(2)
 
-        const historyAddress = new Address(
-          bigIntToAddressBytes(common.param('vm', 'historyStorageAddress'))
-        )
-        const historyServeWindow = common.param('vm', 'historyServeWindow')
-        const key = setLengthLeft(bigIntToBytes(number % historyServeWindow), 32)
+  let r
+  const bComp = BigInt.asIntN(256, b)
+  const isSigned = bComp < 0
+  if (a > 256) {
+    if (isSigned) {
+      r = MAX_INTEGER_BIGINT
+    } else {
+      r = BIGINT_0
+    }
+    runState.stack.push(r)
+    return
+  }
 
-        if (common.isActivatedEIP(6800)) {
-          const { treeIndex, subIndex } = getVerkleTreeIndexesForStorageSlot(number)
-          // create witnesses and charge gas
-          const statelessGas = runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-            historyAddress,
-            treeIndex,
-            subIndex
-          )
-          runState.interpreter.useGas(statelessGas, `BLOCKHASH`)
-        }
-        const storage = await runState.stateManager.getContractStorage(historyAddress, key)
+  const c = b >> a
+  if (isSigned) {
+    const shiftedOutWidth = BIGINT_255 - a
+    const mask = (MAX_INTEGER_BIGINT >> shiftedOutWidth) << shiftedOutWidth
+    r = c | mask
+  } else {
+    r = c
+  }
+  runState.stack.push(r)
+}
 
-        runState.stack.push(bytesToBigInt(storage))
-      } else {
-        const diff = runState.interpreter.getBlockNumber() - number
-        // block lookups must be within the past 256 blocks
-        if (diff > BIGINT_256 || diff <= BIGINT_0) {
-          runState.stack.push(BIGINT_0)
-          return
-        }
+// 0x20 range - crypto
+// 0x20: KECCAK256
+handlers[0x20] = function (runState, common) {
+  const [offset, length] = runState.stack.popN(2)
+  let data = new Uint8Array(0)
+  if (length !== BIGINT_0) {
+    data = runState.memory.read(Number(offset), Number(length))
+  }
+  const r = BigInt(bytesToHex((common.customCrypto.keccak256 ?? keccak256)(data)))
+  runState.stack.push(r)
+}
 
-        const block = await runState.blockchain.getBlock(Number(number))
+// 0x30 range - closure state
+// 0x30: ADDRESS
+handlers[0x30] = function (runState) {
+  const address = bytesToBigInt(runState.interpreter.getAddress().bytes)
+  runState.stack.push(address)
+}
 
-        runState.stack.push(bytesToBigInt(block.hash()))
-      }
-    },
-  ],
-  // 0x41: COINBASE
-  [
-    0x41,
-    function (runState) {
-      runState.stack.push(runState.interpreter.getBlockCoinbase())
-    },
-  ],
-  // 0x42: TIMESTAMP
-  [
-    0x42,
-    function (runState) {
-      runState.stack.push(runState.interpreter.getBlockTimestamp())
-    },
-  ],
-  // 0x43: NUMBER
-  [
-    0x43,
-    function (runState) {
-      runState.stack.push(runState.interpreter.getBlockNumber())
-    },
-  ],
-  // 0x44: DIFFICULTY (EIP-4399: supplanted as PREVRANDAO)
-  [
-    0x44,
-    function (runState, common) {
-      if (common.isActivatedEIP(4399)) {
-        runState.stack.push(runState.interpreter.getBlockPrevRandao())
-      } else {
-        runState.stack.push(runState.interpreter.getBlockDifficulty())
-      }
-    },
-  ],
-  // 0x45: GASLIMIT
-  [
-    0x45,
-    function (runState) {
-      runState.stack.push(runState.interpreter.getBlockGasLimit())
-    },
-  ],
-  // 0x46: CHAINID
-  [
-    0x46,
-    function (runState) {
-      runState.stack.push(runState.interpreter.getChainId())
-    },
-  ],
-  // 0x47: SELFBALANCE
-  [
-    0x47,
-    function (runState) {
-      runState.stack.push(runState.interpreter.getSelfBalance())
-    },
-  ],
-  // 0x48: BASEFEE
-  [
-    0x48,
-    function (runState) {
-      runState.stack.push(runState.interpreter.getBlockBaseFee())
-    },
-  ],
-  // 0x49: BLOBHASH
-  [
-    0x49,
-    function (runState) {
-      const index = runState.stack.pop()
-      if (runState.env.blobVersionedHashes.length > Number(index)) {
-        runState.stack.push(bytesToBigInt(runState.env.blobVersionedHashes[Number(index)]))
-      } else {
-        runState.stack.push(BIGINT_0)
-      }
-    },
-  ],
-  // 0x4a: BLOBBASEFEE
-  [
-    0x4a,
-    function (runState) {
-      runState.stack.push(runState.interpreter.getBlobBaseFee())
-    },
-  ],
-  // 0x50 range - 'storage' and execution
-  // 0x50: POP
-  [
-    0x50,
-    function (runState) {
-      runState.stack.pop()
-    },
-  ],
-  // 0x51: MLOAD
-  [
-    0x51,
-    function (runState) {
-      const pos = runState.stack.pop()
-      const word = runState.memory.read(Number(pos), 32, true)
-      runState.stack.push(bytesToBigInt(word))
-    },
-  ],
-  // 0x52: MSTORE
-  [
-    0x52,
-    function (runState) {
-      const [offset, word] = runState.stack.popN(2)
-      const buf = setLengthLeft(bigIntToBytes(word), 32)
-      const offsetNum = Number(offset)
-      runState.memory.write(offsetNum, 32, buf)
-    },
-  ],
-  // 0x53: MSTORE8
-  [
-    0x53,
-    function (runState) {
-      const [offset, byte] = runState.stack.popN(2)
+// 0x31: BALANCE
+handlers[0x31] = async function (runState) {
+  const addressBigInt = runState.stack.pop()
+  const address = new Address(addresstoBytes(addressBigInt))
+  const balance = await runState.interpreter.getExternalBalance(address)
+  runState.stack.push(balance)
+}
 
-      const buf = bigIntToBytes(byte & BIGINT_255)
-      const offsetNum = Number(offset)
-      runState.memory.write(offsetNum, 1, buf)
-    },
-  ],
-  // 0x54: SLOAD
-  [
-    0x54,
-    async function (runState) {
-      const key = runState.stack.pop()
-      const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
-      const value = await runState.interpreter.storageLoad(keyBuf)
-      const valueBigInt = value.length ? bytesToBigInt(value) : BIGINT_0
-      runState.stack.push(valueBigInt)
-    },
-  ],
-  // 0x55: SSTORE
-  [
-    0x55,
-    async function (runState) {
-      const [key, val] = runState.stack.popN(2)
+// 0x32: ORIGIN
+handlers[0x32] = function (runState) {
+  runState.stack.push(runState.interpreter.getTxOrigin())
+}
 
-      const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
-      // NOTE: this should be the shortest representation
-      let value
-      if (val === BIGINT_0) {
-        value = Uint8Array.from([])
-      } else {
-        value = bigIntToBytes(val)
-      }
+// 0x33: CALLER
+handlers[0x33] = function (runState) {
+  runState.stack.push(runState.interpreter.getCaller())
+}
 
-      await runState.interpreter.storageStore(keyBuf, value)
-    },
-  ],
-  // 0x56: JUMP
-  [
-    0x56,
-    function (runState) {
-      const dest = runState.stack.pop()
-      if (dest > runState.interpreter.getCodeSize()) {
-        trap(ERROR.INVALID_JUMP + ' at ' + describeLocation(runState))
-      }
+// 0x34: CALLVALUE
+handlers[0x34] = function (runState) {
+  runState.stack.push(runState.interpreter.getCallValue())
+}
 
-      const destNum = Number(dest)
+// 0x35: CALLDATALOAD
+handlers[0x35] = function (runState) {
+  const pos = runState.stack.pop()
+  if (pos > runState.interpreter.getCallDataSize()) {
+    runState.stack.push(BIGINT_0)
+    return
+  }
 
-      if (!jumpIsValid(runState, destNum)) {
-        trap(ERROR.INVALID_JUMP + ' at ' + describeLocation(runState))
-      }
+  const i = Number(pos)
+  let loaded = runState.interpreter.getCallData().subarray(i, i + 32)
+  loaded = loaded.length ? loaded : Uint8Array.from(0)
+  let r = bytesToBigInt(loaded)
+  if (loaded.length < 32) {
+    r = r << (BIGINT_8 * BigInt(32 - loaded.length))
+  }
+  runState.stack.push(r)
+}
 
-      runState.programCounter = destNum
-    },
-  ],
-  // 0x57: JUMPI
-  [
-    0x57,
-    function (runState) {
-      const [dest, cond] = runState.stack.popN(2)
-      if (cond !== BIGINT_0) {
-        if (dest > runState.interpreter.getCodeSize()) {
-          trap(ERROR.INVALID_JUMP + ' at ' + describeLocation(runState))
-        }
+// 0x36: CALLDATASIZE
+handlers[0x36] = function (runState) {
+  const r = runState.interpreter.getCallDataSize()
+  runState.stack.push(r)
+}
 
-        const destNum = Number(dest)
+// 0x37: CALLDATACOPY
+handlers[0x37] = function (runState) {
+  const [memOffset, dataOffset, dataLength] = runState.stack.popN(3)
 
-        if (!jumpIsValid(runState, destNum)) {
-          trap(ERROR.INVALID_JUMP + ' at ' + describeLocation(runState))
-        }
+  if (dataLength !== BIGINT_0) {
+    const data = getDataSlice(runState.interpreter.getCallData(), dataOffset, dataLength)
+    const memOffsetNum = Number(memOffset)
+    const dataLengthNum = Number(dataLength)
+    runState.memory.write(memOffsetNum, dataLengthNum, data)
+  }
+}
 
-        runState.programCounter = destNum
-      }
-    },
-  ],
-  // 0x58: PC
-  [
-    0x58,
-    function (runState) {
-      runState.stack.push(BigInt(runState.programCounter - 1))
-    },
-  ],
-  // 0x59: MSIZE
-  [
-    0x59,
-    function (runState) {
-      runState.stack.push(runState.memoryWordCount * BIGINT_32)
-    },
-  ],
-  // 0x5a: GAS
-  [
-    0x5a,
-    function (runState) {
-      runState.stack.push(runState.interpreter.getGasLeft())
-    },
-  ],
-  // 0x5b: JUMPDEST
-  [0x5b, function () {}],
-  // 0x5c: TLOAD (EIP 1153)
-  [
-    0x5c,
-    function (runState) {
-      const key = runState.stack.pop()
-      const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
-      const value = runState.interpreter.transientStorageLoad(keyBuf)
-      const valueBN = value.length ? bytesToBigInt(value) : BIGINT_0
-      runState.stack.push(valueBN)
-    },
-  ],
-  // 0x5d: TSTORE (EIP 1153)
-  [
-    0x5d,
-    function (runState) {
-      // TSTORE
-      if (runState.interpreter.isStatic()) {
-        trap(ERROR.STATIC_STATE_CHANGE)
-      }
-      const [key, val] = runState.stack.popN(2)
+// 0x38: CODESIZE
+handlers[0x38] = function (runState) {
+  runState.stack.push(runState.interpreter.getCodeSize())
+}
 
-      const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
-      // NOTE: this should be the shortest representation
-      let value
-      if (val === BIGINT_0) {
-        value = Uint8Array.from([])
-      } else {
-        value = bigIntToBytes(val)
-      }
+// 0x39: CODECOPY
+handlers[0x39] = function (runState) {
+  const [memOffset, codeOffset, dataLength] = runState.stack.popN(3)
 
-      runState.interpreter.transientStorageStore(keyBuf, value)
-    },
-  ],
-  // 0x5e: MCOPY (5656)
-  [
-    0x5e,
-    function (runState) {
-      const [dst, src, length] = runState.stack.popN(3)
-      const data = runState.memory.read(Number(src), Number(length), true)
-      runState.memory.write(Number(dst), Number(length), data)
-    },
-  ],
-  // 0x5f: PUSH0
-  [
-    0x5f,
-    function (runState) {
+  if (dataLength !== BIGINT_0) {
+    const data = getDataSlice(runState.interpreter.getCode(), codeOffset, dataLength)
+    const memOffsetNum = Number(memOffset)
+    const lengthNum = Number(dataLength)
+    runState.memory.write(memOffsetNum, lengthNum, data)
+  }
+}
+
+// 0x3b: EXTCODESIZE
+handlers[0x3b] = async function (runState) {
+  const addressBigInt = runState.stack.pop()
+  const address = new Address(addresstoBytes(addressBigInt))
+  // EOF check
+  const code = await runState.stateManager.getContractCode(address)
+  if (isEOF(code)) {
+    // In legacy code the target code is treated as to be "EOFBYTES" code
+    runState.stack.push(BigInt(EOFBYTES.length))
+    return
+  }
+
+  let size
+  if (typeof runState.stateManager.getContractCodeSize === 'function') {
+    size = BigInt(
+      await runState.stateManager.getContractCodeSize(new Address(addresstoBytes(addressBigInt)))
+    )
+  } else {
+    size = BigInt(
+      (await runState.stateManager.getContractCode(new Address(addresstoBytes(addressBigInt))))
+        .length
+    )
+  }
+
+  runState.stack.push(size)
+}
+
+// 0x3c: EXTCODECOPY
+handlers[0x3c] = async function (runState) {
+  const [addressBigInt, memOffset, codeOffset, dataLength] = runState.stack.popN(4)
+
+  if (dataLength !== BIGINT_0) {
+    let code = await runState.stateManager.getContractCode(
+      new Address(addresstoBytes(addressBigInt))
+    )
+
+    if (isEOF(code)) {
+      // In legacy code the target code is treated as to be "EOFBYTES" code
+      code = EOFBYTES
+    }
+
+    const data = getDataSlice(code, codeOffset, dataLength)
+    const memOffsetNum = Number(memOffset)
+    const lengthNum = Number(dataLength)
+    runState.memory.write(memOffsetNum, lengthNum, data)
+  }
+}
+
+// 0x3f: EXTCODEHASH
+handlers[0x3f] = async function (runState) {
+  const addressBigInt = runState.stack.pop()
+  const address = new Address(addresstoBytes(addressBigInt))
+
+  // EOF check
+  const code = await runState.stateManager.getContractCode(address)
+  if (isEOF(code)) {
+    // In legacy code the target code is treated as to be "EOFBYTES" code
+    // Therefore push the hash of EOFBYTES to the stack
+    runState.stack.push(bytesToBigInt(EOFHASH))
+    return
+  }
+
+  const account = await runState.stateManager.getAccount(address)
+  if (!account || account.isEmpty()) {
+    runState.stack.push(BIGINT_0)
+    return
+  }
+
+  runState.stack.push(BigInt(bytesToHex(account.codeHash)))
+}
+
+// 0x3d: RETURNDATASIZE
+handlers[0x3d] = function (runState) {
+  runState.stack.push(runState.interpreter.getReturnDataSize())
+}
+
+// 0x3e: RETURNDATACOPY
+handlers[0x3e] = function (runState) {
+  const [memOffset, returnDataOffset, dataLength] = runState.stack.popN(3)
+
+  if (dataLength !== BIGINT_0) {
+    const data = getDataSlice(runState.interpreter.getReturnData(), returnDataOffset, dataLength)
+    const memOffsetNum = Number(memOffset)
+    const lengthNum = Number(dataLength)
+    runState.memory.write(memOffsetNum, lengthNum, data)
+  }
+}
+
+// 0x3a: GASPRICE
+handlers[0x3a] = function (runState) {
+  runState.stack.push(runState.interpreter.getTxGasPrice())
+}
+
+// '0x40' range - block operations
+// 0x40: BLOCKHASH
+handlers[0x40] = async function (runState, common) {
+  const number = runState.stack.pop()
+
+  if (common.isActivatedEIP(7709)) {
+    if (number >= runState.interpreter.getBlockNumber()) {
       runState.stack.push(BIGINT_0)
-    },
-  ],
-  // 0x60: PUSH
-  [
-    0x60,
-    function (runState, common) {
-      const numToPush = runState.opCode - 0x5f
-      if (
-        runState.programCounter + numToPush > runState.code.length &&
-        common.isActivatedEIP(3540)
-      ) {
-        trap(ERROR.OUT_OF_RANGE)
-      }
+      return
+    }
 
-      if (common.isActivatedEIP(6800) && runState.env.chargeCodeAccesses === true) {
-        const contract = runState.interpreter.getAddress()
-        const startOffset = Math.min(runState.code.length, runState.programCounter + 1)
-        const endOffset = Math.min(runState.code.length, startOffset + numToPush - 1)
-        const statelessGas = runState.env.accessWitness!.touchCodeChunksRangeOnReadAndChargeGas(
-          contract,
-          startOffset,
-          endOffset
-        )
-        runState.interpreter.useGas(statelessGas, `PUSH`)
-      }
+    const diff = runState.interpreter.getBlockNumber() - number
+    // block lookups must be within the original window even if historyStorageAddress's
+    // historyServeWindow is much greater than 256
+    if (diff > BIGINT_256 || diff <= BIGINT_0) {
+      runState.stack.push(BIGINT_0)
+      return
+    }
 
-      if (!runState.shouldDoJumpAnalysis) {
-        runState.stack.push(runState.cachedPushes[runState.programCounter])
-        runState.programCounter += numToPush
-      } else {
-        const loaded = bytesToBigInt(
-          runState.code.subarray(runState.programCounter, runState.programCounter + numToPush)
-        )
-        runState.programCounter += numToPush
-        runState.stack.push(loaded)
-      }
-    },
-  ],
-  // 0x80: DUP
-  [
-    0x80,
-    function (runState) {
-      const stackPos = runState.opCode - 0x7f
-      runState.stack.dup(stackPos)
-    },
-  ],
-  // 0x90: SWAP
-  [
-    0x90,
-    function (runState) {
-      const stackPos = runState.opCode - 0x8f
-      runState.stack.swap(stackPos)
-    },
-  ],
-  // 0xa0: LOG
-  [
-    0xa0,
-    function (runState) {
-      const [memOffset, memLength] = runState.stack.popN(2)
+    const historyAddress = new Address(
+      bigIntToAddressBytes(common.param('vm', 'historyStorageAddress'))
+    )
+    const historyServeWindow = common.param('vm', 'historyServeWindow')
+    const key = setLengthLeft(bigIntToBytes(number % historyServeWindow), 32)
 
-      const topicsCount = runState.opCode - 0xa0
-
-      const topics = runState.stack.popN(topicsCount)
-      const topicsBuf = topics.map(function (a: bigint) {
-        return setLengthLeft(bigIntToBytes(a), 32)
-      })
-
-      let mem = new Uint8Array(0)
-      if (memLength !== BIGINT_0) {
-        mem = runState.memory.read(Number(memOffset), Number(memLength))
-      }
-
-      runState.interpreter.log(mem, topicsCount, topicsBuf)
-    },
-  ],
-  // 0xd0: DATALOAD
-  [
-    0xd0,
-    function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      }
-      const pos = runState.stack.pop()
-      if (pos > runState.env.eof!.container.body.dataSection.length) {
-        runState.stack.push(BIGINT_0)
-        return
-      }
-
-      const i = Number(pos)
-      let loaded = runState.env.eof!.container.body.dataSection.subarray(i, i + 32)
-      loaded = loaded.length ? loaded : Uint8Array.from([0])
-      let r = bytesToBigInt(loaded)
-      // Pad the loaded length with 0 bytes in case it is smaller than 32
-      if (loaded.length < 32) {
-        r = r << (BIGINT_8 * BigInt(32 - loaded.length))
-      }
-      runState.stack.push(r)
-    },
-  ],
-  // 0xd1: DATALOADN
-  [
-    0xd1,
-    function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      }
-      const toLoad = Number(
-        bytesToBigInt(runState.code.subarray(runState.programCounter, runState.programCounter + 2))
+    if (common.isActivatedEIP(6800)) {
+      const { treeIndex, subIndex } = getVerkleTreeIndexesForStorageSlot(number)
+      // create witnesses and charge gas
+      const statelessGas = runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
+        historyAddress,
+        treeIndex,
+        subIndex
       )
-      const data = bytesToBigInt(
-        runState.env.eof!.container.body.dataSection.subarray(toLoad, toLoad + 32)
-      )
-      runState.stack.push(data)
-      runState.programCounter += 2
-    },
-  ],
-  // 0xd2: DATASIZE
-  [
-    0xd2,
-    function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      }
-      runState.stack.push(BigInt(runState.env.eof!.container.body.dataSection.length))
-    },
-  ],
-  // 0xd3: DATACOPY
-  [
-    0xd3,
-    function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      }
-      const [memOffset, offset, size] = runState.stack.popN(3)
-      if (size !== BIGINT_0) {
-        const data = getDataSlice(runState.env.eof!.container.body.dataSection, offset, size)
-        const memOffsetNum = Number(memOffset)
-        const dataLengthNum = Number(size)
-        runState.memory.write(memOffsetNum, dataLengthNum, data)
-      }
-    },
-  ],
-  // 0xe0: RJUMP
-  [
-    0xe0,
-    function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      } else {
-        const code = runState.env.code
-        const rjumpDest = new DataView(code.buffer).getInt16(runState.programCounter)
-        runState.programCounter += 2 + rjumpDest
-      }
-    },
-  ],
-  // 0xe1: RJUMPI
-  [
-    0xe1,
-    function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      } else {
-        const cond = runState.stack.pop()
-        // Move PC to the PC post instruction
-        if (cond > 0) {
-          const code = runState.env.code
-          const rjumpDest = new DataView(code.buffer).getInt16(runState.programCounter)
-          runState.programCounter += rjumpDest
-        }
-        // In all cases, increment PC with 2 (also in the case if `cond` is `0`)
-        runState.programCounter += 2
-      }
-    },
-  ],
-  // 0xe2: RJUMPV
-  [
-    0xe2,
-    function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      } else {
-        const code = runState.env.code
-        const jumptableEntries = code[runState.programCounter]
-        // Note: if the size of the immediate is `0`, this thus means that the actual size is `2`
-        // This allows for 256 entries in the table instead of 255
-        const jumptableSize = (jumptableEntries + 1) * 2
-        // Move PC to start of the jump table
-        runState.programCounter += 1
-        const jumptableCase = runState.stack.pop()
-        if (jumptableCase <= jumptableEntries) {
-          const rjumpDest = new DataView(code.buffer).getInt16(
-            runState.programCounter + Number(jumptableCase) * 2
-          )
-          runState.programCounter += jumptableSize + rjumpDest
-        } else {
-          runState.programCounter += jumptableSize
-        }
-      }
-    },
-  ],
-  // 0xe3: CALLF
-  [
-    0xe3,
-    function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      }
-      const sectionTarget = bytesToInt(
-        runState.code.slice(runState.programCounter, runState.programCounter + 2)
-      )
-      const stackItems = runState.stack.length
-      const typeSection = runState.env.eof!.container.body.typeSections[sectionTarget]
-      if (1024 < stackItems + typeSection?.inputs - typeSection?.maxStackHeight) {
-        trap(EOFError.StackOverflow)
-      }
-      if (runState.env.eof!.eofRunState.returnStack.length >= 1024) {
-        trap(EOFError.ReturnStackOverflow)
-      }
-      runState.env.eof?.eofRunState.returnStack.push(runState.programCounter + 2)
+      runState.interpreter.useGas(statelessGas, `BLOCKHASH`)
+    }
+    const storage = await runState.stateManager.getContractStorage(historyAddress, key)
 
-      // Find out the opcode we should jump into
-      runState.programCounter = runState.env.eof!.container.header.getCodePosition(sectionTarget)
-    },
-  ],
-  // 0xe4: RETF
-  [
-    0xe4,
-    function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      }
-      const newPc = runState.env.eof!.eofRunState.returnStack.pop()
-      if (newPc === undefined) {
-        // This should NEVER happen since it is validated that functions either terminate (the call frame) or return
-        trap(EOFError.RetfNoReturn)
-      }
-      runState.programCounter = newPc!
-    },
-  ],
-  // 0xe5: JUMPF
-  [
-    0xe5,
-    function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      }
-      // NOTE: (and also TODO) this code is exactly the same as CALLF, except pushing to the return stack is now skipped
-      // (and also the return stack overflow check)
-      // It is commented out here
-      const sectionTarget = bytesToInt(
-        runState.code.slice(runState.programCounter, runState.programCounter + 2)
+    runState.stack.push(bytesToBigInt(storage))
+  } else {
+    const diff = runState.interpreter.getBlockNumber() - number
+    // block lookups must be within the past 256 blocks
+    if (diff > BIGINT_256 || diff <= BIGINT_0) {
+      runState.stack.push(BIGINT_0)
+      return
+    }
+
+    const block = await runState.blockchain.getBlock(Number(number))
+
+    runState.stack.push(bytesToBigInt(block.hash()))
+  }
+}
+
+// 0x41: COINBASE
+handlers[0x41] = function (runState) {
+  runState.stack.push(runState.interpreter.getBlockCoinbase())
+}
+
+// 0x42: TIMESTAMP
+handlers[0x42] = function (runState) {
+  runState.stack.push(runState.interpreter.getBlockTimestamp())
+}
+
+// 0x43: NUMBER
+handlers[0x43] = function (runState) {
+  runState.stack.push(runState.interpreter.getBlockNumber())
+}
+
+// 0x44: DIFFICULTY (EIP-4399: supplanted as PREVRANDAO)
+handlers[0x44] = function (runState, common) {
+  if (common.isActivatedEIP(4399)) {
+    runState.stack.push(runState.interpreter.getBlockPrevRandao())
+  } else {
+    runState.stack.push(runState.interpreter.getBlockDifficulty())
+  }
+}
+
+// 0x45: GASLIMIT
+handlers[0x45] = function (runState) {
+  runState.stack.push(runState.interpreter.getBlockGasLimit())
+}
+
+// 0x46: CHAINID
+handlers[0x46] = function (runState) {
+  runState.stack.push(runState.interpreter.getChainId())
+}
+
+// 0x47: SELFBALANCE
+handlers[0x47] = function (runState) {
+  runState.stack.push(runState.interpreter.getSelfBalance())
+}
+
+// 0x48: BASEFEE
+handlers[0x48] = function (runState) {
+  runState.stack.push(runState.interpreter.getBlockBaseFee())
+}
+
+// 0x49: BLOBHASH
+handlers[0x49] = function (runState) {
+  const index = runState.stack.pop()
+  if (runState.env.blobVersionedHashes.length > Number(index)) {
+    runState.stack.push(bytesToBigInt(runState.env.blobVersionedHashes[Number(index)]))
+  } else {
+    runState.stack.push(BIGINT_0)
+  }
+}
+
+// 0x4a: BLOBBASEFEE
+handlers[0x4a] = function (runState) {
+  runState.stack.push(runState.interpreter.getBlobBaseFee())
+}
+
+// 0x50 range - 'storage' and execution
+// 0x50: POP
+handlers[0x50] = function (runState) {
+  runState.stack.pop()
+}
+
+// 0x51: MLOAD
+handlers[0x51] = function (runState) {
+  const pos = runState.stack.pop()
+  const word = runState.memory.read(Number(pos), 32, true)
+  runState.stack.push(bytesToBigInt(word))
+}
+
+// 0x52: MSTORE
+handlers[0x52] = function (runState) {
+  const [offset, word] = runState.stack.popN(2)
+  const buf = setLengthLeft(bigIntToBytes(word), 32)
+  const offsetNum = Number(offset)
+  runState.memory.write(offsetNum, 32, buf)
+}
+
+// 0x53: MSTORE8
+handlers[0x53] = function (runState) {
+  const [offset, byte] = runState.stack.popN(2)
+
+  const buf = bigIntToBytes(byte & BIGINT_255)
+  const offsetNum = Number(offset)
+  runState.memory.write(offsetNum, 1, buf)
+}
+
+// 0x54: SLOAD
+handlers[0x54] = async function (runState) {
+  const key = runState.stack.pop()
+  const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
+  const value = await runState.interpreter.storageLoad(keyBuf)
+  const valueBigInt = value.length ? bytesToBigInt(value) : BIGINT_0
+  runState.stack.push(valueBigInt)
+}
+
+// 0x55: SSTORE
+handlers[0x55] = async function (runState) {
+  const [key, val] = runState.stack.popN(2)
+
+  const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
+  // NOTE: this should be the shortest representation
+  let value
+  if (val === BIGINT_0) {
+    value = Uint8Array.from([])
+  } else {
+    value = bigIntToBytes(val)
+  }
+
+  await runState.interpreter.storageStore(keyBuf, value)
+}
+
+// 0x56: JUMP
+handlers[0x56] = function (runState) {
+  const dest = runState.stack.pop()
+  if (dest > runState.interpreter.getCodeSize()) {
+    trap(ERROR.INVALID_JUMP + ' at ' + describeLocation(runState))
+  }
+
+  const destNum = Number(dest)
+
+  if (!jumpIsValid(runState, destNum)) {
+    trap(ERROR.INVALID_JUMP + ' at ' + describeLocation(runState))
+  }
+
+  runState.programCounter = destNum
+}
+
+// 0x57: JUMPI
+handlers[0x57] = function (runState) {
+  const [dest, cond] = runState.stack.popN(2)
+  if (cond !== BIGINT_0) {
+    if (dest > runState.interpreter.getCodeSize()) {
+      trap(ERROR.INVALID_JUMP + ' at ' + describeLocation(runState))
+    }
+
+    const destNum = Number(dest)
+
+    if (!jumpIsValid(runState, destNum)) {
+      trap(ERROR.INVALID_JUMP + ' at ' + describeLocation(runState))
+    }
+
+    runState.programCounter = destNum
+  }
+}
+
+// 0x58: PC
+handlers[0x58] = function (runState) {
+  runState.stack.push(BigInt(runState.programCounter - 1))
+}
+
+// 0x59: MSIZE
+handlers[0x59] = function (runState) {
+  runState.stack.push(runState.memoryWordCount * BIGINT_32)
+}
+
+// 0x5a: GAS
+handlers[0x5a] = function (runState) {
+  runState.stack.push(runState.interpreter.getGasLeft())
+}
+
+// 0x5b: JUMPDEST
+handlers[0x5b] = function () {}
+
+// 0x5c: TLOAD (EIP 1153)
+handlers[0x5c] = function (runState) {
+  const key = runState.stack.pop()
+  const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
+  const value = runState.interpreter.transientStorageLoad(keyBuf)
+  const valueBN = value.length ? bytesToBigInt(value) : BIGINT_0
+  runState.stack.push(valueBN)
+}
+
+// 0x5d: TSTORE (EIP 1153)
+handlers[0x5d] = function (runState) {
+  // TSTORE
+  if (runState.interpreter.isStatic()) {
+    trap(ERROR.STATIC_STATE_CHANGE)
+  }
+  const [key, val] = runState.stack.popN(2)
+
+  const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
+  // NOTE: this should be the shortest representation
+  let value
+  if (val === BIGINT_0) {
+    value = Uint8Array.from([])
+  } else {
+    value = bigIntToBytes(val)
+  }
+
+  runState.interpreter.transientStorageStore(keyBuf, value)
+}
+
+// 0x5e: MCOPY (5656)
+handlers[0x5e] = function (runState) {
+  const [dst, src, length] = runState.stack.popN(3)
+  const data = runState.memory.read(Number(src), Number(length), true)
+  runState.memory.write(Number(dst), Number(length), data)
+}
+
+// 0x5f: PUSH0
+handlers[0x5f] = function (runState) {
+  runState.stack.push(BIGINT_0)
+}
+
+// 0x60: PUSH
+handlers[0x60] = function (runState, common) {
+  const numToPush = runState.opCode - 0x5f
+  if (runState.programCounter + numToPush > runState.code.length && common.isActivatedEIP(3540)) {
+    trap(ERROR.OUT_OF_RANGE)
+  }
+
+  if (common.isActivatedEIP(6800) && runState.env.chargeCodeAccesses === true) {
+    const contract = runState.interpreter.getAddress()
+    const startOffset = Math.min(runState.code.length, runState.programCounter + 1)
+    const endOffset = Math.min(runState.code.length, startOffset + numToPush - 1)
+    const statelessGas = runState.env.accessWitness!.touchCodeChunksRangeOnReadAndChargeGas(
+      contract,
+      startOffset,
+      endOffset
+    )
+    runState.interpreter.useGas(statelessGas, `PUSH`)
+  }
+
+  if (!runState.shouldDoJumpAnalysis) {
+    runState.stack.push(runState.cachedPushes[runState.programCounter])
+    runState.programCounter += numToPush
+  } else {
+    const loaded = bytesToBigInt(
+      runState.code.subarray(runState.programCounter, runState.programCounter + numToPush)
+    )
+    runState.programCounter += numToPush
+    runState.stack.push(loaded)
+  }
+}
+
+// 0x80: DUP
+handlers[0x80] = function (runState) {
+  const stackPos = runState.opCode - 0x7f
+  runState.stack.dup(stackPos)
+}
+
+// 0x90: SWAP
+handlers[0x90] = function (runState) {
+  const stackPos = runState.opCode - 0x8f
+  runState.stack.swap(stackPos)
+}
+
+// 0xa0: LOG
+handlers[0xa0] = function (runState) {
+  const [memOffset, memLength] = runState.stack.popN(2)
+
+  const topicsCount = runState.opCode - 0xa0
+
+  const topics = runState.stack.popN(topicsCount)
+  const topicsBuf = topics.map(function (a: bigint) {
+    return setLengthLeft(bigIntToBytes(a), 32)
+  })
+
+  let mem = new Uint8Array(0)
+  if (memLength !== BIGINT_0) {
+    mem = runState.memory.read(Number(memOffset), Number(memLength))
+  }
+
+  runState.interpreter.log(mem, topicsCount, topicsBuf)
+}
+
+// 0xd0: DATALOAD
+handlers[0xd0] = function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  }
+  const pos = runState.stack.pop()
+  if (pos > runState.env.eof!.container.body.dataSection.length) {
+    runState.stack.push(BIGINT_0)
+    return
+  }
+
+  const i = Number(pos)
+  let loaded = runState.env.eof!.container.body.dataSection.subarray(i, i + 32)
+  loaded = loaded.length ? loaded : Uint8Array.from(0)
+  let r = bytesToBigInt(loaded)
+  // Pad the loaded length with 0 bytes in case it is smaller than 32
+  if (loaded.length < 32) {
+    r = r << (BIGINT_8 * BigInt(32 - loaded.length))
+  }
+  runState.stack.push(r)
+}
+
+// 0xd1: DATALOADN
+handlers[0xd1] = function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  }
+  const toLoad = Number(
+    bytesToBigInt(runState.code.subarray(runState.programCounter, runState.programCounter + 2))
+  )
+  const data = bytesToBigInt(
+    runState.env.eof!.container.body.dataSection.subarray(toLoad, toLoad + 32)
+  )
+  runState.stack.push(data)
+  runState.programCounter += 2
+}
+
+// 0xd2: DATASIZE
+handlers[0xd2] = function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  }
+  runState.stack.push(BigInt(runState.env.eof!.container.body.dataSection.length))
+}
+
+// 0xd3: DATACOPY
+handlers[0xd3] = function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  }
+  const [memOffset, offset, size] = runState.stack.popN(3)
+  if (size !== BIGINT_0) {
+    const data = getDataSlice(runState.env.eof!.container.body.dataSection, offset, size)
+    const memOffsetNum = Number(memOffset)
+    const dataLengthNum = Number(size)
+    runState.memory.write(memOffsetNum, dataLengthNum, data)
+  }
+}
+
+// 0xe0: RJUMP
+handlers[0xe0] = function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  } else {
+    const code = runState.env.code
+    const rjumpDest = new DataView(code.buffer).getInt16(runState.programCounter)
+    runState.programCounter += 2 + rjumpDest
+  }
+}
+
+// 0xe1: RJUMPI
+handlers[0xe1] = function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  } else {
+    const cond = runState.stack.pop()
+    // Move PC to the PC post instruction
+    if (cond > 0) {
+      const code = runState.env.code
+      const rjumpDest = new DataView(code.buffer).getInt16(runState.programCounter)
+      runState.programCounter += rjumpDest
+    }
+    // In all cases increment PC with 2 (also in the case if `cond` is `0`)
+    runState.programCounter += 2
+  }
+}
+
+// 0xe2: RJUMPV
+handlers[0xe2] = function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  } else {
+    const code = runState.env.code
+    const jumptableEntries = code[runState.programCounter]
+    // Note: if the size of the immediate is `0` this thus means that the actual size is `2`
+    // This allows for 256 entries in the table instead of 255
+    const jumptableSize = (jumptableEntries + 1) * 2
+    // Move PC to start of the jump table
+    runState.programCounter += 1
+    const jumptableCase = runState.stack.pop()
+    if (jumptableCase <= jumptableEntries) {
+      const rjumpDest = new DataView(code.buffer).getInt16(
+        runState.programCounter + Number(jumptableCase) * 2
       )
-      const stackItems = runState.stack.length
-      const typeSection = runState.env.eof!.container.body.typeSections[sectionTarget]
-      if (1024 < stackItems + typeSection?.inputs - typeSection?.maxStackHeight) {
-        trap(EOFError.StackOverflow)
-      }
-      /*if (runState.env.eof!.eofRunState.returnStack.length >= 1024) {
+      runState.programCounter += jumptableSize + rjumpDest
+    } else {
+      runState.programCounter += jumptableSize
+    }
+  }
+}
+
+// 0xe3: CALLF
+handlers[0xe3] = function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  }
+  const sectionTarget = bytesToInt(
+    runState.code.slice(runState.programCounter, runState.programCounter + 2)
+  )
+  const stackItems = runState.stack.length
+  const typeSection = runState.env.eof!.container.body.typeSections[sectionTarget]
+  if (1024 < stackItems + typeSection?.inputs - typeSection?.maxStackHeight) {
+    trap(EOFError.StackOverflow)
+  }
+  if (runState.env.eof!.eofRunState.returnStack.length >= 1024) {
+    trap(EOFError.ReturnStackOverflow)
+  }
+  runState.env.eof?.eofRunState.returnStack.push(runState.programCounter + 2)
+
+  // Find out the opcode we should jump into
+  runState.programCounter = runState.env.eof!.container.header.getCodePosition(sectionTarget)
+}
+
+// 0xe4: RETF
+handlers[0xe4] = function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  }
+  const newPc = runState.env.eof!.eofRunState.returnStack.pop()
+  if (newPc === undefined) {
+    // This should NEVER happen since it is validated that functions either terminate (the call frame) or return
+    trap(EOFError.RetfNoReturn)
+  }
+  runState.programCounter = newPc!
+}
+
+// 0xe5: JUMPF
+handlers[0xe5] = function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  }
+  // NOTE: (and also TODO) this code is exactly the same as CALLF except pushing to the return stack is now skipped
+  // (and also the return stack overflow check)
+  // It is commented out here
+  const sectionTarget = bytesToInt(
+    runState.code.slice(runState.programCounter, runState.programCounter + 2)
+  )
+  const stackItems = runState.stack.length
+  const typeSection = runState.env.eof!.container.body.typeSections[sectionTarget]
+  if (1024 < stackItems + typeSection?.inputs - typeSection?.maxStackHeight) {
+    trap(EOFError.StackOverflow)
+  }
+  /*if (runState.env.eof!.eofRunState.returnStack.length >= 1024) {
         trap(EOFError.ReturnStackOverflow)
       }
       runState.env.eof?.eofRunState.returnStack.push(runState.programCounter + 2)*/
 
-      // Find out the opcode we should jump into
-      runState.programCounter = runState.env.eof!.container.header.getCodePosition(sectionTarget)
-    },
-  ],
-  // 0xe6: DUPN
-  [
-    0xe6,
-    function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      }
-      const toDup =
-        Number(
-          bytesToBigInt(
-            runState.code.subarray(runState.programCounter, runState.programCounter + 1)
-          )
-        ) + 1
-      runState.stack.dup(toDup)
-      runState.programCounter++
-    },
-  ],
-  // 0xe7: SWAPN
-  [
-    0xe7,
-    function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      }
-      const toSwap =
-        Number(
-          bytesToBigInt(
-            runState.code.subarray(runState.programCounter, runState.programCounter + 1)
-          )
-        ) + 1
-      runState.stack.swap(toSwap)
-      runState.programCounter++
-    },
-  ],
-  // 0xe8: EXCHANGE
-  [
-    0xe8,
-    function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      }
-      const toExchange = Number(
-        bytesToBigInt(runState.code.subarray(runState.programCounter, runState.programCounter + 1))
-      )
-      const n = (toExchange >> 4) + 1
-      const m = (toExchange & 0x0f) + 1
-      runState.stack.exchange(n, n + m)
-      runState.programCounter++
-    },
-  ],
-  // 0xec: EOFCREATE
-  [
-    0xec,
-    async function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      } else {
-        // Read container index
-        const containerIndex = runState.env.code[runState.programCounter]
-        const containerCode = runState.env.eof!.container.body.containerSections[containerIndex]
+  // Find out the opcode we should jump into
+  runState.programCounter = runState.env.eof!.container.header.getCodePosition(sectionTarget)
+}
 
-        // Pop stack values
-        const [value, salt, inputOffset, inputSize] = runState.stack.popN(4)
+// 0xe6: DUPN
+handlers[0xe6] = function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  }
+  const toDup =
+    Number(
+      bytesToBigInt(runState.code.subarray(runState.programCounter, runState.programCounter + 1))
+    ) + 1
+  runState.stack.dup(toDup)
+  runState.programCounter++
+}
 
-        const gasLimit = runState.messageGasLimit!
-        runState.messageGasLimit = undefined
+// 0xe7: SWAPN
+handlers[0xe7] = function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  }
+  const toSwap =
+    Number(
+      bytesToBigInt(runState.code.subarray(runState.programCounter, runState.programCounter + 1))
+    ) + 1
+  runState.stack.swap(toSwap)
+  runState.programCounter++
+}
 
-        let data = new Uint8Array(0)
-        if (inputSize !== BIGINT_0) {
-          data = runState.memory.read(Number(inputOffset), Number(inputSize), true)
-        }
+// 0xe8: EXCHANGE
+handlers[0xe8] = function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  }
+  const toExchange = Number(
+    bytesToBigInt(runState.code.subarray(runState.programCounter, runState.programCounter + 1))
+  )
+  const n = (toExchange >> 4) + 1
+  const m = (toExchange & 0x0f) + 1
+  runState.stack.exchange(n, n + m)
+  runState.programCounter++
+}
 
-        runState.programCounter++ // Jump over the immediate byte
+// 0xec: EOFCREATE
+handlers[0xec] = async function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  } else {
+    // Read container index
+    const containerIndex = runState.env.code[runState.programCounter]
+    const containerCode = runState.env.eof!.container.body.containerSections[containerIndex]
 
-        const ret = await runState.interpreter.eofcreate(
-          gasLimit,
-          value,
-          containerCode,
-          setLengthLeft(bigIntToBytes(salt), 32),
-          data
-        )
-        runState.stack.push(ret)
-      }
-    },
-  ],
-  // 0xee: RETURNCONTRACT
-  [
-    0xee,
-    async function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      } else {
-        // Read container index
-        const containerIndex = runState.env.code[runState.programCounter]
-        const containerCode = runState.env.eof!.container.body.containerSections[containerIndex]
+    // Pop stack values
+    const [value, salt, inputOffset, inputSize] = runState.stack.popN(4)
 
-        // Read deployContainer as EOFCreate (initcode) container
-        const deployContainer = new EOFContainer(containerCode, EOFContainerMode.Initmode)
+    const gasLimit = runState.messageGasLimit!
+    runState.messageGasLimit = undefined
 
-        // Pop stack values
-        const [auxDataOffset, auxDataSize] = runState.stack.popN(2)
+    let data = new Uint8Array(0)
+    if (inputSize !== BIGINT_0) {
+      data = runState.memory.read(Number(inputOffset), Number(inputSize), true)
+    }
 
-        let auxData = new Uint8Array(0)
-        if (auxDataSize !== BIGINT_0) {
-          auxData = runState.memory.read(Number(auxDataOffset), Number(auxDataSize))
-        }
+    runState.programCounter++ // Jump over the immediate byte
 
-        const originalDataSize = deployContainer.header.dataSize
-        const preDeployDataSectionSize = deployContainer.body.dataSection.length
-        const actualSectionSize = preDeployDataSectionSize + Number(auxDataSize)
+    const ret = await runState.interpreter.eofcreate(
+      gasLimit,
+      value,
+      containerCode,
+      setLengthLeft(bigIntToBytes(salt), 32),
+      data
+    )
+    runState.stack.push(ret)
+  }
+}
 
-        if (actualSectionSize < originalDataSize) {
-          trap(EOFError.InvalidReturnContractDataSize)
-        }
+// 0xee: RETURNCONTRACT
+handlers[0xee] = async function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  } else {
+    // Read container index
+    const containerIndex = runState.env.code[runState.programCounter]
+    const containerCode = runState.env.eof!.container.body.containerSections[containerIndex]
 
-        if (actualSectionSize > 0xffff) {
-          // Data section size is now larger than the max data section size
-          // Temp: trap OOG?
-          trap(ERROR.OUT_OF_GAS)
-        }
+    // Read deployContainer as EOFCreate (initcode) container
+    const deployContainer = new EOFContainer(containerCode, EOFContainerMode.Initmode)
 
-        const newSize = setLengthLeft(bigIntToBytes(BigInt(actualSectionSize)), 2)
+    // Pop stack values
+    const [auxDataOffset, auxDataSize] = runState.stack.popN(2)
 
-        // Write the bytes to the containerCode
-        const dataSizePtr = deployContainer.header.dataSizePtr
-        containerCode[dataSizePtr] = newSize[0]
-        containerCode[dataSizePtr + 1] = newSize[1]
+    let auxData = new Uint8Array(0)
+    if (auxDataSize !== BIGINT_0) {
+      auxData = runState.memory.read(Number(auxDataOffset), Number(auxDataSize))
+    }
 
-        const returnContainer = concatBytes(containerCode, auxData)
+    const originalDataSize = deployContainer.header.dataSize
+    const preDeployDataSectionSize = deployContainer.body.dataSection.length
+    const actualSectionSize = preDeployDataSectionSize + Number(auxDataSize)
 
-        runState.interpreter.finish(returnContainer)
-      }
-    },
-  ],
-  // '0xf0' range - closures
-  // 0xf0: CREATE
-  [
-    0xf0,
-    async function (runState, common) {
-      const [value, offset, length] = runState.stack.popN(3)
+    if (actualSectionSize < originalDataSize) {
+      trap(EOFError.InvalidReturnContractDataSize)
+    }
 
-      if (
-        common.isActivatedEIP(3860) &&
-        length > Number(common.param('vm', 'maxInitCodeSize')) &&
-        !runState.interpreter._evm.allowUnlimitedInitCodeSize
-      ) {
-        trap(ERROR.INITCODE_SIZE_VIOLATION)
-      }
+    if (actualSectionSize > 0xffff) {
+      // Data section size is now larger than the max data section size
+      // Temp: trap OOG?
+      trap(ERROR.OUT_OF_GAS)
+    }
 
-      const gasLimit = runState.messageGasLimit!
-      runState.messageGasLimit = undefined
+    const newSize = setLengthLeft(bigIntToBytes(BigInt(actualSectionSize)), 2)
 
-      let data = new Uint8Array(0)
-      if (length !== BIGINT_0) {
-        data = runState.memory.read(Number(offset), Number(length), true)
-      }
+    // Write the bytes to the containerCode
+    const dataSizePtr = deployContainer.header.dataSizePtr
+    containerCode[dataSizePtr] = newSize[0]
+    containerCode[dataSizePtr + 1] = newSize[1]
 
-      if (isEOF(data)) {
-        // Legacy cannot deploy EOF code
-        runState.stack.push(BIGINT_0)
-        return
-      }
+    const returnContainer = concatBytes(containerCode, auxData)
 
-      const ret = await runState.interpreter.create(gasLimit, value, data)
-      runState.stack.push(ret)
-    },
-  ],
-  // 0xf5: CREATE2
-  [
-    0xf5,
-    async function (runState, common) {
-      if (runState.interpreter.isStatic()) {
-        trap(ERROR.STATIC_STATE_CHANGE)
-      }
+    runState.interpreter.finish(returnContainer)
+  }
+}
 
-      const [value, offset, length, salt] = runState.stack.popN(4)
+// '0xf0' range - closures
+// 0xf0: CREATE
+handlers[0xf0] = async function (runState, common) {
+  const [value, offset, length] = runState.stack.popN(3)
 
-      if (
-        common.isActivatedEIP(3860) &&
-        length > Number(common.param('vm', 'maxInitCodeSize')) &&
-        !runState.interpreter._evm.allowUnlimitedInitCodeSize
-      ) {
-        trap(ERROR.INITCODE_SIZE_VIOLATION)
-      }
+  if (
+    common.isActivatedEIP(3860) &&
+    length > Number(common.param('vm', 'maxInitCodeSize')) &&
+    !runState.interpreter._evm.allowUnlimitedInitCodeSize
+  ) {
+    trap(ERROR.INITCODE_SIZE_VIOLATION)
+  }
 
-      const gasLimit = runState.messageGasLimit!
-      runState.messageGasLimit = undefined
+  const gasLimit = runState.messageGasLimit!
+  runState.messageGasLimit = undefined
 
-      let data = new Uint8Array(0)
-      if (length !== BIGINT_0) {
-        data = runState.memory.read(Number(offset), Number(length), true)
-      }
+  let data = new Uint8Array(0)
+  if (length !== BIGINT_0) {
+    data = runState.memory.read(Number(offset), Number(length), true)
+  }
 
-      if (isEOF(data)) {
-        // Legacy cannot deploy EOF code
-        runState.stack.push(BIGINT_0)
-        return
-      }
+  if (isEOF(data)) {
+    // Legacy cannot deploy EOF code
+    runState.stack.push(BIGINT_0)
+    return
+  }
 
-      const ret = await runState.interpreter.create2(
-        gasLimit,
-        value,
-        data,
-        setLengthLeft(bigIntToBytes(salt), 32)
-      )
-      runState.stack.push(ret)
-    },
-  ],
-  // 0xf1: CALL
-  [
-    0xf1,
-    async function (runState: RunState, common: Common) {
-      const [_currentGasLimit, toAddr, value, inOffset, inLength, outOffset, outLength] =
-        runState.stack.popN(7)
-      const toAddress = new Address(addresstoBytes(toAddr))
+  const ret = await runState.interpreter.create(gasLimit, value, data)
+  runState.stack.push(ret)
+}
 
-      let data = new Uint8Array(0)
-      if (inLength !== BIGINT_0) {
-        data = runState.memory.read(Number(inOffset), Number(inLength), true)
-      }
+// 0xf5: CREATE2
+handlers[0xf5] = async function (runState, common) {
+  if (runState.interpreter.isStatic()) {
+    trap(ERROR.STATIC_STATE_CHANGE)
+  }
 
-      let gasLimit = runState.messageGasLimit!
-      if (value !== BIGINT_0) {
-        const callStipend = common.param('gasPrices', 'callStipend')
-        runState.interpreter.addStipend(callStipend)
-        gasLimit += callStipend
-      }
+  const [value, offset, length, salt] = runState.stack.popN(4)
 
-      runState.messageGasLimit = undefined
+  if (
+    common.isActivatedEIP(3860) &&
+    length > Number(common.param('vm', 'maxInitCodeSize')) &&
+    !runState.interpreter._evm.allowUnlimitedInitCodeSize
+  ) {
+    trap(ERROR.INITCODE_SIZE_VIOLATION)
+  }
 
-      const ret = await runState.interpreter.call(gasLimit, toAddress, value, data)
-      // Write return data to memory
-      writeCallOutput(runState, outOffset, outLength)
-      runState.stack.push(ret)
-    },
-  ],
-  // 0xf2: CALLCODE
-  [
-    0xf2,
-    async function (runState: RunState, common: Common) {
-      const [_currentGasLimit, toAddr, value, inOffset, inLength, outOffset, outLength] =
-        runState.stack.popN(7)
-      const toAddress = new Address(addresstoBytes(toAddr))
+  const gasLimit = runState.messageGasLimit!
+  runState.messageGasLimit = undefined
 
-      let gasLimit = runState.messageGasLimit!
-      if (value !== BIGINT_0) {
-        const callStipend = common.param('gasPrices', 'callStipend')
-        runState.interpreter.addStipend(callStipend)
-        gasLimit += callStipend
-      }
+  let data = new Uint8Array(0)
+  if (length !== BIGINT_0) {
+    data = runState.memory.read(Number(offset), Number(length), true)
+  }
 
-      runState.messageGasLimit = undefined
+  if (isEOF(data)) {
+    // Legacy cannot deploy EOF code
+    runState.stack.push(BIGINT_0)
+    return
+  }
 
-      let data = new Uint8Array(0)
-      if (inLength !== BIGINT_0) {
-        data = runState.memory.read(Number(inOffset), Number(inLength), true)
-      }
+  const ret = await runState.interpreter.create2(
+    gasLimit,
+    value,
+    data,
+    setLengthLeft(bigIntToBytes(salt), 32)
+  )
+  runState.stack.push(ret)
+}
 
-      const ret = await runState.interpreter.callCode(gasLimit, toAddress, value, data)
-      // Write return data to memory
-      writeCallOutput(runState, outOffset, outLength)
-      runState.stack.push(ret)
-    },
-  ],
-  // 0xf4: DELEGATECALL
-  [
-    0xf4,
-    async function (runState) {
-      const value = runState.interpreter.getCallValue()
-      const [_currentGasLimit, toAddr, inOffset, inLength, outOffset, outLength] =
-        runState.stack.popN(6)
-      const toAddress = new Address(addresstoBytes(toAddr))
+// 0xf1: CALL
+handlers[0xf1] = async function (runState, common) {
+  const [_currentGasLimit, toAddr, value, inOffset, inLength, outOffset, outLength] =
+    runState.stack.popN(7)
+  const toAddress = new Address(addresstoBytes(toAddr))
 
-      let data = new Uint8Array(0)
-      if (inLength !== BIGINT_0) {
-        data = runState.memory.read(Number(inOffset), Number(inLength), true)
-      }
+  let data = new Uint8Array(0)
+  if (inLength !== BIGINT_0) {
+    data = runState.memory.read(Number(inOffset), Number(inLength), true)
+  }
 
-      const gasLimit = runState.messageGasLimit!
-      runState.messageGasLimit = undefined
+  let gasLimit = runState.messageGasLimit!
+  if (value !== BIGINT_0) {
+    const callStipend = common.param('gasPrices', 'callStipend')
+    runState.interpreter.addStipend(callStipend)
+    gasLimit += callStipend
+  }
 
-      const ret = await runState.interpreter.callDelegate(gasLimit, toAddress, value, data)
-      // Write return data to memory
-      writeCallOutput(runState, outOffset, outLength)
-      runState.stack.push(ret)
-    },
-  ],
-  // 0xf6: AUTH
-  [
-    0xf6,
-    async function (runState) {
-      // eslint-disable-next-line prefer-const
-      let [authority, memOffset, memLength] = runState.stack.popN(3)
+  runState.messageGasLimit = undefined
 
-      if (memLength > BigInt(97)) {
-        memLength = BigInt(97)
-      }
+  const ret = await runState.interpreter.call(gasLimit, toAddress, value, data)
+  // Write return data to memory
+  writeCallOutput(runState, outOffset, outLength)
+  runState.stack.push(ret)
+}
 
-      let mem = runState.memory.read(Number(memOffset), Number(memLength))
-      if (mem.length < 97) {
-        mem = setLengthRight(mem, 97)
-      }
+// 0xf2: CALLCODE
+handlers[0xf2] = async function (runState, common) {
+  const [_currentGasLimit, toAddr, value, inOffset, inLength, outOffset, outLength] =
+    runState.stack.popN(7)
+  const toAddress = new Address(addresstoBytes(toAddr))
 
-      const yParity = BigInt(mem[0])
-      const r = mem.subarray(1, 33)
-      const s = mem.subarray(33, 65)
-      const commit = mem.subarray(65, 97)
+  let gasLimit = runState.messageGasLimit!
+  if (value !== BIGINT_0) {
+    const callStipend = common.param('gasPrices', 'callStipend')
+    runState.interpreter.addStipend(callStipend)
+    gasLimit += callStipend
+  }
 
-      if (bytesToBigInt(s) > SECP256K1_ORDER_DIV_2) {
-        runState.stack.push(BIGINT_0)
-        runState.auth = undefined
-        return
-      }
-      if (yParity > BIGINT_1) {
-        runState.stack.push(BIGINT_0)
-        runState.auth = undefined
-        return
-      }
+  runState.messageGasLimit = undefined
 
-      // we don't want strick check here on authority being in address range just last 20 bytes
-      const expectedAddress = new Address(bigIntToAddressBytes(authority, false))
-      const account = (await runState.stateManager.getAccount(expectedAddress)) ?? new Account()
+  let data = new Uint8Array(0)
+  if (inLength !== BIGINT_0) {
+    data = runState.memory.read(Number(inOffset), Number(inLength), true)
+  }
 
-      if (account.isContract()) {
-        // EXTCODESIZE > 0
-        runState.stack.push(BIGINT_0)
-        runState.auth = undefined
-        return
-      }
+  const ret = await runState.interpreter.callCode(gasLimit, toAddress, value, data)
+  // Write return data to memory
+  writeCallOutput(runState, outOffset, outLength)
+  runState.stack.push(ret)
+}
 
-      const accountNonce = account.nonce
+// 0xf4: DELEGATECALL
+handlers[0xf4] = async function (runState) {
+  const value = runState.interpreter.getCallValue()
+  const [_currentGasLimit, toAddr, inOffset, inLength, outOffset, outLength] =
+    runState.stack.popN(6)
+  const toAddress = new Address(addresstoBytes(toAddr))
 
-      const invokedAddress = setLengthLeft(runState.interpreter._env.address.bytes, 32)
-      const chainId = setLengthLeft(bigIntToBytes(runState.interpreter.getChainId()), 32)
-      const nonce = setLengthLeft(bigIntToBytes(accountNonce), 32)
-      const message = concatBytes(EIP3074MAGIC, chainId, nonce, invokedAddress, commit)
+  let data = new Uint8Array(0)
+  if (inLength !== BIGINT_0) {
+    data = runState.memory.read(Number(inOffset), Number(inLength), true)
+  }
 
-      const keccakFunction = runState.interpreter._evm.common.customCrypto.keccak256 ?? keccak256
-      const msgHash = keccakFunction(message)
+  const gasLimit = runState.messageGasLimit!
+  runState.messageGasLimit = undefined
 
-      let recover
-      const ecrecoverFunction = runState.interpreter._evm.common.customCrypto.ecrecover ?? ecrecover
-      try {
-        recover = ecrecoverFunction(msgHash, yParity + BIGINT_27, r, s)
-      } catch (e) {
-        // Malformed signature, push 0 on stack, clear auth variable
-        runState.stack.push(BIGINT_0)
-        runState.auth = undefined
-        return
-      }
+  const ret = await runState.interpreter.callDelegate(gasLimit, toAddress, value, data)
+  // Write return data to memory
+  writeCallOutput(runState, outOffset, outLength)
+  runState.stack.push(ret)
+}
 
-      const addressBuffer = publicToAddress(recover)
-      const address = new Address(addressBuffer)
-      runState.auth = address
+// 0xf6: AUTH
+handlers[0xf6] = async function (runState) {
+  // eslint-disable-next-line prefer-const
+  let [authority, memOffset, memLength] = runState.stack.popN(3)
 
-      if (!expectedAddress.equals(address)) {
-        // expected address does not equal the recovered address, clear auth variable
-        runState.stack.push(BIGINT_0)
-        runState.auth = undefined
-        return
-      }
+  if (memLength > BigInt(97)) {
+    memLength = BigInt(97)
+  }
 
-      runState.auth = address
+  let mem = runState.memory.read(Number(memOffset), Number(memLength))
+  if (mem.length < 97) {
+    mem = setLengthRight(mem, 97)
+  }
+
+  const yParity = BigInt(mem[0])
+  const r = mem.subarray(1, 33)
+  const s = mem.subarray(33, 65)
+  const commit = mem.subarray(65, 97)
+
+  if (bytesToBigInt(s) > SECP256K1_ORDER_DIV_2) {
+    runState.stack.push(BIGINT_0)
+    runState.auth = undefined
+    return
+  }
+  if (yParity > BIGINT_1) {
+    runState.stack.push(BIGINT_0)
+    runState.auth = undefined
+    return
+  }
+
+  // we don't want strick check here on authority being in address range just last 20 bytes
+  const expectedAddress = new Address(bigIntToAddressBytes(authority, false))
+  const account = (await runState.stateManager.getAccount(expectedAddress)) ?? new Account()
+
+  if (account.isContract()) {
+    // EXTCODESIZE > 0
+    runState.stack.push(BIGINT_0)
+    runState.auth = undefined
+    return
+  }
+
+  const accountNonce = account.nonce
+
+  const invokedAddress = setLengthLeft(runState.interpreter._env.address.bytes, 32)
+  const chainId = setLengthLeft(bigIntToBytes(runState.interpreter.getChainId()), 32)
+  const nonce = setLengthLeft(bigIntToBytes(accountNonce), 32)
+  const message = concatBytes(EIP3074MAGIC, chainId, nonce, invokedAddress, commit)
+
+  const keccakFunction = runState.interpreter._evm.common.customCrypto.keccak256 ?? keccak256
+  const msgHash = keccakFunction(message)
+
+  let recover
+  const ecrecoverFunction = runState.interpreter._evm.common.customCrypto.ecrecover ?? ecrecover
+  try {
+    recover = ecrecoverFunction(msgHash, yParity + BIGINT_27, r, s)
+  } catch (e) {
+    // Malformed signature push 0 on stack clear auth variable
+    runState.stack.push(BIGINT_0)
+    runState.auth = undefined
+    return
+  }
+
+  const addressBuffer = publicToAddress(recover)
+  const address = new Address(addressBuffer)
+  runState.auth = address
+
+  if (!expectedAddress.equals(address)) {
+    // expected address does not equal the recovered address clear auth variable
+    runState.stack.push(BIGINT_0)
+    runState.auth = undefined
+    return
+  }
+
+  runState.auth = address
+  runState.stack.push(BIGINT_1)
+}
+
+// 0xf7: AUTHCALL (3074) / RETURNDATALOAD (7069)
+handlers[0xf7] = async function (runState, common) {
+  if (common.isActivatedEIP(3074) && runState.env.eof === undefined) {
+    // AUTHCALL logic
+    const [_currentGasLimit, addr, value, argsOffset, argsLength, retOffset, retLength] =
+      runState.stack.popN(7)
+
+    const toAddress = new Address(addresstoBytes(addr))
+
+    const gasLimit = runState.messageGasLimit!
+    runState.messageGasLimit = undefined
+
+    let data = new Uint8Array(0)
+    if (argsLength !== BIGINT_0) {
+      data = runState.memory.read(Number(argsOffset), Number(argsLength))
+    }
+
+    const ret = await runState.interpreter.authcall(gasLimit, toAddress, value, data)
+    // Write return data to memory
+    writeCallOutput(runState, retOffset, retLength)
+    runState.stack.push(ret)
+  } else if (common.isActivatedEIP(7069)) {
+    // RETURNDATALOAD logic
+    const returnDataOffset = runState.stack.pop()
+    const data = getDataSlice(runState.interpreter.getReturnData(), returnDataOffset, BIGINT_32)
+    runState.stack.push(bytesToBigInt(data))
+  } else {
+    // This should be unreachable
+    trap(ERROR.INVALID_OPCODE)
+  }
+}
+
+// 0xf8: EXTCALL
+handlers[0xf8] = async function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  } else {
+    const [toAddr, inOffset, inLength, value] = runState.stack.popN(4)
+
+    const gasLimit = runState.messageGasLimit!
+    runState.messageGasLimit = undefined
+
+    if (gasLimit === -BIGINT_1) {
+      // Special case abort doing any logic (this logic is defined in `gas.ts`) and put `1` on stack per spec
       runState.stack.push(BIGINT_1)
-    },
-  ],
-  // 0xf7: AUTHCALL (3074) / RETURNDATALOAD (7069)
-  [
-    0xf7,
-    async function (runState, common) {
-      if (common.isActivatedEIP(3074) && runState.env.eof === undefined) {
-        // AUTHCALL logic
-        const [_currentGasLimit, addr, value, argsOffset, argsLength, retOffset, retLength] =
-          runState.stack.popN(7)
+      runState.returnBytes = new Uint8Array(0)
+      return
+    }
 
-        const toAddress = new Address(addresstoBytes(addr))
+    const toAddress = new Address(addresstoBytes(toAddr))
 
-        const gasLimit = runState.messageGasLimit!
-        runState.messageGasLimit = undefined
+    let data = new Uint8Array(0)
+    if (inLength !== BIGINT_0) {
+      data = runState.memory.read(Number(inOffset), Number(inLength), true)
+    }
 
-        let data = new Uint8Array(0)
-        if (argsLength !== BIGINT_0) {
-          data = runState.memory.read(Number(argsOffset), Number(argsLength))
-        }
+    const ret = await runState.interpreter.call(gasLimit, toAddress, value, data)
+    // Write return data to memory
 
-        const ret = await runState.interpreter.authcall(gasLimit, toAddress, value, data)
-        // Write return data to memory
-        writeCallOutput(runState, retOffset, retLength)
-        runState.stack.push(ret)
-      } else if (common.isActivatedEIP(7069)) {
-        // RETURNDATALOAD logic
-        const returnDataOffset = runState.stack.pop()
-        const data = getDataSlice(runState.interpreter.getReturnData(), returnDataOffset, BIGINT_32)
-        runState.stack.push(bytesToBigInt(data))
-      } else {
-        // This should be unreachable
-        trap(ERROR.INVALID_OPCODE)
-      }
-    },
-  ],
-  // 0xf8: EXTCALL
-  [
-    0xf8,
-    async function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      } else {
-        const [toAddr, inOffset, inLength, value] = runState.stack.popN(4)
+    runState.stack.push(ret)
+  }
+}
 
-        const gasLimit = runState.messageGasLimit!
-        runState.messageGasLimit = undefined
+// 0xf9: EXTDELEGATECALL
+handlers[0xf9] = async function (runState) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  } else {
+    const value = runState.interpreter.getCallValue()
+    const [toAddr, inOffset, inLength] = runState.stack.popN(3)
 
-        if (gasLimit === -BIGINT_1) {
-          // Special case, abort doing any logic (this logic is defined in `gas.ts`), and put `1` on stack per spec
-          runState.stack.push(BIGINT_1)
-          runState.returnBytes = new Uint8Array(0)
-          return
-        }
+    const gasLimit = runState.messageGasLimit!
+    runState.messageGasLimit = undefined
 
-        const toAddress = new Address(addresstoBytes(toAddr))
+    if (gasLimit === -BIGINT_1) {
+      // Special case abort doing any logic (this logic is defined in `gas.ts`) and put `1` on stack per spec
+      runState.stack.push(BIGINT_1)
+      runState.returnBytes = new Uint8Array(0)
+      return
+    }
 
-        let data = new Uint8Array(0)
-        if (inLength !== BIGINT_0) {
-          data = runState.memory.read(Number(inOffset), Number(inLength), true)
-        }
+    const toAddress = new Address(addresstoBytes(toAddr))
 
-        const ret = await runState.interpreter.call(gasLimit, toAddress, value, data)
-        // Write return data to memory
+    const code = await runState.stateManager.getContractCode(toAddress)
 
-        runState.stack.push(ret)
-      }
-    },
-  ],
-  // 0xf9: EXTDELEGATECALL
-  [
-    0xf9,
-    async function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      } else {
-        const value = runState.interpreter.getCallValue()
-        const [toAddr, inOffset, inLength] = runState.stack.popN(3)
+    if (!isEOF(code)) {
+      // EXTDELEGATECALL cannot call legacy contracts
+      runState.stack.push(BIGINT_1)
+      return
+    }
 
-        const gasLimit = runState.messageGasLimit!
-        runState.messageGasLimit = undefined
+    let data = new Uint8Array(0)
+    if (inLength !== BIGINT_0) {
+      data = runState.memory.read(Number(inOffset), Number(inLength), true)
+    }
 
-        if (gasLimit === -BIGINT_1) {
-          // Special case, abort doing any logic (this logic is defined in `gas.ts`), and put `1` on stack per spec
-          runState.stack.push(BIGINT_1)
-          runState.returnBytes = new Uint8Array(0)
-          return
-        }
+    const ret = await runState.interpreter.callDelegate(gasLimit, toAddress, value, data)
+    runState.stack.push(ret)
+  }
+}
 
-        const toAddress = new Address(addresstoBytes(toAddr))
+// 0xfa: STATICCALL
+handlers[0xfa] = async function (runState) {
+  const value = BIGINT_0
+  const [_currentGasLimit, toAddr, inOffset, inLength, outOffset, outLength] =
+    runState.stack.popN(6)
+  const toAddress = new Address(addresstoBytes(toAddr))
 
-        const code = await runState.stateManager.getContractCode(toAddress)
+  const gasLimit = runState.messageGasLimit!
+  runState.messageGasLimit = undefined
 
-        if (!isEOF(code)) {
-          // EXTDELEGATECALL cannot call legacy contracts
-          runState.stack.push(BIGINT_1)
-          return
-        }
+  let data = new Uint8Array(0)
+  if (inLength !== BIGINT_0) {
+    data = runState.memory.read(Number(inOffset), Number(inLength), true)
+  }
 
-        let data = new Uint8Array(0)
-        if (inLength !== BIGINT_0) {
-          data = runState.memory.read(Number(inOffset), Number(inLength), true)
-        }
+  const ret = await runState.interpreter.callStatic(gasLimit, toAddress, value, data)
+  // Write return data to memory
+  writeCallOutput(runState, outOffset, outLength)
+  runState.stack.push(ret)
+}
 
-        const ret = await runState.interpreter.callDelegate(gasLimit, toAddress, value, data)
-        runState.stack.push(ret)
-      }
-    },
-  ],
-  // 0xfa: STATICCALL
-  [
-    0xfa,
-    async function (runState) {
-      const value = BIGINT_0
-      const [_currentGasLimit, toAddr, inOffset, inLength, outOffset, outLength] =
-        runState.stack.popN(6)
-      const toAddress = new Address(addresstoBytes(toAddr))
+// 0xfb: EXTSTATICCALL
+handlers[0xfb] = async function (runState, _common) {
+  if (runState.env.eof === undefined) {
+    // Opcode not available in legacy contracts
+    trap(ERROR.INVALID_OPCODE)
+  } else {
+    const value = BIGINT_0
+    const [toAddr, inOffset, inLength] = runState.stack.popN(3)
 
-      const gasLimit = runState.messageGasLimit!
-      runState.messageGasLimit = undefined
+    const gasLimit = runState.messageGasLimit!
+    runState.messageGasLimit = undefined
 
-      let data = new Uint8Array(0)
-      if (inLength !== BIGINT_0) {
-        data = runState.memory.read(Number(inOffset), Number(inLength), true)
-      }
+    if (gasLimit === -BIGINT_1) {
+      // Special case abort doing any logic (this logic is defined in `gas.ts`) and put `1` on stack per spec
+      runState.stack.push(BIGINT_1)
+      runState.returnBytes = new Uint8Array(0)
+      return
+    }
 
-      const ret = await runState.interpreter.callStatic(gasLimit, toAddress, value, data)
-      // Write return data to memory
-      writeCallOutput(runState, outOffset, outLength)
-      runState.stack.push(ret)
-    },
-  ],
-  // 0xfb: EXTSTATICCALL
-  [
-    0xfb,
-    async function (runState, _common) {
-      if (runState.env.eof === undefined) {
-        // Opcode not available in legacy contracts
-        trap(ERROR.INVALID_OPCODE)
-      } else {
-        const value = BIGINT_0
-        const [toAddr, inOffset, inLength] = runState.stack.popN(3)
+    const toAddress = new Address(addresstoBytes(toAddr))
 
-        const gasLimit = runState.messageGasLimit!
-        runState.messageGasLimit = undefined
+    let data = new Uint8Array(0)
+    if (inLength !== BIGINT_0) {
+      data = runState.memory.read(Number(inOffset), Number(inLength), true)
+    }
 
-        if (gasLimit === -BIGINT_1) {
-          // Special case, abort doing any logic (this logic is defined in `gas.ts`), and put `1` on stack per spec
-          runState.stack.push(BIGINT_1)
-          runState.returnBytes = new Uint8Array(0)
-          return
-        }
+    const ret = await runState.interpreter.callStatic(gasLimit, toAddress, value, data)
+    runState.stack.push(ret)
+  }
+}
 
-        const toAddress = new Address(addresstoBytes(toAddr))
+// 0xf3: RETURN
+handlers[0xf3] = function (runState) {
+  const [offset, length] = runState.stack.popN(2)
+  let returnData = new Uint8Array(0)
+  if (length !== BIGINT_0) {
+    returnData = runState.memory.read(Number(offset), Number(length))
+  }
+  runState.interpreter.finish(returnData)
+}
 
-        let data = new Uint8Array(0)
-        if (inLength !== BIGINT_0) {
-          data = runState.memory.read(Number(inOffset), Number(inLength), true)
-        }
+// 0xfd: REVERT
+handlers[0xfd] = function (runState) {
+  const [offset, length] = runState.stack.popN(2)
+  let returnData = new Uint8Array(0)
+  if (length !== BIGINT_0) {
+    returnData = runState.memory.read(Number(offset), Number(length))
+  }
+  runState.interpreter.revert(returnData)
+}
 
-        const ret = await runState.interpreter.callStatic(gasLimit, toAddress, value, data)
-        runState.stack.push(ret)
-      }
-    },
-  ],
-  // 0xf3: RETURN
-  [
-    0xf3,
-    function (runState) {
-      const [offset, length] = runState.stack.popN(2)
-      let returnData = new Uint8Array(0)
-      if (length !== BIGINT_0) {
-        returnData = runState.memory.read(Number(offset), Number(length))
-      }
-      runState.interpreter.finish(returnData)
-    },
-  ],
-  // 0xfd: REVERT
-  [
-    0xfd,
-    function (runState) {
-      const [offset, length] = runState.stack.popN(2)
-      let returnData = new Uint8Array(0)
-      if (length !== BIGINT_0) {
-        returnData = runState.memory.read(Number(offset), Number(length))
-      }
-      runState.interpreter.revert(returnData)
-    },
-  ],
-  // '0x70', range - other
-  // 0xff: SELFDESTRUCT
-  [
-    0xff,
-    async function (runState) {
-      const selfdestructToAddressBigInt = runState.stack.pop()
-      const selfdestructToAddress = new Address(addresstoBytes(selfdestructToAddressBigInt))
-      return runState.interpreter.selfDestruct(selfdestructToAddress)
-    },
-  ],
-])
+// '0x70' range - other
+// 0xff: SELFDESTRUCT
+handlers[0xff] = async function (runState) {
+  const selfdestructToAddressBigInt = runState.stack.pop()
+  const selfdestructToAddress = new Address(addresstoBytes(selfdestructToAddressBigInt))
+  return runState.interpreter.selfDestruct(selfdestructToAddress)
+}
 
-// Fill in rest of PUSHn, DUPn, SWAPn, LOGn for handlers
-const pushFn = handlers.get(0x60)!
+// Fill in rest of PUSHn DUPn SWAPn LOGn for handlers
+const pushFn = handlers[0x60]
 for (let i = 0x61; i <= 0x7f; i++) {
-  handlers.set(i, pushFn)
+  handlers[i] = pushFn
 }
-const dupFn = handlers.get(0x80)!
+const dupFn = handlers[0x80]
 for (let i = 0x81; i <= 0x8f; i++) {
-  handlers.set(i, dupFn)
+  handlers[i] = dupFn
 }
-const swapFn = handlers.get(0x90)!
+const swapFn = handlers[0x90]
 for (let i = 0x91; i <= 0x9f; i++) {
-  handlers.set(i, swapFn)
+  handlers[i] = swapFn
 }
-const logFn = handlers.get(0xa0)!
+const logFn = handlers[0xa0]
 for (let i = 0xa1; i <= 0xa4; i++) {
-  handlers.set(i, logFn)
+  handlers[i] = logFn
 }

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -55,441 +55,388 @@ export interface SyncDynamicGasHandler {
   (runState: RunState, gas: bigint, common: Common): bigint
 }
 
-export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynamicGasHandler> =
-  new Map<number, AsyncDynamicGasHandler>([
-    [
-      /* EXP */
-      0x0a,
-      async function (runState, gas, common): Promise<bigint> {
-        const [_base, exponent] = runState.stack.peek(2)
-        if (exponent === BIGINT_0) {
-          return gas
-        }
-        let byteLength = exponent.toString(2).length / 8
-        if (byteLength > Math.trunc(byteLength)) {
-          byteLength = Math.trunc(byteLength) + 1
-        }
-        if (byteLength < 1 || byteLength > 32) {
-          trap(ERROR.OUT_OF_RANGE)
-        }
-        const expPricePerByte = common.param('gasPrices', 'expByte')
-        gas += BigInt(byteLength) * expPricePerByte
-        return gas
-      },
-    ],
-    [
-      /* KECCAK256 */
-      0x20,
-      async function (runState, gas, common): Promise<bigint> {
-        const [offset, length] = runState.stack.peek(2)
-        gas += subMemUsage(runState, offset, length, common)
-        gas += common.param('gasPrices', 'keccak256Word') * divCeil(length, BIGINT_32)
-        return gas
-      },
-    ],
-    [
-      /* BALANCE */
-      0x31,
-      async function (runState, gas, common): Promise<bigint> {
-        const address = addresstoBytes(runState.stack.peek()[0])
-        let charge2929Gas = true
-        if (common.isActivatedEIP(6800)) {
-          const balanceAddress = new Address(address)
-          const coldAccessGas = runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-            balanceAddress,
-            0,
-            VERKLE_BALANCE_LEAF_KEY
-          )
+export type GasHandler = AsyncDynamicGasHandler | SyncDynamicGasHandler
 
-          gas += coldAccessGas
-          charge2929Gas = coldAccessGas === BIGINT_0
-        }
+export const dynamicGasHandlers: GasHandler[] = []
 
-        if (common.isActivatedEIP(2929)) {
-          gas += accessAddressEIP2929(runState, address, common, charge2929Gas)
-        }
+/* EXP */
+dynamicGasHandlers[0x0a] = async function (runState, gas, common): Promise<bigint> {
+  const [_base, exponent] = runState.stack.peek(2)
+  if (exponent === BIGINT_0) {
+    return gas
+  }
+  let byteLength = exponent.toString(2).length / 8
+  if (byteLength > Math.trunc(byteLength)) {
+    byteLength = Math.trunc(byteLength) + 1
+  }
+  if (byteLength < 1 || byteLength > 32) {
+    trap(ERROR.OUT_OF_RANGE)
+  }
+  const expPricePerByte = common.param('gasPrices', 'expByte')
+  gas += BigInt(byteLength) * expPricePerByte
+  return gas
+}
+/* KECCAK256 */
+dynamicGasHandlers[0x20] = async function (runState, gas, common): Promise<bigint> {
+  const [offset, length] = runState.stack.peek(2)
+  gas += subMemUsage(runState, offset, length, common)
+  gas += common.param('gasPrices', 'keccak256Word') * divCeil(length, BIGINT_32)
+  return gas
+}
+/* BALANCE */
+dynamicGasHandlers[0x31] = async function (runState, gas, common): Promise<bigint> {
+  const address = addresstoBytes(runState.stack.peek()[0])
+  let charge2929Gas = true
+  if (common.isActivatedEIP(6800)) {
+    const balanceAddress = new Address(address)
+    const coldAccessGas = runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
+      balanceAddress,
+      0,
+      VERKLE_BALANCE_LEAF_KEY
+    )
 
-        return gas
-      },
-    ],
-    [
-      /* CALLDATACOPY */
-      0x37,
-      async function (runState, gas, common): Promise<bigint> {
-        const [memOffset, _dataOffset, dataLength] = runState.stack.peek(3)
+    gas += coldAccessGas
+    charge2929Gas = coldAccessGas === BIGINT_0
+  }
 
-        gas += subMemUsage(runState, memOffset, dataLength, common)
-        if (dataLength !== BIGINT_0) {
-          gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BIGINT_32)
-        }
-        return gas
-      },
-    ],
-    [
-      /* CODECOPY */
-      0x39,
-      async function (runState, gas, common): Promise<bigint> {
-        const [memOffset, _codeOffset, dataLength] = runState.stack.peek(3)
+  if (common.isActivatedEIP(2929)) {
+    gas += accessAddressEIP2929(runState, address, common, charge2929Gas)
+  }
 
-        gas += subMemUsage(runState, memOffset, dataLength, common)
-        if (dataLength !== BIGINT_0) {
-          gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BIGINT_32)
+  return gas
+}
+/* CALLDATACOPY */
+dynamicGasHandlers[0x37] = async function (runState, gas, common): Promise<bigint> {
+  const [memOffset, _dataOffset, dataLength] = runState.stack.peek(3)
 
-          if (common.isActivatedEIP(6800) && runState.env.chargeCodeAccesses === true) {
-            const contract = runState.interpreter.getAddress()
-            let codeEnd = _codeOffset + dataLength
-            const codeSize = runState.interpreter.getCodeSize()
-            if (codeEnd > codeSize) {
-              codeEnd = codeSize
-            }
+  gas += subMemUsage(runState, memOffset, dataLength, common)
+  if (dataLength !== BIGINT_0) {
+    gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BIGINT_32)
+  }
+  return gas
+}
+/* CODECOPY */
+dynamicGasHandlers[0x39] = async function (runState, gas, common): Promise<bigint> {
+  const [memOffset, _codeOffset, dataLength] = runState.stack.peek(3)
 
-            gas += runState.env.accessWitness!.touchCodeChunksRangeOnReadAndChargeGas(
-              contract,
-              Number(_codeOffset),
-              Number(codeEnd)
-            )
-          }
-        }
-        return gas
-      },
-    ],
-    [
-      /* EXTCODESIZE */
-      0x3b,
-      async function (runState, gas, common): Promise<bigint> {
-        const addressBytes = addresstoBytes(runState.stack.peek()[0])
-        const address = new Address(addressBytes)
+  gas += subMemUsage(runState, memOffset, dataLength, common)
+  if (dataLength !== BIGINT_0) {
+    gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BIGINT_32)
 
-        let charge2929Gas = true
-        if (
-          common.isActivatedEIP(6800) &&
-          runState.interpreter._evm.getPrecompile(address) === undefined
-        ) {
-          let coldAccessGas = BIGINT_0
-          coldAccessGas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-            address,
-            0,
-            VERKLE_VERSION_LEAF_KEY
-          )
-          coldAccessGas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-            address,
-            0,
-            VERKLE_CODE_SIZE_LEAF_KEY
-          )
+    if (common.isActivatedEIP(6800) && runState.env.chargeCodeAccesses === true) {
+      const contract = runState.interpreter.getAddress()
+      let codeEnd = _codeOffset + dataLength
+      const codeSize = runState.interpreter.getCodeSize()
+      if (codeEnd > codeSize) {
+        codeEnd = codeSize
+      }
 
-          gas += coldAccessGas
-          // if cold access gas has been charged 2929 gas shouldn't be charged
-          charge2929Gas = coldAccessGas === BIGINT_0
-        }
+      gas += runState.env.accessWitness!.touchCodeChunksRangeOnReadAndChargeGas(
+        contract,
+        Number(_codeOffset),
+        Number(codeEnd)
+      )
+    }
+  }
+  return gas
+}
+/* EXTCODESIZE */
+dynamicGasHandlers[0x3b] = async function (runState, gas, common): Promise<bigint> {
+  const addressBytes = addresstoBytes(runState.stack.peek()[0])
+  const address = new Address(addressBytes)
 
-        if (common.isActivatedEIP(2929)) {
-          gas += accessAddressEIP2929(runState, addressBytes, common, charge2929Gas)
-        }
+  let charge2929Gas = true
+  if (
+    common.isActivatedEIP(6800) &&
+    runState.interpreter._evm.getPrecompile(address) === undefined
+  ) {
+    let coldAccessGas = BIGINT_0
+    coldAccessGas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
+      address,
+      0,
+      VERKLE_VERSION_LEAF_KEY
+    )
+    coldAccessGas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
+      address,
+      0,
+      VERKLE_CODE_SIZE_LEAF_KEY
+    )
 
-        return gas
-      },
-    ],
-    [
-      /* EXTCODECOPY */
-      0x3c,
-      async function (runState, gas, common): Promise<bigint> {
-        const [addressBigInt, memOffset, _codeOffset, dataLength] = runState.stack.peek(4)
-        const addressBytes = addresstoBytes(addressBigInt)
-        const address = new Address(addressBytes)
+    gas += coldAccessGas
+    // if cold access gas has been charged 2929 gas shouldn't be charged
+    charge2929Gas = coldAccessGas === BIGINT_0
+  }
 
-        gas += subMemUsage(runState, memOffset, dataLength, common)
+  if (common.isActivatedEIP(2929)) {
+    gas += accessAddressEIP2929(runState, addressBytes, common, charge2929Gas)
+  }
 
-        let charge2929Gas = true
-        if (
-          common.isActivatedEIP(6800) &&
-          runState.interpreter._evm.getPrecompile(address) === undefined
-        ) {
-          let coldAccessGas = BIGINT_0
-          coldAccessGas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-            address,
-            0,
-            VERKLE_VERSION_LEAF_KEY
-          )
-          coldAccessGas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-            address,
-            0,
-            VERKLE_CODE_SIZE_LEAF_KEY
-          )
+  return gas
+}
+/* EXTCODECOPY */
+dynamicGasHandlers[0x3c] = async function (runState, gas, common): Promise<bigint> {
+  const [addressBigInt, memOffset, _codeOffset, dataLength] = runState.stack.peek(4)
+  const addressBytes = addresstoBytes(addressBigInt)
+  const address = new Address(addressBytes)
 
-          gas += coldAccessGas
-          // if cold access gas has been charged 2929 gas shouldn't be charged
-          charge2929Gas = coldAccessGas === BIGINT_0
-        }
+  gas += subMemUsage(runState, memOffset, dataLength, common)
 
-        if (common.isActivatedEIP(2929)) {
-          gas += accessAddressEIP2929(runState, addressBytes, common, charge2929Gas)
-        }
+  let charge2929Gas = true
+  if (
+    common.isActivatedEIP(6800) &&
+    runState.interpreter._evm.getPrecompile(address) === undefined
+  ) {
+    let coldAccessGas = BIGINT_0
+    coldAccessGas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
+      address,
+      0,
+      VERKLE_VERSION_LEAF_KEY
+    )
+    coldAccessGas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
+      address,
+      0,
+      VERKLE_CODE_SIZE_LEAF_KEY
+    )
 
-        if (dataLength !== BIGINT_0) {
-          gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BIGINT_32)
+    gas += coldAccessGas
+    // if cold access gas has been charged 2929 gas shouldn't be charged
+    charge2929Gas = coldAccessGas === BIGINT_0
+  }
 
-          if (common.isActivatedEIP(6800)) {
-            let codeEnd = _codeOffset + dataLength
-            const codeSize = BigInt((await runState.stateManager.getContractCode(address)).length)
-            if (codeEnd > codeSize) {
-              codeEnd = codeSize
-            }
+  if (common.isActivatedEIP(2929)) {
+    gas += accessAddressEIP2929(runState, addressBytes, common, charge2929Gas)
+  }
 
-            gas += runState.env.accessWitness!.touchCodeChunksRangeOnReadAndChargeGas(
-              address,
-              Number(_codeOffset),
-              Number(codeEnd)
-            )
-          }
-        }
-        return gas
-      },
-    ],
-    [
-      /* RETURNDATACOPY */
-      0x3e,
-      async function (runState, gas, common): Promise<bigint> {
-        const [memOffset, returnDataOffset, dataLength] = runState.stack.peek(3)
+  if (dataLength !== BIGINT_0) {
+    gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BIGINT_32)
 
-        if (returnDataOffset + dataLength > runState.interpreter.getReturnDataSize()) {
-          // For an EOF contract, the behavior is changed (see EIP 7069)
-          // RETURNDATACOPY in that case does not throw OOG when reading out-of-bounds
-          if (runState.env.eof === undefined) {
-            trap(ERROR.OUT_OF_GAS)
-          }
-        }
+    if (common.isActivatedEIP(6800)) {
+      let codeEnd = _codeOffset + dataLength
+      const codeSize = BigInt((await runState.stateManager.getContractCode(address)).length)
+      if (codeEnd > codeSize) {
+        codeEnd = codeSize
+      }
 
-        gas += subMemUsage(runState, memOffset, dataLength, common)
+      gas += runState.env.accessWitness!.touchCodeChunksRangeOnReadAndChargeGas(
+        address,
+        Number(_codeOffset),
+        Number(codeEnd)
+      )
+    }
+  }
+  return gas
+}
+/* RETURNDATACOPY */
+dynamicGasHandlers[0x3e] = async function (runState, gas, common): Promise<bigint> {
+  const [memOffset, returnDataOffset, dataLength] = runState.stack.peek(3)
 
-        if (dataLength !== BIGINT_0) {
-          gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BIGINT_32)
-        }
-        return gas
-      },
-    ],
-    [
-      /* EXTCODEHASH */
-      0x3f,
-      async function (runState, gas, common): Promise<bigint> {
-        const address = addresstoBytes(runState.stack.peek()[0])
-        let charge2929Gas = true
+  if (returnDataOffset + dataLength > runState.interpreter.getReturnDataSize()) {
+    // For an EOF contract, the behavior is changed (see EIP 7069)
+    // RETURNDATACOPY in that case does not throw OOG when reading out-of-bounds
+    if (runState.env.eof === undefined) {
+      trap(ERROR.OUT_OF_GAS)
+    }
+  }
 
-        if (common.isActivatedEIP(6800)) {
-          const codeAddress = new Address(address)
+  gas += subMemUsage(runState, memOffset, dataLength, common)
 
-          let coldAccessGas = BIGINT_0
-          coldAccessGas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-            codeAddress,
-            0,
-            VERKLE_CODE_HASH_LEAF_KEY
-          )
+  if (dataLength !== BIGINT_0) {
+    gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BIGINT_32)
+  }
+  return gas
+}
+/* EXTCODEHASH */
+dynamicGasHandlers[0x3f] = async function (runState, gas, common): Promise<bigint> {
+  const address = addresstoBytes(runState.stack.peek()[0])
+  let charge2929Gas = true
 
-          gas += coldAccessGas
-          charge2929Gas = coldAccessGas === BIGINT_0
-        }
+  if (common.isActivatedEIP(6800)) {
+    const codeAddress = new Address(address)
 
-        if (common.isActivatedEIP(2929)) {
-          gas += accessAddressEIP2929(runState, address, common, charge2929Gas)
-        }
+    let coldAccessGas = BIGINT_0
+    coldAccessGas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
+      codeAddress,
+      0,
+      VERKLE_CODE_HASH_LEAF_KEY
+    )
 
-        return gas
-      },
-    ],
-    [
-      /* MLOAD */
-      0x51,
-      async function (runState, gas, common): Promise<bigint> {
-        const pos = runState.stack.peek()[0]
-        gas += subMemUsage(runState, pos, BIGINT_32, common)
-        return gas
-      },
-    ],
-    [
-      /* MSTORE */
-      0x52,
-      async function (runState, gas, common): Promise<bigint> {
-        const offset = runState.stack.peek()[0]
-        gas += subMemUsage(runState, offset, BIGINT_32, common)
-        return gas
-      },
-    ],
-    [
-      /* MSTORE8 */
-      0x53,
-      async function (runState, gas, common): Promise<bigint> {
-        const offset = runState.stack.peek()[0]
-        gas += subMemUsage(runState, offset, BIGINT_1, common)
-        return gas
-      },
-    ],
-    [
-      /* SLOAD */
-      0x54,
-      async function (runState, gas, common): Promise<bigint> {
-        const key = runState.stack.peek()[0]
-        const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
+    gas += coldAccessGas
+    charge2929Gas = coldAccessGas === BIGINT_0
+  }
 
-        let charge2929Gas = true
-        if (common.isActivatedEIP(6800)) {
-          const address = runState.interpreter.getAddress()
-          const { treeIndex, subIndex } = getVerkleTreeIndexesForStorageSlot(key)
-          const coldAccessGas = runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-            address,
-            treeIndex,
-            subIndex
-          )
+  if (common.isActivatedEIP(2929)) {
+    gas += accessAddressEIP2929(runState, address, common, charge2929Gas)
+  }
 
-          gas += coldAccessGas
-          charge2929Gas = coldAccessGas === BIGINT_0
-        }
+  return gas
+}
+/* MLOAD */
+dynamicGasHandlers[0x51] = async function (runState, gas, common): Promise<bigint> {
+  const pos = runState.stack.peek()[0]
+  gas += subMemUsage(runState, pos, BIGINT_32, common)
+  return gas
+}
+/* MSTORE */
+dynamicGasHandlers[0x52] = async function (runState, gas, common): Promise<bigint> {
+  const offset = runState.stack.peek()[0]
+  gas += subMemUsage(runState, offset, BIGINT_32, common)
+  return gas
+}
+/* MSTORE8 */
+dynamicGasHandlers[0x53] = async function (runState, gas, common): Promise<bigint> {
+  const offset = runState.stack.peek()[0]
+  gas += subMemUsage(runState, offset, BIGINT_1, common)
+  return gas
+}
+/* SLOAD */
+dynamicGasHandlers[0x54] = async function (runState, gas, common): Promise<bigint> {
+  const key = runState.stack.peek()[0]
+  const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
 
-        if (common.isActivatedEIP(2929)) {
-          gas += accessStorageEIP2929(runState, keyBuf, false, common, charge2929Gas)
-        }
+  let charge2929Gas = true
+  if (common.isActivatedEIP(6800)) {
+    const address = runState.interpreter.getAddress()
+    const { treeIndex, subIndex } = getVerkleTreeIndexesForStorageSlot(key)
+    const coldAccessGas = runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
+      address,
+      treeIndex,
+      subIndex
+    )
 
-        return gas
-      },
-    ],
-    [
-      /* SSTORE */
-      0x55,
-      async function (runState, gas, common): Promise<bigint> {
-        if (runState.interpreter.isStatic()) {
-          trap(ERROR.STATIC_STATE_CHANGE)
-        }
-        const [key, val] = runState.stack.peek(2)
+    gas += coldAccessGas
+    charge2929Gas = coldAccessGas === BIGINT_0
+  }
 
-        const keyBytes = setLengthLeft(bigIntToBytes(key), 32)
-        // NOTE: this should be the shortest representation
-        let value
-        if (val === BIGINT_0) {
-          value = Uint8Array.from([])
-        } else {
-          value = bigIntToBytes(val)
-        }
+  if (common.isActivatedEIP(2929)) {
+    gas += accessStorageEIP2929(runState, keyBuf, false, common, charge2929Gas)
+  }
 
-        const currentStorage = setLengthLeftStorage(
-          await runState.interpreter.storageLoad(keyBytes)
-        )
-        const originalStorage = setLengthLeftStorage(
-          await runState.interpreter.storageLoad(keyBytes, true)
-        )
-        if (common.hardfork() === Hardfork.Constantinople) {
-          gas += updateSstoreGasEIP1283(
-            runState,
-            currentStorage,
-            originalStorage,
-            setLengthLeftStorage(value),
-            common
-          )
-        } else if (common.gteHardfork(Hardfork.Istanbul)) {
-          if (!common.isActivatedEIP(6800)) {
-            gas += updateSstoreGasEIP2200(
-              runState,
-              currentStorage,
-              originalStorage,
-              setLengthLeftStorage(value),
-              keyBytes,
-              common
-            )
-          }
-        } else {
-          gas += updateSstoreGas(runState, currentStorage, setLengthLeftStorage(value), common)
-        }
+  return gas
+}
+/* SSTORE */
+dynamicGasHandlers[0x55] = async function (runState, gas, common): Promise<bigint> {
+  if (runState.interpreter.isStatic()) {
+    trap(ERROR.STATIC_STATE_CHANGE)
+  }
+  const [key, val] = runState.stack.peek(2)
 
-        let charge2929Gas = true
-        if (common.isActivatedEIP(6800)) {
-          const contract = runState.interpreter.getAddress()
-          const { treeIndex, subIndex } = getVerkleTreeIndexesForStorageSlot(key)
-          const coldAccessGas = runState.env.accessWitness!.touchAddressOnWriteAndComputeGas(
-            contract,
-            treeIndex,
-            subIndex
-          )
+  const keyBytes = setLengthLeft(bigIntToBytes(key), 32)
+  // NOTE: this should be the shortest representation
+  let value
+  if (val === BIGINT_0) {
+    value = Uint8Array.from([])
+  } else {
+    value = bigIntToBytes(val)
+  }
 
-          gas += coldAccessGas
-          charge2929Gas = coldAccessGas === BIGINT_0
-        }
+  const currentStorage = setLengthLeftStorage(await runState.interpreter.storageLoad(keyBytes))
+  const originalStorage = setLengthLeftStorage(
+    await runState.interpreter.storageLoad(keyBytes, true)
+  )
+  if (common.hardfork() === Hardfork.Constantinople) {
+    gas += updateSstoreGasEIP1283(
+      runState,
+      currentStorage,
+      originalStorage,
+      setLengthLeftStorage(value),
+      common
+    )
+  } else if (common.gteHardfork(Hardfork.Istanbul)) {
+    if (!common.isActivatedEIP(6800)) {
+      gas += updateSstoreGasEIP2200(
+        runState,
+        currentStorage,
+        originalStorage,
+        setLengthLeftStorage(value),
+        keyBytes,
+        common
+      )
+    }
+  } else {
+    gas += updateSstoreGas(runState, currentStorage, setLengthLeftStorage(value), common)
+  }
 
-        if (common.isActivatedEIP(2929)) {
-          // We have to do this after the Istanbul (EIP2200) checks.
-          // Otherwise, we might run out of gas, due to "sentry check" of 2300 gas,
-          // if we deduct extra gas first.
-          gas += accessStorageEIP2929(runState, keyBytes, true, common, charge2929Gas)
-        }
+  let charge2929Gas = true
+  if (common.isActivatedEIP(6800)) {
+    const contract = runState.interpreter.getAddress()
+    const { treeIndex, subIndex } = getVerkleTreeIndexesForStorageSlot(key)
+    const coldAccessGas = runState.env.accessWitness!.touchAddressOnWriteAndComputeGas(
+      contract,
+      treeIndex,
+      subIndex
+    )
 
-        return gas
-      },
-    ],
-    [
-      /* MCOPY */
-      0x5e,
-      async function (runState, gas, common): Promise<bigint> {
-        const [dst, src, length] = runState.stack.peek(3)
-        const wordsCopied = (length + BIGINT_31) / BIGINT_32
-        gas += BIGINT_3 * wordsCopied
-        gas += subMemUsage(runState, src, length, common)
-        gas += subMemUsage(runState, dst, length, common)
-        return gas
-      },
-    ],
-    [
-      /* LOG */
-      0xa0,
-      async function (runState, gas, common): Promise<bigint> {
-        if (runState.interpreter.isStatic()) {
-          trap(ERROR.STATIC_STATE_CHANGE)
-        }
+    gas += coldAccessGas
+    charge2929Gas = coldAccessGas === BIGINT_0
+  }
 
-        const [memOffset, memLength] = runState.stack.peek(2)
+  if (common.isActivatedEIP(2929)) {
+    // We have to do this after the Istanbul (EIP2200) checks.
+    // Otherwise, we might run out of gas, due to "sentry check" of 2300 gas,
+    // if we deduct extra gas first.
+    gas += accessStorageEIP2929(runState, keyBytes, true, common, charge2929Gas)
+  }
 
-        const topicsCount = runState.opCode - 0xa0
+  return gas
+}
+/* MCOPY */
+dynamicGasHandlers[0x5e] = async function (runState, gas, common): Promise<bigint> {
+  const [dst, src, length] = runState.stack.peek(3)
+  const wordsCopied = (length + BIGINT_31) / BIGINT_32
+  gas += BIGINT_3 * wordsCopied
+  gas += subMemUsage(runState, src, length, common)
+  gas += subMemUsage(runState, dst, length, common)
+  return gas
+}
+/* LOG */
+dynamicGasHandlers[0xa0] = async function (runState, gas, common): Promise<bigint> {
+  if (runState.interpreter.isStatic()) {
+    trap(ERROR.STATIC_STATE_CHANGE)
+  }
 
-        if (topicsCount < 0 || topicsCount > 4) {
-          trap(ERROR.OUT_OF_RANGE)
-        }
+  const [memOffset, memLength] = runState.stack.peek(2)
 
-        gas += subMemUsage(runState, memOffset, memLength, common)
-        gas +=
-          common.param('gasPrices', 'logTopic') * BigInt(topicsCount) +
-          memLength * common.param('gasPrices', 'logData')
-        return gas
-      },
-    ],
-    /* DATACOPY */
-    [
-      0xd3,
-      async function (runState, gas, common) {
-        const [memOffset, _dataOffset, dataLength] = runState.stack.peek(3)
+  const topicsCount = runState.opCode - 0xa0
 
-        gas += subMemUsage(runState, memOffset, dataLength, common)
-        if (dataLength !== BIGINT_0) {
-          gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BIGINT_32)
-        }
-        return gas
-      },
-    ],
-    /* EOFCREATE */
-    [
-      0xec,
-      async function (runState, gas, common): Promise<bigint> {
-        // Note: TX_CREATE_COST is in the base fee (this is 32000 and same as CREATE / CREATE2)
+  if (topicsCount < 0 || topicsCount > 4) {
+    trap(ERROR.OUT_OF_RANGE)
+  }
 
-        // Note: in `gas.ts` programCounter is not yet incremented (which it is in `functions.ts`)
-        // So have to manually add to programCounter here to get the right container index
+  gas += subMemUsage(runState, memOffset, memLength, common)
+  gas +=
+    common.param('gasPrices', 'logTopic') * BigInt(topicsCount) +
+    memLength * common.param('gasPrices', 'logData')
+  return gas
+}
+/* DATACOPY */
+dynamicGasHandlers[0xd3] = async function (runState, gas, common) {
+  const [memOffset, _dataOffset, dataLength] = runState.stack.peek(3)
 
-        // Read container index
-        const containerIndex = runState.env.code[runState.programCounter + 1]
+  gas += subMemUsage(runState, memOffset, dataLength, common)
+  if (dataLength !== BIGINT_0) {
+    gas += common.param('gasPrices', 'copy') * divCeil(dataLength, BIGINT_32)
+  }
+  return gas
+}
+/* EOFCREATE */
+dynamicGasHandlers[0xec] = async function (runState, gas, common): Promise<bigint> {
+  // Note: TX_CREATE_COST is in the base fee (this is 32000 and same as CREATE / CREATE2)
 
-        // Pop stack values
-        const [_value, _salt, inputOffset, inputSize] = runState.stack.peek(4)
+  // Note: in `gas.ts` programCounter is not yet incremented (which it is in `functions.ts`)
+  // So have to manually add to programCounter here to get the right container index
 
-        //if (common.isActivatedEIP(2929)) {
-        // TODO: adding or not adding this makes test
-        // --test=tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py::test_eofcreate_then_call[fork_CancunEIP7692-blockchain_test]
-        // still succeed. This only warms the current address?? This is also in CREATE/CREATE2
-        // Can this be removed in both?
-        /*gas += accessAddressEIP2929(
+  // Read container index
+  const containerIndex = runState.env.code[runState.programCounter + 1]
+
+  // Pop stack values
+  const [_value, _salt, inputOffset, inputSize] = runState.stack.peek(4)
+
+  //if (common.isActivatedEIP(2929)) {
+  // TODO: adding or not adding this makes test
+  // --test=tests/prague/eip7692_eof_v1/eip7620_eof_create/test_eofcreate.py::test_eofcreate_then_call[fork_CancunEIP7692-blockchain_test]
+  // still succeed. This only warms the current address?? This is also in CREATE/CREATE2
+  // Can this be removed in both?
+  /*gas += accessAddressEIP2929(
             runState,
             runState.interpreter.getAddress().bytes,
             common,
@@ -497,670 +444,598 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           )
         }*/
 
-        // Expand memory
-        gas += subMemUsage(runState, inputOffset, inputSize, common)
-
-        // Read container
-        const container = runState.env.eof!.container.body.containerSections[containerIndex]
-
-        // Charge for hashing cost
-        gas +=
-          common.param('gasPrices', 'keccak256Word') * divCeil(BigInt(container.length), BIGINT_32)
-
-        const gasLeft = runState.interpreter.getGasLeft() - gas
-        runState.messageGasLimit = maxCallGas(gasLeft, gasLeft, runState, common)
-
-        return gas
-      },
-    ],
-    /* RETURNCONTRACT */
-    [
-      0xee,
-      async function (runState, gas, common): Promise<bigint> {
-        // Pop stack values
-        const [auxDataOffset, auxDataSize] = runState.stack.peek(2)
-
-        // Expand memory
-        gas += subMemUsage(runState, auxDataOffset, auxDataSize, common)
-
-        return gas
-      },
-    ],
-    [
-      /* CREATE */
-      0xf0,
-      async function (runState, gas, common): Promise<bigint> {
-        if (runState.interpreter.isStatic()) {
-          trap(ERROR.STATIC_STATE_CHANGE)
-        }
-        const [_value, offset, length] = runState.stack.peek(3)
-
-        if (common.isActivatedEIP(2929)) {
-          gas += accessAddressEIP2929(
-            runState,
-            runState.interpreter.getAddress().bytes,
-            common,
-            false
-          )
-        }
-
-        if (common.isActivatedEIP(3860)) {
-          gas += ((length + BIGINT_31) / BIGINT_32) * common.param('gasPrices', 'initCodeWordCost')
-        }
-
-        gas += subMemUsage(runState, offset, length, common)
-
-        let gasLimit = BigInt(runState.interpreter.getGasLeft()) - gas
-        gasLimit = maxCallGas(gasLimit, gasLimit, runState, common)
-
-        runState.messageGasLimit = gasLimit
-        return gas
-      },
-    ],
-    [
-      /* CALL */
-      0xf1,
-      async function (runState, gas, common): Promise<bigint> {
-        const [currentGasLimit, toAddr, value, inOffset, inLength, outOffset, outLength] =
-          runState.stack.peek(7)
-        const toAddress = new Address(addresstoBytes(toAddr))
-
-        if (runState.interpreter.isStatic() && value !== BIGINT_0) {
-          trap(ERROR.STATIC_STATE_CHANGE)
-        }
-        gas += subMemUsage(runState, inOffset, inLength, common)
-        gas += subMemUsage(runState, outOffset, outLength, common)
-
-        let charge2929Gas = true
-        if (
-          common.isActivatedEIP(6800) &&
-          runState.interpreter._evm.getPrecompile(toAddress) === undefined
-        ) {
-          // TODO: add check if toAddress is not a precompile
-          const coldAccessGas = runState.env.accessWitness!.touchAndChargeMessageCall(toAddress)
-          if (value !== BIGINT_0) {
-            const contractAddress = runState.interpreter.getAddress()
-            gas += runState.env.accessWitness!.touchAndChargeValueTransfer(
-              contractAddress,
-              toAddress
-            )
-          }
-
-          gas += coldAccessGas
-          charge2929Gas = coldAccessGas === BIGINT_0
-        }
-
-        if (common.isActivatedEIP(2929)) {
-          gas += accessAddressEIP2929(runState, toAddress.bytes, common, charge2929Gas)
-        }
-
-        if (value !== BIGINT_0 && !common.isActivatedEIP(6800)) {
-          gas += common.param('gasPrices', 'callValueTransfer')
-        }
-
-        if (common.gteHardfork(Hardfork.SpuriousDragon)) {
-          // We are at or after Spurious Dragon
-          // Call new account gas: account is DEAD and we transfer nonzero value
-
-          const account = await runState.stateManager.getAccount(toAddress)
-          let deadAccount = false
-          if (account === undefined || account.isEmpty()) {
-            deadAccount = true
-          }
-
-          if (deadAccount && !(value === BIGINT_0)) {
-            gas += common.param('gasPrices', 'callNewAccount')
-          }
-        } else if ((await runState.stateManager.getAccount(toAddress)) === undefined) {
-          // We are before Spurious Dragon and the account does not exist.
-          // Call new account gas: account does not exist (it is not in the state trie, not even as an "empty" account)
-          gas += common.param('gasPrices', 'callNewAccount')
-        }
-
-        const gasLimit = maxCallGas(
-          currentGasLimit,
-          runState.interpreter.getGasLeft() - gas,
-          runState,
-          common
-        )
-        // note that TangerineWhistle or later this cannot happen
-        // (it could have ran out of gas prior to getting here though)
-        if (gasLimit > runState.interpreter.getGasLeft() - gas) {
-          trap(ERROR.OUT_OF_GAS)
-        }
-
-        if (gas > runState.interpreter.getGasLeft()) {
-          trap(ERROR.OUT_OF_GAS)
-        }
-
-        runState.messageGasLimit = gasLimit
-        return gas
-      },
-    ],
-    [
-      /* CALLCODE */
-      0xf2,
-      async function (runState, gas, common): Promise<bigint> {
-        const [currentGasLimit, toAddr, value, inOffset, inLength, outOffset, outLength] =
-          runState.stack.peek(7)
-        const toAddress = new Address(addresstoBytes(toAddr))
-
-        gas += subMemUsage(runState, inOffset, inLength, common)
-        gas += subMemUsage(runState, outOffset, outLength, common)
-
-        let charge2929Gas = true
-        if (
-          common.isActivatedEIP(6800) &&
-          runState.interpreter._evm.getPrecompile(toAddress) === undefined
-        ) {
-          const coldAccessGas = runState.env.accessWitness!.touchAndChargeMessageCall(toAddress)
-
-          gas += coldAccessGas
-          charge2929Gas = coldAccessGas === BIGINT_0
-        }
-
-        if (common.isActivatedEIP(2929)) {
-          gas += accessAddressEIP2929(runState, addresstoBytes(toAddr), common, charge2929Gas)
-        }
-
-        if (value !== BIGINT_0) {
-          gas += common.param('gasPrices', 'callValueTransfer')
-        }
-
-        const gasLimit = maxCallGas(
-          currentGasLimit,
-          runState.interpreter.getGasLeft() - gas,
-          runState,
-          common
-        )
-        // note that TangerineWhistle or later this cannot happen
-        // (it could have ran out of gas prior to getting here though)
-        if (gasLimit > runState.interpreter.getGasLeft() - gas) {
-          trap(ERROR.OUT_OF_GAS)
-        }
-
-        runState.messageGasLimit = gasLimit
-        return gas
-      },
-    ],
-    [
-      /* RETURN */
-      0xf3,
-      async function (runState, gas, common): Promise<bigint> {
-        const [offset, length] = runState.stack.peek(2)
-        gas += subMemUsage(runState, offset, length, common)
-        return gas
-      },
-    ],
-    [
-      /* DELEGATECALL */
-      0xf4,
-      async function (runState, gas, common): Promise<bigint> {
-        const [currentGasLimit, toAddr, inOffset, inLength, outOffset, outLength] =
-          runState.stack.peek(6)
-        const toAddress = new Address(addresstoBytes(toAddr))
-
-        gas += subMemUsage(runState, inOffset, inLength, common)
-        gas += subMemUsage(runState, outOffset, outLength, common)
-
-        let charge2929Gas = true
-        if (
-          common.isActivatedEIP(6800) &&
-          runState.interpreter._evm.getPrecompile(toAddress) === undefined
-        ) {
-          // TODO: add check if toAddress is not a precompile
-          const coldAccessGas = runState.env.accessWitness!.touchAndChargeMessageCall(toAddress)
-
-          gas += coldAccessGas
-          charge2929Gas = coldAccessGas === BIGINT_0
-        }
-
-        if (common.isActivatedEIP(2929)) {
-          gas += accessAddressEIP2929(runState, addresstoBytes(toAddr), common, charge2929Gas)
-        }
-
-        const gasLimit = maxCallGas(
-          currentGasLimit,
-          runState.interpreter.getGasLeft() - gas,
-          runState,
-          common
-        )
-        // note that TangerineWhistle or later this cannot happen
-        // (it could have ran out of gas prior to getting here though)
-        if (gasLimit > runState.interpreter.getGasLeft() - gas) {
-          trap(ERROR.OUT_OF_GAS)
-        }
-
-        runState.messageGasLimit = gasLimit
-        return gas
-      },
-    ],
-    [
-      /* CREATE2 */
-      0xf5,
-      async function (runState, gas, common): Promise<bigint> {
-        if (runState.interpreter.isStatic()) {
-          trap(ERROR.STATIC_STATE_CHANGE)
-        }
-
-        const [_value, offset, length, _salt] = runState.stack.peek(4)
-
-        gas += subMemUsage(runState, offset, length, common)
-
-        if (common.isActivatedEIP(2929)) {
-          gas += accessAddressEIP2929(
-            runState,
-            runState.interpreter.getAddress().bytes,
-            common,
-            false
-          )
-        }
-
-        if (common.isActivatedEIP(3860)) {
-          gas += ((length + BIGINT_31) / BIGINT_32) * common.param('gasPrices', 'initCodeWordCost')
-        }
-
-        gas += common.param('gasPrices', 'keccak256Word') * divCeil(length, BIGINT_32)
-        let gasLimit = runState.interpreter.getGasLeft() - gas
-        gasLimit = maxCallGas(gasLimit, gasLimit, runState, common) // CREATE2 is only available after TangerineWhistle (Constantinople introduced this opcode)
-        runState.messageGasLimit = gasLimit
-        return gas
-      },
-    ],
-    [
-      /* AUTH */
-      0xf6,
-      async function (runState, gas, common): Promise<bigint> {
-        const [address, memOffset, memLength] = runState.stack.peek(3)
-        // Note: 2929 is always active if AUTH can be reached,
-        // since it needs London as minimum hardfork
-        gas += accessAddressEIP2929(runState, bigIntToBytes(address), common)
-        gas += subMemUsage(runState, memOffset, memLength, common)
-        return gas
-      },
-    ],
-    [
-      /* AUTHCALL */
-      0xf7,
-      async function (runState, gas, common): Promise<bigint> {
-        if (runState.auth === undefined) {
-          trap(ERROR.AUTHCALL_UNSET)
-        }
-
-        const [currentGasLimit, addr, value, argsOffset, argsLength, retOffset, retLength] =
-          runState.stack.peek(7)
-
-        const toAddress = new Address(addresstoBytes(addr))
-
-        gas += common.param('gasPrices', 'warmstorageread')
-
-        gas += accessAddressEIP2929(runState, toAddress.bytes, common, true, true)
-
-        gas += subMemUsage(runState, argsOffset, argsLength, common)
-        gas += subMemUsage(runState, retOffset, retLength, common)
-
-        if (value > BIGINT_0) {
-          gas += common.param('gasPrices', 'authcallValueTransfer')
-          const account = await runState.stateManager.getAccount(toAddress)
-          if (!account) {
-            gas += common.param('gasPrices', 'callNewAccount')
-          }
-        }
-
-        let gasLimit = maxCallGas(
-          runState.interpreter.getGasLeft() - gas,
-          runState.interpreter.getGasLeft() - gas,
-          runState,
-          common
-        )
-        if (currentGasLimit !== BIGINT_0) {
-          if (currentGasLimit > gasLimit) {
-            trap(ERROR.OUT_OF_GAS)
-          }
-          gasLimit = currentGasLimit
-        }
-
-        runState.messageGasLimit = gasLimit
-
-        if (value > BIGINT_0) {
-          const account = (await runState.stateManager.getAccount(runState.auth!)) ?? new Account()
-          if (account.balance < value) {
-            trap(ERROR.OUT_OF_GAS)
-          }
-          account.balance -= value
-
-          const toAddr = new Address(addresstoBytes(addr))
-          const target = (await runState.stateManager.getAccount(toAddr)) ?? new Account()
-          target.balance += value
-
-          await runState.stateManager.putAccount(toAddr, target)
-        }
-
-        return gas
-      },
-    ],
-    /* EXTCALL */
-    [
-      0xf8,
-      async function (runState, gas, common): Promise<bigint> {
-        // Charge WARM_STORAGE_READ_COST (100) -> done in accessAddressEIP2929
-
-        // Peek stack values
-        const [toAddr, inOffset, inLength, value] = runState.stack.peek(4)
-
-        // If value is nonzero and in static mode, throw:
-        if (runState.interpreter.isStatic() && value !== BIGINT_0) {
-          trap(ERROR.STATIC_STATE_CHANGE)
-        }
-
-        // If value > 0, charge CALL_VALUE_COST
-        if (value > BIGINT_0) {
-          gas += common.param('gasPrices', 'callValueTransfer')
-        }
-
-        // Check if the target address > 20 bytes
-        if (toAddr > EXTCALL_TARGET_MAX) {
-          trap(EOFError.InvalidExtcallTarget)
-        }
-
-        // Charge for memory expansion
-        gas += subMemUsage(runState, inOffset, inLength, common)
-
-        const toAddress = new Address(addresstoBytes(toAddr))
-        // Charge to make address warm (2600 gas)
-        // (in case if address is already warm, this charges the 100 gas)
-        gas += accessAddressEIP2929(runState, toAddress.bytes, common)
-
-        // Charge account creation cost if value is nonzero
-        if (value > BIGINT_0) {
-          const account = await runState.stateManager.getAccount(toAddress)
-          const deadAccount = account === undefined || account.isEmpty()
-
-          if (deadAccount) {
-            gas += common.param('gasPrices', 'callNewAccount')
-          }
-        }
-
-        const minRetainedGas = common.param('gasPrices', 'minRetainedGas')
-        const minCalleeGas = common.param('gasPrices', 'minCalleeGas')
-
-        const currentGasAvailable = runState.interpreter.getGasLeft() - gas
-        const reducedGas = currentGasAvailable / BIGINT_64
-        // Calculate the gas limit for the callee
-        // (this is the gas available for the next call frame)
-        let gasLimit: bigint
-        if (reducedGas < minRetainedGas) {
-          gasLimit = currentGasAvailable - minRetainedGas
-        } else {
-          gasLimit = currentGasAvailable - reducedGas
-        }
-
-        if (
-          runState.env.depth >= Number(common.param('vm', 'stackLimit')) ||
-          runState.env.contract.balance < value ||
-          gasLimit < minCalleeGas
-        ) {
-          // Note: this is a hack, TODO: get around this hack and clean this up
-          // This special case will ensure that the actual EXT*CALL is being ran,
-          // But, the code in `function.ts` will note that `runState.messageGasLimit` is set to a negative number
-          // This special number signals that `1` should be put on the stack (per spec)
-          gasLimit = -BIGINT_1
-        }
-
-        runState.messageGasLimit = gasLimit
-
-        return gas
-      },
-    ],
-    /* EXTDELEGATECALL */
-    [
-      0xf9,
-      async function (runState, gas, common): Promise<bigint> {
-        // Charge WARM_STORAGE_READ_COST (100) -> done in accessAddressEIP2929
-
-        // Peek stack values
-        const [toAddr, inOffset, inLength] = runState.stack.peek(3)
-
-        // Check if the target address > 20 bytes
-        if (toAddr > EXTCALL_TARGET_MAX) {
-          trap(EOFError.InvalidExtcallTarget)
-        }
-
-        // Charge for memory expansion
-        gas += subMemUsage(runState, inOffset, inLength, common)
-
-        const toAddress = new Address(addresstoBytes(toAddr))
-        // Charge to make address warm (2600 gas)
-        // (in case if address is already warm, this charges the 100 gas)
-        gas += accessAddressEIP2929(runState, toAddress.bytes, common)
-
-        const minRetainedGas = common.param('gasPrices', 'minRetainedGas')
-        const minCalleeGas = common.param('gasPrices', 'minCalleeGas')
-
-        const currentGasAvailable = runState.interpreter.getGasLeft() - gas
-        const reducedGas = currentGasAvailable / BIGINT_64
-        // Calculate the gas limit for the callee
-        // (this is the gas available for the next call frame)
-        let gasLimit: bigint
-        if (reducedGas < minRetainedGas) {
-          gasLimit = currentGasAvailable - minRetainedGas
-        } else {
-          gasLimit = currentGasAvailable - reducedGas
-        }
-
-        if (
-          runState.env.depth >= Number(common.param('vm', 'stackLimit')) ||
-          gasLimit < minCalleeGas
-        ) {
-          // Note: this is a hack, TODO: get around this hack and clean this up
-          // This special case will ensure that the actual EXT*CALL is being ran,
-          // But, the code in `function.ts` will note that `runState.messageGasLimit` is set to a negative number
-          // This special number signals that `1` should be put on the stack (per spec)
-          gasLimit = -BIGINT_1
-        }
-
-        runState.messageGasLimit = gasLimit
-
-        return gas
-      },
-    ],
-    [
-      /* STATICCALL */
-      0xfa,
-      async function (runState, gas, common): Promise<bigint> {
-        const [currentGasLimit, toAddr, inOffset, inLength, outOffset, outLength] =
-          runState.stack.peek(6)
-
-        gas += subMemUsage(runState, inOffset, inLength, common)
-        gas += subMemUsage(runState, outOffset, outLength, common)
-
-        let charge2929Gas = true
-        if (common.isActivatedEIP(6800)) {
-          const toAddress = new Address(addresstoBytes(toAddr))
-          // TODO: add check if toAddress is not a precompile
-          const coldAccessGas = runState.env.accessWitness!.touchAndChargeMessageCall(toAddress)
-
-          gas += coldAccessGas
-          charge2929Gas = coldAccessGas === BIGINT_0
-        }
-
-        if (common.isActivatedEIP(2929)) {
-          gas += accessAddressEIP2929(runState, addresstoBytes(toAddr), common, charge2929Gas)
-        }
-
-        const gasLimit = maxCallGas(
-          currentGasLimit,
-          runState.interpreter.getGasLeft() - gas,
-          runState,
-          common
-        ) // we set TangerineWhistle or later to true here, as STATICCALL was available from Byzantium (which is after TangerineWhistle)
-
-        runState.messageGasLimit = gasLimit
-        return gas
-      },
-    ],
-    /* EXTSTATICCALL */
-    [
-      0xfb,
-      async function (runState, gas, common): Promise<bigint> {
-        // Charge WARM_STORAGE_READ_COST (100) -> done in accessAddressEIP2929
-
-        // Peek stack values
-        const [toAddr, inOffset, inLength] = runState.stack.peek(3)
-
-        // Check if the target address > 20 bytes
-        if (toAddr > EXTCALL_TARGET_MAX) {
-          trap(EOFError.InvalidExtcallTarget)
-        }
-
-        // Charge for memory expansion
-        gas += subMemUsage(runState, inOffset, inLength, common)
-
-        const toAddress = new Address(addresstoBytes(toAddr))
-        // Charge to make address warm (2600 gas)
-        // (in case if address is already warm, this charges the 100 gas)
-        gas += accessAddressEIP2929(runState, toAddress.bytes, common)
-
-        const minRetainedGas = common.param('gasPrices', 'minRetainedGas')
-        const minCalleeGas = common.param('gasPrices', 'minCalleeGas')
-
-        const currentGasAvailable = runState.interpreter.getGasLeft() - gas
-        const reducedGas = currentGasAvailable / BIGINT_64
-        // Calculate the gas limit for the callee
-        // (this is the gas available for the next call frame)
-        let gasLimit: bigint
-        if (reducedGas < minRetainedGas) {
-          gasLimit = currentGasAvailable - minRetainedGas
-        } else {
-          gasLimit = currentGasAvailable - reducedGas
-        }
-
-        if (
-          runState.env.depth >= Number(common.param('vm', 'stackLimit')) ||
-          gasLimit < minCalleeGas
-        ) {
-          // Note: this is a hack, TODO: get around this hack and clean this up
-          // This special case will ensure that the actual EXT*CALL is being ran,
-          // But, the code in `function.ts` will note that `runState.messageGasLimit` is set to a negative number
-          // This special number signals that `1` should be put on the stack (per spec)
-          gasLimit = -BIGINT_1
-        }
-
-        runState.messageGasLimit = gasLimit
-
-        return gas
-      },
-    ],
-    [
-      /* REVERT */
-      0xfd,
-      async function (runState, gas, common): Promise<bigint> {
-        const [offset, length] = runState.stack.peek(2)
-        gas += subMemUsage(runState, offset, length, common)
-        return gas
-      },
-    ],
-    [
-      /* SELFDESTRUCT */
-      0xff,
-      async function (runState, gas, common): Promise<bigint> {
-        if (runState.interpreter.isStatic()) {
-          trap(ERROR.STATIC_STATE_CHANGE)
-        }
-        const selfdestructToaddressBigInt = runState.stack.peek()[0]
-
-        const selfdestructToAddress = new Address(addresstoBytes(selfdestructToaddressBigInt))
-        const contractAddress = runState.interpreter.getAddress()
-
-        let deductGas = false
-        const balance = await runState.interpreter.getExternalBalance(contractAddress)
-
-        if (common.gteHardfork(Hardfork.SpuriousDragon)) {
-          // EIP-161: State Trie Clearing
-          if (balance > BIGINT_0) {
-            // This technically checks if account is empty or non-existent
-            const account = await runState.stateManager.getAccount(selfdestructToAddress)
-            if (account === undefined || account.isEmpty()) {
-              deductGas = true
-            }
-          }
-        } else if (common.gteHardfork(Hardfork.TangerineWhistle)) {
-          // EIP-150 (Tangerine Whistle) gas semantics
-          const exists =
-            (await runState.stateManager.getAccount(selfdestructToAddress)) !== undefined
-          if (!exists) {
-            deductGas = true
-          }
-        }
-        if (deductGas) {
-          gas += common.param('gasPrices', 'callNewAccount')
-        }
-
-        let selfDestructToCharge2929Gas = true
-        if (common.isActivatedEIP(6800)) {
-          // read accesses for version and code size
-          if (runState.interpreter._evm.getPrecompile(contractAddress) === undefined) {
-            gas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-              contractAddress,
-              0,
-              VERKLE_VERSION_LEAF_KEY
-            )
-            gas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-              contractAddress,
-              0,
-              VERKLE_CODE_SIZE_LEAF_KEY
-            )
-          }
-
-          gas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-            contractAddress,
-            0,
-            VERKLE_BALANCE_LEAF_KEY
-          )
-          if (balance > BIGINT_0) {
-            gas += runState.env.accessWitness!.touchAddressOnWriteAndComputeGas(
-              contractAddress,
-              0,
-              VERKLE_BALANCE_LEAF_KEY
-            )
-          }
-
-          let selfDestructToColdAccessGas =
-            runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-              selfdestructToAddress,
-              0,
-              VERKLE_BALANCE_LEAF_KEY
-            )
-          if (balance > BIGINT_0) {
-            selfDestructToColdAccessGas +=
-              runState.env.accessWitness!.touchAddressOnWriteAndComputeGas(
-                selfdestructToAddress,
-                0,
-                VERKLE_BALANCE_LEAF_KEY
-              )
-          }
-
-          gas += selfDestructToColdAccessGas
-          selfDestructToCharge2929Gas = selfDestructToColdAccessGas === BIGINT_0
-        }
-
-        if (common.isActivatedEIP(2929)) {
-          gas += accessAddressEIP2929(
-            runState,
-            selfdestructToAddress.bytes,
-            common,
-            selfDestructToCharge2929Gas,
-            true
-          )
-        }
-
-        return gas
-      },
-    ],
-  ])
+  // Expand memory
+  gas += subMemUsage(runState, inputOffset, inputSize, common)
+
+  // Read container
+  const container = runState.env.eof!.container.body.containerSections[containerIndex]
+
+  // Charge for hashing cost
+  gas += common.param('gasPrices', 'keccak256Word') * divCeil(BigInt(container.length), BIGINT_32)
+
+  const gasLeft = runState.interpreter.getGasLeft() - gas
+  runState.messageGasLimit = maxCallGas(gasLeft, gasLeft, runState, common)
+
+  return gas
+}
+/* RETURNCONTRACT */
+dynamicGasHandlers[0xee] = async function (runState, gas, common): Promise<bigint> {
+  // Pop stack values
+  const [auxDataOffset, auxDataSize] = runState.stack.peek(2)
+
+  // Expand memory
+  gas += subMemUsage(runState, auxDataOffset, auxDataSize, common)
+
+  return gas
+}
+/* CREATE */
+dynamicGasHandlers[0xf0] = async function (runState, gas, common): Promise<bigint> {
+  if (runState.interpreter.isStatic()) {
+    trap(ERROR.STATIC_STATE_CHANGE)
+  }
+  const [_value, offset, length] = runState.stack.peek(3)
+
+  if (common.isActivatedEIP(2929)) {
+    gas += accessAddressEIP2929(runState, runState.interpreter.getAddress().bytes, common, false)
+  }
+
+  if (common.isActivatedEIP(3860)) {
+    gas += ((length + BIGINT_31) / BIGINT_32) * common.param('gasPrices', 'initCodeWordCost')
+  }
+
+  gas += subMemUsage(runState, offset, length, common)
+
+  let gasLimit = BigInt(runState.interpreter.getGasLeft()) - gas
+  gasLimit = maxCallGas(gasLimit, gasLimit, runState, common)
+
+  runState.messageGasLimit = gasLimit
+  return gas
+}
+/* CALL */
+dynamicGasHandlers[0xf1] = async function (runState, gas, common): Promise<bigint> {
+  const [currentGasLimit, toAddr, value, inOffset, inLength, outOffset, outLength] =
+    runState.stack.peek(7)
+  const toAddress = new Address(addresstoBytes(toAddr))
+
+  if (runState.interpreter.isStatic() && value !== BIGINT_0) {
+    trap(ERROR.STATIC_STATE_CHANGE)
+  }
+  gas += subMemUsage(runState, inOffset, inLength, common)
+  gas += subMemUsage(runState, outOffset, outLength, common)
+
+  let charge2929Gas = true
+  if (
+    common.isActivatedEIP(6800) &&
+    runState.interpreter._evm.getPrecompile(toAddress) === undefined
+  ) {
+    // TODO: add check if toAddress is not a precompile
+    const coldAccessGas = runState.env.accessWitness!.touchAndChargeMessageCall(toAddress)
+    if (value !== BIGINT_0) {
+      const contractAddress = runState.interpreter.getAddress()
+      gas += runState.env.accessWitness!.touchAndChargeValueTransfer(contractAddress, toAddress)
+    }
+
+    gas += coldAccessGas
+    charge2929Gas = coldAccessGas === BIGINT_0
+  }
+
+  if (common.isActivatedEIP(2929)) {
+    gas += accessAddressEIP2929(runState, toAddress.bytes, common, charge2929Gas)
+  }
+
+  if (value !== BIGINT_0 && !common.isActivatedEIP(6800)) {
+    gas += common.param('gasPrices', 'callValueTransfer')
+  }
+
+  if (common.gteHardfork(Hardfork.SpuriousDragon)) {
+    // We are at or after Spurious Dragon
+    // Call new account gas: account is DEAD and we transfer nonzero value
+
+    const account = await runState.stateManager.getAccount(toAddress)
+    let deadAccount = false
+    if (account === undefined || account.isEmpty()) {
+      deadAccount = true
+    }
+
+    if (deadAccount && !(value === BIGINT_0)) {
+      gas += common.param('gasPrices', 'callNewAccount')
+    }
+  } else if ((await runState.stateManager.getAccount(toAddress)) === undefined) {
+    // We are before Spurious Dragon and the account does not exist.
+    // Call new account gas: account does not exist (it is not in the state trie, not even as an "empty" account)
+    gas += common.param('gasPrices', 'callNewAccount')
+  }
+
+  const gasLimit = maxCallGas(
+    currentGasLimit,
+    runState.interpreter.getGasLeft() - gas,
+    runState,
+    common
+  )
+  // note that TangerineWhistle or later this cannot happen
+  // (it could have ran out of gas prior to getting here though)
+  if (gasLimit > runState.interpreter.getGasLeft() - gas) {
+    trap(ERROR.OUT_OF_GAS)
+  }
+
+  if (gas > runState.interpreter.getGasLeft()) {
+    trap(ERROR.OUT_OF_GAS)
+  }
+
+  runState.messageGasLimit = gasLimit
+  return gas
+}
+/* CALLCODE */
+dynamicGasHandlers[0xf2] = async function (runState, gas, common): Promise<bigint> {
+  const [currentGasLimit, toAddr, value, inOffset, inLength, outOffset, outLength] =
+    runState.stack.peek(7)
+  const toAddress = new Address(addresstoBytes(toAddr))
+
+  gas += subMemUsage(runState, inOffset, inLength, common)
+  gas += subMemUsage(runState, outOffset, outLength, common)
+
+  let charge2929Gas = true
+  if (
+    common.isActivatedEIP(6800) &&
+    runState.interpreter._evm.getPrecompile(toAddress) === undefined
+  ) {
+    const coldAccessGas = runState.env.accessWitness!.touchAndChargeMessageCall(toAddress)
+
+    gas += coldAccessGas
+    charge2929Gas = coldAccessGas === BIGINT_0
+  }
+
+  if (common.isActivatedEIP(2929)) {
+    gas += accessAddressEIP2929(runState, addresstoBytes(toAddr), common, charge2929Gas)
+  }
+
+  if (value !== BIGINT_0) {
+    gas += common.param('gasPrices', 'callValueTransfer')
+  }
+
+  const gasLimit = maxCallGas(
+    currentGasLimit,
+    runState.interpreter.getGasLeft() - gas,
+    runState,
+    common
+  )
+  // note that TangerineWhistle or later this cannot happen
+  // (it could have ran out of gas prior to getting here though)
+  if (gasLimit > runState.interpreter.getGasLeft() - gas) {
+    trap(ERROR.OUT_OF_GAS)
+  }
+
+  runState.messageGasLimit = gasLimit
+  return gas
+}
+/* RETURN */
+dynamicGasHandlers[0xf3] = async function (runState, gas, common): Promise<bigint> {
+  const [offset, length] = runState.stack.peek(2)
+  gas += subMemUsage(runState, offset, length, common)
+  return gas
+}
+/* DELEGATECALL */
+dynamicGasHandlers[0xf4] = async function (runState, gas, common): Promise<bigint> {
+  const [currentGasLimit, toAddr, inOffset, inLength, outOffset, outLength] = runState.stack.peek(6)
+  const toAddress = new Address(addresstoBytes(toAddr))
+
+  gas += subMemUsage(runState, inOffset, inLength, common)
+  gas += subMemUsage(runState, outOffset, outLength, common)
+
+  let charge2929Gas = true
+  if (
+    common.isActivatedEIP(6800) &&
+    runState.interpreter._evm.getPrecompile(toAddress) === undefined
+  ) {
+    // TODO: add check if toAddress is not a precompile
+    const coldAccessGas = runState.env.accessWitness!.touchAndChargeMessageCall(toAddress)
+
+    gas += coldAccessGas
+    charge2929Gas = coldAccessGas === BIGINT_0
+  }
+
+  if (common.isActivatedEIP(2929)) {
+    gas += accessAddressEIP2929(runState, addresstoBytes(toAddr), common, charge2929Gas)
+  }
+
+  const gasLimit = maxCallGas(
+    currentGasLimit,
+    runState.interpreter.getGasLeft() - gas,
+    runState,
+    common
+  )
+  // note that TangerineWhistle or later this cannot happen
+  // (it could have ran out of gas prior to getting here though)
+  if (gasLimit > runState.interpreter.getGasLeft() - gas) {
+    trap(ERROR.OUT_OF_GAS)
+  }
+
+  runState.messageGasLimit = gasLimit
+  return gas
+}
+/* CREATE2 */
+dynamicGasHandlers[0xf5] = async function (runState, gas, common): Promise<bigint> {
+  if (runState.interpreter.isStatic()) {
+    trap(ERROR.STATIC_STATE_CHANGE)
+  }
+
+  const [_value, offset, length, _salt] = runState.stack.peek(4)
+
+  gas += subMemUsage(runState, offset, length, common)
+
+  if (common.isActivatedEIP(2929)) {
+    gas += accessAddressEIP2929(runState, runState.interpreter.getAddress().bytes, common, false)
+  }
+
+  if (common.isActivatedEIP(3860)) {
+    gas += ((length + BIGINT_31) / BIGINT_32) * common.param('gasPrices', 'initCodeWordCost')
+  }
+
+  gas += common.param('gasPrices', 'keccak256Word') * divCeil(length, BIGINT_32)
+  let gasLimit = runState.interpreter.getGasLeft() - gas
+  gasLimit = maxCallGas(gasLimit, gasLimit, runState, common) // CREATE2 is only available after TangerineWhistle (Constantinople introduced this opcode)
+  runState.messageGasLimit = gasLimit
+  return gas
+}
+/* AUTH */
+dynamicGasHandlers[0xf6] = async function (runState, gas, common): Promise<bigint> {
+  const [address, memOffset, memLength] = runState.stack.peek(3)
+  // Note: 2929 is always active if AUTH can be reached,
+  // since it needs London as minimum hardfork
+  gas += accessAddressEIP2929(runState, bigIntToBytes(address), common)
+  gas += subMemUsage(runState, memOffset, memLength, common)
+  return gas
+}
+/* AUTHCALL */
+dynamicGasHandlers[0xf7] = async function (runState, gas, common): Promise<bigint> {
+  if (runState.auth === undefined) {
+    trap(ERROR.AUTHCALL_UNSET)
+  }
+
+  const [currentGasLimit, addr, value, argsOffset, argsLength, retOffset, retLength] =
+    runState.stack.peek(7)
+
+  const toAddress = new Address(addresstoBytes(addr))
+
+  gas += common.param('gasPrices', 'warmstorageread')
+
+  gas += accessAddressEIP2929(runState, toAddress.bytes, common, true, true)
+
+  gas += subMemUsage(runState, argsOffset, argsLength, common)
+  gas += subMemUsage(runState, retOffset, retLength, common)
+
+  if (value > BIGINT_0) {
+    gas += common.param('gasPrices', 'authcallValueTransfer')
+    const account = await runState.stateManager.getAccount(toAddress)
+    if (!account) {
+      gas += common.param('gasPrices', 'callNewAccount')
+    }
+  }
+
+  let gasLimit = maxCallGas(
+    runState.interpreter.getGasLeft() - gas,
+    runState.interpreter.getGasLeft() - gas,
+    runState,
+    common
+  )
+  if (currentGasLimit !== BIGINT_0) {
+    if (currentGasLimit > gasLimit) {
+      trap(ERROR.OUT_OF_GAS)
+    }
+    gasLimit = currentGasLimit
+  }
+
+  runState.messageGasLimit = gasLimit
+
+  if (value > BIGINT_0) {
+    const account = (await runState.stateManager.getAccount(runState.auth!)) ?? new Account()
+    if (account.balance < value) {
+      trap(ERROR.OUT_OF_GAS)
+    }
+    account.balance -= value
+
+    const toAddr = new Address(addresstoBytes(addr))
+    const target = (await runState.stateManager.getAccount(toAddr)) ?? new Account()
+    target.balance += value
+
+    await runState.stateManager.putAccount(toAddr, target)
+  }
+
+  return gas
+}
+/* EXTCALL */
+dynamicGasHandlers[0xf8] = async function (runState, gas, common): Promise<bigint> {
+  // Charge WARM_STORAGE_READ_COST (100) -> done in accessAddressEIP2929
+
+  // Peek stack values
+  const [toAddr, inOffset, inLength, value] = runState.stack.peek(4)
+
+  // If value is nonzero and in static mode, throw:
+  if (runState.interpreter.isStatic() && value !== BIGINT_0) {
+    trap(ERROR.STATIC_STATE_CHANGE)
+  }
+
+  // If value > 0, charge CALL_VALUE_COST
+  if (value > BIGINT_0) {
+    gas += common.param('gasPrices', 'callValueTransfer')
+  }
+
+  // Check if the target address > 20 bytes
+  if (toAddr > EXTCALL_TARGET_MAX) {
+    trap(EOFError.InvalidExtcallTarget)
+  }
+
+  // Charge for memory expansion
+  gas += subMemUsage(runState, inOffset, inLength, common)
+
+  const toAddress = new Address(addresstoBytes(toAddr))
+  // Charge to make address warm (2600 gas)
+  // (in case if address is already warm, this charges the 100 gas)
+  gas += accessAddressEIP2929(runState, toAddress.bytes, common)
+
+  // Charge account creation cost if value is nonzero
+  if (value > BIGINT_0) {
+    const account = await runState.stateManager.getAccount(toAddress)
+    const deadAccount = account === undefined || account.isEmpty()
+
+    if (deadAccount) {
+      gas += common.param('gasPrices', 'callNewAccount')
+    }
+  }
+
+  const minRetainedGas = common.param('gasPrices', 'minRetainedGas')
+  const minCalleeGas = common.param('gasPrices', 'minCalleeGas')
+
+  const currentGasAvailable = runState.interpreter.getGasLeft() - gas
+  const reducedGas = currentGasAvailable / BIGINT_64
+  // Calculate the gas limit for the callee
+  // (this is the gas available for the next call frame)
+  let gasLimit: bigint
+  if (reducedGas < minRetainedGas) {
+    gasLimit = currentGasAvailable - minRetainedGas
+  } else {
+    gasLimit = currentGasAvailable - reducedGas
+  }
+
+  if (
+    runState.env.depth >= Number(common.param('vm', 'stackLimit')) ||
+    runState.env.contract.balance < value ||
+    gasLimit < minCalleeGas
+  ) {
+    // Note: this is a hack, TODO: get around this hack and clean this up
+    // This special case will ensure that the actual EXT*CALL is being ran,
+    // But, the code in `function.ts` will note that `runState.messageGasLimit` is set to a negative number
+    // This special number signals that `1` should be put on the stack (per spec)
+    gasLimit = -BIGINT_1
+  }
+
+  runState.messageGasLimit = gasLimit
+
+  return gas
+}
+/* EXTDELEGATECALL */
+dynamicGasHandlers[0xf9] = async function (runState, gas, common): Promise<bigint> {
+  // Charge WARM_STORAGE_READ_COST (100) -> done in accessAddressEIP2929
+
+  // Peek stack values
+  const [toAddr, inOffset, inLength] = runState.stack.peek(3)
+
+  // Check if the target address > 20 bytes
+  if (toAddr > EXTCALL_TARGET_MAX) {
+    trap(EOFError.InvalidExtcallTarget)
+  }
+
+  // Charge for memory expansion
+  gas += subMemUsage(runState, inOffset, inLength, common)
+
+  const toAddress = new Address(addresstoBytes(toAddr))
+  // Charge to make address warm (2600 gas)
+  // (in case if address is already warm, this charges the 100 gas)
+  gas += accessAddressEIP2929(runState, toAddress.bytes, common)
+
+  const minRetainedGas = common.param('gasPrices', 'minRetainedGas')
+  const minCalleeGas = common.param('gasPrices', 'minCalleeGas')
+
+  const currentGasAvailable = runState.interpreter.getGasLeft() - gas
+  const reducedGas = currentGasAvailable / BIGINT_64
+  // Calculate the gas limit for the callee
+  // (this is the gas available for the next call frame)
+  let gasLimit: bigint
+  if (reducedGas < minRetainedGas) {
+    gasLimit = currentGasAvailable - minRetainedGas
+  } else {
+    gasLimit = currentGasAvailable - reducedGas
+  }
+
+  if (runState.env.depth >= Number(common.param('vm', 'stackLimit')) || gasLimit < minCalleeGas) {
+    // Note: this is a hack, TODO: get around this hack and clean this up
+    // This special case will ensure that the actual EXT*CALL is being ran,
+    // But, the code in `function.ts` will note that `runState.messageGasLimit` is set to a negative number
+    // This special number signals that `1` should be put on the stack (per spec)
+    gasLimit = -BIGINT_1
+  }
+
+  runState.messageGasLimit = gasLimit
+
+  return gas
+}
+/* STATICCALL */
+dynamicGasHandlers[0xfa] = async function (runState, gas, common): Promise<bigint> {
+  const [currentGasLimit, toAddr, inOffset, inLength, outOffset, outLength] = runState.stack.peek(6)
+
+  gas += subMemUsage(runState, inOffset, inLength, common)
+  gas += subMemUsage(runState, outOffset, outLength, common)
+
+  let charge2929Gas = true
+  if (common.isActivatedEIP(6800)) {
+    const toAddress = new Address(addresstoBytes(toAddr))
+    // TODO: add check if toAddress is not a precompile
+    const coldAccessGas = runState.env.accessWitness!.touchAndChargeMessageCall(toAddress)
+
+    gas += coldAccessGas
+    charge2929Gas = coldAccessGas === BIGINT_0
+  }
+
+  if (common.isActivatedEIP(2929)) {
+    gas += accessAddressEIP2929(runState, addresstoBytes(toAddr), common, charge2929Gas)
+  }
+
+  const gasLimit = maxCallGas(
+    currentGasLimit,
+    runState.interpreter.getGasLeft() - gas,
+    runState,
+    common
+  ) // we set TangerineWhistle or later to true here, as STATICCALL was available from Byzantium (which is after TangerineWhistle)
+
+  runState.messageGasLimit = gasLimit
+  return gas
+}
+/* EXTSTATICCALL */
+dynamicGasHandlers[0xfb] = async function (runState, gas, common): Promise<bigint> {
+  // Charge WARM_STORAGE_READ_COST (100) -> done in accessAddressEIP2929
+
+  // Peek stack values
+  const [toAddr, inOffset, inLength] = runState.stack.peek(3)
+
+  // Check if the target address > 20 bytes
+  if (toAddr > EXTCALL_TARGET_MAX) {
+    trap(EOFError.InvalidExtcallTarget)
+  }
+
+  // Charge for memory expansion
+  gas += subMemUsage(runState, inOffset, inLength, common)
+
+  const toAddress = new Address(addresstoBytes(toAddr))
+  // Charge to make address warm (2600 gas)
+  // (in case if address is already warm, this charges the 100 gas)
+  gas += accessAddressEIP2929(runState, toAddress.bytes, common)
+
+  const minRetainedGas = common.param('gasPrices', 'minRetainedGas')
+  const minCalleeGas = common.param('gasPrices', 'minCalleeGas')
+
+  const currentGasAvailable = runState.interpreter.getGasLeft() - gas
+  const reducedGas = currentGasAvailable / BIGINT_64
+  // Calculate the gas limit for the callee
+  // (this is the gas available for the next call frame)
+  let gasLimit: bigint
+  if (reducedGas < minRetainedGas) {
+    gasLimit = currentGasAvailable - minRetainedGas
+  } else {
+    gasLimit = currentGasAvailable - reducedGas
+  }
+
+  if (runState.env.depth >= Number(common.param('vm', 'stackLimit')) || gasLimit < minCalleeGas) {
+    // Note: this is a hack, TODO: get around this hack and clean this up
+    // This special case will ensure that the actual EXT*CALL is being ran,
+    // But, the code in `function.ts` will note that `runState.messageGasLimit` is set to a negative number
+    // This special number signals that `1` should be put on the stack (per spec)
+    gasLimit = -BIGINT_1
+  }
+
+  runState.messageGasLimit = gasLimit
+
+  return gas
+}
+/* REVERT */
+dynamicGasHandlers[0xfd] = async function (runState, gas, common): Promise<bigint> {
+  const [offset, length] = runState.stack.peek(2)
+  gas += subMemUsage(runState, offset, length, common)
+  return gas
+}
+/* SELFDESTRUCT */
+dynamicGasHandlers[0xff] = async function (runState, gas, common): Promise<bigint> {
+  if (runState.interpreter.isStatic()) {
+    trap(ERROR.STATIC_STATE_CHANGE)
+  }
+  const selfdestructToaddressBigInt = runState.stack.peek()[0]
+
+  const selfdestructToAddress = new Address(addresstoBytes(selfdestructToaddressBigInt))
+  const contractAddress = runState.interpreter.getAddress()
+
+  let deductGas = false
+  const balance = await runState.interpreter.getExternalBalance(contractAddress)
+
+  if (common.gteHardfork(Hardfork.SpuriousDragon)) {
+    // EIP-161: State Trie Clearing
+    if (balance > BIGINT_0) {
+      // This technically checks if account is empty or non-existent
+      const account = await runState.stateManager.getAccount(selfdestructToAddress)
+      if (account === undefined || account.isEmpty()) {
+        deductGas = true
+      }
+    }
+  } else if (common.gteHardfork(Hardfork.TangerineWhistle)) {
+    // EIP-150 (Tangerine Whistle) gas semantics
+    const exists = (await runState.stateManager.getAccount(selfdestructToAddress)) !== undefined
+    if (!exists) {
+      deductGas = true
+    }
+  }
+  if (deductGas) {
+    gas += common.param('gasPrices', 'callNewAccount')
+  }
+
+  let selfDestructToCharge2929Gas = true
+  if (common.isActivatedEIP(6800)) {
+    // read accesses for version and code size
+    if (runState.interpreter._evm.getPrecompile(contractAddress) === undefined) {
+      gas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
+        contractAddress,
+        0,
+        VERKLE_VERSION_LEAF_KEY
+      )
+      gas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
+        contractAddress,
+        0,
+        VERKLE_CODE_SIZE_LEAF_KEY
+      )
+    }
+
+    gas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
+      contractAddress,
+      0,
+      VERKLE_BALANCE_LEAF_KEY
+    )
+    if (balance > BIGINT_0) {
+      gas += runState.env.accessWitness!.touchAddressOnWriteAndComputeGas(
+        contractAddress,
+        0,
+        VERKLE_BALANCE_LEAF_KEY
+      )
+    }
+
+    let selfDestructToColdAccessGas = runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
+      selfdestructToAddress,
+      0,
+      VERKLE_BALANCE_LEAF_KEY
+    )
+    if (balance > BIGINT_0) {
+      selfDestructToColdAccessGas += runState.env.accessWitness!.touchAddressOnWriteAndComputeGas(
+        selfdestructToAddress,
+        0,
+        VERKLE_BALANCE_LEAF_KEY
+      )
+    }
+
+    gas += selfDestructToColdAccessGas
+    selfDestructToCharge2929Gas = selfDestructToColdAccessGas === BIGINT_0
+  }
+
+  if (common.isActivatedEIP(2929)) {
+    gas += accessAddressEIP2929(
+      runState,
+      selfdestructToAddress.bytes,
+      common,
+      selfDestructToCharge2929Gas,
+      true
+    )
+  }
+
+  return gas
+}
 
 // Set the range [0xa0, 0xa4] to the LOG handler
-const logDynamicFunc = dynamicGasHandlers.get(0xa0)!
+const logDynamicFunc = dynamicGasHandlers[0xa0]
 for (let i = 0xa1; i <= 0xa4; i++) {
-  dynamicGasHandlers.set(i, logDynamicFunc)
+  dynamicGasHandlers[i] = logDynamicFunc
 }


### PR DESCRIPTION
This PR changes the internal Opcodes / Dynamic Gas type from Map -> Array. Array lookups seem faster than Map.

Also super small code cleanup, such as removing unused arguments (`_common`)