### PR TITLE
Make logging consistent

### DIFF
--- a/packages/client/src/sync/fetcher/accountfetcher.ts
+++ b/packages/client/src/sync/fetcher/accountfetcher.ts
@@ -136,11 +136,12 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
     const origin = this.getOrigin(syncRange)
     const limit = this.getLimit(syncRange)
 
-    this.debug(
-      `Account fetcher instantiated root=${short(this.root)} origin=${short(origin)} limit=${short(
-        limit,
-      )} destroyWhenDone=${this.destroyWhenDone}`,
-    )
+    this.DEBUG &&
+      this.debug(
+        `Account fetcher instantiated root=${short(this.root)} origin=${short(origin)} limit=${short(
+          limit,
+        )} destroyWhenDone=${this.destroyWhenDone}`,
+      )
   }
 
   async blockingFetch(): Promise<boolean> {
@@ -302,11 +303,12 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
     origin: Uint8Array,
     { accounts, proof }: { accounts: AccountData[]; proof: Uint8Array[] },
   ): Promise<boolean> {
-    this.debug(
-      `verifyRangeProof accounts:${accounts.length} first=${bytesToHex(
-        accounts[0].hash,
-      )} last=${short(accounts[accounts.length - 1].hash)}`,
-    )
+    this.DEBUG &&
+      this.debug(
+        `verifyRangeProof accounts:${accounts.length} first=${bytesToHex(
+          accounts[0].hash,
+        )} last=${short(accounts[accounts.length - 1].hash)}`,
+      )
 
     for (let i = 0; i < accounts.length - 1; i++) {
       // ensure the range is monotonically increasing
@@ -382,7 +384,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
 
     if (this.highestKnownHash && compareBytes(limit, this.highestKnownHash) < 0) {
       // skip this job and don't rerequest it if it's limit is lower than the highest known key hash
-      this.debug(`skipping request with limit lower than highest known hash`)
+      this.DEBUG && this.debug(`skipping request with limit lower than highest known hash`)
       return Object.assign([], [{ skipped: true }], { completed: true })
     }
 
@@ -415,12 +417,12 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
           // if proof is false, reject corrupt peer
           if (isMissingRightRange !== false) return undefined
         } catch (e) {
-          this.debug(e)
+          this.DEBUG && this.debug(e)
           // if proof is false, reject corrupt peer
           return undefined
         }
 
-        this.debug(`Data for last range has been received`)
+        this.DEBUG && this.debug(`Data for last range has been received`)
         // response contains empty object so that task can be terminated in store phase and not reenqueued
         return Object.assign([], [Object.create(null)], { completed: true })
       }
@@ -436,11 +438,12 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
       // Check if there is any pending data to be synced to the right
       let completed: boolean
       if (isMissingRightRange && this.isMissingRightRange(limit, rangeResult)) {
-        this.debug(
-          `Peer ${peerInfo} returned missing right range account=${bytesToHex(
-            rangeResult.accounts[rangeResult.accounts.length - 1].hash,
-          )} limit=${bytesToHex(limit)}`,
-        )
+        this.DEBUG &&
+          this.debug(
+            `Peer ${peerInfo} returned missing right range account=${bytesToHex(
+              rangeResult.accounts[rangeResult.accounts.length - 1].hash,
+            )} limit=${bytesToHex(limit)}`,
+          )
         completed = false
       } else {
         completed = true
@@ -487,7 +490,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
    * @param result fetch result
    */
   async store(result: AccountData[]): Promise<void> {
-    this.debug(`Stored ${result.length} accounts in account trie`)
+    this.DEBUG && this.debug(`Stored ${result.length} accounts in account trie`)
 
     if (JSON.stringify(result[0]) === JSON.stringify({ skipped: true })) {
       // return without storing to skip this task
@@ -495,7 +498,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
     }
     if (JSON.stringify(result[0]) === JSON.stringify(Object.create(null))) {
       // TODO fails to handle case where there is a proof of non existence and returned accounts for last requested range
-      this.debug('Final range received with no elements remaining to the right')
+      this.DEBUG && this.debug('Final range received with no elements remaining to the right')
 
       await this.accountTrie.persistRoot()
       this.snapFetchersCompleted(AccountFetcher, this.accountTrie.root())
@@ -579,7 +582,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
     debugStr += ` limit=${short(
       setLengthLeft(bigIntToBytes(startedWith + pushedCount - BIGINT_1), 32),
     )}`
-    this.debug(`Created new tasks num=${tasks.length} ${debugStr}`)
+    this.DEBUG && this.debug(`Created new tasks num=${tasks.length} ${debugStr}`)
     return tasks
   }
 
@@ -602,7 +605,7 @@ export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData>
       const origin = this.getOrigin(pendingRange)
       const limit = this.getLimit(pendingRange)
 
-      this.debug(`Fetcher pending with origin=${short(origin)} limit=${short(limit)}`)
+      this.DEBUG && this.debug(`Fetcher pending with origin=${short(origin)} limit=${short(limit)}`)
       const tasks = this.tasks()
       for (const task of tasks) {
         this.enqueueTask(task)

--- a/packages/client/src/sync/fetcher/blockfetcher.ts
+++ b/packages/client/src/sync/fetcher/blockfetcher.ts
@@ -53,7 +53,7 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
     })
     if (!Array.isArray(headersResult) || headersResult[1].length === 0) {
       // Catch occasional null or empty responses
-      this.debug(`Peer ${peerInfo} returned no headers for blocks=${blocksRange}`)
+      this.DEBUG && this.debug(`Peer ${peerInfo} returned no headers for blocks=${blocksRange}`)
       return []
     }
     const headers = headersResult[1]
@@ -64,13 +64,14 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
       bodiesResult[1].length === 0
     ) {
       // Catch occasional null or empty responses
-      this.debug(`Peer ${peerInfo} returned no bodies for blocks=${blocksRange}`)
+      this.DEBUG && this.debug(`Peer ${peerInfo} returned no bodies for blocks=${blocksRange}`)
       return []
     }
     const bodies = bodiesResult[1]
