### PR TITLE
tx: rename method names (remove EIP word)

### DIFF
--- a/packages/block/examples/4844.ts
+++ b/packages/block/examples/4844.ts
@@ -1,6 +1,6 @@
 import { createBlock } from '@ethereumjs/block'
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
-import { create4844BlobTx } from '@ethereumjs/tx'
+import { createBlob4844Tx } from '@ethereumjs/tx'
 import { createAddressFromPrivateKey } from '@ethereumjs/util'
 import { randomBytes } from 'crypto'
 import { loadKZG } from 'kzg-wasm'
@@ -15,7 +15,7 @@ const main = async () => {
       kzg,
     },
   })
-  const blobTx = create4844BlobTx(
+  const blobTx = createBlob4844Tx(
     { blobsData: ['myFirstBlob'], to: createAddressFromPrivateKey(randomBytes(32)) },
     { common },
   )

--- a/packages/block/src/block/block.ts
+++ b/packages/block/src/block/block.ts
@@ -1,7 +1,7 @@
 import { ConsensusType } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import { Trie } from '@ethereumjs/trie'
-import { BlobEIP4844Transaction, Capability } from '@ethereumjs/tx'
+import { Blob4844Tx, Capability } from '@ethereumjs/tx'
 import {
   BIGINT_0,
   CLRequestType,
@@ -34,11 +34,7 @@ import {
 /* eslint-enable */
 import type { BlockBytes, BlockOptions, ExecutionPayload, JsonBlock } from '../types.js'
 import type { Common } from '@ethereumjs/common'
-import type {
-  FeeMarketEIP1559Transaction,
-  LegacyTransaction,
-  TypedTransaction,
-} from '@ethereumjs/tx'
+import type { FeeMarket1559Tx, LegacyTx, TypedTransaction } from '@ethereumjs/tx'
 import type {
   CLRequest,
   ConsolidationRequest,
@@ -284,12 +280,12 @@ export class Block {
       const errs = tx.getValidationErrors()
       if (this.common.isActivatedEIP(1559)) {
         if (tx.supports(Capability.EIP1559FeeMarket)) {
-          tx = tx as FeeMarketEIP1559Transaction
+          tx = tx as FeeMarket1559Tx
           if (tx.maxFeePerGas < this.header.baseFeePerGas!) {
             errs.push('tx unable to pay base fee (EIP-1559 tx)')
           }
         } else {
-          tx = tx as LegacyTransaction
+          tx = tx as LegacyTx
           if (tx.gasPrice < this.header.baseFeePerGas!) {
             errs.push('tx unable to pay base fee (non EIP-1559 tx)')
           }
@@ -298,7 +294,7 @@ export class Block {
       if (this.common.isActivatedEIP(4844)) {
         const blobGasLimit = this.common.param('maxblobGasPerBlock')
         const blobGasPerBlob = this.common.param('blobGasPerBlob')
-        if (tx instanceof BlobEIP4844Transaction) {
+        if (tx instanceof Blob4844Tx) {
           blobGasUsed += BigInt(tx.numBlobs()) * blobGasPerBlob
           if (blobGasUsed > blobGasLimit) {
             errs.push(
@@ -414,7 +410,7 @@ export class Block {
       let blobGasPrice
 
       for (const tx of this.transactions) {
-        if (tx instanceof BlobEIP4844Transaction) {
+        if (tx instanceof Blob4844Tx) {
           blobGasPrice = blobGasPrice ?? this.header.getBlobGasPrice()
           if (tx.maxFeePerBlobGas < blobGasPrice) {
             throw new Error(

--- a/packages/block/src/helpers.ts
+++ b/packages/block/src/helpers.ts
@@ -1,6 +1,6 @@
 import { RLP } from '@ethereumjs/rlp'
 import { Trie } from '@ethereumjs/trie'
-import { BlobEIP4844Transaction } from '@ethereumjs/tx'
+import { Blob4844Tx } from '@ethereumjs/tx'
 import { BIGINT_0, BIGINT_1, TypeOutput, isHexString, toType } from '@ethereumjs/util'
 
 import type { BlockHeaderBytes, HeaderData } from './types.js'
@@ -96,7 +96,7 @@ export function getDifficulty(headerData: HeaderData): bigint | null {
 export const getNumBlobs = (transactions: TypedTransaction[]) => {
   let numBlobs = 0
   for (const tx of transactions) {
-    if (tx instanceof BlobEIP4844Transaction) {
+    if (tx instanceof Blob4844Tx) {
       numBlobs += tx.blobVersionedHashes.length
     }
   }

--- a/packages/block/test/eip1559block.spec.ts
+++ b/packages/block/test/eip1559block.spec.ts
@@ -1,5 +1,5 @@
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
-import { create1559FeeMarketTx } from '@ethereumjs/tx'
+import { createFeeMarket1559Tx } from '@ethereumjs/tx'
 import { hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
@@ -408,7 +408,7 @@ describe('EIP1559 tests', () => {
   })
 
   it('Header -> validateTransactions() -> tx', async () => {
-    const transaction = create1559FeeMarketTx(
+    const transaction = createFeeMarket1559Tx(
       {
         maxFeePerGas: BigInt(0),
         maxPriorityFeePerGas: BigInt(0),

--- a/packages/block/test/eip4844block.spec.ts
+++ b/packages/block/test/eip4844block.spec.ts
@@ -1,5 +1,5 @@
 import { Common, Hardfork, Mainnet, createCommonFromGethGenesis } from '@ethereumjs/common'
-import { create4844BlobTx } from '@ethereumjs/tx'
+import { createBlob4844Tx } from '@ethereumjs/tx'
 import {
   blobsToCommitments,
   commitmentsToVersionedHashes,
@@ -176,7 +176,7 @@ describe('transaction validation tests', () => {
     const commitments = blobsToCommitments(kzg, blobs)
     const blobVersionedHashes = commitmentsToVersionedHashes(commitments)
 
-    const tx1 = create4844BlobTx(
+    const tx1 = createBlob4844Tx(
       {
         blobVersionedHashes,
         blobs,
@@ -187,7 +187,7 @@ describe('transaction validation tests', () => {
       },
       { common },
     ).sign(randomBytes(32))
-    const tx2 = create4844BlobTx(
+    const tx2 = createBlob4844Tx(
       {
         blobVersionedHashes,
         blobs,

--- a/packages/block/test/from-rpc.spec.ts
+++ b/packages/block/test/from-rpc.spec.ts
@@ -22,7 +22,7 @@ import * as blockDataWithWithdrawals from './testdata/testdata-from-rpc-with-wit
 import * as blockData from './testdata/testdata-from-rpc.json'
 
 import type { JsonRpcBlock } from '../src/index.js'
-import type { LegacyTransaction } from '@ethereumjs/tx'
+import type { LegacyTx } from '@ethereumjs/tx'
 import type { PrefixedHexString } from '@ethereumjs/util'
 
 describe('[fromRPC]: block #2924874', () => {
@@ -69,9 +69,7 @@ describe('[fromRPC]:', () => {
       { common },
     )
     assert.equal(
-      (
-        createBlockFromTransactionGasPriceAsInteger.transactions[0] as LegacyTransaction
-      ).gasPrice.toString(),
+      (createBlockFromTransactionGasPriceAsInteger.transactions[0] as LegacyTx).gasPrice.toString(),
       gasPriceAsIntegerString,
     )
   })

--- a/packages/client/src/miner/pendingBlock.ts
+++ b/packages/client/src/miner/pendingBlock.ts
@@ -1,5 +1,5 @@
 import { Hardfork } from '@ethereumjs/common'
-import { BlobEIP4844Transaction } from '@ethereumjs/tx'
+import { Blob4844Tx } from '@ethereumjs/tx'
 import {
   BIGINT_1,
   BIGINT_2,
@@ -322,7 +322,7 @@ export class PendingBlock {
       switch (addTxResult) {
         case AddTxResult.Success:
           // Push the tx in blobTxs only after successful addTransaction
-          if (tx instanceof BlobEIP4844Transaction) blobTxs.push(tx)
+          if (tx instanceof Blob4844Tx) blobTxs.push(tx)
           break
 
         case AddTxResult.BlockFull:
@@ -382,10 +382,10 @@ export class PendingBlock {
   /**
    * An internal helper for storing the blob bundle associated with each transaction in an EIP4844 world
    * @param payloadId the payload Id of the pending block
-   * @param txs an array of {@BlobEIP4844Transaction } transactions
+   * @param txs an array of {@Blob4844Tx } transactions
    * @param blockHash the blockhash of the pending block (computed from the header data provided)
    */
-  private constructBlobsBundle = (payloadId: string, txs: BlobEIP4844Transaction[]) => {
+  private constructBlobsBundle = (payloadId: string, txs: Blob4844Tx[]) => {
     let blobs: Uint8Array[] = []
     let commitments: Uint8Array[] = []
     let proofs: Uint8Array[] = []
@@ -397,7 +397,7 @@ export class PendingBlock {
     }
 
     for (let tx of txs) {
-      tx = tx as BlobEIP4844Transaction
+      tx = tx as Blob4844Tx
       if (tx.blobs !== undefined && tx.blobs.length > 0) {
         blobs = blobs.concat(tx.blobs)
         commitments = commitments.concat(tx.kzgCommitments!)

--- a/packages/client/src/net/protocol/ethprotocol.ts
+++ b/packages/client/src/net/protocol/ethprotocol.ts
@@ -1,14 +1,14 @@
 import { createBlockFromBytesArray, createBlockHeaderFromBytesArray } from '@ethereumjs/block'
 import { RLP } from '@ethereumjs/rlp'
 import {
-  BlobEIP4844Transaction,
-  create4844BlobTxFromSerializedNetworkWrapper,
+  Blob4844Tx,
+  createBlob4844TxFromSerializedNetworkWrapper,
   createTxFromBlockBodyData,
   createTxFromSerializedData,
-  isAccessListEIP2930Tx,
-  isBlobEIP4844Tx,
-  isEOACodeEIP7702Tx,
-  isFeeMarketEIP1559Tx,
+  isAccessList2930Tx,
+  isBlob4844Tx,
+  isEOACode7702Tx,
+  isFeeMarket1559Tx,
   isLegacyTx,
 } from '@ethereumjs/tx'
 import {
@@ -117,7 +117,7 @@ export class EthProtocol extends Protocol {
         const serializedTxs = []
         for (const tx of txs) {
           // Don't automatically broadcast blob transactions - they should only be announced using NewPooledTransactionHashes
-          if (tx instanceof BlobEIP4844Transaction) continue
+          if (tx instanceof Blob4844Tx) continue
           serializedTxs.push(tx.serialize())
         }
         return serializedTxs
@@ -253,13 +253,9 @@ export class EthProtocol extends Protocol {
         const serializedTxs = []
         for (const tx of txs) {
           // serialize txs as per type
-          if (isBlobEIP4844Tx(tx)) {
+          if (isBlob4844Tx(tx)) {
             serializedTxs.push(tx.serializeNetworkWrapper())
-          } else if (
-            isFeeMarketEIP1559Tx(tx) ||
-            isAccessListEIP2930Tx(tx) ||
-            isEOACodeEIP7702Tx(tx)
-          ) {
+          } else if (isFeeMarket1559Tx(tx) || isAccessList2930Tx(tx) || isEOACode7702Tx(tx)) {
             serializedTxs.push(tx.serialize())
           } else if (isLegacyTx(tx)) {
             serializedTxs.push(tx.raw())
@@ -288,7 +284,7 @@ export class EthProtocol extends Protocol {
           txs.map((txData) => {
             // Blob transactions are deserialized with network wrapper
             if (txData[0] === 3) {
-              return create4844BlobTxFromSerializedNetworkWrapper(txData, { common })
+              return createBlob4844TxFromSerializedNetworkWrapper(txData, { common })
             } else {
               return createTxFromBlockBodyData(txData, { common })
             }

--- a/packages/client/src/rpc/modules/engine/util/newPayload.ts
+++ b/packages/client/src/rpc/modules/engine/util/newPayload.ts
@@ -1,5 +1,5 @@
 import { createBlockFromExecutionPayload } from '@ethereumjs/block'
-import { BlobEIP4844Transaction } from '@ethereumjs/tx'
+import { Blob4844Tx } from '@ethereumjs/tx'
 import { equalsBytes, hexToBytes } from '@ethereumjs/util'
 
 import { short } from '../../../../util/index.js'
@@ -59,7 +59,7 @@ export const validate4844BlobVersionedHashes = (
   // Collect versioned hashes in the flat array `txVersionedHashes` to match with received
   const txVersionedHashes = []
   for (const tx of headBlock.transactions) {
-    if (tx instanceof BlobEIP4844Transaction) {
+    if (tx instanceof Blob4844Tx) {
       for (const vHash of tx.blobVersionedHashes) {
         txVersionedHashes.push(vHash)
       }

--- a/packages/client/src/service/fullethereumservice.ts
+++ b/packages/client/src/service/fullethereumservice.ts
@@ -19,7 +19,7 @@ import { TxPool } from './txpool.js'
 import type { Peer } from '../net/peer/peer.js'
 import type { Protocol } from '../net/protocol/index.js'
 import type { Block } from '@ethereumjs/block'
-import type { BlobEIP4844Transaction } from '@ethereumjs/tx'
+import type { Blob4844Tx } from '@ethereumjs/tx'
 
 interface FullEthereumServiceOptions extends ServiceOptions {
   /** Serve LES requests (default: false) */
@@ -175,7 +175,7 @@ export class FullEthereumService extends Service {
           if (rawTx.type !== TransactionType.BlobEIP4844) {
             txs[1].push(rawTx.serialize().byteLength)
           } else {
-            txs[1].push((rawTx as BlobEIP4844Transaction).serializeNetworkWrapper().byteLength)
+            txs[1].push((rawTx as Blob4844Tx).serializeNetworkWrapper().byteLength)
           }
           txs[2].push(hexToBytes(`0x${tx.hash}`))
         }

--- a/packages/client/src/service/txpool.ts
+++ b/packages/client/src/service/txpool.ts
@@ -1,9 +1,9 @@
 import {
-  BlobEIP4844Transaction,
+  Blob4844Tx,
   Capability,
-  isAccessListEIP2930Tx,
-  isBlobEIP4844Tx,
-  isFeeMarketEIP1559Tx,
+  isAccessList2930Tx,
+  isBlob4844Tx,
+  isFeeMarket1559Tx,
   isLegacyTx,
 } from '@ethereumjs/tx'
 import {
@@ -25,11 +25,7 @@ import type { Peer } from '../net/peer/peer.js'
 import type { PeerPool } from '../net/peerpool.js'
 import type { FullEthereumService } from './fullethereumservice.js'
 import type { Block } from '@ethereumjs/block'
-import type {
-  FeeMarketEIP1559Transaction,
-  LegacyTransaction,
-  TypedTransaction,
-} from '@ethereumjs/tx'
+import type { FeeMarket1559Tx, LegacyTx, TypedTransaction } from '@ethereumjs/tx'
 import type { VM } from '@ethereumjs/vm'
 
 // Configuration constants
@@ -246,7 +242,7 @@ export class TxPool {
       )
     }
 
-    if (addedTx instanceof BlobEIP4844Transaction && existingTx instanceof BlobEIP4844Transaction) {
+    if (addedTx instanceof Blob4844Tx && existingTx instanceof Blob4844Tx) {
       const minblobGasFee =
         existingTx.maxFeePerBlobGas +
         (existingTx.maxFeePerBlobGas * BigInt(MIN_GAS_PRICE_BUMP_PERCENT)) / BigInt(100)
@@ -368,13 +364,13 @@ export class TxPool {
       if (isLegacyTx(tx)) {
         this.config.metrics?.legacyTxGauge?.inc()
       }
-      if (isAccessListEIP2930Tx(tx)) {
+      if (isAccessList2930Tx(tx)) {
         this.config.metrics?.accessListEIP2930TxGauge?.inc()
       }
-      if (isFeeMarketEIP1559Tx(tx)) {
+      if (isFeeMarket1559Tx(tx)) {
         this.config.metrics?.feeMarketEIP1559TxGauge?.inc()
       }
-      if (isBlobEIP4844Tx(tx)) {
+      if (isBlob4844Tx(tx)) {
         this.config.metrics?.blobEIP4844TxGauge?.inc()
       }
     } catch (e) {
@@ -419,13 +415,13 @@ export class TxPool {
     if (isLegacyTx(tx)) {
       this.config.metrics?.legacyTxGauge?.dec()
     }
-    if (isAccessListEIP2930Tx(tx)) {
+    if (isAccessList2930Tx(tx)) {
       this.config.metrics?.accessListEIP2930TxGauge?.dec()
     }
-    if (isFeeMarketEIP1559Tx(tx)) {
+    if (isFeeMarket1559Tx(tx)) {
       this.config.metrics?.feeMarketEIP1559TxGauge?.dec()
     }
-    if (isBlobEIP4844Tx(tx)) {
+    if (isBlob4844Tx(tx)) {
       this.config.metrics?.blobEIP4844TxGauge?.dec()
     }
 
@@ -707,15 +703,15 @@ export class TxPool {
     const supports1559 = tx.supports(Capability.EIP1559FeeMarket)
     if (typeof baseFee === 'bigint' && baseFee !== BIGINT_0) {
       if (supports1559) {
-        return (tx as FeeMarketEIP1559Transaction).maxPriorityFeePerGas
+        return (tx as FeeMarket1559Tx).maxPriorityFeePerGas
       } else {
-        return (tx as LegacyTransaction).gasPrice - baseFee
+        return (tx as LegacyTx).gasPrice - baseFee
       }
     } else {
       if (supports1559) {
-        return (tx as FeeMarketEIP1559Transaction).maxFeePerGas
+        return (tx as FeeMarket1559Tx).maxFeePerGas
       } else {
-        return (tx as LegacyTransaction).gasPrice
+        return (tx as LegacyTx).gasPrice
       }
     }
   }
@@ -732,14 +728,14 @@ export class TxPool {
       }
     }
 
-    if (isAccessListEIP2930Tx(tx)) {
+    if (isAccessList2930Tx(tx)) {
       return {
         maxFee: tx.gasPrice,
         tip: tx.gasPrice,
       }
     }
 
-    if (isFeeMarketEIP1559Tx(tx) || isBlobEIP4844Tx(tx)) {
+    if (isFeeMarket1559Tx(tx) || isBlob4844Tx(tx)) {
       return {
         maxFee: tx.maxFeePerGas,
         tip: tx.maxPriorityFeePerGas,
@@ -825,9 +821,9 @@ export class TxPool {
       //   ii) or there is no blobs limit provided
       //   iii) or blobs are still within limit if this best tx's blobs are included
       if (
-        !(best instanceof BlobEIP4844Transaction) ||
+        !(best instanceof Blob4844Tx) ||
         allowedBlobs === undefined ||
-        ((best as BlobEIP4844Transaction).blobs ?? []).length + blobsCount <= allowedBlobs
+        ((best as Blob4844Tx).blobs ?? []).length + blobsCount <= allowedBlobs
       ) {
         if (accTxs.length > 0) {
           byPrice.insert(accTxs[0])
@@ -835,8 +831,8 @@ export class TxPool {
         }
         // Accumulate the best priced transaction and increment blobs count
         txs.push(best)
-        if (best instanceof BlobEIP4844Transaction) {
-          blobsCount += ((best as BlobEIP4844Transaction).blobs ?? []).length
+        if (best instanceof Blob4844Tx) {
+          blobsCount += ((best as Blob4844Tx).blobs ?? []).length
         }
       } else {
         // Since no more blobs can fit in the block, not only skip inserting in byPrice but also remove all other

--- a/packages/client/test/integration/fullethereumservice.spec.ts
+++ b/packages/client/test/integration/fullethereumservice.spec.ts
@@ -2,7 +2,7 @@ import { createBlock } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
 import { Hardfork } from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
-import { create1559FeeMarketTxFromRLP } from '@ethereumjs/tx'
+import { createFeeMarket1559TxFromRLP } from '@ethereumjs/tx'
 import { Account, bytesToHex, equalsBytes, hexToBytes, toBytes } from '@ethereumjs/util'
 import * as td from 'testdouble'
 import { assert, describe, it } from 'vitest'
@@ -94,7 +94,7 @@ describe(
 
     const txData =
       '0x02f901100180843b9aca00843b9aca008402625a0094cccccccccccccccccccccccccccccccccccccccc830186a0b8441a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f85bf859940000000000000000000000000000000000000101f842a00000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000060a701a0afb6e247b1c490e284053c87ab5f6b59e219d51f743f7a4d83e400782bc7e4b9a0479a268e0e0acd4de3f1e28e4fac2a6b32a4195e8dfa9d19147abe8807aa6f64'
-    const tx = create1559FeeMarketTxFromRLP(toBytes(txData))
+    const tx = createFeeMarket1559TxFromRLP(toBytes(txData))
     await service.execution.vm.stateManager.putAccount(
       tx.getSenderAddress(),
       new Account(BigInt(0), BigInt('40000000000100000')),

--- a/packages/client/test/miner/miner.spec.ts
+++ b/packages/client/test/miner/miner.spec.ts
@@ -7,7 +7,7 @@ import {
   createCustomCommon,
 } from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
-import { create1559FeeMarketTx, createLegacyTx } from '@ethereumjs/tx'
+import { createFeeMarket1559Tx, createLegacyTx } from '@ethereumjs/tx'
 import { Address, equalsBytes, hexToBytes } from '@ethereumjs/util'
 import { AbstractLevel } from 'abstract-level'
 // import { keccak256 } from 'ethereum-cryptography/keccak'
@@ -453,7 +453,7 @@ describe('assembleBlocks() -> should not include tx under the baseFee', async ()
 
   // the default block baseFee will be 7
   // add tx with maxFeePerGas of 6
-  const tx = create1559FeeMarketTx({ to: B.address, maxFeePerGas: 6 }, { common }).sign(
+  const tx = createFeeMarket1559Tx({ to: B.address, maxFeePerGas: 6 }, { common }).sign(
     A.privateKey,
   )
   try {

--- a/packages/client/test/miner/pendingBlock.spec.ts
+++ b/packages/client/test/miner/pendingBlock.spec.ts
@@ -1,7 +1,7 @@
 import { Block, BlockHeader, createBlockHeader } from '@ethereumjs/block'
 import { Common, Goerli, Hardfork, Mainnet, createCommonFromGethGenesis } from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
-import { create1559FeeMarketTx, create4844BlobTx, createLegacyTx } from '@ethereumjs/tx'
+import { createBlob4844Tx, createFeeMarket1559Tx, createLegacyTx } from '@ethereumjs/tx'
 import {
   Account,
   Address,
@@ -369,7 +369,7 @@ describe('[PendingBlock]', async () => {
 
     // Create 3 txs with 2 blobs each so that only 2 of them can be included in a build
     for (let x = 0; x <= 2; x++) {
-      const txA01 = create4844BlobTx(
+      const txA01 = createBlob4844Tx(
         {
           blobVersionedHashes: [
             ...blobVersionedHashes,
@@ -392,7 +392,7 @@ describe('[PendingBlock]', async () => {
     }
 
     // Add one other normal tx for nonce 3 which should also be not included in the build
-    const txNorm = create1559FeeMarketTx(
+    const txNorm = createFeeMarket1559Tx(
       {
         gasLimit: 0xffffffn,
         maxFeePerGas: 1000000000n,
@@ -447,7 +447,7 @@ describe('[PendingBlock]', async () => {
     const proofs = blobsToProofs(kzg, blobs, commitments)
 
     // create a tx with missing blob data which should be excluded from the build
-    const missingBlobTx = create4844BlobTx(
+    const missingBlobTx = createBlob4844Tx(
       {
         blobVersionedHashes,
         kzgCommitments: commitments,

--- a/packages/client/test/net/protocol/ethprotocol.spec.ts
+++ b/packages/client/test/net/protocol/ethprotocol.spec.ts
@@ -1,6 +1,6 @@
 import { createBlock } from '@ethereumjs/block'
 import { Common, Hardfork, Holesky } from '@ethereumjs/common'
-import { TransactionType, create1559FeeMarketTx, createTxFromTxData } from '@ethereumjs/tx'
+import { TransactionType, createFeeMarket1559Tx, createTxFromTxData } from '@ethereumjs/tx'
 import {
   bigIntToBytes,
   bytesToBigInt,
@@ -128,7 +128,7 @@ describe('[EthProtocol]', () => {
     const p = new EthProtocol({ config, chain })
 
     chain.config.chainCommon.setHardfork(Hardfork.London)
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       {
         maxFeePerGas: 10,
         maxPriorityFeePerGas: 8,

--- a/packages/client/test/rpc/debug/getRawBlock.spec.ts
+++ b/packages/client/test/rpc/debug/getRawBlock.spec.ts
@@ -1,6 +1,6 @@
 import { createBlock, createBlockHeader } from '@ethereumjs/block'
 import { Mainnet, createCustomCommon } from '@ethereumjs/common'
-import { create4844BlobTx, createLegacyTx } from '@ethereumjs/tx'
+import { createBlob4844Tx, createLegacyTx } from '@ethereumjs/tx'
 import { bytesToHex, createZeroAddress, hexToBytes } from '@ethereumjs/util'
 import { loadKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
@@ -15,7 +15,7 @@ const common = createCustomCommon({ chainId: 1 }, Mainnet, { customCrypto: { kzg
 common.setHardfork('cancun')
 const mockedTx1 = createLegacyTx({}).sign(dummy.privKey)
 const mockedTx2 = createLegacyTx({ nonce: 1 }).sign(dummy.privKey)
-const mockedBlobTx3 = create4844BlobTx(
+const mockedBlobTx3 = createBlob4844Tx(
   { nonce: 2, blobsData: ['0x1234'], to: createZeroAddress() },
   { common },
 ).sign(dummy.privKey)

--- a/packages/client/test/rpc/debug/getRawHeader.spec.ts
+++ b/packages/client/test/rpc/debug/getRawHeader.spec.ts
@@ -1,6 +1,6 @@
 import { createBlock, createBlockHeader } from '@ethereumjs/block'
 import { Mainnet, createCustomCommon } from '@ethereumjs/common'
-import { create4844BlobTx, createLegacyTx } from '@ethereumjs/tx'
+import { createBlob4844Tx, createLegacyTx } from '@ethereumjs/tx'
 import { bytesToHex, createZeroAddress, hexToBytes } from '@ethereumjs/util'
 import { loadKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
@@ -15,7 +15,7 @@ const common = createCustomCommon({ chainId: 1 }, Mainnet, { customCrypto: { kzg
 common.setHardfork('cancun')
 const mockedTx1 = createLegacyTx({}).sign(dummy.privKey)
 const mockedTx2 = createLegacyTx({ nonce: 1 }).sign(dummy.privKey)
-const mockedBlobTx3 = create4844BlobTx(
+const mockedBlobTx3 = createBlob4844Tx(
   { nonce: 2, blobsData: ['0x1234'], to: createZeroAddress() },
   { common },
 ).sign(dummy.privKey)

--- a/packages/client/test/rpc/debug/getRawReceipts.spec.ts
+++ b/packages/client/test/rpc/debug/getRawReceipts.spec.ts
@@ -1,5 +1,5 @@
 import { Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
-import { create1559FeeMarketTx, create4844BlobTx, createLegacyTx } from '@ethereumjs/tx'
+import { createBlob4844Tx, createFeeMarket1559Tx, createLegacyTx } from '@ethereumjs/tx'
 import {
   bigIntToHex,
   blobsToCommitments,
@@ -60,7 +60,7 @@ describe(method, () => {
     )
     const rpc = getRpcClient(server)
     // construct tx
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       {
         gasLimit: 2000000,
         maxFeePerGas: 975000000,
@@ -121,7 +121,7 @@ describe(method, () => {
       const commitments = blobsToCommitments(kzg, blobs)
       const blobVersionedHashes = commitmentsToVersionedHashes(commitments)
       const proofs = blobs.map((blob, ctx) => kzg.computeBlobKzgProof(blob, commitments[ctx]))
-      const tx = create4844BlobTx(
+      const tx = createBlob4844Tx(
         {
           blobVersionedHashes,
           blobs,

--- a/packages/client/test/rpc/debug/getRawTransaction.spec.ts
+++ b/packages/client/test/rpc/debug/getRawTransaction.spec.ts
@@ -1,4 +1,4 @@
-import { create1559FeeMarketTx, createLegacyTx } from '@ethereumjs/tx'
+import { createFeeMarket1559Tx, createLegacyTx } from '@ethereumjs/tx'
 import { bytesToHex } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
@@ -42,7 +42,7 @@ describe(method, () => {
     )
     const rpc = getRpcClient(server)
     // construct tx
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       {
         gasLimit: 2000000,
         maxFeePerGas: 975000000,

--- a/packages/client/test/rpc/engine/newPayloadV1.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV1.spec.ts
@@ -1,4 +1,4 @@
-import { create1559FeeMarketTx } from '@ethereumjs/tx'
+import { createFeeMarket1559Tx } from '@ethereumjs/tx'
 import {
   bytesToHex,
   createAddressFromPrivateKey,
@@ -137,7 +137,7 @@ describe(method, () => {
     chain.config.logger.silent = true
 
     // Let's mock a non-signed transaction so execution fails
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       {
         gasLimit: 21_000,
         maxFeePerGas: 10,
@@ -177,7 +177,7 @@ describe(method, () => {
 
     const { server, common } = await setupChain(newGenesisJSON, 'post-merge', { engine: true })
     const rpc = getRpcClient(server)
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       {
         maxFeePerGas: '0x7',
         value: 6,
@@ -220,7 +220,7 @@ describe(method, () => {
     })
     const rpc = getRpcClient(server)
     const transactions = Array.from({ length: 101 }, (_v, i) => {
-      const tx = create1559FeeMarketTx(
+      const tx = createFeeMarket1559Tx(
         {
           nonce: i,
           maxFeePerGas: '0x7',

--- a/packages/client/test/rpc/engine/newPayloadV2.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV2.spec.ts
@@ -1,4 +1,4 @@
-import { create1559FeeMarketTx } from '@ethereumjs/tx'
+import { createFeeMarket1559Tx } from '@ethereumjs/tx'
 import {
   bytesToHex,
   createAddressFromPrivateKey,
@@ -135,7 +135,7 @@ describe(`${method}: call with executionPayloadV1`, () => {
     chain.config.logger.silent = true
 
     // Let's mock a non-signed transaction so execution fails
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       {
         gasLimit: 21_000,
         maxFeePerGas: 10,
@@ -174,7 +174,7 @@ describe(`${method}: call with executionPayloadV1`, () => {
 
     const { server, common } = await setupChain(newGenesisJSON, 'post-merge', { engine: true })
     const rpc = getRpcClient(server)
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       {
         maxFeePerGas: '0x7',
         value: 6,

--- a/packages/client/test/rpc/eth/gasPrice.spec.ts
+++ b/packages/client/test/rpc/eth/gasPrice.spec.ts
@@ -1,4 +1,4 @@
-import { create1559FeeMarketTx, createLegacyTx } from '@ethereumjs/tx'
+import { createFeeMarket1559Tx, createLegacyTx } from '@ethereumjs/tx'
 import { bigIntToHex, intToHex } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
@@ -11,7 +11,7 @@ import {
   setupChain,
 } from '../helpers.js'
 
-import type { LegacyTransaction } from '@ethereumjs/tx'
+import type { LegacyTx } from '@ethereumjs/tx'
 
 const method = 'eth_gasPrice'
 
@@ -92,7 +92,7 @@ describe(method, () => {
       'powLondon',
     )
     const rpc = getRpcClient(server)
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       {
         gasLimit: 21000,
         maxPriorityFeePerGas: 10,
@@ -122,7 +122,7 @@ describe(method, () => {
     const rpc = getRpcClient(server)
     const maxPriority1 = 10
     const maxPriority2 = 1231231
-    const tx1 = create1559FeeMarketTx(
+    const tx1 = createFeeMarket1559Tx(
       {
         gasLimit: 21000,
         maxPriorityFeePerGas: maxPriority1,
@@ -131,7 +131,7 @@ describe(method, () => {
       },
       { common },
     ).sign(dummy.privKey)
-    const tx2 = create1559FeeMarketTx(
+    const tx2 = createFeeMarket1559Tx(
       {
         nonce: 1,
         gasLimit: 21000,
@@ -161,7 +161,7 @@ describe(method, () => {
     const iterations = BigInt(21)
     const gasPrice = BigInt(20)
     const firstBlockGasPrice = BigInt(11111111111111)
-    let tx: LegacyTransaction
+    let tx: LegacyTx
     for (let i = 0; i < iterations; i++) {
       if (i === 0) {
         tx = createLegacyTx(

--- a/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
+++ b/packages/client/test/rpc/eth/getBlockByNumber.spec.ts
@@ -1,6 +1,6 @@
 import { createBlock } from '@ethereumjs/block'
 import { Mainnet, createCustomCommon } from '@ethereumjs/common'
-import { create4844BlobTx, createLegacyTx } from '@ethereumjs/tx'
+import { createBlob4844Tx, createLegacyTx } from '@ethereumjs/tx'
 import { createZeroAddress, hexToBytes } from '@ethereumjs/util'
 import { loadKZG } from 'kzg-wasm'
 import { assert, describe, it } from 'vitest'
@@ -15,7 +15,7 @@ const common = createCustomCommon({ chainId: 1 }, Mainnet, { customCrypto: { kzg
 common.setHardfork('cancun')
 const mockedTx1 = createLegacyTx({}).sign(dummy.privKey)
 const mockedTx2 = createLegacyTx({ nonce: 1 }).sign(dummy.privKey)
-const mockedBlobTx3 = create4844BlobTx(
+const mockedBlobTx3 = createBlob4844Tx(
   { nonce: 2, blobsData: ['0x1234'], to: createZeroAddress() },
   { common },
 ).sign(dummy.privKey)

--- a/packages/client/test/rpc/eth/getBlockReceipts.spec.ts
+++ b/packages/client/test/rpc/eth/getBlockReceipts.spec.ts
@@ -1,5 +1,5 @@
 import { Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
-import { create1559FeeMarketTx, create4844BlobTx, createLegacyTx } from '@ethereumjs/tx'
+import { createBlob4844Tx, createFeeMarket1559Tx, createLegacyTx } from '@ethereumjs/tx'
 import {
   bigIntToHex,
   blobsToCommitments,
@@ -59,7 +59,7 @@ describe(method, () => {
     )
     const rpc = getRpcClient(server)
     // construct tx
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       {
         gasLimit: 2000000,
         maxFeePerGas: 975000000,
@@ -68,7 +68,7 @@ describe(method, () => {
       },
       { common },
     ).sign(dummy.privKey)
-    const tx1 = create1559FeeMarketTx(
+    const tx1 = createFeeMarket1559Tx(
       {
         gasLimit: 2000000,
         maxFeePerGas: 975000000,
@@ -124,7 +124,7 @@ describe(method, () => {
       const commitments = blobsToCommitments(kzg, blobs)
       const blobVersionedHashes = commitmentsToVersionedHashes(commitments)
       const proofs = blobs.map((blob, ctx) => kzg.computeBlobKzgProof(blob, commitments[ctx]))
-      const tx = create4844BlobTx(
+      const tx = createBlob4844Tx(
         {
           blobVersionedHashes,
           blobs,

--- a/packages/client/test/rpc/eth/getTransactionByHash.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionByHash.spec.ts
@@ -1,4 +1,4 @@
-import { create1559FeeMarketTx, createLegacyTx } from '@ethereumjs/tx'
+import { createFeeMarket1559Tx, createLegacyTx } from '@ethereumjs/tx'
 import { bytesToHex } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
@@ -43,7 +43,7 @@ describe(method, () => {
     )
     const rpc = getRpcClient(server)
     // construct tx
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       {
         gasLimit: 2000000,
         maxFeePerGas: 975000000,

--- a/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
+++ b/packages/client/test/rpc/eth/getTransactionReceipt.spec.ts
@@ -1,5 +1,5 @@
 import { Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
-import { create1559FeeMarketTx, create4844BlobTx, createLegacyTx } from '@ethereumjs/tx'
+import { createBlob4844Tx, createFeeMarket1559Tx, createLegacyTx } from '@ethereumjs/tx'
 import {
   blobsToCommitments,
   bytesToHex,
@@ -49,7 +49,7 @@ describe(method, () => {
     )
     const rpc = getRpcClient(server)
     // construct tx
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       {
         gasLimit: 2000000,
         maxFeePerGas: 975000000,
@@ -104,7 +104,7 @@ describe(method, () => {
       const commitments = blobsToCommitments(kzg, blobs)
       const blobVersionedHashes = commitmentsToVersionedHashes(commitments)
       const proofs = blobs.map((blob, ctx) => kzg.computeBlobKzgProof(blob, commitments[ctx]))
-      const tx = create4844BlobTx(
+      const tx = createBlob4844Tx(
         {
           blobVersionedHashes,
           blobs,

--- a/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
+++ b/packages/client/test/rpc/eth/sendRawTransaction.spec.ts
@@ -1,7 +1,7 @@
 import { BlockHeader } from '@ethereumjs/block'
 import { Common, Hardfork, Mainnet, createCommonFromGethGenesis } from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
-import { create1559FeeMarketTxFromRLP, create4844BlobTx, createLegacyTx } from '@ethereumjs/tx'
+import { createBlob4844Tx, createFeeMarket1559TxFromRLP, createLegacyTx } from '@ethereumjs/tx'
 import {
   Account,
   blobsToCommitments,
@@ -44,7 +44,7 @@ describe(method, () => {
     // Mainnet EIP-1559 tx
     const txData =
       '0x02f90108018001018402625a0094cccccccccccccccccccccccccccccccccccccccc830186a0b8441a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f85bf859940000000000000000000000000000000000000101f842a00000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000060a701a0afb6e247b1c490e284053c87ab5f6b59e219d51f743f7a4d83e400782bc7e4b9a0479a268e0e0acd4de3f1e28e4fac2a6b32a4195e8dfa9d19147abe8807aa6f64'
-    const transaction = create1559FeeMarketTxFromRLP(hexToBytes(txData))
+    const transaction = createFeeMarket1559TxFromRLP(hexToBytes(txData))
     const address = transaction.getSenderAddress()
     const vm = (client.services.find((s) => s.name === 'eth') as FullEthereumService).execution.vm
     await vm.stateManager.putAccount(address, new Account())
@@ -148,7 +148,7 @@ describe(method, () => {
     const txData =
       '0x02f90108018001018402625a0094cccccccccccccccccccccccccccccccccccccccc830186a0b8441a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f85bf859940000000000000000000000000000000000000101f842a00000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000060a701a0afb6e247b1c490e284053c87ab5f6b59e219d51f743f7a4d83e400782bc7e4b9a0479a268e0e0acd4de3f1e28e4fac2a6b32a4195e8dfa9d19147abe8807aa6f64'
     const common = new Common({ chain: Mainnet, hardfork: Hardfork.London })
-    const tx = create1559FeeMarketTxFromRLP(hexToBytes(txData), {
+    const tx = createFeeMarket1559TxFromRLP(hexToBytes(txData), {
       common,
       freeze: false,
     })
@@ -183,7 +183,7 @@ describe(method, () => {
     // Mainnet EIP-1559 tx
     const txData =
       '0x02f90108018001018402625a0094cccccccccccccccccccccccccccccccccccccccc830186a0b8441a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000f85bf859940000000000000000000000000000000000000101f842a00000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000060a701a0afb6e247b1c490e284053c87ab5f6b59e219d51f743f7a4d83e400782bc7e4b9a0479a268e0e0acd4de3f1e28e4fac2a6b32a4195e8dfa9d19147abe8807aa6f64'
-    const transaction = create1559FeeMarketTxFromRLP(hexToBytes(txData))
+    const transaction = createFeeMarket1559TxFromRLP(hexToBytes(txData))
     const address = transaction.getSenderAddress()
     const vm = (client.services.find((s) => s.name === 'eth') as FullEthereumService).execution.vm
 
@@ -233,7 +233,7 @@ describe(method, () => {
     const blobVersionedHashes = commitmentsToVersionedHashes(commitments)
     const proofs = blobs.map((blob, ctx) => kzg.computeBlobKzgProof(blob, commitments[ctx]))
     const pk = randomBytes(32)
-    const tx = create4844BlobTx(
+    const tx = createBlob4844Tx(
       {
         blobVersionedHashes,
         blobs,
@@ -248,7 +248,7 @@ describe(method, () => {
       { common },
     ).sign(pk)
 
-    const replacementTx = create4844BlobTx(
+    const replacementTx = createBlob4844Tx(
       {
         blobVersionedHashes,
         blobs,

--- a/packages/client/test/rpc/mockBlockchain.ts
+++ b/packages/client/test/rpc/mockBlockchain.ts
@@ -4,7 +4,7 @@ import { equalsBytes, toBytes } from '@ethereumjs/util'
 
 import { dummy } from './helpers.js'
 
-import type { LegacyTransaction } from '@ethereumjs/tx'
+import type { LegacyTx } from '@ethereumjs/tx'
 
 export function mockBlockchain(options: any = {}) {
   const number = options.number ?? '0x444444'
@@ -21,7 +21,7 @@ export function mockBlockchain(options: any = {}) {
     toJSON: () => ({
       ...createBlock({ header: { number } }).toJSON(),
       hash: options.hash ?? blockHash,
-      transactions: transactions.map((t: LegacyTransaction) => t.toJSON()),
+      transactions: transactions.map((t: LegacyTx) => t.toJSON()),
     }),
     transactions,
     uncleHeaders: [],

--- a/packages/client/test/sim/simutils.ts
+++ b/packages/client/test/sim/simutils.ts
@@ -1,6 +1,6 @@
 import { executionPayloadFromBeaconPayload } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
-import { create1559FeeMarketTx, create4844BlobTx } from '@ethereumjs/tx'
+import { createBlob4844Tx, createFeeMarket1559Tx } from '@ethereumjs/tx'
 import {
   BIGINT_1,
   blobsToCommitments,
@@ -279,7 +279,7 @@ export async function runTxHelper(
   const block = await client.request('eth_getBlockByNumber', ['latest', false])
   const baseFeePerGas = BigInt(block.result.baseFeePerGas) * 100n
   const maxPriorityFeePerGas = 100000000n
-  const tx = create1559FeeMarketTx(
+  const tx = createFeeMarket1559Tx(
     {
       data,
       gasLimit: 1000000,
@@ -346,7 +346,7 @@ export const runBlobTx = async (
   txData.gasLimit = BigInt(1000000)
   const nonce = await client.request('eth_getTransactionCount', [sender.toString(), 'latest'], 2.0)
   txData.nonce = BigInt(nonce.result)
-  const blobTx = create4844BlobTx(txData, opts).sign(pkey)
+  const blobTx = createBlob4844Tx(txData, opts).sign(pkey)
 
   const serializedWrapper = blobTx.serializeNetworkWrapper()
 
@@ -407,7 +407,7 @@ export const createBlobTxs = async (
       gas: undefined,
     }
 
-    const blobTx = create4844BlobTx(txData, opts).sign(pkey)
+    const blobTx = createBlob4844Tx(txData, opts).sign(pkey)
 
     const serializedWrapper = blobTx.serializeNetworkWrapper()
     await fs.appendFile('./blobs.txt', bytesToHex(serializedWrapper) + '\n')

--- a/packages/client/test/sim/txGenerator.ts
+++ b/packages/client/test/sim/txGenerator.ts
@@ -1,5 +1,5 @@
 // Adapted from - https://github.com/Inphi/eip4844-interop/blob/master/blob_tx_generator/blob.js
-import { create4844BlobTx } from '@ethereumjs/tx'
+import { createBlob4844Tx } from '@ethereumjs/tx'
 import {
   blobsToCommitments,
   bytesToHex,
@@ -121,7 +121,7 @@ async function run(data: any) {
   txData.gasLimit = BigInt(28000000)
   const nonce = await getNonce(client, sender.toString())
   txData.nonce = BigInt(nonce)
-  const blobTx = create4844BlobTx(txData).sign(pkey)
+  const blobTx = createBlob4844Tx(txData).sign(pkey)
 
   const serializedWrapper = blobTx.serializeNetworkWrapper()
 

--- a/packages/client/test/sync/txpool.spec.ts
+++ b/packages/client/test/sync/txpool.spec.ts
@@ -1,7 +1,7 @@
 import { createBlock } from '@ethereumjs/block'
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { DefaultStateManager } from '@ethereumjs/statemanager'
-import { create1559FeeMarketTx, create2930AccessListTx } from '@ethereumjs/tx'
+import { createAccessList2930Tx, createFeeMarket1559Tx } from '@ethereumjs/tx'
 import {
   Account,
   bytesToHex,
@@ -176,7 +176,7 @@ describe('[TxPool]', async () => {
     }
     txData.maxFeePerGas += (txData.maxFeePerGas * feeBump) / 100
     txData.maxPriorityFeePerGas += (txData.maxPriorityFeePerGas * feeBump) / 100
-    const tx = create1559FeeMarketTx(txData, { common })
+    const tx = createFeeMarket1559Tx(txData, { common })
     const signedTx = tx.sign(from.privateKey)
     return signedTx
   }
@@ -531,7 +531,7 @@ describe('[TxPool]', async () => {
     const txs = []
 
     txs.push(
-      create1559FeeMarketTx({
+      createFeeMarket1559Tx({
         maxFeePerGas: 1000000000,
         maxPriorityFeePerGas: 1000000000,
       }),
@@ -547,7 +547,7 @@ describe('[TxPool]', async () => {
     const txs = []
 
     txs.push(
-      create1559FeeMarketTx({
+      createFeeMarket1559Tx({
         maxFeePerGas: 1000000000,
         maxPriorityFeePerGas: 1000000000,
         nonce: 0,
@@ -567,7 +567,7 @@ describe('[TxPool]', async () => {
 
     const txs = []
     txs.push(
-      create1559FeeMarketTx(
+      createFeeMarket1559Tx(
         {
           maxFeePerGas: 1000000000,
           maxPriorityFeePerGas: 1000000000,
@@ -590,7 +590,7 @@ describe('[TxPool]', async () => {
     const txs = []
 
     txs.push(
-      create1559FeeMarketTx({
+      createFeeMarket1559Tx({
         maxFeePerGas: 1000000000,
         maxPriorityFeePerGas: 1000000000,
         gasLimit: 21000,
@@ -610,7 +610,7 @@ describe('[TxPool]', async () => {
     const txs = []
 
     txs.push(
-      create1559FeeMarketTx({
+      createFeeMarket1559Tx({
         maxFeePerGas: 1000000000,
         maxPriorityFeePerGas: 1000000000,
         nonce: 0,
@@ -633,7 +633,7 @@ describe('[TxPool]', async () => {
     const txs = []
 
     txs.push(
-      create1559FeeMarketTx({
+      createFeeMarket1559Tx({
         maxFeePerGas: 1000000000,
         maxPriorityFeePerGas: 1000000000,
         nonce: 0,
@@ -657,7 +657,7 @@ describe('[TxPool]', async () => {
     const txs = []
 
     txs.push(
-      create1559FeeMarketTx({
+      createFeeMarket1559Tx({
         maxFeePerGas: 1000000000,
         maxPriorityFeePerGas: 1000000000,
       }).sign(A.privateKey),
@@ -677,7 +677,7 @@ describe('[TxPool]', async () => {
     const txs = []
 
     txs.push(
-      create1559FeeMarketTx({
+      createFeeMarket1559Tx({
         maxFeePerGas: 10000000,
         maxPriorityFeePerGas: 10000000,
         nonce: 0,
@@ -694,7 +694,7 @@ describe('[TxPool]', async () => {
     const txs = []
 
     txs.push(
-      create2930AccessListTx({
+      createAccessList2930Tx({
         gasPrice: 10000000,
         nonce: 0,
       }).sign(A.privateKey),
@@ -709,7 +709,7 @@ describe('[TxPool]', async () => {
   it('announcedTxHashes() -> reject txs with too low gas price (invalid tx type)', async () => {
     const txs = []
 
-    const tx = create2930AccessListTx(
+    const tx = createAccessList2930Tx(
       {
         gasPrice: 1000000000 - 1,
         nonce: 0,

--- a/packages/statemanager/test/rpcStateManager.spec.ts
+++ b/packages/statemanager/test/rpcStateManager.spec.ts
@@ -1,7 +1,7 @@
 import { createBlockFromJsonRpcProvider, createBlockFromRPC } from '@ethereumjs/block'
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { type EVMRunCallOpts, createEVM } from '@ethereumjs/evm'
-import { create1559FeeMarketTx, createTxFromRPC } from '@ethereumjs/tx'
+import { createFeeMarket1559Tx, createTxFromRPC } from '@ethereumjs/tx'
 import {
   Address,
   bigIntToBytes,
@@ -237,7 +237,7 @@ describe('runTx custom transaction test', () => {
     const privateKey = hexToBytes(
       '0xe331b6d69882b4cb4ea581d88e0b604039a3de5967688d3dcffdd2270c0fd109',
     )
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       { to: vitalikDotEth, value: '0x100', gasLimit: 500000n, maxFeePerGas: 7 },
       { common },
     ).sign(privateKey)

--- a/packages/tx/examples/EOACodeTx.ts
+++ b/packages/tx/examples/EOACodeTx.ts
@@ -1,12 +1,12 @@
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
-import { create7702EOACodeTx } from '@ethereumjs/tx'
+import { createEOACode7702Tx } from '@ethereumjs/tx'
 
 import type { PrefixedHexString } from '@ethereumjs/util'
 
 const ones32 = `0x${'01'.repeat(32)}` as PrefixedHexString
 
 const common = new Common({ chain: Mainnet, hardfork: Hardfork.Cancun, eips: [7702] })
-const tx = create7702EOACodeTx(
+const tx = createEOACode7702Tx(
   {
     authorizationList: [
       {

--- a/packages/tx/examples/accessListTx.ts
+++ b/packages/tx/examples/accessListTx.ts
@@ -1,5 +1,5 @@
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
-import { create2930AccessListTx } from '@ethereumjs/tx'
+import { createAccessList2930Tx } from '@ethereumjs/tx'
 import { bytesToHex } from '@ethereumjs/util'
 
 const common = new Common({ chain: Mainnet, hardfork: Hardfork.Berlin })
@@ -27,5 +27,5 @@ const txData = {
   type: '0x01',
 }
 
-const tx = create2930AccessListTx(txData, { common })
+const tx = createAccessList2930Tx(txData, { common })
 console.log(bytesToHex(tx.hash())) // 0x9150cdebad74e88b038e6c6b964d99af705f9c0883d7f0bbc0f3e072358f5b1d

--- a/packages/tx/examples/blobTx.ts
+++ b/packages/tx/examples/blobTx.ts
@@ -1,5 +1,5 @@
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
-import { create4844BlobTx } from '@ethereumjs/tx'
+import { createBlob4844Tx } from '@ethereumjs/tx'
 import { bytesToHex } from '@ethereumjs/util'
 import { loadKZG } from 'kzg-wasm'
 
@@ -31,7 +31,7 @@ const main = async () => {
     blobsData: ['abcd'],
   }
 
-  const tx = create4844BlobTx(txData, { common })
+  const tx = createBlob4844Tx(txData, { common })
 
   console.log(bytesToHex(tx.hash())) //0x3c3e7c5e09c250d2200bcc3530f4a9088d7e3fb4ea3f4fccfd09f535a3539e84
 }

--- a/packages/tx/examples/londonTx.ts
+++ b/packages/tx/examples/londonTx.ts
@@ -1,5 +1,5 @@
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
-import { create1559FeeMarketTx } from '@ethereumjs/tx'
+import { createFeeMarket1559Tx } from '@ethereumjs/tx'
 import { bytesToHex } from '@ethereumjs/util'
 
 const common = new Common({ chain: Mainnet, hardfork: Hardfork.London })
@@ -20,5 +20,5 @@ const txData = {
   type: '0x02',
 }
 
-const tx = create1559FeeMarketTx(txData, { common })
+const tx = createFeeMarket1559Tx(txData, { common })
 console.log(bytesToHex(tx.hash())) // 0x6f9ef69ccb1de1aea64e511efd6542541008ced321887937c95b03779358ec8a

--- a/packages/tx/src/1559/constructors.ts
+++ b/packages/tx/src/1559/constructors.ts
@@ -4,7 +4,7 @@ import { bytesToBigInt, bytesToHex, equalsBytes, validateNoLeadingZeroes } from 
 import { TransactionType } from '../types.js'
 import { txTypeBytes, validateNotArray } from '../util.js'
 
-import { FeeMarketEIP1559Transaction } from './tx.js'
+import { FeeMarket1559Tx } from './tx.js'
 
 import type { TxOptions } from '../types.js'
 import type { TxData, TxValuesArray } from './tx.js'
@@ -19,8 +19,8 @@ import type { TxData, TxValuesArray } from './tx.js'
  * - `chainId` will be set automatically if not provided
  * - All parameters are optional and have some basic default values
  */
-export function create1559FeeMarketTx(txData: TxData, opts: TxOptions = {}) {
-  return new FeeMarketEIP1559Transaction(txData, opts)
+export function createFeeMarket1559Tx(txData: TxData, opts: TxOptions = {}) {
+  return new FeeMarket1559Tx(txData, opts)
 }
 
 /**
@@ -29,10 +29,7 @@ export function create1559FeeMarketTx(txData: TxData, opts: TxOptions = {}) {
  * Format: `[chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data,
  * accessList, signatureYParity, signatureR, signatureS]`
  */
-export function createEIP1559FeeMarketTxFromBytesArray(
-  values: TxValuesArray,
-  opts: TxOptions = {},
-) {
+export function create1559FeeMarketTxFromBytesArray(values: TxValuesArray, opts: TxOptions = {}) {
   if (values.length !== 9 && values.length !== 12) {
     throw new Error(
       'Invalid EIP-1559 transaction. Only expecting 9 values (for unsigned tx) or 12 values (for signed tx).',
@@ -57,7 +54,7 @@ export function createEIP1559FeeMarketTxFromBytesArray(
   validateNotArray({ chainId, v })
   validateNoLeadingZeroes({ nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, value, v, r, s })
 
-  return new FeeMarketEIP1559Transaction(
+  return new FeeMarket1559Tx(
     {
       chainId: bytesToBigInt(chainId),
       nonce,
@@ -82,7 +79,7 @@ export function createEIP1559FeeMarketTxFromBytesArray(
  * Format: `0x02 || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data,
  * accessList, signatureYParity, signatureR, signatureS])`
  */
-export function create1559FeeMarketTxFromRLP(serialized: Uint8Array, opts: TxOptions = {}) {
+export function createFeeMarket1559TxFromRLP(serialized: Uint8Array, opts: TxOptions = {}) {
   if (
     equalsBytes(serialized.subarray(0, 1), txTypeBytes(TransactionType.FeeMarketEIP1559)) === false
   ) {
@@ -99,5 +96,5 @@ export function create1559FeeMarketTxFromRLP(serialized: Uint8Array, opts: TxOpt
     throw new Error('Invalid serialized tx input: must be array')
   }
 
-  return createEIP1559FeeMarketTxFromBytesArray(values as TxValuesArray, opts)
+  return create1559FeeMarketTxFromBytesArray(values as TxValuesArray, opts)
 }

--- a/packages/tx/src/1559/index.ts
+++ b/packages/tx/src/1559/index.ts
@@ -1,2 +1,2 @@
 export * from './constructors.js'
-export { FeeMarketEIP1559Transaction } from './tx.js'
+export { FeeMarket1559Tx } from './tx.js'

--- a/packages/tx/src/1559/tx.ts
+++ b/packages/tx/src/1559/tx.ts
@@ -18,7 +18,7 @@ import { paramsTx } from '../params.js'
 import { TransactionType } from '../types.js'
 import { AccessLists, validateNotArray } from '../util.js'
 
-import { create1559FeeMarketTx } from './constructors.js'
+import { createFeeMarket1559Tx } from './constructors.js'
 
 import type {
   AccessList,
@@ -38,7 +38,7 @@ export type TxValuesArray = AllTypesTxValuesArray[TransactionType.FeeMarketEIP15
  * - TransactionType: 2
  * - EIP: [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559)
  */
-export class FeeMarketEIP1559Transaction extends BaseTransaction<TransactionType.FeeMarketEIP1559> {
+export class FeeMarket1559Tx extends BaseTransaction<TransactionType.FeeMarketEIP1559> {
   // implements EIP1559CompatibleTx<TransactionType.FeeMarketEIP1559>
   public readonly chainId: bigint
   public readonly accessList: AccessListBytes
@@ -140,12 +140,12 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<TransactionType
    * Format: `[chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data,
    * accessList, signatureYParity, signatureR, signatureS]`
    *
-   * Use {@link FeeMarketEIP1559Transaction.serialize} to add a transaction to a block
+   * Use {@link FeeMarket1559Tx.serialize} to add a transaction to a block
    * with {@link createBlockFromBytesArray}.
    *
    * For an unsigned tx this method uses the empty Bytes values for the
    * signature parameters `v`, `r` and `s` for encoding. For an EIP-155 compliant
-   * representation for external signing use {@link FeeMarketEIP1559Transaction.getMessageToSign}.
+   * representation for external signing use {@link FeeMarket1559Tx.getMessageToSign}.
    */
   raw(): TxValuesArray {
     return [
@@ -208,7 +208,7 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<TransactionType
    * Computes a sha3-256 hash of the serialized tx.
    *
    * This method can only be used for signed txs (it throws otherwise).
-   * Use {@link FeeMarketEIP1559Transaction.getMessageToSign} to get a tx hash for the purpose of signing.
+   * Use {@link FeeMarket1559Tx.getMessageToSign} to get a tx hash for the purpose of signing.
    */
   public hash(): Uint8Array {
     return Legacy.hash(this)
@@ -233,12 +233,12 @@ export class FeeMarketEIP1559Transaction extends BaseTransaction<TransactionType
     r: Uint8Array | bigint,
     s: Uint8Array | bigint,
     convertV: boolean = false,
-  ): FeeMarketEIP1559Transaction {
+  ): FeeMarket1559Tx {
     r = toBytes(r)
     s = toBytes(s)
     const opts = { ...this.txOptions, common: this.common }
 
-    return create1559FeeMarketTx(
+    return createFeeMarket1559Tx(
       {
         chainId: this.chainId,
         nonce: this.nonce,

--- a/packages/tx/src/2930/constructors.ts
+++ b/packages/tx/src/2930/constructors.ts
@@ -4,7 +4,7 @@ import { bytesToBigInt, bytesToHex, equalsBytes, validateNoLeadingZeroes } from 
 import { TransactionType } from '../types.js'
 import { txTypeBytes, validateNotArray } from '../util.js'
 
-import { AccessListEIP2930Transaction } from './tx.js'
+import { AccessList2930Transaction } from './tx.js'
 
 import type { AccessList, TxOptions } from '../types.js'
 import type { TxData, TxValuesArray } from './tx.js'
@@ -19,8 +19,8 @@ import type { TxData, TxValuesArray } from './tx.js'
  * - `chainId` will be set automatically if not provided
  * - All parameters are optional and have some basic default values
  */
-export function create2930AccessListTx(txData: TxData, opts: TxOptions = {}) {
-  return new AccessListEIP2930Transaction(txData, opts)
+export function createAccessList2930Tx(txData: TxData, opts: TxOptions = {}) {
+  return new AccessList2930Transaction(txData, opts)
 }
 
 /**
@@ -29,7 +29,7 @@ export function create2930AccessListTx(txData: TxData, opts: TxOptions = {}) {
  * Format: `[chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
  * signatureYParity (v), signatureR (r), signatureS (s)]`
  */
-export function create2930AccessListTxFromBytesArray(values: TxValuesArray, opts: TxOptions = {}) {
+export function createAccessList2930TxFromBytesArray(values: TxValuesArray, opts: TxOptions = {}) {
   if (values.length !== 8 && values.length !== 11) {
     throw new Error(
       'Invalid EIP-2930 transaction. Only expecting 8 values (for unsigned tx) or 11 values (for signed tx).',
@@ -43,7 +43,7 @@ export function create2930AccessListTxFromBytesArray(values: TxValuesArray, opts
 
   const emptyAccessList: AccessList = []
 
-  return new AccessListEIP2930Transaction(
+  return new AccessList2930Transaction(
     {
       chainId: bytesToBigInt(chainId),
       nonce,
@@ -67,7 +67,7 @@ export function create2930AccessListTxFromBytesArray(values: TxValuesArray, opts
  * Format: `0x01 || rlp([chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
  * signatureYParity (v), signatureR (r), signatureS (s)])`
  */
-export function create2930AccessListTxFromRLP(serialized: Uint8Array, opts: TxOptions = {}) {
+export function createAccessList2930TxFromRLP(serialized: Uint8Array, opts: TxOptions = {}) {
   if (
     equalsBytes(serialized.subarray(0, 1), txTypeBytes(TransactionType.AccessListEIP2930)) === false
   ) {
@@ -84,5 +84,5 @@ export function create2930AccessListTxFromRLP(serialized: Uint8Array, opts: TxOp
     throw new Error('Invalid serialized tx input: must be array')
   }
 
-  return create2930AccessListTxFromBytesArray(values as TxValuesArray, opts)
+  return createAccessList2930TxFromBytesArray(values as TxValuesArray, opts)
 }

--- a/packages/tx/src/2930/index.ts
+++ b/packages/tx/src/2930/index.ts
@@ -1,2 +1,2 @@
 export * from './constructors.js'
-export { AccessListEIP2930Transaction } from './tx.js'
+export { AccessList2930Transaction } from './tx.js'

--- a/packages/tx/src/2930/tx.ts
+++ b/packages/tx/src/2930/tx.ts
@@ -16,7 +16,7 @@ import { paramsTx } from '../index.js'
 import { TransactionType } from '../types.js'
 import { AccessLists, validateNotArray } from '../util.js'
 
-import { create2930AccessListTx } from './constructors.js'
+import { createAccessList2930Tx } from './constructors.js'
 
 import type {
   AccessList,
@@ -36,7 +36,7 @@ export type TxValuesArray = AllTypesTxValuesArray[TransactionType.AccessListEIP2
  * - TransactionType: 1
  * - EIP: [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930)
  */
-export class AccessListEIP2930Transaction extends BaseTransaction<TransactionType.AccessListEIP2930> {
+export class AccessList2930Transaction extends BaseTransaction<TransactionType.AccessListEIP2930> {
   public readonly chainId: bigint
   public readonly accessList: AccessListBytes
   public readonly AccessListJSON: AccessList
@@ -123,12 +123,12 @@ export class AccessListEIP2930Transaction extends BaseTransaction<TransactionTyp
    * Format: `[chainId, nonce, gasPrice, gasLimit, to, value, data, accessList,
    * signatureYParity (v), signatureR (r), signatureS (s)]`
    *
-   * Use {@link AccessListEIP2930Transaction.serialize} to add a transaction to a block
+   * Use {@link AccessList2930Transaction.serialize} to add a transaction to a block
    * with {@link createBlockFromBytesArray}.
    *
    * For an unsigned tx this method uses the empty Bytes values for the
    * signature parameters `v`, `r` and `s` for encoding. For an EIP-155 compliant
-   * representation for external signing use {@link AccessListEIP2930Transaction.getMessageToSign}.
+   * representation for external signing use {@link AccessList2930Transaction.getMessageToSign}.
    */
   raw(): TxValuesArray {
     return [
@@ -190,7 +190,7 @@ export class AccessListEIP2930Transaction extends BaseTransaction<TransactionTyp
    * Computes a sha3-256 hash of the serialized tx.
    *
    * This method can only be used for signed txs (it throws otherwise).
-   * Use {@link AccessListEIP2930Transaction.getMessageToSign} to get a tx hash for the purpose of signing.
+   * Use {@link AccessList2930Transaction.getMessageToSign} to get a tx hash for the purpose of signing.
    */
   public hash(): Uint8Array {
     return Legacy.hash(this)
@@ -215,12 +215,12 @@ export class AccessListEIP2930Transaction extends BaseTransaction<TransactionTyp
     r: Uint8Array | bigint,
     s: Uint8Array | bigint,
     convertV: boolean = false,
-  ): AccessListEIP2930Transaction {
+  ): AccessList2930Transaction {
     r = toBytes(r)
     s = toBytes(s)
     const opts = { ...this.txOptions, common: this.common }
 
-    return create2930AccessListTx(
+    return createAccessList2930Tx(
       {
         chainId: this.chainId,
         nonce: this.nonce,

--- a/packages/tx/src/4844/constructors.ts
+++ b/packages/tx/src/4844/constructors.ts
@@ -16,7 +16,7 @@ import { paramsTx } from '../params.js'
 import { TransactionType } from '../types.js'
 import { AccessLists, txTypeBytes, validateNotArray } from '../util.js'
 
-import { BlobEIP4844Transaction } from './tx.js'
+import { Blob4844Tx } from './tx.js'
 
 import type {
   BlobEIP4844NetworkValuesArray,
@@ -71,7 +71,7 @@ const validateBlobTransactionNetworkWrapper = (
  * - `blobs` cannot be supplied as well as `kzgCommittments`, `blobVersionedHashes`, `kzgProofs`
  * - If `blobs` is passed in,  `kzgCommittments`, `blobVersionedHashes`, `kzgProofs` will be derived by the constructor
  */
-export function create4844BlobTx(txData: TxData, opts?: TxOptions) {
+export function createBlob4844Tx(txData: TxData, opts?: TxOptions) {
   if (opts?.common?.customCrypto?.kzg === undefined) {
     throw new Error(
       'A common object with customCrypto.kzg initialized required to instantiate a 4844 blob tx',
@@ -101,7 +101,7 @@ export function create4844BlobTx(txData: TxData, opts?: TxOptions) {
     )
   }
 
-  return new BlobEIP4844Transaction(txData, opts)
+  return new Blob4844Tx(txData, opts)
 }
 
 /**
@@ -110,7 +110,7 @@ export function create4844BlobTx(txData: TxData, opts?: TxOptions) {
  * Format: `[chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data,
  * accessList, signatureYParity, signatureR, signatureS]`
  */
-export function create4844BlobTxFromBytesArray(values: TxValuesArray, opts: TxOptions = {}) {
+export function createBlob4844TxFromBytesArray(values: TxValuesArray, opts: TxOptions = {}) {
   if (opts.common?.customCrypto?.kzg === undefined) {
     throw new Error(
       'A common object with customCrypto.kzg initialized required to instantiate a 4844 blob tx',
@@ -153,7 +153,7 @@ export function create4844BlobTxFromBytesArray(values: TxValuesArray, opts: TxOp
     s,
   })
 
-  return new BlobEIP4844Transaction(
+  return new Blob4844Tx(
     {
       chainId: bytesToBigInt(chainId),
       nonce,
@@ -180,7 +180,7 @@ export function create4844BlobTxFromBytesArray(values: TxValuesArray, opts: TxOp
  * Format: `0x03 || rlp([chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value, data,
  * access_list, max_fee_per_data_gas, blob_versioned_hashes, y_parity, r, s])`
  */
-export function create4844BlobTxFromRLP(serialized: Uint8Array, opts: TxOptions = {}) {
+export function createBlob4844TxFromRLP(serialized: Uint8Array, opts: TxOptions = {}) {
   if (opts.common?.customCrypto?.kzg === undefined) {
     throw new Error(
       'A common object with customCrypto.kzg initialized required to instantiate a 4844 blob tx',
@@ -201,19 +201,19 @@ export function create4844BlobTxFromRLP(serialized: Uint8Array, opts: TxOptions 
     throw new Error('Invalid serialized tx input: must be array')
   }
 
-  return create4844BlobTxFromBytesArray(values as TxValuesArray, opts)
+  return createBlob4844TxFromBytesArray(values as TxValuesArray, opts)
 }
 
 /**
  * Creates a transaction from the network encoding of a blob transaction (with blobs/commitments/proof)
  * @param serialized a buffer representing a serialized BlobTransactionNetworkWrapper
  * @param opts any TxOptions defined
- * @returns a BlobEIP4844Transaction
+ * @returns a Blob4844Tx
  */
-export function create4844BlobTxFromSerializedNetworkWrapper(
+export function createBlob4844TxFromSerializedNetworkWrapper(
   serialized: Uint8Array,
   opts?: TxOptions,
-): BlobEIP4844Transaction {
+): Blob4844Tx {
   if (!opts || !opts.common) {
     throw new Error('common instance required to validate versioned hashes')
   }
@@ -241,9 +241,9 @@ export function create4844BlobTxFromSerializedNetworkWrapper(
     networkTxValues as BlobEIP4844NetworkValuesArray
 
   // Construct the tx but don't freeze yet, we will assign blobs etc once validated
-  const decodedTx = create4844BlobTxFromBytesArray(txValues, { ...opts, freeze: false })
+  const decodedTx = createBlob4844TxFromBytesArray(txValues, { ...opts, freeze: false })
   if (decodedTx.to === undefined) {
-    throw Error('BlobEIP4844Transaction can not be send without a valid `to`')
+    throw Error('Blob4844Tx can not be send without a valid `to`')
   }
 
   const commonCopy = opts.common.copy()
@@ -276,21 +276,21 @@ export function create4844BlobTxFromSerializedNetworkWrapper(
 /**
  * Creates the minimal representation of a blob transaction from the network wrapper version.
  * The minimal representation is used when adding transactions to an execution payload/block
- * @param txData a {@link BlobEIP4844Transaction} containing optional blobs/kzg commitments
+ * @param txData a {@link Blob4844Tx} containing optional blobs/kzg commitments
  * @param opts - dictionary of {@link TxOptions}
- * @returns the "minimal" representation of a BlobEIP4844Transaction (i.e. transaction object minus blobs and kzg commitments)
+ * @returns the "minimal" representation of a Blob4844Tx (i.e. transaction object minus blobs and kzg commitments)
  */
 export function createMinimal4844TxFromNetworkWrapper(
-  txData: BlobEIP4844Transaction,
+  txData: Blob4844Tx,
   opts?: TxOptions,
-): BlobEIP4844Transaction {
+): Blob4844Tx {
   if (opts?.common?.customCrypto?.kzg === undefined) {
     throw new Error(
       'A common object with customCrypto.kzg initialized required to instantiate a 4844 blob tx',
     )
   }
 
-  const tx = create4844BlobTx(
+  const tx = createBlob4844Tx(
     {
       ...txData,
       ...{ blobs: undefined, kzgCommitments: undefined, kzgProofs: undefined },
@@ -311,7 +311,7 @@ export function blobTxNetworkWrapperToJSON(
   serialized: Uint8Array,
   opts?: TxOptions,
 ): JsonBlobTxNetworkWrapper {
-  const tx = create4844BlobTxFromSerializedNetworkWrapper(serialized, opts)
+  const tx = createBlob4844TxFromSerializedNetworkWrapper(serialized, opts)
 
   const accessListJSON = AccessLists.getAccessListJSON(tx.accessList)
   const baseJson = tx.toJSON()

--- a/packages/tx/src/4844/index.ts
+++ b/packages/tx/src/4844/index.ts
@@ -1,2 +1,2 @@
 export * from './constructors.js'
-export { BlobEIP4844Transaction } from './tx.js'
+export { Blob4844Tx } from './tx.js'

--- a/packages/tx/src/4844/tx.ts
+++ b/packages/tx/src/4844/tx.ts
@@ -20,7 +20,7 @@ import { paramsTx } from '../index.js'
 import { TransactionType } from '../types.js'
 import { AccessLists, validateNotArray } from '../util.js'
 
-import { create4844BlobTx } from './constructors.js'
+import { createBlob4844Tx } from './constructors.js'
 
 import type {
   AccessList,
@@ -40,7 +40,7 @@ export type TxValuesArray = AllTypesTxValuesArray[TransactionType.BlobEIP4844]
  * - TransactionType: 3
  * - EIP: [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844)
  */
-export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.BlobEIP4844> {
+export class Blob4844Tx extends BaseTransaction<TransactionType.BlobEIP4844> {
   public readonly chainId: bigint
   public readonly accessList: AccessListBytes
   public readonly AccessListJSON: AccessList
@@ -182,12 +182,12 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
    * Format: [chain_id, nonce, max_priority_fee_per_gas, max_fee_per_gas, gas_limit, to, value, data,
    * access_list, max_fee_per_data_gas, blob_versioned_hashes, y_parity, r, s]`.
    *
-   * Use {@link BlobEIP4844Transaction.serialize} to add a transaction to a block
+   * Use {@link Blob4844Tx.serialize} to add a transaction to a block
    * with {@link createBlockFromBytesArray}.
    *
    * For an unsigned tx this method uses the empty Bytes values for the
    * signature parameters `v`, `r` and `s` for encoding. For an EIP-155 compliant
-   * representation for external signing use {@link BlobEIP4844Transaction.getMessageToSign}.
+   * representation for external signing use {@link Blob4844Tx.getMessageToSign}.
    */
   raw(): TxValuesArray {
     return [
@@ -269,7 +269,7 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
    * Computes a sha3-256 hash of the serialized tx.
    *
    * This method can only be used for signed txs (it throws otherwise).
-   * Use {@link BlobEIP4844Transaction.getMessageToSign} to get a tx hash for the purpose of signing.
+   * Use {@link Blob4844Tx.getMessageToSign} to get a tx hash for the purpose of signing.
    */
   public hash(): Uint8Array {
     return Legacy.hash(this)
@@ -306,12 +306,12 @@ export class BlobEIP4844Transaction extends BaseTransaction<TransactionType.Blob
     r: Uint8Array | bigint,
     s: Uint8Array | bigint,
     convertV: boolean = false,
-  ): BlobEIP4844Transaction {
+  ): Blob4844Tx {
     r = toBytes(r)
     s = toBytes(s)
     const opts = { ...this.txOptions, common: this.common }
 
-    return create4844BlobTx(
+    return createBlob4844Tx(
       {
         chainId: this.chainId,
         nonce: this.nonce,

--- a/packages/tx/src/7702/constructors.ts
+++ b/packages/tx/src/7702/constructors.ts
@@ -4,7 +4,7 @@ import { bytesToBigInt, bytesToHex, equalsBytes, validateNoLeadingZeroes } from 
 import { TransactionType } from '../types.js'
 import { txTypeBytes, validateNotArray } from '../util.js'
 
-import { EOACodeEIP7702Transaction } from './tx.js'
+import { EOACode7702Transaction } from './tx.js'
 
 import type { TxOptions } from '../types.js'
 import type { TxData, TxValuesArray } from './tx.js'
@@ -19,8 +19,8 @@ import type { TxData, TxValuesArray } from './tx.js'
  * - `chainId` will be set automatically if not provided
  * - All parameters are optional and have some basic default values
  */
-export function create7702EOACodeTx(txData: TxData, opts: TxOptions = {}) {
-  return new EOACodeEIP7702Transaction(txData, opts)
+export function createEOACode7702Tx(txData: TxData, opts: TxOptions = {}) {
+  return new EOACode7702Transaction(txData, opts)
 }
 
 /**
@@ -29,7 +29,7 @@ export function create7702EOACodeTx(txData: TxData, opts: TxOptions = {}) {
  * Format: `[chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data,
  * accessList, signatureYParity, signatureR, signatureS]`
  */
-export function create7702EOACodeTxFromBytesArray(values: TxValuesArray, opts: TxOptions = {}) {
+export function createEOACode7702TxFromBytesArray(values: TxValuesArray, opts: TxOptions = {}) {
   if (values.length !== 10 && values.length !== 13) {
     throw new Error(
       'Invalid EIP-7702 transaction. Only expecting 10 values (for unsigned tx) or 13 values (for signed tx).',
@@ -55,7 +55,7 @@ export function create7702EOACodeTxFromBytesArray(values: TxValuesArray, opts: T
   validateNotArray({ chainId, v })
   validateNoLeadingZeroes({ nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, value, v, r, s })
 
-  return new EOACodeEIP7702Transaction(
+  return new EOACode7702Transaction(
     {
       chainId: bytesToBigInt(chainId),
       nonce,
@@ -81,7 +81,7 @@ export function create7702EOACodeTxFromBytesArray(values: TxValuesArray, opts: T
  * Format: `0x04 || rlp([chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data,
  * accessList, signatureYParity, signatureR, signatureS])`
  */
-export function create7702EOACodeTxFromRLP(serialized: Uint8Array, opts: TxOptions = {}) {
+export function createEOACode7702TxFromRLP(serialized: Uint8Array, opts: TxOptions = {}) {
   if (
     equalsBytes(serialized.subarray(0, 1), txTypeBytes(TransactionType.EOACodeEIP7702)) === false
   ) {
@@ -98,5 +98,5 @@ export function create7702EOACodeTxFromRLP(serialized: Uint8Array, opts: TxOptio
     throw new Error('Invalid serialized tx input: must be array')
   }
 
-  return create7702EOACodeTxFromBytesArray(values as TxValuesArray, opts)
+  return createEOACode7702TxFromBytesArray(values as TxValuesArray, opts)
 }

--- a/packages/tx/src/7702/index.ts
+++ b/packages/tx/src/7702/index.ts
@@ -1,2 +1,2 @@
 export * from './constructors.js'
-export { EOACodeEIP7702Transaction } from './tx.js'
+export { EOACode7702Transaction } from './tx.js'

--- a/packages/tx/src/7702/tx.ts
+++ b/packages/tx/src/7702/tx.ts
@@ -18,7 +18,7 @@ import { paramsTx } from '../index.js'
 import { TransactionType } from '../types.js'
 import { AccessLists, AuthorizationLists, validateNotArray } from '../util.js'
 
-import { create7702EOACodeTx } from './constructors.js'
+import { createEOACode7702Tx } from './constructors.js'
 
 import type {
   AccessList,
@@ -40,7 +40,7 @@ export type TxValuesArray = AllTypesTxValuesArray[TransactionType.EOACodeEIP7702
  * - TransactionType: 4
  * - EIP: [EIP-7702](https://github.com/ethereum/EIPs/blob/62419ca3f45375db00b04a368ea37c0bfb05386a/EIPS/eip-7702.md)
  */
-export class EOACodeEIP7702Transaction extends BaseTransaction<TransactionType.EOACodeEIP7702> {
+export class EOACode7702Transaction extends BaseTransaction<TransactionType.EOACodeEIP7702> {
   public readonly chainId: bigint
   public readonly accessList: AccessListBytes
   public readonly AccessListJSON: AccessList
@@ -152,12 +152,12 @@ export class EOACodeEIP7702Transaction extends BaseTransaction<TransactionType.E
    * Format: `[chainId, nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, to, value, data,
    * accessList, authorizationList, signatureYParity, signatureR, signatureS]`
    *
-   * Use {@link EOACodeEIP7702Transaction.serialize} to add a transaction to a block
+   * Use {@link EOACode7702Transaction.serialize} to add a transaction to a block
    * with {@link createBlockFromBytesArray}.
    *
    * For an unsigned tx this method uses the empty Bytes values for the
    * signature parameters `v`, `r` and `s` for encoding. For an EIP-155 compliant
-   * representation for external signing use {@link EOACodeEIP7702Transaction.getMessageToSign}.
+   * representation for external signing use {@link EOACode7702Transaction.getMessageToSign}.
    */
   raw(): TxValuesArray {
     return [
@@ -221,7 +221,7 @@ export class EOACodeEIP7702Transaction extends BaseTransaction<TransactionType.E
    * Computes a sha3-256 hash of the serialized tx.
    *
    * This method can only be used for signed txs (it throws otherwise).
-   * Use {@link EOACodeEIP7702Transaction.getMessageToSign} to get a tx hash for the purpose of signing.
+   * Use {@link EOACode7702Transaction.getMessageToSign} to get a tx hash for the purpose of signing.
    */
   public hash(): Uint8Array {
     return Legacy.hash(this)
@@ -246,12 +246,12 @@ export class EOACodeEIP7702Transaction extends BaseTransaction<TransactionType.E
     r: Uint8Array | bigint,
     s: Uint8Array | bigint,
     convertV: boolean = false,
-  ): EOACodeEIP7702Transaction {
+  ): EOACode7702Transaction {
     r = toBytes(r)
     s = toBytes(s)
     const opts = { ...this.txOptions, common: this.common }
 
-    return create7702EOACodeTx(
+    return createEOACode7702Tx(
       {
         chainId: this.chainId,
         nonce: this.nonce,

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -62,7 +62,7 @@ export abstract class BaseTransaction<T extends TransactionType>
   /**
    * List of tx type defining EIPs,
    * e.g. 1559 (fee market) and 2930 (access lists)
-   * for FeeMarketEIP1559Transaction objects
+   * for FeeMarket1559Tx objects
    */
   protected activeCapabilities: number[] = []
 

--- a/packages/tx/src/legacy/constructors.ts
+++ b/packages/tx/src/legacy/constructors.ts
@@ -1,7 +1,7 @@
 import { RLP } from '@ethereumjs/rlp'
 import { validateNoLeadingZeroes } from '@ethereumjs/util'
 
-import { LegacyTransaction } from './tx.js'
+import { LegacyTx } from './tx.js'
 
 import type { TxOptions } from '../types.js'
 import type { TxData, TxValuesArray } from './tx.js'
@@ -15,7 +15,7 @@ import type { TxData, TxValuesArray } from './tx.js'
  * - All parameters are optional and have some basic default values
  */
 export function createLegacyTx(txData: TxData, opts: TxOptions = {}) {
-  return new LegacyTransaction(txData, opts)
+  return new LegacyTx(txData, opts)
 }
 
 /**
@@ -36,7 +36,7 @@ export function createLegacyTxFromBytesArray(values: TxValuesArray, opts: TxOpti
 
   validateNoLeadingZeroes({ nonce, gasPrice, gasLimit, value, v, r, s })
 
-  return new LegacyTransaction(
+  return new LegacyTx(
     {
       nonce,
       gasPrice,

--- a/packages/tx/src/legacy/index.ts
+++ b/packages/tx/src/legacy/index.ts
@@ -1,2 +1,2 @@
 export * from './constructors.js'
-export { LegacyTransaction } from './tx.js'
+export { LegacyTx } from './tx.js'

--- a/packages/tx/src/legacy/tx.ts
+++ b/packages/tx/src/legacy/tx.ts
@@ -39,7 +39,7 @@ function meetsEIP155(_v: bigint, chainId: bigint) {
 /**
  * An Ethereum non-typed (legacy) transaction
  */
-export class LegacyTransaction extends BaseTransaction<TransactionType.Legacy> {
+export class LegacyTx extends BaseTransaction<TransactionType.Legacy> {
   public readonly gasPrice: bigint
 
   public readonly common: Common
@@ -229,7 +229,7 @@ export class LegacyTransaction extends BaseTransaction<TransactionType.Legacy> {
     r: Uint8Array | bigint,
     s: Uint8Array | bigint,
     convertV: boolean = false,
-  ): LegacyTransaction {
+  ): LegacyTx {
     r = toBytes(r)
     s = toBytes(s)
     if (convertV && this.supports(Capability.EIP155ReplayProtection)) {

--- a/packages/tx/src/transactionFactory.ts
+++ b/packages/tx/src/transactionFactory.ts
@@ -1,9 +1,9 @@
 import { fetchFromProvider, getProvider } from '@ethereumjs/util'
 
-import { create1559FeeMarketTx, create1559FeeMarketTxFromRLP } from './1559/constructors.js'
-import { create2930AccessListTx, create2930AccessListTxFromRLP } from './2930/constructors.js'
-import { create4844BlobTx, create4844BlobTxFromRLP } from './4844/constructors.js'
-import { create7702EOACodeTx, create7702EOACodeTxFromRLP } from './7702/constructors.js'
+import { createFeeMarket1559Tx, createFeeMarket1559TxFromRLP } from './1559/constructors.js'
+import { createAccessList2930Tx, createAccessList2930TxFromRLP } from './2930/constructors.js'
+import { createBlob4844Tx, createBlob4844TxFromRLP } from './4844/constructors.js'
+import { createEOACode7702Tx, createEOACode7702TxFromRLP } from './7702/constructors.js'
 import {
   createLegacyTx,
   createLegacyTxFromBytesArray,
@@ -11,10 +11,10 @@ import {
 } from './legacy/constructors.js'
 import {
   TransactionType,
-  isAccessListEIP2930TxData,
-  isBlobEIP4844TxData,
-  isEOACodeEIP7702TxData,
-  isFeeMarketEIP1559TxData,
+  isAccessList2930TxData,
+  isBlob4844TxData,
+  isEOACode7702TxData,
+  isFeeMarket1559TxData,
   isLegacyTxData,
 } from './types.js'
 import { normalizeTxParams } from './util.js'
@@ -37,14 +37,14 @@ export function createTxFromTxData<T extends TransactionType>(
   } else {
     if (isLegacyTxData(txData)) {
       return createLegacyTx(txData, txOptions) as Transaction[T]
-    } else if (isAccessListEIP2930TxData(txData)) {
-      return create2930AccessListTx(txData, txOptions) as Transaction[T]
-    } else if (isFeeMarketEIP1559TxData(txData)) {
-      return create1559FeeMarketTx(txData, txOptions) as Transaction[T]
-    } else if (isBlobEIP4844TxData(txData)) {
-      return create4844BlobTx(txData, txOptions) as Transaction[T]
-    } else if (isEOACodeEIP7702TxData(txData)) {
-      return create7702EOACodeTx(txData, txOptions) as Transaction[T]
+    } else if (isAccessList2930TxData(txData)) {
+      return createAccessList2930Tx(txData, txOptions) as Transaction[T]
+    } else if (isFeeMarket1559TxData(txData)) {
+      return createFeeMarket1559Tx(txData, txOptions) as Transaction[T]
+    } else if (isBlob4844TxData(txData)) {
+      return createBlob4844Tx(txData, txOptions) as Transaction[T]
+    } else if (isEOACode7702TxData(txData)) {
+      return createEOACode7702Tx(txData, txOptions) as Transaction[T]
     } else {
       throw new Error(`Tx instantiation with type ${(txData as TypedTxData)?.type} not supported`)
     }
@@ -65,13 +65,13 @@ export function createTxFromSerializedData<T extends TransactionType>(
     // Determine the type.
     switch (data[0]) {
       case TransactionType.AccessListEIP2930:
-        return create2930AccessListTxFromRLP(data, txOptions) as Transaction[T]
+        return createAccessList2930TxFromRLP(data, txOptions) as Transaction[T]
       case TransactionType.FeeMarketEIP1559:
-        return create1559FeeMarketTxFromRLP(data, txOptions) as Transaction[T]
+        return createFeeMarket1559TxFromRLP(data, txOptions) as Transaction[T]
       case TransactionType.BlobEIP4844:
-        return create4844BlobTxFromRLP(data, txOptions) as Transaction[T]
+        return createBlob4844TxFromRLP(data, txOptions) as Transaction[T]
       case TransactionType.EOACodeEIP7702:
-        return create7702EOACodeTxFromRLP(data, txOptions) as Transaction[T]
+        return createEOACode7702TxFromRLP(data, txOptions) as Transaction[T]
       default:
         throw new Error(`TypedTransaction with ID ${data[0]} unknown`)
     }

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -1,10 +1,10 @@
 import { bytesToBigInt, toBytes } from '@ethereumjs/util'
 
-import type { FeeMarketEIP1559Transaction } from './1559/tx.js'
-import type { AccessListEIP2930Transaction } from './2930/tx.js'
-import type { BlobEIP4844Transaction } from './4844/tx.js'
-import type { EOACodeEIP7702Transaction } from './7702/tx.js'
-import type { LegacyTransaction } from './legacy/tx.js'
+import type { FeeMarket1559Tx } from './1559/tx.js'
+import type { AccessList2930Transaction } from './2930/tx.js'
+import type { Blob4844Tx } from './4844/tx.js'
+import type { EOACode7702Transaction } from './7702/tx.js'
+import type { LegacyTx } from './legacy/tx.js'
 import type { Common, Hardfork, ParamsDict } from '@ethereumjs/common'
 import type {
   Address,
@@ -156,32 +156,32 @@ export enum TransactionType {
 }
 
 export interface Transaction {
-  [TransactionType.Legacy]: LegacyTransaction
-  [TransactionType.FeeMarketEIP1559]: FeeMarketEIP1559Transaction
-  [TransactionType.AccessListEIP2930]: AccessListEIP2930Transaction
-  [TransactionType.BlobEIP4844]: BlobEIP4844Transaction
-  [TransactionType.EOACodeEIP7702]: EOACodeEIP7702Transaction
+  [TransactionType.Legacy]: LegacyTx
+  [TransactionType.FeeMarketEIP1559]: FeeMarket1559Tx
+  [TransactionType.AccessListEIP2930]: AccessList2930Transaction
+  [TransactionType.BlobEIP4844]: Blob4844Tx
+  [TransactionType.EOACodeEIP7702]: EOACode7702Transaction
 }
 
 export type TypedTransaction = Transaction[TransactionType]
 
-export function isLegacyTx(tx: TypedTransaction): tx is LegacyTransaction {
+export function isLegacyTx(tx: TypedTransaction): tx is LegacyTx {
   return tx.type === TransactionType.Legacy
 }
 
-export function isAccessListEIP2930Tx(tx: TypedTransaction): tx is AccessListEIP2930Transaction {
+export function isAccessList2930Tx(tx: TypedTransaction): tx is AccessList2930Transaction {
   return tx.type === TransactionType.AccessListEIP2930
 }
 
-export function isFeeMarketEIP1559Tx(tx: TypedTransaction): tx is FeeMarketEIP1559Transaction {
+export function isFeeMarket1559Tx(tx: TypedTransaction): tx is FeeMarket1559Tx {
   return tx.type === TransactionType.FeeMarketEIP1559
 }
 
-export function isBlobEIP4844Tx(tx: TypedTransaction): tx is BlobEIP4844Transaction {
+export function isBlob4844Tx(tx: TypedTransaction): tx is Blob4844Tx {
   return tx.type === TransactionType.BlobEIP4844
 }
 
-export function isEOACodeEIP7702Tx(tx: TypedTransaction): tx is EOACodeEIP7702Transaction {
+export function isEOACode7702Tx(tx: TypedTransaction): tx is EOACode7702Transaction {
   return tx.type === TransactionType.EOACodeEIP7702
 }
 
@@ -259,10 +259,10 @@ export interface EIP7702CompatibleTx<T extends TransactionType = TransactionType
 
 export interface TxData {
   [TransactionType.Legacy]: LegacyTxData
-  [TransactionType.AccessListEIP2930]: AccessListEIP2930TxData
+  [TransactionType.AccessListEIP2930]: AccessList2930TxData
   [TransactionType.FeeMarketEIP1559]: FeeMarketEIP1559TxData
   [TransactionType.BlobEIP4844]: BlobEIP4844TxData
-  [TransactionType.EOACodeEIP7702]: EOACodeEIP7702TxData
+  [TransactionType.EOACodeEIP7702]: EOACode7702TxData
 }
 
 export type TypedTxData = TxData[TransactionType]
@@ -272,22 +272,22 @@ export function isLegacyTxData(txData: TypedTxData): txData is LegacyTxData {
   return txType === TransactionType.Legacy
 }
 
-export function isAccessListEIP2930TxData(txData: TypedTxData): txData is AccessListEIP2930TxData {
+export function isAccessList2930TxData(txData: TypedTxData): txData is AccessList2930TxData {
   const txType = Number(bytesToBigInt(toBytes(txData.type)))
   return txType === TransactionType.AccessListEIP2930
 }
 
-export function isFeeMarketEIP1559TxData(txData: TypedTxData): txData is FeeMarketEIP1559TxData {
+export function isFeeMarket1559TxData(txData: TypedTxData): txData is FeeMarketEIP1559TxData {
   const txType = Number(bytesToBigInt(toBytes(txData.type)))
   return txType === TransactionType.FeeMarketEIP1559
 }
 
-export function isBlobEIP4844TxData(txData: TypedTxData): txData is BlobEIP4844TxData {
+export function isBlob4844TxData(txData: TypedTxData): txData is BlobEIP4844TxData {
   const txType = Number(bytesToBigInt(toBytes(txData.type)))
   return txType === TransactionType.BlobEIP4844
 }
 
-export function isEOACodeEIP7702TxData(txData: TypedTxData): txData is EOACodeEIP7702TxData {
+export function isEOACode7702TxData(txData: TypedTxData): txData is EOACode7702TxData {
   const txType = Number(bytesToBigInt(toBytes(txData.type)))
   return txType === TransactionType.EOACodeEIP7702
 }
@@ -349,9 +349,9 @@ export type LegacyTxData = {
 }
 
 /**
- * {@link AccessListEIP2930Transaction} data.
+ * {@link AccessList2930Transaction} data.
  */
-export interface AccessListEIP2930TxData extends LegacyTxData {
+export interface AccessList2930TxData extends LegacyTxData {
   /**
    * The transaction's chain ID
    */
@@ -364,9 +364,9 @@ export interface AccessListEIP2930TxData extends LegacyTxData {
 }
 
 /**
- * {@link FeeMarketEIP1559Transaction} data.
+ * {@link FeeMarket1559Tx} data.
  */
-export interface FeeMarketEIP1559TxData extends AccessListEIP2930TxData {
+export interface FeeMarketEIP1559TxData extends AccessList2930TxData {
   /**
    * The transaction's gas price, inherited from {@link Transaction}.  This property is not used for EIP1559
    * transactions and should always be undefined for this specific transaction type.
@@ -383,7 +383,7 @@ export interface FeeMarketEIP1559TxData extends AccessListEIP2930TxData {
 }
 
 /**
- * {@link BlobEIP4844Transaction} data.
+ * {@link Blob4844Tx} data.
  */
 export interface BlobEIP4844TxData extends FeeMarketEIP1559TxData {
   /**
@@ -413,18 +413,18 @@ export interface BlobEIP4844TxData extends FeeMarketEIP1559TxData {
 }
 
 /**
- * {@link EOACodeEIP7702Tx} data.
+ * {@link EOACode7702Tx} data.
  */
-export interface EOACodeEIP7702TxData extends FeeMarketEIP1559TxData {
+export interface EOACode7702TxData extends FeeMarketEIP1559TxData {
   authorizationList?: AuthorizationListBytes | AuthorizationList | never
 }
 
 export interface TxValuesArray {
   [TransactionType.Legacy]: LegacyTxValuesArray
-  [TransactionType.AccessListEIP2930]: AccessListEIP2930TxValuesArray
+  [TransactionType.AccessListEIP2930]: AccessList2930TxValuesArray
   [TransactionType.FeeMarketEIP1559]: FeeMarketEIP1559TxValuesArray
   [TransactionType.BlobEIP4844]: BlobEIP4844TxValuesArray
-  [TransactionType.EOACodeEIP7702]: EOACodeEIP7702TxValuesArray
+  [TransactionType.EOACodeEIP7702]: EOACode7702TxValuesArray
 }
 
 /**
@@ -433,9 +433,9 @@ export interface TxValuesArray {
 type LegacyTxValuesArray = Uint8Array[]
 
 /**
- * Bytes values array for an {@link AccessListEIP2930Transaction}
+ * Bytes values array for an {@link AccessList2930Transaction}
  */
-type AccessListEIP2930TxValuesArray = [
+type AccessList2930TxValuesArray = [
   Uint8Array,
   Uint8Array,
   Uint8Array,
@@ -450,7 +450,7 @@ type AccessListEIP2930TxValuesArray = [
 ]
 
 /**
- * Bytes values array for a {@link FeeMarketEIP1559Transaction}
+ * Bytes values array for a {@link FeeMarket1559Tx}
  */
 type FeeMarketEIP1559TxValuesArray = [
   Uint8Array,
@@ -468,9 +468,9 @@ type FeeMarketEIP1559TxValuesArray = [
 ]
 
 /**
- * Bytes values array for a {@link EOACodeEIP7702Transaction}
+ * Bytes values array for a {@link EOACode7702Transaction}
  */
-type EOACodeEIP7702TxValuesArray = [
+type EOACode7702TxValuesArray = [
   Uint8Array,
   Uint8Array,
   Uint8Array,
@@ -487,7 +487,7 @@ type EOACodeEIP7702TxValuesArray = [
 ]
 
 /**
- * Bytes values array for a {@link BlobEIP4844Transaction}
+ * Bytes values array for a {@link Blob4844Tx}
  */
 type BlobEIP4844TxValuesArray = [
   Uint8Array,

--- a/packages/tx/test/base.spec.ts
+++ b/packages/tx/test/base.spec.ts
@@ -13,17 +13,17 @@ import {
 import { assert, describe, it } from 'vitest'
 
 import {
-  AccessListEIP2930Transaction,
+  AccessList2930Transaction,
   Capability,
-  FeeMarketEIP1559Transaction,
-  LegacyTransaction,
+  FeeMarket1559Tx,
+  LegacyTx,
   TransactionType,
-  create1559FeeMarketTx,
-  create1559FeeMarketTxFromRLP,
-  create2930AccessListTx,
-  create2930AccessListTxFromBytesArray,
-  create2930AccessListTxFromRLP,
-  createEIP1559FeeMarketTxFromBytesArray,
+  create1559FeeMarketTxFromBytesArray,
+  createAccessList2930Tx,
+  createAccessList2930TxFromBytesArray,
+  createAccessList2930TxFromRLP,
+  createFeeMarket1559Tx,
+  createFeeMarket1559TxFromRLP,
   createLegacyTx,
   createLegacyTxFromBytesArray,
   createLegacyTxFromRLP,
@@ -35,7 +35,7 @@ import eip2930Fixtures from './json/eip2930txs.json'
 import legacyFixtures from './json/txs.json'
 
 import type { BaseTransaction } from '../src/baseTransaction.js'
-import type { AccessListEIP2930TxData, FeeMarketEIP1559TxData, LegacyTxData } from '../src/index.js'
+import type { AccessList2930TxData, FeeMarketEIP1559TxData, LegacyTxData } from '../src/index.js'
 
 describe('[BaseTransaction]', () => {
   // EIP-2930 is not enabled in Common by default (2021-03-06)
@@ -48,19 +48,19 @@ describe('[BaseTransaction]', () => {
 
   const eip2930Txs: BaseTransaction<TransactionType.AccessListEIP2930>[] = []
   for (const tx of eip2930Fixtures) {
-    eip2930Txs.push(create2930AccessListTx(tx.data as AccessListEIP2930TxData, { common }))
+    eip2930Txs.push(createAccessList2930Tx(tx.data as AccessList2930TxData, { common }))
   }
 
   const eip1559Txs: BaseTransaction<TransactionType.FeeMarketEIP1559>[] = []
   for (const tx of eip1559Fixtures) {
-    eip1559Txs.push(create1559FeeMarketTx(tx.data as FeeMarketEIP1559TxData, { common }))
+    eip1559Txs.push(createFeeMarket1559Tx(tx.data as FeeMarketEIP1559TxData, { common }))
   }
 
   const zero = new Uint8Array(0)
   const txTypes = [
     {
-      class: LegacyTransaction,
-      name: 'LegacyTransaction',
+      class: LegacyTx,
+      name: 'LegacyTx',
       type: TransactionType.Legacy,
       values: Array(6).fill(zero),
       txs: legacyTxs,
@@ -79,23 +79,23 @@ describe('[BaseTransaction]', () => {
       ],
     },
     {
-      class: AccessListEIP2930Transaction,
-      name: 'AccessListEIP2930Transaction',
+      class: AccessList2930Transaction,
+      name: 'AccessList2930Transaction',
       type: TransactionType.AccessListEIP2930,
       values: [new Uint8Array([1])].concat(Array(7).fill(zero)),
       txs: eip2930Txs,
       fixtures: eip2930Fixtures,
       activeCapabilities: [Capability.EIP2718TypedTransaction, Capability.EIP2930AccessLists],
       create: {
-        txData: create2930AccessListTx,
-        rlp: create2930AccessListTxFromRLP,
-        bytesArray: create2930AccessListTxFromBytesArray,
+        txData: createAccessList2930Tx,
+        rlp: createAccessList2930TxFromRLP,
+        bytesArray: createAccessList2930TxFromBytesArray,
       },
       notActiveCapabilities: [Capability.EIP1559FeeMarket, 9999],
     },
     {
-      class: FeeMarketEIP1559Transaction,
-      name: 'FeeMarketEIP1559Transaction',
+      class: FeeMarket1559Tx,
+      name: 'FeeMarket1559Tx',
       type: TransactionType.FeeMarketEIP1559,
       values: [new Uint8Array([1])].concat(Array(8).fill(zero)),
       txs: eip1559Txs,
@@ -106,9 +106,9 @@ describe('[BaseTransaction]', () => {
         Capability.EIP2930AccessLists,
       ],
       create: {
-        txData: create1559FeeMarketTx,
-        rlp: create1559FeeMarketTxFromRLP,
-        bytesArray: createEIP1559FeeMarketTxFromBytesArray,
+        txData: createFeeMarket1559Tx,
+        rlp: createFeeMarket1559TxFromRLP,
+        bytesArray: create1559FeeMarketTxFromBytesArray,
       },
       notActiveCapabilities: [9999],
     },
@@ -210,7 +210,7 @@ describe('[BaseTransaction]', () => {
     rlpData = eip2930Txs[0].raw()
     rlpData[3] = toBytes('0x0')
     try {
-      create2930AccessListTxFromBytesArray(rlpData)
+      createAccessList2930TxFromBytesArray(rlpData)
       assert.fail('should have thrown when gasLimit has leading zeroes')
     } catch (err: any) {
       assert.ok(
@@ -221,7 +221,7 @@ describe('[BaseTransaction]', () => {
     rlpData = eip1559Txs[0].raw()
     rlpData[2] = toBytes('0x0')
     try {
-      createEIP1559FeeMarketTxFromBytesArray(rlpData)
+      create1559FeeMarketTxFromBytesArray(rlpData)
       assert.fail('should have thrown when maxPriorityFeePerGas has leading zeroes')
     } catch (err: any) {
       assert.ok(
@@ -435,7 +435,7 @@ describe('[BaseTransaction]', () => {
   })
 
   it('_validateCannotExceedMaxInteger()', () => {
-    const tx = create1559FeeMarketTx(eip1559Txs[0])
+    const tx = createFeeMarket1559Tx(eip1559Txs[0])
     try {
       ;(tx as any)._validateCannotExceedMaxInteger({ a: MAX_INTEGER }, 256, true)
     } catch (err: any) {

--- a/packages/tx/test/eip1559.spec.ts
+++ b/packages/tx/test/eip1559.spec.ts
@@ -3,7 +3,7 @@ import { RLP } from '@ethereumjs/rlp'
 import { TWO_POW256, ecsign, equalsBytes, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { create1559FeeMarketTx } from '../src/index.js'
+import { createFeeMarket1559Tx } from '../src/index.js'
 
 import testdata from './json/eip1559.json' // Source: Besu
 
@@ -17,7 +17,7 @@ const validAddress = hexToBytes(`0x${'01'.repeat(20)}`)
 const validSlot = hexToBytes(`0x${'01'.repeat(32)}`)
 const chainId = BigInt(4)
 
-describe('[FeeMarketEIP1559Transaction]', () => {
+describe('[FeeMarket1559Tx]', () => {
   it(`cannot input decimal or negative values`, () => {
     const values = [
       'maxFeePerGas',
@@ -60,7 +60,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
         ) {
           txData[value] = testCase
           assert.throws(() => {
-            create1559FeeMarketTx(txData)
+            createFeeMarket1559Tx(txData)
           })
         }
       }
@@ -68,7 +68,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
   })
 
   it('getUpfrontCost()', () => {
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       {
         maxFeePerGas: 10,
         maxPriorityFeePerGas: 8,
@@ -89,7 +89,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
   })
 
   it('getEffectivePriorityFee()', () => {
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       {
         maxFeePerGas: 10,
         maxPriorityFeePerGas: 8,
@@ -109,7 +109,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
     for (let index = 0; index < testdata.length; index++) {
       const data = testdata[index]
       const pkey = hexToBytes(data.privateKey as PrefixedHexString)
-      const txn = create1559FeeMarketTx(data as FeeMarketEIP1559TxData, { common })
+      const txn = createFeeMarket1559Tx(data as FeeMarketEIP1559TxData, { common })
       const signed = txn.sign(pkey)
       const rlpSerialized = RLP.encode(Uint8Array.from(signed.serialize()))
       assert.ok(
@@ -121,7 +121,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
 
   it('addSignature() -> correctly adds correct signature values', () => {
     const privKey = hexToBytes(testdata[0].privateKey as PrefixedHexString)
-    const tx = create1559FeeMarketTx({})
+    const tx = createFeeMarket1559Tx({})
     const signedTx = tx.sign(privKey)
     const addSignatureTx = tx.addSignature(signedTx.v!, signedTx.r!, signedTx.s!)
 
@@ -130,7 +130,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
 
   it('addSignature() -> correctly converts raw ecrecover values', () => {
     const privKey = hexToBytes(testdata[0].privateKey as PrefixedHexString)
-    const tx = create1559FeeMarketTx({})
+    const tx = createFeeMarket1559Tx({})
 
     const msgHash = tx.getHashedMessageToSign()
     const { v, r, s } = ecsign(msgHash, privKey)
@@ -143,7 +143,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
 
   it('addSignature() -> throws when adding the wrong v value', () => {
     const privKey = hexToBytes(testdata[0].privateKey as PrefixedHexString)
-    const tx = create1559FeeMarketTx({})
+    const tx = createFeeMarket1559Tx({})
 
     const msgHash = tx.getHashedMessageToSign()
     const { v, r, s } = ecsign(msgHash, privKey)
@@ -157,7 +157,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
   it('hash()', () => {
     const data = testdata[0]
     const pkey = hexToBytes(data.privateKey as PrefixedHexString)
-    let txn = create1559FeeMarketTx(data as FeeMarketEIP1559TxData, { common })
+    let txn = createFeeMarket1559Tx(data as FeeMarketEIP1559TxData, { common })
     let signed = txn.sign(pkey)
     const expectedHash = hexToBytes(
       '0x2e564c87eb4b40e7f469b2eec5aa5d18b0b46a24e8bf0919439cfb0e8fcae446',
@@ -166,7 +166,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
       equalsBytes(signed.hash(), expectedHash),
       'Should provide the correct hash when frozen',
     )
-    txn = create1559FeeMarketTx(data as FeeMarketEIP1559TxData, {
+    txn = createFeeMarket1559Tx(data as FeeMarketEIP1559TxData, {
       common,
       freeze: false,
     })
@@ -180,7 +180,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
   it('freeze property propagates from unsigned tx to signed tx', () => {
     const data = testdata[0]
     const pkey = hexToBytes(data.privateKey as PrefixedHexString)
-    const txn = create1559FeeMarketTx(data as FeeMarketEIP1559TxData, {
+    const txn = createFeeMarket1559Tx(data as FeeMarketEIP1559TxData, {
       common,
       freeze: false,
     })
@@ -192,7 +192,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
   it('common propagates from the common of tx, not the common in TxOptions', () => {
     const data = testdata[0]
     const pkey = hexToBytes(data.privateKey as PrefixedHexString)
-    const txn = create1559FeeMarketTx(data as FeeMarketEIP1559TxData, {
+    const txn = createFeeMarket1559Tx(data as FeeMarketEIP1559TxData, {
       common,
       freeze: false,
     })
@@ -214,7 +214,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
   })
 
   it('unsigned tx -> getMessageToSign()/getHashedMessageToSign()', () => {
-    const unsignedTx = create1559FeeMarketTx(
+    const unsignedTx = createFeeMarket1559Tx(
       {
         data: hexToBytes('0x010200'),
         to: validAddress,
@@ -241,7 +241,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
   it('toJSON()', () => {
     const data = testdata[0]
     const pkey = hexToBytes(data.privateKey as PrefixedHexString)
-    const txn = create1559FeeMarketTx(data as FeeMarketEIP1559TxData, { common })
+    const txn = createFeeMarket1559Tx(data as FeeMarketEIP1559TxData, { common })
     const signed = txn.sign(pkey)
 
     const json = signed.toJSON()
@@ -266,7 +266,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
 
   it('Fee validation', () => {
     assert.doesNotThrow(() => {
-      create1559FeeMarketTx(
+      createFeeMarket1559Tx(
         {
           maxFeePerGas: TWO_POW256 - BigInt(1),
           maxPriorityFeePerGas: 100,
@@ -278,7 +278,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
     }, 'fee can be 2^256 - 1')
     assert.throws(
       () => {
-        create1559FeeMarketTx(
+        createFeeMarket1559Tx(
           {
             maxFeePerGas: TWO_POW256 - BigInt(1),
             maxPriorityFeePerGas: 100,
@@ -294,7 +294,7 @@ describe('[FeeMarketEIP1559Transaction]', () => {
     )
     assert.throws(
       () => {
-        create1559FeeMarketTx(
+        createFeeMarket1559Tx(
           {
             maxFeePerGas: 1,
             maxPriorityFeePerGas: 2,

--- a/packages/tx/test/eip7702.spec.ts
+++ b/packages/tx/test/eip7702.spec.ts
@@ -2,7 +2,7 @@ import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { createAddressFromPrivateKey, createZeroAddress, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { create7702EOACodeTx } from '../src/index.js'
+import { createEOACode7702Tx } from '../src/index.js'
 
 import type { TxData } from '../src/7702/tx.js'
 import type { AuthorizationListItem } from '../src/index.js'
@@ -35,9 +35,9 @@ function getTxData(override: Partial<AuthorizationListItem> = {}): TxData {
   }
 }
 
-describe('[EOACodeEIP7702Transaction]', () => {
+describe('[EOACode7702Transaction]', () => {
   it('sign()', () => {
-    const txn = create7702EOACodeTx(
+    const txn = createEOACode7702Tx(
       {
         value: 1,
         maxFeePerGas: 1,
@@ -83,12 +83,12 @@ describe('[EOACodeEIP7702Transaction]', () => {
       const txData = getTxData(test[0])
       const testName = test[1]
       assert.throws(() => {
-        create7702EOACodeTx(txData, { common }), testName
+        createEOACode7702Tx(txData, { common }), testName
       })
     }
 
     assert.doesNotThrow(() => {
-      create7702EOACodeTx(getTxData(), { common })
+      createEOACode7702Tx(getTxData(), { common })
     })
   })
 })

--- a/packages/tx/test/inputValue.spec.ts
+++ b/packages/tx/test/inputValue.spec.ts
@@ -4,8 +4,8 @@ import { assert, describe, it } from 'vitest'
 
 import {
   TransactionType,
-  create2930AccessListTxFromBytesArray,
-  createEIP1559FeeMarketTxFromBytesArray,
+  create1559FeeMarketTxFromBytesArray,
+  createAccessList2930TxFromBytesArray,
   createLegacyTx,
   createLegacyTxFromBytesArray,
   createTxFromTxData,
@@ -167,14 +167,14 @@ describe('[Invalid Array Input values]', () => {
               break
             case TransactionType.AccessListEIP2930:
               assert.throws(() =>
-                create2930AccessListTxFromBytesArray(
+                createAccessList2930TxFromBytesArray(
                   rawValues as TxValuesArray[TransactionType.AccessListEIP2930],
                 ),
               )
               break
             case TransactionType.FeeMarketEIP1559:
               assert.throws(() =>
-                createEIP1559FeeMarketTxFromBytesArray(
+                create1559FeeMarketTxFromBytesArray(
                   rawValues as TxValuesArray[TransactionType.FeeMarketEIP1559],
                 ),
               )
@@ -242,14 +242,14 @@ describe('[Invalid Access Lists]', () => {
           switch (txType) {
             case TransactionType.AccessListEIP2930:
               assert.throws(() =>
-                create2930AccessListTxFromBytesArray(
+                createAccessList2930TxFromBytesArray(
                   rawValues as TxValuesArray[TransactionType.AccessListEIP2930],
                 ),
               )
               break
             case TransactionType.FeeMarketEIP1559:
               assert.throws(() =>
-                createEIP1559FeeMarketTxFromBytesArray(
+                create1559FeeMarketTxFromBytesArray(
                   rawValues as TxValuesArray[TransactionType.FeeMarketEIP1559],
                 ),
               )

--- a/packages/tx/test/legacy.spec.ts
+++ b/packages/tx/test/legacy.spec.ts
@@ -356,7 +356,7 @@ describe('[Transaction]', () => {
 
     // Note that Vitalik's example has a very similar value denoted "signing data".
     // It's not the output of `serialize()`, but the pre-image of the hash returned by `tx.hash(false)`.
-    // We don't have a getter for such a value in LegacyTransaction.
+    // We don't have a getter for such a value in LegacyTx.
     assert.equal(
       bytesToHex(pt.serialize()),
       '0xec098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a764000080808080',

--- a/packages/tx/test/transactionFactory.spec.ts
+++ b/packages/tx/test/transactionFactory.spec.ts
@@ -3,12 +3,12 @@ import { hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
 import {
-  AccessListEIP2930Transaction,
-  FeeMarketEIP1559Transaction,
-  LegacyTransaction,
+  AccessList2930Transaction,
+  FeeMarket1559Tx,
+  LegacyTx,
   TransactionType,
-  create1559FeeMarketTx,
-  create2930AccessListTx,
+  createAccessList2930Tx,
+  createFeeMarket1559Tx,
   createLegacyTx,
   createTxFromBlockBodyData,
   createTxFromSerializedData,
@@ -25,31 +25,31 @@ const pKey = hexToBytes('0x46464646464646464646464646464646464646464646464646464
 const unsignedLegacyTx = createLegacyTx({})
 const signedLegacyTx = unsignedLegacyTx.sign(pKey)
 
-const unsignedEIP2930Tx = create2930AccessListTx({ chainId: BigInt(1) }, { common })
+const unsignedEIP2930Tx = createAccessList2930Tx({ chainId: BigInt(1) }, { common })
 const signedEIP2930Tx = unsignedEIP2930Tx.sign(pKey)
-const unsignedEIP1559Tx = create1559FeeMarketTx({ chainId: BigInt(1) }, { common })
+const unsignedEIP1559Tx = createFeeMarket1559Tx({ chainId: BigInt(1) }, { common })
 const signedEIP1559Tx = unsignedEIP1559Tx.sign(pKey)
 
 const txTypes = [
   {
-    class: LegacyTransaction,
-    name: 'LegacyTransaction',
+    class: LegacyTx,
+    name: 'LegacyTx',
     unsigned: unsignedLegacyTx,
     signed: signedLegacyTx,
     eip2718: false,
     type: TransactionType.Legacy,
   },
   {
-    class: AccessListEIP2930Transaction,
-    name: 'AccessListEIP2930Transaction',
+    class: AccessList2930Transaction,
+    name: 'AccessList2930Transaction',
     unsigned: unsignedEIP2930Tx,
     signed: signedEIP2930Tx,
     eip2718: true,
     type: TransactionType.AccessListEIP2930,
   },
   {
-    class: FeeMarketEIP1559Transaction,
-    name: 'FeeMarketEIP1559Transaction',
+    class: FeeMarket1559Tx,
+    name: 'FeeMarket1559Tx',
     unsigned: unsignedEIP1559Tx,
     signed: signedEIP1559Tx,
     eip2718: true,

--- a/packages/tx/test/typedTxsAndEIP2930.spec.ts
+++ b/packages/tx/test/typedTxsAndEIP2930.spec.ts
@@ -15,14 +15,14 @@ import {
 import { assert, describe, it } from 'vitest'
 
 import {
-  AccessListEIP2930Transaction,
-  FeeMarketEIP1559Transaction,
+  AccessList2930Transaction,
+  FeeMarket1559Tx,
   TransactionType,
-  create1559FeeMarketTx,
-  create1559FeeMarketTxFromRLP,
-  create2930AccessListTx,
-  create2930AccessListTxFromBytesArray,
-  create2930AccessListTxFromRLP,
+  createAccessList2930Tx,
+  createAccessList2930TxFromBytesArray,
+  createAccessList2930TxFromRLP,
+  createFeeMarket1559Tx,
+  createFeeMarket1559TxFromRLP,
   paramsTx,
 } from '../src/index.js'
 
@@ -39,21 +39,21 @@ const common = new Common({
 
 const txTypes = [
   {
-    class: AccessListEIP2930Transaction,
-    name: 'AccessListEIP2930Transaction',
+    class: AccessList2930Transaction,
+    name: 'AccessList2930Transaction',
     type: TransactionType.AccessListEIP2930,
     create: {
-      txData: create2930AccessListTx,
-      rlp: create2930AccessListTxFromRLP,
+      txData: createAccessList2930Tx,
+      rlp: createAccessList2930TxFromRLP,
     },
   },
   {
-    class: FeeMarketEIP1559Transaction,
-    name: 'FeeMarketEIP1559Transaction',
+    class: FeeMarket1559Tx,
+    name: 'FeeMarket1559Tx',
     type: TransactionType.FeeMarketEIP1559,
     create: {
-      txData: create1559FeeMarketTx,
-      rlp: create1559FeeMarketTxFromRLP,
+      txData: createFeeMarket1559Tx,
+      rlp: createFeeMarket1559TxFromRLP,
     },
   },
 ]
@@ -62,7 +62,7 @@ const validAddress = hexToBytes(`0x${'01'.repeat(20)}`)
 const validSlot = hexToBytes(`0x${'01'.repeat(32)}`)
 const chainId = 1
 
-describe('[AccessListEIP2930Transaction / FeeMarketEIP1559Transaction] -> EIP-2930 Compatibility', () => {
+describe('[AccessList2930Transaction / FeeMarket1559Tx] -> EIP-2930 Compatibility', () => {
   it('Initialization / Getter -> fromTxData()', () => {
     for (const txType of txTypes) {
       let tx = txType.create.txData({}, { common })
@@ -151,7 +151,7 @@ describe('[AccessListEIP2930Transaction / FeeMarketEIP1559Transaction] -> EIP-29
         ) {
           txData[value] = testCase
           assert.throws(() => {
-            create2930AccessListTx(txData)
+            createAccessList2930Tx(txData)
           })
         }
       }
@@ -377,7 +377,7 @@ describe('[AccessListEIP2930Transaction / FeeMarketEIP1559Transaction] -> EIP-29
 
   it('addSignature() -> correctly adds correct signature values', () => {
     const privateKey = pKey
-    const tx = create2930AccessListTx({})
+    const tx = createAccessList2930Tx({})
     const signedTx = tx.sign(privateKey)
     const addSignatureTx = tx.addSignature(signedTx.v!, signedTx.r!, signedTx.s!)
 
@@ -386,7 +386,7 @@ describe('[AccessListEIP2930Transaction / FeeMarketEIP1559Transaction] -> EIP-29
 
   it('addSignature() -> correctly converts raw ecrecover values', () => {
     const privKey = pKey
-    const tx = create2930AccessListTx({})
+    const tx = createAccessList2930Tx({})
 
     const msgHash = tx.getHashedMessageToSign()
     const { v, r, s } = ecsign(msgHash, privKey)
@@ -399,7 +399,7 @@ describe('[AccessListEIP2930Transaction / FeeMarketEIP1559Transaction] -> EIP-29
 
   it('addSignature() -> throws when adding the wrong v value', () => {
     const privKey = pKey
-    const tx = create2930AccessListTx({})
+    const tx = createAccessList2930Tx({})
 
     const msgHash = tx.getHashedMessageToSign()
     const { v, r, s } = ecsign(msgHash, privKey)
@@ -426,11 +426,11 @@ describe('[AccessListEIP2930Transaction / FeeMarketEIP1559Transaction] -> EIP-29
   })
 })
 
-describe('[AccessListEIP2930Transaction] -> Class Specific Tests', () => {
+describe('[AccessList2930Transaction] -> Class Specific Tests', () => {
   it(`Initialization`, () => {
-    const tx = create2930AccessListTx({}, { common })
+    const tx = createAccessList2930Tx({}, { common })
     assert.ok(
-      create2930AccessListTx(tx, { common }),
+      createAccessList2930Tx(tx, { common }),
       'should initialize correctly from its own data',
     )
 
@@ -438,7 +438,7 @@ describe('[AccessListEIP2930Transaction] -> Class Specific Tests', () => {
     const validSlot = hexToBytes(`0x${'01'.repeat(32)}`)
     const chainId = BigInt(1)
     try {
-      create2930AccessListTx(
+      createAccessList2930Tx(
         {
           data: hexToBytes('0x010200'),
           to: validAddress,
@@ -463,7 +463,7 @@ describe('[AccessListEIP2930Transaction] -> Class Specific Tests', () => {
       const address = new Uint8Array(0)
       const storageKeys = [new Uint8Array(0), new Uint8Array(0)]
       const aclBytes: AccessListBytesItem = [address, storageKeys]
-      create2930AccessListTxFromBytesArray(
+      createAccessList2930TxFromBytesArray(
         [bytes, bytes, bytes, bytes, bytes, bytes, bytes, [aclBytes], bytes],
         {},
       )
@@ -474,7 +474,7 @@ describe('[AccessListEIP2930Transaction] -> Class Specific Tests', () => {
   )
 
   it(`should return right upfront cost`, () => {
-    let tx = create2930AccessListTx(
+    let tx = createAccessList2930Tx(
       {
         data: hexToBytes('0x010200'),
         to: validAddress,
@@ -504,7 +504,7 @@ describe('[AccessListEIP2930Transaction] -> Class Specific Tests', () => {
     )
 
     // In this Tx, `to` is `undefined`, so we should charge homestead creation gas.
-    tx = create2930AccessListTx(
+    tx = createAccessList2930Tx(
       {
         data: hexToBytes('0x010200'),
         accessList: [[validAddress, [validSlot]]],
@@ -526,7 +526,7 @@ describe('[AccessListEIP2930Transaction] -> Class Specific Tests', () => {
     )
 
     // Explicitly check that even if we have duplicates in our list, we still charge for those
-    tx = create2930AccessListTx(
+    tx = createAccessList2930Tx(
       {
         to: validAddress,
         accessList: [
@@ -545,7 +545,7 @@ describe('[AccessListEIP2930Transaction] -> Class Specific Tests', () => {
   })
 
   it('getEffectivePriorityFee() -> should return correct values', () => {
-    const tx = create2930AccessListTx({
+    const tx = createAccessList2930Tx({
       gasPrice: BigInt(100),
     })
 
@@ -556,7 +556,7 @@ describe('[AccessListEIP2930Transaction] -> Class Specific Tests', () => {
   })
 
   it('getUpfrontCost() -> should return upfront cost', () => {
-    const tx = create2930AccessListTx(
+    const tx = createAccessList2930Tx(
       {
         gasPrice: 1000,
         gasLimit: 10000000,
@@ -568,7 +568,7 @@ describe('[AccessListEIP2930Transaction] -> Class Specific Tests', () => {
   })
 
   it('unsigned tx -> getHashedMessageToSign()/getMessageToSign()', () => {
-    const unsignedTx = create2930AccessListTx(
+    const unsignedTx = createAccessList2930Tx(
       {
         data: hexToBytes('0x010200'),
         to: validAddress,
@@ -637,7 +637,7 @@ describe('[AccessListEIP2930Transaction] -> Class Specific Tests', () => {
       hexToBytes('0x0be950468ba1c25a5cb50e9f6d8aa13c8cd21f24ba909402775b262ac76d374d'),
     )
 
-    const unsignedTx = create2930AccessListTx(txData, { common: usedCommon })
+    const unsignedTx = createAccessList2930Tx(txData, { common: usedCommon })
 
     const serializedMessageRaw = unsignedTx.serialize()
 
@@ -679,14 +679,14 @@ describe('[AccessListEIP2930Transaction] -> Class Specific Tests', () => {
   })
 
   it('freeze property propagates from unsigned tx to signed tx', () => {
-    const tx = create2930AccessListTx({}, { freeze: false })
+    const tx = createAccessList2930Tx({}, { freeze: false })
     assert.notOk(Object.isFrozen(tx), 'tx object is not frozen')
     const signedTxn = tx.sign(pKey)
     assert.notOk(Object.isFrozen(signedTxn), 'tx object is not frozen')
   })
 
   it('common propagates from the common of tx, not the common in TxOptions', () => {
-    const txn = create2930AccessListTx({}, { common, freeze: false })
+    const txn = createAccessList2930Tx({}, { common, freeze: false })
     const newCommon = new Common({ chain: Mainnet, hardfork: Hardfork.Paris })
     assert.notDeepEqual(newCommon, common, 'new common is different than original common')
     Object.defineProperty(txn, 'common', {

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -8,7 +8,7 @@ import {
 import { ConsensusType, Hardfork } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import { Trie } from '@ethereumjs/trie'
-import { BlobEIP4844Transaction, createMinimal4844TxFromNetworkWrapper } from '@ethereumjs/tx'
+import { Blob4844Tx, createMinimal4844TxFromNetworkWrapper } from '@ethereumjs/tx'
 import {
   Address,
   BIGINT_0,
@@ -233,11 +233,11 @@ export class BlockBuilder {
       throw new Error('tx has a higher gas limit than the remaining gas in the block')
     }
     let blobGasUsed = undefined
-    if (tx instanceof BlobEIP4844Transaction) {
+    if (tx instanceof Blob4844Tx) {
       if (this.blockOpts.common?.isActivatedEIP(4844) === false) {
         throw Error('eip4844 not activated yet for adding a blob transaction')
       }
-      const blobTx = tx as BlobEIP4844Transaction
+      const blobTx = tx as Blob4844Tx
 
       // Guard against the case if a tx came into the pool without blobs i.e. network wrapper payload
       if (blobTx.blobs === undefined) {
@@ -263,8 +263,8 @@ export class BlockBuilder {
     const result = await runTx(this.vm, { tx, block, skipHardForkValidation })
 
     // If tx is a blob transaction, remove blobs/kzg commitments before adding to block per EIP-4844
-    if (tx instanceof BlobEIP4844Transaction) {
-      const txData = tx as BlobEIP4844Transaction
+    if (tx instanceof Blob4844Tx) {
+      const txData = tx as Blob4844Tx
       this.blobGasUsed += BigInt(txData.blobVersionedHashes.length) * blobGasPerBlob
       tx = createMinimal4844TxFromNetworkWrapper(txData, {
         common: this.blockOpts.common,

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -2,7 +2,7 @@ import { cliqueSigner, createBlock } from '@ethereumjs/block'
 import { ConsensusType, Hardfork } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import { StatelessVerkleStateManager } from '@ethereumjs/statemanager'
-import { BlobEIP4844Transaction, Capability, isBlobEIP4844Tx } from '@ethereumjs/tx'
+import { Blob4844Tx, Capability, isBlob4844Tx } from '@ethereumjs/tx'
 import {
   Account,
   Address,
@@ -41,11 +41,11 @@ import type { Common } from '@ethereumjs/common'
 import type { EVM } from '@ethereumjs/evm'
 import type {
   AccessList,
-  AccessListEIP2930Transaction,
+  AccessList2930Transaction,
   AccessListItem,
   EIP7702CompatibleTx,
-  FeeMarketEIP1559Transaction,
-  LegacyTransaction,
+  FeeMarket1559Tx,
+  LegacyTx,
   TypedTransaction,
 } from '@ethereumjs/tx'
 
@@ -142,7 +142,7 @@ export async function runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
       throw new Error(msg)
     }
 
-    const castedTx = <AccessListEIP2930Transaction>opts.tx
+    const castedTx = <AccessList2930Transaction>opts.tx
 
     for (const accessListItem of castedTx.AccessListJSON) {
       vm.evm.journal.addAlwaysWarmAddress(accessListItem.address, true)
@@ -324,10 +324,10 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     // EIP-1559 spec:
     // The signer must be able to afford the transaction
     // `assert balance >= gas_limit * max_fee_per_gas`
-    maxCost += tx.gasLimit * (tx as FeeMarketEIP1559Transaction).maxFeePerGas
+    maxCost += tx.gasLimit * (tx as FeeMarket1559Tx).maxFeePerGas
   }
 
-  if (tx instanceof BlobEIP4844Transaction) {
+  if (tx instanceof Blob4844Tx) {
     if (!vm.common.isActivatedEIP(4844)) {
       const msg = _errorMsg('blob transactions are only valid with EIP4844 active', vm, block, tx)
       throw new Error(msg)
@@ -335,7 +335,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     // EIP-4844 spec
     // the signer must be able to afford the transaction
     // assert signer(tx).balance >= tx.message.gas * tx.message.max_fee_per_gas + get_total_data_gas(tx) * tx.message.max_fee_per_data_gas
-    const castTx = tx as BlobEIP4844Transaction
+    const castTx = tx as Blob4844Tx
     totalblobGas = vm.common.param('blobGasPerBlob') * BigInt(castTx.numBlobs())
     maxCost += totalblobGas * castTx.maxFeePerBlobGas
 
@@ -400,17 +400,17 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     gasPrice = inclusionFeePerGas + baseFee
   } else {
     // Have to cast as legacy tx since EIP1559 tx does not have gas price
-    gasPrice = (<LegacyTransaction>tx).gasPrice
+    gasPrice = (<LegacyTx>tx).gasPrice
     if (vm.common.isActivatedEIP(1559)) {
       const baseFee = block.header.baseFeePerGas!
-      inclusionFeePerGas = (<LegacyTransaction>tx).gasPrice - baseFee
+      inclusionFeePerGas = (<LegacyTx>tx).gasPrice - baseFee
     }
   }
 
   // EIP-4844 tx
   let blobVersionedHashes
-  if (tx instanceof BlobEIP4844Transaction) {
-    blobVersionedHashes = (tx as BlobEIP4844Transaction).blobVersionedHashes
+  if (tx instanceof Blob4844Tx) {
+    blobVersionedHashes = (tx as Blob4844Tx).blobVersionedHashes
   }
 
   // Update from account's balance
@@ -549,7 +549,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   }
 
   // Add blob gas used to result
-  if (isBlobEIP4844Tx(tx)) {
+  if (isBlob4844Tx(tx)) {
     results.blobGasUsed = totalblobGas
   }
 
@@ -812,7 +812,7 @@ export async function generateTxReceipt(
     }
   } else {
     // Typed EIP-2718 Transaction
-    if (isBlobEIP4844Tx(tx)) {
+    if (isBlob4844Tx(tx)) {
       receipt = {
         blobGasUsed,
         blobGasPrice,

--- a/packages/vm/test/api/EIPs/eip-1559-FeeMarket.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-1559-FeeMarket.spec.ts
@@ -1,10 +1,6 @@
 import { createBlock } from '@ethereumjs/block'
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
-import {
-  AccessListEIP2930Transaction,
-  FeeMarketEIP1559Transaction,
-  LegacyTransaction,
-} from '@ethereumjs/tx'
+import { AccessList2930Transaction, FeeMarket1559Tx, LegacyTx } from '@ethereumjs/tx'
 import {
   Account,
   Address,
@@ -71,7 +67,7 @@ function makeBlock(baseFee: bigint, transaction: TypedTransaction, txType: Trans
 
 describe('EIP1559 tests', () => {
   it('test EIP1559 with all transaction types', async () => {
-    const tx = new FeeMarketEIP1559Transaction(
+    const tx = new FeeMarket1559Tx(
       {
         maxFeePerGas: GWEI * BigInt(5),
         maxPriorityFeePerGas: GWEI * BigInt(2),
@@ -111,7 +107,7 @@ describe('EIP1559 tests', () => {
     assert.equal(account!.balance, expectedAccountBalance, 'account balance correct')
     assert.equal(results.amountSpent, expectedCost, 'reported cost correct')
 
-    const tx2 = new AccessListEIP2930Transaction(
+    const tx2 = new AccessList2930Transaction(
       {
         gasLimit: 21000,
         gasPrice: GWEI * BigInt(5),
@@ -139,7 +135,7 @@ describe('EIP1559 tests', () => {
     assert.equal(account!.balance, expectedAccountBalance, 'account balance correct')
     assert.equal(results2.amountSpent, expectedCost, 'reported cost correct')
 
-    const tx3 = new LegacyTransaction(
+    const tx3 = new LegacyTx(
       {
         gasLimit: 21000,
         gasPrice: GWEI * BigInt(5),
@@ -170,7 +166,7 @@ describe('EIP1559 tests', () => {
 
   it('gasPrice uses the effective gas price', async () => {
     const contractAddress = new Address(hexToBytes(`0x${'20'.repeat(20)}`))
-    const tx = new FeeMarketEIP1559Transaction(
+    const tx = new FeeMarket1559Tx(
       {
         maxFeePerGas: GWEI * BigInt(5),
         maxPriorityFeePerGas: GWEI * BigInt(2),

--- a/packages/vm/test/api/EIPs/eip-2930-accesslists.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-2930-accesslists.spec.ts
@@ -1,5 +1,5 @@
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
-import { create2930AccessListTx } from '@ethereumjs/tx'
+import { createAccessList2930Tx } from '@ethereumjs/tx'
 import {
   Address,
   bytesToHex,
@@ -32,7 +32,7 @@ describe('EIP-2930 Optional Access Lists tests', () => {
         storageKeys: [bytesToHex(validSlot)],
       },
     ]
-    const txnWithAccessList = create2930AccessListTx(
+    const txnWithAccessList = createAccessList2930Tx(
       {
         accessList: access,
         chainId: BigInt(1),
@@ -41,7 +41,7 @@ describe('EIP-2930 Optional Access Lists tests', () => {
       },
       { common },
     ).sign(privateKey)
-    const txnWithoutAccessList = create2930AccessListTx(
+    const txnWithoutAccessList = createAccessList2930Tx(
       {
         accessList: [],
         chainId: BigInt(1),

--- a/packages/vm/test/api/EIPs/eip-3198-BaseFee.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-3198-BaseFee.spec.ts
@@ -1,6 +1,6 @@
 import { createBlock } from '@ethereumjs/block'
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
-import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
+import { FeeMarket1559Tx } from '@ethereumjs/tx'
 import { Address, hexToBytes, privateToAddress } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
@@ -62,7 +62,7 @@ describe('EIP3198 tests', () => {
   it('test EIP3198 gas fee and correct value', async () => {
     // Initial base fee for EIP1559
     const fee = BigInt(1000000000)
-    const tx = new FeeMarketEIP1559Transaction(
+    const tx = new FeeMarket1559Tx(
       {
         maxFeePerGas: GWEI * BigInt(5),
         maxPriorityFeePerGas: GWEI * BigInt(2),

--- a/packages/vm/test/api/EIPs/eip-3860.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-3860.spec.ts
@@ -1,5 +1,5 @@
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
-import { create1559FeeMarketTx } from '@ethereumjs/tx'
+import { createFeeMarket1559Tx } from '@ethereumjs/tx'
 import { Account, Address, bytesToHex, hexToBytes, privateToAddress } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
@@ -27,7 +27,7 @@ describe('EIP 3860 tests', () => {
     // We create a tx with a common which has eip not yet activated else tx creation will
     // throw error
     const txCommon = new Common({ chain: Mainnet, hardfork: Hardfork.London })
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       {
         data: `0x7F6000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000060005260206000F3${bytesToHex(
           bytes,

--- a/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-4844-blobs.spec.ts
@@ -1,7 +1,7 @@
 import { createBlock } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
 import { Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
-import { create4844BlobTx } from '@ethereumjs/tx'
+import { createBlob4844Tx } from '@ethereumjs/tx'
 import {
   blobsToCommitments,
   blobsToProofs,
@@ -65,7 +65,7 @@ describe('EIP4844 tests', () => {
     const commitments = blobsToCommitments(kzg, blobs)
     const blobVersionedHashes = commitmentsToVersionedHashes(commitments)
     const proofs = blobsToProofs(kzg, blobs, commitments)
-    const unsignedTx = create4844BlobTx(
+    const unsignedTx = createBlob4844Tx(
       {
         blobVersionedHashes,
         blobs,

--- a/packages/vm/test/api/EIPs/eip-4895-withdrawals.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-4895-withdrawals.spec.ts
@@ -2,7 +2,7 @@ import { createBlock, genWithdrawalsTrieRoot } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
 import { Common, Hardfork, Mainnet, createCommonFromGethGenesis } from '@ethereumjs/common'
 import { decode } from '@ethereumjs/rlp'
-import { create1559FeeMarketTx } from '@ethereumjs/tx'
+import { createFeeMarket1559Tx } from '@ethereumjs/tx'
 import {
   Account,
   Address,
@@ -67,7 +67,7 @@ describe('EIP4895 tests', () => {
       hexToBytes(`0x73${addresses[0]}3160005260206000F3`),
     )
 
-    const transaction = create1559FeeMarketTx({
+    const transaction = createFeeMarket1559Tx({
       to: contractAddress,
       maxFeePerGas: BigInt(7),
       maxPriorityFeePerGas: BigInt(0),

--- a/packages/vm/test/api/EIPs/eip-7702.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-7702.spec.ts
@@ -1,6 +1,6 @@
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
-import { create7702EOACodeTx } from '@ethereumjs/tx'
+import { createEOACode7702Tx } from '@ethereumjs/tx'
 import {
   Account,
   Address,
@@ -67,7 +67,7 @@ async function runTest(
 ) {
   vm = vm ?? (await VM.create({ common }))
   const authList = authorizationListOpts.map((opt) => getAuthorizationListItem(opt))
-  const tx = create7702EOACodeTx(
+  const tx = createEOACode7702Tx(
     {
       gasLimit: 100000,
       maxFeePerGas: 1000,
@@ -208,7 +208,7 @@ describe('EIP 7702: set code to EOA accounts', () => {
 
     await vm.stateManager.putCode(checkAddressWarm, checkAddressWarmCode)
 
-    const tx = create7702EOACodeTx(
+    const tx = createEOACode7702Tx(
       {
         gasLimit: 100000,
         maxFeePerGas: 1000,
@@ -240,7 +240,7 @@ describe('EIP 7702: set code to EOA accounts', () => {
         address: code1Addr,
       }),
     ]
-    const tx = create7702EOACodeTx(
+    const tx = createEOACode7702Tx(
       {
         gasLimit: 100000,
         maxFeePerGas: 1000,

--- a/packages/vm/test/api/buildBlock.spec.ts
+++ b/packages/vm/test/api/buildBlock.spec.ts
@@ -13,7 +13,7 @@ import {
   createCommonFromGethGenesis,
 } from '@ethereumjs/common'
 import { Ethash } from '@ethereumjs/ethash'
-import { create1559FeeMarketTx, createLegacyTx } from '@ethereumjs/tx'
+import { createFeeMarket1559Tx, createLegacyTx } from '@ethereumjs/tx'
 import {
   Address,
   concatBytes,
@@ -340,7 +340,7 @@ describe('BlockBuilder', () => {
       { common, freeze: false },
     ).sign(privateKey)
 
-    const tx2 = create1559FeeMarketTx(
+    const tx2 = createFeeMarket1559Tx(
       { to: createZeroAddress(), value: 1000, gasLimit: 21000, maxFeePerGas: 10 },
       { common, freeze: false },
     ).sign(privateKey)
@@ -363,7 +363,7 @@ describe('BlockBuilder', () => {
       { common, freeze: false },
     ).sign(privateKey)
 
-    const tx4 = create1559FeeMarketTx(
+    const tx4 = createFeeMarket1559Tx(
       { to: createZeroAddress(), value: 1000, gasLimit: 21000, maxFeePerGas: 101, nonce: 1 },
       { common, freeze: false },
     ).sign(privateKey)

--- a/packages/vm/test/api/events.spec.ts
+++ b/packages/vm/test/api/events.spec.ts
@@ -1,5 +1,5 @@
 import { Block } from '@ethereumjs/block'
-import { create1559FeeMarketTx } from '@ethereumjs/tx'
+import { createFeeMarket1559Tx } from '@ethereumjs/tx'
 import { Account, bytesToHex, createAddressFromPrivateKey, toBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
@@ -56,7 +56,7 @@ describe('VM events', () => {
       emitted = val
     })
 
-    const tx = create1559FeeMarketTx({
+    const tx = createFeeMarket1559Tx({
       gasLimit: 90000,
       maxFeePerGas: 40000,
       to: '0x1111111111111111111111111111111111111111',
@@ -76,7 +76,7 @@ describe('VM events', () => {
       emitted = val
     })
 
-    const tx = create1559FeeMarketTx({
+    const tx = createFeeMarket1559Tx({
       gasLimit: 90000,
       maxFeePerGas: 40000,
       to: '0x1111111111111111111111111111111111111111',
@@ -97,7 +97,7 @@ describe('VM events', () => {
       emitted = val
     })
 
-    const tx = create1559FeeMarketTx({
+    const tx = createFeeMarket1559Tx({
       gasLimit: 90000,
       maxFeePerGas: 40000,
       to: '0x1111111111111111111111111111111111111111',
@@ -119,7 +119,7 @@ describe('VM events', () => {
       emitted = val
     })
 
-    const tx = create1559FeeMarketTx({
+    const tx = createFeeMarket1559Tx({
       gasLimit: 90000,
       maxFeePerGas: 40000,
       to: '0x1111111111111111111111111111111111111111',
@@ -142,7 +142,7 @@ describe('VM events', () => {
     // This is a deployment transaction that pushes 0x41 (i.e. ascii A) followed by 31 0s to
     // the stack, stores that in memory, and then returns the first byte from memory.
     // This deploys a contract which has a single byte of code, 0x41.
-    const tx = create1559FeeMarketTx({
+    const tx = createFeeMarket1559Tx({
       gasLimit: 90000,
       maxFeePerGas: 40000,
       data: '0x7f410000000000000000000000000000000000000000000000000000000000000060005260016000f3',
@@ -164,7 +164,7 @@ describe('VM events', () => {
     // This is a deployment transaction that pushes 0x41 (i.e. ascii A) followed by 31 0s to
     // the stack, stores that in memory, and then returns the first byte from memory.
     // This deploys a contract which has a single byte of code, 0x41.
-    const tx = create1559FeeMarketTx({
+    const tx = createFeeMarket1559Tx({
       gasLimit: 90000,
       maxFeePerGas: 40000,
       data: '0x7f410000000000000000000000000000000000000000000000000000000000000060005260016000f3',

--- a/packages/vm/test/api/runBlock.spec.ts
+++ b/packages/vm/test/api/runBlock.spec.ts
@@ -8,10 +8,10 @@ import { Common, Goerli, Hardfork, Mainnet, createCustomCommon } from '@ethereum
 import { RLP } from '@ethereumjs/rlp'
 import {
   Capability,
-  LegacyTransaction,
-  create1559FeeMarketTx,
-  create2930AccessListTx,
-  create7702EOACodeTx,
+  LegacyTx,
+  createAccessList2930Tx,
+  createEOACode7702Tx,
+  createFeeMarket1559Tx,
   createLegacyTx,
 } from '@ethereumjs/tx'
 import {
@@ -294,7 +294,7 @@ describe('runBlock() -> API parameter usage/data errors', async () => {
 
     const gasLimit = BigInt('0x3fefba')
     const opts = { common: block.common }
-    block.transactions[0] = new LegacyTransaction(
+    block.transactions[0] = new LegacyTx(
       { nonce, gasPrice, gasLimit, to, value, data, v, r, s },
       opts,
     )
@@ -539,7 +539,7 @@ describe('runBlock() -> tx types', async () => {
     const address = createAddressFromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
     await setBalance(vm, address)
 
-    const tx = create2930AccessListTx(
+    const tx = createAccessList2930Tx(
       { gasLimit: 53000, value: 1, v: 1, r: 1, s: 1 },
       { common, freeze: false },
     )
@@ -558,7 +558,7 @@ describe('runBlock() -> tx types', async () => {
     const address = createAddressFromString('0xccfd725760a68823ff1e062f4cc97e1360e8d997')
     await setBalance(vm, address)
 
-    const tx = create1559FeeMarketTx(
+    const tx = createFeeMarket1559Tx(
       { maxFeePerGas: 10, maxPriorityFeePerGas: 4, gasLimit: 100000, value: 6 },
       { common, freeze: false },
     )
@@ -644,7 +644,7 @@ describe('runBlock() -> tx types', async () => {
 
     const authList = authorizationListOpts.map((opt) => getAuthorizationListItem(opt))
     const authList2 = authorizationListOpts2.map((opt) => getAuthorizationListItem(opt))
-    const tx1 = create7702EOACodeTx(
+    const tx1 = createEOACode7702Tx(
       {
         gasLimit: 1000000000,
         maxFeePerGas: 100000,
@@ -655,7 +655,7 @@ describe('runBlock() -> tx types', async () => {
       },
       { common },
     ).sign(defaultSenderPkey)
-    const tx2 = create7702EOACodeTx(
+    const tx2 = createEOACode7702Tx(
       {
         gasLimit: 1000000000,
         maxFeePerGas: 100000,

--- a/packages/vm/test/api/types.spec.ts
+++ b/packages/vm/test/api/types.spec.ts
@@ -1,10 +1,10 @@
 import { createBlock } from '@ethereumjs/block'
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
-import { create2930AccessListTx, createLegacyTx } from '@ethereumjs/tx'
+import { createAccessList2930Tx, createLegacyTx } from '@ethereumjs/tx'
 import { assert, describe, it } from 'vitest'
 
 import type { BlockData } from '@ethereumjs/block'
-import type { AccessListEIP2930TxData, TransactionType, TxData } from '@ethereumjs/tx'
+import type { AccessList2930TxData, TransactionType, TxData } from '@ethereumjs/tx'
 
 describe('[Types]', () => {
   it('should ensure that the actual objects can be safely used as their data types', () => {
@@ -36,8 +36,8 @@ describe('[Types]', () => {
     assert.ok(legacyTx, 'legacy tx')
 
     // Access List tx
-    const accessListTx: RequiredExceptOptionals<AccessListEIP2930TxData, OptionalTxFields> =
-      create2930AccessListTx({}, { common })
+    const accessListTx: RequiredExceptOptionals<AccessList2930TxData, OptionalTxFields> =
+      createAccessList2930Tx({}, { common })
     assert.ok(accessListTx, 'accessList tx')
   })
 })

--- a/packages/vm/test/util.ts
+++ b/packages/vm/test/util.ts
@@ -2,10 +2,10 @@ import { Block, createBlockHeader } from '@ethereumjs/block'
 import { Common, Hardfork, Mainnet, createCustomCommon } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import {
-  create1559FeeMarketTx,
-  create2930AccessListTx,
-  create4844BlobTx,
-  create7702EOACodeTx,
+  createAccessList2930Tx,
+  createBlob4844Tx,
+  createEOACode7702Tx,
+  createFeeMarket1559Tx,
   createLegacyTx,
 } from '@ethereumjs/tx'
 import {
@@ -28,11 +28,11 @@ import { keccak256 } from 'ethereum-cryptography/keccak'
 import type { BlockOptions } from '@ethereumjs/block'
 import type { StateManagerInterface } from '@ethereumjs/common'
 import type {
-  AccessListEIP2930Transaction,
-  BlobEIP4844Transaction,
-  EOACodeEIP7702Transaction,
-  FeeMarketEIP1559Transaction,
-  LegacyTransaction,
+  AccessList2930Transaction,
+  Blob4844Tx,
+  EOACode7702Transaction,
+  FeeMarket1559Tx,
+  LegacyTx,
   TxOptions,
 } from '@ethereumjs/tx'
 import type * as tape from 'tape'
@@ -121,17 +121,12 @@ export function format(a: any, toZero: boolean = false, isHex: boolean = false):
  * Make a tx using JSON from tests repo
  * @param {Object} txData The tx object from tests repo
  * @param {TxOptions} opts Tx opts that can include an @ethereumjs/common object
- * @returns {BlobEIP4844Transaction | FeeMarketEIP1559Transaction | AccessListEIP2930Transaction | LegacyTransaction} Transaction to be passed to runTx() function
+ * @returns {Blob4844Tx | FeeMarket1559Tx | AccessList2930Transaction | LegacyTx} Transaction to be passed to runTx() function
  */
 export function makeTx(
   txData: any,
   opts?: TxOptions,
-):
-  | EOACodeEIP7702Transaction
-  | BlobEIP4844Transaction
-  | FeeMarketEIP1559Transaction
-  | AccessListEIP2930Transaction
-  | LegacyTransaction {
+): EOACode7702Transaction | Blob4844Tx | FeeMarket1559Tx | AccessList2930Transaction | LegacyTx {
   let tx
   if (txData.authorizationList !== undefined) {
     // Convert `v` keys to `yParity`
@@ -143,13 +138,13 @@ export function makeTx(
         signature.nonce[0] = '0x'
       }
     }
-    tx = create7702EOACodeTx(txData, opts)
+    tx = createEOACode7702Tx(txData, opts)
   } else if (txData.blobVersionedHashes !== undefined) {
-    tx = create4844BlobTx(txData, opts)
+    tx = createBlob4844Tx(txData, opts)
   } else if (txData.maxFeePerGas !== undefined) {
-    tx = create1559FeeMarketTx(txData, opts)
+    tx = createFeeMarket1559Tx(txData, opts)
   } else if (txData.accessLists !== undefined) {
-    tx = create2930AccessListTx(txData, opts)
+    tx = createAccessList2930Tx(txData, opts)
   } else {
     tx = createLegacyTx(txData, opts)
   }


### PR DESCRIPTION
This PR does one thing and that is to remove the EIP word from the Tx library methods and classes. (Also renames constructors as `create7702EOACodeTx` to `createEOACode7702Tx`)

I have only used "find-and-replace" so if CI passes this should be fine.

To quickly test the renames, build the library, and then in node `require('@ethereumjs/tx')` and verify the output names of the exported methods/classes.