### PR TITLE
monorepo: type cleanup

### DIFF
--- a/packages/blockchain/src/consensus/ethash.ts
+++ b/packages/blockchain/src/consensus/ethash.ts
@@ -46,7 +46,7 @@ export class EthashConsensus implements Consensus {
   public async genesisInit(): Promise<void> {}
   public async setup({ blockchain }: ConsensusOptions): Promise<void> {
     this.blockchain = blockchain
-    this._ethash.cacheDB = this.blockchain!.db as any
+    this._ethash.cacheDB = this.blockchain.db
   }
   public async newBlock(): Promise<void> {}
 }

--- a/packages/client/src/rpc/modules/admin.ts
+++ b/packages/client/src/rpc/modules/admin.ts
@@ -81,8 +81,7 @@ export class Admin {
     return peers?.map((peer) => {
       return {
         id: peer.id,
-        // Typescript complains about the typing of `_hello` if we make rlpxPeer possibly null
-        name: (peer.rlpxPeer as any)['_hello'].clientId ?? null,
+        name: peer.rlpxPeer?.['_hello']?.clientId ?? null,
         protocols: {
           eth: {
             head: peer.eth?.updatedBestHeader


### PR DESCRIPTION
Spotted two instances where `as any` typecasting could be removed