-    this.debug(
-      `Requested blocks=${blocksRange} from ${peerInfo} (received: ${headers.length} headers / ${bodies.length} bodies)`,
-    )
+    this.DEBUG &&
+      this.debug(
+        `Requested blocks=${blocksRange} from ${peerInfo} (received: ${headers.length} headers / ${bodies.length} bodies)`,
+      )
     const blocks: Block[] = []
     for (const [i, [txsData, unclesData, withdrawalsData]] of bodies.entries()) {
       const header = headers[i]
@@ -81,9 +82,10 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
           !equalsBytes(header.withdrawalsRoot, KECCAK256_RLP) &&
           (withdrawalsData?.length ?? 0) === 0)
       ) {
-        this.debug(
-          `Requested block=${headers[i].number}} from peer ${peerInfo} missing non-empty txs=${txsData.length} or uncles=${unclesData.length} or withdrawals=${withdrawalsData?.length}`,
-        )
+        this.DEBUG &&
+          this.debug(
+            `Requested block=${headers[i].number}} from peer ${peerInfo} missing non-empty txs=${txsData.length} or uncles=${unclesData.length} or withdrawals=${withdrawalsData?.length}`,
+          )
         return []
       }
       const values: BlockBytes = [headers[i].raw(), txsData, unclesData]
@@ -99,9 +101,10 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
       await block.validateData(false, false)
       blocks.push(block)
     }
-    this.debug(
-      `Returning blocks=${blocksRange} from ${peerInfo} (received: ${headers.length} headers / ${bodies.length} bodies)`,
-    )
+    this.DEBUG &&
+      this.debug(
+        `Returning blocks=${blocksRange} from ${peerInfo} (received: ${headers.length} headers / ${bodies.length} bodies)`,
+      )
     return blocks
   }
 
@@ -120,7 +123,8 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
       } else if (result.length > 0 && result.length < job.task.count) {
         // Save partial result to re-request missing items.
         job.partialResult = result
-        this.debug(`Partial result received=${result.length} expected=${job.task.count}`)
+        this.DEBUG &&
+          this.debug(`Partial result received=${result.length} expected=${job.task.count}`)
       }
     }
     return
@@ -133,18 +137,20 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
   async store(blocks: Block[]) {
     try {
       const num = await this.chain.putBlocks(blocks)
-      this.debug(
-        `Fetcher results stored in blockchain (blocks num=${blocks.length} first=${
-          blocks[0]?.header.number
-        } last=${blocks[blocks.length - 1]?.header.number})`,
-      )
+      this.DEBUG &&
+        this.debug(
+          `Fetcher results stored in blockchain (blocks num=${blocks.length} first=${
+            blocks[0]?.header.number
+          } last=${blocks[blocks.length - 1]?.header.number})`,
+        )
       this.config.events.emit(Event.SYNC_FETCHED_BLOCKS, blocks.slice(0, num))
     } catch (e: any) {
-      this.debug(
-        `Error storing fetcher results in blockchain (blocks num=${blocks.length} first=${
-          blocks[0]?.header.number
-        } last=${blocks[blocks.length - 1]?.header.number}): ${e}`,
-      )
+      this.DEBUG &&
+        this.debug(
+          `Error storing fetcher results in blockchain (blocks num=${blocks.length} first=${
+            blocks[0]?.header.number
+          } last=${blocks[blocks.length - 1]?.header.number}): ${e}`,
+        )
       throw e
     }
   }

--- a/packages/client/src/sync/fetcher/blockfetcherbase.ts
+++ b/packages/client/src/sync/fetcher/blockfetcherbase.ts
@@ -44,6 +44,7 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
   count: bigint
 
   protected reverse: boolean
