### PR TITLE
Remove almost all `cspell:ignore`

### DIFF
--- a/config/cspell-ts.json
+++ b/config/cspell-ts.json
@@ -582,6 +582,17 @@
     "dedicatedly",
     "EVMBLS",
     "EVMBN",
-    "EVMONEs"
+    "EVMONEs",
+    "INTURN",
+    "NOTURN",
+    "Andras",
+    "Radics",
+    "Fedor",
+    "Indutny",
+    "Kademlia",
+    "Slominski",
+    "patarapolw",
+    "nickdodson",
+    "Kintsugi"
   ]
 }

--- a/config/cspell-ts.json
+++ b/config/cspell-ts.json
@@ -593,6 +593,7 @@
     "Slominski",
     "patarapolw",
     "nickdodson",
-    "Kintsugi"
+    "Kintsugi",
+    "deauthorization"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "checkNpmVersion": "./scripts/check-npm-version.sh",
     "clean": "./config/cli/clean-root.sh",
     "cspell": "npm run cspell:ts && npm run cspell:md",
-    "cspell:ts": "npx cspell --gitignore -e \"./packages/ethereum-tests\" -e \"./packages/wallet/test\" -c ./config/cspell-ts.json \"./packages/**/*.ts\" --cache --show-suggestions --show-context",
+    "cspell:ts": "npx cspell --gitignore -e \"./packages/ethereum-tests\" -e \"./packages/wallet/test\" -e \"./packages/client/archive\" -c ./config/cspell-ts.json \"./packages/**/*.ts\" --cache --show-suggestions --show-context",
     "cspell:md": "npx cspell --gitignore -e \"./packages/ethereum-tests\" -e \"./packages/client/withdrawals-testnet/**\" -e \"./packages/**/docs\" -c ./config/cspell-md.json \"**.md\" --cache --show-suggestions --show-context",
     "docs:build": "npm run docs:build --workspaces --if-present",
     "e2e:inject": "node ./scripts/e2e-inject-resolutions.js",

--- a/packages/block/src/from-beacon-payload.ts
+++ b/packages/block/src/from-beacon-payload.ts
@@ -1,4 +1,3 @@
-// cspell:ignore breq
 import { bigIntToHex } from '@ethereumjs/util'
 
 import type { ExecutionPayload } from './types.js'
