### PR TITLE
verkle: extract static constructor

### DIFF
--- a/packages/verkle/src/constructors.ts
+++ b/packages/verkle/src/constructors.ts
@@ -1,0 +1,41 @@
+import { KeyEncoding, MapDB, ValueEncoding } from '@ethereumjs/util'
+import { loadVerkleCrypto } from 'verkle-cryptography-wasm'
+
+import { ROOT_DB_KEY } from './types.js'
+import { VerkleTree } from './verkleTree.js'
+
+import type { VerkleTreeOpts } from './types.js'
+
+export async function createVerkleTree(opts?: VerkleTreeOpts) {
+  const key = ROOT_DB_KEY
+
+  if (opts?.db !== undefined && opts?.useRootPersistence === true) {
+    if (opts?.root === undefined) {
+      opts.root = await opts?.db.get(key, {
+        keyEncoding: KeyEncoding.Bytes,
+        valueEncoding: ValueEncoding.Bytes,
+      })
+    } else {
+      await opts?.db.put(key, opts.root, {
+        keyEncoding: KeyEncoding.Bytes,
+        valueEncoding: ValueEncoding.Bytes,
+      })
+    }
+  }
+
+  if (opts?.verkleCrypto === undefined) {
+    const verkleCrypto = await loadVerkleCrypto()
+    if (opts === undefined)
+      opts = {
+        verkleCrypto,
+        db: new MapDB<Uint8Array, Uint8Array>(),
+      }
+    else {
+      opts.verkleCrypto = verkleCrypto
+    }
+  }
+
+  const trie = new VerkleTree(opts)
+  await trie['_createRootNode']()
+  return trie
+}

--- a/packages/verkle/src/index.ts
+++ b/packages/verkle/src/index.ts
@@ -1,3 +1,4 @@
+export * from './constructors.js'
 export * from './db/index.js'
 export * from './node/index.js'
 export * from './types.js'

--- a/packages/verkle/src/verkleTree.ts
+++ b/packages/verkle/src/verkleTree.ts
@@ -9,8 +9,6 @@ import {
 } from '@ethereumjs/util'
 import debug from 'debug'
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { createVerkleTree } from './constructors.js'
 import { CheckpointDB } from './db/checkpoint.js'
 import { InternalNode } from './node/internalNode.js'
 import { LeafNode } from './node/leafNode.js'
