### PR TITLE
Common: Optional Param Dict Name to avoid Parameter Re-Addition

### DIFF
--- a/packages/block/src/header/header.ts
+++ b/packages/block/src/header/header.ts
@@ -99,7 +99,7 @@ export class BlockHeader {
         chain: Mainnet, // default
       })
     }
-    this.common.updateParams(opts.params ?? paramsBlock)
+    this.common.updateParams(opts.params ?? paramsBlock, '@ethereumjs/block')
 
     this.keccakFunction = this.common.customCrypto.keccak256 ?? keccak256
 

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -47,6 +47,7 @@ export class Common {
   protected _hardfork: string | Hardfork
   protected _eips: number[] = []
   protected _params: ParamsDict
+  protected _includedParams: string[] = []
 
   public readonly customCrypto: CustomCrypto
 
@@ -101,8 +102,15 @@ export class Common {
    * ```
    *
    * @param params
+   * @param name Provide a self-chosen name for a param set to not unnecessarily re-include parameters
    */
-  updateParams(params: ParamsDict) {
+  updateParams(params: ParamsDict, name?: string) {
+    if (name !== undefined) {
+      if (this._includedParams.includes(name)) {
+        return
+      }
+      this._includedParams.push(name)
+    }
     for (const [eip, paramsConfig] of Object.entries(params)) {
       if (!(eip in this._params)) {
         this._params[eip] = JSON.parse(JSON.stringify(paramsConfig)) // copy
@@ -111,26 +119,6 @@ export class Common {
       }
     }
 
-    this._buildParamsCache()
-  }
-
-  /**
-   * Fully resets the internal Common EIP params set with the values provided.
-   *
-   * Example Format:
-   *
-   * ```ts
-   * {
-   *   1559: {
-   *     initialBaseFee: 1000000000,
-   *   }
-   * }
-   * ```
-   *
-   * @param params
-   */
-  resetParams(params: ParamsDict) {
-    this._params = JSON.parse(JSON.stringify(params)) // copy
     this._buildParamsCache()
   }
 

--- a/packages/common/test/params.spec.ts
+++ b/packages/common/test/params.spec.ts
@@ -18,16 +18,14 @@ describe('[Common]: Parameter instantiation / params option / Updates', () => {
     c.updateParams(params)
     msg = 'Should update parameter on updateParams() and properly rebuild cache'
     assert.equal(c.param('bn254AddGas'), BigInt(250), msg)
-
-    c.resetParams(params)
-    msg = 'Should reset all parameters on resetParams() and properly rebuild cache'
-    assert.equal(c.param('bn254AddGas'), BigInt(250), msg)
-    assert.throws(() => {
-      c.param('bn254MulGas'), BigInt(250)
-    })
+    assert.equal(c['_includedParams'].length, 0, msg)
 
     msg = 'Should not side-manipulate the original params file during updating internally'
     assert.equal(paramsTest['1679']['bn254AddGas'], 150)
+
+    msg = 'Should add optional parameter set name to parameter set names array'
+    c.updateParams(params, 'myparams')
+    assert.equal(c['_includedParams'].length, 1, msg)
   })
 })
 

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -195,7 +195,7 @@ export class EVM implements EVMInterface {
       )
     }
 
-    this.common.updateParams(opts.params ?? paramsEVM)
+    this.common.updateParams(opts.params ?? paramsEVM, '@ethereumjs/evm')
 
     this.allowUnlimitedContractSize = opts.allowUnlimitedContractSize ?? false
     this.allowUnlimitedInitCodeSize = opts.allowUnlimitedInitCodeSize ?? false

--- a/packages/tx/src/1559/tx.ts
+++ b/packages/tx/src/1559/tx.ts
@@ -65,7 +65,7 @@ export class FeeMarket1559Tx extends BaseTransaction<TransactionType.FeeMarketEI
         `Common chain ID ${this.common.chainId} not matching the derived chain ID ${chainId}`,
       )
     }
-    this.common.updateParams(opts.params ?? paramsTx)
+    this.common.updateParams(opts.params ?? paramsTx, '@ethereumjs/tx')
     this.chainId = this.common.chainId()
 
     if (!this.common.isActivatedEIP(1559)) {

--- a/packages/tx/src/2930/tx.ts
+++ b/packages/tx/src/2930/tx.ts
@@ -61,7 +61,7 @@ export class AccessList2930Transaction extends BaseTransaction<TransactionType.A
         `Common chain ID ${this.common.chainId} not matching the derived chain ID ${chainId}`,
       )
     }
-    this.common.updateParams(opts.params ?? paramsTx)
+    this.common.updateParams(opts.params ?? paramsTx, '@ethereumjs/tx')
     this.chainId = this.common.chainId()
 
     // EIP-2718 check is done in Common

--- a/packages/tx/src/4844/constructors.ts
+++ b/packages/tx/src/4844/constructors.ts
@@ -249,7 +249,7 @@ export function createBlob4844TxFromSerializedNetworkWrapper(
   }
 
   const commonCopy = opts.common.copy()
-  commonCopy.updateParams(opts.params ?? paramsTx)
+  commonCopy.updateParams(opts.params ?? paramsTx, '@ethereumjs/tx')
 
   const version = Number(commonCopy.param('blobCommitmentVersionKzg'))
   const blobsHex = blobs.map((blob) => bytesToHex(blob))

--- a/packages/tx/src/4844/tx.ts
+++ b/packages/tx/src/4844/tx.ts
@@ -74,7 +74,7 @@ export class Blob4844Tx extends BaseTransaction<TransactionType.BlobEIP4844> {
         `Common chain ID ${this.common.chainId} not matching the derived chain ID ${chainId}`,
       )
     }
-    this.common.updateParams(opts.params ?? paramsTx)
+    this.common.updateParams(opts.params ?? paramsTx, '@ethereumjs/tx')
     this.chainId = this.common.chainId()
 
     if (!this.common.isActivatedEIP(1559)) {

--- a/packages/tx/src/7702/tx.ts
+++ b/packages/tx/src/7702/tx.ts
@@ -68,7 +68,7 @@ export class EOACode7702Transaction extends BaseTransaction<TransactionType.EOAC
         `Common chain ID ${this.common.chainId} not matching the derived chain ID ${chainId}`,
       )
     }
-    this.common.updateParams(opts.params ?? paramsTx)
+    this.common.updateParams(opts.params ?? paramsTx, '@ethereumjs/tx')
     this.chainId = this.common.chainId()
 
     if (!this.common.isActivatedEIP(7702)) {

--- a/packages/tx/src/baseTransaction.ts
+++ b/packages/tx/src/baseTransaction.ts
@@ -110,7 +110,7 @@ export abstract class BaseTransaction<T extends TransactionType>
     const createContract = this.to === undefined || this.to === null
     const allowUnlimitedInitCodeSize = opts.allowUnlimitedInitCodeSize ?? false
 
-    this.common.updateParams(opts.params ?? paramsTx)
+    this.common.updateParams(opts.params ?? paramsTx, '@ethereumjs/tx')
     if (
       createContract &&
       this.common.isActivatedEIP(3860) &&

--- a/packages/tx/src/legacy/tx.ts
+++ b/packages/tx/src/legacy/tx.ts
@@ -63,7 +63,7 @@ export class LegacyTx extends BaseTransaction<TransactionType.Legacy> {
       )
     }
 
-    this.common.updateParams(opts.params ?? paramsTx)
+    this.common.updateParams(opts.params ?? paramsTx, '@ethereumjs/tx')
     this.keccakFunction = this.common.customCrypto.keccak256 ?? keccak256
     this.gasPrice = bytesToBigInt(toBytes(txData.gasPrice))
 

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -68,7 +68,7 @@ export class VM {
    */
   constructor(opts: VMOpts = {}) {
     this.common = opts.common!
-    this.common.updateParams(opts.params ?? paramsVM)
+    this.common.updateParams(opts.params ?? paramsVM, '@ethereumjs/vm')
     this.stateManager = opts.stateManager!
     this.blockchain = opts.blockchain!
     this.evm = opts.evm!


### PR DESCRIPTION
When experimenting along #3694 I realized that (re-)adding the Common parameters with `updateParams()` comes with a somewhat significant performance cost and often - e.g. for a shared Common in Client - the addition is not necessary since the parameter set is already there.

This PR adds the ability to give the parameter set a name which is then checked for along further additions to void re-adding unnecessarily.

The PR also removes the `resetParam()` method. This was a hypothetical method I added, because I thought it *might* be useful for someone. Seems overblown to me now (respectively we can always re-add), we ourselves use this method nowhere in the monorepo.