### PR TITLE
Prometheus cleanup

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -308,7 +308,7 @@ dist/bin/cli.js --d
 ## Metrics
 
 The client can optionally collect metrics using the Prometheus metrics platform and expose them via an HTTP endpoint with the following CLI flags.  
-The current metrics that are reported by the client can be found [here](./src/util//metrics.ts).
+The current metrics that are reported by the client can be found at the default port and route: `localhost:8000/metrics`.
 
 ```sh
 # npm installation
@@ -317,8 +317,6 @@ ethereumjs --prometheus
 # source installation
 npm run client:start:ts -- --prometheus --prometheusPort=9123
 ```
-
-Note: The Prometheus endpoint runs on port 8000 by default
 
 ## API
 

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -1122,10 +1122,15 @@ async function run() {
       const reqUrl = new url.URL(req.url, `http://${req.headers.host}`)
       const route = reqUrl.pathname
 
-      if (route === '/metrics') {
-        // Return all metrics in the Prometheus exposition format
-        res.setHeader('Content-Type', register.contentType)
-        res.end(await register.metrics())
+      switch (route) {
+        case '/metrics':
+          // Return all metrics in the Prometheus exposition format
+          res.setHeader('Content-Type', register.contentType)
+          res.end(await register.metrics())
+        default:
+          res.statusCode = 404
+          res.end('Not found')
+          return
       }
     })
     // Start the HTTP server which exposes the metrics on http://localhost:${args.prometheusPort}/metrics

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -1127,6 +1127,7 @@ async function run() {
           // Return all metrics in the Prometheus exposition format
           res.setHeader('Content-Type', register.contentType)
           res.end(await register.metrics())
+          break
         default:
           res.statusCode = 404
           res.end('Not found')


### PR DESCRIPTION
This change does two things:
* clean up the Prometheus metrics server documentation for the client
* adds a default case of returning a `404` not found response in the case of navigating to an unkown/unhandled route