### PR TITLE
RPC: add data field to RpcError / eth_call error

### DIFF
--- a/packages/client/src/rpc/helpers.ts
+++ b/packages/client/src/rpc/helpers.ts
@@ -10,6 +10,7 @@ type RpcError = {
   code: number
   message: string
   trace?: string
+  data?: string
 }
 
 export function callWithStackTrace(handler: Function, debug: boolean) {
@@ -21,6 +22,7 @@ export function callWithStackTrace(handler: Function, debug: boolean) {
       const e: RpcError = {
         code: error.code ?? INTERNAL_ERROR,
         message: error.message,
+        data: error.data,
       }
       if (debug === true) {
         e['trace'] = error.stack

--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -526,6 +526,13 @@ export class Eth {
       block,
     }
     const { execResult } = await vm.evm.runCall(runCallOpts)
+    if (execResult.exceptionError !== undefined) {
+      throw {
+        code: 3,
+        data: bytesToHex(execResult.returnValue),
+        message: execResult.exceptionError.error,
+      }
+    }
     return bytesToHex(execResult.returnValue)
   }
 

--- a/packages/client/test/rpc/eth/call.spec.ts
+++ b/packages/client/test/rpc/eth/call.spec.ts
@@ -101,6 +101,7 @@ describe(method, () => {
       { ...estimateTxData, gas: estimateTxData.gasLimit },
       'latest',
     ])
+    assert.equal(res.error.code, 3, 'should return the correct error code')
     assert.equal(
       res.error.data,
       bytesToHex(execResult.returnValue),
@@ -108,6 +109,7 @@ describe(method, () => {
     )
 
     res = await rpc.request(method, [{ ...estimateTxData }, 'latest'])
+    assert.equal(res.error.code, 3, 'should return the correct error code')
     assert.equal(
       res.error.data,
       bytesToHex(execResult.returnValue),

--- a/packages/client/test/rpc/eth/call.spec.ts
+++ b/packages/client/test/rpc/eth/call.spec.ts
@@ -102,14 +102,14 @@ describe(method, () => {
       'latest',
     ])
     assert.equal(
-      res.result,
+      res.error.data,
       bytesToHex(execResult.returnValue),
       'should return the correct return value',
     )
 
     res = await rpc.request(method, [{ ...estimateTxData }, 'latest'])
     assert.equal(
-      res.result,
+      res.error.data,
       bytesToHex(execResult.returnValue),
       'should return the correct return value with no gas limit provided',
     )


### PR DESCRIPTION
Updates to satisfy `hive` **rpc-spec** tests.

Adds an optional `data` field to the type `RpcError`:
```
RpcError = {
  code: number
  message: string
  trace?: string
  data?: string
}
```

### eth_call

per `hive` tests: **eth_call/call-revert-abi-error** and **eth_call/call-revert-abi-panic**

when `eth_call` reverts, it should return an error object:
```ts
{ code: 3,
data: <executionResult>,
message: <error message> }
```

This change to `eth_call` fixes these 2 failing hive tests:
```ts
 if (execResult.exceptionError !== undefined) {
      throw {
        code: 3,
        data: bytesToHex(execResult.returnValue),
        message: execResult.exceptionError.error,
      }
    }
```