+  protected DEBUG: boolean
 
   /**
    * Create new block fetcher
@@ -51,13 +52,17 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
   constructor(options: BlockFetcherOptions) {
     super(options)
 
+    this.DEBUG =
+      typeof window === 'undefined' ? (process?.env?.DEBUG?.includes('ethjs') ?? false) : false
+
     this.chain = options.chain
     this.first = options.first
     this.count = options.count
     this.reverse = options.reverse ?? false
-    this.debug(
-      `Block fetcher instantiated interval=${this.interval} first=${this.first} count=${this.count} reverse=${this.reverse} destroyWhenDone=${this.destroyWhenDone}`,
-    )
+    this.DEBUG &&
+      this.debug(
+        `Block fetcher instantiated interval=${this.interval} first=${this.first} count=${this.count} reverse=${this.reverse} destroyWhenDone=${this.destroyWhenDone}`,
+      )
   }
 
   /**
@@ -92,7 +97,7 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
     }
 
     debugStr += ` count=${pushedCount} reverse=${this.reverse}`
-    this.debug(`Created new tasks num=${tasks.length} ${debugStr}`)
+    this.DEBUG && this.debug(`Created new tasks num=${tasks.length} ${debugStr}`)
     return tasks
   }
 
@@ -104,18 +109,20 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
       this.count > BIGINT_0 &&
       this.processed - this.finished < this.config.maxFetcherRequests
     ) {
-      this.debug(
-        `Fetcher pending with first=${this.first} count=${this.count} reverse=${this.reverse}`,
-      )
+      this.DEBUG &&
+        this.debug(
+          `Fetcher pending with first=${this.first} count=${this.count} reverse=${this.reverse}`,
+        )
       const tasks = this.tasks(this.first, this.count)
       for (const task of tasks) {
         this.enqueueTask(task)
       }
-      this.debug(`Enqueued num=${tasks.length} tasks`)
+      this.DEBUG && this.debug(`Enqueued num=${tasks.length} tasks`)
     } else {
-      this.debug(
-        `No new tasks enqueued in=${this.in.length} count=${this.count} processed=${this.processed} finished=${this.finished}`,
-      )
+      this.DEBUG &&
+        this.debug(
+          `No new tasks enqueued in=${this.in.length} count=${this.count} processed=${this.processed} finished=${this.finished}`,
+        )
     }
   }
 
@@ -198,9 +205,10 @@ export abstract class BlockFetcherBase<JobResult, StorageItem> extends Fetcher<
         )
       }
     }
-    this.debug(
-      `Enqueued tasks by number list num=${numberList.length} min=${min} bulkRequest=${bulkRequest} ${updateHeightStr}`,
-    )
+    this.DEBUG &&
+      this.debug(
+        `Enqueued tasks by number list num=${numberList.length} min=${min} bulkRequest=${bulkRequest} ${updateHeightStr}`,
+      )
     if (this.in.length === 0) {
       this.nextTasks()
     }

--- a/packages/client/src/sync/fetcher/bytecodefetcher.ts
+++ b/packages/client/src/sync/fetcher/bytecodefetcher.ts
@@ -64,9 +64,10 @@ export class ByteCodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
     this.debug = debug('client:ByteCodeFetcher')
     if (this.hashes.length > 0) {
       const fullJob = { task: { hashes: this.hashes } } as Job<JobTask, Uint8Array[], Uint8Array>
-      this.debug(
-        `Bytecode fetcher instantiated ${fullJob.task.hashes.length} hash requests destroyWhenDone=${this.destroyWhenDone}`,
-      )
+      this.DEBUG &&
+        this.debug(
+          `Bytecode fetcher instantiated ${fullJob.task.hashes.length} hash requests destroyWhenDone=${this.destroyWhenDone}`,
+        )
     }
   }
 
@@ -91,7 +92,8 @@ export class ByteCodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
     // 2. Properly implement ETH request IDs -> allow to call on non-idle in Peer Pool
     await peer?.latest()
 
-    this.debug(`requested code hashes: ${Array.from(task.hashes).map((h) => bytesToHex(h))}`)
+    this.DEBUG &&
+      this.debug(`requested code hashes: ${Array.from(task.hashes).map((h) => bytesToHex(h))}`)
 
     const rangeResult = await peer!.snap!.getByteCodes({
       hashes: Array.from(task.hashes),
@@ -102,7 +104,7 @@ export class ByteCodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
     // the requested data. For bytecode range queries that means the peer is not
     // yet synced.
     if (rangeResult === undefined || task.hashes.length < rangeResult.codes.length) {
-      this.debug(`Peer rejected bytecode request`)
+      this.DEBUG && this.debug(`Peer rejected bytecode request`)
       return undefined
     }
 
@@ -140,7 +142,8 @@ export class ByteCodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
 
     // requeue missed requests for fetching
     if (missingCodeHashes.length > 0) {
-      this.debug(`${missingCodeHashes.length} missed requests adding them to request backlog`)
+      this.DEBUG &&
+        this.debug(`${missingCodeHashes.length} missed requests adding them to request backlog`)
       this.hashes.push(...missingCodeHashes)
     }
     return Object.assign([], [receivedCodes], { completed: true })
@@ -192,7 +195,7 @@ export class ByteCodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
     this.fetcherDoneFlags.byteCodeFetcher.count =
       this.fetcherDoneFlags.byteCodeFetcher.first + BigInt(this.hashes.length)
 
-    this.debug(`Stored ${storeCount} bytecode in code trie`)
+    this.DEBUG && this.debug(`Stored ${storeCount} bytecode in code trie`)
   }
 
   /**
@@ -212,9 +215,10 @@ export class ByteCodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
     // weird method of tracking the count
     this.fetcherDoneFlags.byteCodeFetcher.count =
       this.fetcherDoneFlags.byteCodeFetcher.first + BigInt(this.hashes.length)
-    this.debug(
-      `Number of bytecode fetch requests added to fetcher queue: ${byteCodeRequestList.length}`,
-    )
+    this.DEBUG &&
+      this.debug(
+        `Number of bytecode fetch requests added to fetcher queue: ${byteCodeRequestList.length}`,
+      )
     this.nextTasks()
   }
 
@@ -228,16 +232,17 @@ export class ByteCodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
     while (tasks.length < maxTasks && this.hashes.length > 0) {
       tasks.push({ hashes: this.hashes.splice(0, max) })
     }
-    this.debug(`Created new tasks num=${tasks.length}`)
+    this.DEBUG && this.debug(`Created new tasks num=${tasks.length}`)
     return tasks
   }
 
   nextTasks(): void {
-    this.debug(`Entering nextTasks with hash request queue length of ${this.hashes.length}`)
-    this.debug('Bytecode requests in primary queue:')
+    this.DEBUG &&
+      this.debug(`Entering nextTasks with hash request queue length of ${this.hashes.length}`)
+    this.DEBUG && this.debug('Bytecode requests in primary queue:')
     for (const h of this.hashes) {
-      this.debug(`\tCode hash: ${bytesToHex(h)}`)
-      this.debug('\t---')
+      this.DEBUG && this.debug(`\tCode hash: ${bytesToHex(h)}`)
+      this.DEBUG && this.debug('\t---')
     }
     try {
       if (this.in.length === 0 && this.hashes.length > 0) {
@@ -246,10 +251,11 @@ export class ByteCodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
         for (const task of tasks) {
           this.enqueueTask(task, true)
         }
-        this.debug(`Fetcher pending with ${fullJob!.task.hashes.length} code hashes requested`)
+        this.DEBUG &&
+          this.debug(`Fetcher pending with ${fullJob!.task.hashes.length} code hashes requested`)
       }
     } catch (err) {
-      this.debug(err)
+      this.DEBUG && this.debug(err)
     }
   }
 

--- a/packages/client/src/sync/fetcher/headerfetcher.ts
+++ b/packages/client/src/sync/fetcher/headerfetcher.ts
@@ -89,18 +89,20 @@ export class HeaderFetcher extends BlockFetcherBase<BlockHeaderResult, BlockHead
   async store(headers: BlockHeader[]) {
     try {
       const num = await this.chain.putHeaders(headers)
-      this.debug(
-        `Fetcher results stored in blockchain (headers num=${headers.length} first=${
-          headers[0]?.number
-        } last=${headers[headers.length - 1]?.number})`,
-      )
+      this.DEBUG &&
+        this.debug(
+          `Fetcher results stored in blockchain (headers num=${headers.length} first=${
+            headers[0]?.number
+          } last=${headers[headers.length - 1]?.number})`,
+        )
       this.config.events.emit(Event.SYNC_FETCHED_HEADERS, headers.slice(0, num))
     } catch (e: any) {
-      this.debug(
-        `Error storing fetcher results in blockchain (headers num=${headers.length} first=${
-          headers[0]?.number
-        } last=${headers[headers.length - 1]?.number}): ${e}`,
-      )
+      this.DEBUG &&
+        this.debug(
+          `Error storing fetcher results in blockchain (headers num=${headers.length} first=${
+            headers[0]?.number
+          } last=${headers[headers.length - 1]?.number}): ${e}`,
+        )
       throw e
     }
   }

--- a/packages/client/src/sync/fetcher/reverseblockfetcher.ts
+++ b/packages/client/src/sync/fetcher/reverseblockfetcher.ts
@@ -36,25 +36,27 @@ export class ReverseBlockFetcher extends BlockFetcher {
   async store(blocks: Block[]) {
     try {
       const num = await this.skeleton.putBlocks(blocks)
-      this.debug(
-        `Fetcher results stored in skeleton chain (blocks num=${blocks.length} first=${
-          blocks[0]?.header.number
-        } last=${blocks[blocks.length - 1]?.header.number})`,
-      )
+      this.DEBUG &&
+        this.debug(
+          `Fetcher results stored in skeleton chain (blocks num=${blocks.length} first=${
+            blocks[0]?.header.number
+          } last=${blocks[blocks.length - 1]?.header.number})`,
+        )
       this.config.events.emit(Event.SYNC_FETCHED_BLOCKS, blocks.slice(0, num))
     } catch (e: any) {
       if (e === errSyncMerged) {
         // Tear down the syncer to restart from new subchain segments
-        this.debug('Skeleton subchains merged, restarting sync')
+        this.DEBUG && this.debug('Skeleton subchains merged, restarting sync')
         this.running = false
         this.clear()
         this.destroy()
       } else {
-        this.debug(
-          `Error storing fetcher results in skeleton chain (blocks num=${blocks.length} first=${
-            blocks[0]?.header.number
-          } last=${blocks[blocks.length - 1]?.header.number}): ${e}`,
-        )
+        this.DEBUG &&
+          this.debug(
+            `Error storing fetcher results in skeleton chain (blocks num=${blocks.length} first=${
+              blocks[0]?.header.number
+            } last=${blocks[blocks.length - 1]?.header.number}): ${e}`,
+          )
         throw e
       }
     }

--- a/packages/client/src/sync/fetcher/storagefetcher.ts
+++ b/packages/client/src/sync/fetcher/storagefetcher.ts
@@ -101,15 +101,16 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
       } as Job<JobTask, StorageData[][], StorageData[]>
       const origin = this.getOrigin(fullJob)
       const limit = this.getLimit(fullJob)
-      this.debug(
-        `Storage fetcher instantiated with ${
-          fullJob.task.storageRequests.length
-        } accounts requested and root=${short(this.root)} origin=${short(origin)} limit=${short(
-          limit,
-        )} destroyWhenDone=${this.destroyWhenDone}`,
-      )
+      this.DEBUG &&
+        this.debug(
+          `Storage fetcher instantiated with ${
+            fullJob.task.storageRequests.length
+          } accounts requested and root=${short(this.root)} origin=${short(origin)} limit=${short(
+            limit,
+          )} destroyWhenDone=${this.destroyWhenDone}`,
+        )
     } else if (this.storageRequests.length === 0) {
-      this.debug('Idle storage fetcher has been instantiated')
+      this.DEBUG && this.debug('Idle storage fetcher has been instantiated')
     }
   }
 
@@ -119,11 +120,12 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
     { slots, proof }: { slots: StorageData[]; proof: Uint8Array[] | undefined },
   ): Promise<boolean> {
     try {
-      this.debug(
-        `verifyRangeProof slots:${slots.length} first=${short(slots[0].hash)} last=${short(
-          slots[slots.length - 1].hash,
-        )}`,
-      )
+      this.DEBUG &&
+        this.debug(
+          `verifyRangeProof slots:${slots.length} first=${short(slots[0].hash)} last=${short(
+            slots[slots.length - 1].hash,
+          )}`,
+        )
       const keys = slots.map((slot: any) => slot.hash)
       const values = slots.map((slot: any) => slot.body)
       return await verifyTrieRangeProof(
@@ -139,7 +141,7 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
         },
       )
     } catch (err) {
-      this.debug(`verifyRangeProof failure: ${(err as Error).stack}`)
+      this.DEBUG && this.debug(`verifyRangeProof failure: ${(err as Error).stack}`)
       throw Error((err as Error).message)
     }
   }
@@ -171,7 +173,7 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
       }
       return setLengthLeft(origin, 32)
     } catch (e: any) {
-      this.debug(e)
+      this.DEBUG && this.debug(e)
     }
     return new Uint8Array(0)
   }
@@ -226,13 +228,14 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
     const origin = this.getOrigin(job)
     const limit = this.getLimit(job)
 
-    this.debug(`requested root: ${bytesToHex(this.root)}`)
-    this.debug(`requested origin: ${bytesToHex(origin)}`)
-    this.debug(`requested limit: ${bytesToHex(limit)}`)
-    this.debug(
-      `requested account hashes: ${task.storageRequests.map((req) => bytesToHex(req.accountHash))}`,
-    )
-    this.debug(`request is multi: ${job.task.multi}`)
+    this.DEBUG && this.debug(`requested root: ${bytesToHex(this.root)}`)
+    this.DEBUG && this.debug(`requested origin: ${bytesToHex(origin)}`)
+    this.DEBUG && this.debug(`requested limit: ${bytesToHex(limit)}`)
+    this.DEBUG &&
+      this.debug(
+        `requested account hashes: ${task.storageRequests.map((req) => bytesToHex(req.accountHash))}`,
+      )
+    this.DEBUG && this.debug(`request is multi: ${job.task.multi}`)
 
     // only single account requests need their highest known hash tracked since multiaccount requests
     // are guaranteed to not have any known hashes until they have been filled and switched over to a
@@ -243,7 +246,7 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
       )
       if (highestKnownHash && compareBytes(limit, highestKnownHash) < 0) {
         // skip this job and don't rerequest it if it's limit is lower than the highest known key hash
-        this.debug(`skipping request with limit lower than highest known hash`)
+        this.DEBUG && this.debug(`skipping request with limit lower than highest known hash`)
         return Object.assign([], [{ skipped: true }], { completed: true })
       }
     }
@@ -258,13 +261,14 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
 
     // Reject the response if the hash sets and slot sets don't match
     if (rangeResult === undefined || task.storageRequests.length < rangeResult.slots.length) {
-      this.debug(
-        `Slot set is larger than hash set: slotset ${
-          rangeResult?.slots !== undefined ? rangeResult.slots.length : 0
-        } hashset ${task.storageRequests.length} proofset ${
-          rangeResult?.proof !== undefined ? rangeResult.proof.length : 0
-        } `,
-      )
+      this.DEBUG &&
+        this.debug(
+          `Slot set is larger than hash set: slotset ${
+            rangeResult?.slots !== undefined ? rangeResult.slots.length : 0
+          } hashset ${task.storageRequests.length} proofset ${
+            rangeResult?.proof !== undefined ? rangeResult.proof.length : 0
+          } `,
+        )
       return undefined
     }
 
@@ -289,24 +293,24 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
           // if proof is false, reject corrupt peer
           if (isMissingRightRange !== false) return undefined
         } catch (e) {
-          this.debug(e)
+          this.DEBUG && this.debug(e)
           // if proof is false, reject corrupt peer
           return undefined
         }
 
-        this.debug(`Empty range was requested - Terminating task`)
+        this.DEBUG && this.debug(`Empty range was requested - Terminating task`)
         // response contains empty object so that task can be terminated in store phase and not reenqueued
         return Object.assign([], [Object.create(null) as any], { completed: true })
       }
-      this.debug(`Peer rejected storage request`)
+      this.DEBUG && this.debug(`Peer rejected storage request`)
       return undefined
     }
 
-    this.debug(`number of slot arrays returned: ${rangeResult.slots.length}`)
+    this.DEBUG && this.debug(`number of slot arrays returned: ${rangeResult.slots.length}`)
     for (let i = 0; i < rangeResult.slots.length; i++) {
-      this.debug(`number of slots in slot array ${i}: ${rangeResult.slots[i].length}`)
+      this.DEBUG && this.debug(`number of slots in slot array ${i}: ${rangeResult.slots[i].length}`)
     }
-    this.debug(`length of proof array: ${rangeResult.proof.length}`)
+    this.DEBUG && this.debug(`length of proof array: ${rangeResult.proof.length}`)
 
     const peerInfo = `id=${peer?.id.slice(0, 8)} address=${peer?.address}`
 
@@ -364,11 +368,12 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
               completed = true
             } else {
               if (this.isMissingRightRange(limit, rangeResult)) {
-                this.debug(
-                  `Peer ${peerInfo} returned missing right range Slot=${bytesToHex(
-                    rangeResult.slots[0][rangeResult.slots.length - 1].hash,
-                  )} limit=${bytesToHex(limit)}`,
-                )
+                this.DEBUG &&
+                  this.debug(
+                    `Peer ${peerInfo} returned missing right range Slot=${bytesToHex(
+                      rangeResult.slots[0][rangeResult.slots.length - 1].hash,
+                    )} limit=${bytesToHex(limit)}`,
+                  )
                 completed = false
               } else {
                 completed = true
@@ -377,11 +382,12 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
             return Object.assign([], [rangeResult.slots], { completed })
           }
           if (hasRightElement) {
-            this.debug(
-              `Account fragmented at ${bytesToHex(
-                highestReceivedhash,
-              )} as part of multiaccount fetch`,
-            )
+            this.DEBUG &&
+              this.debug(
+                `Account fragmented at ${bytesToHex(
+                  highestReceivedhash,
+                )} as part of multiaccount fetch`,
+              )
             this.fragmentedRequests.unshift({
               ...task.storageRequests[i],
               // start fetching from next hash after last slot hash of last account received
@@ -393,9 +399,10 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
           // due to response limit
           const ignoredRequests = task.storageRequests.slice(i + 1)
           if (ignoredRequests.length > 0) {
-            this.debug(
-              `Number of ignored account requests due to fragmentation: ${ignoredRequests.length}`,
-            )
+            this.DEBUG &&
+              this.debug(
+                `Number of ignored account requests due to fragmentation: ${ignoredRequests.length}`,
+              )
             this.storageRequests.push(...ignoredRequests)
           }
         }
@@ -467,9 +474,10 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
         return
       }
       if (JSON.stringify(result[0]) === JSON.stringify(Object.create(null))) {
-        this.debug(
-          'Empty result detected - Associated range requested was empty with no elements remaining to the right',
-        )
+        this.DEBUG &&
+          this.debug(
+            'Empty result detected - Associated range requested was empty with no elements remaining to the right',
+          )
         return
       }
       let slotCount = 0
@@ -492,9 +500,9 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
       this.fetcherDoneFlags.storageFetcher.first += BigInt(result[0].length)
       this.fetcherDoneFlags.storageFetcher.count =
         this.fetcherDoneFlags.storageFetcher.first + BigInt(this.storageRequests.length)
-      this.debug(`Stored ${slotCount} slot(s)`)
+      this.DEBUG && this.debug(`Stored ${slotCount} slot(s)`)
     } catch (err) {
-      this.debug(err)
+      this.DEBUG && this.debug(err)
       throw err
     }
   }
@@ -514,9 +522,10 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
     this.storageRequests.push(...storageRequestList)
     this.fetcherDoneFlags.storageFetcher.count =
       this.fetcherDoneFlags.storageFetcher.first + BigInt(this.storageRequests.length)
-    this.debug(
-      `Number of storage fetch requests added to fetcher queue: ${storageRequestList.length}`,
-    )
+    this.DEBUG &&
+      this.debug(
+        `Number of storage fetch requests added to fetcher queue: ${storageRequestList.length}`,
+      )
     this.nextTasks()
   }
 
@@ -539,9 +548,10 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
     let myFirst = first
     let myCount = count
     if (this.storageRequests.length > 0) {
-      this.debug(
-        `Number of accounts requested as a part of a multi-account request: ${this.storageRequests.length}`,
-      )
+      this.DEBUG &&
+        this.debug(
+          `Number of accounts requested as a part of a multi-account request: ${this.storageRequests.length}`,
+        )
       tasks.unshift({
         storageRequests: this.storageRequests, // TODO limit max number of accounts per single fetch request
         multi: true,
@@ -549,7 +559,7 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
       this.storageRequests = [] // greedily request as many account slots by requesting all known ones
       return tasks
     } else if (this.fragmentedRequests.length > 0) {
-      this.debug('Single account request is being initiated')
+      this.DEBUG && this.debug('Single account request is being initiated')
       storageRequest = this.fragmentedRequests.shift()
       whereFirstWas = storageRequest!.first
       startedWith = storageRequest!.first
@@ -612,27 +622,28 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
       })
     }
     debugStr += ` limit=${short(setLengthLeft(bigIntToBytes(startedWith + pushedCount), 32))}`
-    this.debug(`Created new tasks num=${tasks.length} ${debugStr}`)
+    this.DEBUG && this.debug(`Created new tasks num=${tasks.length} ${debugStr}`)
     return tasks
   }
 
   nextTasks(): void {
-    this.debug(
-      `Entering nextTasks with primary queue length of ${this.storageRequests.length} and secondary queue length of ${this.fragmentedRequests.length}`,
-    )
-    this.debug('Storage requests in primary queue:')
+    this.DEBUG &&
+      this.debug(
+        `Entering nextTasks with primary queue length of ${this.storageRequests.length} and secondary queue length of ${this.fragmentedRequests.length}`,
+      )
+    this.DEBUG && this.debug('Storage requests in primary queue:')
     for (const r of this.storageRequests) {
-      this.debug(`\tAccount hash: ${bytesToHex(r.accountHash)}`)
-      this.debug(`\tFirst: ${bigIntToHex(r.first)}`)
-      this.debug(`\tCount: ${bigIntToHex(r.count)}`)
-      this.debug('\t---')
+      this.DEBUG && this.debug(`\tAccount hash: ${bytesToHex(r.accountHash)}`)
+      this.DEBUG && this.debug(`\tFirst: ${bigIntToHex(r.first)}`)
+      this.DEBUG && this.debug(`\tCount: ${bigIntToHex(r.count)}`)
+      this.DEBUG && this.debug('\t---')
     }
-    this.debug('Storage requests in secondary queue:')
+    this.DEBUG && this.debug('Storage requests in secondary queue:')
     for (const r of this.fragmentedRequests) {
-      this.debug(`\tAccount hash: ${bytesToHex(r.accountHash)}`)
-      this.debug(`\tFirst: ${bigIntToHex(r.first)}`)
-      this.debug(`\tCount: ${bigIntToHex(r.count)}`)
-      this.debug('\t---')
+      this.DEBUG && this.debug(`\tAccount hash: ${bytesToHex(r.accountHash)}`)
+      this.DEBUG && this.debug(`\tFirst: ${bigIntToHex(r.first)}`)
+      this.DEBUG && this.debug(`\tCount: ${bigIntToHex(r.count)}`)
+      this.DEBUG && this.debug('\t---')
     }
     // this strategy is open to change, but currently, multi-account requests are greedily prioritized over fragmented requests
     try {
@@ -650,7 +661,7 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
             },
           } as Job<JobTask, StorageData[][], StorageData[]>
         } else {
-          this.debug('No requests left to queue')
+          this.DEBUG && this.debug('No requests left to queue')
           return
         }
         const origin = this.getOrigin(fullJob)
@@ -660,14 +671,15 @@ export class StorageFetcher extends Fetcher<JobTask, StorageData[][], StorageDat
         for (const task of tasks) {
           this.enqueueTask(task, true)
         }
-        this.debug(
-          `Fetcher pending with ${
-            fullJob!.task.storageRequests.length
-          } accounts requested and origin=${short(origin)} limit=${short(limit)}`,
-        )
+        this.DEBUG &&
+          this.debug(
+            `Fetcher pending with ${
+              fullJob!.task.storageRequests.length
+            } accounts requested and origin=${short(origin)} limit=${short(limit)}`,
+          )
       }
     } catch (err) {
-      this.debug(err)
+      this.DEBUG && this.debug(err)
     }
   }
 

--- a/packages/client/src/sync/fetcher/trienodefetcher.ts
+++ b/packages/client/src/sync/fetcher/trienodefetcher.ts
@@ -120,11 +120,12 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
       nodeParentHash: '', // root node does not have a parent
     } as NodeRequestData)
 
-    this.debug(
-      `Trie node fetcher instantiated with ${this.pathToNodeRequestData.size()} node requests destroyWhenDone=${
-        this.destroyWhenDone
-      }`,
-    )
+    this.DEBUG &&
+      this.debug(
+        `Trie node fetcher instantiated with ${this.pathToNodeRequestData.size()} node requests destroyWhenDone=${
+          this.destroyWhenDone
+        }`,
+      )
   }
 
   setDestroyWhenDone() {
@@ -161,7 +162,7 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
     // yet synced.
     const requestedNodeCount = pathStrings.length
     if (rangeResult === undefined || requestedNodeCount < rangeResult.nodes.length) {
-      this.debug(`Peer rejected trienode request`)
+      this.DEBUG && this.debug(`Peer rejected trienode request`)
 
       return undefined
     }
@@ -180,7 +181,7 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
       }
       return Object.assign([], [receivedNodes], { completed: true })
     } catch (e) {
-      this.debug(e)
+      this.DEBUG && this.debug(e)
     }
   }
 
@@ -210,7 +211,7 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
    * @param result fetch result
    */
   async store(result: Uint8Array[]): Promise<void> {
-    this.debug('At start of store phase')
+    this.DEBUG && this.debug('At start of store phase')
 
     try {
       // process received node data and request unknown child nodes
@@ -232,7 +233,7 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
               const newStoragePath = nodePath.concat(bytesToHex(Uint8Array.from([i])))
               const syncPath =
                 storagePath === undefined ? newStoragePath : [accountPath, newStoragePath].join('/')
-              this.debug('branch node found')
+              this.DEBUG && this.debug('branch node found')
               childNodes.push({
                 nodeHash: embeddedNode,
                 path: syncPath,
@@ -240,7 +241,7 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
             }
           }
         } else if (node instanceof ExtensionNode) {
-          this.debug('extension node found')
+          this.DEBUG && this.debug('extension node found')
           const stringPath = bytesToHex(pathToHexKey(nodePath, node.key(), 'hex'))
           const syncPath =
             storagePath === undefined ? stringPath : [accountPath, stringPath].join('/')
@@ -250,13 +251,13 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
           }
           childNodes.push(val)
         } else {
-          this.debug('leaf node found')
+          this.DEBUG && this.debug('leaf node found')
           if (storagePath === undefined) {
-            this.debug('account leaf node found')
+            this.DEBUG && this.debug('account leaf node found')
             const account = createAccountFromRLP(node.value())
             const storageRoot: Uint8Array = account.storageRoot
             if (equalsBytes(storageRoot, KECCAK256_RLP) === false) {
-              this.debug('storage component found')
+              this.DEBUG && this.debug('storage component found')
               const syncPath = [
                 bytesToHex(pathToHexKey(accountPath, node.key(), 'hex')),
                 storagePath,
@@ -273,7 +274,7 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
               // TODO
             }
           } else {
-            this.debug('Storage leaf node found')
+            this.DEBUG && this.debug('Storage leaf node found')
           }
         }
 
@@ -333,7 +334,7 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
 
       // for an initial implementation, just put nodes into trie and see if root matches stateRoot
       if (this.pathToNodeRequestData.length === 0) {
-        this.debug('All requests for current heal phase have been filled')
+        this.DEBUG && this.debug('All requests for current heal phase have been filled')
         const ops: BatchDBOp[] = []
         for (const [_, data] of this.fetchedAccountNodes) {
           const { nodeData, path, pathToStorageNode } = data
@@ -367,24 +368,26 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
               await storageTrie.batch(storageTrieOps, true)
               await storageTrie.persistRoot()
               const a = createAccountFromRLP(node.value())
-              this.debug(
-                `Stored storageTrie with root actual=${bytesToHex(
-                  storageTrie.root(),
-                )} expected=${bytesToHex(a.storageRoot)}`,
-              )
+              this.DEBUG &&
+                this.debug(
+                  `Stored storageTrie with root actual=${bytesToHex(
+                    storageTrie.root(),
+                  )} expected=${bytesToHex(a.storageRoot)}`,
+                )
             }
           }
         }
         await this.accountTrie.batch(ops, true)
         await this.accountTrie.persistRoot()
