### PR TITLE
util: add string[] type to rpcParams type

### DIFF
--- a/packages/statemanager/src/rpcStateManager.ts
+++ b/packages/statemanager/src/rpcStateManager.ts
@@ -53,10 +53,6 @@ export class RPCStateManager implements StateManagerInterface {
 
     this._caches = new Caches({ storage: { size: 100000 }, code: { size: 100000 } })
 
-    // this._contractCache = new Map()
-    // this._storageCache = new StorageCache({ size: 100000, type: CacheType.ORDERED_MAP })
-    // this._accountCache = new AccountCache({ size: 100000, type: CacheType.ORDERED_MAP })
-
     this.originalStorageCache = new OriginalStorageCache(this.getStorage.bind(this))
     this.common = opts.common ?? new Common({ chain: Mainnet })
     this.keccakFunction = opts.common?.customCrypto.keccak256 ?? keccak256

--- a/packages/statemanager/src/rpcStateManager.ts
+++ b/packages/statemanager/src/rpcStateManager.ts
@@ -333,7 +333,7 @@ export class RPCStateManager implements StateManagerInterface {
     if (this.DEBUG) this._debug(`retrieving proof from provider for ${address.toString()}`)
     const proof = await fetchFromProvider(this._provider, {
       method: 'eth_getProof',
-      params: [address.toString(), storageSlots.map(bytesToHex).join(','), this._blockTag],
+      params: [address.toString(), storageSlots.map(bytesToHex), this._blockTag],
     })
 
     return proof

--- a/packages/util/src/provider.ts
+++ b/packages/util/src/provider.ts
@@ -1,6 +1,6 @@
 type rpcParams = {
   method: string
-  params: (string | boolean | number)[]
+  params: (string | string[] | boolean | number)[]
 }
 
 /**


### PR DESCRIPTION
This PR adds the `string[]` type to the rpcParams type, as it is a valid param in some contets, notably the eth_getProof JSON-RPC second param. 