### PR TITLE
update ethereum tests to v14.1

### DIFF
--- a/packages/evm/vitest.config.browser.mts
+++ b/packages/evm/vitest.config.browser.mts
@@ -6,11 +6,12 @@ export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      exclude:      [
+      exclude: [
         ...configDefaults.exclude,
         // readDirSync method not provided fs mock for vite
         'test/precompiles/eip-2537-bls.spec.ts',
       ]
-    }
+    },
+    optimizeDeps: { entries: ['vite-plugin-node-polyfills/shims/buffer', 'vite-plugin-node-polyfills/shims/global', 'vite-plugin-node-polyfills/shims/process'] }
   })
 )


### PR DESCRIPTION
I somehow messed up updating the tests to v14.1, seems like we still are on v14.0, this should fix the nightly tests.

I think I pushed the wrong version in https://github.com/ethereumjs/ethereumjs-monorepo/pull/3633

I checked locally, this should fix the nightly tests.

To test: 

`git submodule update --recursive`

`npm run test:blockchain -- --fork=Istanbul --test=wrongRLPGenesis_Istanbul`

`npm run test:blockchain -- --fork=Istanbul --test=lastblockhashException_Istanbul`

This runs 0 tests (which is expected, since these "faulty tests" are now removed)