-        this.debug(
-          `Stored accountTrie with root actual=${bytesToHex(
-            this.accountTrie.root(),
-          )} expected=${bytesToHex(this.root)}`,
-        )
+        this.DEBUG &&
+          this.debug(
+            `Stored accountTrie with root actual=${bytesToHex(
+              this.accountTrie.root(),
+            )} expected=${bytesToHex(this.root)}`,
+          )
       }
     } catch (e) {
-      this.debug(e)
+      this.DEBUG && this.debug(e)
     }
   }
 
@@ -417,18 +420,18 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
             if (nodeHash === undefined) throw Error('Path should exist')
             this.requestedNodeToPath.set(nodeHash as unknown as string, pathString)
           }
-          this.debug('At start of mergeAndFormatPaths')
+          this.DEBUG && this.debug('At start of mergeAndFormatPaths')
           const paths = mergeAndFormatKeyPaths(requestedPathStrings) as unknown as Uint8Array[][]
           tasks.push({
             pathStrings: requestedPathStrings,
             paths,
           })
-          this.debug(`Created new tasks num=${tasks.length}`)
+          this.DEBUG && this.debug(`Created new tasks num=${tasks.length}`)
         }
       }
-      this.debug(`Created new tasks num=${tasks.length}`)
+      this.DEBUG && this.debug(`Created new tasks num=${tasks.length}`)
     } catch (e) {
-      this.debug(e)
+      this.DEBUG && this.debug(e)
     }
 
     return tasks
