### PR TITLE
blockchain: move chain,skeleton to blockchain

### DIFF
--- a/packages/blockchain/src/chain.ts
+++ b/packages/blockchain/src/chain.ts
@@ -25,6 +25,7 @@ export type ChainConfig = {
   skeletonFillCanonicalBackStep: number
   maxPerRequest: number
   chainCommon: Common
+  logger?: Logger
 }
 
 /**
@@ -34,7 +35,6 @@ export interface ChainOptions {
   /**
    * Client configuration instance
    */
-  logger?: Logger
   config: ChainConfig
 
   /**
@@ -140,7 +140,6 @@ type BlockCache = {
  */
 export class Chain {
   public config: ChainConfig
-  public logger?: Logger
   public chainDB: DB<string | Uint8Array, string | Uint8Array | DBObject>
   public blockchain: Blockchain
   public blockCache: BlockCache
@@ -207,7 +206,6 @@ export class Chain {
    */
   protected constructor(options: ChainOptions) {
     this.config = options.config
-    this.logger = options.logger
     this.blockchain = options.blockchain!
     this.blockCache = {
       remoteBlocks: new Map(),
@@ -229,11 +227,11 @@ export class Chain {
     for (const msg of msgs) {
       len = msg.length > len ? msg.length : len
     }
-    this.logger?.info('-'.repeat(len), meta)
+    this.config.logger?.info('-'.repeat(len), meta)
     for (const msg of msgs) {
-      this.logger?.info(msg, meta)
+      this.config.logger?.info(msg, meta)
     }
-    this.logger?.info('-'.repeat(len), meta)
+    this.config.logger?.info('-'.repeat(len), meta)
   }
 
   /**
@@ -384,24 +382,24 @@ export class Chain {
         td: headers.td,
       })
       if (this.config.chainCommon.hardforkGteHardfork(nextBlockHf, Hardfork.Paris)) {
-        this.logger?.info('*'.repeat(85))
-        this.logger?.info(
+        this.config.logger?.info('*'.repeat(85))
+        this.config.logger?.info(
           `Paris (Merge) hardfork reached 🐼 👉 👈 🐼 ! block=${headers.height} td=${headers.td}`
         )
-        this.logger?.info('-'.repeat(85))
-        this.logger?.info(' ')
-        this.logger?.info('Consensus layer client (CL) needed for continued sync:')
-        this.logger?.info(
+        this.config.logger?.info('-'.repeat(85))
+        this.config.logger?.info(' ')
+        this.config.logger?.info('Consensus layer client (CL) needed for continued sync:')
+        this.config.logger?.info(
           'https://ethereum.org/en/developers/docs/nodes-and-clients/#consensus-clients'
         )
-        this.logger?.info(' ')
-        this.logger?.info(
+        this.config.logger?.info(' ')
+        this.config.logger?.info(
           'Make sure to have the JSON RPC (--rpc) and Engine API (--rpcEngine) endpoints exposed'
         )
-        this.logger?.info('and JWT authentication configured (see client README).')
-        this.logger?.info(' ')
-        this.logger?.info('*'.repeat(85))
-        this.logger?.info(
+        this.config.logger?.info('and JWT authentication configured (see client README).')
+        this.config.logger?.info(' ')
+        this.config.logger?.info('*'.repeat(85))
+        this.config.logger?.info(
           `Transitioning to PoS! First block for CL-framed execution: block=${
             headers.height + BIGINT_1
           }`

--- a/packages/blockchain/src/db/constants.ts
+++ b/packages/blockchain/src/db/constants.ts
@@ -39,6 +39,8 @@ const BLOCK_HASH_PEFIX = utf8ToBytes('H')
  */
 const BODY_PREFIX = utf8ToBytes('b')
 
+export const SKELETON_PREFIX = utf8ToBytes('s')
+
 // Utility functions
 
 /**

--- a/packages/blockchain/src/index.ts
+++ b/packages/blockchain/src/index.ts
@@ -1,4 +1,5 @@
 export { Blockchain } from './blockchain.js'
+export { Chain, ChainConfig } from './chain.js'
 export { CasperConsensus, CliqueConsensus, EthashConsensus } from './consensus/index.js'
 export * from './constructors.js'
 export {
@@ -9,4 +10,5 @@ export {
   DBSetTD,
 } from './db/helpers.js'
 export * from './helpers.js'
+export { errSyncMerged, PutStatus, Skeleton } from './skeleton.js'
 export * from './types.js'

--- a/packages/blockchain/src/level.ts
+++ b/packages/blockchain/src/level.ts
@@ -1,0 +1,122 @@
+import { KeyEncoding, ValueEncoding } from '@ethereumjs/util'
+import { MemoryLevel } from 'memory-level'
+
+import type { BatchDBOp, DB, DBObject, EncodingOpts } from '@ethereumjs/util'
+import type { AbstractLevel } from 'abstract-level'
+
+// Helper to infer the `valueEncoding` option for `putting` a value in a levelDB
+const getEncodings = (opts: EncodingOpts = {}) => {
+  const encodings = { keyEncoding: '', valueEncoding: '' }
+  switch (opts.valueEncoding) {
+    case ValueEncoding.String:
+      encodings.valueEncoding = 'utf8'
+      break
+    case ValueEncoding.Bytes:
+      encodings.valueEncoding = 'view'
+      break
+    case ValueEncoding.JSON:
+      encodings.valueEncoding = 'json'
+      break
+    default:
+      encodings.valueEncoding = 'view'
+  }
+  switch (opts.keyEncoding) {
+    case KeyEncoding.Bytes:
+      encodings.keyEncoding = 'view'
+      break
+    case KeyEncoding.Number:
+    case KeyEncoding.String:
+      encodings.keyEncoding = 'utf8'
+      break
+    default:
+      encodings.keyEncoding = 'utf8'
+  }
+
+  return encodings
+}
+
+/**
+ * LevelDB is a thin wrapper around the underlying levelup db,
+ * corresponding to the {@link DB}
+ */
+export class LevelDB<
+  TKey extends Uint8Array | string = Uint8Array | string,
+  TValue extends Uint8Array | string | DBObject = Uint8Array | string | DBObject
+> implements DB<TKey, TValue>
+{
+  _leveldb: AbstractLevel<string | Uint8Array, string | Uint8Array, string | Uint8Array>
+
+  /**
+   * Initialize a DB instance. If `leveldb` is not provided, DB
+   * defaults to an [in-memory store](https://github.com/Level/memdown).
+   * @param leveldb - An abstract-leveldown compliant store
+   */
+  constructor(
+    leveldb?: AbstractLevel<string | Uint8Array, string | Uint8Array, string | Uint8Array>
+  ) {
+    this._leveldb = leveldb ?? new MemoryLevel()
+  }
+
+  /**
+   * @inheritDoc
+   */
+  async get(key: TKey, opts?: EncodingOpts): Promise<TValue | undefined> {
+    let value
+    const encodings = getEncodings(opts)
+
+    try {
+      value = await this._leveldb.get(key, encodings)
+      if (value === null) return undefined
+    } catch (error: any) {
+      // https://github.com/Level/abstract-level/blob/915ad1317694d0ce8c580b5ab85d81e1e78a3137/abstract-level.js#L309
+      // This should be `true` if the error came from LevelDB
+      // so we can check for `NOT true` to identify any non-404 errors
+      if (error.notFound !== true) {
+        throw error
+      }
+    }
+    // eslint-disable-next-line
+    if (value instanceof Buffer) value = Uint8Array.from(value)
+    return value as TValue
+  }
+
+  /**
+   * @inheritDoc
+   */
+  async put(key: TKey, val: TValue, opts?: {}): Promise<void> {
+    const encodings = getEncodings(opts)
+    await this._leveldb.put(key, val, encodings)
+  }
+
+  /**
+   * @inheritDoc
+   */
+  async del(key: TKey): Promise<void> {
+    await this._leveldb.del(key)
+  }
+
+  /**
+   * @inheritDoc
+   */
+  async batch(opStack: BatchDBOp<TKey, TValue>[]): Promise<void> {
+    const levelOps = []
+    for (const op of opStack) {
+      const encodings = getEncodings(op.opts)
+      levelOps.push({ ...op, ...encodings })
+    }
+
+    // TODO: Investigate why as any is necessary
+    await this._leveldb.batch(levelOps as any)
+  }
+
+  /**
+   * @inheritDoc
+   */
+  shallowCopy(): DB<TKey, TValue> {
+    return new LevelDB<TKey, TValue>(this._leveldb)
+  }
+
+  open() {
+    return this._leveldb.open()
+  }
+}

--- a/packages/blockchain/src/skeleton.ts
+++ b/packages/blockchain/src/skeleton.ts
@@ -3,28 +3,46 @@ import { RLP } from '@ethereumjs/rlp'
 import {
   BIGINT_0,
   BIGINT_1,
-  BIGINT_100,
-  BIGINT_2EXP256,
+  KeyEncoding,
   Lock,
+  ValueEncoding,
   bigIntToBytes,
   bytesToBigInt,
   bytesToInt,
+  concatBytes,
   equalsBytes,
-  formatBigDecimal,
   intToBytes,
+  short,
   utf8ToBytes,
   zeros,
 } from '@ethereumjs/util'
 
-import { short, timeDuration } from '../util/index.js'
-import { DBKey, MetaDBManager } from '../util/metaDBManager.js'
+import { SKELETON_PREFIX } from './db/constants.js'
 
-import type { SnapFetcherDoneFlags } from '../sync/fetcher/types.js'
-import type { MetaDBManagerOptions } from '../util/metaDBManager.js'
+import type { Chain } from './chain.js'
 import type { Block, BlockHeader } from '@ethereumjs/block'
 import type { Hardfork } from '@ethereumjs/common'
+import type { Logger as WinstonLogger } from 'winston'
+export type Logger = WinstonLogger
 
 const INVALID_PARAMS = -32602
+
+export enum DBKey {
+  Receipts,
+  TxHash,
+  SkeletonBlock,
+  SkeletonBlockHashToNumber,
+  SkeletonStatus,
+  SkeletonUnfinalizedBlockByHash,
+  Preimage,
+}
+const encodingOpts = { keyEncoding: KeyEncoding.Bytes, valueEncoding: ValueEncoding.Bytes }
+
+export interface SkeletonOptions {
+  /* Chain */
+  chain: Chain
+  logger?: Logger
+}
 
 export enum PutStatus {
   VALID = 'VALID',
@@ -90,41 +108,18 @@ export const errReorgDenied = new Error('non-forced head reorg denied')
 export const errSyncMerged = new Error('sync merged')
 
 const zeroBlockHash = zeros(32)
-/**
- * The Skeleton chain class helps support beacon sync by accepting head blocks
- * while backfill syncing the rest of the chain.
- */
 
-const STALE_WINDOW = 10 * 60_000
-
-export class Skeleton extends MetaDBManager {
+export class Skeleton {
   private _lock = new Lock()
+  private logger?: Logger
 
-  private status: SkeletonStatus
+  chain: Chain
+  status: SkeletonStatus
   fillStatus: FillStatus | null = null
 
-  private started: number /** Timestamp when the skeleton syncer was created */
-
-  private syncedchain = 0
-  private pulled = BIGINT_0 /** Number of headers downloaded in this run */
-
-  private filling = false /** Whether we are actively filling the canonical chain */
-  private lastfilledAt = 0
-  private lastfilled = BIGINT_0
-
-  private lastexecutedAt = 0
-  private lastexecuted = BIGINT_0
-
-  private lastfetchedAt = 0
-  private lastfetched = BIGINT_0
-
-  private lastvalid = 0
-
-  private lastFcuTime = 0
-  private lastsyncedAt = 0
-
-  private STATUS_LOG_INTERVAL = 8000 /** How often to log sync status (in ms) */
-
+  started: number /** Timestamp when the skeleton syncer was created */
+  pulled = BIGINT_0 /** Number of headers downloaded in this run */
+  filling = false /** Whether we are actively filling the canonical chain *
   /**
    * safeBlock as indicated by engine api, set
    */
@@ -135,9 +130,10 @@ export class Skeleton extends MetaDBManager {
   synchronized = false
   private lastsyncronized = false
   private lastSyncDate = 0
+  lastFcuTime = 0
 
-  constructor(opts: MetaDBManagerOptions) {
-    super(opts)
+  constructor(opts: SkeletonOptions) {
+    this.chain = opts.chain
     this.status = {
       progress: { subchains: [] },
       linked: false,
@@ -146,6 +142,48 @@ export class Skeleton extends MetaDBManager {
       finalized: BIGINT_0,
     }
     this.started = 0
+  }
+
+  superMsg(msgs: string | string[], meta?: any) {
+    if (typeof msgs === 'string') {
+      msgs = [msgs]
+    }
+    let len = 0
+    for (const msg of msgs) {
+      len = msg.length > len ? msg.length : len
+    }
+    this.logger?.info('-'.repeat(len), meta)
+    for (const msg of msgs) {
+      this.logger?.info(msg, meta)
+    }
+    this.logger?.info('-'.repeat(len), meta)
+  }
+
+  private dbKey(type: DBKey, key: Uint8Array) {
+    return concatBytes(SKELETON_PREFIX, intToBytes(type), key)
+  }
+
+  async put(type: DBKey, hash: Uint8Array, value: Uint8Array) {
+    await this.chain.chainDB.put(this.dbKey(type, hash), value, encodingOpts)
+  }
+
+  async get(type: DBKey, hash: Uint8Array): Promise<Uint8Array | null> {
+    try {
+      return (
+        ((await this.chain.chainDB.get(this.dbKey(type, hash), encodingOpts)) as
+          | Uint8Array
+          | undefined) ?? null
+      )
+    } catch (error: any) {
+      if (error.code === 'LEVEL_NOT_FOUND') {
+        return null
+      }
+      throw Error
+    }
+  }
+
+  async delete(type: DBKey, hash: Uint8Array) {
+    await this.chain.chainDB.del(this.dbKey(type, hash), encodingOpts)
   }
 
   /**
@@ -213,7 +251,7 @@ export class Skeleton extends MetaDBManager {
       if (linked && this.status.progress.subchains.length > 1) {
         // Remove all other subchains as no more relevant
         const junkedSubChains = this.status.progress.subchains.splice(1)
-        this.config.logger.debug(
+        this.logger?.debug(
           `Canonical subchain linked with main, removing junked chains ${junkedSubChains
             .map((s) => `[tail=${s.tail} head=${s.head} next=${short(s.next)}]`)
             .join(',')}`
@@ -261,7 +299,7 @@ export class Skeleton extends MetaDBManager {
       headBlock = newBlock
     }
     lastchain.head = headBlock.header.number
-    this.config.logger.debug(
+    this.logger?.debug(
       `lastchain head fast forwarded from=${head} to=${lastchain.head} tail=${lastchain.tail}`
     )
   }
@@ -301,14 +339,14 @@ export class Skeleton extends MetaDBManager {
     if (lastchain.tail > number) {
       // Not a noop / double head announce, abort with a reorg
       if (force) {
-        this.config.logger.warn(
+        this.logger?.warn(
           `Skeleton setHead before tail, resetting skeleton tail=${lastchain.tail} head=${lastchain.head} newHead=${number}`
         )
         lastchain.head = number
         lastchain.tail = number
         lastchain.next = head.header.parentHash
       } else {
-        this.config.logger.debug(
+        this.logger?.debug(
           `Skeleton announcement before tail, will reset skeleton tail=${lastchain.tail} head=${lastchain.head} newHead=${number}`
         )
       }
@@ -318,7 +356,7 @@ export class Skeleton extends MetaDBManager {
       // post this if block
       const mayBeDupBlock = await this.getBlock(number)
       if (mayBeDupBlock !== undefined && equalsBytes(mayBeDupBlock.header.hash(), head.hash())) {
-        this.config.logger.debug(
+        this.logger?.debug(
           `Skeleton duplicate ${force ? 'setHead' : 'announcement'} tail=${lastchain.tail} head=${
             lastchain.head
           } number=${number} hash=${short(head.hash())}`
@@ -328,7 +366,7 @@ export class Skeleton extends MetaDBManager {
         // Since its not a dup block, so there is reorg in the chain or at least in the head
         // which we will let it get addressed post this if else block
         if (force) {
-          this.config.logger.debug(
+          this.logger?.debug(
             `Skeleton head reorg tail=${lastchain.tail} head=${
               lastchain.head
             } number=${number} expected=${short(
@@ -336,7 +374,7 @@ export class Skeleton extends MetaDBManager {
             )} actual=${short(head.hash())}`
           )
         } else {
-          this.config.logger.debug(
+          this.logger?.debug(
             `Skeleton differing announcement tail=${lastchain.tail} head=${lastchain.head} number=${number}`
           )
         }
@@ -347,13 +385,11 @@ export class Skeleton extends MetaDBManager {
         await this.fastForwardHead(lastchain, number - BIGINT_1)
         // If its still less than number then its gapped head
         if (lastchain.head + BIGINT_1 < number) {
-          this.config.logger.debug(
-            `Beacon chain gapped setHead head=${lastchain.head} newHead=${number}`
-          )
+          this.logger?.debug(`Beacon chain gapped setHead head=${lastchain.head} newHead=${number}`)
           return true
         }
       } else {
-        this.config.logger.debug(
+        this.logger?.debug(
           `Beacon chain gapped announcement head=${lastchain.head} newHead=${number}`
         )
         return true
@@ -362,7 +398,7 @@ export class Skeleton extends MetaDBManager {
     const parent = await this.getBlock(number - BIGINT_1)
     if (parent === undefined || !equalsBytes(parent.hash(), head.header.parentHash)) {
       if (force) {
-        this.config.logger.warn(
+        this.logger?.warn(
           `Beacon chain forked ancestor=${parent?.header.number} hash=${short(
             parent?.hash() ?? 'NA'
           )} want=${short(head.header.parentHash)}`
@@ -378,7 +414,7 @@ export class Skeleton extends MetaDBManager {
         this.status.progress.subchains.push(lastchain)
         this.status.linked = await this.checkLinked()
       }
-      this.config.logger.debug(
+      this.logger?.debug(
         `Beacon chain extended new head=${lastchain.head} tail=${lastchain.tail} next=${short(
           lastchain.next
         )}`
@@ -399,10 +435,10 @@ export class Skeleton extends MetaDBManager {
    */
   async setHead(head: Block, force = true, init = false, reorgthrow = false): Promise<boolean> {
     if (
-      this.config.syncTargetHeight === undefined ||
-      this.config.syncTargetHeight < head.header.number
+      this.chain.config.syncTargetHeight === undefined ||
+      this.chain.config.syncTargetHeight < head.header.number
     ) {
-      this.config.syncTargetHeight = head.header.number
+      this.chain.config.syncTargetHeight = head.header.number
     }
 
     return this.runWithLock<boolean>(async () => {
@@ -413,7 +449,7 @@ export class Skeleton extends MetaDBManager {
         this.lastFcuTime = Date.now()
       }
 
-      this.config.logger.debug(
+      this.logger?.debug(
         `New skeleton head announced number=${head.header.number} hash=${short(
           head.hash()
         )} force=${force}`
@@ -429,7 +465,7 @@ export class Skeleton extends MetaDBManager {
         }
         this.status.linked = true
         this.status.canonicalHeadReset = false
-        this.config.logger.debug(
+        this.logger?.debug(
           `Initing empty skeleton with current chain head tail=${lastchain.tail} head=${
             lastchain.head
           } next=${short(lastchain.next)}`
@@ -470,14 +506,14 @@ export class Skeleton extends MetaDBManager {
             if (trucateTailTo !== undefined) {
               subchain.tail = trucateTailTo.header.number
               subchain.next = trucateTailTo.header.parentHash
-              this.config.logger.info(
+              this.logger?.info(
                 `Truncated subchain0 with head=${subchain.head} to a new tail=${
                   subchain.tail
                 } next=${short(subchain.next)} before overlaying a new subchain`
               )
             } else {
               // clear out this subchain
-              this.config.logger.info(
+              this.logger?.info(
                 `Dropping subchain0 with head=${subchain.head} before overlaying a new subchain as trucateTailToNumber=${trucateTailToNumber} block not available `
               )
               this.status.progress.subchains.splice(0, 1)
@@ -500,7 +536,7 @@ export class Skeleton extends MetaDBManager {
             `Created new subchain tail=${s.tail} head=${s.head} next=${short(s.next)}`,
             'Note: Subchain will be backfilled and merged with the canonical chain on success.',
           ]
-          this.config.superMsg(msgs)
+          this.superMsg(msgs)
           // Reset the filling of canonical head from tail only on tail reorg and exit any ongoing fill
           this.status.canonicalHeadReset = s.tail > BIGINT_0
         } else {
@@ -526,7 +562,7 @@ export class Skeleton extends MetaDBManager {
               // reset canonical head, don't change linked status because parent was
               // found in canonical chain
               this.status.canonicalHeadReset = true
-              this.config.logger.info(
+              this.logger?.info(
                 `Truncated subchain tail for chain reorg to the subchain head=${
                   subchain.tail
                 } next=${short(subchain.next)} linked=${this.status.linked} canonicalHeadReset=${
@@ -537,7 +573,7 @@ export class Skeleton extends MetaDBManager {
               subchain.tail = trucateTailTo.header.number
               subchain.next = trucateTailTo.header.parentHash
               // just reset tail and no need to modify linked status
-              this.config.logger.info(
+              this.logger?.info(
                 `Truncated subchain with head=${subchain.head} to a new tail=${
                   subchain.tail
                 } next=${short(subchain.next)} linked=${this.status.linked} canonicalHeadReset=${
@@ -572,7 +608,7 @@ export class Skeleton extends MetaDBManager {
         await this.writeSyncStatus()
       }
       if (init) {
-        this.logSyncStatus('init', { forceShowInfo: true })
+        this.logSyncStatus('init')
       }
 
       // Earlier we were throwing on reorg, essentially for the purposes for killing the reverse fetcher
@@ -597,14 +633,14 @@ export class Skeleton extends MetaDBManager {
     // If no syncTargetHeight has been discovered from peer or fcU sync state can't be
     // determined
     const subchain0 = this.status.progress.subchains[0]
-    if ((this.config.syncTargetHeight ?? BIGINT_0) === BIGINT_0 || subchain0 === undefined) {
+    if ((this.chain.config.syncTargetHeight ?? BIGINT_0) === BIGINT_0 || subchain0 === undefined) {
       return
     }
 
     if (latest !== null && latest !== undefined) {
       const height = subchain0.head
-      if (height >= (this.config.syncTargetHeight ?? BIGINT_0)) {
-        this.config.syncTargetHeight = height
+      if (height >= (this.chain.config.syncTargetHeight ?? BIGINT_0)) {
+        this.chain.config.syncTargetHeight = height
         this.lastSyncDate =
           typeof latest.timestamp === 'bigint' && latest.timestamp > 0n
             ? Number(latest.timestamp) * 1000
@@ -612,11 +648,11 @@ export class Skeleton extends MetaDBManager {
 
         const diff = Date.now() - this.lastSyncDate
         // update synchronized
-        if (diff < this.config.syncedStateRemovalPeriod) {
+        if (diff < this.chain.config.syncedStateRemovalPeriod) {
           if (!this.synchronized) {
             this.synchronized = true
             // Log to console the sync status
-            this.config.superMsg(
+            this.superMsg(
               `Synchronized cl (skeleton) at height=${height} hash=${short(latest.hash())} 🎉`
             )
           }
@@ -625,9 +661,9 @@ export class Skeleton extends MetaDBManager {
     } else {
       if (this.synchronized) {
         const diff = Date.now() - this.lastSyncDate
-        if (diff >= this.config.syncedStateRemovalPeriod) {
+        if (diff >= this.chain.config.syncedStateRemovalPeriod) {
           this.synchronized = false
-          this.config.logger.info(
+          this.logger?.info(
             `Cl (skeleton) sync status reset (no chain updates for ${Math.round(
               diff / 1000
             )} seconds).`
@@ -637,10 +673,10 @@ export class Skeleton extends MetaDBManager {
     }
 
     if (this.synchronized !== this.lastsyncronized) {
-      this.config.logger.debug(
+      this.logger?.debug(
         `Cl (skeleton) synchronized=${this.synchronized}${
           latest !== null && latest !== undefined ? ' height=' + latest.number : ''
-        } syncTargetHeight=${this.config.syncTargetHeight} lastSyncDate=${
+        } syncTargetHeight=${this.chain.config.syncTargetHeight} lastSyncDate=${
           (Date.now() - this.lastSyncDate) / 1000
         } secs ago`
       )
@@ -664,7 +700,7 @@ export class Skeleton extends MetaDBManager {
       // blocking fill with engineParentLookupMaxDepth as fcU tries to put max engineParentLookupMaxDepth
       await this.blockingTailBackfillWithCutoff(this.chain.config.engineParentLookupMaxDepth).catch(
         (e) => {
-          this.config.logger.debug(`blockingTailBackfillWithCutoff exited with error=${e}`)
+          this.logger?.debug(`blockingTailBackfillWithCutoff exited with error=${e}`)
         }
       )
     }
@@ -826,7 +862,7 @@ export class Skeleton extends MetaDBManager {
         ((this.safeBlock !== undefined &&
           syncedBlock.header.number <= this.safeBlock.header.number) ||
           syncedBlock.header.number <=
-            this.chain.blocks.height - this.config.snapTransitionSafeDepth)
+            this.chain.blocks.height - this.chain.config.snapTransitionSafeDepth)
       ) {
         await this.chain.blockchain.setIteratorHead('vm', syncedHash)
         await this.chain.update(false)
@@ -882,7 +918,7 @@ export class Skeleton extends MetaDBManager {
       // its head independent of matching or mismatching content
       if (tail >= this.status.progress.subchains[0].tail) {
         // Fully overwritten, get rid of the subchain as a whole
-        this.config.logger.debug(
+        this.logger?.debug(
           `Previous subchain fully overwritten tail=${tail} head=${head} next=${short(next)}`
         )
         this.status.progress.subchains.splice(1, 1)
@@ -891,7 +927,7 @@ export class Skeleton extends MetaDBManager {
       } else {
         // Partially overwritten, trim the head to the overwritten size
         this.status.progress.subchains[1].head = this.status.progress.subchains[0].tail - BIGINT_1
-        this.config.logger.debug(
+        this.logger?.debug(
           `Previous subchain partially overwritten tail=${tail} head=${head} next=${short(
             next
           )} with newHead=${this.status.progress.subchains[1].head}`
@@ -912,7 +948,7 @@ export class Skeleton extends MetaDBManager {
       ) {
         // if subChain1Head is not in the skeleton then all previous subchains are not useful
         // and better to junk
-        this.config.logger.debug(
+        this.logger?.debug(
           `Removing all previous subchains as skeleton missing block at previous subchain head=${this.status.progress.subchains[1].head} or its tail=${this.status.progress.subchains[1].tail}`
         )
         this.status.progress.subchains.splice(1, this.status.progress.subchains.length - 1)
@@ -921,8 +957,8 @@ export class Skeleton extends MetaDBManager {
       ) {
         // only merge is we can integrate a big progress, as each merge leads
         // to disruption of the block fetcher to start a fresh
-        if (head - tail > this.config.skeletonSubchainMergeMinimum) {
-          this.config.logger.debug(
+        if (head - tail > this.chain.config.skeletonSubchainMergeMinimum) {
+          this.logger?.debug(
             `Previous subchain merged tail=${tail} head=${head} next=${short(next)}`
           )
           this.status.progress.subchains[0].tail = tail
@@ -932,7 +968,7 @@ export class Skeleton extends MetaDBManager {
           // are invalid since we skipped ahead.
           merged = true
         } else {
-          this.config.logger.debug(
+          this.logger?.debug(
             `Subchain ignored for merge tail=${tail} head=${head} count=${head - tail}`
           )
           this.status.progress.subchains.splice(1, 1)
@@ -960,7 +996,7 @@ export class Skeleton extends MetaDBManager {
 
       let merged = false
       let tailUpdated = false
-      this.config.logger.debug(
+      this.logger?.debug(
         `Skeleton putBlocks start=${blocks[0]?.header.number} hash=${short(
           blocks[0]?.hash()
         )} fork=${blocks[0].common.hardfork()} end=${
@@ -999,7 +1035,7 @@ export class Skeleton extends MetaDBManager {
           // Critical error, we expect new incoming blocks to extend the canonical
           // subchain which is the [0]'th
           const tailBlock = await this.getBlock(this.status.progress.subchains[0].tail)
-          this.config.logger.warn(
+          this.logger?.warn(
             `Blocks don't extend canonical subchain tail=${
               this.status.progress.subchains[0].tail
             } head=${this.status.progress.subchains[0].head} next=${short(
@@ -1034,9 +1070,7 @@ export class Skeleton extends MetaDBManager {
 
       // If the sync is finished, start filling the canonical chain.
       if (this.status.linked) {
-        this.config.superMsg(
-          `Backfilling subchain completed, filling canonical chain=${!skipForwardFill}`
-        )
+        this.superMsg(`Backfilling subchain completed, filling canonical chain=${!skipForwardFill}`)
         if (!skipForwardFill) {
           void this.fillCanonicalChain()
         }
@@ -1049,14 +1083,14 @@ export class Skeleton extends MetaDBManager {
 
   private async backStep(fromBlock: bigint): Promise<bigint | null> {
     try {
-      if (this.config.skeletonFillCanonicalBackStep <= 0) return null
+      if (this.chain.config.skeletonFillCanonicalBackStep <= 0) return null
       const { head, tail } = this.bounds()
       // by default we try back stepping from tail or fromBlock whichever is bigger
       let newTail: bigint | null = tail < fromBlock ? fromBlock : tail
 
       let tailBlock
       do {
-        newTail = newTail + BigInt(this.config.skeletonFillCanonicalBackStep)
+        newTail = newTail + BigInt(this.chain.config.skeletonFillCanonicalBackStep)
         tailBlock = await this.getBlock(newTail, true)
       } while (tailBlock === undefined && newTail <= head)
       if (newTail > head) {
@@ -1065,7 +1099,7 @@ export class Skeleton extends MetaDBManager {
       }
 
       if (tailBlock !== undefined && newTail) {
-        this.config.logger.info(`Backstepped skeleton tail=${newTail} head=${head}`)
+        this.logger?.info(`Backstepped skeleton tail=${newTail} head=${head}`)
         this.status.progress.subchains[0].tail = tailBlock.header.number
         this.status.progress.subchains[0].next = tailBlock.header.parentHash
         await this.writeSyncStatus()
@@ -1074,9 +1108,7 @@ export class Skeleton extends MetaDBManager {
         // we need a new head, emptying the subchains
         this.status.progress.subchains = []
         await this.writeSyncStatus()
-        this.config.logger.warn(
-          `Couldn't backStep subchain 0, dropping subchains for new head signal`
-        )
+        this.logger?.warn(`Couldn't backStep subchain 0, dropping subchains for new head signal`)
         return null
       }
     } finally {
@@ -1098,7 +1130,7 @@ export class Skeleton extends MetaDBManager {
         subchain0.head - BigInt(cutoffLen) <
         (this.status.canonicalHeadReset ? subchain0.tail : this.chain.blocks.height)
       ) {
-        this.config.logger.debug('Attempting blocking fill')
+        this.logger?.debug('Attempting blocking fill')
         await fillPromise
       }
     }
@@ -1150,7 +1182,7 @@ export class Skeleton extends MetaDBManager {
       // fill
       if (!this.status.linked && blocks.length === maxItems) {
         void this.tryTailBackfill().catch((e) => {
-          this.chain.config.logger.debug(`tryTailBackfill exited with error ${e}`)
+          this.logger?.debug(`tryTailBackfill exited with error ${e}`)
         })
       }
     }
@@ -1177,7 +1209,7 @@ export class Skeleton extends MetaDBManager {
       }
 
       if (canonicalHead > BIGINT_0) {
-        this.config.logger.debug(
+        this.logger?.debug(
           `Resetting canonicalHead for fillCanonicalChain from=${canonicalHead} to=${newHead}`
         )
         canonicalHead = newHead
@@ -1191,7 +1223,7 @@ export class Skeleton extends MetaDBManager {
 
     const start = canonicalHead
     // This subchain is a reference to update the tail for the very subchain we are filling the data for
-    this.config.logger.debug(
+    this.logger?.debug(
       `Starting canonical chain fill canonicalHead=${canonicalHead} subchainHead=${subchain.head}`
     )
 
@@ -1209,16 +1241,14 @@ export class Skeleton extends MetaDBManager {
         //   i) Only if canonicalHeadReset was flagged on causing skeleton to change its tail canonicality
         // Else we should back step and fetch again as it indicates some concurrency/db errors
         if (!this.status.canonicalHeadReset) {
-          this.config.logger.debug(
-            `fillCanonicalChain block number=${number} not found, backStepping...`
-          )
+          this.logger?.debug(`fillCanonicalChain block number=${number} not found, backStepping...`)
           await this.runWithLock<void>(async () => {
             // backstep the subchain from the block that was not found only if the canonicalHeadReset
             // has not been flagged or else the chain tail has already been reset by sethead
             await this.backStep(number)
           })
         } else {
-          this.config.logger.debug(
+          this.logger?.debug(
             `fillCanonicalChain block number=${number} not found canonicalHeadReset=${this.status.canonicalHeadReset}, breaking out...`
           )
         }
@@ -1244,18 +1274,18 @@ export class Skeleton extends MetaDBManager {
           }
         } catch (e) {
           const validationError = `${e}`
-          this.config.logger.error(`fillCanonicalChain putBlock error=${validationError}`)
+          this.logger?.error(`fillCanonicalChain putBlock error=${validationError}`)
           const errorMsg = `${validationError}`.toLowerCase()
           if (errorMsg.includes('block') && errorMsg.includes('not found')) {
             // see if backstepping is required ot this is just canonicalHeadReset
             await this.runWithLock<void>(async () => {
               if (!this.status.canonicalHeadReset) {
-                this.config.logger.debug(
+                this.logger?.debug(
                   `fillCanonicalChain canonicalHeadReset=${this.status.canonicalHeadReset}, backStepping...`
                 )
                 await this.backStep(number)
               } else {
-                this.config.logger.debug(
+                this.logger?.debug(
                   `fillCanonicalChain canonicalHeadReset=${this.status.canonicalHeadReset}, breaking out...`
                 )
               }
@@ -1272,7 +1302,7 @@ export class Skeleton extends MetaDBManager {
 
         // handle insertion failures
         if (numBlocksInserted !== 1) {
-          this.config.logger.error(
+          this.logger?.error(
             `Failed to put block number=${number} fork=${block.common.hardfork()} hash=${short(
               block.hash()
             )} parentHash=${short(block.header.parentHash)}from skeleton chain to canonical`
@@ -1281,25 +1311,25 @@ export class Skeleton extends MetaDBManager {
           let parent = null
           try {
             parent = await this.chain.getBlock(number - BIGINT_1)
-            this.config.logger.info(
+            this.logger?.info(
               `ParentByNumber number=${parent?.header.number}, hash=${short(
                 parent?.hash() ?? 'undefined'
               )} hf=${parent?.common.hardfork()}`
             )
           } catch (e) {
-            this.config.logger.error(`Failed to fetch parent of number=${number}`)
+            this.logger?.error(`Failed to fetch parent of number=${number}`)
           }
 
           let parentWithHash = null
           try {
             parentWithHash = await this.chain.getBlock(block.header.parentHash)
-            this.config.logger.info(
+            this.logger?.info(
               `parentByHash number=${parentWithHash?.header.number}, hash=${short(
                 parentWithHash?.hash() ?? 'undefined'
               )} hf=${parentWithHash?.common.hardfork()}  `
             )
           } catch (e) {
-            this.config.logger.error(
+            this.logger?.error(
               `Failed to fetch parent with parentWithHash=${short(block.header.parentHash)}`
             )
           }
@@ -1328,16 +1358,16 @@ export class Skeleton extends MetaDBManager {
           await this.deleteBlock(block)
         }
       })
-      if (fillLogIndex >= this.config.numBlocksPerIteration) {
-        this.config.logger.debug(
+      if (fillLogIndex >= this.chain.config.numBlocksPerIteration) {
+        this.logger?.debug(
           `Skeleton canonical chain fill status: canonicalHead=${canonicalHead} chainHead=${this.chain.blocks.height} subchainHead=${subchain.head}`
         )
         fillLogIndex = 0
       }
     }
     this.filling = false
-    this.config.logger.debug(
-      `Successfully put=${fillLogIndex} skipped (because already inserted)=${skippedLogIndex} blocks start=${start} end=${canonicalHead} skeletonHead=${subchain.head} from skeleton chain to canonical syncTargetHeight=${this.config.syncTargetHeight}`
+    this.logger?.debug(
+      `Successfully put=${fillLogIndex} skipped (because already inserted)=${skippedLogIndex} blocks start=${start} end=${canonicalHead} skeletonHead=${subchain.head} from skeleton chain to canonical syncTargetHeight=${this.chain.config.syncTargetHeight}`
     )
   }
 
@@ -1382,7 +1412,7 @@ export class Skeleton extends MetaDBManager {
 
   skeletonBlockRlpToBlock(skeletonBlockRlp: Uint8Array): Block {
     const { hardfork, blockRLP } = this.deserialize(skeletonBlockRlp)
-    const common = this.config.chainCommon.copy()
+    const common = this.chain.config.chainCommon.copy()
     common.setHardfork(hardfork)
 
     const block = createBlockFromRLPSerializedBlock(blockRLP, {
@@ -1489,301 +1519,6 @@ export class Skeleton extends MetaDBManager {
     return
   }
 
-  logSyncStatus(
-    logPrefix: string,
-    {
-      forceShowInfo,
-      lastStatus,
-      vmexecution,
-      fetching,
-      snapsync,
-      peers,
-    }: {
-      forceShowInfo?: boolean
-      lastStatus?: string
-      vmexecution?: { running: boolean; started: boolean }
-      fetching?: boolean
-      snapsync?: SnapFetcherDoneFlags
-      peers?: number | string
-    } = {}
-  ): string {
-    const vmHead = this.chain.blocks.vm
-    const subchain0 = this.status.progress.subchains[0]
-
-    const isValid =
-      vmHead !== undefined &&
-      this.status.linked &&
-      (vmHead?.header.number ?? BIGINT_0) === (subchain0?.head ?? BIGINT_0)
-
-    // track for printing log because validation oscillates between multiple calls
-    if (forceShowInfo === true) {
-      if (isValid) {
-        if (this.lastvalid === 0) {
-          this.config.superMsg('Chain validation completed')
-        }
-        this.lastvalid = Date.now()
-      } else {
-        this.lastvalid = 0
-      }
-    }
-
-    const isSynced =
-      this.status.linked &&
-      (this.chain.blocks.latest?.header.number ?? BIGINT_0) === (subchain0?.head ?? BIGINT_0)
-
-    const status = isValid
-      ? 'VALID'
-      : isSynced
-      ? vmexecution?.running === true
-        ? `EXECUTING`
-        : `SYNCED`
-      : `SYNCING`
-
-    if (peers === undefined || peers === 0) {
-      this.lastsyncedAt = 0
-    } else {
-      if (
-        status === 'SYNCING' &&
-        lastStatus !== undefined &&
-        (lastStatus !== status || this.lastsyncedAt === 0)
-      ) {
-        this.lastsyncedAt = Date.now()
-      }
-    }
-
-    if (status !== 'EXECUTING') {
-      this.lastexecutedAt = 0
-    } else {
-      if (this.lastexecutedAt === 0 || this.lastexecuted !== vmHead?.header.number) {
-        this.lastexecutedAt = Date.now()
-      }
-      this.lastexecuted = vmHead?.header.number ?? BIGINT_0
-    }
-
-    if (status !== 'SYNCED') {
-      this.syncedchain = 0
-    } else {
-      if (this.syncedchain === 0) {
-        this.syncedchain = Date.now()
-      }
-    }
-
-    if (fetching === false) {
-      this.lastfetchedAt = 0
-    } else if (fetching === true) {
-      if (this.lastfetchedAt === 0 || subchain0.tail !== this.lastfetched) {
-        this.lastfetchedAt = Date.now()
-      }
-      this.lastfetched = subchain0.tail
-    }
-
-    if (!this.filling) {
-      this.lastfilledAt = 0
-    } else {
-      if (this.lastfilledAt === 0 || this.lastfilled !== this.chain.blocks.height) {
-        this.lastfilledAt = Date.now()
-      }
-      this.lastfilled = this.chain.blocks.height
-    }
-
-    let extraStatus
-    let scenario = ''
-    switch (status) {
-      case 'EXECUTING':
-        scenario = Date.now() - this.lastexecutedAt > STALE_WINDOW ? 'execution stalled?' : ''
-        extraStatus = ` (${scenario} vm=${vmHead?.header.number} cl=el=${this.chain.blocks.height})`
-        break
-      case 'SYNCED':
-        if (vmexecution?.started === true) {
-          scenario =
-            Date.now() - this.syncedchain > STALE_WINDOW
-              ? 'execution stalled?'
-              : 'awaiting execution'
-        } else if (snapsync !== undefined) {
-          // stall detection yet to be added
-          if (snapsync.done) {
-            scenario = `snapsync-to-vm-transition=${
-              (snapsync.snapTargetHeight ?? BIGINT_0) + this.config.snapTransitionSafeDepth
-            }`
-          } else {
-            scenario = `snapsync target=${snapsync.snapTargetHeight}`
-          }
-        } else {
-          scenario = 'execution none'
-        }
-        extraStatus = ` (${scenario} vm=${vmHead?.header.number} cl=el=${this.chain.blocks.height} )`
-        break
-      case 'SYNCING':
-        if (this.filling) {
-          scenario = Date.now() - this.lastfilledAt > STALE_WINDOW ? 'filling stalled?' : 'filling'
-          extraStatus = ` (${scenario} | el=${this.chain.blocks.height} cl=${subchain0?.head})`
-        } else {
-          if (fetching === true) {
-            scenario =
-              Date.now() - this.lastfetchedAt > STALE_WINDOW ? 'backfill stalled?' : 'backfilling'
-            extraStatus = ` (${scenario} tail=${subchain0.tail} | el=${this.chain.blocks.height} cl=${subchain0?.head})`
-          } else {
-            if (subchain0 === undefined) {
-              scenario = 'awaiting fcu'
-            } else if (peers === undefined || peers === 0) {
-              scenario = 'awaiting peers'
-            } else {
-              if (Date.now() - this.lastFcuTime > STALE_WINDOW) {
-                scenario = this.lastFcuTime === 0 ? `awaiting fcu` : `cl stalled?`
-              } else {
-                scenario =
-                  Date.now() - this.lastsyncedAt > STALE_WINDOW ? `sync stalled?` : `awaiting sync`
-              }
-            }
-            extraStatus = ` (${scenario} | el=${this.chain.blocks.height} cl=${subchain0?.head})`
-          }
-        }
-        break
-
-      // no additional status is needed on valid
-      default:
-        extraStatus = ''
-    }
-    const chainHead = `el=${this.chain.blocks.latest?.header.number ?? 'na'} hash=${short(
-      this.chain.blocks.latest?.hash() ?? 'na'
-    )}`
-
-    forceShowInfo = forceShowInfo ?? false
-    lastStatus = lastStatus ?? status
-
-    if (forceShowInfo || status !== lastStatus) {
-      let beaconSyncETA = 'na'
-      if (!this.status.linked && subchain0 !== undefined) {
-        // Print a progress report making the UX a bit nicer
-        let left = this.bounds().tail - BIGINT_1 - this.chain.blocks.height
-        if (this.status.linked) left = BIGINT_0
-        if (left > BIGINT_0) {
-          if (this.pulled !== BIGINT_0 && fetching === true) {
-            const sinceStarted = (new Date().getTime() - this.started) / 1000
-            beaconSyncETA = `${timeDuration((sinceStarted / Number(this.pulled)) * Number(left))}`
-            this.config.logger.debug(
-              `Syncing beacon headers downloaded=${this.pulled} left=${left} eta=${beaconSyncETA}`
-            )
-          }
-        }
-      }
-
-      let vmlogInfo
-      let snapLogInfo
-      let subchainLog = ''
-      if (isValid) {
-        vmlogInfo = `vm=cl=${chainHead}`
-      } else {
-        vmlogInfo = `vm=${vmHead?.header.number} hash=${short(vmHead?.hash() ?? 'na')} started=${
-          vmexecution?.started
-        }`
-
-        if (vmexecution?.started === true) {
-          vmlogInfo = `${vmlogInfo} executing=${vmexecution?.running}`
-        } else {
-          if (snapsync === undefined) {
-            snapLogInfo = `snapsync=false`
-          } else {
-            const { snapTargetHeight, snapTargetRoot, snapTargetHash } = snapsync
-            if (snapsync.done === true) {
-              snapLogInfo = `snapsync=synced height=${snapTargetHeight} hash=${short(
-                snapTargetHash ?? 'na'
-              )} root=${short(snapTargetRoot ?? 'na')}`
-            } else if (snapsync.syncing) {
-              const accountsDone = formatBigDecimal(
-                snapsync.accountFetcher.first * BIGINT_100,
-                BIGINT_2EXP256,
-                BIGINT_100
-              )
-              const storageReqsDone = formatBigDecimal(
-                snapsync.storageFetcher.first * BIGINT_100,
-                snapsync.storageFetcher.count,
-                BIGINT_100
-              )
-              const codeReqsDone = formatBigDecimal(
-                snapsync.byteCodeFetcher.first * BIGINT_100,
-                snapsync.byteCodeFetcher.count,
-                BIGINT_100
-              )
-
-              const snapprogress = `accounts=${accountsDone}% storage=${storageReqsDone}% of ${snapsync.storageFetcher.count} codes=${codeReqsDone}% of ${snapsync.byteCodeFetcher.count}`
-
-              let stage = 'snapsync=??'
-              stage = `snapsync=accounts`
-              // move the stage along
-              if (snapsync.accountFetcher.done === true) {
-                stage = `snapsync=storage&codes`
-              }
-              if (snapsync.storageFetcher.done === true && snapsync.byteCodeFetcher.done === true) {
-                stage = `snapsync=trienodes`
-              }
-              if (snapsync.trieNodeFetcher.done === true) {
-                stage = `finished`
-              }
-
-              snapLogInfo = `${stage} ${snapprogress} (hash=${short(
-                snapTargetHash ?? 'na'
-              )} root=${short(snapTargetRoot ?? 'na')})`
-            } else {
-              if (this.synchronized) {
-                snapLogInfo = `snapsync=??`
-              } else {
-                snapLogInfo = `snapsync awaiting cl synchronization`
-              }
-            }
-          }
-        }
-
-        // if not synced add subchain info
-        if (!isSynced) {
-          const subchainLen = this.status.progress.subchains.length
-          subchainLog = `subchains(${subchainLen}) linked=${
-            this.status.linked
-          } ${this.status.progress.subchains
-            // if info log show only first subchain to be succinct
-            .slice(0, 1)
-            .map((s) => `[tail=${s.tail} head=${s.head} next=${short(s.next)}]`)
-            .join(',')}${subchainLen > 1 ? '…' : ''} ${
-            beaconSyncETA !== undefined ? 'eta=' + beaconSyncETA : ''
-          } reorgsHead=${
-            this.status.canonicalHeadReset &&
-            (subchain0?.tail ?? BIGINT_0) <= this.chain.blocks.height
-          } synchronized=${this.synchronized}`
-        }
-      }
-      peers = peers !== undefined ? `${peers}` : 'na'
-
-      // if valid then the status info is short and sweet
-      this.config.logger.info('')
-      if (isValid) {
-        this.config.logger.info(`${logPrefix} ${status}${extraStatus} ${vmlogInfo} peers=${peers}`)
-      } else {
-        // else break into two
-        this.config.logger.info(
-          `${logPrefix} ${status}${extraStatus} synchronized=${this.config.synchronized} peers=${peers}`
-        )
-        if (snapLogInfo !== undefined && snapLogInfo !== '') {
-          this.config.logger.info(`${logPrefix} ${snapLogInfo}`)
-        }
-        if (vmlogInfo !== undefined && vmlogInfo !== '') {
-          this.config.logger.info(`${logPrefix} ${vmlogInfo}`)
-        }
-        if (!isSynced) {
-          this.config.logger.info(`${logPrefix} ${subchainLog}`)
-        }
-      }
-    } else {
-      this.config.logger.debug(
-        `${logPrefix} ${status} linked=${
-          this.status.linked
-        } subchains=${this.status.progress.subchains
-          .map((s) => `[tail=${s.tail} head=${s.head} next=${short(s.next)}]`)
-          .join(',')} reset=${this.status.canonicalHeadReset} ${chainHead}`
-      )
-    }
-    return status
-  }
-
   /**
    * Writes the {@link SkeletonStatus} to db
    */
@@ -1792,6 +1527,17 @@ export class Skeleton extends MetaDBManager {
     const encodedStatus = this.statusToRLP()
     await this.put(DBKey.SkeletonStatus, new Uint8Array(0), encodedStatus)
     return true
+  }
+
+  logSyncStatus(logPrefix: string) {
+    const chainHead = `el=${this.chain.blocks.latest?.header.number ?? 'na'} hash=${short(
+      this.chain.blocks.latest?.hash() ?? 'na'
+    )}`
+    this.logger?.debug(
+      `${logPrefix} linked=${this.status.linked} subchains=${this.status.progress.subchains
+        .map((s) => `[tail=${s.tail} head=${s.head} next=${short(s.next)}]`)
+        .join(',')} reset=${this.status.canonicalHeadReset} ${chainHead}`
+    )
   }
 
   /**

--- a/packages/blockchain/test/skeleton.spec.ts
+++ b/packages/blockchain/test/skeleton.spec.ts
@@ -1,0 +1,81 @@
+import { createBlockFromBlockData } from '@ethereumjs/block'
+import { Common } from '@ethereumjs/common'
+import { KeyEncoding, ValueEncoding, bytesToHex, equalsBytes, utf8ToBytes } from '@ethereumjs/util'
+import { assert, describe, it, vi } from 'vitest'
+
+import { Chain } from '../src/chain.js'
+import { Skeleton } from '../src/skeleton.js'
+
+import type { ChainConfig } from '../src/chain.js'
+import type { LevelDB } from '../src/level.js'
+
+const common = new Common({ chain: 1 })
+const block49 = createBlockFromBlockData({ header: { number: 49 } }, { common })
+const block50 = createBlockFromBlockData(
+  { header: { number: 50, parentHash: block49.hash() } },
+  { common }
+)
+const block51 = createBlockFromBlockData(
+  { header: { number: 51, parentHash: block50.hash() } },
+  { common }
+)
+
+const syncConfig = {
+  syncedStateRemovalPeriod: 60000,
+  engineParentLookupMaxDepth: 128,
+  snapTransitionSafeDepth: 5n,
+  skeletonSubchainMergeMinimum: 1000,
+  numBlocksPerIteration: 100,
+  skeletonFillCanonicalBackStep: 100,
+  maxPerRequest: 100,
+}
+
+describe('[Skeleton]/ startup scenarios ', () => {
+  it('should test blockchain DB is initialized', async () => {
+    const config: ChainConfig = {
+      ...syncConfig,
+      chainCommon: common,
+    }
+    const chain = await Chain.create({ config })
+
+    const db = chain.chainDB as LevelDB
+    const testKey = 'name'
+    const testValue = 'test'
+    await db.put(testKey, testValue, {
+      keyEncoding: KeyEncoding.String,
+      valueEncoding: ValueEncoding.String,
+    })
+
+    const value = await db.get(testKey, {
+      keyEncoding: KeyEncoding.String,
+      valueEncoding: ValueEncoding.String,
+    })
+    assert.equal(value, testValue, 'read value matches written value')
+  })
+
+  it('construct skeleton and test basic put/get block ops', async () => {
+    const config: ChainConfig = {
+      syncedStateRemovalPeriod: 60000,
+      engineParentLookupMaxDepth: 128,
+      snapTransitionSafeDepth: 5n,
+      skeletonSubchainMergeMinimum: 1000,
+      numBlocksPerIteration: 100,
+      skeletonFillCanonicalBackStep: 100,
+      maxPerRequest: 100,
+      chainCommon: common,
+    }
+    const chain = await Chain.create({ config })
+    const skeleton = new Skeleton({ chain })
+    assert.equal(chain.opened, false, 'chain is not started')
+    await skeleton.open()
+    assert.equal(chain.opened, true, 'chain is opened by skeleton')
+
+    await skeleton['putBlock'](block51)
+    const skeletonBlock = await skeleton.getBlock(block51.header.number)
+    assert.equal(
+      equalsBytes(skeletonBlock.hash(), block51.hash()),
+      true,
+      'same block should be retrived'
+    )
+  })
+})

--- a/packages/client/src/blockchain/index.ts
+++ b/packages/client/src/blockchain/index.ts
@@ -2,4 +2,6 @@
  * @module blockchain
  */
 
-export * from './chain.js'
+import { Chain } from '@ethereumjs/blockchain'
+
+export { Chain }

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -11,6 +11,7 @@ import { isBrowser, short } from './util/index.js'
 import type { Logger } from './logging.js'
 import type { EventBusType, MultiaddrLike, PrometheusMetrics } from './types.js'
 import type { BlockHeader } from '@ethereumjs/block'
+import type { ChainConfig } from '@ethereumjs/blockchain'
 import type { VM, VMProfilerOpts } from '@ethereumjs/vm'
 import type { Multiaddr } from '@multiformats/multiaddr'
 
@@ -346,7 +347,7 @@ export interface ConfigOptions {
   prometheusMetrics?: PrometheusMetrics
 }
 
-export class Config {
+export class Config implements ChainConfig {
   /**
    * Central event bus for events emitted by the different
    * components of the client

--- a/packages/client/src/rpc/modules/engine/types.ts
+++ b/packages/client/src/rpc/modules/engine/types.ts
@@ -1,7 +1,7 @@
 import { UNKNOWN_PAYLOAD } from '../../error-code.js'
 
-import type { Skeleton } from '../../../service/index.js'
 import type { Block, ExecutionPayload } from '@ethereumjs/block'
+import type { Skeleton } from '@ethereumjs/blockchain'
 import type {
   ConsolidationRequestV1,
   DepositRequestV1,

--- a/packages/client/src/rpc/modules/engine/util/forkchoiceUpdated.ts
+++ b/packages/client/src/rpc/modules/engine/util/forkchoiceUpdated.ts
@@ -1,7 +1,11 @@
 import type { Chain } from '../../../../blockchain/index.js'
 import type { ChainCache } from '../types.js'
 
-export const pruneCachedBlocks = (chain: Chain, chainCache: ChainCache) => {
+export const pruneCachedBlocks = (
+  config: { maxInvalidBlocksErrorCache: number },
+  chain: Chain,
+  chainCache: ChainCache
+) => {
   const { remoteBlocks, executedBlocks, invalidBlocks } = chainCache
   const finalized = chain.blocks.finalized
   if (finalized !== null) {
@@ -28,7 +32,7 @@ export const pruneCachedBlocks = (chain: Chain, chainCache: ChainCache) => {
     }
 
     // prune invalidBlocks with some max length
-    const pruneInvalidLength = invalidBlocks.size - chain.config.maxInvalidBlocksErrorCache
+    const pruneInvalidLength = invalidBlocks.size - config.maxInvalidBlocksErrorCache
     let pruned = 0
     for (const blockHash of invalidBlocks.keys()) {
       if (pruned >= pruneInvalidLength) {

--- a/packages/client/src/rpc/modules/engine/util/generic.ts
+++ b/packages/client/src/rpc/modules/engine/util/generic.ts
@@ -13,6 +13,7 @@ import type { PrefixedHexString } from '@ethereumjs/util'
  * Recursively finds parent blocks starting from the parentHash.
  */
 export const recursivelyFindParents = async (
+  config: { engineParentLookupMaxDepth: number },
   vmHeadHash: Uint8Array,
   parentHash: Uint8Array,
   chain: Chain
@@ -20,7 +21,7 @@ export const recursivelyFindParents = async (
   if (equalsBytes(parentHash, vmHeadHash) || equalsBytes(parentHash, new Uint8Array(32))) {
     return []
   }
-  const maxDepth = chain.config.engineParentLookupMaxDepth
+  const maxDepth = config.engineParentLookupMaxDepth
 
   const parentBlocks = []
   const block = await chain.getBlock(parentHash)
@@ -75,12 +76,13 @@ export const validExecutedChainBlock = async (
  * Returns the block hash as a 0x-prefixed hex string if found valid in the blockchain, otherwise returns null.
  */
 export const validHash = async (
+  config: { engineParentLookupMaxDepth: number },
   hash: Uint8Array,
   chain: Chain,
   chainCache: ChainCache
 ): Promise<PrefixedHexString | null> => {
   const { remoteBlocks, executedBlocks, invalidBlocks, skeleton } = chainCache
-  const maxDepth = chain.config.engineParentLookupMaxDepth
+  const maxDepth = config.engineParentLookupMaxDepth
 
   try {
     let validParent: Block | null = null
@@ -118,8 +120,12 @@ export const validHash = async (
 /**
  * Validates that the block satisfies post-merge conditions.
  */
-export const validateTerminalBlock = async (block: Block, chain: Chain): Promise<boolean> => {
-  const ttd = chain.config.chainCommon.hardforkTTD(Hardfork.Paris)
+export const validateTerminalBlock = async (
+  config: { chainCommon: Common },
+  block: Block,
+  chain: Chain
+): Promise<boolean> => {
+  const ttd = config.chainCommon.hardforkTTD(Hardfork.Paris)
   if (ttd === null) return false
   const blockTd = await chain.getTd(block.hash(), block.header.number)
 

--- a/packages/client/src/rpc/modules/engine/util/newPayload.ts
+++ b/packages/client/src/rpc/modules/engine/util/newPayload.ts
@@ -9,8 +9,10 @@ import { Status } from '../types.js'
 import { validHash } from './generic.js'
 
 import type { Chain } from '../../../../blockchain/index.js'
+import type { Logger } from '../../../../logging.js'
 import type { ChainCache, PayloadStatusV1 } from '../types.js'
 import type { Block, ExecutionPayload } from '@ethereumjs/block'
+import type { Common } from '@ethereumjs/common'
 import type { PrefixedHexString } from '@ethereumjs/util'
 
 /**
@@ -18,12 +20,12 @@ import type { PrefixedHexString } from '@ethereumjs/util'
  * If errors, returns {@link PayloadStatusV1}
  */
 export const assembleBlock = async (
+  config: { chainCommon: Common; logger: Logger; engineParentLookupMaxDepth: number },
   payload: ExecutionPayload,
   chain: Chain,
   chainCache: ChainCache
 ): Promise<{ block?: Block; error?: PayloadStatusV1 }> => {
   const { blockNumber, timestamp } = payload
-  const { config } = chain
   const common = config.chainCommon.copy()
 
   // This is a post merge block, so set its common accordingly
@@ -42,6 +44,7 @@ export const assembleBlock = async (
     const validationError = `Error assembling block from payload: ${error}`
     config.logger.error(validationError)
     const latestValidHash = await validHash(
+      config,
       hexToBytes(payload.parentHash as PrefixedHexString),
       chain,
       chainCache

--- a/packages/client/src/rpc/modules/eth.ts
+++ b/packages/client/src/rpc/modules/eth.ts
@@ -30,7 +30,7 @@ import { middleware, validators } from '../validation.js'
 
 import type { Chain } from '../../blockchain/index.js'
 import type { ReceiptsManager } from '../../execution/receipt.js'
-import type { EthereumClient } from '../../index.js'
+import type { Config, EthereumClient } from '../../index.js'
 import type { EthProtocol } from '../../net/protocol/index.js'
 import type { FullEthereumService, Service } from '../../service/index.js'
 import type { RpcTx } from '../types.js'
@@ -292,6 +292,7 @@ export class Eth {
   private service: Service
   private receiptsManager: ReceiptsManager | undefined
   private _chain: Chain
+  private _config: Config
   private _vm: VM | undefined
   private _rpcDebug: boolean
   public ethVersion: number
@@ -304,6 +305,7 @@ export class Eth {
     this.client = client
     this.service = client.services.find((s) => s.name === 'eth') as Service
     this._chain = this.service.chain
+    this._config = this.service.config
     this._vm = (this.service as FullEthereumService).execution?.vm
     this.receiptsManager = (this.service as FullEthereumService).execution?.receiptsManager
     this._rpcDebug = rpcDebug
@@ -533,7 +535,7 @@ export class Eth {
    * @returns The chain ID.
    */
   async chainId(_params = []) {
-    const chainId = this._chain.config.chainCommon.chainId()
+    const chainId = this._config.chainCommon.chainId()
     return bigIntToHex(chainId)
   }
 
@@ -1318,7 +1320,7 @@ export class Eth {
    * @returns a hex code of an integer representing the suggested gas price in wei.
    */
   async gasPrice() {
-    const minGasPrice: bigint = this._chain.config.chainCommon.param('gasConfig', 'minPrice')
+    const minGasPrice: bigint = this._config.chainCommon.param('gasConfig', 'minPrice')
     let gasPrice = BIGINT_0
     const latest = await this._chain.getCanonicalHeadHeader()
     if (this._vm !== undefined && this._vm.common.isActivatedEIP(1559)) {

--- a/packages/client/src/rpc/modules/net.ts
+++ b/packages/client/src/rpc/modules/net.ts
@@ -4,7 +4,7 @@ import { callWithStackTrace } from '../helpers.js'
 import { middleware } from '../validation.js'
 
 import type { Chain } from '../../blockchain/index.js'
-import type { EthereumClient } from '../../index.js'
+import type { Config, EthereumClient } from '../../index.js'
 import type { PeerPool } from '../../net/peerpool.js'
 import type { Service } from '../../service/service.js'
 
@@ -14,6 +14,7 @@ import type { Service } from '../../service/service.js'
  */
 export class Net {
   private _chain: Chain
+  private _config: Config
   private _client: EthereumClient
   private _peerPool: PeerPool
   private _rpcDebug: boolean
@@ -25,6 +26,7 @@ export class Net {
   constructor(client: EthereumClient, rpcDebug: boolean) {
     const service = client.services.find((s) => s.name === 'eth') as Service
     this._chain = service.chain
+    this._config = service.config
     this._client = client
     this._peerPool = service.pool
     this._rpcDebug = rpcDebug
@@ -47,7 +49,7 @@ export class Net {
    * @param params An empty array
    */
   version(_params = []) {
-    return this._chain.config.chainCommon.chainId().toString()
+    return this._config.chainCommon.chainId().toString()
   }
 
   /**

--- a/packages/client/src/service/fullethereumservice.ts
+++ b/packages/client/src/service/fullethereumservice.ts
@@ -60,7 +60,6 @@ export class FullEthereumService extends Service {
       // directly passon chainCommon which Skeleton can set hardfork on
       this.skeleton = new Skeleton({
         chain: this.chain,
-        logger: this.config.logger,
       })
     }
 

--- a/packages/client/src/service/fullethereumservice.ts
+++ b/packages/client/src/service/fullethereumservice.ts
@@ -1,3 +1,4 @@
+import { Skeleton } from '@ethereumjs/blockchain'
 import { Hardfork } from '@ethereumjs/common'
 import { TransactionType } from '@ethereumjs/tx'
 import { concatBytes, hexToBytes } from '@ethereumjs/util'
@@ -13,7 +14,6 @@ import { BeaconSynchronizer, FullSynchronizer, SnapSynchronizer } from '../sync/
 import { Event } from '../types.js'
 
 import { Service, type ServiceOptions } from './service.js'
-import { Skeleton } from './skeleton.js'
 import { TxPool } from './txpool.js'
 
 import type { Peer } from '../net/peer/peer.js'
@@ -57,10 +57,10 @@ export class FullEthereumService extends Service {
 
     const { metaDB } = options
     if (metaDB !== undefined) {
+      // directly passon chainCommon which Skeleton can set hardfork on
       this.skeleton = new Skeleton({
-        config: this.config,
         chain: this.chain,
-        metaDB,
+        logger: this.config.logger,
       })
     }
 

--- a/packages/client/src/service/index.ts
+++ b/packages/client/src/service/index.ts
@@ -5,4 +5,3 @@
 export * from './fullethereumservice.js'
 export * from './lightethereumservice.js'
 export * from './service.js'
-export * from './skeleton.js'

--- a/packages/client/src/sync/beaconsync.ts
+++ b/packages/client/src/sync/beaconsync.ts
@@ -8,9 +8,9 @@ import { Synchronizer } from './sync.js'
 
 import type { VMExecution } from '../execution/index.js'
 import type { Peer } from '../net/peer/peer.js'
-import type { Skeleton } from '../service/skeleton.js'
 import type { SynchronizerOptions } from './sync.js'
 import type { Block } from '@ethereumjs/block'
+import type { Skeleton } from '@ethereumjs/blockchain'
 
 interface BeaconSynchronizerOptions extends SynchronizerOptions {
   /** Skeleton chain */

--- a/packages/client/src/sync/fetcher/reverseblockfetcher.ts
+++ b/packages/client/src/sync/fetcher/reverseblockfetcher.ts
@@ -1,13 +1,13 @@
+import { errSyncMerged } from '@ethereumjs/blockchain'
 import { BIGINT_0 } from '@ethereumjs/util'
 
-import { errSyncMerged } from '../../service/skeleton.js'
 import { Event } from '../../types.js'
 
 import { BlockFetcher } from './blockfetcher.js'
 
-import type { Skeleton } from '../../service/skeleton.js'
 import type { BlockFetcherOptions, JobTask } from './blockfetcherbase.js'
 import type { Block } from '@ethereumjs/block'
+import type { Skeleton } from '@ethereumjs/blockchain'
 
 interface ReverseBlockFetcherOptions extends BlockFetcherOptions {
   /** Skeleton */

--- a/packages/client/src/sync/index.ts
+++ b/packages/client/src/sync/index.ts
@@ -2,7 +2,6 @@
  * @module sync
  */
 // need this weird re-export for vitest to be able to mock reverseblockfetcher in test/sync/beaconsync.spec.ts
-export * from '../service/skeleton.js'
 export * from './beaconsync.js'
 export * from './fullsync.js'
 export * from './lightsync.js'

--- a/packages/client/src/sync/snapsync.ts
+++ b/packages/client/src/sync/snapsync.ts
@@ -9,9 +9,9 @@ import { Synchronizer } from './sync.js'
 
 import type { VMExecution } from '../execution/index.js'
 import type { Peer } from '../net/peer/peer.js'
-import type { Skeleton } from '../service/skeleton.js'
 import type { SnapFetcherDoneFlags } from './fetcher/types.js'
 import type { SynchronizerOptions } from './sync.js'
+import type { Skeleton } from '@ethereumjs/blockchain'
 import type { DefaultStateManager } from '@ethereumjs/statemanager'
 
 interface SnapSynchronizerOptions extends SynchronizerOptions {


### PR DESCRIPTION
move skeleton,chain from client to blockchain class

first cut after a few iterations
 - doesn't yet merges db ops of skeleton to dbmanager, could be done in followup
 - need to ensure that skeleton to main db movement is minimzed (or even eliminated?)


aim of PR is to get and keep everything working

TODO:
 - [ ] readd chain updated event back
 - [ ] find the correct structure for status logging and its bookkeeping variables
 - [ ] fix the tests and all
 