@@ -23,6 +21,8 @@ import {
   type VerkleTreeOptsWithDefaults,
 } from './types.js'
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { createVerkleTree } from './constructors.js' // Imported so intellisense can display docs
 import type { DB, PutBatch, VerkleCrypto } from '@ethereumjs/util'
 import type { Debugger } from 'debug'
 interface Path {

--- a/packages/verkle/src/verkleTree.ts
+++ b/packages/verkle/src/verkleTree.ts
@@ -1,8 +1,6 @@
 import {
-  KeyEncoding,
   Lock,
   MapDB,
-  ValueEncoding,
   bytesToHex,
   equalsBytes,
   intToHex,
@@ -10,8 +8,9 @@ import {
   zeros,
 } from '@ethereumjs/util'
 import debug from 'debug'
-import { loadVerkleCrypto } from 'verkle-cryptography-wasm'
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { createVerkleTree } from './constructors.js'
 import { CheckpointDB } from './db/checkpoint.js'
 import { InternalNode } from './node/internalNode.js'
 import { LeafNode } from './node/leafNode.js'
@@ -62,7 +61,7 @@ export class VerkleTree {
    * Creates a new verkle tree.
    * @param opts Options for instantiating the verkle tree
    *
-   * Note: in most cases, the static {@link VerkleTree.create} constructor should be used.  It uses the same API but provides sensible defaults
+   * Note: in most cases, the static {@link createVerkleTree} constructor should be used.  It uses the same API but provides sensible defaults
    */
   constructor(opts?: VerkleTreeOpts) {
     if (opts !== undefined) {
@@ -103,40 +102,6 @@ export class VerkleTree {
     || Persistent: ${this._opts.useRootPersistence}
     || CacheSize: ${this._opts.cacheSize}
     || ----------------`)
-  }
-
-  static async create(opts?: VerkleTreeOpts) {
-    const key = ROOT_DB_KEY
-
-    if (opts?.db !== undefined && opts?.useRootPersistence === true) {
-      if (opts?.root === undefined) {
-        opts.root = await opts?.db.get(key, {
-          keyEncoding: KeyEncoding.Bytes,
-          valueEncoding: ValueEncoding.Bytes,
-        })
-      } else {
-        await opts?.db.put(key, opts.root, {
-          keyEncoding: KeyEncoding.Bytes,
-          valueEncoding: ValueEncoding.Bytes,
-        })
-      }
-    }
-
-    if (opts?.verkleCrypto === undefined) {
-      const verkleCrypto = await loadVerkleCrypto()
-      if (opts === undefined)
-        opts = {
-          verkleCrypto,
-          db: new MapDB<Uint8Array, Uint8Array>(),
-        }
-      else {
-        opts.verkleCrypto = verkleCrypto
-      }
-    }
-
-    const trie = new VerkleTree(opts)
-    await trie._createRootNode()
-    return trie
   }
 
   database(db?: DB<Uint8Array, Uint8Array>) {

--- a/packages/verkle/test/verkle.spec.ts
+++ b/packages/verkle/test/verkle.spec.ts
@@ -109,13 +109,13 @@ describe('Verkle tree', () => {
       '0x318dfa512b6f3237a2d4763cf49bf26de3b617fb0cabe38a97807a5549df4d02',
       // A key with a partially matching stem 0x318dfa51 to above key
       '0x318dfa513b6f3237a2d4763cf49bf26de3b617fb0cabe38a97807a5549df4d02',
-    ]
+    ] as PrefixedHexString[]
     const values = [
       '0x320122e8584be00d000000000000000000000000000000000000000000000000',
       '0x0000000000000000000000000000000000000000000000000000000000000001',
       '0x0000000000000000000000000000000000000000000000000000000000000000',
       '0x0300000000000000000000000000000000000000000000000000000000000000',
-    ]
+    ] as PrefixedHexString[]
     const trie = await createVerkleTree({
       verkleCrypto,
       db: new MapDB<Uint8Array, Uint8Array>(),
@@ -220,13 +220,13 @@ describe('Verkle tree', () => {
       '0x318dfa512b6f3237a2d4763cf49bf26de3b617fb0cabe38a97807a5549df4d02',
       // A key with a partially matching stem 0x318dfa51 to above key
       '0x318dfa513b6f3237a2d4763cf49bf26de3b617fb0cabe38a97807a5549df4d02',
-    ]
+    ] as PrefixedHexString[]
     const values = [
       '0x320122e8584be00d000000000000000000000000000000000000000000000000',
       '0x0000000000000000000000000000000000000000000000000000000000000001',
       '0x0000000000000000000000000000000000000000000000000000000000000000',
       '0x0300000000000000000000000000000000000000000000000000000000000000',
-    ]
+    ] as PrefixedHexString[]
     const trie = await createVerkleTree({
       verkleCrypto,
       db: new MapDB<Uint8Array, Uint8Array>(),
@@ -249,7 +249,9 @@ describe('Verkle tree', () => {
     assert.deepEqual(await trie.get(hexToBytes(keys[0])), hexToBytes(values[0]))
   })
   it('should put zeros in leaf node when del called with stem that was not in the trie before', async () => {
-    const keys = ['0x318dea512b6f3237a2d4763cf49bf26de3b617fb0cabe38a97807a5549df4d01']
+    const keys = [
+      '0x318dea512b6f3237a2d4763cf49bf26de3b617fb0cabe38a97807a5549df4d01',
+    ] as PrefixedHexString[]
 
     const trie = await createVerkleTree({
       verkleCrypto,

--- a/packages/verkle/test/verkle.spec.ts
+++ b/packages/verkle/test/verkle.spec.ts
@@ -7,9 +7,9 @@ import {
   LeafNode,
   VerkleLeafNodeValue,
   VerkleNodeType,
+  createVerkleTree,
   decodeNode,
 } from '../src/index.js'
-import { VerkleTree } from '../src/verkleTree.js'
 
 import type { VerkleNode } from '../src/index.js'
 import type { PrefixedHexString, VerkleCrypto } from '@ethereumjs/util'
@@ -67,7 +67,7 @@ describe('Verkle tree', () => {
       '0x318dea512b6f3237a2d4763cf49bf26de3b617fb0cabe38a97807a5549df4d04',
     ].map((key) => hexToBytes(key as PrefixedHexString))
 
-    const tree = await VerkleTree.create({
+    const tree = await createVerkleTree({
       verkleCrypto,
       db: new MapDB<Uint8Array, Uint8Array>(),
     })
@@ -116,7 +116,7 @@ describe('Verkle tree', () => {
       '0x0000000000000000000000000000000000000000000000000000000000000000',
       '0x0300000000000000000000000000000000000000000000000000000000000000',
     ]
-    const trie = await VerkleTree.create({
+    const trie = await createVerkleTree({
       verkleCrypto,
       db: new MapDB<Uint8Array, Uint8Array>(),
     })
@@ -227,7 +227,7 @@ describe('Verkle tree', () => {
       '0x0000000000000000000000000000000000000000000000000000000000000000',
       '0x0300000000000000000000000000000000000000000000000000000000000000',
     ]
-    const trie = await VerkleTree.create({
+    const trie = await createVerkleTree({
       verkleCrypto,
       db: new MapDB<Uint8Array, Uint8Array>(),
     })
@@ -251,7 +251,7 @@ describe('Verkle tree', () => {
   it('should put zeros in leaf node when del called with stem that was not in the trie before', async () => {
     const keys = ['0x318dea512b6f3237a2d4763cf49bf26de3b617fb0cabe38a97807a5549df4d01']
 
-    const trie = await VerkleTree.create({
+    const trie = await createVerkleTree({
       verkleCrypto,
       db: new MapDB<Uint8Array, Uint8Array>(),
     })


### PR DESCRIPTION
ref issue: #3560

**VerkleTree:**
moves state `VerkleTree.create` to 'constructors.ts' 
renames it to `createVerkleTree`