### PR TITLE
client/block: ensure BlockBodies requests get properly propagated

### DIFF
--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -160,7 +160,7 @@ export type BlockBodyBytes = [
   TransactionsBytes,
   UncleHeadersBytes,
   WithdrawalsBytes?,
-  RequestBytes?,
+  RequestsBytes?,
 ]
 /**
  * TransactionsBytes can be an array of serialized txs for Typed Transactions or an array of Uint8Array Arrays for legacy transactions.

--- a/packages/client/src/sync/fetcher/blockfetcher.ts
+++ b/packages/client/src/sync/fetcher/blockfetcher.ts
@@ -73,7 +73,7 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
         `Requested blocks=${blocksRange} from ${peerInfo} (received: ${headers.length} headers / ${bodies.length} bodies)`,
       )
     const blocks: Block[] = []
-    for (const [i, [txsData, unclesData, withdrawalsData]] of bodies.entries()) {
+    for (const [i, [txsData, unclesData, withdrawalsData, requestsData]] of bodies.entries()) {
       const header = headers[i]
       if (
         (!equalsBytes(header.transactionsTrie, KECCAK256_RLP) && txsData.length === 0) ||
@@ -91,6 +91,9 @@ export class BlockFetcher extends BlockFetcherBase<Block[], Block> {
       const values: BlockBytes = [headers[i].raw(), txsData, unclesData]
       if (withdrawalsData !== undefined) {
         values.push(withdrawalsData)
+      }
+      if (requestsData !== undefined) {
+        values.push(requestsData)
       }
       // Supply the common from the corresponding block header already set on correct fork
       const block = createBlockFromBytesArray(values, { common: headers[i].common })


### PR DESCRIPTION
This PR:

- Fixes the BlockBytes type in Block (note: `RequestBytes` and `RequestsBytes` (plural!!) is a mistake hard-to-miss, maybe we should think of better naming for those types to avoid these kind of mistakes?)
- Ensures that BlockBodies now take the Requests sent with the BlockBodies response used to create the relevant blocks.

Will keep this at draft, will test (or someone else) later on devnet-3 if this fixes the issue where we report that clients are not sending us BlockBodies. So please only merge if this has been tested!