### PR TITLE
Proof function renaming

### DIFF
--- a/packages/statemanager/src/rpcStateManager.ts
+++ b/packages/statemanager/src/rpcStateManager.ts
@@ -231,7 +231,7 @@ export class RPCStateManager implements StateManagerInterface {
     const verified = await verifyTrieProof(address.bytes, proofBuf, {
       useKeyHashing: true,
     })
-    // if not verified (i.e. verifyProof returns null), account does not exist
+    // if not verified (i.e. verifyMerkleProof returns null), account does not exist
     return verified === null ? false : true
   }
 

--- a/packages/statemanager/src/rpcStateManager.ts
+++ b/packages/statemanager/src/rpcStateManager.ts
@@ -231,7 +231,7 @@ export class RPCStateManager implements StateManagerInterface {
     const verified = await verifyTrieProof(address.bytes, proofBuf, {
       useKeyHashing: true,
     })
-    // if not verified (i.e. verifyMerkleProof returns null), account does not exist
+    // if not verified (i.e. verifyProof returns null), account does not exist
     return verified === null ? false : true
   }
 

--- a/packages/statemanager/src/stateManager.ts
+++ b/packages/statemanager/src/stateManager.ts
@@ -2,7 +2,7 @@ import { CacheType, Common, Mainnet } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import {
   Trie,
-  createProof,
+  createMerkleProof,
   createTrieFromProof,
   updateFromProof,
   verifyTrieProof,
@@ -579,19 +579,21 @@ export class DefaultStateManager implements StateManagerInterface {
         codeHash: KECCAK256_NULL_S,
         nonce: '0x0',
         storageHash: KECCAK256_RLP_S,
-        accountProof: (await createProof(this._trie, address.bytes)).map((p) => bytesToHex(p)),
+        accountProof: (await createMerkleProof(this._trie, address.bytes)).map((p) =>
+          bytesToHex(p),
+        ),
         storageProof: [],
       }
       return returnValue
     }
