### PR TITLE
Add `admin_peer` RPC endpoint

### DIFF
--- a/packages/client/src/rpc/modules/admin.ts
+++ b/packages/client/src/rpc/modules/admin.ts
@@ -88,7 +88,7 @@ export class Admin {
               ? bytesToHex(peer.eth.updatedBestHeader?.hash())
               : bytesToHex(peer.eth?.status.bestHash),
             difficulty: peer.eth?.status.td.toString(10),
-            version: peer.eth?.['versions'][-1] ?? null,
+            version: peer.eth?.['versions'].slice(-1)[0] ?? null,
           },
         },
         caps: peer.eth?.['versions'].map((ver) => 'eth/' + ver),

--- a/packages/client/src/rpc/modules/admin.ts
+++ b/packages/client/src/rpc/modules/admin.ts
@@ -87,9 +87,14 @@ export class Admin {
             head: peer.eth?.updatedBestHeader
               ? bytesToHex(peer.eth.updatedBestHeader?.hash())
               : bytesToHex(peer.eth?.status.bestHash),
+            difficulty: peer.eth?.status.td.toString(10),
+            version: peer.eth?.['versions'][-1] ?? null,
           },
         },
         caps: peer.eth?.['versions'].map((ver) => 'eth/' + ver),
+        network: {
+          remoteAddress: peer.address,
+        },
       }
     })
   }

--- a/packages/client/src/rpc/modules/admin.ts
+++ b/packages/client/src/rpc/modules/admin.ts
@@ -75,7 +75,8 @@ export class Admin {
    * @returns an array of objects containing information about peers (including id, eth protocol versions supported, client name, etc.)
    */
   async peers() {
-    const peers = this._client.service('eth')?.pool.peers as RlpxPeer[]
+    const peers = this._client.services.filter((serv) => serv.name === 'eth')[0]?.pool
+      .peers as RlpxPeer[]
 
     return peers?.map((peer) => {
       return {

--- a/packages/client/test/rpc/admin/peers.spec.ts
+++ b/packages/client/test/rpc/admin/peers.spec.ts
@@ -1,0 +1,38 @@
+import { randomBytes } from 'crypto'
+import { assert, describe, it } from 'vitest'
+
+import { createClient, createManager, getRpcClient, startRPC } from '../helpers.js'
+
+const method = 'admin_peers'
+
+describe(method, () => {
+  it('works', async () => {
+    const manager = createManager(await createClient({ opened: true, noPeers: true }))
+    const rpc = getRpcClient(startRPC(manager.getMethods()))
+
+    console.log(manager['_client'].services[0].pool)
+    //@ts-ignore
+    manager['_client'].services[0].pool.peers = [
+      {
+        id: 'abcd',
+        eth: {
+          versions: ['68'],
+          status: {
+            td: 1n,
+            bestHash: randomBytes(32),
+          },
+        },
+        rlpxPeer: {
+          _hello: {
+            clientId: 'fakeClient',
+          },
+        },
+        address: '127.0.0.1:8545',
+      },
+    ]
+    const res = await rpc.request(method, [])
+    const { result } = res
+    console.log(res)
+    assert.notEqual(result, undefined, 'admin_peers returns a value')
+  })
+})


### PR DESCRIPTION
Addresses #3565

Adds a new `admin_peers` function that mirrors the functionality of the geth RPC endpoint as described [here](https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-admin#admin_peers)