### PR TITLE
Adjust ttd checks in `parseGethParams`

### DIFF
--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -85,7 +85,8 @@ function parseGethParams(json: any) {
   // so the Merge/Paris hardfork block must be 0
   if (
     config.terminalTotalDifficulty !== undefined &&
-    (config.terminalTotalDifficulty > 0 || config.terminalTotalDifficultyPassed === false)
+    (BigInt(difficulty) < BigInt(config.terminalTotalDifficulty) ||
+      config.terminalTotalDifficultyPassed === false)
   ) {
     throw new Error('nonzero terminal total difficulty is not supported')
   }


### PR DESCRIPTION
In #3518, we removed almost all of the TTD related logic in the code base and with that tightened up what we accept in our parsing of geth genesis parameters.  This caused an issue with Hive where the hive genesis parameters would provide a nonzero TTD but still expecting that merge would be at genesis (since the difficulty of the genesis block is higher than the provided TTD).  This adjusts our logic to compare genesis block difficulty vs TTD to accomodate this quirk in hive.