-    const accountProof: PrefixedHexString[] = (await createProof(this._trie, address.bytes)).map(
-      (p) => bytesToHex(p),
-    )
+    const accountProof: PrefixedHexString[] = (
+      await createMerkleProof(this._trie, address.bytes)
+    ).map((p) => bytesToHex(p))
     const storageProof: StorageProof[] = []
     const storageTrie = this._getStorageTrie(address, account)
 
     for (const storageKey of storageSlots) {
-      const proof = (await createProof(storageTrie, storageKey)).map((p) => bytesToHex(p))
+      const proof = (await createMerkleProof(storageTrie, storageKey)).map((p) => bytesToHex(p))
       const value = bytesToHex(await this.getStorage(address, storageKey))
       const proofItem: StorageProof = {
         key: bytesToHex(storageKey),

--- a/packages/statemanager/src/stateManager.ts
+++ b/packages/statemanager/src/stateManager.ts
@@ -4,7 +4,7 @@ import {
   Trie,
   createMerkleProof,
   createTrieFromProof,
-  updateFromProof,
+  updateTrieFromMerkleProof,
   verifyTrieProof,
 } from '@ethereumjs/trie'
 import {
@@ -669,7 +669,7 @@ export class DefaultStateManager implements StateManagerInterface {
     const trie = this._getStorageTrie(address)
     trie.root(hexToBytes(storageHash))
     for (let i = 0; i < storageProof.length; i++) {
-      await updateFromProof(
+      await updateTrieFromMerkleProof(
         trie,
         storageProof[i].proof.map((e) => hexToBytes(e)),
         safe,
@@ -686,7 +686,7 @@ export class DefaultStateManager implements StateManagerInterface {
   async addProofData(proof: Proof | Proof[], safe: boolean = false) {
     if (Array.isArray(proof)) {
       for (let i = 0; i < proof.length; i++) {
-        await updateFromProof(
+        await updateTrieFromMerkleProof(
           this._trie,
           proof[i].accountProof.map((e) => hexToBytes(e)),
           safe,

--- a/packages/trie/examples/createFromProof.ts
+++ b/packages/trie/examples/createFromProof.ts
@@ -1,4 +1,4 @@
-import { Trie, createProof, createTrieFromProof, updateFromProof } from '@ethereumjs/trie'
+import { Trie, createMerkleProof, createTrieFromProof, updateFromProof } from '@ethereumjs/trie'
 import { bytesToUtf8, utf8ToBytes } from '@ethereumjs/util'
 
 async function main() {
@@ -9,9 +9,9 @@ async function main() {
   await someOtherTrie.put(k1, utf8ToBytes('valueOne'))
   await someOtherTrie.put(k2, utf8ToBytes('valueTwo'))
 
-  const proof = await createProof(someOtherTrie, k1)
+  const proof = await createMerkleProof(someOtherTrie, k1)
   const trie = await createTrieFromProof(proof, { useKeyHashing: true })
-  const otherProof = await createProof(someOtherTrie, k2)
+  const otherProof = await createMerkleProof(someOtherTrie, k2)
 
   // To add more proofs to the trie, use `updateFromProof`
   await updateFromProof(trie, otherProof)

--- a/packages/trie/examples/createFromProof.ts
+++ b/packages/trie/examples/createFromProof.ts
@@ -1,4 +1,9 @@
-import { Trie, createMerkleProof, createTrieFromProof, updateFromProof } from '@ethereumjs/trie'
+import {
+  Trie,
+  createMerkleProof,
+  createTrieFromProof,
+  updateTrieFromMerkleProof,
+} from '@ethereumjs/trie'
 import { bytesToUtf8, utf8ToBytes } from '@ethereumjs/util'
 
 async function main() {
@@ -13,8 +18,8 @@ async function main() {
   const trie = await createTrieFromProof(proof, { useKeyHashing: true })
   const otherProof = await createMerkleProof(someOtherTrie, k2)
 
-  // To add more proofs to the trie, use `updateFromProof`
-  await updateFromProof(trie, otherProof)
+  // To add more proofs to the trie, use `updateTrieFromMerkleProof`
+  await updateTrieFromMerkleProof(trie, otherProof)
 
   const value = await trie.get(k1)
   console.log(bytesToUtf8(value!)) // valueOne

--- a/packages/trie/examples/logDemo.ts
+++ b/packages/trie/examples/logDemo.ts
@@ -1,7 +1,7 @@
 /**
  * Run with DEBUG=ethjs,trie:* to see debug log ouput
  */
-import { Trie, createMerkleProof, verifyProof } from '@ethereumjs/trie'
+import { Trie, createMerkleProof, verifyMerkleProof } from '@ethereumjs/trie'
 import { utf8ToBytes } from '@ethereumjs/util'
 
 const trie_entries: [string, string | null][] = [
@@ -23,7 +23,7 @@ const main = async () => {
     await trie.put(utf8ToBytes(key), value === null ? Uint8Array.from([]) : utf8ToBytes(value))
   }
   const proof = await createMerkleProof(trie, utf8ToBytes('doge'))
-  const valid = await verifyProof(trie, trie.root(), utf8ToBytes('doge'), proof)
+  const valid = await verifyMerkleProof(trie, trie.root(), utf8ToBytes('doge'), proof)
   console.log('valid', valid)
 }
 

--- a/packages/trie/examples/logDemo.ts
+++ b/packages/trie/examples/logDemo.ts
@@ -1,7 +1,7 @@
 /**
  * Run with DEBUG=ethjs,trie:* to see debug log ouput
  */
-import { Trie, createProof, verifyProof } from '@ethereumjs/trie'
+import { Trie, createMerkleProof, verifyProof } from '@ethereumjs/trie'
 import { utf8ToBytes } from '@ethereumjs/util'
 
 const trie_entries: [string, string | null][] = [
@@ -22,7 +22,7 @@ const main = async () => {
   for (const [key, value] of trie_entries) {
     await trie.put(utf8ToBytes(key), value === null ? Uint8Array.from([]) : utf8ToBytes(value))
   }
-  const proof = await createProof(trie, utf8ToBytes('doge'))
+  const proof = await createMerkleProof(trie, utf8ToBytes('doge'))
   const valid = await verifyProof(trie, trie.root(), utf8ToBytes('doge'), proof)
   console.log('valid', valid)
 }

--- a/packages/trie/examples/proofs.ts
+++ b/packages/trie/examples/proofs.ts
@@ -1,4 +1,4 @@
-import { Trie, createMerkleProof, verifyProof } from '@ethereumjs/trie'
+import { Trie, createMerkleProof, verifyMerkleProof } from '@ethereumjs/trie'
 import { bytesToUtf8, utf8ToBytes } from '@ethereumjs/util'
 
 const trie = new Trie()
@@ -12,14 +12,14 @@ async function main() {
   // proof-of-inclusion
   await trie.put(k1, v1)
   let proof = await createMerkleProof(trie, k1)
-  let value = await verifyProof(trie, trie.root(), k1, proof)
+  let value = await verifyMerkleProof(trie, trie.root(), k1, proof)
   console.log(value ? bytesToUtf8(value) : 'not found') // 'one'
 
   // proof-of-exclusion
   await trie.put(k1, v1)
   await trie.put(k2, v2)
   proof = await createMerkleProof(trie, utf8ToBytes('key3'))
-  value = await verifyProof(trie, trie.root(), utf8ToBytes('key3'), proof)
+  value = await verifyMerkleProof(trie, trie.root(), utf8ToBytes('key3'), proof)
   console.log(value ? bytesToUtf8(value) : 'null') // null
 
   // invalid proof
@@ -28,7 +28,7 @@ async function main() {
   proof = await createMerkleProof(trie, k2)
   proof[0].reverse()
   try {
-    const _value = await verifyProof(trie, trie.root(), k2, proof) // results in error
+    const _value = await verifyMerkleProof(trie, trie.root(), k2, proof) // results in error
   } catch (err) {
     console.log(err)
   }

--- a/packages/trie/examples/proofs.ts
+++ b/packages/trie/examples/proofs.ts
@@ -1,4 +1,4 @@
-import { Trie, createProof, verifyProof } from '@ethereumjs/trie'
+import { Trie, createMerkleProof, verifyProof } from '@ethereumjs/trie'
 import { bytesToUtf8, utf8ToBytes } from '@ethereumjs/util'
 
 const trie = new Trie()
@@ -11,21 +11,21 @@ async function main() {
 
   // proof-of-inclusion
   await trie.put(k1, v1)
-  let proof = await createProof(trie, k1)
+  let proof = await createMerkleProof(trie, k1)
   let value = await verifyProof(trie, trie.root(), k1, proof)
   console.log(value ? bytesToUtf8(value) : 'not found') // 'one'
 
   // proof-of-exclusion
   await trie.put(k1, v1)
   await trie.put(k2, v2)
-  proof = await createProof(trie, utf8ToBytes('key3'))
+  proof = await createMerkleProof(trie, utf8ToBytes('key3'))
   value = await verifyProof(trie, trie.root(), utf8ToBytes('key3'), proof)
   console.log(value ? bytesToUtf8(value) : 'null') // null
 
   // invalid proof
   await trie.put(k1, v1)
   await trie.put(k2, v2)
-  proof = await createProof(trie, k2)
+  proof = await createMerkleProof(trie, k2)
   proof[0].reverse()
   try {
     const _value = await verifyProof(trie, trie.root(), k2, proof) // results in error

--- a/packages/trie/src/constructors.ts
+++ b/packages/trie/src/constructors.ts
@@ -7,7 +7,7 @@ import {
 import { keccak256 } from 'ethereum-cryptography/keccak'
 import { concatBytes } from 'ethereum-cryptography/utils'
 
-import { ROOT_DB_KEY, Trie, updateFromProof } from './index.js'
+import { ROOT_DB_KEY, Trie, updateTrieFromMerkleProof } from './index.js'
 
 import type { Proof, TrieOpts } from './index.js'
 
@@ -63,7 +63,7 @@ export async function createTrie(opts?: TrieOpts) {
 export async function createTrieFromProof(proof: Proof, trieOpts?: TrieOpts) {
   const shouldVerifyRoot = trieOpts?.root !== undefined
   const trie = new Trie(trieOpts)
-  const root = await updateFromProof(trie, proof, shouldVerifyRoot)
+  const root = await updateTrieFromMerkleProof(trie, proof, shouldVerifyRoot)
   trie.root(root)
   await trie.persistRoot()
   return trie

--- a/packages/trie/src/proof/index.ts
+++ b/packages/trie/src/proof/index.ts
@@ -71,7 +71,7 @@ export function verifyTrieRangeProof(
  * serialized branch, extension, and/or leaf nodes.
  * @param key key to create a proof for
  */
-export async function createProof(trie: Trie, key: Uint8Array): Promise<Proof> {
+export async function createMerkleProof(trie: Trie, key: Uint8Array): Promise<Proof> {
   trie['DEBUG'] && trie['debug'](`Creating Proof for Key: ${bytesToHex(key)}`, ['CREATE_PROOF'])
   const { stack } = await trie.findPath(trie['appliedKey'](key))
   const p = stack.map((stackElem) => {

--- a/packages/trie/src/proof/index.ts
+++ b/packages/trie/src/proof/index.ts
@@ -128,7 +128,7 @@ export async function updateTrieFromMerkleProof(
  * @throws If proof is found to be invalid.
  * @returns The value from the key, or null if valid proof of non-existence.
  */
-export async function verifyProof(
+export async function verifyMerkleProof(
   trie: Trie,
   rootHash: Uint8Array,
   key: Uint8Array,

--- a/packages/trie/src/proof/index.ts
+++ b/packages/trie/src/proof/index.ts
@@ -89,7 +89,11 @@ export async function createMerkleProof(trie: Trie, key: Uint8Array): Promise<Pr
  * @param shouldVerifyRoot - defaults to false. If `true`, verifies that the root key of the proof matches the trie root and throws if not (i.e invalid proof).
  * @returns The root of the proof
  */
-export async function updateFromProof(trie: Trie, proof: Proof, shouldVerifyRoot: boolean = false) {
+export async function updateTrieFromMerkleProof(
+  trie: Trie,
+  proof: Proof,
+  shouldVerifyRoot: boolean = false,
+) {
   trie['DEBUG'] && trie['debug'](`Saving (${proof.length}) proof nodes in DB`, ['FROM_PROOF'])
   const opStack = proof.map((nodeValue) => {
     let key = Uint8Array.from(trie['hash'](nodeValue))
@@ -144,7 +148,7 @@ export async function verifyProof(
     common: trie['_opts'].common,
   })
   try {
-    await updateFromProof(proofTrie, proof, true)
+    await updateTrieFromMerkleProof(proofTrie, proof, true)
   } catch (e: any) {
     throw new Error('Invalid proof nodes given')
   }

--- a/packages/trie/src/proof/range.ts
+++ b/packages/trie/src/proof/range.ts
@@ -317,7 +317,7 @@ async function unsetInternal(trie: Trie, left: Nibbles, right: Nibbles): Promise
  * @throws If proof is found to be invalid.
  * @returns The value from the key, or null if valid proof of non-existence.
  */
-async function verifyProof(
+async function verifyMerkleProof(
   rootHash: Uint8Array,
   key: Uint8Array,
   proof: Uint8Array[],
@@ -450,7 +450,7 @@ export async function verifyRangeProof(
   if (proof !== null && firstKey !== null && lastKey === null) {
     // Zero element proof
     if (keys.length === 0) {
-      const { trie, value } = await verifyProof(
+      const { trie, value } = await verifyMerkleProof(
         rootHash,
         nibblesTypeToPackedBytes(firstKey),
         proof,
@@ -473,7 +473,7 @@ export async function verifyRangeProof(
 
   // One element proof
   if (keys.length === 1 && nibblesCompare(firstKey, lastKey) === 0) {
-    const { trie, value } = await verifyProof(
+    const { trie, value } = await verifyMerkleProof(
       rootHash,
       nibblesTypeToPackedBytes(firstKey),
       proof,

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -513,7 +513,7 @@ export class Trie {
     const value = (await this._db.get(key)) ?? null
 
     if (value === null) {
-      // Dev note: this error message text is used for error checking in `checkRoot`, `verifyProof`, and `findPath`
+      // Dev note: this error message text is used for error checking in `checkRoot`, `verifyMerkleProof`, and `findPath`
       throw new Error('Missing node in DB')
     }
 

--- a/packages/trie/test/proof.spec.ts
+++ b/packages/trie/test/proof.spec.ts
@@ -4,7 +4,7 @@ import { assert, describe, it } from 'vitest'
 
 import {
   Trie,
-  createProof as createMerkleProof,
+  createMerkleProof,
   createTrieFromProof,
   updateFromProof,
   verifyTrieProof,

--- a/packages/trie/test/proof.spec.ts
+++ b/packages/trie/test/proof.spec.ts
@@ -4,7 +4,7 @@ import { assert, describe, it } from 'vitest'
 
 import {
   Trie,
-  createProof,
+  createProof as createMerkleProof,
   createTrieFromProof,
   updateFromProof,
   verifyTrieProof,
@@ -18,27 +18,27 @@ describe('simple merkle proofs generation and verification', () => {
     await trie.put(utf8ToBytes('key2bb'), utf8ToBytes('aval2'))
     await trie.put(utf8ToBytes('key3cc'), utf8ToBytes('aval3'))
 
-    let proof = await createProof(trie, utf8ToBytes('key2bb'))
+    let proof = await createMerkleProof(trie, utf8ToBytes('key2bb'))
     let val = await verifyTrieProof(utf8ToBytes('key2bb'), proof)
     assert.equal(bytesToUtf8(val!), 'aval2')
 
-    proof = await createProof(trie, utf8ToBytes('key1aa'))
+    proof = await createMerkleProof(trie, utf8ToBytes('key1aa'))
     val = await verifyTrieProof(utf8ToBytes('key1aa'), proof)
     assert.equal(bytesToUtf8(val!), '0123456789012345678901234567890123456789xx')
 
-    proof = await createProof(trie, utf8ToBytes('key2bb'))
+    proof = await createMerkleProof(trie, utf8ToBytes('key2bb'))
     val = await verifyTrieProof(utf8ToBytes('key2'), proof)
     // In this case, the proof _happens_ to contain enough nodes to prove `key2` because
     // traversing into `key22` would touch all the same nodes as traversing into `key2`
     assert.equal(val, null, 'Expected value at a random key to be null')
 
     let myKey = utf8ToBytes('anyrandomkey')
-    proof = await createProof(trie, myKey)
+    proof = await createMerkleProof(trie, myKey)
     val = await verifyTrieProof(myKey, proof)
     assert.equal(val, null, 'Expected value to be null')
 
     myKey = utf8ToBytes('anothergarbagekey') // should generate a valid proof of null
-    proof = await createProof(trie, myKey)
+    proof = await createMerkleProof(trie, myKey)
     proof.push(utf8ToBytes('123456')) // extra nodes are just ignored
     val = await verifyTrieProof(myKey, proof)
     assert.equal(val, null, 'Expected value to be null')
@@ -46,7 +46,7 @@ describe('simple merkle proofs generation and verification', () => {
     await trie.put(utf8ToBytes('another'), utf8ToBytes('3498h4riuhgwe'))
 
     // to fail our proof we can request a proof for one key
-    proof = await createProof(trie, utf8ToBytes('another'))
+    proof = await createMerkleProof(trie, utf8ToBytes('another'))
     // and try to use that proof on another key
     try {
       await verifyTrieProof(utf8ToBytes('key1aa'), proof)
@@ -56,7 +56,7 @@ describe('simple merkle proofs generation and verification', () => {
     }
 
     // we can also corrupt a valid proof
-    proof = await createProof(trie, utf8ToBytes('key2bb'))
+    proof = await createMerkleProof(trie, utf8ToBytes('key2bb'))
     proof[0].reverse()
     try {
       await verifyTrieProof(utf8ToBytes('key2bb'), proof)
@@ -68,7 +68,7 @@ describe('simple merkle proofs generation and verification', () => {
     // test an invalid exclusion proof by creating
     // a valid exclusion proof then making it non-null
     myKey = utf8ToBytes('anyrandomkey')
-    proof = await createProof(trie, myKey)
+    proof = await createMerkleProof(trie, myKey)
     val = await verifyTrieProof(myKey, proof)
     assert.equal(val, null, 'Expected value to be null')
     // now make the key non-null so the exclusion proof becomes invalid
@@ -86,7 +86,7 @@ describe('simple merkle proofs generation and verification', () => {
 
     await trie.put(utf8ToBytes('key1aa'), utf8ToBytes('0123456789012345678901234567890123456789xx'))
 
-    const proof = await createProof(trie, utf8ToBytes('key1aa'))
+    const proof = await createMerkleProof(trie, utf8ToBytes('key1aa'))
     const val = await verifyTrieProof(utf8ToBytes('key1aa'), proof)
     assert.equal(bytesToUtf8(val!), '0123456789012345678901234567890123456789xx')
   })
@@ -96,7 +96,7 @@ describe('simple merkle proofs generation and verification', () => {
 
     await trie.put(utf8ToBytes('key1aa'), utf8ToBytes('01234'))
 
-    const proof = await createProof(trie, utf8ToBytes('key1aa'))
+    const proof = await createMerkleProof(trie, utf8ToBytes('key1aa'))
     const val = await verifyTrieProof(utf8ToBytes('key1aa'), proof)
     assert.equal(bytesToUtf8(val!), '01234')
   })
@@ -117,15 +117,15 @@ describe('simple merkle proofs generation and verification', () => {
     await trie.put(utf8ToBytes('key3cc'), utf8ToBytes('aval3'))
     await trie.put(utf8ToBytes('key3'), utf8ToBytes('1234567890123456789012345678901'))
 
-    let proof = await createProof(trie, utf8ToBytes('key1'))
+    let proof = await createMerkleProof(trie, utf8ToBytes('key1'))
     let val = await verifyTrieProof(utf8ToBytes('key1'), proof)
     assert.equal(bytesToUtf8(val!), '0123456789012345678901234567890123456789Very_Long')
 
-    proof = await createProof(trie, utf8ToBytes('key2'))
+    proof = await createMerkleProof(trie, utf8ToBytes('key2'))
     val = await verifyTrieProof(utf8ToBytes('key2'), proof)
     assert.equal(bytesToUtf8(val!), 'short')
 
-    proof = await createProof(trie, utf8ToBytes('key3'))
+    proof = await createMerkleProof(trie, utf8ToBytes('key3'))
     val = await verifyTrieProof(utf8ToBytes('key3'), proof)
     assert.equal(bytesToUtf8(val!), '1234567890123456789012345678901')
   })
@@ -137,15 +137,15 @@ describe('simple merkle proofs generation and verification', () => {
     await trie.put(utf8ToBytes('b'), utf8ToBytes('b'))
     await trie.put(utf8ToBytes('c'), utf8ToBytes('c'))
 
-    let proof = await createProof(trie, utf8ToBytes('a'))
+    let proof = await createMerkleProof(trie, utf8ToBytes('a'))
     let val = await verifyTrieProof(utf8ToBytes('a'), proof)
     assert.equal(bytesToUtf8(val!), 'a')
 
-    proof = await createProof(trie, utf8ToBytes('b'))
+    proof = await createMerkleProof(trie, utf8ToBytes('b'))
     val = await verifyTrieProof(utf8ToBytes('b'), proof)
     assert.equal(bytesToUtf8(val!), 'b')
 
-    proof = await createProof(trie, utf8ToBytes('c'))
+    proof = await createMerkleProof(trie, utf8ToBytes('c'))
     val = await verifyTrieProof(utf8ToBytes('c'), proof)
     assert.equal(bytesToUtf8(val!), 'c')
   })
@@ -165,7 +165,7 @@ describe('simple merkle proofs generation and verification', () => {
     await trie.put(key, encodedValue)
     await trie.put(key2, encodedValue2)
     await trie.put(key3, encodedValue3)
-    const proof = await createProof(trie, key)
+    const proof = await createMerkleProof(trie, key)
 
     const newTrie = await createTrieFromProof(proof, { useKeyHashing: true })
     const trieValue = await newTrie.get(key)
@@ -173,7 +173,7 @@ describe('simple merkle proofs generation and verification', () => {
     assert.ok(equalsBytes(trieValue!, encodedValue), 'trie value sucessfully copied')
     assert.ok(equalsBytes(trie.root(), newTrie.root()), 'root set correctly')
 
-    const proof2 = await createProof(trie, key2)
+    const proof2 = await createMerkleProof(trie, key2)
     await updateFromProof(newTrie, proof2)
     const trieValue2 = await newTrie.get(key2)
 
@@ -188,7 +188,7 @@ describe('simple merkle proofs generation and verification', () => {
     const safeValue = RLP.encode(new Uint8Array([1337]))
 
     await safeTrie.put(safeKey, safeValue)
-    const safeProof = await createProof(safeTrie, safeKey)
+    const safeProof = await createMerkleProof(safeTrie, safeKey)
 
     try {
       await updateFromProof(newTrie, safeProof, true)

--- a/packages/trie/test/proof.spec.ts
+++ b/packages/trie/test/proof.spec.ts
@@ -6,7 +6,7 @@ import {
   Trie,
   createMerkleProof,
   createTrieFromProof,
-  updateFromProof,
+  updateTrieFromMerkleProof,
   verifyTrieProof,
 } from '../src/index.js'
 
@@ -174,7 +174,7 @@ describe('simple merkle proofs generation and verification', () => {
     assert.ok(equalsBytes(trie.root(), newTrie.root()), 'root set correctly')
 
     const proof2 = await createMerkleProof(trie, key2)
-    await updateFromProof(newTrie, proof2)
+    await updateTrieFromMerkleProof(newTrie, proof2)
     const trieValue2 = await newTrie.get(key2)
 
     assert.ok(equalsBytes(trieValue2!, encodedValue2), 'trie value succesfully updated')
@@ -191,13 +191,13 @@ describe('simple merkle proofs generation and verification', () => {
     const safeProof = await createMerkleProof(safeTrie, safeKey)
 
     try {
-      await updateFromProof(newTrie, safeProof, true)
+      await updateTrieFromMerkleProof(newTrie, safeProof, true)
       assert.fail('cannot reach this')
     } catch (e) {
       assert.ok(true, 'throws on unmatching proof')
     }
 
-    await updateFromProof(newTrie, safeProof)
+    await updateTrieFromMerkleProof(newTrie, safeProof)
     assert.ok(equalsBytes(trie.root(), newTrie.root()), 'root set correctly')
 
     const newSafeValue = await newTrie.get(safeKey)

--- a/packages/trie/test/proof/range.spec.ts
+++ b/packages/trie/test/proof/range.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Trie, createProof, verifyTrieRangeProof } from '../../src/index.js'
+import { Trie, createMerkleProof, verifyTrieRangeProof } from '../../src/index.js'
 
 import type { DB } from '@ethereumjs/util'
 
@@ -94,7 +94,7 @@ async function verify(
     endKey,
     keys ?? targetRange.map(([key]) => key),
     vals ?? targetRange.map(([, val]) => val),
-    [...(await createProof(trie, startKey)), ...(await createProof(trie, endKey))],
+    [...(await createMerkleProof(trie, startKey)), ...(await createMerkleProof(trie, endKey))],
   )
 }
 
@@ -474,7 +474,7 @@ describe('simple merkle range proofs generation and verification', () => {
 
     let bloatedProof: Uint8Array[] = []
     for (let i = 0; i < TRIE_SIZE; i++) {
-      bloatedProof = bloatedProof.concat(await createProof(trie, entries[i][0]))
+      bloatedProof = bloatedProof.concat(await createMerkleProof(trie, entries[i][0]))
     }
 
     assert.equal(await verify(trie, entries, 0, entries.length - 1), false)

--- a/packages/trie/test/trie/secure.spec.ts
+++ b/packages/trie/test/trie/secure.spec.ts
@@ -10,7 +10,7 @@ import { keccak256 } from 'ethereum-cryptography/keccak.js'
 import { sha256 } from 'ethereum-cryptography/sha256.js'
 import { assert, describe, it } from 'vitest'
 
-import { ROOT_DB_KEY, Trie, createProof, verifyTrieProof } from '../../src/index.js'
+import { ROOT_DB_KEY, Trie, createMerkleProof, verifyTrieProof } from '../../src/index.js'
 import secureTrieTests from '../fixtures/trietest_secureTrie.json'
 
 describe('SecureTrie', () => {
@@ -52,7 +52,7 @@ describe('SecureTrie proof', () => {
     const trie = new Trie({ useKeyHashing: true, db: new MapDB() })
     await trie.put(utf8ToBytes('key1aa'), utf8ToBytes('01234'))
 
-    const proof = await createProof(trie, utf8ToBytes('key1aa'))
+    const proof = await createMerkleProof(trie, utf8ToBytes('key1aa'))
     const val = await verifyTrieProof(utf8ToBytes('key1aa'), proof, {
       useKeyHashing: true,
     })

--- a/packages/trie/test/util/asyncWalk.spec.ts
+++ b/packages/trie/test/util/asyncWalk.spec.ts
@@ -4,7 +4,7 @@ import { assert, describe, it } from 'vitest'
 import {
   LeafNode,
   Trie,
-  createProof,
+  createMerkleProof,
   createTrieFromProof,
   verifyTrieProof,
 } from '../../src/index.js'
@@ -84,7 +84,7 @@ describe('walk a sparse trie', async () => {
   })
   // Generate a proof for inputs[0]
   const proofKey = inputs[0][0]
-  const proof = await createProof(trie, proofKey)
+  const proof = await createMerkleProof(trie, proofKey)
   assert.ok(await verifyTrieProof(proofKey, proof))
 
   // Build a sparse trie from the proof

--- a/packages/trie/test/util/log.spec.ts
+++ b/packages/trie/test/util/log.spec.ts
@@ -1,7 +1,7 @@
 import { utf8ToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { createMerkleProof, createTrieFromProof, verifyProof } from '../../src/index.js'
+import { createMerkleProof, createTrieFromProof, verifyMerkleProof } from '../../src/index.js'
 import { Trie } from '../../src/trie.js'
 
 describe('Run Trie script with DEBUG enabled', async () => {
@@ -21,7 +21,7 @@ describe('Run Trie script with DEBUG enabled', async () => {
   }
 
   const proof = await createMerkleProof(trie, utf8ToBytes('doge'))
-  const valid = await verifyProof(trie, trie.root(), utf8ToBytes('doge'), proof)
+  const valid = await verifyMerkleProof(trie, trie.root(), utf8ToBytes('doge'), proof)
 
   it('should be valid', async () => {
     assert.deepEqual(valid, utf8ToBytes('coin'))

--- a/packages/trie/test/util/log.spec.ts
+++ b/packages/trie/test/util/log.spec.ts
@@ -1,7 +1,7 @@
 import { utf8ToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { createProof, createTrieFromProof, verifyProof } from '../../src/index.js'
+import { createMerkleProof, createTrieFromProof, verifyProof } from '../../src/index.js'
 import { Trie } from '../../src/trie.js'
 
 describe('Run Trie script with DEBUG enabled', async () => {
@@ -20,7 +20,7 @@ describe('Run Trie script with DEBUG enabled', async () => {
     await trie.put(utf8ToBytes(key), value === null ? Uint8Array.from([]) : utf8ToBytes(value))
   }
 
-  const proof = await createProof(trie, utf8ToBytes('doge'))
+  const proof = await createMerkleProof(trie, utf8ToBytes('doge'))
   const valid = await verifyProof(trie, trie.root(), utf8ToBytes('doge'), proof)
 
   it('should be valid', async () => {

--- a/packages/verkle/src/verkleTree.ts
+++ b/packages/verkle/src/verkleTree.ts
@@ -532,7 +532,7 @@ export class VerkleTree {
    * Creates a proof from a tree and key that can be verified using {@link VerkleTree.verifyProof}.
    * @param key
    */
-  async createProof(_key: Uint8Array): Promise<Proof> {
+  async createVerkleProof(_key: Uint8Array): Promise<Proof> {
     throw new Error('Not implemented')
   }
 

--- a/packages/verkle/src/verkleTree.ts
+++ b/packages/verkle/src/verkleTree.ts
@@ -529,7 +529,7 @@ export class VerkleTree {
   }
 
   /**
-   * Creates a proof from a tree and key that can be verified using {@link VerkleTree.verifyProof}.
+   * Creates a proof from a tree and key that can be verified using {@link VerkleTree.verifyVerkleProof}.
    * @param key
    */
   async createVerkleProof(_key: Uint8Array): Promise<Proof> {
@@ -544,7 +544,7 @@ export class VerkleTree {
    * @throws If proof is found to be invalid.
    * @returns The value from the key, or null if valid proof of non-existence.
    */
-  async verifyProof(
+  async verifyVerkleProof(
     _rootHash: Uint8Array,
     _key: Uint8Array,
     _proof: Proof,


### PR DESCRIPTION
This change aims to provide more detail in the naming of the now standalone proof functions in the Verkle and Merkle datastructures:

The following functions have been renamed in Merkle-Land:
* `createProof` -> `createMerkleProof`
* `updateFromProof` -> `updateTrieFromMerkleProof`
* `verifyProof` -> `verifyMerkleProof`

The following functions have been renamed in the still experimental and under development Verkle-Land:
* `createProof` -> `createVerkleProof`
* `verifyProof` -> `verifyVerkleProof`

The statemanager wrapper function `verifyProof` remains unchanged since keeping it general will allow for a Merkle or Verkle backend.
