### PR TITLE
StateManager: Interface Refactor/Simplification

### DIFF
--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -296,7 +296,7 @@ export class VMExecution extends Execution {
           this.chain['_customGenesisState'] ?? getGenesis(Number(blockchain.common.chainId()))
         if (
           !genesisState &&
-          (!('generateCanonicalGenesis' in this.vm) || !this.config.statelessVerkle)
+          (!('generateCanonicalGenesis' in this.vm.stateManager) || !this.config.statelessVerkle)
         ) {
           throw new Error('genesisState not available')
         } else {

--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -296,11 +296,11 @@ export class VMExecution extends Execution {
           this.chain['_customGenesisState'] ?? getGenesis(Number(blockchain.common.chainId()))
         if (
           !genesisState &&
-          (this.vm instanceof DefaultStateManager || !this.config.statelessVerkle)
+          (!('generateCanonicalGenesis' in this.vm) || !this.config.statelessVerkle)
         ) {
           throw new Error('genesisState not available')
         } else {
-          await this.vm.stateManager.generateCanonicalGenesis(genesisState)
+          await this.vm.stateManager.generateCanonicalGenesis!(genesisState)
         }
       }
 

--- a/packages/client/src/rpc/modules/debug.ts
+++ b/packages/client/src/rpc/modules/debug.ts
@@ -359,13 +359,19 @@ export class Debug {
     const parentBlock = await this.chain.getBlock(block.header.parentHash)
     // Copy the VM and run transactions including the relevant transaction.
     const vmCopy = await this.vm.shallowCopy()
+    if (!('dumpStorageRange' in vmCopy.stateManager)) {
+      throw {
+        code: INTERNAL_ERROR,
+        message: 'stateManager has no dumpStorageRange implementation',
+      }
+    }
     await vmCopy.stateManager.setStateRoot(parentBlock.header.stateRoot)
     for (let i = 0; i <= txIndex; i++) {
       await runTx(vmCopy, { tx: block.transactions[i], block })
     }
 
     // await here so that any error can be handled in the catch below for proper response
-    return vmCopy.stateManager.dumpStorageRange(
+    return vmCopy.stateManager.dumpStorageRange!(
       // Validator already verified that `account` and `startKey` are properly formatted.
       Address.fromString(account),
       BigInt(startKey),

--- a/packages/client/src/rpc/modules/debug.ts
+++ b/packages/client/src/rpc/modules/debug.ts
@@ -179,7 +179,13 @@ export class Debug {
       const memory = []
       let storage = {}
       if (opts.disableStorage === false) {
-        storage = await vmCopy.stateManager.dumpStorage(step.address)
+        if (!('dumpStorage' in vmCopy.stateManager)) {
+          throw {
+            message: 'stateManager has no dumpStorage implementation',
+            code: INTERNAL_ERROR,
+          }
+        }
+        storage = await vmCopy.stateManager.dumpStorage!(step.address)
       }
       if (opts.enableMemory === true) {
         for (let x = 0; x < step.memoryWordCount; x++) {
@@ -260,7 +266,13 @@ export class Debug {
       const memory = []
       let storage = {}
       if (opts.disableStorage === false) {
-        storage = await vm.stateManager.dumpStorage(step.address)
+        if (!('dumpStorage' in vm.stateManager)) {
+          throw {
+            message: 'stateManager has no dumpStorage implementation',
+            code: INTERNAL_ERROR,
+          }
+        }
+        storage = await vm.stateManager.dumpStorage!(step.address)
       }
       if (opts.enableMemory === true) {
         for (let x = 0; x < step.memoryWordCount; x++) {

--- a/packages/client/test/rpc/eth/estimateGas.spec.ts
+++ b/packages/client/test/rpc/eth/estimateGas.spec.ts
@@ -39,7 +39,7 @@ describe(
       const { execution } = client.services.find((s) => s.name === 'eth') as FullEthereumService
       assert.notEqual(execution, undefined, 'should have valid execution')
       const { vm } = execution
-      await vm.stateManager.generateCanonicalGenesis(getGenesis(1))
+      await vm.stateManager.generateCanonicalGenesis!(getGenesis(1))
 
       // genesis address with balance
       const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')

--- a/packages/client/test/rpc/eth/getBalance.spec.ts
+++ b/packages/client/test/rpc/eth/getBalance.spec.ts
@@ -32,7 +32,7 @@ describe(
 
       // since synchronizer.run() is not executed in the mock setup,
       // manually run stateManager.generateCanonicalGenesis()
-      await vm.stateManager.generateCanonicalGenesis(getGenesis(1))
+      await vm.stateManager.generateCanonicalGenesis!(getGenesis(1))
 
       // genesis address with balance
       const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')

--- a/packages/client/test/rpc/eth/getBlockTransactionCountByNumber.spec.ts
+++ b/packages/client/test/rpc/eth/getBlockTransactionCountByNumber.spec.ts
@@ -33,7 +33,7 @@ describe(method, () => {
     assert.notEqual(execution, undefined, 'should have valid execution')
     const { vm } = execution
 
-    await vm.stateManager.generateCanonicalGenesis(getGenesis(1))
+    await vm.stateManager.generateCanonicalGenesis!(getGenesis(1))
 
     const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
 
@@ -80,7 +80,7 @@ describe(method, () => {
     assert.notEqual(execution, undefined, 'should have valid execution')
     const { vm } = execution
 
-    await vm.stateManager.generateCanonicalGenesis(getGenesis(1))
+    await vm.stateManager.generateCanonicalGenesis!(getGenesis(1))
 
     const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
 

--- a/packages/client/test/rpc/eth/getCode.spec.ts
+++ b/packages/client/test/rpc/eth/getCode.spec.ts
@@ -28,7 +28,7 @@ describe(method, () => {
     const { execution } = client.services.find((s) => s.name === 'eth') as FullEthereumService
     assert.notEqual(execution, undefined, 'should have valid execution')
     const { vm } = execution
-    await vm.stateManager.generateCanonicalGenesis(getGenesis(1))
+    await vm.stateManager.generateCanonicalGenesis!(getGenesis(1))
 
     // genesis address
     const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')

--- a/packages/client/test/rpc/eth/getTransactionCount.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionCount.spec.ts
@@ -34,7 +34,7 @@ describe(method, () => {
 
     // since synchronizer.run() is not executed in the mock setup,
     // manually run stateManager.generateCanonicalGenesis()
-    await vm.stateManager.generateCanonicalGenesis(getGenesis(1))
+    await vm.stateManager.generateCanonicalGenesis!(getGenesis(1))
 
     // a genesis address
     const address = Address.fromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')

--- a/packages/client/test/rpc/txpool/content.spec.ts
+++ b/packages/client/test/rpc/txpool/content.spec.ts
@@ -29,7 +29,7 @@ describe(method, () => {
     const { execution } = client.services.find((s) => s.name === 'eth') as FullEthereumService
     assert.notEqual(execution, undefined, 'should have valid execution')
     const { vm } = execution
-    await vm.stateManager.generateCanonicalGenesis(getGenesis(1))
+    await vm.stateManager.generateCanonicalGenesis!(getGenesis(1))
     const gasLimit = 2000000
     const parent = await blockchain.getCanonicalHeadHeader()
     const block = createBlockFromBlockData(

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -184,11 +184,10 @@ export interface StateManagerInterface {
   /*
    * Proof Functionality
    */
-  // Only client, should not be mandatory
+  // Only client (should not be mandatory)
   getProof?(address: Address, storageSlots: Uint8Array[]): Promise<Proof>
 
   shallowCopy(downlevelCaches?: boolean): StateManagerInterface
-  getAppliedKey?(address: Uint8Array): Uint8Array
 
   /*
    * EVM/VM Specific Functionality
@@ -197,14 +196,15 @@ export interface StateManagerInterface {
     get(address: Address, key: Uint8Array): Promise<Uint8Array>
     clear(): void
   }
+  generateCanonicalGenesis?(initState: any): Promise<void> // TODO make input more typesafe
   // only Verkle/EIP-6800 (experimental)
   checkChunkWitnessPresent?(contract: Address, programCounter: number): Promise<boolean>
+  getAppliedKey?(address: Uint8Array): Uint8Array // only for preimages
 }
 
 export interface EVMStateManagerInterface extends StateManagerInterface {
   dumpStorage(address: Address): Promise<StorageDump> // only used in client
   dumpStorageRange(address: Address, startKey: bigint, limit: number): Promise<StorageRange> // only used in client
-  generateCanonicalGenesis(initState: any): Promise<void> // TODO make input more typesafe
 
   shallowCopy(downlevelCaches?: boolean): EVMStateManagerInterface
 }

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -207,5 +207,6 @@ export interface StateManagerInterface {
   /*
    * Generic
    */
+  clearCaches(): void
   shallowCopy(downlevelCaches?: boolean): StateManagerInterface
 }

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -179,16 +179,17 @@ export interface StateManagerInterface {
   shallowCopy(downlevelCaches?: boolean): StateManagerInterface
   getAppliedKey?(address: Uint8Array): Uint8Array
 
-  // Verkle (experimental)
-  checkChunkWitnessPresent?(contract: Address, programCounter: number): Promise<boolean>
-}
-
-export interface EVMStateManagerInterface extends StateManagerInterface {
+  // EVM/VM
   originalStorageCache: {
     get(address: Address, key: Uint8Array): Promise<Uint8Array>
     clear(): void
   }
 
+  // EVM, only Verkle/EIP-6800 (experimental)
+  checkChunkWitnessPresent?(contract: Address, programCounter: number): Promise<boolean>
+}
+
+export interface EVMStateManagerInterface extends StateManagerInterface {
   dumpStorage(address: Address): Promise<StorageDump> // only used in client
   dumpStorageRange(address: Address, startKey: bigint, limit: number): Promise<StorageRange> // only used in client
   generateCanonicalGenesis(initState: any): Promise<void> // TODO make input more typesafe

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -205,7 +205,7 @@ export interface StateManagerInterface {
   getAppliedKey?(address: Uint8Array): Uint8Array // only for preimages
 
   /*
-   * Generic
+   * Utility
    */
   clearCaches(): void
   shallowCopy(downlevelCaches?: boolean): StateManagerInterface

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -148,6 +148,9 @@ export interface AccessWitnessInterface {
  *
  */
 export interface StateManagerInterface {
+  /*
+   * Core Access Functionality
+   */
   // Account methods
   getAccount(address: Address): Promise<Account | undefined>
   putAccount(address: Address, account?: Account): Promise<void>
@@ -164,28 +167,37 @@ export interface StateManagerInterface {
   putStorage(address: Address, key: Uint8Array, value: Uint8Array): Promise<void>
   clearStorage(address: Address): Promise<void>
 
-  // Checkpointing methods
+  /*
+   * Checkpointing Functionality
+   */
   checkpoint(): Promise<void>
   commit(): Promise<void>
   revert(): Promise<void>
 
-  // State root methods
+  /*
+   * State Root Functionality
+   */
   getStateRoot(): Promise<Uint8Array>
   setStateRoot(stateRoot: Uint8Array, clearCache?: boolean): Promise<void>
   hasStateRoot(root: Uint8Array): Promise<boolean> // only used in client
 
-  // Other
+  /*
+   * Proof Functionality
+   */
+  // Only client, should not be mandatory
   getProof?(address: Address, storageSlots: Uint8Array[]): Promise<Proof>
+
   shallowCopy(downlevelCaches?: boolean): StateManagerInterface
   getAppliedKey?(address: Uint8Array): Uint8Array
 
-  // EVM/VM
+  /*
+   * EVM/VM Specific Functionality
+   */
   originalStorageCache: {
     get(address: Address, key: Uint8Array): Promise<Uint8Array>
     clear(): void
   }
-
-  // EVM, only Verkle/EIP-6800 (experimental)
+  // only Verkle/EIP-6800 (experimental)
   checkChunkWitnessPresent?(contract: Address, programCounter: number): Promise<boolean>
 }
 
@@ -193,7 +205,6 @@ export interface EVMStateManagerInterface extends StateManagerInterface {
   dumpStorage(address: Address): Promise<StorageDump> // only used in client
   dumpStorageRange(address: Address, startKey: bigint, limit: number): Promise<StorageRange> // only used in client
   generateCanonicalGenesis(initState: any): Promise<void> // TODO make input more typesafe
-  getProof(address: Address, storageSlots?: Uint8Array[]): Promise<Proof>
 
   shallowCopy(downlevelCaches?: boolean): EVMStateManagerInterface
 }

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -182,12 +182,14 @@ export interface StateManagerInterface {
   hasStateRoot(root: Uint8Array): Promise<boolean> // only used in client
 
   /*
-   * Proof Functionality
+   * Extra Functionality
+   *
+   * Optional non-essential methods, these methods should always be guarded
+   * on usage (check for existance)
    */
-  // Only client (should not be mandatory)
+  // Client
   getProof?(address: Address, storageSlots: Uint8Array[]): Promise<Proof>
-
-  shallowCopy(downlevelCaches?: boolean): StateManagerInterface
+  dumpStorage?(address: Address): Promise<StorageDump>
 
   /*
    * EVM/VM Specific Functionality
@@ -200,10 +202,14 @@ export interface StateManagerInterface {
   // only Verkle/EIP-6800 (experimental)
   checkChunkWitnessPresent?(contract: Address, programCounter: number): Promise<boolean>
   getAppliedKey?(address: Uint8Array): Uint8Array // only for preimages
+
+  /*
+   * Generic
+   */
+  shallowCopy(downlevelCaches?: boolean): StateManagerInterface
 }
 
 export interface EVMStateManagerInterface extends StateManagerInterface {
-  dumpStorage(address: Address): Promise<StorageDump> // only used in client
   dumpStorageRange(address: Address, startKey: bigint, limit: number): Promise<StorageRange> // only used in client
 
   shallowCopy(downlevelCaches?: boolean): EVMStateManagerInterface

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -209,7 +209,3 @@ export interface StateManagerInterface {
    */
   shallowCopy(downlevelCaches?: boolean): StateManagerInterface
 }
-
-export interface EVMStateManagerInterface extends StateManagerInterface {
-  shallowCopy(downlevelCaches?: boolean): EVMStateManagerInterface
-}

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -187,9 +187,10 @@ export interface StateManagerInterface {
    * Optional non-essential methods, these methods should always be guarded
    * on usage (check for existance)
    */
-  // Client
+  // Client RPC
   getProof?(address: Address, storageSlots: Uint8Array[]): Promise<Proof>
   dumpStorage?(address: Address): Promise<StorageDump>
+  dumpStorageRange?(address: Address, startKey: bigint, limit: number): Promise<StorageRange>
 
   /*
    * EVM/VM Specific Functionality
@@ -210,7 +211,5 @@ export interface StateManagerInterface {
 }
 
 export interface EVMStateManagerInterface extends StateManagerInterface {
-  dumpStorageRange(address: Address, startKey: bigint, limit: number): Promise<StorageRange> // only used in client
-
   shallowCopy(downlevelCaches?: boolean): EVMStateManagerInterface
 }

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -50,7 +50,7 @@ import type {
   ExecResult,
   bn128,
 } from './types.js'
-import type { Common, EVMStateManagerInterface } from '@ethereumjs/common'
+import type { Common, StateManagerInterface } from '@ethereumjs/common'
 
 const debug = debugDefault('evm:evm')
 const debugGas = debugDefault('evm:gas')
@@ -94,7 +94,7 @@ export class EVM implements EVMInterface {
   public readonly common: Common
   public readonly events: AsyncEventEmitter<EVMEvents>
 
-  public stateManager: EVMStateManagerInterface
+  public stateManager: StateManagerInterface
   public blockchain: Blockchain
   public journal: Journal
 

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -27,7 +27,7 @@ import type { EVM } from './evm.js'
 import type { Journal } from './journal.js'
 import type { AsyncOpHandler, Opcode, OpcodeMapEntry } from './opcodes/index.js'
 import type { Block, Blockchain, EOFEnv, EVMProfilerOpts, EVMResult, Log } from './types.js'
-import type { AccessWitnessInterface, Common, EVMStateManagerInterface } from '@ethereumjs/common'
+import type { AccessWitnessInterface, Common, StateManagerInterface } from '@ethereumjs/common'
 import type { Address, PrefixedHexString } from '@ethereumjs/util'
 
 const debugGas = debugDefault('evm:gas')
@@ -86,7 +86,7 @@ export interface RunState {
   shouldDoJumpAnalysis: boolean
   validJumps: Uint8Array // array of values where validJumps[index] has value 0 (default), 1 (jumpdest), 2 (beginsub)
   cachedPushes: { [pc: number]: bigint }
-  stateManager: EVMStateManagerInterface
+  stateManager: StateManagerInterface
   blockchain: Blockchain
   env: Env
   messageGasLimit?: bigint // Cache value from `gas.ts` to save gas limit for a message call
@@ -105,7 +105,7 @@ export interface InterpreterResult {
 export interface InterpreterStep {
   gasLeft: bigint
   gasRefund: bigint
-  stateManager: EVMStateManagerInterface
+  stateManager: StateManagerInterface
   stack: bigint[]
   pc: number
   depth: number
@@ -128,7 +128,7 @@ export interface InterpreterStep {
 export class Interpreter {
   protected _vm: any
   protected _runState: RunState
-  protected _stateManager: EVMStateManagerInterface
+  protected _stateManager: StateManagerInterface
   protected common: Common
   public _evm: EVM
   public journal: Journal
@@ -147,7 +147,7 @@ export class Interpreter {
   // TODO remove gasLeft as constructor argument
   constructor(
     evm: EVM,
-    stateManager: EVMStateManagerInterface,
+    stateManager: StateManagerInterface,
     blockchain: Blockchain,
     env: Env,
     gasLeft: bigint,

--- a/packages/evm/src/journal.ts
+++ b/packages/evm/src/journal.ts
@@ -10,7 +10,7 @@ import {
 import debugDefault from 'debug'
 import { hexToBytes } from 'ethereum-cryptography/utils'
 
-import type { Common, EVMStateManagerInterface } from '@ethereumjs/common'
+import type { Common, StateManagerInterface } from '@ethereumjs/common'
 import type { Account, PrefixedHexString } from '@ethereumjs/util'
 import type { Debugger } from 'debug'
 
@@ -32,7 +32,7 @@ type JournalDiffItem = [Set<AddressString>, Map<AddressString, Set<SlotString>>,
 type JournalHeight = number
 
 export class Journal {
-  private stateManager: EVMStateManagerInterface
+  private stateManager: StateManagerInterface
   private common: Common
   private DEBUG: boolean
   private _debug: Debugger
@@ -47,7 +47,7 @@ export class Journal {
   public accessList?: Map<AddressString, Set<SlotString>>
   public preimages?: Map<PrefixedHexString, Uint8Array>
 
-  constructor(stateManager: EVMStateManagerInterface, common: Common) {
+  constructor(stateManager: StateManagerInterface, common: Common) {
     // Skip DEBUG calls unless 'ethjs' included in environmental DEBUG variables
     // Additional window check is to prevent vite browser bundling (and potentially other) to break
     this.DEBUG =

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -11,7 +11,7 @@ import type { PrecompileFunc } from './precompiles/types.js'
 import type {
   AccessWitnessInterface,
   Common,
-  EVMStateManagerInterface,
+  StateManagerInterface,
   ParamsDict,
 } from '@ethereumjs/common'
 import type { Account, Address, AsyncEventEmitter, PrefixedHexString } from '@ethereumjs/util'
@@ -162,7 +162,7 @@ export interface EVMInterface {
     startReportingAccessList(): void
     startReportingPreimages?(): void
   }
-  stateManager: EVMStateManagerInterface
+  stateManager: StateManagerInterface
   precompiles: Map<string, PrecompileFunc>
   runCall(opts: EVMRunCallOpts): Promise<EVMResult>
   runCode(opts: EVMRunCodeOpts): Promise<ExecResult>
@@ -312,7 +312,7 @@ export interface EVMOpts {
    * implementations for different needs (MPT-tree backed, RPC, experimental verkle)
    * which can be used by this option as a replacement.
    */
-  stateManager?: EVMStateManagerInterface
+  stateManager?: StateManagerInterface
 
   /**
    *

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -11,8 +11,8 @@ import type { PrecompileFunc } from './precompiles/types.js'
 import type {
   AccessWitnessInterface,
   Common,
-  StateManagerInterface,
   ParamsDict,
+  StateManagerInterface,
 } from '@ethereumjs/common'
 import type { Account, Address, AsyncEventEmitter, PrefixedHexString } from '@ethereumjs/util'
 

--- a/packages/statemanager/src/rpcStateManager.ts
+++ b/packages/statemanager/src/rpcStateManager.ts
@@ -19,12 +19,7 @@ import { keccak256 } from 'ethereum-cryptography/keccak.js'
 import { AccountCache, CacheType, OriginalStorageCache, StorageCache } from './cache/index.js'
 
 import type { Proof, RPCStateManagerOpts } from './index.js'
-import type {
-  AccountFields,
-  EVMStateManagerInterface,
-  StorageDump,
-  StorageRange,
-} from '@ethereumjs/common'
+import type { AccountFields, EVMStateManagerInterface, StorageDump } from '@ethereumjs/common'
 import type { Address, PrefixedHexString } from '@ethereumjs/util'
 import type { Debugger } from 'debug'
 
@@ -211,11 +206,6 @@ export class RPCStateManager implements EVMStateManagerInterface {
       }
     }
     return Promise.resolve(dump)
-  }
-
-  dumpStorageRange(_address: Address, _startKey: bigint, _limit: number): Promise<StorageRange> {
-    // TODO: Implement.
-    return Promise.reject()
   }
 
   /**

--- a/packages/statemanager/src/rpcStateManager.ts
+++ b/packages/statemanager/src/rpcStateManager.ts
@@ -19,13 +19,13 @@ import { keccak256 } from 'ethereum-cryptography/keccak.js'
 import { AccountCache, CacheType, OriginalStorageCache, StorageCache } from './cache/index.js'
 
 import type { Proof, RPCStateManagerOpts } from './index.js'
-import type { AccountFields, EVMStateManagerInterface, StorageDump } from '@ethereumjs/common'
+import type { AccountFields, StateManagerInterface, StorageDump } from '@ethereumjs/common'
 import type { Address, PrefixedHexString } from '@ethereumjs/util'
 import type { Debugger } from 'debug'
 
 const KECCAK256_RLP_EMPTY_ACCOUNT = RLP.encode(new Account().serialize()).slice(2)
 
-export class RPCStateManager implements EVMStateManagerInterface {
+export class RPCStateManager implements StateManagerInterface {
   protected _provider: string
   protected _contractCache: Map<string, Uint8Array>
   protected _storageCache: StorageCache

--- a/packages/statemanager/src/rpcStateManager.ts
+++ b/packages/statemanager/src/rpcStateManager.ts
@@ -436,10 +436,6 @@ export class RPCStateManager implements EVMStateManagerInterface {
   hasStateRoot = () => {
     throw new Error('function not implemented')
   }
-
-  generateCanonicalGenesis(_initState: any): Promise<void> {
-    return Promise.resolve()
-  }
 }
 
 export class RPCBlockChain {

--- a/packages/statemanager/src/simpleStateManager.ts
+++ b/packages/statemanager/src/simpleStateManager.ts
@@ -4,14 +4,7 @@ import { keccak256 } from 'ethereum-cryptography/keccak.js'
 import { OriginalStorageCache } from './cache/originalStorageCache.js'
 
 import type { SimpleStateManagerOpts } from './index.js'
-import type {
-  AccountFields,
-  Common,
-  EVMStateManagerInterface,
-  Proof,
-  StorageDump,
-  StorageRange,
-} from '@ethereumjs/common'
+import type { AccountFields, Common, EVMStateManagerInterface } from '@ethereumjs/common'
 import type { Address, PrefixedHexString } from '@ethereumjs/util'
 
 /**
@@ -166,9 +159,4 @@ export class SimpleStateManager implements EVMStateManagerInterface {
 
   // Only goes for long term create situations, skip
   async clearStorage(): Promise<void> {}
-
-  // Only "core" methods implemented
-  dumpStorageRange(): Promise<StorageRange> {
-    throw new Error('Method not implemented.')
-  }
 }

--- a/packages/statemanager/src/simpleStateManager.ts
+++ b/packages/statemanager/src/simpleStateManager.ts
@@ -174,9 +174,6 @@ export class SimpleStateManager implements EVMStateManagerInterface {
   dumpStorageRange(): Promise<StorageRange> {
     throw new Error('Method not implemented.')
   }
-  generateCanonicalGenesis(): Promise<void> {
-    throw new Error('Method not implemented.')
-  }
   getProof(): Promise<Proof> {
     throw new Error('Method not implemented.')
   }

--- a/packages/statemanager/src/simpleStateManager.ts
+++ b/packages/statemanager/src/simpleStateManager.ts
@@ -118,9 +118,7 @@ export class SimpleStateManager implements StateManagerInterface {
     this.topStorageStack().set(`${address.toString()}_${bytesToHex(key)}`, value)
   }
 
-  async clearStorage(): Promise<void> {
-    this.storageStack = []
-  }
+  async clearStorage(): Promise<void> {}
 
   async checkpoint(): Promise<void> {
     this.checkpointSync()

--- a/packages/statemanager/src/simpleStateManager.ts
+++ b/packages/statemanager/src/simpleStateManager.ts
@@ -118,6 +118,10 @@ export class SimpleStateManager implements EVMStateManagerInterface {
     this.topStorageStack().set(`${address.toString()}_${bytesToHex(key)}`, value)
   }
 
+  async clearStorage(): Promise<void> {
+    this.storageStack = []
+  }
+
   async checkpoint(): Promise<void> {
     this.checkpointSync()
   }
@@ -156,7 +160,4 @@ export class SimpleStateManager implements EVMStateManagerInterface {
   hasStateRoot(): Promise<boolean> {
     throw new Error('Method not implemented.')
   }
-
-  // Only goes for long term create situations, skip
-  async clearStorage(): Promise<void> {}
 }

--- a/packages/statemanager/src/simpleStateManager.ts
+++ b/packages/statemanager/src/simpleStateManager.ts
@@ -4,7 +4,7 @@ import { keccak256 } from 'ethereum-cryptography/keccak.js'
 import { OriginalStorageCache } from './cache/originalStorageCache.js'
 
 import type { SimpleStateManagerOpts } from './index.js'
-import type { AccountFields, Common, EVMStateManagerInterface } from '@ethereumjs/common'
+import type { AccountFields, Common, StateManagerInterface } from '@ethereumjs/common'
 import type { Address, PrefixedHexString } from '@ethereumjs/util'
 
 /**
@@ -22,7 +22,7 @@ import type { Address, PrefixedHexString } from '@ethereumjs/util'
  * For a more full fledged and MPT-backed state manager implementation
  * have a look at the `@ethereumjs/statemanager` package.
  */
-export class SimpleStateManager implements EVMStateManagerInterface {
+export class SimpleStateManager implements StateManagerInterface {
   public accountStack: Map<PrefixedHexString, Account | undefined>[] = []
   public codeStack: Map<PrefixedHexString, Uint8Array>[] = []
   public storageStack: Map<string, Uint8Array>[] = []
@@ -140,7 +140,7 @@ export class SimpleStateManager implements EVMStateManagerInterface {
   async flush(): Promise<void> {}
   clearCaches(): void {}
 
-  shallowCopy(): EVMStateManagerInterface {
+  shallowCopy(): StateManagerInterface {
     const copy = new SimpleStateManager({ common: this.common })
     for (let i = 0; i < this.accountStack.length; i++) {
       copy.accountStack.push(new Map(this.accountStack[i]))

--- a/packages/statemanager/src/simpleStateManager.ts
+++ b/packages/statemanager/src/simpleStateManager.ts
@@ -168,16 +168,7 @@ export class SimpleStateManager implements EVMStateManagerInterface {
   async clearStorage(): Promise<void> {}
 
   // Only "core" methods implemented
-  dumpStorage(): Promise<StorageDump> {
-    throw new Error('Method not implemented.')
-  }
   dumpStorageRange(): Promise<StorageRange> {
-    throw new Error('Method not implemented.')
-  }
-  getProof(): Promise<Proof> {
-    throw new Error('Method not implemented.')
-  }
-  getAppliedKey?(): Uint8Array {
     throw new Error('Method not implemented.')
   }
 }

--- a/packages/statemanager/src/stateManager.ts
+++ b/packages/statemanager/src/stateManager.ts
@@ -38,8 +38,8 @@ import { CODEHASH_PREFIX, type CacheSettings, type DefaultStateManagerOpts } fro
 import type { StorageProof } from './index.js'
 import type {
   AccountFields,
-  StateManagerInterface,
   Proof,
+  StateManagerInterface,
   StorageDump,
   StorageRange,
 } from '@ethereumjs/common'

--- a/packages/statemanager/src/stateManager.ts
+++ b/packages/statemanager/src/stateManager.ts
@@ -38,7 +38,7 @@ import { CODEHASH_PREFIX, type CacheSettings, type DefaultStateManagerOpts } fro
 import type { StorageProof } from './index.js'
 import type {
   AccountFields,
-  EVMStateManagerInterface,
+  StateManagerInterface,
   Proof,
   StorageDump,
   StorageRange,
@@ -61,7 +61,7 @@ import type { Debugger } from 'debug'
  * package which might be an alternative to this implementation
  * for many basic use cases.
  */
-export class DefaultStateManager implements EVMStateManagerInterface {
+export class DefaultStateManager implements StateManagerInterface {
   protected _debug: Debugger
   protected _accountCache?: AccountCache
   protected _storageCache?: StorageCache

--- a/packages/statemanager/src/statelessVerkleStateManager.ts
+++ b/packages/statemanager/src/statelessVerkleStateManager.ts
@@ -871,10 +871,6 @@ export class StatelessVerkleStateManager implements EVMStateManagerInterface {
     this._storageCache?.clear()
   }
 
-  generateCanonicalGenesis(_initState: any): Promise<void> {
-    return Promise.resolve()
-  }
-
   getAppliedKey(_: Uint8Array): Uint8Array {
     throw Error('not implemented')
   }

--- a/packages/statemanager/src/statelessVerkleStateManager.ts
+++ b/packages/statemanager/src/statelessVerkleStateManager.ts
@@ -847,17 +847,6 @@ export class StatelessVerkleStateManager implements EVMStateManagerInterface {
     this._cachedStateRoot = stateRoot
   }
 
-  /**
-   * Dumps the RLP-encoded storage values for an `account` specified by `address`.
-   * @param address - The address of the `account` to return storage for
-   * @returns {Promise<StorageDump>} - The state of the account as an `Object` map.
-   * Keys are are the storage keys, values are the storage values as strings.
-   * Both are represented as hex strings without the `0x` prefix.
-   */
-  async dumpStorage(_: Address): Promise<StorageDump> {
-    throw Error('not implemented')
-  }
-
   dumpStorageRange(_: Address, __: bigint, ___: number): Promise<StorageRange> {
     throw Error('not implemented')
   }

--- a/packages/statemanager/src/statelessVerkleStateManager.ts
+++ b/packages/statemanager/src/statelessVerkleStateManager.ts
@@ -36,7 +36,7 @@ import {
 import type { AccessedStateWithAddress } from './accessWitness.js'
 import type { CacheSettings, StatelessVerkleStateManagerOpts, VerkleState } from './index.js'
 import type { DefaultStateManager } from './stateManager.js'
-import type { AccountFields, EVMStateManagerInterface, Proof } from '@ethereumjs/common'
+import type { AccountFields, StateManagerInterface, Proof } from '@ethereumjs/common'
 import type {
   Address,
   PrefixedHexString,
@@ -66,7 +66,7 @@ const ZEROVALUE = '0x00000000000000000000000000000000000000000000000000000000000
  * to fetch data requested by the the VM.
  *
  */
-export class StatelessVerkleStateManager implements EVMStateManagerInterface {
+export class StatelessVerkleStateManager implements StateManagerInterface {
   _accountCache?: AccountCache
   _storageCache?: StorageCache
   _codeCache?: CodeCache
@@ -253,7 +253,7 @@ export class StatelessVerkleStateManager implements EVMStateManagerInterface {
    * at the last fully committed point, i.e. as if all current
    * checkpoints were reverted.
    */
-  shallowCopy(): EVMStateManagerInterface {
+  shallowCopy(): StateManagerInterface {
     const stateManager = new StatelessVerkleStateManager({ verkleCrypto: this.verkleCrypto })
     return stateManager
   }

--- a/packages/statemanager/src/statelessVerkleStateManager.ts
+++ b/packages/statemanager/src/statelessVerkleStateManager.ts
@@ -36,13 +36,7 @@ import {
 import type { AccessedStateWithAddress } from './accessWitness.js'
 import type { CacheSettings, StatelessVerkleStateManagerOpts, VerkleState } from './index.js'
 import type { DefaultStateManager } from './stateManager.js'
-import type {
-  AccountFields,
-  EVMStateManagerInterface,
-  Proof,
-  StorageDump,
-  StorageRange,
-} from '@ethereumjs/common'
+import type { AccountFields, EVMStateManagerInterface, Proof } from '@ethereumjs/common'
 import type {
   Address,
   PrefixedHexString,
@@ -847,10 +841,6 @@ export class StatelessVerkleStateManager implements EVMStateManagerInterface {
     this._cachedStateRoot = stateRoot
   }
 
-  dumpStorageRange(_: Address, __: bigint, ___: number): Promise<StorageRange> {
-    throw Error('not implemented')
-  }
-
   /**
    * Clears all underlying caches
    */
@@ -858,9 +848,5 @@ export class StatelessVerkleStateManager implements EVMStateManagerInterface {
     this._accountCache?.clear()
     this._codeCache?.clear()
     this._storageCache?.clear()
-  }
-
-  getAppliedKey(_: Uint8Array): Uint8Array {
-    throw Error('not implemented')
   }
 }

--- a/packages/statemanager/src/statelessVerkleStateManager.ts
+++ b/packages/statemanager/src/statelessVerkleStateManager.ts
@@ -849,4 +849,12 @@ export class StatelessVerkleStateManager implements EVMStateManagerInterface {
     this._codeCache?.clear()
     this._storageCache?.clear()
   }
+
+  // TODO: Removing this causes a Kaustinen6 test in client to fail
+  // Seems to point to a more general (non-severe) bug and can likely be fixed
+  // by having the `statelessVerkle` config option more properly set by the
+  // test for the check in the VM execution to call into this method
+  generateCanonicalGenesis(_initState: any): Promise<void> {
+    return Promise.resolve()
+  }
 }

--- a/packages/statemanager/src/statelessVerkleStateManager.ts
+++ b/packages/statemanager/src/statelessVerkleStateManager.ts
@@ -36,7 +36,7 @@ import {
 import type { AccessedStateWithAddress } from './accessWitness.js'
 import type { CacheSettings, StatelessVerkleStateManagerOpts, VerkleState } from './index.js'
 import type { DefaultStateManager } from './stateManager.js'
-import type { AccountFields, StateManagerInterface, Proof } from '@ethereumjs/common'
+import type { AccountFields, Proof, StateManagerInterface } from '@ethereumjs/common'
 import type {
   Address,
   PrefixedHexString,

--- a/packages/vm/src/types.ts
+++ b/packages/vm/src/types.ts
@@ -1,7 +1,7 @@
 import type { Bloom } from './bloom/index.js'
 import type { Block, BlockOptions, HeaderData } from '@ethereumjs/block'
 import type { BlockchainInterface } from '@ethereumjs/blockchain'
-import type { Common, EVMStateManagerInterface, ParamsDict } from '@ethereumjs/common'
+import type { Common, StateManagerInterface, ParamsDict } from '@ethereumjs/common'
 import type { EVMInterface, EVMOpts, EVMResult, Log } from '@ethereumjs/evm'
 import type { AccessList, TypedTransaction } from '@ethereumjs/tx'
 import type {
@@ -117,7 +117,7 @@ export interface VMOpts {
   /**
    * A {@link StateManager} instance to use as the state store
    */
-  stateManager?: EVMStateManagerInterface
+  stateManager?: StateManagerInterface
   /**
    * A {@link Blockchain} object for storing/retrieving blocks
    */

--- a/packages/vm/src/types.ts
+++ b/packages/vm/src/types.ts
@@ -1,7 +1,7 @@
 import type { Bloom } from './bloom/index.js'
 import type { Block, BlockOptions, HeaderData } from '@ethereumjs/block'
 import type { BlockchainInterface } from '@ethereumjs/blockchain'
-import type { Common, StateManagerInterface, ParamsDict } from '@ethereumjs/common'
+import type { Common, ParamsDict, StateManagerInterface } from '@ethereumjs/common'
 import type { EVMInterface, EVMOpts, EVMResult, Log } from '@ethereumjs/evm'
 import type { AccessList, TypedTransaction } from '@ethereumjs/tx'
 import type {

--- a/packages/vm/src/types.ts
+++ b/packages/vm/src/types.ts
@@ -8,7 +8,6 @@ import type {
   BigIntLike,
   CLRequest,
   CLRequestType,
-  GenesisState,
   PrefixedHexString,
   WithdrawalData,
 } from '@ethereumjs/util'
@@ -137,11 +136,6 @@ export interface VMOpts {
    * Default: `false`
    */
   activatePrecompiles?: boolean
-  /**
-   * A genesisState to generate canonical genesis for the "in-house" created stateManager if external
-   * stateManager not provided for the VM, defaults to an empty state
-   */
-  genesisState?: GenesisState
 
   /**
    * Set the hardfork either by timestamp (for HFs from Shanghai onwards) or by block number

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -14,7 +14,7 @@ import { paramsVM } from './params.js'
 
 import type { VMEvents, VMOpts } from './types.js'
 import type { BlockchainInterface } from '@ethereumjs/blockchain'
-import type { EVMStateManagerInterface } from '@ethereumjs/common'
+import type { StateManagerInterface } from '@ethereumjs/common'
 import type { EVMInterface } from '@ethereumjs/evm'
 import type { BigIntLike } from '@ethereumjs/util'
 
@@ -28,7 +28,7 @@ export class VM {
   /**
    * The StateManager used by the VM
    */
-  readonly stateManager: EVMStateManagerInterface
+  readonly stateManager: StateManagerInterface
 
   /**
    * The blockchain the VM operates on

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -89,11 +89,6 @@ export class VM {
       opts.blockchain = await createBlockchain({ common: opts.common })
     }
 
-    const genesisState = opts.genesisState ?? {}
-    if (opts.genesisState !== undefined) {
-      await opts.stateManager.generateCanonicalGenesis(genesisState)
-    }
-
     if (opts.profilerOpts !== undefined) {
       const profilerOpts = opts.profilerOpts
       if (profilerOpts.reportAfterBlock === true && profilerOpts.reportAfterTx === true) {

--- a/packages/vm/test/api/EIPs/eip-4895-withdrawals.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-4895-withdrawals.spec.ts
@@ -130,7 +130,7 @@ describe('EIP4895 tests', () => {
   it('EIP4895: state updation should exclude 0 amount updates', async () => {
     const vm = await VM.create({ common })
 
-    await vm.stateManager.generateCanonicalGenesis(parseGethGenesisState(genesisJSON))
+    await vm.stateManager.generateCanonicalGenesis!(parseGethGenesisState(genesisJSON))
     const preState = bytesToHex(await vm.stateManager.getStateRoot())
     assert.equal(
       preState,
@@ -208,7 +208,7 @@ describe('EIP4895 tests', () => {
       'correct state root should be generated',
     )
     const vm = await VM.create({ common, blockchain })
-    await vm.stateManager.generateCanonicalGenesis(parseGethGenesisState(genesisJSON))
+    await vm.stateManager.generateCanonicalGenesis!(parseGethGenesisState(genesisJSON))
     const vmCopy = await vm.shallowCopy()
 
     const gethBlockBufferArray = decode(hexToBytes(gethWithdrawals8BlockRlp))

--- a/packages/vm/test/api/customChain.spec.ts
+++ b/packages/vm/test/api/customChain.spec.ts
@@ -65,7 +65,8 @@ const privateKey = hexToBytes('0xe331b6d69882b4cb4ea581d88e0b604039a3de5967688d3
 describe('VM initialized with custom state', () => {
   it('should transfer eth from already existent account', async () => {
     const blockchain = await createBlockchain({ common, genesisState })
-    const vm = await VM.create({ blockchain, common, genesisState })
+    const vm = await VM.create({ blockchain, common })
+    await vm.stateManager.generateCanonicalGenesis!(genesisState)
 
     const to = '0x00000000000000000000000000000000000000ff'
     const tx = createTxFromTxData(
@@ -93,7 +94,8 @@ describe('VM initialized with custom state', () => {
   it('should retrieve value from storage', async () => {
     const blockchain = await createBlockchain({ common, genesisState })
     common.setHardfork(Hardfork.London)
-    const vm = await VM.create({ blockchain, common, genesisState })
+    const vm = await VM.create({ blockchain, common })
+    await vm.stateManager.generateCanonicalGenesis!(genesisState)
     const sigHash = new Interface(['function retrieve()']).getSighash(
       'retrieve',
     ) as PrefixedHexString
@@ -114,10 +116,10 @@ describe('VM initialized with custom state', () => {
     const customChains = [testnetMerge] as ChainConfig[]
     const common = new Common({ chain: 'testnetMerge', hardfork: Hardfork.Istanbul, customChains })
 
-    let vm = await VM.create({ common, setHardfork: true, genesisState: {} })
+    let vm = await VM.create({ common, setHardfork: true })
     assert.equal((vm as any)._setHardfork, true, 'should set setHardfork option')
 
-    vm = await VM.create({ common, setHardfork: 5001, genesisState: {} })
+    vm = await VM.create({ common, setHardfork: 5001 })
     assert.equal((vm as any)._setHardfork, BigInt(5001), 'should set setHardfork option')
   })
 })

--- a/packages/vm/test/util.ts
+++ b/packages/vm/test/util.ts
@@ -26,7 +26,7 @@ import {
 import { keccak256 } from 'ethereum-cryptography/keccak'
 
 import type { BlockOptions } from '@ethereumjs/block'
-import type { EVMStateManagerInterface } from '@ethereumjs/common'
+import type { StateManagerInterface } from '@ethereumjs/common'
 import type {
   AccessListEIP2930Transaction,
   BlobEIP4844Transaction,
@@ -363,7 +363,7 @@ export function makeBlockFromEnv(env: any, opts?: BlockOptions): Block {
  * @param state - the state DB/trie
  * @param testData - JSON from tests repo
  */
-export async function setupPreConditions(state: EVMStateManagerInterface, testData: any) {
+export async function setupPreConditions(state: StateManagerInterface, testData: any) {
   await state.checkpoint()
   for (const addressStr of Object.keys(testData.pre)) {
     const { nonce, balance, code, storage } = testData.pre[addressStr]


### PR DESCRIPTION
This PR refactors and simplifies the `StateManager` interfaces located in `Common`. Especially the double structure with the more generic `StateManagerInterface` and the inheriting `EVMStateManagerInterface` turned out to be too inflexible and more and more non-EVM methods had been added there over the years, since one could not "escape the inheritance structure".

![grafik](https://github.com/user-attachments/assets/35c2514d-3f96-4b58-9c95-86b10d2f99dc)

After some discussion of some more complex solutions (multiple interfaces, by case API definitions citing the various interfaces needed), this PR now goes for a more simple solution, which nevertheless should suit the practical needs. The two interfaces are unified again, and instead not so central functionality is made optional (`getProof()`, `dumpStorage(),..). This allows to free the various state manager implementations from most of the "dummy methods" which simply throw when called (which is inherently dangerous).

Instead it should be made sure (mostly) on the constructor level of consuming classes that a state manager is passed in which provides the respective functionality for some applied configuration (e.g. the EVM checking for the Verkle-needed methods when 6800 is activated in the constructor).

The whole refactoring is accompanied by a stronger grouping and documentation of the various state manager properties in the `StateManagerInterface`. This should additionally help to not get lost again what functionality is used where and for what and to make proper decisions in the future on how to place a new state manager method and if to make optional or not.

Best reviewed commit-by-commit (I guess), ready for review! 🙂 