@@ -157,27 +156,29 @@ export function executionPayloadFromBeaconPayload(payload: BeaconPayloadJson): E
 
   // requests
   if (payload.deposit_requests !== undefined && payload.deposit_requests !== null) {
-    executionPayload.depositRequests = payload.deposit_requests.map((breq) => ({
-      pubkey: breq.pubkey,
-      withdrawalCredentials: breq.withdrawal_credentials,
-      amount: breq.amount,
-      signature: breq.signature,
-      index: breq.index,
+    executionPayload.depositRequests = payload.deposit_requests.map((beaconRequest) => ({
+      pubkey: beaconRequest.pubkey,
+      withdrawalCredentials: beaconRequest.withdrawal_credentials,
+      amount: beaconRequest.amount,
+      signature: beaconRequest.signature,
+      index: beaconRequest.index,
     }))
   }
   if (payload.withdrawal_requests !== undefined && payload.withdrawal_requests !== null) {
-    executionPayload.withdrawalRequests = payload.withdrawal_requests.map((breq) => ({
-      sourceAddress: breq.source_address,
-      validatorPubkey: breq.validator_pubkey,
-      amount: breq.amount,
+    executionPayload.withdrawalRequests = payload.withdrawal_requests.map((beaconRequest) => ({
+      sourceAddress: beaconRequest.source_address,
+      validatorPubkey: beaconRequest.validator_pubkey,
+      amount: beaconRequest.amount,
     }))
   }
   if (payload.consolidation_requests !== undefined && payload.consolidation_requests !== null) {
-    executionPayload.consolidationRequests = payload.consolidation_requests.map((breq) => ({
-      sourceAddress: breq.source_address,
-      sourcePubkey: breq.source_pubkey,
-      targetPubkey: breq.target_pubkey,
-    }))
+    executionPayload.consolidationRequests = payload.consolidation_requests.map(
+      (beaconRequest) => ({
+        sourceAddress: beaconRequest.source_address,
+        sourcePubkey: beaconRequest.source_pubkey,
+        targetPubkey: beaconRequest.target_pubkey,
+      }),
+    )
   }
 
   if (payload.execution_witness !== undefined && payload.execution_witness !== null) {

--- a/packages/block/src/helpers.ts
+++ b/packages/block/src/helpers.ts
@@ -1,4 +1,3 @@
-// cspell:ignore accum
 import { RLP } from '@ethereumjs/rlp'
 import { Trie } from '@ethereumjs/trie'
 import { BlobEIP4844Transaction } from '@ethereumjs/tx'
@@ -110,10 +109,10 @@ export const getNumBlobs = (transactions: TypedTransaction[]) => {
 export const fakeExponential = (factor: bigint, numerator: bigint, denominator: bigint) => {
   let i = BIGINT_1
   let output = BIGINT_0
-  let numerator_accum = factor * denominator
-  while (numerator_accum > BIGINT_0) {
-    output += numerator_accum
-    numerator_accum = (numerator_accum * numerator) / (denominator * i)
+  let numerator_accumulator = factor * denominator
+  while (numerator_accumulator > BIGINT_0) {
+    output += numerator_accumulator
+    numerator_accumulator = (numerator_accumulator * numerator) / (denominator * i)
     i++
   }
 

--- a/packages/block/test/from-rpc.spec.ts
+++ b/packages/block/test/from-rpc.spec.ts
@@ -133,7 +133,6 @@ describe('[fromRPC] - Alchemy/Infura API block responses', () => {
   it('should create pre and post merge blocks from Infura API responses to eth_getBlockByHash and eth_getBlockByNumber', () => {
     const common = new Common({ chain: Mainnet })
     let block = createBlockFromRPC(infura2000004woTxs as JsonRpcBlock, [], {
-      // cspell:disable-line
       common,
       setHardfork: true,
     })
@@ -142,14 +141,13 @@ describe('[fromRPC] - Alchemy/Infura API block responses', () => {
       infura2000004woTxs.hash,
       'created premerge block w/o txns',
     )
-    block = createBlockFromRPC(infura2000004wTxs as JsonRpcBlock, [], { common, setHardfork: true }) // cspell:disable-line
+    block = createBlockFromRPC(infura2000004wTxs as JsonRpcBlock, [], { common, setHardfork: true })
     assert.equal(
       bytesToHex(block.hash()),
       infura2000004wTxs.hash,
       'created premerge block with txns',
     )
     block = createBlockFromRPC(infura15571241woTxs as JsonRpcBlock, [], {
-      // cspell:disable-line
       common,
       setHardfork: true,
     })
@@ -160,7 +158,6 @@ describe('[fromRPC] - Alchemy/Infura API block responses', () => {
     )
 
     block = createBlockFromRPC(infura15571241wTxs as JsonRpcBlock, [], {
-      // cspell:disable-line
       common,
       setHardfork: true,
     })

--- a/packages/block/test/from-rpc.spec.ts
+++ b/packages/block/test/from-rpc.spec.ts
@@ -1,4 +1,3 @@
-// cspell:ignore wtxns wtxs wotxns
 import { Common, Goerli, Hardfork, Mainnet } from '@ethereumjs/common'
 import { bytesToHex, equalsBytes, hexToBytes, randomBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
@@ -12,9 +11,9 @@ import {
 import * as alchemy14151203 from './testdata/alchemy14151203.json'
 import * as infuraGoerliBlock10536893 from './testdata/infura-goerli-block-10536893.json'
 import * as infura15571241woTxs from './testdata/infura15571241.json'
-import * as infura15571241wTxs from './testdata/infura15571241wtxns.json'
-import * as infura2000004woTxs from './testdata/infura2000004wotxns.json'
-import * as infura2000004wTxs from './testdata/infura2000004wtxs.json'
+import * as infura15571241wTxs from './testdata/infura15571241wtxns.json' // cspell:disable-line
+import * as infura2000004woTxs from './testdata/infura2000004wotxns.json' // cspell:disable-line
+import * as infura2000004wTxs from './testdata/infura2000004wtxs.json' // cspell:disable-line
 import * as blockDataDifficultyAsInteger from './testdata/testdata-from-rpc-difficulty-as-integer.json'
 import * as testDataFromRpcGoerliLondon from './testdata/testdata-from-rpc-goerli-london.json'
 import * as blockDataWithUncles from './testdata/testdata-from-rpc-with-uncles.json'
@@ -134,6 +133,7 @@ describe('[fromRPC] - Alchemy/Infura API block responses', () => {
   it('should create pre and post merge blocks from Infura API responses to eth_getBlockByHash and eth_getBlockByNumber', () => {
     const common = new Common({ chain: Mainnet })
     let block = createBlockFromRPC(infura2000004woTxs as JsonRpcBlock, [], {
+      // cspell:disable-line
       common,
       setHardfork: true,
     })
@@ -142,13 +142,14 @@ describe('[fromRPC] - Alchemy/Infura API block responses', () => {
       infura2000004woTxs.hash,
       'created premerge block w/o txns',
     )
-    block = createBlockFromRPC(infura2000004wTxs as JsonRpcBlock, [], { common, setHardfork: true })
+    block = createBlockFromRPC(infura2000004wTxs as JsonRpcBlock, [], { common, setHardfork: true }) // cspell:disable-line
     assert.equal(
       bytesToHex(block.hash()),
       infura2000004wTxs.hash,
       'created premerge block with txns',
     )
     block = createBlockFromRPC(infura15571241woTxs as JsonRpcBlock, [], {
+      // cspell:disable-line
       common,
       setHardfork: true,
     })
@@ -159,6 +160,7 @@ describe('[fromRPC] - Alchemy/Infura API block responses', () => {
     )
 
     block = createBlockFromRPC(infura15571241wTxs as JsonRpcBlock, [], {
+      // cspell:disable-line
       common,
       setHardfork: true,
     })
@@ -171,7 +173,7 @@ describe('[fromRPC] - Alchemy/Infura API block responses', () => {
 
   it('should correctly parse a cancun block over rpc', () => {
     const common = new Common({ chain: Goerli, hardfork: Hardfork.Cancun })
-    const block = blockHeaderFromRpc(infuraGoerliBlock10536893 as JsonRpcBlock, { common })
+    const block = blockHeaderFromRpc(infuraGoerliBlock10536893 as JsonRpcBlock, { common }) // cspell:disable-line
     const hash = hexToBytes(infuraGoerliBlock10536893.hash as PrefixedHexString)
     assert.ok(equalsBytes(block.hash(), hash))
   })
@@ -187,7 +189,7 @@ describe('[fromJsonRpcProvider]', () => {
     global.fetch = async (_url: string, req: any) => {
       const json = JSON.parse(req.body)
       if (json.params[0] === '0x1850b014065b23d804ecf71a8a4691d076ca87c2e6fb8fe81ee20a4d8e884c24') {
-        const txData = await import(`./testdata/infura15571241wtxns.json`)
+        const txData = await import(`./testdata/infura15571241wtxns.json`) // cspell:disable-line
         return {
           ok: true,
           status: 200,

--- a/packages/block/test/header.spec.ts
+++ b/packages/block/test/header.spec.ts
@@ -1,4 +1,3 @@
-// cspell:ignore NOTURN
 import { Common, Goerli, Hardfork, Mainnet } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import {

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -1,4 +1,3 @@
-// cspell:ignore NOTURN
 import { Block, BlockHeader, createBlock } from '@ethereumjs/block'
 import { Common, ConsensusAlgorithm, ConsensusType, Hardfork, Mainnet } from '@ethereumjs/common'
 import {

--- a/packages/blockchain/src/consensus/clique.ts
+++ b/packages/blockchain/src/consensus/clique.ts
@@ -1,4 +1,3 @@
-// cspell:ignore NOTURN addrs
 import {
   cliqueEpochTransitionSigners,
   cliqueIsEpochTransition,
@@ -548,8 +547,8 @@ export class CliqueConsensus implements Consensus {
     const states = RLP.decode(signerStates as Uint8Array) as [Uint8Array, Uint8Array[]]
     return states.map((state) => {
       const blockNum = bytesToBigInt(state[0] as Uint8Array)
-      const addrs = (<any>state[1]).map((bytes: Uint8Array) => new Address(bytes))
-      return [blockNum, addrs]
+      const addresses = (<any>state[1]).map((bytes: Uint8Array) => new Address(bytes))
+      return [blockNum, addresses]
     }) as CliqueLatestSignerStates
   }
 

--- a/packages/blockchain/test/clique.spec.ts
+++ b/packages/blockchain/test/clique.spec.ts
@@ -802,7 +802,7 @@ describe('clique: reorgs', () => {
     const { blocks, blockchain } = await initWithSigners([A, B])
     const genesis = blocks[0]
     await addNextBlock(blockchain, blocks, A, [C, true])
-    const headBlockNotForked = await addNextBlock(blockchain, blocks, B, [C, true]) // cspell:disable-line
+    const headBlockNotForked = await addNextBlock(blockchain, blocks, B, [C, true])
     assert.deepEqual(
       (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
         blocks[blocks.length - 1].header.number + BigInt(1),

--- a/packages/blockchain/test/clique.spec.ts
+++ b/packages/blockchain/test/clique.spec.ts
@@ -1,4 +1,3 @@
-// cspell:ignore NOTURN deauth unforked
 import {
   cliqueEpochTransitionSigners,
   createBlock,
@@ -536,7 +535,7 @@ describe('Clique: Initialization', () => {
         blocks[blocks.length - 1].header.number + BigInt(1),
       ),
       [A.address, B.address],
-      'deauth votes',
+      'deauthorized votes',
     )
   })
 
@@ -556,7 +555,7 @@ describe('Clique: Initialization', () => {
     )
   })
 
-  it('Clique Voting: Changes reaching consensus out of bounds (via a deauth) execute on touch', async () => {
+  it('Clique Voting: Changes reaching consensus out of bounds (via a deauthorization) execute on touch', async () => {
     const { blocks, blockchain } = await initWithSigners([A, B, C, D])
     await addNextBlock(blockchain, blocks, A, [C, false])
     await addNextBlock(blockchain, blocks, B)
@@ -578,7 +577,7 @@ describe('Clique: Initialization', () => {
     )
   })
 
-  it('Clique Voting: Changes reaching consensus out of bounds (via a deauth) may go out of consensus on first touch', async () => {
+  it('Clique Voting: Changes reaching consensus out of bounds (via a deauthorization) may go out of consensus on first touch', async () => {
     const { blocks, blockchain } = await initWithSigners([A, B, C, D])
     await addNextBlock(blockchain, blocks, A, [C, false])
     await addNextBlock(blockchain, blocks, B)
@@ -803,7 +802,7 @@ describe('clique: reorgs', () => {
     const { blocks, blockchain } = await initWithSigners([A, B])
     const genesis = blocks[0]
     await addNextBlock(blockchain, blocks, A, [C, true])
-    const headBlockUnforked = await addNextBlock(blockchain, blocks, B, [C, true])
+    const headBlockNotForked = await addNextBlock(blockchain, blocks, B, [C, true]) // cspell:disable-line
     assert.deepEqual(
       (blockchain.consensus as CliqueConsensus).cliqueActiveSigners(
         blocks[blocks.length - 1].header.number + BigInt(1),
@@ -811,7 +810,7 @@ describe('clique: reorgs', () => {
       [A.address, B.address, C.address],
       'address C added to signers',
     )
-    assert.deepEqual((await blockchain.getCanonicalHeadBlock()).hash(), headBlockUnforked.hash())
+    assert.deepEqual((await blockchain.getCanonicalHeadBlock()).hash(), headBlockNotForked.hash())
     await addNextBlockReorg(blockchain, blocks, genesis, B)
     const headBlock = await addNextBlock(blockchain, blocks, A)
     assert.deepEqual((await blockchain.getCanonicalHeadBlock()).hash(), headBlock.hash())
@@ -853,7 +852,7 @@ describe('clique: reorgs', () => {
       await addNextBlock(blockchain, blocks, A, [C, true], undefined, common)
       await addNextBlock(blockchain, blocks, B, [C, true], undefined, common)
       await addNextBlock(blockchain, blocks, A, undefined, undefined, common)
-      const headBlockUnforked = await addNextBlock(
+      const headBlockNotForked = await addNextBlock(
         blockchain,
         blocks,
         B,
@@ -868,7 +867,7 @@ describe('clique: reorgs', () => {
         [A.address, B.address, C.address],
         'address C added to signers'
       )
-     assert.deepEqual((await blockchain.getCanonicalHeadBlock()).hash(), headBlockUnforked.hash())
+     assert.deepEqual((await blockchain.getCanonicalHeadBlock()).hash(), headBlockNotForked.hash())
       await addNextBlockReorg(blockchain, blocks, genesis, B, undefined, undefined, common)
       await addNextBlock(blockchain, blocks, A, undefined, undefined, common)
 

--- a/packages/blockchain/test/index.spec.ts
+++ b/packages/blockchain/test/index.spec.ts
@@ -1,4 +1,3 @@
-// cspell:ignore staletest
 import {
   createBlock,
   createBlockFromRLPSerializedBlock,
@@ -445,11 +444,11 @@ describe('blockchain test', () => {
       calcDifficultyFromHeader: blocks[14].header,
     })
 
-    blockchain._heads['staletest'] = blockchain._headHeaderHash
+    blockchain._heads['staleTest'] = blockchain._headHeaderHash
 
     await blockchain.putHeader(forkHeader)
 
-    assert.deepEqual(blockchain._heads['staletest'], blocks[14].hash(), 'should update stale head')
+    assert.deepEqual(blockchain._heads['staleTest'], blocks[14].hash(), 'should update stale head')
     assert.deepEqual(blockchain._headBlockHash, blocks[14].hash(), 'should update stale headBlock')
   })
 
@@ -470,11 +469,11 @@ describe('blockchain test', () => {
       calcDifficultyFromHeader: blocks[14].header,
     })
 
-    blockchain._heads['staletest'] = blockchain._headHeaderHash
+    blockchain._heads['staleTest'] = blockchain._headHeaderHash
 
     await blockchain.putHeader(forkHeader)
 
-    assert.deepEqual(blockchain._heads['staletest'], blocks[14].hash(), 'should update stale head')
+    assert.deepEqual(blockchain._heads['staleTest'], blocks[14].hash(), 'should update stale head')
     assert.deepEqual(blockchain._headBlockHash, blocks[14].hash(), 'should update stale headBlock')
 
     await blockchain.delBlock(forkHeader.hash())

--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -1,4 +1,3 @@
-// cspell:ignore PARENTLOOKUP refeed
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { genPrivateKey } from '@ethereumjs/devp2p'
 import { type Address, BIGINT_0, BIGINT_1, BIGINT_2, BIGINT_256 } from '@ethereumjs/util'
@@ -277,7 +276,7 @@ export interface ConfigOptions {
 
   /**
    * If there is a reorg, this is a safe distance from which
-   * to try to refetch and refeed the blocks.
+   * to try to refetch and re-feed the blocks.
    */
   safeReorgDistance?: number
 
@@ -387,7 +386,7 @@ export class Config {
 
   public static readonly SYNCED_STATE_REMOVAL_PERIOD = 60000
   // engine new payload calls can come in batch of 64, keeping 128 as the lookup factor
-  public static readonly ENGINE_PARENTLOOKUP_MAX_DEPTH = 128
+  public static readonly ENGINE_PARENT_LOOKUP_MAX_DEPTH = 128
   public static readonly ENGINE_NEWPAYLOAD_MAX_EXECUTE = 2
   public static readonly ENGINE_NEWPAYLOAD_MAX_TXS_EXECUTE = 200
   public static readonly SNAP_AVAILABILITY_DEPTH = BigInt(128)
@@ -528,7 +527,7 @@ export class Config {
     this.syncedStateRemovalPeriod =
       options.syncedStateRemovalPeriod ?? Config.SYNCED_STATE_REMOVAL_PERIOD
     this.engineParentLookupMaxDepth =
-      options.engineParentLookupMaxDepth ?? Config.ENGINE_PARENTLOOKUP_MAX_DEPTH
+      options.engineParentLookupMaxDepth ?? Config.ENGINE_PARENT_LOOKUP_MAX_DEPTH
     this.engineNewpayloadMaxExecute =
       options.engineNewpayloadMaxExecute ?? Config.ENGINE_NEWPAYLOAD_MAX_EXECUTE
     this.engineNewpayloadMaxTxsExecute =

--- a/packages/client/src/ext/qheap.ts
+++ b/packages/client/src/ext/qheap.ts
@@ -1,4 +1,3 @@
-// cspell:ignore Andras Radics
 /**
  * nodejs heap, classic array implementation
  *

--- a/packages/client/src/miner/miner.ts
+++ b/packages/client/src/miner/miner.ts
@@ -1,4 +1,3 @@
-// cspell:ignore NOTURN
 import { type BlockHeader, createSealedCliqueBlockHeader } from '@ethereumjs/block'
 import { ConsensusType, Hardfork } from '@ethereumjs/common'
 import { Ethash } from '@ethereumjs/ethash'

--- a/packages/client/src/net/server/rlpxserver.ts
+++ b/packages/client/src/net/server/rlpxserver.ts
@@ -1,4 +1,3 @@
-// cspell:ignore pirl ubiq gwhale prichain
 import { DPT as Devp2pDPT, RLPx as Devp2pRLPx } from '@ethereumjs/devp2p'
 import { bytesToUnprefixedHex, unprefixedHexToBytes, utf8ToBytes } from '@ethereumjs/util'
 
@@ -73,11 +72,11 @@ export class RlpxServer extends Server {
       'go1.6',
       'go1.7',
       'quorum',
-      'pirl',
-      'ubiq',
-      'gmc',
-      'gwhale',
-      'prichain',
+      'pirl', // cspell:disable-line
+      'ubiq', // cspell:disable-line
+      'gmc', // cspell:disable-line
+      'gwhale', // cspell:disable-line
+      'prichain', // cspell:disable-line
     ]
   }
 

--- a/packages/client/src/util/parse.ts
+++ b/packages/client/src/util/parse.ts
@@ -1,4 +1,3 @@
-// cspell:ignore WHATWG
 import { hexToBytes } from '@ethereumjs/util'
 import { isMultiaddr, multiaddr } from '@multiformats/multiaddr'
 import { URL } from 'url'
@@ -60,7 +59,7 @@ export function parseMultiaddrs(input: MultiaddrLike): Multiaddr[] {
         const { ip6, port } = matchip6.groups!
         return multiaddr(`/ip6/${ip6}/tcp/${port}`)
       }
-      // parse using WHATWG URL API
+      // parse using WHATWG URL API // cspell:disable-line
       const { hostname: ip, port } = new URL(s)
       if (ip && port) {
         return multiaddr(`/ip4/${ip}/tcp/${port}`)

--- a/packages/client/test/rpc/engine/kaustinen6.spec.ts
+++ b/packages/client/test/rpc/engine/kaustinen6.spec.ts
@@ -1,4 +1,3 @@
-// cspell:ignore gethk vecs
 import {
   BlockHeader,
   createBlockFromExecutionPayload,
@@ -33,7 +32,7 @@ const genesisVerkleBlockHash = '0x3fe165c03e7a77d1e3759362ebeeb16fd964cb411ce11f
  *   a. On the saved blocks, comma separated (were produced for kaustinen4 )
  *      `TEST_SAVED_NUMBERS=353,368,374,467 npx vitest run test/rpc/engine/kaustinen5.spec.ts`
  *   b. Geth produced testvectors (were produced for kaustinen5)
- *     `TEST_GETH_VEC_DIR=test/testdata/gethk5vecs DEBUG=ethjs,vm:*,evm:*,statemanager:verkle* npx vitest run test/rpc/engine/kaustinen6.spec.ts`
+ *     `TEST_GETH_VEC_DIR=test/testdata/gethk5vecs DEBUG=ethjs,vm:*,evm:*,statemanager:verkle* npx vitest run test/rpc/engine/kaustinen6.spec.ts` // cspell:disable-line
  */
 
 const originalValidate = (BlockHeader as any).prototype._consensusFormatValidation
@@ -147,10 +146,10 @@ describe(`valid verkle network setup`, async () => {
 
   if (process.env.TEST_GETH_VEC_DIR !== undefined) {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    const gethVecs = await loadGethVectors(process.env.TEST_GETH_VEC_DIR, { common })
-    let parent = gethVecs[0]
-    for (let i = 1; i < gethVecs.length; i++) {
-      const execute = gethVecs[i]
+    const gethVectors = await loadGethVectors(process.env.TEST_GETH_VEC_DIR, { common })
+    let parent = gethVectors[0]
+    for (let i = 1; i < gethVectors.length; i++) {
+      const execute = gethVectors[i]
       it(`run geth vector: ${execute.blockNumber}`, async (context) => {
         await runBlock({ common, chain, rpc }, { parent, execute }, false, context)
         parent = execute

--- a/packages/client/test/sim/simutils.ts
+++ b/packages/client/test/sim/simutils.ts
@@ -1,4 +1,3 @@
-// cspell:ignore pkill
 import { executionPayloadFromBeaconPayload } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
 import { create1559FeeMarketTx, create4844BlobTx } from '@ethereumjs/tx'
@@ -241,10 +240,10 @@ export function runNetwork(
       throw Error('network is killed before end of test')
     }
     console.log('Killing network process', runProc.pid)
-    execSync(`pkill -15 -P ${runProc.pid}`)
+    execSync(`pkill -15 -P ${runProc.pid}`) // cspell:disable-line pkill
     if (peerRunProc !== undefined) {
       console.log('Killing peer network process', peerRunProc.pid)
-      execSync(`pkill -15 -P ${peerRunProc.pid}`)
+      execSync(`pkill -15 -P ${peerRunProc.pid}`) // cspell:disable-line pkill
     }
     // Wait for the P2P to be offline
     await waitForELOffline()

--- a/packages/client/test/sim/txGenerator.ts
+++ b/packages/client/test/sim/txGenerator.ts
@@ -30,10 +30,10 @@ const kzg = await loadKZG()
 
 function get_padded(data: any, blobs_len: number) {
   const pData = new Uint8Array(blobs_len * USEFUL_BYTES_PER_BLOB)
-  const datalen = (data as Uint8Array).byteLength
-  pData.fill(data, 0, datalen)
+  const dataLen = (data as Uint8Array).byteLength
+  pData.fill(data, 0, dataLen)
   // TODO: if data already fits in a pad, then ka-boom
-  pData[datalen] = 0x80
+  pData[dataLen] = 0x80
   return pData
 }
 

--- a/packages/client/test/sim/txGenerator.ts
+++ b/packages/client/test/sim/txGenerator.ts
@@ -1,4 +1,3 @@
-// cspell:ignore pdata datalen
 // Adapted from - https://github.com/Inphi/eip4844-interop/blob/master/blob_tx_generator/blob.js
 import { create4844BlobTx } from '@ethereumjs/tx'
 import {
@@ -30,12 +29,12 @@ const sender = createAddressFromPrivateKey(pkey)
 const kzg = await loadKZG()
 
 function get_padded(data: any, blobs_len: number) {
-  const pdata = new Uint8Array(blobs_len * USEFUL_BYTES_PER_BLOB)
+  const pData = new Uint8Array(blobs_len * USEFUL_BYTES_PER_BLOB)
   const datalen = (data as Uint8Array).byteLength
-  pdata.fill(data, 0, datalen)
+  pData.fill(data, 0, datalen)
   // TODO: if data already fits in a pad, then ka-boom
-  pdata[datalen] = 0x80
-  return pdata
+  pData[datalen] = 0x80
+  return pData
 }
 
 function get_blob(data: any) {
@@ -62,11 +61,11 @@ function get_blobs(data: any) {
 
   const blobs_len = Math.ceil(len / USEFUL_BYTES_PER_BLOB)
 
-  const pdata = get_padded(data, blobs_len)
+  const pData = get_padded(data, blobs_len)
 
   const blobs: Uint8Array[] = []
   for (let i = 0; i < blobs_len; i++) {
-    const chunk = pdata.subarray(i * USEFUL_BYTES_PER_BLOB, (i + 1) * USEFUL_BYTES_PER_BLOB)
+    const chunk = pData.subarray(i * USEFUL_BYTES_PER_BLOB, (i + 1) * USEFUL_BYTES_PER_BLOB)
     const blob = get_blob(chunk)
     blobs.push(blob)
   }

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -1,4 +1,3 @@
-// cspell:ignore blockperiodseconds
 import { intToHex, isHexString, stripHexPrefix } from '@ethereumjs/util'
 
 import { Goerli, Holesky, Kaustinen6, Mainnet, Sepolia } from './chains.js'
@@ -116,10 +115,10 @@ function parseGethParams(json: any) {
             type: 'poa',
             algorithm: 'clique',
             clique: {
-              // The recent geth genesis seems to be using blockperiodseconds
+              // The recent geth genesis seems to be using blockperiodseconds // cspell:disable-line
               // and epochlength for clique specification
               // see: https://hackmd.io/PqZgMpnkSWCWv5joJoFymQ
-              period: config.clique.period ?? config.clique.blockperiodseconds,
+              period: config.clique.period ?? config.clique.blockperiodseconds, // cspell:disable-line
               epoch: config.clique.epoch ?? config.clique.epochlength,
             },
           }

--- a/packages/common/test/hardforks.spec.ts
+++ b/packages/common/test/hardforks.spec.ts
@@ -1,4 +1,3 @@
-// cspell:ignore yolov
 import { hexToBytes, zeros } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
@@ -294,8 +293,8 @@ describe('[Common]: Hardfork logic', () => {
         istanbulBlock: 0,
         muirGlacierBlock: 0,
         berlinBlock: 0,
-        yolov2Block: 0,
-        yolov3Block: 0,
+        yolov2Block: 0, // cspell:disable-line
+        yolov3Block: 0, // cspell:disable-line
         londonBlock: 0,
         mergeForkBlock: 0,
         terminalTotalDifficulty: 0,

--- a/packages/devp2p/src/dns/enr.ts
+++ b/packages/devp2p/src/dns/enr.ts
@@ -1,4 +1,3 @@
-// cspell:ignore Vals
 import { RLP } from '@ethereumjs/rlp'
 import { bytesToUtf8, utf8ToBytes } from '@ethereumjs/util'
 import { base32, base64url } from '@scure/base'
@@ -151,17 +150,17 @@ export class ENR {
     if (!tree.startsWith(this.TREE_PREFIX))
       throw new Error(`ENR tree entry must start with '${this.TREE_PREFIX}'`)
 
-    const treeVals = sscanf(
+    const treeValues = sscanf(
       tree,
       `${this.TREE_PREFIX}//%s@%s`,
       'publicKey',
       'domain',
     ) as ENRTreeValues
 
-    if (!treeVals.publicKey) throw new Error('Could not parse public key from ENR tree entry')
-    if (!treeVals.domain) throw new Error('Could not parse domain from ENR tree entry')
+    if (!treeValues.publicKey) throw new Error('Could not parse public key from ENR tree entry')
+    if (!treeValues.domain) throw new Error('Could not parse domain from ENR tree entry')
 
-    return treeVals
+    return treeValues
   }
 
   /**

--- a/packages/devp2p/src/dpt/server.ts
+++ b/packages/devp2p/src/dpt/server.ts
@@ -1,4 +1,3 @@
-// cspell:ignore rckey rkey
 import { bytesToHex, bytesToUnprefixedHex } from '@ethereumjs/util'
 import debugDefault from 'debug'
 import * as dgram from 'dgram'
@@ -91,8 +90,8 @@ export class Server {
   async ping(peer: PeerInfo): Promise<any> {
     this._isAliveCheck()
 
-    const rckey = `${peer.address}:${peer.udpPort}`
-    const promise = this._requestsCache.get(rckey)
+    const rcKey = `${peer.address}:${peer.udpPort}`
+    const promise = this._requestsCache.get(rcKey)
     if (promise !== undefined) return promise
 
     const hash = this._send(peer, 'ping', {
@@ -102,12 +101,12 @@ export class Server {
     })
 
     const deferred = createDeferred()
-    const rkey = bytesToUnprefixedHex(hash)
-    this._requests.set(rkey, {
+    const rKey = bytesToUnprefixedHex(hash)
+    this._requests.set(rKey, {
       peer,
       deferred,
       timeoutId: setTimeout(() => {
-        if (this._requests.get(rkey) !== undefined) {
+        if (this._requests.get(rKey) !== undefined) {
           if (this.DEBUG) {
             this._debug(
               `ping timeout: ${peer.address}:${peer.udpPort} ${
@@ -115,14 +114,14 @@ export class Server {
               }`,
             )
           }
-          this._requests.delete(rkey)
+          this._requests.delete(rKey)
           deferred.reject(new Error(`Timeout error: ping ${peer.address}:${peer.udpPort}`))
         } else {
           return deferred.promise
         }
       }, this._timeout),
     })
-    this._requestsCache.set(rckey, deferred.promise)
+    this._requestsCache.set(rcKey, deferred.promise)
     return deferred.promise
   }
 
@@ -190,10 +189,10 @@ export class Server {
       }
 
       case 'pong': {
-        const rkey = bytesToUnprefixedHex(info.data.hash)
-        const request = this._requests.get(rkey)
+        const rKey = bytesToUnprefixedHex(info.data.hash)
+        const request = this._requests.get(rKey)
         if (request !== undefined) {
-          this._requests.delete(rkey)
+          this._requests.delete(rKey)
           request.deferred.resolve({
             id: peerId,
             address: request.peer.address,

--- a/packages/devp2p/src/ext/kbucket.ts
+++ b/packages/devp2p/src/ext/kbucket.ts
@@ -1,4 +1,3 @@
-// cspell:ignore Kademlia Slominski tomonari dont
 /*
 index.js - Kademlia DHT K-bucket implementation as a binary tree.
 
@@ -30,7 +29,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 // TODO: Also internalize types from Definitely Typed at some point
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/266eae5148c535e6b41fe5d0adb2ad23f302bc8a/types/k-bucket/index.d.ts#L4
-// (side note: this was once done by tomonari-t dedicatedly for this library
+// (side note: this was once done by tomonari-t dedicatedly for this library // cspell:disable-line
 // (please nevertheless include the original license reference))
 
 import { equalsBytes, randomBytes } from '@ethereumjs/util'
@@ -39,12 +38,12 @@ import { EventEmitter } from 'events'
 import type { Contact, KBucketOptions, PeerInfo } from '../types.js'
 
 function createNode() {
-  return { contacts: [], dontSplit: false, left: null, right: null }
+  return { contacts: [], noSplit: false, left: null, right: null }
 }
 
 type KBucketNode = {
   contacts: Contact[] | null
-  dontSplit: boolean
+  noSplit: boolean
   left: KBucketNode | null
   right: KBucketNode | null
 }
@@ -150,7 +149,7 @@ export class KBucket {
     }
 
     // the bucket is full
-    if (node.dontSplit) {
+    if (node.noSplit) {
       // we are not allowed to split the bucket
       // we need to ping the first this._numberOfNodesToPing
       // in order to determine if they are alive
@@ -340,10 +339,10 @@ export class KBucket {
 
     // don't split the "far away" node
     // we check where the local node would end up and mark the other one as
-    // "dontSplit" (i.e. "far away")
+    // "noSplit" (i.e. "far away")
     const detNode = this._determineNode(node, this._localNodeId, bitIndex)
     const otherNode = node.left === detNode ? node.right : node.left
-    otherNode.dontSplit = true
+    otherNode.noSplit = true
   }
 
   /**

--- a/packages/devp2p/src/rlpx/ecies.ts
+++ b/packages/devp2p/src/rlpx/ecies.ts
@@ -1,4 +1,3 @@
-// cspell:ignore mkey
 import { RLP } from '@ethereumjs/rlp'
 import { bytesToInt, concatBytes, hexToBytes, intToBytes } from '@ethereumjs/util'
 import * as crypto from 'crypto'
@@ -109,7 +108,7 @@ export class ECIES {
     const x = ecdhX(this._remotePublicKey, privateKey)
     const key = concatKDF(x, 32)
     const ekey = key.subarray(0, 16) // encryption key
-    const mkey = crypto.createHash('sha256').update(key.subarray(16, 32)).digest() // MAC key
+    const mKey = crypto.createHash('sha256').update(key.subarray(16, 32)).digest() // MAC key
 
     // encrypt
     const IV = getRandomBytesSync(16)
@@ -122,7 +121,7 @@ export class ECIES {
       sharedMacData = Uint8Array.from([])
     }
     const tag = Uint8Array.from(
-      crypto.createHmac('sha256', mkey).update(concatBytes(dataIV, sharedMacData)).digest(),
+      crypto.createHmac('sha256', mKey).update(concatBytes(dataIV, sharedMacData)).digest(),
     )
 
     const publicKey = secp256k1.getPublicKey(privateKey, false)
@@ -145,14 +144,14 @@ export class ECIES {
     const x = ecdhX(publicKey, this._privateKey)
     const key = concatKDF(x, 32)
     const ekey = key.subarray(0, 16) // encryption key
-    const mkey = Uint8Array.from(crypto.createHash('sha256').update(key.subarray(16, 32)).digest()) // MAC key
+    const mKey = Uint8Array.from(crypto.createHash('sha256').update(key.subarray(16, 32)).digest()) // MAC key
 
     // check the tag
     if (!sharedMacData) {
       sharedMacData = Uint8Array.from([])
     }
     const _tag = crypto
-      .createHmac('sha256', mkey)
+      .createHmac('sha256', mKey)
       .update(concatBytes(dataIV, sharedMacData))
       .digest()
     assertEq(_tag, tag, 'should have valid tag', debug)

--- a/packages/devp2p/src/util.ts
+++ b/packages/devp2p/src/util.ts
@@ -1,4 +1,3 @@
-// cspell:ignore Fedor Indutny
 import { RLP } from '@ethereumjs/rlp'
 import { bytesToHex, bytesToUnprefixedHex, concatBytes, equalsBytes } from '@ethereumjs/util'
 import debug from 'debug'

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -1,4 +1,3 @@
-// cspell:ignore dests
 import { ConsensusAlgorithm } from '@ethereumjs/common'
 import {
   Account,
@@ -275,7 +274,9 @@ export class Interpreter {
         opCode = this._runState.code[programCounter]
         // Only run the jump destination analysis if `code` actually contains a JUMP/JUMPI/JUMPSUB opcode
         if (opCode === 0x56 || opCode === 0x57 || opCode === 0x5e) {
-          const { jumps, pushes, opcodesCached } = this._getValidJumpDests(this._runState.code)
+          const { jumps, pushes, opcodesCached } = this._getValidJumpDestinations(
+            this._runState.code,
+          )
           this._runState.validJumps = jumps
           this._runState.cachedPushes = pushes
           this._runState.shouldDoJumpAnalysis = false
@@ -494,7 +495,7 @@ export class Interpreter {
   }
 
   // Returns all valid jump and jumpsub destinations.
-  _getValidJumpDests(code: Uint8Array) {
+  _getValidJumpDestinations(code: Uint8Array) {
     const jumps = new Uint8Array(code.length).fill(0)
     const pushes: { [pc: number]: bigint } = {}
 

--- a/packages/evm/src/opcodes/util.ts
+++ b/packages/evm/src/opcodes/util.ts
@@ -173,7 +173,7 @@ export function subMemUsage(runState: RunState, offset: bigint, length: bigint, 
 
   const words = newMemoryWordCount
   const fee = common.param('memoryGas')
-  const quadCoefficient = common.param('quadCoefficientDivGas') // cspell:disable-line
+  const quadCoefficient = common.param('quadCoefficientDivGas')
   // words * 3 + words ^2 / 512
   let cost = words * fee + (words * words) / quadCoefficient
 

--- a/packages/evm/src/opcodes/util.ts
+++ b/packages/evm/src/opcodes/util.ts
@@ -173,7 +173,7 @@ export function subMemUsage(runState: RunState, offset: bigint, length: bigint, 
 
   const words = newMemoryWordCount
   const fee = common.param('memoryGas')
-  const quadCoefficient = common.param('quadCoeffDivGas') // cspell:disable-line
+  const quadCoefficient = common.param('quadCoefficientDivGas') // cspell:disable-line
   // words * 3 + words ^2 / 512
   let cost = words * fee + (words * words) / quadCoefficient
 

--- a/packages/evm/src/params.ts
+++ b/packages/evm/src/params.ts
@@ -1,4 +1,3 @@
-// cspell:ignore coeff
 import type { ParamsDict } from '@ethereumjs/common'
 
 export const paramsEVM: ParamsDict = {
@@ -29,7 +28,7 @@ export const paramsEVM: ParamsDict = {
     callNewAccountGas: 25000, // Paid for CALL when the destination address didn't exist prior
     selfdestructRefundGas: 24000, // Refunded following a selfdestruct operation
     memoryGas: 3, // Times the address of the (highest referenced byte in memory + 1). NOTE: referencing happens on read, write and in instructions such as RETURN and CALL
-    quadCoeffDivGas: 512, // Divisor for the quadratic particle of the memory cost equation
+    quadCoefficientDivGas: 512, // Divisor for the quadratic particle of the memory cost equation
     createDataGas: 200, //
     copyGas: 3, // Multiplied by the number of 32-byte words that are copied (round up) for any *COPY operation and added
     ecRecoverGas: 3000,

--- a/packages/evm/src/precompiles/05-modexp.ts
+++ b/packages/evm/src/precompiles/05-modexp.ts
@@ -1,4 +1,3 @@
-// cspell:ignore mult expmod
 import {
   BIGINT_0,
   BIGINT_1,
@@ -32,7 +31,7 @@ const BIGINT_199680 = BigInt(199680)
 const maxInt = BigInt(Number.MAX_SAFE_INTEGER)
 const maxSize = BigInt(2147483647) // @ethereumjs/util setLengthRight limitation
 
-function multComplexity(x: bigint): bigint {
+function multiplicationComplexity(x: bigint): bigint {
   let fac1
   let fac2
   if (x <= BIGINT_64) {
@@ -50,7 +49,7 @@ function multComplexity(x: bigint): bigint {
   }
 }
 
-function multComplexityEIP2565(x: bigint): bigint {
+function multiplicationComplexityEIP2565(x: bigint): bigint {
   const words = (x + BIGINT_7) / BIGINT_8
   return words * words
 }
@@ -90,7 +89,7 @@ function getAdjustedExponentLength(data: Uint8Array): bigint {
   return adjustedExpLen
 }
 
-export function expmod(a: bigint, power: bigint, modulo: bigint) {
+export function expMod(a: bigint, power: bigint, modulo: bigint) {
   if (power === BIGINT_0) {
     return BIGINT_1 % modulo
   }
@@ -130,9 +129,9 @@ export function precompile05(opts: PrecompileInput): ExecResult {
   const mEnd = mStart + mLen
 
   if (!opts.common.isActivatedEIP(2565)) {
-    gasUsed = (adjustedELen * multComplexity(maxLen)) / Gquaddivisor
+    gasUsed = (adjustedELen * multiplicationComplexity(maxLen)) / Gquaddivisor
   } else {
-    gasUsed = (adjustedELen * multComplexityEIP2565(maxLen)) / Gquaddivisor
+    gasUsed = (adjustedELen * multiplicationComplexityEIP2565(maxLen)) / Gquaddivisor
     if (gasUsed < BIGINT_200) {
       gasUsed = BIGINT_200
     }
@@ -181,7 +180,7 @@ export function precompile05(opts: PrecompileInput): ExecResult {
   if (M === BIGINT_0) {
     R = new Uint8Array()
   } else {
-    R = expmod(B, E, M)
+    R = expMod(B, E, M)
     if (R === BIGINT_0) {
       R = new Uint8Array()
     } else {

--- a/packages/evm/test/runCall.spec.ts
+++ b/packages/evm/test/runCall.spec.ts
@@ -1,4 +1,3 @@
-// cspell:ignore AACC AAAB
 import { Common, Hardfork, Mainnet, createCommonFromGethGenesis } from '@ethereumjs/common'
 import {
   Account,
@@ -696,7 +695,7 @@ describe('RunCall tests', () => {
       ['f1', 36600 + 7 * 3, '0x01'], // 36600 is CALL fee + 7 * 3 gas for 7 PUSH opcodes
       ['f2', 11600 + 7 * 3, '0x01'], // 11600 is CALLCODE fee + 7 * 3 gas for 7 PUSH opcodes
     ]) {
-      // Code to either CALL or CALLCODE into AACC empty contract, with value 1
+      // Code to either CALL or CALLCODE into AACC empty contract, with value 1 // cspell:disable-line
       // If enough gas is provided, then since nonzero value is sent, the gas limit
       // in the call(coded) contract will get the "bonus gas" stipend of 2300
       // Previously, we added this gas stipend to the current gas available (which is wrong)
@@ -718,7 +717,7 @@ describe('RunCall tests', () => {
       const gasLimit = gas.toString(16).padStart(4, '0')
 
       /***
-       * Bytecode for AAAB contract (used to call contract AAAA and stores result of call execution)
+       * Bytecode for AAAB contract (used to call contract AAAA and stores result of call execution) // cspell:disable-line
        * PUSH1 0x00
        * DUP1
        * DUP1

--- a/packages/rlp/src/index.ts
+++ b/packages/rlp/src/index.ts
@@ -1,4 +1,3 @@
-// cspell:ignore llength
 export type Input = string | number | bigint | Uint8Array | Array<Input> | null | undefined
 
 export type NestedUint8Array = Array<Uint8Array | NestedUint8Array>
@@ -99,7 +98,7 @@ export function decode(input: Input, stream = false): Uint8Array | NestedUint8Ar
 
 /** Decode an input with RLP */
 function _decode(input: Uint8Array): Decoded {
-  let length: number, llength: number, data: Uint8Array, innerRemainder: Uint8Array, d: Decoded
+  let length: number, lLength: number, data: Uint8Array, innerRemainder: Uint8Array, d: Decoded
   const decoded = []
   const firstByte = input[0]
 
@@ -132,19 +131,19 @@ function _decode(input: Uint8Array): Decoded {
   } else if (firstByte <= 0xbf) {
     // string is greater than 55 bytes long. A single byte with the value (0xb7 plus the length of the length),
     // followed by the length, followed by the string
-    llength = firstByte - 0xb6
-    if (input.length - 1 < llength) {
+    lLength = firstByte - 0xb6
+    if (input.length - 1 < lLength) {
       throw new Error('invalid RLP: not enough bytes for string length')
     }
-    length = decodeLength(safeSlice(input, 1, llength))
+    length = decodeLength(safeSlice(input, 1, lLength))
     if (length <= 55) {
       throw new Error('invalid RLP: expected string length to be greater than 55')
     }
-    data = safeSlice(input, llength, length + llength)
+    data = safeSlice(input, lLength, length + lLength)
 
     return {
       data,
-      remainder: input.subarray(length + llength),
+      remainder: input.subarray(length + lLength),
     }
   } else if (firstByte <= 0xf7) {
     // a list between 0-55 bytes long
@@ -162,17 +161,17 @@ function _decode(input: Uint8Array): Decoded {
     }
   } else {
     // a list over 55 bytes long
-    llength = firstByte - 0xf6
-    length = decodeLength(safeSlice(input, 1, llength))
+    lLength = firstByte - 0xf6
+    length = decodeLength(safeSlice(input, 1, lLength))
     if (length < 56) {
       throw new Error('invalid RLP: encoded list too short')
     }
-    const totalLength = llength + length
+    const totalLength = lLength + length
     if (totalLength > input.length) {
       throw new Error('invalid RLP: total length is larger than the data')
     }
 
-    innerRemainder = safeSlice(input, llength, totalLength)
+    innerRemainder = safeSlice(input, lLength, totalLength)
 
     while (innerRemainder.length) {
       d = _decode(innerRemainder)

--- a/packages/statemanager/src/cache/account.ts
+++ b/packages/statemanager/src/cache/account.ts
@@ -1,4 +1,3 @@
-// cspell:ignore dels
 import { bytesToUnprefixedHex } from '@ethereumjs/util'
 import { OrderedMap } from '@js-sdsl/ordered-map'
 import debugDefault from 'debug'
@@ -136,7 +135,7 @@ export class AccountCache extends Cache {
       })
     }
 
-    this._stats.dels += 1
+    this._stats.deletions += 1
   }
 
   /**
@@ -253,7 +252,7 @@ export class AccountCache extends Cache {
         reads: 0,
         hits: 0,
         writes: 0,
-        dels: 0,
+        deletions: 0,
       }
     }
     return stats

--- a/packages/statemanager/src/cache/cache.ts
+++ b/packages/statemanager/src/cache/cache.ts
@@ -1,4 +1,3 @@
-// cspell:ignore dels
 import debugDefault from 'debug'
 
 import type { Debugger } from 'debug'
@@ -13,7 +12,7 @@ export class Cache {
     reads: 0,
     hits: 0,
     writes: 0,
-    dels: 0,
+    deletions: 0,
   }
 
   /**

--- a/packages/statemanager/src/cache/code.ts
+++ b/packages/statemanager/src/cache/code.ts
@@ -1,4 +1,3 @@
-// cspell:ignore dels
 import { bytesToUnprefixedHex } from '@ethereumjs/util'
 import { OrderedMap } from '@js-sdsl/ordered-map'
 import debugDefault from 'debug'
@@ -134,7 +133,7 @@ export class CodeCache extends Cache {
       })
     }
 
-    this._stats.dels += 1
+    this._stats.deletions += 1
   }
 
   /**
@@ -253,7 +252,7 @@ export class CodeCache extends Cache {
         reads: 0,
         hits: 0,
         writes: 0,
-        dels: 0,
+        deletions: 0,
       }
     }
     return stats

--- a/packages/statemanager/src/cache/storage.ts
+++ b/packages/statemanager/src/cache/storage.ts
@@ -1,4 +1,3 @@
-// cspell:ignore dels
 import { bytesToUnprefixedHex, hexToBytes } from '@ethereumjs/util'
 import { OrderedMap } from '@js-sdsl/ordered-map'
 import debugDefault from 'debug'
@@ -166,7 +165,7 @@ export class StorageCache extends Cache {
       this._orderedMapCache!.setElement(addressHex, storageMap)
     }
 
-    this._stats.dels += 1
+    this._stats.deletions += 1
   }
 
   /**
@@ -330,7 +329,7 @@ export class StorageCache extends Cache {
         reads: 0,
         hits: 0,
         writes: 0,
-        dels: 0,
+        deletions: 0,
       }
     }
     return stats

--- a/packages/statemanager/test/rpcStateManager.spec.ts
+++ b/packages/statemanager/test/rpcStateManager.spec.ts
@@ -90,40 +90,40 @@ describe('RPC State Manager API tests', () => {
 
     assert.ok(state.getAccount(vitalikDotEth) !== undefined, 'vitalik.eth does exist')
 
-    const UNIERC20ContractAddress = createAddressFromString(
+    const UniswapERC20ContractAddress = createAddressFromString(
       '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
     )
-    const UNIContractCode = await state.getCode(UNIERC20ContractAddress)
+    const UNIContractCode = await state.getCode(UniswapERC20ContractAddress)
     assert.ok(UNIContractCode.length > 0, 'was able to retrieve UNI contract code')
 
-    await state.putCode(UNIERC20ContractAddress, UNIContractCode)
+    await state.putCode(UniswapERC20ContractAddress, UNIContractCode)
     assert.ok(
-      state['_caches'].code?.get(UNIERC20ContractAddress) !== undefined,
+      state['_caches'].code?.get(UniswapERC20ContractAddress) !== undefined,
       'UNI ERC20 contract code was found in cache',
     )
 
     const storageSlot = await state.getStorage(
-      UNIERC20ContractAddress,
+      UniswapERC20ContractAddress,
       setLengthLeft(bigIntToBytes(1n), 32),
     )
     assert.ok(storageSlot.length > 0, 'was able to retrieve storage slot 1 for the UNI contract')
 
     await expect(async () => {
-      await state.getStorage(UNIERC20ContractAddress, setLengthLeft(bigIntToBytes(1n), 31))
+      await state.getStorage(UniswapERC20ContractAddress, setLengthLeft(bigIntToBytes(1n), 31))
     }).rejects.toThrowError('Storage key must be 32 bytes long')
 
     await state.putStorage(
-      UNIERC20ContractAddress,
+      UniswapERC20ContractAddress,
       setLengthLeft(bigIntToBytes(2n), 32),
       utf8ToBytes('abcd'),
     )
     const slotValue = await state.getStorage(
-      UNIERC20ContractAddress,
+      UniswapERC20ContractAddress,
       setLengthLeft(bigIntToBytes(2n), 32),
     )
     assert.ok(equalsBytes(slotValue, utf8ToBytes('abcd')), 'should retrieve slot 2 value')
 
-    const dumpedStorage = await state.dumpStorage(UNIERC20ContractAddress)
+    const dumpedStorage = await state.dumpStorage(UniswapERC20ContractAddress)
     assert.deepEqual(dumpedStorage, {
       [bytesToUnprefixedHex(setLengthLeft(bigIntToBytes(1n), 32))]: '0xabcd',
       [bytesToUnprefixedHex(setLengthLeft(bigIntToBytes(2n), 32))]: bytesToHex(utf8ToBytes('abcd')),
@@ -137,7 +137,7 @@ describe('RPC State Manager API tests', () => {
     await state.checkpoint()
 
     await state.putStorage(
-      UNIERC20ContractAddress,
+      UniswapERC20ContractAddress,
       setLengthLeft(bigIntToBytes(2n), 32),
       new Uint8Array(0),
     )
@@ -161,7 +161,7 @@ describe('RPC State Manager API tests', () => {
     }
 
     const deletedSlot = await state.getStorage(
-      UNIERC20ContractAddress,
+      UniswapERC20ContractAddress,
       setLengthLeft(bigIntToBytes(2n), 32),
     )
 
@@ -180,7 +180,7 @@ describe('RPC State Manager API tests', () => {
     )
 
     const deletedSlotAfterRevert = await state.getStorage(
-      UNIERC20ContractAddress,
+      UniswapERC20ContractAddress,
       setLengthLeft(bigIntToBytes(2n), 32),
     )
 
@@ -190,14 +190,14 @@ describe('RPC State Manager API tests', () => {
       'slot deleted since last checkpoint should exist in storage cache after revert',
     )
 
-    const cacheStorage = await state.dumpStorage(UNIERC20ContractAddress)
+    const cacheStorage = await state.dumpStorage(UniswapERC20ContractAddress)
     assert.equal(
       2,
       Object.keys(cacheStorage).length,
       'should have 2 storage slots in cache before clear',
     )
-    await state.clearStorage(UNIERC20ContractAddress)
-    const clearedStorage = await state.dumpStorage(UNIERC20ContractAddress)
+    await state.clearStorage(UniswapERC20ContractAddress)
+    const clearedStorage = await state.dumpStorage(UniswapERC20ContractAddress)
     assert.deepEqual({}, clearedStorage, 'storage cache should be empty after clear')
 
     try {
@@ -211,7 +211,7 @@ describe('RPC State Manager API tests', () => {
     }
 
     assert.equal(
-      state['_caches'].account?.get(UNIERC20ContractAddress),
+      state['_caches'].account?.get(UniswapERC20ContractAddress),
       undefined,
       'should not have any code for contract after cache is reverted',
     )

--- a/packages/statemanager/test/rpcStateManager.spec.ts
+++ b/packages/statemanager/test/rpcStateManager.spec.ts
@@ -1,4 +1,3 @@
-// cspell:ignore Ierc
 import { createBlockFromJsonRpcProvider, createBlockFromRPC } from '@ethereumjs/block'
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { type EVMRunCallOpts, createEVM } from '@ethereumjs/evm'
@@ -91,40 +90,40 @@ describe('RPC State Manager API tests', () => {
 
     assert.ok(state.getAccount(vitalikDotEth) !== undefined, 'vitalik.eth does exist')
 
-    const UNIerc20ContractAddress = createAddressFromString(
+    const UNIERC20ContractAddress = createAddressFromString(
       '0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984',
     )
-    const UNIContractCode = await state.getCode(UNIerc20ContractAddress)
+    const UNIContractCode = await state.getCode(UNIERC20ContractAddress)
     assert.ok(UNIContractCode.length > 0, 'was able to retrieve UNI contract code')
 
-    await state.putCode(UNIerc20ContractAddress, UNIContractCode)
+    await state.putCode(UNIERC20ContractAddress, UNIContractCode)
     assert.ok(
-      state['_caches'].code?.get(UNIerc20ContractAddress) !== undefined,
+      state['_caches'].code?.get(UNIERC20ContractAddress) !== undefined,
       'UNI ERC20 contract code was found in cache',
     )
 
     const storageSlot = await state.getStorage(
-      UNIerc20ContractAddress,
+      UNIERC20ContractAddress,
       setLengthLeft(bigIntToBytes(1n), 32),
     )
     assert.ok(storageSlot.length > 0, 'was able to retrieve storage slot 1 for the UNI contract')
 
     await expect(async () => {
-      await state.getStorage(UNIerc20ContractAddress, setLengthLeft(bigIntToBytes(1n), 31))
+      await state.getStorage(UNIERC20ContractAddress, setLengthLeft(bigIntToBytes(1n), 31))
     }).rejects.toThrowError('Storage key must be 32 bytes long')
 
     await state.putStorage(
-      UNIerc20ContractAddress,
+      UNIERC20ContractAddress,
       setLengthLeft(bigIntToBytes(2n), 32),
       utf8ToBytes('abcd'),
     )
     const slotValue = await state.getStorage(
-      UNIerc20ContractAddress,
+      UNIERC20ContractAddress,
       setLengthLeft(bigIntToBytes(2n), 32),
     )
     assert.ok(equalsBytes(slotValue, utf8ToBytes('abcd')), 'should retrieve slot 2 value')
 
-    const dumpedStorage = await state.dumpStorage(UNIerc20ContractAddress)
+    const dumpedStorage = await state.dumpStorage(UNIERC20ContractAddress)
     assert.deepEqual(dumpedStorage, {
       [bytesToUnprefixedHex(setLengthLeft(bigIntToBytes(1n), 32))]: '0xabcd',
       [bytesToUnprefixedHex(setLengthLeft(bigIntToBytes(2n), 32))]: bytesToHex(utf8ToBytes('abcd')),
@@ -138,7 +137,7 @@ describe('RPC State Manager API tests', () => {
     await state.checkpoint()
 
     await state.putStorage(
-      UNIerc20ContractAddress,
+      UNIERC20ContractAddress,
       setLengthLeft(bigIntToBytes(2n), 32),
       new Uint8Array(0),
     )
@@ -162,7 +161,7 @@ describe('RPC State Manager API tests', () => {
     }
 
     const deletedSlot = await state.getStorage(
-      UNIerc20ContractAddress,
+      UNIERC20ContractAddress,
       setLengthLeft(bigIntToBytes(2n), 32),
     )
 
@@ -181,7 +180,7 @@ describe('RPC State Manager API tests', () => {
     )
 
     const deletedSlotAfterRevert = await state.getStorage(
-      UNIerc20ContractAddress,
+      UNIERC20ContractAddress,
       setLengthLeft(bigIntToBytes(2n), 32),
     )
 
@@ -191,14 +190,14 @@ describe('RPC State Manager API tests', () => {
       'slot deleted since last checkpoint should exist in storage cache after revert',
     )
 
-    const cacheStorage = await state.dumpStorage(UNIerc20ContractAddress)
+    const cacheStorage = await state.dumpStorage(UNIERC20ContractAddress)
     assert.equal(
       2,
       Object.keys(cacheStorage).length,
       'should have 2 storage slots in cache before clear',
     )
-    await state.clearStorage(UNIerc20ContractAddress)
-    const clearedStorage = await state.dumpStorage(UNIerc20ContractAddress)
+    await state.clearStorage(UNIERC20ContractAddress)
+    const clearedStorage = await state.dumpStorage(UNIERC20ContractAddress)
     assert.deepEqual({}, clearedStorage, 'storage cache should be empty after clear')
 
     try {
@@ -212,7 +211,7 @@ describe('RPC State Manager API tests', () => {
     }
 
     assert.equal(
-      state['_caches'].account?.get(UNIerc20ContractAddress),
+      state['_caches'].account?.get(UNIERC20ContractAddress),
       undefined,
       'should not have any code for contract after cache is reverted',
     )

--- a/packages/trie/src/util/encoding.ts
+++ b/packages/trie/src/util/encoding.ts
@@ -1,4 +1,3 @@
-// cspell:ignore bkey
 import { concatBytes, hexToBytes, toBytes, unprefixedHexToBytes } from '@ethereumjs/util'
 
 import { nibblesTypeToPackedBytes } from './nibbles.js'
@@ -130,12 +129,12 @@ export const nibbleTypeToByteType = (arr: Nibbles): Uint8Array => {
  * @returns Nibble typed nibble array
  */
 export const byteTypeToNibbleType = (key: Uint8Array): Nibbles => {
-  const bkey = toBytes(key)
+  const bKey = toBytes(key)
   const nibbles = [] as Nibbles
 
-  for (let i = 0; i < bkey.length; i++) {
+  for (let i = 0; i < bKey.length; i++) {
     const q = i
-    nibbles[q] = bkey[i] % 16
+    nibbles[q] = bKey[i] % 16
   }
 
   return nibbles

--- a/packages/trie/src/util/nibbles.ts
+++ b/packages/trie/src/util/nibbles.ts
@@ -1,4 +1,3 @@
-// cspell:ignore bkey
 import { toBytes } from '@ethereumjs/util'
 
 import type { Nibbles } from '../types.js'
@@ -9,14 +8,14 @@ import type { Nibbles } from '../types.js'
  * @param key
  */
 export function bytesToNibbles(key: Uint8Array): Nibbles {
-  const bkey = toBytes(key)
+  const bKey = toBytes(key)
   const nibbles = [] as Nibbles
 
-  for (let i = 0; i < bkey.length; i++) {
+  for (let i = 0; i < bKey.length; i++) {
     let q = i * 2
-    nibbles[q] = bkey[i] >> 4
+    nibbles[q] = bKey[i] >> 4
     ++q
-    nibbles[q] = bkey[i] % 16
+    nibbles[q] = bKey[i] % 16
   }
 
   return nibbles

--- a/packages/trie/test/proof.spec.ts
+++ b/packages/trie/test/proof.spec.ts
@@ -1,4 +1,3 @@
-// cspell:ignore aval
 import { RLP } from '@ethereumjs/rlp'
 import { bytesToUtf8, equalsBytes, setLengthLeft, utf8ToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
@@ -16,12 +15,12 @@ describe('simple merkle proofs generation and verification', () => {
     const trie = new Trie()
 
     await trie.put(utf8ToBytes('key1aa'), utf8ToBytes('0123456789012345678901234567890123456789xx'))
-    await trie.put(utf8ToBytes('key2bb'), utf8ToBytes('aval2'))
-    await trie.put(utf8ToBytes('key3cc'), utf8ToBytes('aval3'))
+    await trie.put(utf8ToBytes('key2bb'), utf8ToBytes('aVal2'))
+    await trie.put(utf8ToBytes('key3cc'), utf8ToBytes('aVal3'))
 
     let proof = await createMerkleProof(trie, utf8ToBytes('key2bb'))
     let val = await verifyTrieProof(utf8ToBytes('key2bb'), proof)
-    assert.equal(bytesToUtf8(val!), 'aval2')
+    assert.equal(bytesToUtf8(val!), 'aVal2')
 
     proof = await createMerkleProof(trie, utf8ToBytes('key1aa'))
     val = await verifyTrieProof(utf8ToBytes('key1aa'), proof)
@@ -73,7 +72,7 @@ describe('simple merkle proofs generation and verification', () => {
     val = await verifyTrieProof(myKey, proof)
     assert.equal(val, null, 'Expected value to be null')
     // now make the key non-null so the exclusion proof becomes invalid
-    await trie.put(myKey, utf8ToBytes('thisIsAValue'))
+    await trie.put(myKey, utf8ToBytes('thisIsaValue'))
     try {
       await createTrieFromProof(proof, { root: trie.root() })
       assert.fail(`expected error: 'The provided proof does not have the expected trie root'`)
@@ -113,9 +112,9 @@ describe('simple merkle proofs generation and verification', () => {
       utf8ToBytes('key1'),
       utf8ToBytes('0123456789012345678901234567890123456789Very_Long'),
     )
-    await trie.put(utf8ToBytes('key2bb'), utf8ToBytes('aval3'))
+    await trie.put(utf8ToBytes('key2bb'), utf8ToBytes('aVal3'))
     await trie.put(utf8ToBytes('key2'), utf8ToBytes('short'))
-    await trie.put(utf8ToBytes('key3cc'), utf8ToBytes('aval3'))
+    await trie.put(utf8ToBytes('key3cc'), utf8ToBytes('aVal3'))
     await trie.put(utf8ToBytes('key3'), utf8ToBytes('1234567890123456789012345678901'))
 
     let proof = await createMerkleProof(trie, utf8ToBytes('key1'))

--- a/packages/tx/test/types.ts
+++ b/packages/tx/test/types.ts
@@ -1,4 +1,3 @@
-// cspell:ignore Vitaliks
 export type ForkName =
   | 'London+3860'
   | 'London'
@@ -27,8 +26,9 @@ export interface TxData {
   s: string
 }
 
-// The type of each entry from ./ttTransactionTestEip155VitaliksTests.json
+// The type of each entry from ./ttTransactionTestEip155VitaliksTests.json // cspell:disable-line
 export interface VitaliksTestsDataEntry {
+  // cspell:disable-line
   blocknumber: string
   hash: string
   rlp: string

--- a/packages/tx/test/types.ts
+++ b/packages/tx/test/types.ts
@@ -27,8 +27,9 @@ export interface TxData {
 }
 
 // The type of each entry from ./ttTransactionTestEip155VitaliksTests.json // cspell:disable-line
+// cspell:disable
 export interface VitaliksTestsDataEntry {
-  // cspell:disable-line
+  // cspell:enable
   blocknumber: string
   hash: string
   rlp: string

--- a/packages/util/src/asyncEventEmitter.ts
+++ b/packages/util/src/asyncEventEmitter.ts
@@ -1,4 +1,3 @@
-// cspell:ignore patarapolw
 /**
  * Ported to Typescript from original implementation below:
  * https://github.com/ahultgren/async-eventemitter -- MIT licensed

--- a/packages/util/src/blobs.ts
+++ b/packages/util/src/blobs.ts
@@ -1,4 +1,3 @@
-// cspell:ignore pdata
 import { sha256 } from 'ethereum-cryptography/sha256.js'
 
 import { utf8ToBytes } from './bytes.js'
@@ -16,10 +15,10 @@ const MAX_USEFUL_BYTES_PER_TX = USEFUL_BYTES_PER_BLOB * MAX_BLOBS_PER_TX - 1
 const BLOB_SIZE = BYTES_PER_FIELD_ELEMENT * FIELD_ELEMENTS_PER_BLOB
 
 function get_padded(data: Uint8Array, blobs_len: number): Uint8Array {
-  const pdata = new Uint8Array(blobs_len * USEFUL_BYTES_PER_BLOB).fill(0)
-  pdata.set(data)
-  pdata[data.byteLength] = 0x80
-  return pdata
+  const pData = new Uint8Array(blobs_len * USEFUL_BYTES_PER_BLOB).fill(0)
+  pData.set(data)
+  pData[data.byteLength] = 0x80
+  return pData
 }
 
 function get_blob(data: Uint8Array): Uint8Array {
@@ -45,11 +44,11 @@ export const getBlobs = (input: string) => {
 
   const blobs_len = Math.ceil(len / USEFUL_BYTES_PER_BLOB)
 
-  const pdata = get_padded(data, blobs_len)
+  const pData = get_padded(data, blobs_len)
 
   const blobs: Uint8Array[] = []
   for (let i = 0; i < blobs_len; i++) {
-    const chunk = pdata.subarray(i * USEFUL_BYTES_PER_BLOB, (i + 1) * USEFUL_BYTES_PER_BLOB)
+    const chunk = pData.subarray(i * USEFUL_BYTES_PER_BLOB, (i + 1) * USEFUL_BYTES_PER_BLOB)
     const blob = get_blob(chunk)
     blobs.push(blob)
   }

--- a/packages/util/src/internal.ts
+++ b/packages/util/src/internal.ts
@@ -1,4 +1,3 @@
-// cspell:ignore nickdodson
 /*
 The MIT License
 

--- a/packages/util/test/account.spec.ts
+++ b/packages/util/test/account.spec.ts
@@ -498,8 +498,9 @@ describe('Utility Functions', () => {
     )
   })
 
+  // cspell:disable
   it('generateAddress wt.testh nonce 0 (special case)', () => {
-    // cspell:disable-line
+    // cspell:enable
     const addr = generateAddress(toBytes('0x990ccf8a0de58091c028d6ff76bb235ee67c1c39'), toBytes(0))
     assert.equal(
       bytesToHex(addr),
@@ -508,8 +509,9 @@ describe('Utility Functions', () => {
     )
   })
 
+  // cspell:disable
   it('generateAddress wt.testh non-buffer inputs', () => {
-    // cspell:disable-line
+    // cspell:enable
     assert.throws(
       function () {
         generateAddress(

--- a/packages/util/test/account.spec.ts
+++ b/packages/util/test/account.spec.ts
@@ -1,4 +1,3 @@
-// cspell:ignore testh sant testize
 import { RLP } from '@ethereumjs/rlp'
 import { assert, describe, it } from 'vitest'
 
@@ -279,13 +278,13 @@ describe('Utility Functions', () => {
     )
     assert.ok(
       isValidPublic(pubKey, true),
-      "shouldn't fail on SEC1 key wt.testh sant.testize enabled",
+      "shouldn't fail on SEC1 key wt.testh sant.testize enabled", // cspell:disable-line
     )
 
     pubKey = hexToBytes(
       '0x023a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d',
     )
-    assert.notOk(isValidPublic(pubKey), 'should fail wt.testh an invalid SEC1 public key')
+    assert.notOk(isValidPublic(pubKey), 'should fail wt.testh an invalid SEC1 public key') // cspell:disable-line
 
     pubKey = hexToBytes('0x03fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f')
     assert.notOk(isValidPublic(pubKey), 'should fail an invalid 33-byte public key')
@@ -303,13 +302,13 @@ describe('Utility Functions', () => {
     pubKey = hexToBytes('0x033a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a')
     assert.ok(
       isValidPublic(pubKey, true),
-      'should work wt.testh compressed keys wt.testh sant.testize enabled',
+      'should work wt.testh compressed keys wt.testh sant.testize enabled', // cspell:disable-line
     )
 
     pubKey = hexToBytes(
       '0x043a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d',
     )
-    assert.ok(isValidPublic(pubKey, true), 'should work wt.testh sant.testize enabled')
+    assert.ok(isValidPublic(pubKey, true), 'should work wt.testh sant.testize enabled') // cspell:disable-line
 
     pubKey = hexToBytes(
       '0x3a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d',
@@ -341,7 +340,7 @@ describe('Utility Functions', () => {
         ),
       ),
       pubKey,
-      'should work wt.testh an Ethereum public key',
+      'should work wt.testh an Ethereum public key', // cspell:disable-line
     )
 
     assert.equal(
@@ -353,7 +352,7 @@ describe('Utility Functions', () => {
         ),
       ),
       pubKey,
-      'should work wt.testh uncompressed SEC1 keys',
+      'should work wt.testh uncompressed SEC1 keys', // cspell:disable-line
     )
 
     assert.equal(
@@ -363,7 +362,7 @@ describe('Utility Functions', () => {
         ),
       ),
       pubKey,
-      'should work wt.testh compressed SEC1 keys',
+      'should work wt.testh compressed SEC1 keys', // cspell:disable-line
     )
 
     assert.throws(
@@ -500,6 +499,7 @@ describe('Utility Functions', () => {
   })
 
   it('generateAddress wt.testh nonce 0 (special case)', () => {
+    // cspell:disable-line
     const addr = generateAddress(toBytes('0x990ccf8a0de58091c028d6ff76bb235ee67c1c39'), toBytes(0))
     assert.equal(
       bytesToHex(addr),
@@ -509,6 +509,7 @@ describe('Utility Functions', () => {
   })
 
   it('generateAddress wt.testh non-buffer inputs', () => {
+    // cspell:disable-line
     assert.throws(
       function () {
         generateAddress(

--- a/packages/vm/test/api/runTx.spec.ts
+++ b/packages/vm/test/api/runTx.spec.ts
@@ -1,4 +1,3 @@
-// cspell:ignore Kintsugi
 import { createBlock, createBlockHeader } from '@ethereumjs/block'
 import { Blockchain, createBlockchain } from '@ethereumjs/blockchain'
 import { Common, Goerli, Hardfork, Mainnet, createCommonFromGethGenesis } from '@ethereumjs/common'

--- a/packages/wallet/src/hdkey.ts
+++ b/packages/wallet/src/hdkey.ts
@@ -1,3 +1,4 @@
+// cspell:ignore xprv xpub
 import { mnemonicToSeedSync } from 'ethereum-cryptography/bip39/index.js'
 import { HDKey } from 'ethereum-cryptography/hdkey.js'
 
@@ -28,7 +29,7 @@ export class EthereumHDKey {
   constructor(private readonly _hdkey: HDKey) {}
 
   /**
-   * Returns a BIP32 extended private key (xprv) // cspell:disable-line
+   * Returns a BIP32 extended private key (xprv)
    */
   public privateExtendedKey(): string {
     if (!this._hdkey.privateExtendedKey) {
@@ -38,7 +39,7 @@ export class EthereumHDKey {
   }
 
   /**
-   * Return a BIP32 extended public key (xpub) // cspell:disable-line
+   * Return a BIP32 extended public key (xpub)
    */
   public publicExtendedKey(): string {
     return this._hdkey.publicExtendedKey

--- a/packages/wallet/src/hdkey.ts
+++ b/packages/wallet/src/hdkey.ts
@@ -1,4 +1,3 @@
-// cspell:ignore xprv xpub
 import { mnemonicToSeedSync } from 'ethereum-cryptography/bip39/index.js'
 import { HDKey } from 'ethereum-cryptography/hdkey.js'
 
@@ -29,7 +28,7 @@ export class EthereumHDKey {
   constructor(private readonly _hdkey: HDKey) {}
 
   /**
-   * Returns a BIP32 extended private key (xprv)
+   * Returns a BIP32 extended private key (xprv) // cspell:disable-line
    */
   public privateExtendedKey(): string {
     if (!this._hdkey.privateExtendedKey) {
@@ -39,7 +38,7 @@ export class EthereumHDKey {
   }
 
   /**
-   * Return a BIP32 extended public key (xpub)
+   * Return a BIP32 extended public key (xpub) // cspell:disable-line
    */
   public publicExtendedKey(): string {
     return this._hdkey.publicExtendedKey


### PR DESCRIPTION
This PR removes almost all `cspell:ignore` on top of script files.

Notes:

- Excluded `./packages/client/archive` for cspell. Once we reuse it, it will automatically get into the spell check pool
- Did not remove `cspell:ignore` in wallet, because I don't know what those values mean, and I don't want to touch the wallet code

TODO

- [x] I realized that there might be `// cspell` comments into the docs of methods/classes, this will thus also end up in the end doc. Need to figure out how to fix this, since wrapping the entire comment in `cspell:disable` an then `cspell:enable` will effectively disable the spell check for those docs which is not what we want.