### PR TITLE
Example test runner: make script more readable / ensure examples do not `process.exit`

### DIFF
--- a/packages/devp2p/examples/simple.ts
+++ b/packages/devp2p/examples/simple.ts
@@ -43,5 +43,5 @@ for (const bootnode of BOOTNODES) {
 }
 
 setTimeout(() => {
-  process.exit()
+  throw new Error('Test timed out')
 }, TIMEOUT)

--- a/packages/devp2p/examples/simple.ts
+++ b/packages/devp2p/examples/simple.ts
@@ -43,7 +43,5 @@ for (const bootnode of BOOTNODES) {
 }
 
 setTimeout(() => {
-  // After the timeout, destroy dpt
-  dpt.destroy() // NOTE: this does not seem to stop listening to peers, how to quit/exit?
-  // (client also calls `dpt.destroy()` in `rlpxserver` on `stop()`)
+  process.exit()
 }, TIMEOUT)

--- a/packages/devp2p/examples/simple.ts
+++ b/packages/devp2p/examples/simple.ts
@@ -43,5 +43,7 @@ for (const bootnode of BOOTNODES) {
 }
 
 setTimeout(() => {
-  throw new Error('Test timed out')
+  // After the timeout, destroy dpt
+  dpt.destroy() // NOTE: this does not seem to stop listening to peers, how to quit/exit?
+  // (client also calls `dpt.destroy()` in `rlpxserver` on `stop()`)
 }, TIMEOUT)

--- a/packages/vm/examples/run-blockchain.ts
+++ b/packages/vm/examples/run-blockchain.ts
@@ -94,8 +94,3 @@ async function putBlocks(blockchain: Blockchain, common: Common, data: typeof te
 }
 
 main()
-  .then(() => process.exit(0))
-  .catch((err) => {
-    console.error(err)
-    process.exit(1)
-  })

--- a/packages/vm/examples/run-blockchain.ts
+++ b/packages/vm/examples/run-blockchain.ts
@@ -93,4 +93,4 @@ async function putBlocks(blockchain: Blockchain, common: Common, data: typeof te
   }
 }
 
-main()
+void main()

--- a/packages/vm/examples/run-solidity-contract.ts
+++ b/packages/vm/examples/run-solidity-contract.ts
@@ -228,8 +228,3 @@ async function main() {
 }
 
 main()
-  .then(() => process.exit(0))
-  .catch((err) => {
-    console.error(err)
-    process.exit(1)
-  })

--- a/packages/vm/examples/run-solidity-contract.ts
+++ b/packages/vm/examples/run-solidity-contract.ts
@@ -227,4 +227,4 @@ async function main() {
   console.log('Everything ran correctly!')
 }
 
-main()
+void main()

--- a/packages/vm/examples/vmWithGenesisState.ts
+++ b/packages/vm/examples/vmWithGenesisState.ts
@@ -12,6 +12,7 @@ const main = async () => {
   const account = await vm.stateManager.getAccount(
     createAddressFromString('0x000d836201318ec6899a67540690382780743280'),
   )
+  console.log(account)
   console.log(
     `This balance for account 0x000d836201318ec6899a67540690382780743280 in this chain's genesis state is ${Number(
       account?.balance,

--- a/packages/vm/examples/vmWithGenesisState.ts
+++ b/packages/vm/examples/vmWithGenesisState.ts
@@ -1,4 +1,3 @@
-import { createBlockchain } from '@ethereumjs/blockchain'
 import { Chain } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
 import { createAddressFromString } from '@ethereumjs/util'
@@ -7,12 +6,16 @@ import { VM } from '@ethereumjs/vm'
 const main = async () => {
   const genesisState = getGenesis(Chain.Mainnet)
 
-  const blockchain = await createBlockchain({ genesisState })
-  const vm = await VM.create({ blockchain })
+  const vm = await VM.create()
+  await vm.stateManager.generateCanonicalGenesis!(genesisState)
   const account = await vm.stateManager.getAccount(
     createAddressFromString('0x000d836201318ec6899a67540690382780743280'),
   )
-  console.log(account)
+
+  if (account === undefined) {
+    throw new Error('Account does not exist: failed to import genesis state')
+  }
+
   console.log(
     `This balance for account 0x000d836201318ec6899a67540690382780743280 in this chain's genesis state is ${Number(
       account?.balance,

--- a/scripts/examples-runner.ts
+++ b/scripts/examples-runner.ts
@@ -1,5 +1,5 @@
+import { readdirSync } from 'fs'
 import { extname, join } from 'path'
-import { readdir } from 'fs'
 
 const pkg = process.argv[3]
 if (!pkg) {
@@ -9,17 +9,16 @@ if (!pkg) {
 const examplesPath = `../packages/${pkg}/examples/`
 const path = join(__dirname, examplesPath)
 
-readdir(path, async (err, files) => {
-  if (err) {
-    throw new Error('Error loading examples directory: ' + err.message)
+const getTsFiles = (fileName: string): Promise<NodeModule> | undefined => {
+  if (extname(fileName) === '.cts' || extname(fileName) === '.ts') {
+    return import(examplesPath + fileName)
   }
+}
 
-  const getTsFiles = (fileName: string): Promise<NodeModule> | undefined => {
-    if (extname(fileName) === '.cts' || extname(fileName) === '.ts') {
-      return import(examplesPath + fileName)
-    }
-  }
-
+const main = async () => {
+  const files = readdirSync(path)
   const importedFiles = files.map(getTsFiles).filter((file) => file)
   await Promise.all(importedFiles)
-})
+}
+
+main()

--- a/scripts/examples-runner.ts
+++ b/scripts/examples-runner.ts
@@ -9,7 +9,7 @@ if (!pkg) {
 const examplesPath = `../packages/${pkg}/examples/`
 const path = join(__dirname, examplesPath)
 
-const getTsFiles = (fileName: string): Promise<NodeModule> | undefined => {
+const getExample = (fileName: string): Promise<NodeModule> | undefined => {
   if (extname(fileName) === '.cts' || extname(fileName) === '.ts') {
     return import(examplesPath + fileName)
   }
@@ -17,8 +17,13 @@ const getTsFiles = (fileName: string): Promise<NodeModule> | undefined => {
 
 const main = async () => {
   const files = readdirSync(path)
-  const importedFiles = files.map(getTsFiles).filter((file) => file)
-  await Promise.all(importedFiles)
+  for (const file of files) {
+    const runner = getExample(file)
+    if (runner !== undefined) {
+      console.log(` ---- Run example: ${file} ----`)
+      await runner
+    }
+  }
 }
 
 main()


### PR DESCRIPTION
The examples test runner tries to run each example in a package, and if one of them throws, the `npm run examples` will fail (and will also throw on CI). However, some examples have `process.exit`, if this is hit, the process exits with a successful code and any errors which might have thrown *could* be discarded (depending if the error gets handled first, or the `process.exit`)