### PR TITLE
Block: rename createHeader functions

### DIFF
--- a/packages/block/examples/simple.ts
+++ b/packages/block/examples/simple.ts
@@ -1,4 +1,4 @@
-import { createHeader } from '@ethereumjs/block'
+import { createBlockHeader } from '@ethereumjs/block'
 import { bytesToHex } from '@ethereumjs/util'
 
 import type { HeaderData } from '@ethereumjs/block'
@@ -9,5 +9,5 @@ const headerData: HeaderData = {
   gasLimit: 8000000,
   timestamp: 1562422144,
 }
-const header = createHeader(headerData)
+const header = createBlockHeader(headerData)
 console.log(`Created block header with hash=${bytesToHex(header.hash())}`)

--- a/packages/block/src/constructors.ts
+++ b/packages/block/src/constructors.ts
@@ -62,7 +62,7 @@ import type {
  * @param headerData
  * @param opts
  */
-export function createHeader(headerData: HeaderData = {}, opts: BlockOptions = {}) {
+export function createBlockHeader(headerData: HeaderData = {}, opts: BlockOptions = {}) {
   return new BlockHeader(headerData, opts)
 }
 
@@ -72,11 +72,14 @@ export function createHeader(headerData: HeaderData = {}, opts: BlockOptions = {
  * @param values
  * @param opts
  */
-export function createHeaderFromValuesArray(values: BlockHeaderBytes, opts: BlockOptions = {}) {
+export function createBlockHeaderFromValuesArray(
+  values: BlockHeaderBytes,
+  opts: BlockOptions = {},
+) {
   const headerData = valuesArrayToHeaderData(values)
   const { number, baseFeePerGas, excessBlobGas, blobGasUsed, parentBeaconBlockRoot, requestsRoot } =
     headerData
-  const header = createHeader(headerData, opts)
+  const header = createBlockHeader(headerData, opts)
   if (header.common.isActivatedEIP(1559) && baseFeePerGas === undefined) {
     const eip1559ActivationBlock = bigIntToBytes(header.common.eipBlock(1559)!)
     if (
@@ -109,12 +112,15 @@ export function createHeaderFromValuesArray(values: BlockHeaderBytes, opts: Bloc
  * @param serializedHeaderData
  * @param opts
  */
-export function createHeaderFromRLP(serializedHeaderData: Uint8Array, opts: BlockOptions = {}) {
+export function createBlockHeaderFromRLP(
+  serializedHeaderData: Uint8Array,
+  opts: BlockOptions = {},
+) {
   const values = RLP.decode(serializedHeaderData)
   if (!Array.isArray(values)) {
     throw new Error('Invalid serialized header input. Must be array')
   }
-  return createHeaderFromValuesArray(values as Uint8Array[], opts)
+  return createBlockHeaderFromValuesArray(values as Uint8Array[], opts)
 }
 
 /**
@@ -133,7 +139,7 @@ export function createBlock(blockData: BlockData = {}, opts?: BlockOptions) {
     requests: clRequests,
   } = blockData
 
-  const header = createHeader(headerData, opts)
+  const header = createBlockHeader(headerData, opts)
 
   // parse transactions
   const transactions = []
@@ -160,7 +166,7 @@ export function createBlock(blockData: BlockData = {}, opts?: BlockOptions) {
     uncleOpts.setHardfork = true
   }
   for (const uhData of uhsData ?? []) {
-    const uh = createHeader(uhData, uncleOpts)
+    const uh = createBlockHeader(uhData, uncleOpts)
     uncleHeaders.push(uh)
   }
 
@@ -194,7 +200,7 @@ export function createBlockFromValuesArray(values: BlockBytes, opts?: BlockOptio
   // First try to load header so that we can use its common (in case of setHardfork being activated)
   // to correctly make checks on the hardforks
   const [headerData, txsData, uhsData, ...valuesTail] = values
-  const header = createHeaderFromValuesArray(headerData, opts)
+  const header = createBlockHeaderFromValuesArray(headerData, opts)
 
   // conditional assignment of rest of values and splicing them out from the valuesTail
   const withdrawalBytes = header.common.isActivatedEIP(4895)
@@ -259,7 +265,7 @@ export function createBlockFromValuesArray(values: BlockBytes, opts?: BlockOptio
     uncleOpts.setHardfork = true
   }
   for (const uncleHeaderData of uhsData ?? []) {
-    uncleHeaders.push(createHeaderFromValuesArray(uncleHeaderData, uncleOpts))
+    uncleHeaders.push(createBlockHeaderFromValuesArray(uncleHeaderData, uncleOpts))
   }
 
   const withdrawals = (withdrawalBytes as WithdrawalBytes[])

--- a/packages/block/src/header.ts
+++ b/packages/block/src/header.ts
@@ -92,7 +92,7 @@ export class BlockHeader {
    * This constructor takes the values, validates them, assigns them and freezes the object.
    *
    * @deprecated Use the public static factory methods to assist in creating a Header object from
-   * varying data types. For a default empty header, use {@link createHeader}.
+   * varying data types. For a default empty header, use {@link createBlockHeader}.
    *
    */
   constructor(headerData: HeaderData, opts: BlockOptions = {}) {

--- a/packages/block/test/clique.spec.ts
+++ b/packages/block/test/clique.spec.ts
@@ -2,13 +2,13 @@ import { Common, Goerli, Hardfork } from '@ethereumjs/common'
 import { Address, createZeroAddress, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { createHeader } from '../src/constructors.js'
+import { createBlockHeader } from '../src/constructors.js'
 
 describe('[Header]: Clique PoA Functionality', () => {
   const common = new Common({ chain: Goerli, hardfork: Hardfork.Chainstart })
 
   it('Header Data', () => {
-    let header = createHeader({ number: 1 })
+    let header = createBlockHeader({ number: 1 })
     assert.throws(
       () => {
         header.cliqueIsEpochTransition()
@@ -18,13 +18,13 @@ describe('[Header]: Clique PoA Functionality', () => {
       'cliqueIsEpochTransition() -> should throw on PoW networks',
     )
 
-    header = createHeader({ extraData: new Uint8Array(97) }, { common })
+    header = createBlockHeader({ extraData: new Uint8Array(97) }, { common })
     assert.ok(
       header.cliqueIsEpochTransition(),
       'cliqueIsEpochTransition() -> should indicate an epoch transition for the genesis block',
     )
 
-    header = createHeader({ number: 1, extraData: new Uint8Array(97) }, { common })
+    header = createBlockHeader({ number: 1, extraData: new Uint8Array(97) }, { common })
     assert.notOk(
       header.cliqueIsEpochTransition(),
       'cliqueIsEpochTransition() -> should correctly identify a non-epoch block',
@@ -48,7 +48,7 @@ describe('[Header]: Clique PoA Functionality', () => {
       'cliqueEpochTransitionSigners() -> should throw on non-epch block',
     )
 
-    header = createHeader({ number: 60000, extraData: new Uint8Array(137) }, { common })
+    header = createBlockHeader({ number: 60000, extraData: new Uint8Array(137) }, { common })
     assert.ok(
       header.cliqueIsEpochTransition(),
       'cliqueIsEpochTransition() -> should correctly identify an epoch block',
@@ -89,7 +89,7 @@ describe('[Header]: Clique PoA Functionality', () => {
   it('Signing', () => {
     const cliqueSigner = A.privateKey
 
-    let header = createHeader(
+    let header = createBlockHeader(
       { number: 1, extraData: new Uint8Array(97) },
       { common, freeze: false, cliqueSigner },
     )
@@ -98,7 +98,7 @@ describe('[Header]: Clique PoA Functionality', () => {
     assert.ok(header.cliqueVerifySignature([A.address]), 'should verify signature')
     assert.ok(header.cliqueSigner().equals(A.address), 'should recover the correct signer address')
 
-    header = createHeader({ extraData: new Uint8Array(97) }, { common })
+    header = createBlockHeader({ extraData: new Uint8Array(97) }, { common })
     assert.ok(
       header.cliqueSigner().equals(createZeroAddress()),
       'should return zero address on default block',

--- a/packages/block/test/eip1559block.spec.ts
+++ b/packages/block/test/eip1559block.spec.ts
@@ -3,7 +3,7 @@ import { create1559FeeMarketTx } from '@ethereumjs/tx'
 import { hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { createBlock, createHeader } from '../src/constructors.js'
+import { createBlock, createBlockHeader } from '../src/constructors.js'
 // Test data from Besu (retrieved via Discord)
 // Older version at https://github.com/abdelhamidbakhta/besu/blob/bf54b6c0b40d3015fc85ff9b078fbc26592d80c0/ethereum/core/src/test/resources/org/hyperledger/besu/ethereum/core/fees/basefee-test.json
 import { paramsBlock } from '../src/params.js'
@@ -36,7 +36,7 @@ describe('EIP1559 tests', () => {
     const common = new Common({ chain: Mainnet, hardfork: Hardfork.Istanbul })
     assert.throws(
       () => {
-        createHeader(
+        createBlockHeader(
           {
             number: BigInt(1),
             parentHash: genesis.hash(),
@@ -57,7 +57,7 @@ describe('EIP1559 tests', () => {
 
   it('Header -> genericFormatValidation checks', async () => {
     try {
-      createHeader(
+      createBlockHeader(
         {
           number: BigInt(1),
           parentHash: genesis.hash(),
@@ -81,7 +81,7 @@ describe('EIP1559 tests', () => {
     }
 
     try {
-      const header = createHeader(
+      const header = createBlockHeader(
         {
           number: BigInt(1),
           parentHash: genesis.hash(),
@@ -127,7 +127,7 @@ describe('EIP1559 tests', () => {
 
   it('Header -> validate()', async () => {
     try {
-      createHeader(
+      createBlockHeader(
         {
           baseFeePerGas: BigInt(1000),
           number: BigInt(1),
@@ -182,7 +182,7 @@ describe('EIP1559 tests', () => {
 
   it('Header -> validate() -> gas usage', async () => {
     try {
-      createHeader(
+      createBlockHeader(
         {
           number: BigInt(1),
           parentHash: genesis.hash(),
@@ -205,7 +205,7 @@ describe('EIP1559 tests', () => {
   })
 
   it('Header -> validate() -> gas usage', async () => {
-    createHeader(
+    createBlockHeader(
       {
         number: BigInt(1),
         parentHash: genesis.hash(),
@@ -241,7 +241,7 @@ describe('EIP1559 tests', () => {
 
   it('Header -> validate() -> gasLimit -> success cases', async () => {
     let parentGasLimit = genesis.header.gasLimit * BigInt(2)
-    createHeader(
+    createBlockHeader(
       {
         number: BigInt(1),
         parentHash: genesis.hash(),
@@ -257,7 +257,7 @@ describe('EIP1559 tests', () => {
 
     assert.ok(true, 'should not throw if gas limit is between bounds (HF transition block)')
 
-    createHeader(
+    createBlockHeader(
       {
         number: BigInt(1),
         parentHash: genesis.hash(),
@@ -274,7 +274,7 @@ describe('EIP1559 tests', () => {
     assert.ok(true, 'should not throw if gas limit is between bounds (HF transition block)')
 
     parentGasLimit = block1.header.gasLimit
-    createHeader(
+    createBlockHeader(
       {
         number: BigInt(2),
         parentHash: block1.hash(),
@@ -290,7 +290,7 @@ describe('EIP1559 tests', () => {
 
     assert.ok(true, 'should not throw if gas limit is between bounds (post-HF transition block)')
 
-    createHeader(
+    createBlockHeader(
       {
         number: BigInt(2),
         parentHash: block1.hash(),
@@ -309,7 +309,7 @@ describe('EIP1559 tests', () => {
 
   it('Header -> validateGasLimit() -> error cases', async () => {
     let parentGasLimit = genesis.header.gasLimit * BigInt(2)
-    let header = createHeader(
+    let header = createBlockHeader(
       {
         number: BigInt(1),
         parentHash: genesis.hash(),
@@ -333,7 +333,7 @@ describe('EIP1559 tests', () => {
     }
 
     parentGasLimit = block1.header.gasLimit
-    header = createHeader(
+    header = createBlockHeader(
       {
         number: BigInt(2),
         parentHash: block1.hash(),
@@ -359,7 +359,7 @@ describe('EIP1559 tests', () => {
 
   it('Header -> validateGasLimit() -> error cases', async () => {
     let parentGasLimit = genesis.header.gasLimit * BigInt(2)
-    let header = createHeader(
+    let header = createBlockHeader(
       {
         number: BigInt(1),
         parentHash: genesis.hash(),
@@ -383,7 +383,7 @@ describe('EIP1559 tests', () => {
     }
 
     parentGasLimit = block1.header.gasLimit
-    header = createHeader(
+    header = createBlockHeader(
       {
         number: BigInt(2),
         parentHash: block1.hash(),
@@ -452,7 +452,7 @@ describe('EIP1559 tests', () => {
   it('Header -> calcNextBaseFee()', () => {
     for (let index = 0; index < eip1559BaseFee.length; index++) {
       const item = eip1559BaseFee[index]
-      const result = createHeader(
+      const result = createBlockHeader(
         {
           baseFeePerGas: BigInt(item.parentBaseFee),
           gasUsed: BigInt(item.parentGasUsed),
@@ -466,7 +466,7 @@ describe('EIP1559 tests', () => {
   })
 
   it('Header -> toJSON()', () => {
-    const header = createHeader(
+    const header = createBlockHeader(
       {
         number: BigInt(3),
         parentHash: genesis.hash(),

--- a/packages/block/test/eip4788block.spec.ts
+++ b/packages/block/test/eip4788block.spec.ts
@@ -2,7 +2,7 @@ import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { bytesToHex, zeros } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { createBlock, createHeader } from '../src/constructors.js'
+import { createBlock, createBlockHeader } from '../src/constructors.js'
 
 describe('EIP4788 header tests', () => {
   it('should work', () => {
@@ -11,7 +11,7 @@ describe('EIP4788 header tests', () => {
 
     assert.throws(
       () => {
-        createHeader(
+        createBlockHeader(
           {
             parentBeaconBlockRoot: zeros(32),
           },
@@ -27,7 +27,7 @@ describe('EIP4788 header tests', () => {
 
     assert.throws(
       () => {
-        createHeader(
+        createBlockHeader(
           {
             blobGasUsed: 1n,
           },
@@ -41,7 +41,7 @@ describe('EIP4788 header tests', () => {
       'should throw when setting blobGasUsed with EIP4844 not being activated',
     )
     assert.doesNotThrow(() => {
-      createHeader(
+      createBlockHeader(
         {
           excessBlobGas: 0n,
           blobGasUsed: 0n,
@@ -56,7 +56,7 @@ describe('EIP4788 header tests', () => {
 
     const block = createBlock(
       {
-        header: createHeader({}, { common }),
+        header: createBlockHeader({}, { common }),
       },
       { common, skipConsensusFormatValidation: true },
     )

--- a/packages/block/test/eip4844block.spec.ts
+++ b/packages/block/test/eip4844block.spec.ts
@@ -9,7 +9,7 @@ import {
 import { loadKZG } from 'kzg-wasm'
 import { assert, beforeAll, describe, it } from 'vitest'
 
-import { createBlock, createHeader } from '../src/constructors.js'
+import { createBlock, createBlockHeader } from '../src/constructors.js'
 import { fakeExponential, getNumBlobs } from '../src/helpers.js'
 import { paramsBlock } from '../src/params.js'
 
@@ -36,7 +36,7 @@ describe('EIP4844 header tests', () => {
 
     assert.throws(
       () => {
-        createHeader(
+        createBlockHeader(
           {
             excessBlobGas: 1n,
           },
@@ -52,7 +52,7 @@ describe('EIP4844 header tests', () => {
 
     assert.throws(
       () => {
-        createHeader(
+        createBlockHeader(
           {
             blobGasUsed: 1n,
           },
@@ -66,7 +66,7 @@ describe('EIP4844 header tests', () => {
       'should throw when setting blobGasUsed with EIP4844 not being activated',
     )
 
-    const excessBlobGas = createHeader(
+    const excessBlobGas = createBlockHeader(
       {},
       { common, skipConsensusFormatValidation: true },
     ).excessBlobGas
@@ -76,7 +76,7 @@ describe('EIP4844 header tests', () => {
       'instantiates block with reasonable default excess blob gas value when not provided',
     )
     assert.doesNotThrow(() => {
-      createHeader(
+      createBlockHeader(
         {
           excessBlobGas: 0n,
         },
@@ -89,7 +89,7 @@ describe('EIP4844 header tests', () => {
 
     const block = createBlock(
       {
-        header: createHeader({}, { common, skipConsensusFormatValidation: true }),
+        header: createBlockHeader({}, { common, skipConsensusFormatValidation: true }),
       },
       { common, skipConsensusFormatValidation: true },
     )
@@ -111,7 +111,7 @@ describe('blob gas tests', () => {
     blobGasPerBlob = common.param('blobGasPerBlob')
   })
   it('should work', () => {
-    const preShardingHeader = createHeader({})
+    const preShardingHeader = createBlockHeader({})
 
     let excessBlobGas = preShardingHeader.calcNextExcessBlobGas()
     assert.equal(
@@ -127,7 +127,7 @@ describe('blob gas tests', () => {
       'calcDataFee throws when header has no excessBlobGas field',
     )
 
-    const lowGasHeader = createHeader(
+    const lowGasHeader = createBlockHeader(
       { number: 1, excessBlobGas: 5000 },
       { common, skipConsensusFormatValidation: true },
     )
@@ -136,7 +136,7 @@ describe('blob gas tests', () => {
     let blobGasPrice = lowGasHeader.getBlobGasPrice()
     assert.equal(excessBlobGas, 0n, 'excess blob gas should be 0 for small parent header blob gas')
     assert.equal(blobGasPrice, 1n, 'blob gas price should be 1n when low or no excess blob gas')
-    const highGasHeader = createHeader(
+    const highGasHeader = createBlockHeader(
       { number: 1, excessBlobGas: 6291456, blobGasUsed: BigInt(6) * blobGasPerBlob },
       { common, skipConsensusFormatValidation: true },
     )
@@ -196,7 +196,7 @@ describe('transaction validation tests', () => {
       { common },
     ).sign(randomBytes(32))
 
-    const parentHeader = createHeader(
+    const parentHeader = createBlockHeader(
       { number: 1n, excessBlobGas: 4194304, blobGasUsed: 0 },
       { common, skipConsensusFormatValidation: true },
     )
@@ -206,7 +206,7 @@ describe('transaction validation tests', () => {
     function getBlock(transactions: TypedTransaction[]) {
       const blobs = getNumBlobs(transactions)
 
-      const blockHeader = createHeader(
+      const blockHeader = createBlockHeader(
         {
           number: 2n,
           parentHash: parentHeader.hash(),

--- a/packages/block/test/eip4895block.spec.ts
+++ b/packages/block/test/eip4895block.spec.ts
@@ -13,7 +13,7 @@ import { assert, describe, it } from 'vitest'
 import {
   createBlock,
   createBlockFromRLPSerializedBlock,
-  createHeader,
+  createBlockHeader,
 } from '../src/constructors.js'
 import { genWithdrawalsTrieRoot } from '../src/helpers.js'
 
@@ -59,7 +59,7 @@ describe('EIP4895 tests', () => {
     const earlyCommon = new Common({ chain: Mainnet, hardfork: Hardfork.Istanbul })
     assert.throws(
       () => {
-        createHeader(
+        createBlockHeader(
           {
             withdrawalsRoot: zeros(32),
           },
@@ -73,7 +73,7 @@ describe('EIP4895 tests', () => {
       'should throw when setting withdrawalsRoot with EIP4895 not being activated',
     )
     assert.doesNotThrow(() => {
-      createHeader(
+      createBlockHeader(
         {},
         {
           common,
@@ -81,7 +81,7 @@ describe('EIP4895 tests', () => {
       )
     }, 'should not throw when withdrawalsRoot is undefined with EIP4895 being activated')
     assert.doesNotThrow(() => {
-      createHeader(
+      createBlockHeader(
         {
           withdrawalsRoot: zeros(32),
         },
@@ -144,7 +144,7 @@ describe('EIP4895 tests', () => {
       await block.withdrawalsTrieIsValid(),
       'should invalidate the empty withdrawals root',
     )
-    const validHeader = createHeader(
+    const validHeader = createBlockHeader(
       {
         withdrawalsRoot: KECCAK256_RLP,
       },

--- a/packages/block/test/eip7685block.spec.ts
+++ b/packages/block/test/eip7685block.spec.ts
@@ -12,7 +12,7 @@ import {
   createBlock,
   createBlockFromRPC,
   createBlockFromValuesArray,
-  createHeader,
+  createBlockHeader,
 } from '../src/constructors.js'
 import { genRequestsTrieRoot } from '../src/helpers.js'
 import { Block } from '../src/index.js'
@@ -111,9 +111,12 @@ describe('7685 tests', () => {
 
 describe('fromValuesArray tests', () => {
   it('should construct a block with empty requests root', () => {
-    const block = createBlockFromValuesArray([createHeader({}, { common }).raw(), [], [], [], []], {
-      common,
-    })
+    const block = createBlockFromValuesArray(
+      [createBlockHeader({}, { common }).raw(), [], [], [], []],
+      {
+        common,
+      },
+    )
     assert.deepEqual(block.header.requestsRoot, KECCAK256_RLP)
   })
   it('should construct a block with a valid requests array', async () => {
@@ -125,7 +128,7 @@ describe('fromValuesArray tests', () => {
     const serializedRequests = [request1.serialize(), request2.serialize(), request3.serialize()]
 
     const block = createBlockFromValuesArray(
-      [createHeader({ requestsRoot }, { common }).raw(), [], [], [], serializedRequests],
+      [createBlockHeader({ requestsRoot }, { common }).raw(), [], [], [], serializedRequests],
       {
         common,
       },
@@ -145,7 +148,7 @@ describe('fromRPC tests', () => {
     const serializedRequests = [request1.serialize(), request2.serialize(), request3.serialize()]
 
     const block = createBlockFromValuesArray(
-      [createHeader({ requestsRoot }, { common }).raw(), [], [], [], serializedRequests],
+      [createBlockHeader({ requestsRoot }, { common }).raw(), [], [], [], serializedRequests],
       {
         common,
       },

--- a/packages/block/test/from-beacon-payload.spec.ts
+++ b/packages/block/test/from-beacon-payload.spec.ts
@@ -3,7 +3,7 @@ import { loadKZG } from 'kzg-wasm'
 import { assert, beforeAll, describe, it } from 'vitest'
 
 import * as shardingJson from '../../client/test/sim/configs/4844-devnet.json'
-import { createBlockFromBeaconPayloadJson, createHeader } from '../src/constructors.js'
+import { createBlockFromBeaconPayloadJson, createBlockHeader } from '../src/constructors.js'
 
 import * as payloadKaustinen from './testdata/payload-kaustinen.json'
 import * as payload87335 from './testdata/payload-slot-87335.json'
@@ -34,7 +34,7 @@ describe('[fromExecutionPayloadJson]: 4844 devnet 5', () => {
         const block = await createBlockFromBeaconPayloadJson(payload as BeaconPayloadJson, {
           common,
         })
-        const parentHeader = createHeader(
+        const parentHeader = createBlockHeader(
           { excessBlobGas: BigInt(0), blobGasUsed: block.header.excessBlobGas! + BigInt(393216) },
           { common },
         )
@@ -73,7 +73,7 @@ describe('[fromExecutionPayloadJson]: 4844 devnet 5', () => {
         } as BeaconPayloadJson,
         { common },
       )
-      const parentHeader = createHeader({ excessBlobGas: BigInt(0) }, { common })
+      const parentHeader = createBlockHeader({ excessBlobGas: BigInt(0) }, { common })
       block.validateBlobTransactions(parentHeader)
       assert.fail(`should have failed constructing the block`)
     } catch (e) {

--- a/packages/block/test/header.spec.ts
+++ b/packages/block/test/header.spec.ts
@@ -15,9 +15,9 @@ import { assert, describe, it } from 'vitest'
 import {
   createBlock,
   createBlockFromRLPSerializedBlock,
-  createHeader,
-  createHeaderFromRLP,
-  createHeaderFromValuesArray,
+  createBlockHeader,
+  createBlockHeaderFromRLP,
+  createBlockHeaderFromValuesArray,
 } from '../src/constructors.js'
 import { Block } from '../src/index.js'
 
@@ -49,7 +49,7 @@ describe('[Block]: Header functions', () => {
       assert.ok(equalsBytes(header.nonce, zeros(8)))
     }
 
-    const header = createHeader()
+    const header = createBlockHeader()
     compareDefaultHeader(header)
 
     const block = new Block()
@@ -58,7 +58,7 @@ describe('[Block]: Header functions', () => {
 
   it('Initialization -> fromHeaderData()', () => {
     const common = new Common({ chain: Mainnet, hardfork: Hardfork.Chainstart })
-    let header = createHeader(undefined, { common })
+    let header = createBlockHeader(undefined, { common })
     assert.ok(bytesToHex(header.hash()), 'genesis block should initialize')
     assert.equal(
       header.common.hardfork(),
@@ -73,15 +73,15 @@ describe('[Block]: Header functions', () => {
       'should stay on correct HF if outer common HF changes',
     )
 
-    header = createHeader({}, { common })
+    header = createBlockHeader({}, { common })
     assert.ok(bytesToHex(header.hash()), 'default block should initialize')
 
     // test default freeze values
     // also test if the options are carried over to the constructor
-    header = createHeader({})
+    header = createBlockHeader({})
     assert.ok(Object.isFrozen(header), 'block should be frozen by default')
 
-    header = createHeader({}, { freeze: false })
+    header = createBlockHeader({}, { freeze: false })
     assert.ok(
       !Object.isFrozen(header),
       'block should not be frozen when freeze deactivated in options',
@@ -90,15 +90,15 @@ describe('[Block]: Header functions', () => {
 
   it('Initialization -> fromRLPSerializedHeader()', () => {
     const common = new Common({ chain: Mainnet, hardfork: Hardfork.London })
-    let header = createHeader({}, { common, freeze: false })
+    let header = createBlockHeader({}, { common, freeze: false })
 
     const rlpHeader = header.serialize()
-    header = createHeaderFromRLP(rlpHeader, {
+    header = createBlockHeaderFromRLP(rlpHeader, {
       common,
     })
     assert.ok(Object.isFrozen(header), 'block should be frozen by default')
 
-    header = createHeaderFromRLP(rlpHeader, {
+    header = createBlockHeaderFromRLP(rlpHeader, {
       common,
       freeze: false,
     })
@@ -107,7 +107,7 @@ describe('[Block]: Header functions', () => {
       'block should not be frozen when freeze deactivated in options',
     )
 
-    header = createHeaderFromRLP(
+    header = createBlockHeaderFromRLP(
       hexToBytes(
         '0xf90214a00000000000000000000000000000000000000000000000000000000000000000a01dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347940000000000000000000000000000000000000000a0d7f8974fb5ac78d9ac099b9ad5018bedc2ce0a72dad1827a1709da30580f0544a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421a056e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421b9010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000850400000000808213888080a011bbe8db4e347b4e8c937c1c8370e4b5ed33adb3db69cbdb7a38e1e50b1b82faa00000000000000000000000000000000000000000000000000000000000000000880000000000000042',
       ),
@@ -122,7 +122,7 @@ describe('[Block]: Header functions', () => {
 
   it('Initialization -> fromRLPSerializedHeader() -> error cases', () => {
     try {
-      createHeaderFromRLP(RLP.encode('a'))
+      createBlockHeaderFromRLP(RLP.encode('a'))
     } catch (e: any) {
       const expectedError = 'Invalid serialized header input. Must be array'
       assert.ok(e.message.includes(expectedError), 'should throw with header as rlp encoded string')
@@ -146,10 +146,10 @@ describe('[Block]: Header functions', () => {
     headerArray[13] = zeros(32) // mixHash
     headerArray[14] = zeros(8) // nonce
 
-    let header = createHeaderFromValuesArray(headerArray, { common })
+    let header = createBlockHeaderFromValuesArray(headerArray, { common })
     assert.ok(Object.isFrozen(header), 'block should be frozen by default')
 
-    header = createHeaderFromValuesArray(headerArray, { common, freeze: false })
+    header = createBlockHeaderFromValuesArray(headerArray, { common, freeze: false })
     assert.ok(
       !Object.isFrozen(header),
       'block should not be frozen when freeze deactivated in options',
@@ -169,14 +169,14 @@ describe('[Block]: Header functions', () => {
     headerArray[14] = zeros(8) // nonce
     headerArray[15] = zeros(4) // bad data
     try {
-      createHeaderFromValuesArray(headerArray)
+      createBlockHeaderFromValuesArray(headerArray)
     } catch (e: any) {
       const expectedError = 'invalid header. More values than expected were received'
       assert.ok(e.message.includes(expectedError), 'should throw on more values than expected')
     }
 
     try {
-      createHeaderFromValuesArray(headerArray.slice(0, 5))
+      createBlockHeaderFromValuesArray(headerArray.slice(0, 5))
     } catch (e: any) {
       const expectedError = 'invalid header. Less values than expected were received'
       assert.ok(e.message.includes(expectedError), 'should throw on less values than expected')
@@ -185,7 +185,7 @@ describe('[Block]: Header functions', () => {
 
   it('Initialization -> Clique Blocks', () => {
     const common = new Common({ chain: Goerli, hardfork: Hardfork.Chainstart })
-    const header = createHeader({ extraData: new Uint8Array(97) }, { common })
+    const header = createBlockHeader({ extraData: new Uint8Array(97) }, { common })
     assert.ok(bytesToHex(header.hash()), 'default block should initialize')
   })
 
@@ -206,7 +206,7 @@ describe('[Block]: Header functions', () => {
     let extraData = new Uint8Array(32)
 
     try {
-      createHeader({ ...data, extraData }, opts)
+      createBlockHeader({ ...data, extraData }, opts)
       assert.ok(true, testCase)
     } catch (error: any) {
       assert.fail(testCase)
@@ -217,7 +217,7 @@ describe('[Block]: Header functions', () => {
     extraData = new Uint8Array(12)
 
     try {
-      createHeader({ ...data, extraData }, opts)
+      createBlockHeader({ ...data, extraData }, opts)
       assert.ok(testCase)
     } catch (error: any) {
       assert.fail(testCase)
@@ -228,7 +228,7 @@ describe('[Block]: Header functions', () => {
     extraData = new Uint8Array(42)
 
     try {
-      createHeader({ ...data, extraData }, opts)
+      createBlockHeader({ ...data, extraData }, opts)
       assert.fail(testCase)
     } catch (error: any) {
       assert.ok((error.message as string).includes('invalid amount of extra data'), testCase)
@@ -248,7 +248,7 @@ describe('[Block]: Header functions', () => {
       'clique block should validate with valid number of bytes in extraData: 32 byte vanity + 65 byte seal'
     extraData = concatBytes(new Uint8Array(32), new Uint8Array(65))
     try {
-      createHeader({ ...data, extraData }, opts)
+      createBlockHeader({ ...data, extraData }, opts)
       assert.ok(true, testCase)
     } catch (error: any) {
       assert.fail(testCase)
@@ -258,7 +258,7 @@ describe('[Block]: Header functions', () => {
     testCase = 'clique block should throw on invalid extraData length'
     extraData = new Uint8Array(32)
     try {
-      createHeader({ ...data, extraData }, opts)
+      createBlockHeader({ ...data, extraData }, opts)
       assert.fail(testCase)
     } catch (error: any) {
       assert.ok(
@@ -279,7 +279,7 @@ describe('[Block]: Header functions', () => {
     )
     const epoch = BigInt((common.consensusConfig() as CliqueConfig).epoch)
     try {
-      createHeader({ ...data, number: epoch, extraData }, opts)
+      createBlockHeader({ ...data, number: epoch, extraData }, opts)
       assert.fail(testCase)
     } catch (error: any) {
       assert.ok(
@@ -296,7 +296,7 @@ describe('[Block]: Header functions', () => {
     const extraData = concatBytes(new Uint8Array(1))
 
     try {
-      createHeader({ extraData }, { common, skipConsensusFormatValidation: true })
+      createBlockHeader({ extraData }, { common, skipConsensusFormatValidation: true })
       assert.ok(
         true,
         'should instantiate header with invalid extraData when skipConsensusFormatValidation === true',
@@ -310,26 +310,26 @@ describe('[Block]: Header functions', () => {
     const badHash = new Uint8Array(31)
 
     assert.throws(
-      () => createHeader({ parentHash: badHash }),
+      () => createBlockHeader({ parentHash: badHash }),
       'parentHash must be 32 bytes',
       undefined,
       'throws on invalid parent hash length',
     )
     assert.throws(
-      () => createHeader({ stateRoot: badHash }),
+      () => createBlockHeader({ stateRoot: badHash }),
       'stateRoot must be 32 bytes',
       undefined,
       'throws on invalid state root hash length',
     )
     assert.throws(
-      () => createHeader({ transactionsTrie: badHash }),
+      () => createBlockHeader({ transactionsTrie: badHash }),
       'transactionsTrie must be 32 bytes',
       undefined,
       'throws on invalid transactionsTrie root hash length',
     )
 
     assert.throws(
-      () => createHeader({ nonce: new Uint8Array(5) }),
+      () => createBlockHeader({ nonce: new Uint8Array(5) }),
       'nonce must be 8 bytes',
       undefined,
       'contains nonce length error message',
@@ -354,7 +354,7 @@ describe('[Block]: Header functions', () => {
     headerData.difficulty = BigInt(2)
 
     let testCase = 'should throw on lower than period timestamp diffs'
-    let header = createHeader(headerData, { common })
+    let header = createBlockHeader(headerData, { common })
     try {
       await header.validate(blockchain)
       assert.fail(testCase)
@@ -364,7 +364,7 @@ describe('[Block]: Header functions', () => {
 
     testCase = 'should not throw on timestamp diff equal to period'
     headerData.timestamp = BigInt(1422494864)
-    header = createHeader(headerData, { common })
+    header = createBlockHeader(headerData, { common })
     try {
       await header.validate(blockchain)
       assert.ok(true, testCase)
@@ -375,7 +375,7 @@ describe('[Block]: Header functions', () => {
     testCase = 'should throw on non-zero beneficiary (coinbase) for epoch transition block'
     headerData.number = common.consensusConfig().epoch
     headerData.coinbase = createAddressFromString('0x091dcd914fCEB1d47423e532955d1E62d1b2dAEf')
-    header = createHeader(headerData, { common })
+    header = createBlockHeader(headerData, { common })
     try {
       await header.validate(blockchain)
       assert.fail('should throw')
@@ -391,7 +391,7 @@ describe('[Block]: Header functions', () => {
 
     testCase = 'should throw on non-zero mixHash'
     headerData.mixHash = new Uint8Array(32).fill(1)
-    header = createHeader(headerData, { common })
+    header = createBlockHeader(headerData, { common })
     try {
       await header.validate(blockchain)
       assert.fail('should throw')
@@ -406,7 +406,7 @@ describe('[Block]: Header functions', () => {
 
     testCase = 'should throw on invalid clique difficulty'
     headerData.difficulty = BigInt(3)
-    header = createHeader(headerData, { common })
+    header = createBlockHeader(headerData, { common })
     try {
       header.validateCliqueDifficulty(blockchain)
       assert.fail(testCase)
@@ -427,7 +427,7 @@ describe('[Block]: Header functions', () => {
     const poaBlock = createBlockFromRLPSerializedBlock(genesisRlp, { common, cliqueSigner })
     await poaBlockchain.putBlock(poaBlock)
 
-    header = createHeader(headerData, { common, cliqueSigner })
+    header = createBlockHeader(headerData, { common, cliqueSigner })
     try {
       const res = header.validateCliqueDifficulty(poaBlockchain)
       assert.equal(res, true, testCase)
@@ -438,7 +438,7 @@ describe('[Block]: Header functions', () => {
     testCase =
       'validateCliqueDifficulty() should return false with INTURN difficulty and one signer'
     headerData.difficulty = BigInt(1)
-    header = createHeader(headerData, { common, cliqueSigner })
+    header = createBlockHeader(headerData, { common, cliqueSigner })
     try {
       const res = header.validateCliqueDifficulty(poaBlockchain)
       assert.equal(res, false, testCase)
@@ -467,16 +467,16 @@ describe('[Block]: Header functions', () => {
   })
 
   it('should test isGenesis()', () => {
-    const header1 = createHeader({ number: 1 })
+    const header1 = createBlockHeader({ number: 1 })
     assert.equal(header1.isGenesis(), false)
 
-    const header2 = createHeader()
+    const header2 = createBlockHeader()
     assert.equal(header2.isGenesis(), true)
   })
 
   it('should test hash() function', () => {
     let common = new Common({ chain: Mainnet, hardfork: Hardfork.Chainstart })
-    let header = createHeader((blocksMainnet as any).default[0]['header'], { common })
+    let header = createBlockHeader((blocksMainnet as any).default[0]['header'], { common })
     assert.equal(
       bytesToHex(header.hash()),
       '0x88e96d4537bea4d9c05d12549907b32561d3bf31f45aae734cdc119f13406cb6',
@@ -484,7 +484,7 @@ describe('[Block]: Header functions', () => {
     )
 
     common = new Common({ chain: Goerli, hardfork: Hardfork.Chainstart })
-    header = createHeader((blocksGoerli as any).default[0]['header'], { common })
+    header = createBlockHeader((blocksGoerli as any).default[0]['header'], { common })
     assert.equal(
       bytesToHex(header.hash()),
       '0x8f5bab218b6bb34476f51ca588e9f4553a3a7ce5e13a66c660a5283e97e9a85a',
@@ -494,7 +494,7 @@ describe('[Block]: Header functions', () => {
 
   it('should be able to initialize shanghai header with correct hardfork defaults', () => {
     const common = new Common({ chain: Mainnet, hardfork: Hardfork.Shanghai })
-    const header = createHeader({}, { common })
+    const header = createBlockHeader({}, { common })
     assert.equal(header.common.hardfork(), Hardfork.Shanghai, 'hardfork should be set to shanghai')
     assert.equal(header.baseFeePerGas, BigInt(7), 'baseFeePerGas should be set to minimum default')
     assert.deepEqual(

--- a/packages/block/test/mergeBlock.spec.ts
+++ b/packages/block/test/mergeBlock.spec.ts
@@ -10,7 +10,7 @@ import {
 import { assert, describe, it } from 'vitest'
 
 import { Block } from '../src/block.js'
-import { createBlock, createHeader } from '../src/constructors.js'
+import { createBlock, createBlockHeader } from '../src/constructors.js'
 
 import type { BlockHeader } from '../src/header.js'
 
@@ -39,7 +39,7 @@ function validateMergeHeader(header: BlockHeader) {
 
 describe('[Header]: Casper PoS / The Merge Functionality', () => {
   it('should construct default blocks with post-merge PoS constants fields', () => {
-    const header = createHeader({}, { common })
+    const header = createBlockHeader({}, { common })
     validateMergeHeader(header)
 
     const block = new Block(undefined, undefined, undefined, undefined, { common }, undefined)
@@ -52,7 +52,7 @@ describe('[Header]: Casper PoS / The Merge Functionality', () => {
       const headerData = {
         uncleHash: hexToBytes('0x123abc'),
       }
-      createHeader(headerData, { common })
+      createBlockHeader(headerData, { common })
       assert.fail('should throw')
     } catch (e: any) {
       assert.ok(true, 'should throw on wrong uncleHash')
@@ -63,7 +63,7 @@ describe('[Header]: Casper PoS / The Merge Functionality', () => {
         difficulty: BigInt(123456),
         number: 1n,
       }
-      createHeader(headerData, { common })
+      createBlockHeader(headerData, { common })
       assert.fail('should throw')
     } catch (e: any) {
       assert.ok(true, 'should throw on wrong difficulty')
@@ -74,7 +74,7 @@ describe('[Header]: Casper PoS / The Merge Functionality', () => {
         extraData: new Uint8Array(33).fill(1),
         number: 1n,
       }
-      createHeader(headerData, { common })
+      createBlockHeader(headerData, { common })
       assert.fail('should throw')
     } catch (e: any) {
       assert.ok(true, 'should throw on invalid extraData length')
@@ -84,7 +84,7 @@ describe('[Header]: Casper PoS / The Merge Functionality', () => {
       const headerData = {
         mixHash: new Uint8Array(30).fill(1),
       }
-      createHeader(headerData, { common })
+      createBlockHeader(headerData, { common })
       assert.fail('should throw')
     } catch (e: any) {
       assert.ok(true, 'should throw on invalid mixHash length')
@@ -95,7 +95,7 @@ describe('[Header]: Casper PoS / The Merge Functionality', () => {
         nonce: new Uint8Array(8).fill(1),
         number: 1n,
       }
-      createHeader(headerData, { common })
+      createBlockHeader(headerData, { common })
       assert.fail('should throw')
     } catch (e: any) {
       assert.ok(true, 'should throw on wrong nonce')
@@ -104,7 +104,7 @@ describe('[Header]: Casper PoS / The Merge Functionality', () => {
 
   it('test that a PoS block with uncles cannot be produced', () => {
     try {
-      new Block(undefined, undefined, [createHeader(undefined, { common })], undefined, {
+      new Block(undefined, undefined, [createBlockHeader(undefined, { common })], undefined, {
         common,
       })
       assert.fail('should have thrown')

--- a/packages/blockchain/src/db/manager.ts
+++ b/packages/blockchain/src/db/manager.ts
@@ -1,4 +1,4 @@
-import { createBlockFromValuesArray, createHeaderFromValuesArray } from '@ethereumjs/block'
+import { createBlockFromValuesArray, createBlockHeaderFromValuesArray } from '@ethereumjs/block'
 import { RLP } from '@ethereumjs/rlp'
 import {
   KECCAK256_RLP,
@@ -160,7 +160,7 @@ export class DBManager {
     const headerValues = RLP.decode(encodedHeader)
 
     const opts: BlockOptions = { common: this.common, setHardfork: true }
-    return createHeaderFromValuesArray(headerValues as Uint8Array[], opts)
+    return createBlockHeaderFromValuesArray(headerValues as Uint8Array[], opts)
   }
 
   /**

--- a/packages/blockchain/test/blockValidation.spec.ts
+++ b/packages/blockchain/test/blockValidation.spec.ts
@@ -1,4 +1,4 @@
-import { createBlock, createHeader } from '@ethereumjs/block'
+import { createBlock, createBlockHeader } from '@ethereumjs/block'
 import { Common, ConsensusAlgorithm, Hardfork, Mainnet } from '@ethereumjs/common'
 import { Ethash } from '@ethereumjs/ethash'
 import { RLP } from '@ethereumjs/rlp'
@@ -224,7 +224,7 @@ describe('[Blockchain]: Block validation tests', () => {
       return BigInt(0)
     }
 
-    const header = createHeader(
+    const header = createBlockHeader(
       {
         number: BigInt(1),
         parentHash: genesis.hash(),
@@ -242,7 +242,7 @@ describe('[Blockchain]: Block validation tests', () => {
     const block = createBlock({ header }, { common })
     await blockchain.putBlock(block)
     try {
-      const header = createHeader(
+      const header = createBlockHeader(
         {
           number: BigInt(2),
           parentHash: block.hash(),
@@ -348,7 +348,7 @@ describe('[Blockchain]: Block validation tests', () => {
     const uncleHeaderData = unclePreFork.header.toJSON()
 
     uncleHeaderData.extraData = '0xffff'
-    const uncleHeader = createHeader(uncleHeaderData, {
+    const uncleHeader = createBlockHeader(uncleHeaderData, {
       common: new Common({ chain: Mainnet, hardfork: Hardfork.Berlin }),
     })
 

--- a/packages/blockchain/test/index.spec.ts
+++ b/packages/blockchain/test/index.spec.ts
@@ -1,8 +1,8 @@
 import {
   createBlock,
   createBlockFromRLPSerializedBlock,
-  createHeader,
-  createHeaderFromValuesArray,
+  createBlockHeader,
+  createBlockHeaderFromValuesArray,
 } from '@ethereumjs/block'
 import { Common, Goerli, Hardfork, Holesky, Mainnet, Sepolia } from '@ethereumjs/common'
 import { MapDB, bytesToHex, equalsBytes, hexToBytes, utf8ToBytes } from '@ethereumjs/util'
@@ -439,7 +439,7 @@ describe('blockchain test', () => {
       gasLimit: 8000000,
       timestamp: BigInt(blocks[14].header.timestamp) + BigInt(1),
     }
-    const forkHeader = createHeader(headerData, {
+    const forkHeader = createBlockHeader(headerData, {
       common,
       calcDifficultyFromHeader: blocks[14].header,
     })
@@ -464,7 +464,7 @@ describe('blockchain test', () => {
       //eslint-disable-next-line
       timestamp: BigInt(blocks[14].header.timestamp) + BigInt(1),
     }
-    const forkHeader = createHeader(headerData, {
+    const forkHeader = createBlockHeader(headerData, {
       common,
       calcDifficultyFromHeader: blocks[14].header,
     })
@@ -531,7 +531,7 @@ describe('blockchain test', () => {
     const block2HeaderValuesArray = blocks[2].header.raw()
 
     block2HeaderValuesArray[1] = new Uint8Array(32)
-    const block2Header = createHeaderFromValuesArray(block2HeaderValuesArray, {
+    const block2Header = createBlockHeaderFromValuesArray(block2HeaderValuesArray, {
       common: blocks[2].common,
     })
     await blockchain.putHeader(block2Header)
@@ -629,7 +629,7 @@ describe('blockchain test', () => {
       gasLimit,
       timestamp: genesisBlock.header.timestamp + BigInt(1),
     }
-    const header = createHeader(headerData, {
+    const header = createBlockHeader(headerData, {
       calcDifficultyFromHeader: genesisBlock.header,
       common,
     })
@@ -679,7 +679,7 @@ describe('blockchain test', () => {
       gasLimit,
     }
     opts.calcDifficultyFromHeader = genesisBlock.header
-    const header1 = createHeader(headerData1, opts)
+    const header1 = createBlockHeader(headerData1, opts)
     const headers = [header1]
 
     const headerData2 = {
@@ -689,7 +689,7 @@ describe('blockchain test', () => {
       gasLimit,
     }
     opts.calcDifficultyFromHeader = block.header
-    const header2 = createHeader(headerData2, opts)
+    const header2 = createBlockHeader(headerData2, opts)
     headers.push(header2)
 
     await blockchain.putHeaders(headers)

--- a/packages/blockchain/test/util.ts
+++ b/packages/blockchain/test/util.ts
@@ -1,4 +1,4 @@
-import { Block, createBlock, createHeader } from '@ethereumjs/block'
+import { Block, createBlock, createBlockHeader } from '@ethereumjs/block'
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import {
@@ -83,14 +83,14 @@ export const generateConsecutiveBlock = (
     difficultyChangeFactor = 1
   }
   const common = new Common({ chain: Mainnet, hardfork: Hardfork.MuirGlacier })
-  const tmpHeader = createHeader(
+  const tmpHeader = createBlockHeader(
     {
       number: parentBlock.header.number + BigInt(1),
       timestamp: parentBlock.header.timestamp + BigInt(10 + -difficultyChangeFactor * 9),
     },
     { common },
   )
-  const header = createHeader(
+  const header = createBlockHeader(
     {
       number: parentBlock.header.number + BigInt(1),
       parentHash: parentBlock.hash(),

--- a/packages/client/src/blockchain/chain.ts
+++ b/packages/client/src/blockchain/chain.ts
@@ -1,4 +1,4 @@
-import { createBlockFromValuesArray, createHeaderFromValuesArray } from '@ethereumjs/block'
+import { createBlockFromValuesArray, createBlockHeaderFromValuesArray } from '@ethereumjs/block'
 import { CliqueConsensus, createBlockchain } from '@ethereumjs/blockchain'
 import { ConsensusAlgorithm, Hardfork } from '@ethereumjs/common'
 import { BIGINT_0, equalsBytes } from '@ethereumjs/util'
@@ -468,7 +468,7 @@ export class Chain {
         }
         break
       }
-      const header = createHeaderFromValuesArray(h.raw(), {
+      const header = createBlockHeaderFromValuesArray(h.raw(), {
         common: this.config.chainCommon,
         setHardfork: true,
       })

--- a/packages/client/src/miner/miner.ts
+++ b/packages/client/src/miner/miner.ts
@@ -1,4 +1,4 @@
-import { type BlockHeader, createHeader } from '@ethereumjs/block'
+import { type BlockHeader, createBlockHeader } from '@ethereumjs/block'
 import { ConsensusType, Hardfork } from '@ethereumjs/common'
 import { Ethash } from '@ethereumjs/ethash'
 import { BIGINT_0, BIGINT_1, BIGINT_2, bytesToHex, equalsBytes } from '@ethereumjs/util'
@@ -208,7 +208,10 @@ export class Miner {
     if (this.config.chainCommon.consensusType() === ConsensusType.ProofOfAuthority) {
       // Abort if we have too recently signed
       const cliqueSigner = this.config.accounts[0][1]
-      const header = createHeader({ number }, { common: this.config.chainCommon, cliqueSigner })
+      const header = createBlockHeader(
+        { number },
+        { common: this.config.chainCommon, cliqueSigner },
+      )
       if (
         (this.service.chain.blockchain as any).consensus.cliqueCheckRecentlySigned(header) === true
       ) {

--- a/packages/client/src/net/protocol/ethprotocol.ts
+++ b/packages/client/src/net/protocol/ethprotocol.ts
@@ -1,4 +1,4 @@
-import { createBlockFromValuesArray, createHeaderFromValuesArray } from '@ethereumjs/block'
+import { createBlockFromValuesArray, createBlockHeaderFromValuesArray } from '@ethereumjs/block'
 import { RLP } from '@ethereumjs/rlp'
 import {
   BlobEIP4844Transaction,
@@ -168,7 +168,7 @@ export class EthProtocol extends Protocol {
         bytesToBigInt(reqId),
         headers.map((h) => {
           const common = this.config.chainCommon
-          const header = createHeaderFromValuesArray(h, { common, setHardfork: true })
+          const header = createBlockHeaderFromValuesArray(h, { common, setHardfork: true })
           return header
         }),
       ],

--- a/packages/client/src/net/protocol/lesprotocol.ts
+++ b/packages/client/src/net/protocol/lesprotocol.ts
@@ -1,4 +1,4 @@
-import { createHeaderFromValuesArray } from '@ethereumjs/block'
+import { createBlockHeaderFromValuesArray } from '@ethereumjs/block'
 import {
   BIGINT_0,
   bigIntToUnpaddedBytes,
@@ -109,7 +109,7 @@ export class LesProtocol extends Protocol {
         reqId: bytesToBigInt(reqId),
         bv: bytesToBigInt(bv),
         headers: headers.map((h: BlockHeaderBytes) =>
-          createHeaderFromValuesArray(h, {
+          createBlockHeaderFromValuesArray(h, {
             setHardfork: true,
             common: this.config.chainCommon, // eslint-disable-line no-invalid-this
           }),

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -1,4 +1,4 @@
-import { BlockHeader, createBlock, createHeader } from '@ethereumjs/block'
+import { BlockHeader, createBlock, createBlockHeader } from '@ethereumjs/block'
 import {
   Common,
   Goerli,
@@ -53,7 +53,7 @@ class FakeChain {
   update() {}
   get headers() {
     return {
-      latest: createHeader(),
+      latest: createBlockHeader(),
       height: BigInt(0),
     }
   }
@@ -64,10 +64,10 @@ class FakeChain {
     }
   }
   getBlock() {
-    return createHeader()
+    return createBlockHeader()
   }
   getCanonicalHeadHeader() {
-    return createHeader()
+    return createBlockHeader()
   }
   blockchain: any = {
     putBlock: async () => {},

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -1,4 +1,4 @@
-import { Block, BlockHeader, createHeader } from '@ethereumjs/block'
+import { Block, BlockHeader, createBlockHeader } from '@ethereumjs/block'
 import { Common, Goerli, Hardfork, Mainnet, createCommonFromGethGenesis } from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { create1559FeeMarketTx, create4844BlobTx, createLegacyTx } from '@ethereumjs/tx'
@@ -70,7 +70,7 @@ const setup = () => {
   const service: any = {
     chain: {
       headers: { height: BigInt(0) },
-      getCanonicalHeadHeader: () => createHeader({}, { common }),
+      getCanonicalHeadHeader: () => createBlockHeader({}, { common }),
     },
     execution: {
       vm: {

--- a/packages/client/test/rpc/debug/getRawBlock.spec.ts
+++ b/packages/client/test/rpc/debug/getRawBlock.spec.ts
@@ -1,4 +1,4 @@
-import { createBlock, createHeader } from '@ethereumjs/block'
+import { createBlock, createBlockHeader } from '@ethereumjs/block'
 import { Mainnet, createCustomCommon } from '@ethereumjs/common'
 import { create4844BlobTx, createLegacyTx } from '@ethereumjs/tx'
 import { bytesToHex, createZeroAddress, hexToBytes } from '@ethereumjs/util'
@@ -28,7 +28,7 @@ const block = {
   header: {
     number: BigInt(1),
     hash: () => blockHash,
-    serialize: () => createHeader({ number: 1 }).serialize(),
+    serialize: () => createBlockHeader({ number: 1 }).serialize(),
   },
   toJSON: () => ({
     ...createBlock({ header: { number: 1 } }).toJSON(),

--- a/packages/client/test/rpc/debug/getRawHeader.spec.ts
+++ b/packages/client/test/rpc/debug/getRawHeader.spec.ts
@@ -1,4 +1,4 @@
-import { createBlock, createHeader } from '@ethereumjs/block'
+import { createBlock, createBlockHeader } from '@ethereumjs/block'
 import { Mainnet, createCustomCommon } from '@ethereumjs/common'
 import { create4844BlobTx, createLegacyTx } from '@ethereumjs/tx'
 import { bytesToHex, createZeroAddress, hexToBytes } from '@ethereumjs/util'
@@ -28,7 +28,7 @@ const block = {
   header: {
     number: BigInt(1),
     hash: () => blockHash,
-    serialize: () => createHeader({ number: 1 }).serialize(),
+    serialize: () => createBlockHeader({ number: 1 }).serialize(),
   },
   toJSON: () => ({
     ...createBlock({ header: { number: 1 } }).toJSON(),
@@ -46,7 +46,7 @@ const genesisBlock = {
   hash: () => genesisBlockHash,
   header: {
     number: BigInt(0),
-    serialize: () => createHeader({ number: 0 }).serialize(),
+    serialize: () => createBlockHeader({ number: 0 }).serialize(),
   },
   toJSON: () => ({ ...createBlock({ header: { number: 0 } }).toJSON(), transactions }),
   serialize: () => createBlock({ header: { number: 0 }, transactions }).serialize(),

--- a/packages/client/test/rpc/engine/getPayloadBodiesByHashV1.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadBodiesByHashV1.spec.ts
@@ -1,4 +1,4 @@
-import { createBlock, createHeader } from '@ethereumjs/block'
+import { createBlock, createBlockHeader } from '@ethereumjs/block'
 import { Hardfork } from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { createTxFromTxData } from '@ethereumjs/tx'
@@ -75,7 +75,7 @@ describe(method, () => {
     const block = createBlock(
       {
         transactions: [tx],
-        header: createHeader(
+        header: createBlockHeader(
           { parentHash: chain.genesis.hash(), number: 1n },
           { common, skipConsensusFormatValidation: true },
         ),
@@ -85,7 +85,7 @@ describe(method, () => {
     const block2 = createBlock(
       {
         transactions: [tx2],
-        header: createHeader(
+        header: createBlockHeader(
           { parentHash: block.hash(), number: 2n },
           { common, skipConsensusFormatValidation: true },
         ),
@@ -161,7 +161,7 @@ describe(method, () => {
     const block = createBlock(
       {
         transactions: [tx],
-        header: createHeader(
+        header: createBlockHeader(
           { parentHash: chain.genesis.hash(), number: 1n },
           { common, skipConsensusFormatValidation: true },
         ),
@@ -171,7 +171,7 @@ describe(method, () => {
     const block2 = createBlock(
       {
         transactions: [tx2],
-        header: createHeader(
+        header: createBlockHeader(
           { parentHash: block.hash(), number: 2n },
           { common, skipConsensusFormatValidation: true },
         ),

--- a/packages/client/test/rpc/engine/getPayloadBodiesByRangeV1.spec.ts
+++ b/packages/client/test/rpc/engine/getPayloadBodiesByRangeV1.spec.ts
@@ -1,4 +1,4 @@
-import { createBlock, createHeader } from '@ethereumjs/block'
+import { createBlock, createBlockHeader } from '@ethereumjs/block'
 import { Hardfork } from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
 import { createTxFromTxData } from '@ethereumjs/tx'
@@ -71,7 +71,7 @@ describe(method, () => {
     const block = createBlock(
       {
         transactions: [tx],
-        header: createHeader(
+        header: createBlockHeader(
           { parentHash: chain.genesis.hash(), number: 1n },
           { common, skipConsensusFormatValidation: true },
         ),
@@ -81,7 +81,7 @@ describe(method, () => {
     const block2 = createBlock(
       {
         transactions: [tx2],
-        header: createHeader(
+        header: createBlockHeader(
           { parentHash: block.hash(), number: 2n },
           { common, skipConsensusFormatValidation: true },
         ),
@@ -153,7 +153,7 @@ describe(method, () => {
     const block = createBlock(
       {
         transactions: [tx],
-        header: createHeader(
+        header: createBlockHeader(
           { parentHash: chain.genesis.hash(), number: 1n },
           { common, skipConsensusFormatValidation: true },
         ),
@@ -163,7 +163,7 @@ describe(method, () => {
     const block2 = createBlock(
       {
         transactions: [tx2],
-        header: createHeader(
+        header: createBlockHeader(
           { parentHash: block.hash(), number: 2n },
           { common, skipConsensusFormatValidation: true },
         ),

--- a/packages/client/test/rpc/eth/estimateGas.spec.ts
+++ b/packages/client/test/rpc/eth/estimateGas.spec.ts
@@ -1,4 +1,4 @@
-import { createBlock, createHeader } from '@ethereumjs/block'
+import { createBlock, createBlockHeader } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
 import { createCommonFromGethGenesis } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
@@ -131,7 +131,7 @@ describe(
       const headBlock = await service.chain.getCanonicalHeadBlock()
       const londonBlock = createBlock(
         {
-          header: createHeader(
+          header: createBlockHeader(
             {
               baseFeePerGas: 1000000000n,
               number: 2n,

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -1,4 +1,4 @@
-import { createHeader } from '@ethereumjs/block'
+import { createBlockHeader } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
 import {
   Common,
@@ -128,7 +128,7 @@ export async function createClient(clientOpts: Partial<createClientArgs> = {}) {
 
   chain.getTd = async (_hash: Uint8Array, _num: bigint) => BigInt(1000)
   if ((chain as any)._headers !== undefined) {
-    ;(chain as any)._headers.latest = createHeader(
+    ;(chain as any)._headers.latest = createBlockHeader(
       { withdrawalsRoot: common.isActivatedEIP(4895) ? KECCAK256_RLP : undefined },
       { common },
     )

--- a/packages/client/test/rpc/txpool/content.spec.ts
+++ b/packages/client/test/rpc/txpool/content.spec.ts
@@ -1,4 +1,4 @@
-import { createBlock, createHeader } from '@ethereumjs/block'
+import { createBlock, createBlockHeader } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
@@ -53,7 +53,7 @@ describe(method, () => {
     const headBlock = await service.chain.getCanonicalHeadBlock()
     const londonBlock = createBlock(
       {
-        header: createHeader(
+        header: createBlockHeader(
           {
             baseFeePerGas: 1000000000n,
             number: 2n,

--- a/packages/client/test/sync/fetcher/blockfetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/blockfetcher.spec.ts
@@ -1,4 +1,4 @@
-import { createHeader } from '@ethereumjs/block'
+import { createBlockHeader } from '@ethereumjs/block'
 import { Hardfork } from '@ethereumjs/common'
 import { KECCAK256_RLP } from '@ethereumjs/util'
 import { assert, describe, it, vi } from 'vitest'
@@ -207,7 +207,7 @@ describe('[BlockFetcher]', async () => {
       count: BigInt(0),
     })
 
-    const shanghaiHeader = createHeader(
+    const shanghaiHeader = createBlockHeader(
       { number: 1, withdrawalsRoot: KECCAK256_RLP },
       { common: config.chainCommon, setHardfork: true },
     )

--- a/packages/client/test/sync/lightsync.spec.ts
+++ b/packages/client/test/sync/lightsync.spec.ts
@@ -1,4 +1,4 @@
-import { createHeader } from '@ethereumjs/block'
+import { createBlockHeader } from '@ethereumjs/block'
 import * as td from 'testdouble'
 import { assert, describe, it, vi } from 'vitest'
 
@@ -182,7 +182,7 @@ describe('import headers', () => {
     } as any)
     td.when(HeaderFetcher.prototype.fetch()).thenResolve(true)
     td.when(HeaderFetcher.prototype.fetch()).thenDo(() =>
-      config.events.emit(Event.SYNC_FETCHED_HEADERS, [createHeader({})]),
+      config.events.emit(Event.SYNC_FETCHED_HEADERS, [createBlockHeader({})]),
     )
     config.logger.on('data', async (data) => {
       if ((data.message as string).includes('Imported headers count=1')) {

--- a/packages/client/test/sync/snapsync.spec.ts
+++ b/packages/client/test/sync/snapsync.spec.ts
@@ -1,4 +1,4 @@
-import { createHeader } from '@ethereumjs/block'
+import { createBlockHeader } from '@ethereumjs/block'
 import { assert, describe, it, vi } from 'vitest'
 
 import { Chain } from '../../src/blockchain/index.js'
@@ -72,8 +72,12 @@ describe('[SnapSynchronizer]', async () => {
       chain,
     } as any)
     ;(sync as any).chain = { blocks: { height: 1 } }
-    const getBlockHeaders1 = vi.fn().mockReturnValue([BigInt(1), [createHeader({ number: 1 })]])
-    const getBlockHeaders2 = vi.fn().mockReturnValue([BigInt(2), [createHeader({ number: 2 })]])
+    const getBlockHeaders1 = vi
+      .fn()
+      .mockReturnValue([BigInt(1), [createBlockHeader({ number: 1 })]])
+    const getBlockHeaders2 = vi
+      .fn()
+      .mockReturnValue([BigInt(2), [createBlockHeader({ number: 2 })]])
     const peers = [
       {
         snap: {},

--- a/packages/devp2p/examples/peer-communication-les.ts
+++ b/packages/devp2p/examples/peer-communication-les.ts
@@ -1,4 +1,4 @@
-import { createBlockFromValuesArray, createHeaderFromValuesArray } from '@ethereumjs/block'
+import { createBlockFromValuesArray, createBlockHeaderFromValuesArray } from '@ethereumjs/block'
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import * as devp2p from '@ethereumjs/devp2p'
 import { bytesToHex, bytesToInt, hexToBytes, intToBytes, randomBytes } from '@ethereumjs/util'
@@ -109,7 +109,7 @@ rlpx.events.on('peer:added', (peer) => {
           )
           break
         }
-        const header = createHeaderFromValuesArray(payload[2][0], { common })
+        const header = createBlockHeaderFromValuesArray(payload[2][0], { common })
 
         setTimeout(() => {
           les.sendMessage(devp2p.LES.MESSAGE_CODES.GET_BLOCK_BODIES, [

--- a/packages/devp2p/examples/peer-communication.ts
+++ b/packages/devp2p/examples/peer-communication.ts
@@ -174,7 +174,7 @@ rlpx.events.on('peer:added', (peer) => {
           }
 
           const expectedHash = CHECK_BLOCK
-          const header = createHeaderFromValuesArray(payload[1][0], { common })
+          const header = createBlockHeaderFromValuesArray(payload[1][0], { common })
           if (bytesToUnprefixedHex(header.hash()) === expectedHash) {
             console.log(`${addr} verified to be on the same side of the ${CHECK_BLOCK_TITLE}`)
             clearTimeout(forkDrop)
@@ -189,7 +189,7 @@ rlpx.events.on('peer:added', (peer) => {
           }
 
           let isValidPayload = false
-          const header = createHeaderFromValuesArray(payload[1][0], { common })
+          const header = createBlockHeaderFromValuesArray(payload[1][0], { common })
           while (requests.headers.length > 0) {
             const blockHash = requests.headers.shift()
             if (equalsBytes(header.hash(), blockHash)) {

--- a/packages/devp2p/src/rlpx/ecies.ts
+++ b/packages/devp2p/src/rlpx/ecies.ts
@@ -356,7 +356,7 @@ export class ECIES {
     this.parseAckPlain(data.subarray(2), data.subarray(0, 2))
   }
 
-  createHeader(size: number): Uint8Array | undefined {
+  createBlockHeader(size: number): Uint8Array | undefined {
     const bufSize = zfill(intToBytes(size), 3)
     const headerData = RLP.encode([0, 0]) // [capability-id, context-id] (currently unused in spec)
     let header = concatBytes(bufSize, headerData)

--- a/packages/devp2p/src/rlpx/peer.ts
+++ b/packages/devp2p/src/rlpx/peer.ts
@@ -200,7 +200,7 @@ export class Peer {
     if (this._closed) return false
 
     const msg = concatBytes(RLP.encode(code), data)
-    const header = this._eciesSession.createHeader(msg.length)
+    const header = this._eciesSession.createBlockHeader(msg.length)
     if (!header || this._socket.destroyed) return
     this._socket.write(header)
 

--- a/packages/devp2p/test/rlpx-ecies.spec.ts
+++ b/packages/devp2p/test/rlpx-ecies.spec.ts
@@ -84,8 +84,8 @@ it(
 
     const body = getRandomBytesSync(600)
 
-    const header = t.context.b.parseHeader(t.context.a.createHeader(body.length) as Uint8Array)
-    assert.equal(header, body.length, 'createHeader -> parseHeader should lead to same')
+    const header = t.context.b.parseHeader(t.context.a.createBlockHeader(body.length) as Uint8Array)
+    assert.equal(header, body.length, 'createBlockHeader -> parseHeader should lead to same')
 
     const parsedBody = t.context.b.parseBody(t.context.a.createBody(body) as Uint8Array)
     assert.deepEqual(parsedBody, body, 'createBody -> parseBody should lead to same')

--- a/packages/ethash/src/index.ts
+++ b/packages/ethash/src/index.ts
@@ -1,4 +1,4 @@
-import { Block, BlockHeader, createBlock, createHeader } from '@ethereumjs/block'
+import { Block, BlockHeader, createBlock, createBlockHeader } from '@ethereumjs/block'
 import { RLP } from '@ethereumjs/rlp'
 import {
   BIGINT_0,
@@ -101,7 +101,7 @@ export class Miner {
         const data = <HeaderData>this.blockHeader.toJSON()
         data.mixHash = solution.mixHash
         data.nonce = solution.nonce
-        return createHeader(data, { common: this.blockHeader.common })
+        return createBlockHeader(data, { common: this.blockHeader.common })
       }
     }
   }

--- a/packages/ethash/test/ethash.spec.ts
+++ b/packages/ethash/test/ethash.spec.ts
@@ -1,4 +1,4 @@
-import { createHeaderFromRLP } from '@ethereumjs/block'
+import { createBlockHeaderFromRLP } from '@ethereumjs/block'
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { bytesToHex, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
@@ -16,7 +16,7 @@ describe('POW tests', () => {
   it('should work', async () => {
     for (const key of tests) {
       const test = powTests[key]
-      const header = createHeaderFromRLP(hexToBytes(`0x${test.header}`), { common })
+      const header = createBlockHeaderFromRLP(hexToBytes(`0x${test.header}`), { common })
 
       const headerHash = ethash.headerHash(header.raw())
       assert.equal(bytesToHex(headerHash), '0x' + test.header_hash, 'generate header hash')

--- a/packages/vm/test/api/EIPs/eip-4788-beaconroot.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-4788-beaconroot.spec.ts
@@ -9,7 +9,7 @@
  *      - Input length < 32 bytes (reverts)
  */
 
-import { createBlock, createHeader } from '@ethereumjs/block'
+import { createBlock, createBlockHeader } from '@ethereumjs/block'
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { type TransactionType, type TxData, createTxFromTxData } from '@ethereumjs/tx'
 import {
@@ -56,7 +56,7 @@ function beaconrootBlock(
   }
 
   const root = setLengthLeft(bigIntToBytes(blockroot), 32)
-  const header = createHeader(
+  const header = createBlockHeader(
     {
       parentBeaconBlockRoot: root,
       timestamp,

--- a/packages/vm/test/api/runTx.spec.ts
+++ b/packages/vm/test/api/runTx.spec.ts
@@ -1,4 +1,4 @@
-import { createBlock, createHeader } from '@ethereumjs/block'
+import { createBlock, createBlockHeader } from '@ethereumjs/block'
 import { Blockchain, createBlockchain } from '@ethereumjs/blockchain'
 import { Common, Goerli, Hardfork, Mainnet, createCommonFromGethGenesis } from '@ethereumjs/common'
 import {
@@ -874,7 +874,7 @@ describe('EIP 4844 transaction tests', () => {
     Blockchain.prototype.getBlock = async () => {
       return createBlock(
         {
-          header: createHeader(
+          header: createBlockHeader(
             {
               excessBlobGas: 0n,
               number: 1,
@@ -902,7 +902,7 @@ describe('EIP 4844 transaction tests', () => {
 
     const block = createBlock(
       {
-        header: createHeader(
+        header: createBlockHeader(
           {
             excessBlobGas: 1n,
             number: 2,

--- a/packages/vm/test/util.ts
+++ b/packages/vm/test/util.ts
@@ -1,4 +1,4 @@
-import { Block, createHeader } from '@ethereumjs/block'
+import { Block, createBlockHeader } from '@ethereumjs/block'
 import { Common, Hardfork, Mainnet, createCustomCommon } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import {
@@ -326,7 +326,7 @@ export function makeBlockHeader(data: any, opts?: BlockOptions) {
   if (opts?.common && opts.common.gteHardfork('london')) {
     headerData['baseFeePerGas'] = currentBaseFee
     if (currentBaseFee === undefined) {
-      const parentBlockHeader = createHeader(
+      const parentBlockHeader = createBlockHeader(
         {
           gasLimit: parentGasLimit,
           gasUsed: parentGasUsed,
@@ -344,7 +344,7 @@ export function makeBlockHeader(data: any, opts?: BlockOptions) {
   if (opts?.common && opts.common.gteHardfork('cancun')) {
     headerData['excessBlobGas'] = currentExcessBlobGas
   }
-  return createHeader(headerData, opts)
+  return createBlockHeader(headerData, opts)
 }
 
 /**


### PR DESCRIPTION
Followup to #3550

Updates `createHeader...` functions to more explicit `createBlockHeader...`

- `createHeader` > `createBlockHeader`
- `createHeaderFromRLP` > `createBlockHeaderFromRLP`
- `createHeaderFromValuesArray` > `createBlockHeaderFromValuesArray`