### PR TITLE
monorepo: skip typecheck for node modules

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -13,6 +13,7 @@
     "downlevelIteration": true,
     "strict": true,
     "target": "es2020",
-    "lib": ["ES2020", "DOM"]
+    "lib": ["ES2020", "DOM"],
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
When running typescript's typecheck (npm run `tsc`), some internal errors from node_modules show up, which is a blocker to eventually adding this to the CI. This options skips node_modules internal typechecking 