@@ -444,11 +447,11 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
             count += task.pathStrings.length
             this.enqueueTask(task, true)
           }
-          this.debug(`Fetcher pending with ${count} path requested`)
+          this.DEBUG && this.debug(`Fetcher pending with ${count} path requested`)
         }
       }
     } catch (err) {
-      this.debug(err)
+      this.DEBUG && this.debug(err)
     }
   }
 

--- a/packages/devp2p/src/rlpx/peer.ts
+++ b/packages/devp2p/src/rlpx/peer.ts
@@ -151,9 +151,10 @@ export class Peer {
    */
   _sendAuth() {
     if (this._closed) return
-    this._logger(
-      `Send auth (EIP8: ${this._EIP8}) to ${this._socket.remoteAddress}:${this._socket.remotePort}`,
-    )
+    this.DEBUG &&
+      this._logger(
+        `Send auth (EIP8: ${this._EIP8}) to ${this._socket.remoteAddress}:${this._socket.remotePort}`,
+      )
     if (this._EIP8 === true) {
       const authEIP8 = this._eciesSession.createAuthEIP8()
       if (!authEIP8) return
@@ -172,9 +173,10 @@ export class Peer {
    */
   _sendAck() {
     if (this._closed) return
-    this._logger(
-      `Send ack (EIP8: ${this._eciesSession['_gotEIP8Auth']}) to ${this._socket.remoteAddress}:${this._socket.remotePort}`,
-    )
+    this.DEBUG &&
+      this._logger(
+        `Send ack (EIP8: ${this._eciesSession['_gotEIP8Auth']}) to ${this._socket.remoteAddress}:${this._socket.remotePort}`,
+      )
 
     if (this._eciesSession['_gotEIP8Auth']) {
       const ackEIP8 = this._eciesSession.createAckEIP8()
@@ -339,9 +341,10 @@ export class Peer {
     if (!this._eciesSession['_gotEIP8Ack']) {
       if (parseData.subarray(0, 1) === hexToBytes('0x04')) {
         this._eciesSession.parseAckPlain(parseData)
-        this._logger(
-          `Received ack (old format) from ${this._socket.remoteAddress}:${this._socket.remotePort}`,
-        )
+        this.DEBUG &&
+          this._logger(
+            `Received ack (old format) from ${this._socket.remoteAddress}:${this._socket.remotePort}`,
+          )
       } else {
         this._eciesSession['_gotEIP8Ack'] = true
         this._nextPacketSize = bytesToInt(this._socketData.subarray(0, 2)) + 2
@@ -349,9 +352,10 @@ export class Peer {
       }
     } else {
       this._eciesSession.parseAckEIP8(parseData)
-      this._logger(
-        `Received ack (EIP8) from ${this._socket.remoteAddress}:${this._socket.remotePort}`,
-      )
+      this.DEBUG &&
+        this._logger(
+          `Received ack (EIP8) from ${this._socket.remoteAddress}:${this._socket.remotePort}`,
+        )
     }
     this._state = 'Header'
     this._nextPacketSize = 32
@@ -507,10 +511,11 @@ export class Peer {
   _handleHeader() {
     const bytesCount = this._nextPacketSize
     const parseData = this._socketData.subarray(0, bytesCount)
-    this._logger(`Received header ${this._socket.remoteAddress}:${this._socket.remotePort}`)
+    this.DEBUG &&
+      this._logger(`Received header ${this._socket.remoteAddress}:${this._socket.remotePort}`)
     const size = this._eciesSession.parseHeader(parseData)
     if (size === undefined) {
-      this._logger('invalid header size!')
+      this.DEBUG && this._logger('invalid header size!')
       return
     }
 
@@ -528,15 +533,16 @@ export class Peer {
     const parseData = this._socketData.subarray(0, bytesCount)
     const body = this._eciesSession.parseBody(parseData)
     if (!body) {
-      this._logger('empty body!')
+      this.DEBUG && this._logger('empty body!')
       return
     }
-    this._logger(
-      `Received body ${this._socket.remoteAddress}:${this._socket.remotePort} ${formatLogData(
-        bytesToHex(body),
-        verbose,
-      )}`,
-    )
+    this.DEBUG &&
+      this._logger(
+        `Received body ${this._socket.remoteAddress}:${this._socket.remotePort} ${formatLogData(
+          bytesToHex(body),
+          verbose,
+        )}`,
+      )
     this._state = 'Header'
     this._nextPacketSize = 32
 
@@ -562,7 +568,7 @@ export class Peer {
         this.debug(messageName, `Received ${messageName} message ${postAdd}`)
       }
     } else {
-      this._logger(`Received ${protocolName} subprotocol message ${postAdd}`)
+      this.DEBUG && this._logger(`Received ${protocolName} subprotocol message ${postAdd}`)
     }
 
     try {
@@ -607,7 +613,7 @@ export class Peer {
       protocolObj.protocol._handleMessage?.(msgCode, payload)
     } catch (err: any) {
       this.disconnect(DISCONNECT_REASON.SUBPROTOCOL_ERROR)
-      this._logger(`Error on peer subprotocol message handling: ${err}`)
+      this.DEBUG && this._logger(`Error on peer subprotocol message handling: ${err}`)
       this.events.emit('error', err)
     }
     this._socketData = this._socketData.subarray(bytesCount)
@@ -639,7 +645,7 @@ export class Peer {
       }
     } catch (err: any) {
       this.disconnect(DISCONNECT_REASON.SUBPROTOCOL_ERROR)
-      this._logger(`Error on peer socket data handling: ${err}`)
+      this.DEBUG && this._logger(`Error on peer socket data handling: ${err}`)
       this.events.emit('error', err)
     }
   }

--- a/packages/statemanager/src/statelessVerkleStateManager.ts
+++ b/packages/statemanager/src/statelessVerkleStateManager.ts
@@ -275,7 +275,7 @@ export class StatelessVerkleStateManager implements StateManagerInterface {
       const codeChunk = this._state[chunkKey]
       if (codeChunk === null) {
         const errorMsg = `Invalid access to a non existent code chunk with chunkKey=${chunkKey}`
-        debug(errorMsg)
+        this.DEBUG && debug(errorMsg)
         throw Error(errorMsg)
       }
 
@@ -306,7 +306,7 @@ export class StatelessVerkleStateManager implements StateManagerInterface {
         elem.accountRLP !== undefined ? createPartialAccountFromRLP(elem.accountRLP) : undefined
       if (account === undefined) {
         const errorMsg = `account=${account} in cache`
-        debug(errorMsg)
+        this.DEBUG && debug(errorMsg)
         throw Error(errorMsg)
       }
       return account.codeSize
@@ -404,7 +404,7 @@ export class StatelessVerkleStateManager implements StateManagerInterface {
         const errorMsg = `Invalid witness for a non existing address=${address} stem=${bytesToHex(
           stem,
         )}`
-        debug(errorMsg)
+        this.DEBUG && debug(errorMsg)
         throw Error(errorMsg)
       } else {
         return undefined
@@ -416,13 +416,13 @@ export class StatelessVerkleStateManager implements StateManagerInterface {
       const errorMsg = `Invalid codeHashRaw=${codeHashRaw} for address=${address} chunkKey=${bytesToHex(
         codeHashKey,
       )}`
-      debug(errorMsg)
+      this.DEBUG && debug(errorMsg)
       throw Error(errorMsg)
     }
 
     if (basicDataRaw === undefined && codeHashRaw === undefined) {
       const errorMsg = `No witness bundled for address=${address} stem=${bytesToHex(stem)}`
-      debug(errorMsg)
+      this.DEBUG && debug(errorMsg)
       throw Error(errorMsg)
     }
 
@@ -497,7 +497,7 @@ export class StatelessVerkleStateManager implements StateManagerInterface {
    */
   verifyVerkleProof(): boolean {
     if (this._executionWitness === undefined) {
-      debug('Missing executionWitness')
+      this.DEBUG && debug('Missing executionWitness')
       return false
     }
 
@@ -525,9 +525,10 @@ export class StatelessVerkleStateManager implements StateManagerInterface {
       accessedChunks.set(chunkKey, true)
       const computedValue = this.getComputedValue(accessedState) ?? this._preState[chunkKey]
       if (computedValue === undefined) {
-        debug(
-          `Block accesses missing in canonical address=${address} type=${type} ${extraMeta} chunkKey=${chunkKey}`,
-        )
+        this.DEBUG &&
+          debug(
+            `Block accesses missing in canonical address=${address} type=${type} ${extraMeta} chunkKey=${chunkKey}`,
+          )
         postFailures++
         continue
       }
@@ -535,9 +536,10 @@ export class StatelessVerkleStateManager implements StateManagerInterface {
       let canonicalValue: PrefixedHexString | null | undefined = this._postState[chunkKey]
 
       if (canonicalValue === undefined) {
-        debug(
-          `Block accesses missing in canonical address=${address} type=${type} ${extraMeta} chunkKey=${chunkKey}`,
-        )
+        this.DEBUG &&
+          debug(
+            `Block accesses missing in canonical address=${address} type=${type} ${extraMeta} chunkKey=${chunkKey}`,
+          )
         postFailures++
         continue
       }
@@ -568,24 +570,25 @@ export class StatelessVerkleStateManager implements StateManagerInterface {
             ? canonicalValue
             : `${canonicalValue} (${decodedCanonicalValue})`
 
-        debug(
-          `Block accesses mismatch address=${address} type=${type} ${extraMeta} chunkKey=${chunkKey}`,
-        )
-        debug(`expected=${displayCanonicalValue}`)
-        debug(`computed=${displayComputedValue}`)
+        this.DEBUG &&
+          debug(
+            `Block accesses mismatch address=${address} type=${type} ${extraMeta} chunkKey=${chunkKey}`,
+          )
+        this.DEBUG && debug(`expected=${displayCanonicalValue}`)
+        this.DEBUG && debug(`computed=${displayComputedValue}`)
         postFailures++
       }
     }
 
     for (const canChunkKey of Object.keys(this._postState)) {
       if (accessedChunks.get(canChunkKey) === undefined) {
-        debug(`Missing chunk access for canChunkKey=${canChunkKey}`)
+        this.DEBUG && debug(`Missing chunk access for canChunkKey=${canChunkKey}`)
         postFailures++
       }
     }
 
     const verifyPassed = postFailures === 0
-    debug(`verifyPostState verifyPassed=${verifyPassed} postFailures=${postFailures}`)
+    this.DEBUG && debug(`verifyPostState verifyPassed=${verifyPassed} postFailures=${postFailures}`)
 
     return verifyPassed
   }
@@ -641,7 +644,7 @@ export class StatelessVerkleStateManager implements StateManagerInterface {
           const account = createPartialAccountFromRLP(encodedAccount)
           if (account.isContract()) {
             const errorMsg = `Code cache not found for address=${address.toString()}`
-            debug(errorMsg)
+            this.DEBUG && debug(errorMsg)
             throw Error(errorMsg)
           } else {
             return null


### PR DESCRIPTION
This change checks for the `ethjs` rail guard to be active for logging to be activated in the `client` and `devp2p` packages. This makes them consistent with the rest of the packages that abide by the guard rail, as discussed in #3634.

In order to test this, one can try running `DEBUG='ethjs,*' npm run client:start:dev2` and comparing it's log output to running `DEBUG='*' npm run client:start:dev2`. 

In a followup PR, the documentation of the monorepo packages that support logging will be updated with logging instructions/details.