### PR TITLE
Ensure TransientStorage cleanups after Tx-level contract creation

### DIFF
--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -704,6 +704,10 @@ export class EVM implements EVMInterface {
       }
     }
 
+    if (message.depth === 0) {
+      this.postMessageCleanup()
+    }
+
     return {
       createdAddress: message.to,
       execResult: result,

--- a/packages/evm/test/transientStorage.spec.ts
+++ b/packages/evm/test/transientStorage.spec.ts
@@ -1,6 +1,14 @@
-import { createAddressFromString } from '@ethereumjs/util'
+import {
+  createAddressFromString,
+  createZeroAddress,
+  equalsBytes,
+  hexToBytes,
+  setLengthLeft,
+  unpadBytes,
+} from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
+import { createEVM } from '../src/index.js'
 import { TransientStorage } from '../src/transientStorage.js'
 
 describe('Transient Storage', () => {
@@ -175,5 +183,39 @@ describe('Transient Storage', () => {
     assert.deepEqual(transientStorage.get(address, key), value2)
     transientStorage.revert()
     assert.deepEqual(transientStorage.get(address, key), value1)
+  })
+
+  it('should cleanup after a message create', async () => {
+    const evm = await createEVM()
+    // PUSH 1 PUSH 1 TSTORE
+    const code = hexToBytes('0x600160015D')
+    const keyBuf = setLengthLeft(new Uint8Array([1]), 32)
+    const result = await evm.runCall({
+      data: code,
+      gasLimit: BigInt(100_000),
+    })
+    const created = result.createdAddress!
+    const tstored = evm.transientStorage.get(created, keyBuf)
+    assert.ok(
+      equalsBytes(unpadBytes(tstored), new Uint8Array()),
+      'Transient stoarge has been cleared',
+    )
+  })
+
+  it('should cleanup after a message call', async () => {
+    const evm = await createEVM()
+    const contractAddress = createZeroAddress()
+    // PUSH 1 PUSH 1 TSTORE
+    const code = hexToBytes('0x600160015D')
+    await evm.stateManager.putCode(contractAddress, code)
+    const keyBuf = setLengthLeft(new Uint8Array([1]), 32)
+    await evm.runCall({
+      gasLimit: BigInt(100_000),
+    })
+    const tstored = evm.transientStorage.get(contractAddress, keyBuf)
+    assert.ok(
+      equalsBytes(unpadBytes(tstored), new Uint8Array()),
+      'Transient stoarge has been cleared',
+    )
   })
 })

--- a/packages/evm/test/transientStorage.spec.ts
+++ b/packages/evm/test/transientStorage.spec.ts
@@ -195,10 +195,10 @@ describe('Transient Storage', () => {
       gasLimit: BigInt(100_000),
     })
     const created = result.createdAddress!
-    const tstored = evm.transientStorage.get(created, keyBuf)
+    const stored = evm.transientStorage.get(created, keyBuf)
     assert.ok(
-      equalsBytes(unpadBytes(tstored), new Uint8Array()),
-      'Transient stoarge has been cleared',
+      equalsBytes(unpadBytes(stored), new Uint8Array()),
+      'Transient storage has been cleared',
     )
   })
 
@@ -212,10 +212,10 @@ describe('Transient Storage', () => {
     await evm.runCall({
       gasLimit: BigInt(100_000),
     })
-    const tstored = evm.transientStorage.get(contractAddress, keyBuf)
+    const stored = evm.transientStorage.get(contractAddress, keyBuf)
     assert.ok(
-      equalsBytes(unpadBytes(tstored), new Uint8Array()),
-      'Transient stoarge has been cleared',
+      equalsBytes(unpadBytes(stored), new Uint8Array()),
+      'Transient storage has been cleared',
     )
   })
 })


### PR DESCRIPTION
Fixes a Transient Storage [EIP 1153](https://eips.ethereum.org/EIPS/eip-1153) bug related to not clearing Transient Storage after creating a contract at tx-level. Thanks @yann300 :smile: 