### PR TITLE
trie: rename trie to mpt

### DIFF
--- a/packages/block/src/block/block.ts
+++ b/packages/block/src/block/block.ts
@@ -1,6 +1,6 @@
 import { ConsensusType } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
-import { Trie } from '@ethereumjs/trie'
+import { MerklePatriciaTrie } from '@ethereumjs/trie'
 import { Blob4844Tx, Capability } from '@ethereumjs/tx'
 import {
   BIGINT_0,
@@ -226,7 +226,10 @@ export class Block {
    * Generates transaction trie for validation.
    */
   async genTxTrie(): Promise<Uint8Array> {
-    return genTransactionsTrieRoot(this.transactions, new Trie({ common: this.common }))
+    return genTransactionsTrieRoot(
+      this.transactions,
+      new MerklePatriciaTrie({ common: this.common }),
+    )
   }
 
   /**
@@ -471,7 +474,7 @@ export class Block {
     if (this.cache.withdrawalsTrieRoot === undefined) {
       this.cache.withdrawalsTrieRoot = await genWithdrawalsTrieRoot(
         this.withdrawals!,
-        new Trie({ common: this.common }),
+        new MerklePatriciaTrie({ common: this.common }),
       )
     }
     result = equalsBytes(this.cache.withdrawalsTrieRoot, this.header.withdrawalsRoot!)

--- a/packages/block/src/block/constructors.ts
+++ b/packages/block/src/block/constructors.ts
@@ -1,5 +1,5 @@
 import { RLP } from '@ethereumjs/rlp'
-import { Trie } from '@ethereumjs/trie'
+import { MerklePatriciaTrie } from '@ethereumjs/trie'
 import {
   type TxOptions,
   createTx,
@@ -401,10 +401,13 @@ export async function createBlockFromExecutionPayload(
     }
   }
 
-  const transactionsTrie = await genTransactionsTrieRoot(txs, new Trie({ common: opts?.common }))
+  const transactionsTrie = await genTransactionsTrieRoot(
+    txs,
+    new MerklePatriciaTrie({ common: opts?.common }),
+  )
   const withdrawals = withdrawalsData?.map((wData) => createWithdrawal(wData))
   const withdrawalsRoot = withdrawals
-    ? await genWithdrawalsTrieRoot(withdrawals, new Trie({ common: opts?.common }))
+    ? await genWithdrawalsTrieRoot(withdrawals, new MerklePatriciaTrie({ common: opts?.common }))
     : undefined
 
   const hasDepositRequests = depositRequests !== undefined && depositRequests !== null
@@ -434,7 +437,7 @@ export async function createBlockFromExecutionPayload(
   }
 
   const requestsRoot = requests
-    ? await genRequestsTrieRoot(requests, new Trie({ common: opts?.common }))
+    ? await genRequestsTrieRoot(requests, new MerklePatriciaTrie({ common: opts?.common }))
     : undefined
 
   const header: HeaderData = {

--- a/packages/block/src/helpers.ts
+++ b/packages/block/src/helpers.ts
@@ -1,5 +1,5 @@
 import { RLP } from '@ethereumjs/rlp'
-import { Trie } from '@ethereumjs/trie'
+import { MerklePatriciaTrie } from '@ethereumjs/trie'
 import { Blob4844Tx } from '@ethereumjs/tx'
 import { BIGINT_0, BIGINT_1, TypeOutput, isHexString, toType } from '@ethereumjs/util'
 
@@ -124,8 +124,8 @@ export const fakeExponential = (factor: bigint, numerator: bigint, denominator: 
  * @param wts array of Withdrawal to compute the root of
  * @param optional emptyTrie to use to generate the root
  */
-export async function genWithdrawalsTrieRoot(wts: Withdrawal[], emptyTrie?: Trie) {
-  const trie = emptyTrie ?? new Trie()
+export async function genWithdrawalsTrieRoot(wts: Withdrawal[], emptyTrie?: MerklePatriciaTrie) {
+  const trie = emptyTrie ?? new MerklePatriciaTrie()
   for (const [i, wt] of wts.entries()) {
     await trie.put(RLP.encode(i), RLP.encode(wt.raw()))
   }
@@ -137,8 +137,11 @@ export async function genWithdrawalsTrieRoot(wts: Withdrawal[], emptyTrie?: Trie
  * @param txs array of TypedTransaction to compute the root of
  * @param optional emptyTrie to use to generate the root
  */
-export async function genTransactionsTrieRoot(txs: TypedTransaction[], emptyTrie?: Trie) {
-  const trie = emptyTrie ?? new Trie()
+export async function genTransactionsTrieRoot(
+  txs: TypedTransaction[],
+  emptyTrie?: MerklePatriciaTrie,
+) {
+  const trie = emptyTrie ?? new MerklePatriciaTrie()
   for (const [i, tx] of txs.entries()) {
     await trie.put(RLP.encode(i), tx.serialize())
   }
@@ -151,7 +154,10 @@ export async function genTransactionsTrieRoot(txs: TypedTransaction[], emptyTrie
  * @param emptyTrie optional empty trie used to generate the root
  * @returns a 32 byte Uint8Array representing the requests trie root
  */
-export async function genRequestsTrieRoot(requests: CLRequest<CLRequestType>[], emptyTrie?: Trie) {
+export async function genRequestsTrieRoot(
+  requests: CLRequest<CLRequestType>[],
+  emptyTrie?: MerklePatriciaTrie,
+) {
   // Requests should be sorted in monotonically ascending order based on type
   // and whatever internal sorting logic is defined by each request type
   if (requests.length > 1) {
@@ -160,7 +166,7 @@ export async function genRequestsTrieRoot(requests: CLRequest<CLRequestType>[], 
         throw new Error('requests are not sorted in ascending order')
     }
   }
-  const trie = emptyTrie ?? new Trie()
+  const trie = emptyTrie ?? new MerklePatriciaTrie()
   for (const [i, req] of requests.entries()) {
     await trie.put(RLP.encode(i), req.serialize())
   }

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -30,7 +30,7 @@ export interface EthereumClientOptions {
    * Database to store the state.
    * Should be an abstract-leveldown compliant store.
    *
-   * Default: Database created by the Trie class
+   * Default: Database created by the MerklePatriciaTrie class
    */
   stateDB?: AbstractLevel<string | Uint8Array, string | Uint8Array, string | Uint8Array>
 

--- a/packages/client/src/sync/fetcher/accountfetcher.ts
+++ b/packages/client/src/sync/fetcher/accountfetcher.ts
@@ -33,7 +33,7 @@ import type { AccountData } from '../../net/protocol/snapprotocol.js'
 import type { FetcherOptions } from './fetcher.js'
 import type { StorageRequest } from './storagefetcher.js'
 import type { Job, SnapFetcherDoneFlags } from './types.js'
-import type { Trie } from '@ethereumjs/trie'
+import type { MerklePatriciaTrie } from '@ethereumjs/trie'
 import type { Debugger } from 'debug'
 
 type AccountDataResponse = AccountData[] & { completed?: boolean }
@@ -70,7 +70,7 @@ export type JobTask = {
 export class AccountFetcher extends Fetcher<JobTask, AccountData[], AccountData> {
   protected debug: Debugger
   stateManager: MerkleStateManager
-  accountTrie: Trie
+  accountTrie: MerklePatriciaTrie
 
   root: Uint8Array
   highestKnownHash: Uint8Array | undefined

--- a/packages/client/src/sync/fetcher/trienodefetcher.ts
+++ b/packages/client/src/sync/fetcher/trienodefetcher.ts
@@ -3,7 +3,7 @@ import {
   BranchNode,
   ExtensionNode,
   LeafNode,
-  Trie,
+  MerklePatriciaTrie,
   decodeNode,
   mergeAndFormatKeyPaths,
   pathToHexKey,
@@ -37,7 +37,7 @@ type TrieNodesResponse = Uint8Array[] & { completed?: boolean }
  */
 export interface TrieNodeFetcherOptions extends FetcherOptions {
   root: Uint8Array
-  accountToStorageTrie?: Map<String, Trie>
+  accountToStorageTrie?: Map<String, MerklePatriciaTrie>
   stateManager?: MerkleStateManager
 
   /** Destroy fetcher once all tasks are done */
@@ -71,7 +71,7 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
 
   stateManager: MerkleStateManager
   fetcherDoneFlags: SnapFetcherDoneFlags
-  accountTrie: Trie
+  accountTrie: MerklePatriciaTrie
   codeDB: DB
 
   /**
@@ -351,7 +351,10 @@ export class TrieNodeFetcher extends Fetcher<JobTask, Uint8Array[], Uint8Array> 
 
             // add storage data for account if it has fetched nodes
             // TODO figure out what the key should be for mapping accounts to storage tries
-            const storageTrie = new Trie({ useKeyHashing: true, common: this.config.chainCommon })
+            const storageTrie = new MerklePatriciaTrie({
+              useKeyHashing: true,
+              common: this.config.chainCommon,
+            })
             const storageTrieOps: BatchDBOp[] = []
             if (pathToStorageNode !== undefined && pathToStorageNode.size > 0) {
               for (const [path, data] of pathToStorageNode) {

--- a/packages/client/src/util/debug.ts
+++ b/packages/client/src/util/debug.ts
@@ -29,7 +29,7 @@ import { Level } from 'level';
 import { Common } from '@ethereumjs/common'
 import { Block } from '@ethereumjs/block'
 import { VM, runBlock, createVM }  from './src'
-import { Trie } from '@ethereumjs/trie'
+import { MerklePatriciaTrie } from '@ethereumjs/trie'
 import { MerkleStateManager } from './src/state'
 import { Blockchain } from '@ethereumjs/blockchain'
 
@@ -40,7 +40,7 @@ const main = async () => {
   const block = createBlockFromRLP(hexToBytes('${bytesToHex(block.serialize())}'), { common })
 
   const stateDB = new Level('${execution.config.getDataDirectory(DataDirectory.State)}')
-  const trie = new Trie({ db: stateDB, useKeyHashing: true })
+  const trie = new MerklePatriciaTrie({ db: stateDB, useKeyHashing: true })
   const stateManager = new MerkleStateManager({ trie, common })
   // Ensure we run on the right root
   stateManager.setStateRoot(hexToBytes('${bytesToHex(

--- a/packages/client/test/rpc/engine/withdrawals.spec.ts
+++ b/packages/client/test/rpc/engine/withdrawals.spec.ts
@@ -1,5 +1,5 @@
 import { genWithdrawalsTrieRoot } from '@ethereumjs/block'
-import { Trie } from '@ethereumjs/trie'
+import { MerklePatriciaTrie } from '@ethereumjs/trie'
 import { bigIntToHex, bytesToHex, createWithdrawal, intToHex } from '@ethereumjs/util'
 import { assert, it } from 'vitest'
 
@@ -105,7 +105,7 @@ for (const { name, withdrawals, withdrawalsRoot, gethBlockRlp } of testCases) {
   it(name, async () => {
     // check withdrawals root computation
     const computedWithdrawalsRoot = bytesToHex(
-      await genWithdrawalsTrieRoot(withdrawals.map(createWithdrawal), new Trie()),
+      await genWithdrawalsTrieRoot(withdrawals.map(createWithdrawal), new MerklePatriciaTrie()),
     )
     assert.equal(
       withdrawalsRoot,

--- a/packages/statemanager/src/merkleStateManager.ts
+++ b/packages/statemanager/src/merkleStateManager.ts
@@ -1,6 +1,6 @@
 import { Common, Mainnet } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
-import { Trie } from '@ethereumjs/trie'
+import { MerklePatriciaTrie } from '@ethereumjs/trie'
 import {
   Account,
   bytesToUnprefixedHex,
@@ -65,8 +65,8 @@ export class MerkleStateManager implements StateManagerInterface {
 
   originalStorageCache: OriginalStorageCache
 
-  protected _trie: Trie
-  protected _storageTries: { [key: string]: Trie }
+  protected _trie: MerklePatriciaTrie
+  protected _storageTries: { [key: string]: MerklePatriciaTrie }
 
   protected readonly _prefixCodeHashes: boolean
   protected readonly _prefixStorageTrieKeys: boolean
@@ -102,7 +102,7 @@ export class MerkleStateManager implements StateManagerInterface {
 
     this._checkpointCount = 0
 
-    this._trie = opts.trie ?? new Trie({ useKeyHashing: true, common: this.common })
+    this._trie = opts.trie ?? new MerklePatriciaTrie({ useKeyHashing: true, common: this.common })
     this._storageTries = {}
 
     this.keccakFunction = opts.common?.customCrypto.keccak256 ?? keccak256
@@ -263,14 +263,14 @@ export class MerkleStateManager implements StateManagerInterface {
    * @param  rootAccount (Optional) Account object whose 'storageRoot' is to be used as
    *   the root of the new storageTrie returned when there is no pre-existing trie.
    *   If left undefined, the EMPTY_TRIE_ROOT will be used as the root instead.
-   * @returns storage Trie object
+   * @returns storage MerklePatriciaTrie object
    * @private
    */
   // TODO PR: have a better interface for hashed address pull?
   protected _getStorageTrie(
     addressOrHash: Address | { bytes: Uint8Array } | Uint8Array,
     rootAccount?: Account,
-  ): Trie {
+  ): MerklePatriciaTrie {
     // use hashed key for lookup from storage cache
     const addressBytes: Uint8Array =
       addressOrHash instanceof Uint8Array ? addressOrHash : this.keccakFunction(addressOrHash.bytes)
@@ -295,7 +295,7 @@ export class MerkleStateManager implements StateManagerInterface {
    * cache or does a lookup.
    * @private
    */
-  protected _getAccountTrie(): Trie {
+  protected _getAccountTrie(): MerklePatriciaTrie {
     return this._trie
   }
 
@@ -347,7 +347,7 @@ export class MerkleStateManager implements StateManagerInterface {
   protected async _modifyContractStorage(
     address: Address,
     account: Account,
-    modifyTrie: (storageTrie: Trie, done: Function) => void,
+    modifyTrie: (storageTrie: MerklePatriciaTrie, done: Function) => void,
   ): Promise<void> {
     // eslint-disable-next-line no-async-promise-executor
     return new Promise(async (resolve) => {

--- a/packages/statemanager/src/types.ts
+++ b/packages/statemanager/src/types.ts
@@ -2,7 +2,7 @@ import { type PrefixedHexString } from '@ethereumjs/util'
 
 import type { AccessWitness, Caches } from './index.js'
 import type { Common } from '@ethereumjs/common'
-import type { Trie } from '@ethereumjs/trie'
+import type { MerklePatriciaTrie } from '@ethereumjs/trie'
 import type { VerkleCrypto } from '@ethereumjs/util'
 import type { VerkleTree } from '@ethereumjs/verkle'
 /**
@@ -32,9 +32,9 @@ export interface RPCStateManagerOpts extends BaseStateManagerOpts {
  */
 export interface MerkleStateManagerOpts extends BaseStateManagerOpts {
   /**
-   * A {@link Trie} instance
+   * A {@link MerklePatriciaTrie} instance
    */
-  trie?: Trie
+  trie?: MerklePatriciaTrie
   /**
    * Option to prefix codehashes in the database. This defaults to `true`.
    * If this is disabled, note that it is possible to corrupt the trie, by deploying code

--- a/packages/statemanager/test/proofStateManager.spec.ts
+++ b/packages/statemanager/test/proofStateManager.spec.ts
@@ -1,4 +1,4 @@
-import { Trie, createTrie } from '@ethereumjs/trie'
+import { MerklePatriciaTrie, createTrie } from '@ethereumjs/trie'
 import {
   Account,
   Address,
@@ -140,7 +140,7 @@ describe('ProofStateManager', () => {
     // Account: 0x68268f12253f69f66b188c95b8106b2f847859fc (this account does not exist)
     // Storage slots: empty list
     const address = createAddressFromString('0x68268f12253f69f66b188c95b8106b2f847859fc')
-    const trie = new Trie({ useKeyHashing: true })
+    const trie = new MerklePatriciaTrie({ useKeyHashing: true })
     const stateManager = new MerkleStateManager({ trie })
     // Dump all the account proof data in the DB
     let stateRoot: Uint8Array | undefined
@@ -164,7 +164,7 @@ describe('ProofStateManager', () => {
     // Note: the first slot has a value, but the second slot is empty
     // Note: block hash 0x1d9ea6981b8093a2b63f22f74426ceb6ba1acae3fddd7831442bbeba3fa4f146
     const address = createAddressFromString('0x2D80502854FC7304c3E3457084DE549f5016B73f')
-    const trie = new Trie({ useKeyHashing: true })
+    const trie = new MerklePatriciaTrie({ useKeyHashing: true })
     const stateManager = new MerkleStateManager({ trie })
     // Dump all the account proof data in the DB
     let stateRoot: Uint8Array | undefined
@@ -177,7 +177,7 @@ describe('ProofStateManager', () => {
       await trie['_db'].put(key, bufferData)
     }
     const storageRoot = ropstenContractWithStorageData.storageHash
-    const storageTrie = new Trie({ useKeyHashing: true })
+    const storageTrie = new MerklePatriciaTrie({ useKeyHashing: true })
     const storageKeys: Uint8Array[] = []
     for (const storageProofsData of ropstenContractWithStorageData.storageProof) {
       storageKeys.push(hexToBytes(storageProofsData.key))
@@ -202,7 +202,7 @@ describe('ProofStateManager', () => {
     // Note: the first slot has a value, but the second slot is empty
     // Note: block hash 0x1d9ea6981b8093a2b63f22f74426ceb6ba1acae3fddd7831442bbeba3fa4f146
     const address = createAddressFromString('0x2D80502854FC7304c3E3457084DE549f5016B73f')
-    const trie = new Trie({ useKeyHashing: true })
+    const trie = new MerklePatriciaTrie({ useKeyHashing: true })
     const stateManager = new MerkleStateManager({ trie })
     // Dump all the account proof data in the DB
     let stateRoot: Uint8Array | undefined
@@ -215,7 +215,7 @@ describe('ProofStateManager', () => {
       await trie['_db'].put(key, bufferData)
     }
     const storageRoot = ropstenContractWithStorageData.storageHash
-    const storageTrie = new Trie({ useKeyHashing: true })
+    const storageTrie = new MerklePatriciaTrie({ useKeyHashing: true })
     const storageKeys: Uint8Array[] = []
     for (const storageProofsData of ropstenContractWithStorageData.storageProof) {
       storageKeys.push(hexToBytes(storageProofsData.key))
@@ -268,7 +268,7 @@ describe('ProofStateManager', () => {
     // Note: the first slot has a value, but the second slot is empty
     // Note: block hash 0x1d9ea6981b8093a2b63f22f74426ceb6ba1acae3fddd7831442bbeba3fa4f146
     const address = createAddressFromString('0x68268f12253f69f66b188c95b8106b2f847859fc')
-    const trie = new Trie({ useKeyHashing: true })
+    const trie = new MerklePatriciaTrie({ useKeyHashing: true })
     const stateManager = new MerkleStateManager({ trie })
     // Dump all the account proof data in the DB
     let stateRoot: Uint8Array | undefined
@@ -281,7 +281,7 @@ describe('ProofStateManager', () => {
       await trie['_db'].put(key, bufferData)
     }
     const storageRoot = ropstenNonexistentAccountData.storageHash
-    const storageTrie = new Trie({ useKeyHashing: true })
+    const storageTrie = new MerklePatriciaTrie({ useKeyHashing: true })
     storageTrie.root(hexToBytes(storageRoot))
     const addressHex = bytesToHex(address.bytes)
     stateManager['_storageTries'][addressHex] = storageTrie

--- a/packages/statemanager/test/stateManager.spec.ts
+++ b/packages/statemanager/test/stateManager.spec.ts
@@ -1,4 +1,4 @@
-import { Trie, createTrie, createTrieFromProof } from '@ethereumjs/trie'
+import { MerklePatriciaTrie, createTrie, createTrieFromProof } from '@ethereumjs/trie'
 import {
   Account,
   KECCAK256_RLP,
@@ -83,7 +83,7 @@ describe('StateManager -> General', () => {
   })
 
   it(`copy()`, async () => {
-    const trie = new Trie({ cacheSize: 1000 })
+    const trie = new MerklePatriciaTrie({ cacheSize: 1000 })
     let sm = new MerkleStateManager({
       trie,
       prefixCodeHashes: false,

--- a/packages/trie/CHANGELOG.md
+++ b/packages/trie/CHANGELOG.md
@@ -188,7 +188,7 @@ We nevertheless think this is very much worth it and we tried to make transition
 For this library you should check if you use one of the following constructors, methods, constants or types and do a search and update input and/or output values or general usages and add conversion methods if necessary:
 
 ```ts
-Trie.create() / new Trie() // root constructor option
+Trie.create() / new MerklePatriciaTrie() // root constructor option
 Trie.root(value?: Uint8Array | null): Uint8Array
 Trie.checkRoot(root: Uint8Array): Promise<boolean>
 Trie.get(key: Uint8Array, throwIfMissing = false): Promise<Uint8Array | null>
@@ -287,7 +287,7 @@ Updating is a straightforward process:
 const trie = new SecureTrie()
 
 // New
-const trie = new Trie({ useKeyHashing: true })
+const trie = new MerklePatriciaTrie({ useKeyHashing: true })
 ```
 
 ### Removed Getter and Setter Functions
@@ -302,11 +302,11 @@ For this reason, a single `root(hash?: Buffer): Buffer` function serves as a rep
 
 ```tsx
 // Old
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 trie.root
 
 // New
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 trie.root()
 ```
 
@@ -314,11 +314,11 @@ trie.root()
 
 ```tsx
 // Old
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 trie.root = Buffer.alloc(32)
 
 // New
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 trie.root(Buffer.alloc(32))
 ```
 
@@ -328,11 +328,11 @@ The `isCheckpoint` getter function has been removed, see PR [#2218](https://gith
 
 ```tsx
 // Old
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 trie.isCheckpoint
 
 // New
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 trie.hasCheckpoints()
 ```
 
@@ -381,7 +381,7 @@ To activate root hash persistence you can set the `useRootPersistence` option on
 import { Trie, LevelDB } from '@ethereumjs/trie'
 import { Level } from 'level'
 
-const trie = new Trie({
+const trie = new MerklePatriciaTrie({
   db: new LevelDB(new Level('MY_TRIE_DB_LOCATION')),
   useRootPersistence: true,
 })
@@ -483,7 +483,7 @@ The new `DB` interface can be used like this for LevelDB:
 import { Trie, LevelDB } from '@ethereumjs/trie'
 import { Level } from 'level'
 
-const trie = new Trie({ db: new LevelDB(new Level('MY_TRIE_DB_LOCATION')) })
+const trie = new MerklePatriciaTrie({ db: new LevelDB(new Level('MY_TRIE_DB_LOCATION')) })
 ```
 
 If no `db` option is provided an in-memory [memory-level](https://github.com/Level/memory-level) data storage will be instantiated and used. (Side note: some internal non-persistent trie operations (e.g. proof trie creation for range proofs) will always use the internal `level` based data storage, so there will be some continued `level` DB usage also when you switch to an alternative data store for permanent trie storage).
@@ -584,7 +584,7 @@ Example using async/await syntax:
 
 ```ts
 import { BaseTrie as Trie } from 'merkle-patricia-tree'
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 async function test() {
   await trie.put(Buffer.from('test'), Buffer.from('one'))
   const value = await trie.get(Buffer.from('test'))

--- a/packages/trie/README.md
+++ b/packages/trie/README.md
@@ -111,7 +111,7 @@ async function main() {
   const k1 = utf8ToBytes('keyOne')
   const k2 = utf8ToBytes('keyTwo')
 
-  const someOtherTrie = new Trie({ useKeyHashing: true })
+  const someOtherTrie = new MerklePatriciaTrie({ useKeyHashing: true })
   await someOtherTrie.put(k1, utf8ToBytes('valueOne'))
   await someOtherTrie.put(k2, utf8ToBytes('valueTwo'))
 
@@ -175,7 +175,7 @@ As an example, to leverage `LevelDB` for all operations then you should create a
 ```ts
 // ./examples/customLevelDB.ts#L127-L131
 
-const trie = new Trie({ db: new LevelDB(new Level('MY_TRIE_DB_LOCATION')) })
+const trie = new MerklePatriciaTrie({ db: new LevelDB(new Level('MY_TRIE_DB_LOCATION')) })
 console.log(trie.database().db) // LevelDB { ...
 
 void main()

--- a/packages/trie/UPGRADING.md
+++ b/packages/trie/UPGRADING.md
@@ -31,7 +31,7 @@ Updating is a straightforward process:
 const trie = new SecureTrie()
 
 // New
-const trie = new Trie({ useKeyHashing: true })
+const trie = new MerklePatriciaTrie({ useKeyHashing: true })
 ```
 
 ### Removed Getter and Setter Functions
@@ -46,11 +46,11 @@ For this reason, a single `root(hash?: Buffer): Buffer` function serves as a rep
 
 ```tsx
 // Old
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 trie.root
 
 // New
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 trie.root()
 ```
 
@@ -58,11 +58,11 @@ trie.root()
 
 ```tsx
 // Old
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 trie.root = Buffer.alloc(32)
 
 // New
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 trie.root(Buffer.alloc(32))
 ```
 
@@ -72,11 +72,11 @@ The `isCheckpoint` getter function has been removed. The `hasCheckpoints()` func
 
 ```tsx
 // Old
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 trie.isCheckpoint
 
 // New
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 trie.hasCheckpoints()
 ```
 
@@ -134,7 +134,7 @@ export class LevelDB implements DB {
   readonly _leveldb: AbstractLevel<string | Buffer | Uint8Array, string | Buffer, string | Buffer>
 
   constructor(
-    leveldb?: AbstractLevel<string | Buffer | Uint8Array, string | Buffer, string | Buffer> | null
+    leveldb?: AbstractLevel<string | Buffer | Uint8Array, string | Buffer, string | Buffer> | null,
   ) {
     this._leveldb = leveldb ?? new MemoryLevel(ENCODING_OPTS)
   }
@@ -180,7 +180,7 @@ import { Level } from 'level'
 
 import { LevelDB } from './your-level-implementation'
 
-const trie = new Trie({ db: new LevelDB(new Level('MY_TRIE_DB_LOCATION')) })
+const trie = new MerklePatriciaTrie({ db: new LevelDB(new Level('MY_TRIE_DB_LOCATION')) })
 ```
 
 ##### Alternatives

--- a/packages/trie/benchmarks/suite.ts
+++ b/packages/trie/benchmarks/suite.ts
@@ -2,14 +2,14 @@ import { keccak256 } from 'ethereum-cryptography/keccak.js'
 // @ts-ignore - package has no types...
 import { run, mark, logMem } from 'micro-bmark' // cspell:disable-line
 
-import { Trie } from '../dist/cjs/index.js'
+import { MerklePatriciaTrie } from '../dist/cjs/index.js'
 import { keys } from './keys'
 
 import type { DB } from '@ethereumjs/util'
 
 export function createSuite(db: DB<string, string>) {
-  const trie = new Trie({ db })
-  const checkpointTrie = new Trie({ db })
+  const trie = new MerklePatriciaTrie({ db })
+  const checkpointTrie = new MerklePatriciaTrie({ db })
 
   const ROUNDS = 1000
   const KEY_SIZE = 32

--- a/packages/trie/examples/createFromProof.ts
+++ b/packages/trie/examples/createFromProof.ts
@@ -10,7 +10,7 @@ async function main() {
   const k1 = utf8ToBytes('keyOne')
   const k2 = utf8ToBytes('keyTwo')
 
-  const someOtherTrie = new Trie({ useKeyHashing: true })
+  const someOtherTrie = new MerklePatriciaTrie({ useKeyHashing: true })
   await someOtherTrie.put(k1, utf8ToBytes('valueOne'))
   await someOtherTrie.put(k2, utf8ToBytes('valueTwo'))
 

--- a/packages/trie/examples/customLevelDB.ts
+++ b/packages/trie/examples/customLevelDB.ts
@@ -1,4 +1,4 @@
-import { Trie } from '@ethereumjs/trie'
+import { MerklePatriciaTrie } from '@ethereumjs/trie'
 import { KeyEncoding, ValueEncoding } from '@ethereumjs/util'
 import { Level } from 'level'
 import { MemoryLevel } from 'memory-level'
@@ -127,7 +127,7 @@ export class LevelDB<
 }
 
 async function main() {
-  const trie = new Trie({ db: new LevelDB(new Level('MY_TRIE_DB_LOCATION')) })
+  const trie = new MerklePatriciaTrie({ db: new LevelDB(new Level('MY_TRIE_DB_LOCATION')) })
   console.log(trie.database().db) // LevelDB { ...
 }
 void main()

--- a/packages/trie/examples/level-legacy.js
+++ b/packages/trie/examples/level-legacy.js
@@ -4,7 +4,7 @@
 const { utf8ToBytes, bytesToUtf8 } = require('ethereum-cryptography/utils')
 const level = require('level-mem')
 
-const { Trie } = require('../../dist/cjs/index.js')
+const { MerklePatriciaTrie } = require('../../dist/cjs/index.js')
 
 const ENCODING_OPTS = { keyEncoding: 'binary', valueEncoding: 'binary' }
 
@@ -46,7 +46,7 @@ class LevelDB {
   }
 }
 
-const trie = new Trie({ db: new LevelDB(level('MY_TRIE_DB_LOCATION')) })
+const trie = new MerklePatriciaTrie({ db: new LevelDB(level('MY_TRIE_DB_LOCATION')) })
 
 async function test() {
   await trie.put(utf8ToBytes('test'), utf8ToBytes('one'))

--- a/packages/trie/examples/level.js
+++ b/packages/trie/examples/level.js
@@ -2,7 +2,7 @@ const { utf8ToBytes, bytesToUtf8 } = require('ethereum-cryptography/utils')
 const { Level } = require('level')
 const { MemoryLevel } = require('memory-level')
 
-const { Trie } = require('../../dist/cjs/index.js')
+const { MerklePatriciaTrie } = require('../../dist/cjs/index.js')
 
 const ENCODING_OPTS = { keyEncoding: 'view', valueEncoding: 'view' }
 
@@ -44,7 +44,7 @@ class LevelDB {
   }
 }
 
-const trie = new Trie({ db: new LevelDB(new Level('MY_TRIE_DB_LOCATION')) })
+const trie = new MerklePatriciaTrie({ db: new LevelDB(new Level('MY_TRIE_DB_LOCATION')) })
 
 async function test() {
   await trie.put(utf8ToBytes('test'), utf8ToBytes('one'))

--- a/packages/trie/examples/lmdb.js
+++ b/packages/trie/examples/lmdb.js
@@ -1,7 +1,7 @@
 const { utf8ToBytes, bytesToUtf8 } = require('ethereum-cryptography/utils')
 const { open } = require('lmdb')
 
-const { Trie } = require('../../dist/cjs/index.js')
+const { MerklePatriciaTrie } = require('../../dist/cjs/index.js')
 
 class LMDB {
   constructor(path) {
@@ -42,7 +42,7 @@ class LMDB {
   }
 }
 
-const trie = new Trie({ db: new LMDB('MY_TRIE_DB_LOCATION') })
+const trie = new MerklePatriciaTrie({ db: new LMDB('MY_TRIE_DB_LOCATION') })
 
 async function test() {
   await trie.put(utf8ToBytes('test'), utf8ToBytes('one'))

--- a/packages/trie/examples/logDemo.ts
+++ b/packages/trie/examples/logDemo.ts
@@ -1,7 +1,7 @@
 /**
  * Run with DEBUG=ethjs,trie:* to see debug log output
  */
-import { Trie, createMerkleProof, verifyMerkleProof } from '@ethereumjs/trie'
+import { MerklePatriciaTrie, createMerkleProof, verifyMerkleProof } from '@ethereumjs/trie'
 import { utf8ToBytes } from '@ethereumjs/util'
 
 const trie_entries: [string, string | null][] = [
@@ -16,7 +16,7 @@ const trie_entries: [string, string | null][] = [
 ]
 
 const main = async () => {
-  const trie = new Trie({
+  const trie = new MerklePatriciaTrie({
     useRootPersistence: true,
   })
   for (const [key, value] of trie_entries) {

--- a/packages/trie/examples/merkle_patricia_trees/README.md
+++ b/packages/trie/examples/merkle_patricia_trees/README.md
@@ -39,10 +39,10 @@ At their most basic, Merkle Patricia Trees allow us to store and retrieve key-va
 Let's begin right away with a simple example. Don't worry if things aren't too clear for now, they will become clearer as we go. In this example, we'll create an empty trie:
 
 ```jsx
-const { Trie } = require('@ethereumjs/trie') // We import the library required to create a basic Merkle Patricia Tree
+const { MerklePatriciaTrie } = require('@ethereumjs/trie') // We import the library required to create a basic Merkle Patricia Tree
 const { bytesToHex, bytesToUtf8, utf8ToBytes } = require('@ethereumjs/util')
 
-const trie = new Trie() // We create an empty Merkle Patricia Tree
+const trie = new MerklePatriciaTrie() // We create an empty Merkle Patricia Tree
 console.log('Empty trie root (Bytes): ', bytesToHex(trie.root())) // The trie root (32 bytes)
 ```
 
@@ -83,7 +83,7 @@ Let's retry the example above while respecting the rules we just mentioned. We w
 Here's what this looks like:
 
 ```jsx
-const trie = new Trie() // We create an empty Merkle Patricia Tree
+const trie = new MerklePatriciaTrie() // We create an empty Merkle Patricia Tree
 console.log('Empty trie root (Bytes): ', bytesToHex(trie.root())) // The trie root (32 bytes)
 
 async function test() {
@@ -110,7 +110,7 @@ Nothing spectacular: only the root hash of the tree has changed, as the key has 
 Fortunately, we also have an option called "useKeyHashing" that automatically takes care of the keccak256 hashing for us. We can see that it outputs the same root hash as example1b.js
 
 ```jsx
-const trie = new Trie({ useKeyHashing: true }) // We create an empty Merkle Patricia Tree with key hashing enabled
+const trie = new MerklePatriciaTrie({ useKeyHashing: true }) // We create an empty Merkle Patricia Tree with key hashing enabled
 console.log('Empty trie root (Bytes): ', bytesToHex(trie.root())) // The trie root (32 bytes)
 
 async function test() {

--- a/packages/trie/examples/merkle_patricia_trees/example1a.js
+++ b/packages/trie/examples/merkle_patricia_trees/example1a.js
@@ -2,9 +2,9 @@
 
 const { bytesToHex, bytesToUtf8, utf8ToBytes } = require('@ethereumjs/util')
 
-const { Trie } = require('../../dist/cjs/index.js') // We import the library required to create a basic Merkle Patricia Tree
+const { MerklePatriciaTrie } = require('../../dist/cjs/index.js') // We import the library required to create a basic Merkle Patricia Tree
 
-const trie = new Trie() // We create an empty Merkle Patricia Tree
+const trie = new MerklePatriciaTrie() // We create an empty Merkle Patricia Tree
 console.log('Empty trie root (Bytes): ', bytesToHex(trie.root())) // The trie root (32 bytes)
 
 async function test() {

--- a/packages/trie/examples/merkle_patricia_trees/example1b.js
+++ b/packages/trie/examples/merkle_patricia_trees/example1b.js
@@ -3,9 +3,9 @@
 const { bytesToHex, bytesToUtf8, utf8ToBytes } = require('@ethereumjs/util')
 const { keccak256 } = require('ethereum-cryptography/keccak')
 
-const { Trie } = require('../../dist/cjs/index.js')
+const { MerklePatriciaTrie } = require('../../dist/cjs/index.js')
 
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 console.log('Empty trie root (Bytes): ', bytesToHex(trie.root())) // The trie root (32 bytes)
 
 async function test() {

--- a/packages/trie/examples/merkle_patricia_trees/example1c.js
+++ b/packages/trie/examples/merkle_patricia_trees/example1c.js
@@ -1,9 +1,9 @@
 /* Example 1c - Creating an empty Merkle Patricia Tree and updating it with a single key-value pair */
 const { bytesToHex, bytesToUtf8, utf8ToBytes } = require('@ethereumjs/util')
 
-const { Trie } = require('../../dist/cjs/index.js')
+const { MerklePatriciaTrie } = require('../../dist/cjs/index.js')
 
-const trie = new Trie({ useKeyHashing: true }) // We create an empty Merkle Patricia Tree with key hashing enabled
+const trie = new MerklePatriciaTrie({ useKeyHashing: true }) // We create an empty Merkle Patricia Tree with key hashing enabled
 console.log('Empty trie root (Bytes): ', bytesToHex(trie.root())) // The trie root (32 bytes)
 
 async function test() {

--- a/packages/trie/examples/merkle_patricia_trees/example1d.js
+++ b/packages/trie/examples/merkle_patricia_trees/example1d.js
@@ -2,9 +2,9 @@
 
 const { bytesToHex, bytesToUtf8, utf8ToBytes } = require('@ethereumjs/util')
 
-const { Trie } = require('../../dist/cjs/index.js')
+const { MerklePatriciaTrie } = require('../../dist/cjs/index.js')
 
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 console.log('Empty trie root: ', bytesToHex(trie.root())) // The trie root
 
 async function test() {

--- a/packages/trie/examples/merkle_patricia_trees/example2a.js
+++ b/packages/trie/examples/merkle_patricia_trees/example2a.js
@@ -2,9 +2,9 @@
 
 const { utf8ToBytes } = require('@ethereumjs/util')
 
-const { Trie } = require('../../dist/cjs/index.js')
+const { MerklePatriciaTrie } = require('../../dist/cjs/index.js')
 
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 
 async function test() {
   const node1 = await trie.findPath(utf8ToBytes('testKey')) // We attempt to retrieve the node using our key "testKey"

--- a/packages/trie/examples/merkle_patricia_trees/example2b.js
+++ b/packages/trie/examples/merkle_patricia_trees/example2b.js
@@ -2,9 +2,9 @@
 
 const { bytesToHex, bytesToUtf8, utf8ToBytes } = require('@ethereumjs/util')
 
-const { Trie } = require('../../dist/cjs/index.js')
+const { MerklePatriciaTrie } = require('../../dist/cjs/index.js')
 
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 
 async function test() {
   // Notice how similar the following keys are

--- a/packages/trie/examples/merkle_patricia_trees/example2c.js
+++ b/packages/trie/examples/merkle_patricia_trees/example2c.js
@@ -2,9 +2,9 @@
 
 const { bytesToUtf8, utf8ToBytes } = require('@ethereumjs/util')
 
-const { Trie } = require('../../dist/cjs/index.js')
+const { MerklePatriciaTrie } = require('../../dist/cjs/index.js')
 
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 
 async function test() {
   await trie.put(utf8ToBytes('testKey'), utf8ToBytes('testValue'))

--- a/packages/trie/examples/merkle_patricia_trees/example2d.js
+++ b/packages/trie/examples/merkle_patricia_trees/example2d.js
@@ -2,9 +2,9 @@
 
 const { bytesToHex, utf8ToBytes } = require('@ethereumjs/util')
 
-const { Trie } = require('../../dist/cjs/index.js')
+const { MerklePatriciaTrie } = require('../../dist/cjs/index.js')
 
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 
 async function test() {
   console.log(bytesToHex(utf8ToBytes('testKey')))

--- a/packages/trie/examples/merkle_patricia_trees/example3a.js
+++ b/packages/trie/examples/merkle_patricia_trees/example3a.js
@@ -4,9 +4,9 @@ const rlp = require('@ethereumjs/rlp')
 const { bytesToHex, utf8ToBytes } = require('@ethereumjs/util')
 const { keccak256 } = require('ethereum-cryptography/keccak')
 
-const { Trie } = require('../../dist/cjs/index.js')
+const { MerklePatriciaTrie } = require('../../dist/cjs/index.js')
 
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 
 async function test() {
   // We populate the tree to create an extension node.

--- a/packages/trie/examples/merkle_patricia_trees/example3b.js
+++ b/packages/trie/examples/merkle_patricia_trees/example3b.js
@@ -2,10 +2,10 @@
 
 const { bytesToHex, utf8ToBytes } = require('@ethereumjs/util')
 
-const { Trie } = require('../../dist/cjs/index.js')
+const { MerklePatriciaTrie } = require('../../dist/cjs/index.js')
 
-const trie1 = new Trie()
-const trie2 = new Trie()
+const trie1 = new MerklePatriciaTrie()
+const trie2 = new MerklePatriciaTrie()
 
 async function test() {
   await trie1.put(utf8ToBytes('testKey'), utf8ToBytes('testValue'))

--- a/packages/trie/examples/proofs.ts
+++ b/packages/trie/examples/proofs.ts
@@ -1,7 +1,7 @@
-import { Trie, createMerkleProof, verifyMerkleProof } from '@ethereumjs/trie'
+import { MerklePatriciaTrie, createMerkleProof, verifyMerkleProof } from '@ethereumjs/trie'
 import { bytesToUtf8, utf8ToBytes } from '@ethereumjs/util'
 
-const trie = new Trie()
+const trie = new MerklePatriciaTrie()
 
 async function main() {
   const k1 = utf8ToBytes('key1')

--- a/packages/trie/scripts/view.ts
+++ b/packages/trie/scripts/view.ts
@@ -8,7 +8,7 @@ import {
 } from '@ethereumjs/util'
 
 import { BranchNode, ExtensionNode, LeafNode } from '../node/index.js'
-import { Trie } from '../trie.js'
+import { MerklePatriciaTrie } from '../trie.js'
 
 import { _walkTrie } from './asyncWalk.js'
 
@@ -55,7 +55,7 @@ function getNodeType(node: TrieNode): TNode {
         : 'nl'
 }
 
-function logNode(trie: Trie, node: TrieNode, currentKey: number[]): void {
+function logNode(trie: MerklePatriciaTrie, node: TrieNode, currentKey: number[]): void {
   delimiter(3)
   const type = getNodeType(node)
   if (equalsBytes(trie.hash(node.serialize()), trie.root())) {
@@ -88,7 +88,7 @@ function logNode(trie: Trie, node: TrieNode, currentKey: number[]): void {
 }
 
 export const view = async (testName: string, inputs: any[], root: string) => {
-  const trie = new Trie()
+  const trie = new MerklePatriciaTrie()
   const expect = root
   const testKeys: Map<string, Uint8Array | null> = new Map()
   const testStrings: Map<string, [string, string | null]> = new Map()

--- a/packages/trie/src/constructors.ts
+++ b/packages/trie/src/constructors.ts
@@ -7,7 +7,7 @@ import {
 import { keccak256 } from 'ethereum-cryptography/keccak'
 import { concatBytes } from 'ethereum-cryptography/utils'
 
-import { ROOT_DB_KEY, Trie, updateTrieFromMerkleProof } from './index.js'
+import { MerklePatriciaTrie, ROOT_DB_KEY, updateTrieFromMerkleProof } from './index.js'
 
 import type { Proof, TrieOpts } from './index.js'
 
@@ -49,7 +49,7 @@ export async function createTrie(opts?: TrieOpts) {
     }
   }
 
-  return new Trie(opts)
+  return new MerklePatriciaTrie(opts)
 }
 
 /**
@@ -62,7 +62,7 @@ export async function createTrie(opts?: TrieOpts) {
  */
 export async function createTrieFromProof(proof: Proof, trieOpts?: TrieOpts) {
   const shouldVerifyRoot = trieOpts?.root !== undefined
-  const trie = new Trie(trieOpts)
+  const trie = new MerklePatriciaTrie(trieOpts)
   const root = await updateTrieFromMerkleProof(trie, proof, shouldVerifyRoot)
   trie.root(root)
   await trie.persistRoot()

--- a/packages/trie/src/proof/index.ts
+++ b/packages/trie/src/proof/index.ts
@@ -2,7 +2,7 @@ import { bytesToHex, concatBytes, equalsBytes } from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak'
 
 import { createTrieFromProof } from '../constructors.js'
-import { Trie, verifyRangeProof } from '../index.js'
+import { MerklePatriciaTrie, verifyRangeProof } from '../index.js'
 import { bytesToNibbles } from '../util/nibbles.js'
 
 import type { Proof, TrieOpts } from '../index.js'
@@ -71,7 +71,7 @@ export function verifyTrieRangeProof(
  * serialized branch, extension, and/or leaf nodes.
  * @param key key to create a proof for
  */
-export async function createMerkleProof(trie: Trie, key: Uint8Array): Promise<Proof> {
+export async function createMerkleProof(trie: MerklePatriciaTrie, key: Uint8Array): Promise<Proof> {
   trie['DEBUG'] && trie['debug'](`Creating Proof for Key: ${bytesToHex(key)}`, ['create_proof'])
   const { stack } = await trie.findPath(trie['appliedKey'](key))
   const p = stack.map((stackElem) => {
@@ -90,7 +90,7 @@ export async function createMerkleProof(trie: Trie, key: Uint8Array): Promise<Pr
  * @returns The root of the proof
  */
 export async function updateTrieFromMerkleProof(
-  trie: Trie,
+  trie: MerklePatriciaTrie,
   proof: Proof,
   shouldVerifyRoot: boolean = false,
 ) {
@@ -129,7 +129,7 @@ export async function updateTrieFromMerkleProof(
  * @returns The value from the key, or null if valid proof of non-existence.
  */
 export async function verifyMerkleProof(
-  trie: Trie,
+  trie: MerklePatriciaTrie,
   rootHash: Uint8Array,
   key: Uint8Array,
   proof: Proof,
@@ -142,7 +142,7 @@ export async function verifyMerkleProof(
   `,
       ['VERIFY_PROOF'],
     )
-  const proofTrie = new Trie({
+  const proofTrie = new MerklePatriciaTrie({
     root: rootHash,
     useKeyHashingFunction: trie['_opts'].useKeyHashingFunction,
     common: trie['_opts'].common,

--- a/packages/trie/src/proof/range.ts
+++ b/packages/trie/src/proof/range.ts
@@ -2,7 +2,7 @@ import { equalsBytes } from '@ethereumjs/util'
 
 import { createTrieFromProof } from '../index.js'
 import { BranchNode, ExtensionNode, LeafNode } from '../node/index.js'
-import { Trie } from '../trie.js'
+import { MerklePatriciaTrie } from '../trie.js'
 import { nibblesCompare, nibblesTypeToPackedBytes } from '../util/nibbles.js'
 
 import type { HashKeysFunction, Nibbles, TrieNode } from '../types.js'
@@ -21,7 +21,7 @@ import type { HashKeysFunction, Nibbles, TrieNode } from '../types.js'
  * @returns The end position of key.
  */
 async function unset(
-  trie: Trie,
+  trie: MerklePatriciaTrie,
   parent: TrieNode,
   child: TrieNode | null,
   key: Nibbles,
@@ -105,7 +105,11 @@ async function unset(
  * @param right - right nibbles.
  * @returns Is it an empty trie.
  */
-async function unsetInternal(trie: Trie, left: Nibbles, right: Nibbles): Promise<boolean> {
+async function unsetInternal(
+  trie: MerklePatriciaTrie,
+  left: Nibbles,
+  right: Nibbles,
+): Promise<boolean> {
   // Key position
   let pos = 0
   // Parent node
@@ -322,7 +326,7 @@ async function verifyMerkleProof(
   key: Uint8Array,
   proof: Uint8Array[],
   useKeyHashingFunction: HashKeysFunction,
-): Promise<{ value: Uint8Array | null; trie: Trie }> {
+): Promise<{ value: Uint8Array | null; trie: MerklePatriciaTrie }> {
   const proofTrie = await createTrieFromProof(proof, {
     root: rootHash,
     useKeyHashingFunction,
@@ -348,7 +352,7 @@ async function verifyMerkleProof(
  * @param trie - trie object.
  * @param key - given path.
  */
-async function hasRightElement(trie: Trie, key: Nibbles): Promise<boolean> {
+async function hasRightElement(trie: MerklePatriciaTrie, key: Nibbles): Promise<boolean> {
   let pos = 0
   let node: TrieNode | null = await trie.lookupNode(trie.root())
   while (node !== null) {
@@ -437,7 +441,7 @@ export async function verifyRangeProof(
 
   // All elements proof
   if (proof === null && firstKey === null && lastKey === null) {
-    const trie = new Trie({ useKeyHashingFunction })
+    const trie = new MerklePatriciaTrie({ useKeyHashingFunction })
     for (let i = 0; i < keys.length; i++) {
       await trie.put(nibblesTypeToPackedBytes(keys[i]), values[i])
     }

--- a/packages/trie/src/trie.ts
+++ b/packages/trie/src/trie.ts
@@ -49,9 +49,9 @@ import type { BatchDBOp, DB } from '@ethereumjs/util'
 import type { Debugger } from 'debug'
 
 /**
- * The basic trie interface, use with `import { Trie } from '@ethereumjs/trie'`.
+ * The basic trie interface, use with `import { MerklePatriciaTrie } from '@ethereumjs/trie'`.
  */
-export class Trie {
+export class MerklePatriciaTrie {
   protected readonly _opts: TrieOptsWithDefaults = {
     useKeyHashing: false,
     useKeyHashingFunction: keccak256,
@@ -946,8 +946,8 @@ export class Trie {
    *
    * @param includeCheckpoints - If true and during a checkpoint, the copy will contain the checkpointing metadata and will use the same scratch as underlying db.
    */
-  shallowCopy(includeCheckpoints = true, opts?: TrieShallowCopyOpts): Trie {
-    const trie = new Trie({
+  shallowCopy(includeCheckpoints = true, opts?: TrieShallowCopyOpts): MerklePatriciaTrie {
+    const trie = new MerklePatriciaTrie({
       ...this._opts,
       db: this._db.db.shallowCopy(),
       root: this.root(),

--- a/packages/trie/src/types.ts
+++ b/packages/trie/src/types.ts
@@ -56,11 +56,11 @@ export interface TrieOpts {
   root?: Uint8Array
 
   /**
-   * Create as a secure Trie where the keys are automatically hashed using the
+   * Create as a secure MerklePatriciaTrie where the keys are automatically hashed using the
    * **keccak256** hash function or alternatively the custom hash function provided.
    * Default: `false`
    *
-   * This is the flavor of the Trie which is used in production Ethereum networks
+   * This is the flavor of the MerklePatriciaTrie which is used in production Ethereum networks
    * like Ethereum Mainnet.
    *
    * Note: This functionality has been refactored along the v5 release and was before

--- a/packages/trie/src/util/asyncWalk.ts
+++ b/packages/trie/src/util/asyncWalk.ts
@@ -4,14 +4,14 @@ import { bytesToHex, equalsBytes } from '@ethereumjs/util'
 import { BranchNode } from '../node/branch.js'
 import { ExtensionNode } from '../node/extension.js'
 
-import type { Trie } from '../trie.js'
+import type { MerklePatriciaTrie } from '../trie.js'
 import type { TrieNode } from '../types.js'
 
 export type NodeFilter = (node: TrieNode, key: number[]) => Promise<boolean>
 export type OnFound = (node: TrieNode, key: number[]) => Promise<any>
 
 /**
- * Walk Trie via async generator
+ * Walk MerklePatriciaTrie via async generator
  * @param nodeHash - The root key to walk on.
  * @param currentKey - The current (partial) key.
  * @param onFound - Called on every node found (before filter)
@@ -22,7 +22,7 @@ export type OnFound = (node: TrieNode, key: number[]) => Promise<any>
  * `for await (const { node, currentKey } of trie._walkTrie(root)) { ... }`
  */
 export async function* _walkTrie(
-  this: Trie,
+  this: MerklePatriciaTrie,
   nodeHash: Uint8Array,
   currentKey: number[] = [],
   onFound: OnFound = async (_trieNode: TrieNode, _key: number[]) => {},

--- a/packages/trie/src/util/encoding.ts
+++ b/packages/trie/src/util/encoding.ts
@@ -6,7 +6,7 @@ import type { Nibbles } from '../types.js'
 
 // Reference: https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/
 //
-// Trie keys are dealt with in three distinct encodings:
+// MerklePatriciaTrie keys are dealt with in three distinct encodings:
 //
 // KEYBYTES encoding contains the actual key and nothing else. This encoding is the
 // input to most API functions.

--- a/packages/trie/src/util/genesisState.ts
+++ b/packages/trie/src/util/genesisState.ts
@@ -8,7 +8,7 @@ import {
 } from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak.js'
 
-import { Trie } from '../trie.js'
+import { MerklePatriciaTrie } from '../trie.js'
 
 import type { AccountState, GenesisState } from '@ethereumjs/util'
 
@@ -16,7 +16,7 @@ import type { AccountState, GenesisState } from '@ethereumjs/util'
  * Derives the stateRoot of the genesis block based on genesis allocations
  */
 export async function genesisStateRoot(genesisState: GenesisState) {
-  const trie = new Trie({ useKeyHashing: true })
+  const trie = new MerklePatriciaTrie({ useKeyHashing: true })
   for (const [key, value] of Object.entries(genesisState)) {
     const address = isHexString(key) ? hexToBytes(key) : unprefixedHexToBytes(key)
     const account = new Account()
@@ -32,7 +32,7 @@ export async function genesisStateRoot(genesisState: GenesisState) {
         account.codeHash = keccak256(codeBytes)
       }
       if (storage !== undefined) {
-        const storageTrie = new Trie({ useKeyHashing: true })
+        const storageTrie = new MerklePatriciaTrie({ useKeyHashing: true })
         for (const [k, val] of storage) {
           const storageKey = isHexString(k) ? hexToBytes(k) : unprefixedHexToBytes(k)
           const storageVal = RLP.encode(

--- a/packages/trie/src/util/walkController.ts
+++ b/packages/trie/src/util/walkController.ts
@@ -2,7 +2,7 @@ import { PrioritizedTaskExecutor } from '@ethereumjs/util'
 
 import { BranchNode, ExtensionNode, LeafNode } from '../node/index.js'
 
-import type { Trie } from '../trie.js'
+import type { MerklePatriciaTrie } from '../trie.js'
 import type { FoundNodeFunction, Nibbles, TrieNode } from '../types.js'
 
 /**
@@ -11,7 +11,7 @@ import type { FoundNodeFunction, Nibbles, TrieNode } from '../types.js'
 export class WalkController {
   readonly onNode: FoundNodeFunction
   readonly taskExecutor: PrioritizedTaskExecutor
-  readonly trie: Trie
+  readonly trie: MerklePatriciaTrie
   private resolve: Function
   private reject: Function
 
@@ -21,7 +21,7 @@ export class WalkController {
    * @param trie - The `Trie` to walk on.
    * @param poolSize - The size of the task queue.
    */
-  private constructor(onNode: FoundNodeFunction, trie: Trie, poolSize: number) {
+  private constructor(onNode: FoundNodeFunction, trie: MerklePatriciaTrie, poolSize: number) {
     this.onNode = onNode
     this.taskExecutor = new PrioritizedTaskExecutor(poolSize)
     this.trie = trie
@@ -38,7 +38,7 @@ export class WalkController {
    */
   static async newWalk(
     onNode: FoundNodeFunction,
-    trie: Trie,
+    trie: MerklePatriciaTrie,
     root: Uint8Array,
     poolSize?: number,
   ): Promise<void> {

--- a/packages/trie/test/encoding.spec.ts
+++ b/packages/trie/test/encoding.spec.ts
@@ -8,15 +8,15 @@ import {
 } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Trie } from '../src/index.js'
+import { MerklePatriciaTrie } from '../src/index.js'
 
 const key = new Uint8Array([11])
 const value = new Uint8Array([255, 255])
 
 describe('encoding hex prefixes', () => {
   it('should work', async () => {
-    const trie = new Trie()
-    const trie2 = new Trie()
+    const trie = new MerklePatriciaTrie()
+    const trie2 = new MerklePatriciaTrie()
     const hex = 'FF44A3B3'
     await trie.put(hexToBytes(`0x${hex}`), utf8ToBytes('test'))
     await trie2.put(toBytes(`0x${hex}`), utf8ToBytes('test'))
@@ -26,7 +26,7 @@ describe('encoding hex prefixes', () => {
 
 describe('support for Uint8Array', () => {
   it('should use Uint8Array in memory by default', async () => {
-    const trie = new Trie()
+    const trie = new MerklePatriciaTrie()
     const db = (<any>trie)._db.db as MapDB<any, any>
     await trie.put(key, value)
     const keys = db._database.size
@@ -38,12 +38,12 @@ describe('support for Uint8Array', () => {
 
   it('should throw when setting valueEncoding and no database provided', () => {
     assert.throws(() => {
-      new Trie({ valueEncoding: ValueEncoding.String })
+      new MerklePatriciaTrie({ valueEncoding: ValueEncoding.String })
     })
   })
 
   it('should default to use strings when a database is provided', async () => {
-    const trie = new Trie({ db: new MapDB() })
+    const trie = new MerklePatriciaTrie({ db: new MapDB() })
     const db = (<any>trie)._db.db as MapDB<any, any>
     await trie.put(key, value)
     const keys = db._database.size
@@ -57,7 +57,7 @@ describe('support for Uint8Array', () => {
   })
 
   it('should use Uint8Array in memory by default', async () => {
-    const trie = new Trie({ db: new MapDB(), valueEncoding: ValueEncoding.Bytes })
+    const trie = new MerklePatriciaTrie({ db: new MapDB(), valueEncoding: ValueEncoding.Bytes })
     const db = (<any>trie)._db.db as MapDB<any, any>
     await trie.put(key, value)
     const keys = db._database.size

--- a/packages/trie/test/index.spec.ts
+++ b/packages/trie/test/index.spec.ts
@@ -12,7 +12,7 @@ import { blake2b } from 'ethereum-cryptography/blake2b.js'
 import { keccak256 } from 'ethereum-cryptography/keccak.js'
 import { assert, describe, it } from 'vitest'
 
-import { LeafNode, Trie } from '../src/index.js'
+import { LeafNode, MerklePatriciaTrie } from '../src/index.js'
 import { bytesToNibbles } from '../src/util/nibbles.js'
 
 import type { HashKeysFunction } from '../src/index.js'
@@ -25,12 +25,12 @@ for (const keyPrefix of [undefined, hexToBytes('0x1234')]) {
           '0x3f4399b08efe68945c1cf90ffe85bbe3ce978959da753f9e649f034015b8817d',
         )
 
-        const trie = new Trie({ root, keyPrefix })
+        const trie = new MerklePatriciaTrie({ root, keyPrefix })
         const value = await trie.get(utf8ToBytes('test'))
         assert.equal(value, null)
       })
 
-      const trie = new Trie({ cacheSize })
+      const trie = new MerklePatriciaTrie({ cacheSize })
 
       it('save a value', async () => {
         await trie.put(utf8ToBytes('test'), utf8ToBytes('one'))
@@ -83,7 +83,7 @@ for (const keyPrefix of [undefined, hexToBytes('0x1234')]) {
       })
 
       describe('storing longer values', () => {
-        const trie = new Trie({ cacheSize })
+        const trie = new MerklePatriciaTrie({ cacheSize })
         const longString = 'this will be a really really really long value'
         const longStringRoot = 'b173e2db29e79c78963cff5196f8a983fbe0171388972106b114ef7f5c24dfa3'
 
@@ -104,7 +104,7 @@ for (const keyPrefix of [undefined, hexToBytes('0x1234')]) {
       })
 
       describe('testing extensions and branches', () => {
-        const trie = new Trie({ cacheSize })
+        const trie = new MerklePatriciaTrie({ cacheSize })
 
         it('should store a value', async () => {
           await trie.put(utf8ToBytes('doge'), utf8ToBytes('coin'))
@@ -128,7 +128,7 @@ for (const keyPrefix of [undefined, hexToBytes('0x1234')]) {
       })
 
       describe('testing extensions and branches - reverse', () => {
-        const trie = new Trie({ cacheSize })
+        const trie = new MerklePatriciaTrie({ cacheSize })
 
         it('should create extension to store this value', async () => {
           await trie.put(utf8ToBytes('do'), utf8ToBytes('verb'))
@@ -150,7 +150,7 @@ for (const keyPrefix of [undefined, hexToBytes('0x1234')]) {
 
     describe('testing deletion cases', () => {
       const trieSetup = {
-        trie: new Trie({ cacheSize }),
+        trie: new MerklePatriciaTrie({ cacheSize }),
         msg: 'without DB delete',
       }
 
@@ -234,7 +234,7 @@ for (const keyPrefix of [undefined, hexToBytes('0x1234')]) {
 
     describe('shall handle the case of node not found correctly', () => {
       it('should work', async () => {
-        const trie = new Trie({ cacheSize })
+        const trie = new MerklePatriciaTrie({ cacheSize })
         await trie.put(utf8ToBytes('a'), utf8ToBytes('value1'))
         await trie.put(utf8ToBytes('aa'), utf8ToBytes('value2'))
         await trie.put(utf8ToBytes('aaa'), utf8ToBytes('value3'))
@@ -266,7 +266,7 @@ for (const keyPrefix of [undefined, hexToBytes('0x1234')]) {
 
     describe('it should create the genesis state root from ethereum', () => {
       it('should work', async () => {
-        const trie4 = new Trie({ cacheSize })
+        const trie4 = new MerklePatriciaTrie({ cacheSize })
 
         const g = hexToBytes('0x8a40bfaa73256b60764c1bf40675a99083efb075')
         const j = hexToBytes('0xe6716f9544a56c530d868e4bfbacb172315bdead')
@@ -312,7 +312,7 @@ for (const keyPrefix of [undefined, hexToBytes('0x1234')]) {
         )
 
         const trieSetup = {
-          trie: new Trie({ cacheSize }),
+          trie: new MerklePatriciaTrie({ cacheSize }),
           expected: v1,
           msg: 'should return v1 when setting back the state root when deleteFromDB=false',
         }
@@ -345,7 +345,7 @@ for (const keyPrefix of [undefined, hexToBytes('0x1234')]) {
         const [k, v] = [utf8ToBytes('foo'), utf8ToBytes('bar')]
         const expectedRoot = useKeyHashingFunction(new LeafNode(bytesToNibbles(k), v).serialize())
 
-        const trie = new Trie({ useKeyHashingFunction, cacheSize })
+        const trie = new MerklePatriciaTrie({ useKeyHashingFunction, cacheSize })
         await trie.put(k, v)
         assert.equal(bytesToHex(trie.root()), bytesToHex(expectedRoot))
       })
@@ -353,7 +353,10 @@ for (const keyPrefix of [undefined, hexToBytes('0x1234')]) {
 
     describe('blake2b256 trie root', () => {
       it('should work', async () => {
-        const trie = new Trie({ useKeyHashingFunction: (msg) => blake2b(msg, 32), cacheSize })
+        const trie = new MerklePatriciaTrie({
+          useKeyHashingFunction: (msg) => blake2b(msg, 32),
+          cacheSize,
+        })
         await trie.put(utf8ToBytes('foo'), utf8ToBytes('bar'))
 
         assert.equal(
@@ -365,7 +368,7 @@ for (const keyPrefix of [undefined, hexToBytes('0x1234')]) {
 
     describe('empty root', () => {
       it('should work', async () => {
-        const trie = new Trie({ cacheSize })
+        const trie = new MerklePatriciaTrie({ cacheSize })
 
         assert.equal(bytesToHex(trie.root()), KECCAK256_RLP_S)
       })

--- a/packages/trie/test/official.spec.ts
+++ b/packages/trie/test/official.spec.ts
@@ -1,7 +1,7 @@
 import { bytesToHex, hexToBytes, isHexString, utf8ToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Trie } from '../src/index.js'
+import { MerklePatriciaTrie } from '../src/index.js'
 
 import { trieAnyOrderData } from './fixtures/trieAnyOrder.js'
 import { trieTestData } from './fixtures/trieTest.js'
@@ -9,7 +9,7 @@ import { trieTestData } from './fixtures/trieTest.js'
 describe('official tests', () => {
   it('should work', async () => {
     const testNames = Object.keys(trieTestData.tests) as (keyof typeof trieTestData.tests)[]
-    let trie = new Trie()
+    let trie = new MerklePatriciaTrie()
 
     for (const testName of testNames) {
       const inputs = trieTestData.tests[testName].in
@@ -26,7 +26,7 @@ describe('official tests', () => {
         await trie.put(processedInput[0], processedInput[1])
       }
       assert.equal(bytesToHex(trie.root()), expect)
-      trie = new Trie()
+      trie = new MerklePatriciaTrie()
     }
   })
 })
@@ -34,7 +34,7 @@ describe('official tests', () => {
 describe('official tests any order', async () => {
   it('should work', async () => {
     const testNames = Object.keys(trieAnyOrderData.tests) as (keyof typeof trieAnyOrderData.tests)[]
-    let trie = new Trie()
+    let trie = new MerklePatriciaTrie()
     for (const testName of testNames) {
       const test = trieAnyOrderData.tests[testName]
       const keys = Object.keys(test.in)
@@ -58,7 +58,7 @@ describe('official tests any order', async () => {
         await trie.put(key, value)
       }
       assert.equal(bytesToHex(trie.root()), test.root)
-      trie = new Trie()
+      trie = new MerklePatriciaTrie()
     }
   })
 })

--- a/packages/trie/test/proof.spec.ts
+++ b/packages/trie/test/proof.spec.ts
@@ -3,7 +3,7 @@ import { bytesToUtf8, equalsBytes, setLengthLeft, utf8ToBytes } from '@ethereumj
 import { assert, describe, it } from 'vitest'
 
 import {
-  Trie,
+  MerklePatriciaTrie,
   createMerkleProof,
   createTrieFromProof,
   updateTrieFromMerkleProof,
@@ -12,7 +12,7 @@ import {
 
 describe('simple merkle proofs generation and verification', () => {
   it('create a merkle proof and verify it', async () => {
-    const trie = new Trie()
+    const trie = new MerklePatriciaTrie()
 
     await trie.put(utf8ToBytes('key1aa'), utf8ToBytes('0123456789012345678901234567890123456789xx'))
     await trie.put(utf8ToBytes('key2bb'), utf8ToBytes('aVal2'))
@@ -82,7 +82,7 @@ describe('simple merkle proofs generation and verification', () => {
   })
 
   it('create a merkle proof and verify it with a single long key', async () => {
-    const trie = new Trie()
+    const trie = new MerklePatriciaTrie()
 
     await trie.put(utf8ToBytes('key1aa'), utf8ToBytes('0123456789012345678901234567890123456789xx'))
 
@@ -92,7 +92,7 @@ describe('simple merkle proofs generation and verification', () => {
   })
 
   it('create a merkle proof and verify it with a single short key', async () => {
-    const trie = new Trie()
+    const trie = new MerklePatriciaTrie()
 
     await trie.put(utf8ToBytes('key1aa'), utf8ToBytes('01234'))
 
@@ -102,7 +102,7 @@ describe('simple merkle proofs generation and verification', () => {
   })
 
   it('create a merkle proof and verify it whit keys in the middle', async () => {
-    const trie = new Trie()
+    const trie = new MerklePatriciaTrie()
 
     await trie.put(
       utf8ToBytes('key1aa'),
@@ -131,7 +131,7 @@ describe('simple merkle proofs generation and verification', () => {
   })
 
   it('should succeed with a simple embedded extension-branch', async () => {
-    const trie = new Trie()
+    const trie = new MerklePatriciaTrie()
 
     await trie.put(utf8ToBytes('a'), utf8ToBytes('a'))
     await trie.put(utf8ToBytes('b'), utf8ToBytes('b'))
@@ -151,7 +151,7 @@ describe('simple merkle proofs generation and verification', () => {
   })
 
   it('creates and updates tries from proof', async () => {
-    const trie = new Trie({ useKeyHashing: true })
+    const trie = new MerklePatriciaTrie({ useKeyHashing: true })
 
     const key = setLengthLeft(new Uint8Array([1, 2, 3]), 32)
     const encodedValue = RLP.encode(new Uint8Array([5]))
@@ -183,7 +183,7 @@ describe('simple merkle proofs generation and verification', () => {
     const trieValue3 = await newTrie.get(key3)
     assert.equal(trieValue3, null, 'cannot reach the third key')
 
-    const safeTrie = new Trie({ useKeyHashing: true })
+    const safeTrie = new MerklePatriciaTrie({ useKeyHashing: true })
     const safeKey = setLengthLeft(new Uint8Array([100]), 32)
     const safeValue = RLP.encode(new Uint8Array([1337]))
 

--- a/packages/trie/test/proof/range.spec.ts
+++ b/packages/trie/test/proof/range.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Trie, createMerkleProof, verifyTrieRangeProof } from '../../src/index.js'
+import { MerklePatriciaTrie, createMerkleProof, verifyTrieRangeProof } from '../../src/index.js'
 
 import type { DB } from '@ethereumjs/util'
 
@@ -20,11 +20,11 @@ const TRIE_SIZE = 512
 /**
  * Create a random trie.
  * @param addKey - whether to add 100 ordered keys
- * @returns Trie object and sorted entries
+ * @returns MerklePatriciaTrie object and sorted entries
  */
 async function randomTrie(db: DB<string, string>, addKey: boolean = true) {
   const entries: [Uint8Array, Uint8Array][] = []
-  const trie = new Trie({ db })
+  const trie = new MerklePatriciaTrie({ db })
 
   if (addKey) {
     for (let i = 0; i < 100; i++) {
@@ -76,7 +76,7 @@ function increaseKey(key: Uint8Array) {
 }
 
 async function verify(
-  trie: Trie,
+  trie: MerklePatriciaTrie,
   entries: [Uint8Array, Uint8Array][],
   start: number,
   end: number,
@@ -199,7 +199,7 @@ describe('simple merkle range proofs generation and verification', () => {
     )
 
     // Test the mini trie with only a single element.
-    const tinyTrie = new Trie()
+    const tinyTrie = new MerklePatriciaTrie()
     const tinyEntries: [Uint8Array, Uint8Array][] = [[randomBytes(32), randomBytes(20)]]
     await tinyTrie.put(tinyEntries[0][0], tinyEntries[0][1])
 
@@ -261,7 +261,7 @@ describe('simple merkle range proofs generation and verification', () => {
 
   it('create a bad range proof and verify it', async () => {
     const runTest = async (
-      cb: (trie: Trie, entries: [Uint8Array, Uint8Array][]) => Promise<void>,
+      cb: (trie: MerklePatriciaTrie, entries: [Uint8Array, Uint8Array][]) => Promise<void>,
     ) => {
       const { trie, entries } = await randomTrie(new MapDB(), false)
 
@@ -320,7 +320,7 @@ describe('simple merkle range proofs generation and verification', () => {
   })
 
   it('create a gapped range proof and verify it', async () => {
-    const trie = new Trie()
+    const trie = new MerklePatriciaTrie()
     const entries: [Uint8Array, Uint8Array][] = []
     for (let i = 0; i < 10; i++) {
       const key = setLengthLeft(toBytes(i), 32)

--- a/packages/trie/test/trie/checkpoint.spec.ts
+++ b/packages/trie/test/trie/checkpoint.spec.ts
@@ -10,16 +10,16 @@ import { keccak256 } from 'ethereum-cryptography/keccak.js'
 import { sha256 } from 'ethereum-cryptography/sha256.js'
 import { assert, describe, it } from 'vitest'
 
-import { ROOT_DB_KEY, Trie, createTrie } from '../../src/index.js'
+import { MerklePatriciaTrie, ROOT_DB_KEY, createTrie } from '../../src/index.js'
 
 describe('testing checkpoints', () => {
-  let trie: Trie
-  let trieCopy: Trie
+  let trie: MerklePatriciaTrie
+  let trieCopy: MerklePatriciaTrie
   let preRoot: string
   let postRoot: string
 
   it('setup', async () => {
-    trie = new Trie()
+    trie = new MerklePatriciaTrie()
     await trie.put(utf8ToBytes('do'), utf8ToBytes('verb'))
     await trie.put(utf8ToBytes('doge'), utf8ToBytes('coin'))
     preRoot = bytesToHex(trie.root())
@@ -33,7 +33,7 @@ describe('testing checkpoints', () => {
   })
 
   it('should deactivate cache on copy()', async () => {
-    const trie = new Trie({ cacheSize: 100 })
+    const trie = new MerklePatriciaTrie({ cacheSize: 100 })
     trieCopy = trie.shallowCopy()
     assert.equal((trieCopy as any)._opts.cacheSize, 0)
   })
@@ -61,7 +61,7 @@ describe('testing checkpoints', () => {
   })
 
   it('should copy trie and use the correct hash function', async () => {
-    const trie = new Trie({
+    const trie = new MerklePatriciaTrie({
       db: new MapDB(),
       useKeyHashing: true,
       useKeyHashingFunction: sha256,
@@ -84,7 +84,7 @@ describe('testing checkpoints', () => {
     one has to keep track of what key/values are changed and then re-apply these
     on the trie again. However, by copying the checkpoint, one can immediately
     update the original trie (have to manually copy the root after applying the checkpoint, too).
-    This test also implicitly checks that on copying a Trie, the checkpoints are deep-copied.
+    This test also implicitly checks that on copying a MerklePatriciaTrie, the checkpoints are deep-copied.
     If it would not deep copy, then some checks in this test will fail.
     See PR 2203 and 2236.
   */

--- a/packages/trie/test/trie/checkpointing.spec.ts
+++ b/packages/trie/test/trie/checkpointing.spec.ts
@@ -1,7 +1,7 @@
 import { equalsBytes, hexToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Trie } from '../../src/index.js'
+import { MerklePatriciaTrie } from '../../src/index.js'
 
 // exhaustive testing of checkpoint, revert, flush, and commit functionality of trie, inspired by
 // the statemanager checkpointing.*.spec.ts tests
@@ -67,7 +67,7 @@ describe('trie: checkpointing', () => {
     },
   ]
 
-  const trieEval = async (trie: Trie, value: any) => {
+  const trieEval = async (trie: MerklePatriciaTrie, value: any) => {
     const actualValue = await trie.get(key)
     const pass = actualValue === null ? value === null : equalsBytes(actualValue, value)
     return pass
@@ -75,7 +75,7 @@ describe('trie: checkpointing', () => {
 
   for (const kv of kvs) {
     it('No CP -> V1 -> Flush() (-> V1)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       await trie.put(key, kv.v1)
       trie.flushCheckpoints()
@@ -83,7 +83,7 @@ describe('trie: checkpointing', () => {
       assert.ok(await trieEval(trie, kv.v1))
     })
     it('CP -> V1 -> Commit -> Flush() (-> V1)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       trie.checkpoint()
       await trie.put(key, kv.v1)
@@ -94,7 +94,7 @@ describe('trie: checkpointing', () => {
     })
 
     it('CP -> V1 -> Revert -> Flush() (-> Undefined)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       trie.checkpoint()
       await trie.put(key, kv.v1)
@@ -105,7 +105,7 @@ describe('trie: checkpointing', () => {
     })
 
     it('V1 -> CP -> Commit -> Flush() (-> V1)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       await trie.put(key, kv.v1)
       trie.checkpoint()
@@ -116,7 +116,7 @@ describe('trie: checkpointing', () => {
     })
 
     it('V1 -> CP -> Revert -> Flush() (-> V1)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       await trie.put(key, kv.v1)
       trie.checkpoint()
@@ -127,7 +127,7 @@ describe('trie: checkpointing', () => {
     })
 
     it('V1 -> CP -> V2 -> Commit -> Flush() (-> V2)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       await trie.put(key, kv.v1)
       trie.checkpoint()
@@ -139,7 +139,7 @@ describe('trie: checkpointing', () => {
     })
 
     it('V1 -> CP -> V2 -> Commit -> V3 -> Flush() (-> V3)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       await trie.put(key, kv.v1)
       trie.checkpoint()
@@ -152,7 +152,7 @@ describe('trie: checkpointing', () => {
     })
 
     it('V1 -> CP -> V2 -> V3 -> Commit -> Flush() (-> V3)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       await trie.put(key, kv.v1)
       trie.checkpoint()
@@ -165,7 +165,7 @@ describe('trie: checkpointing', () => {
     })
 
     it('CP -> V1 -> V2 -> Commit -> Flush() (-> V2)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       trie.checkpoint()
       await trie.put(key, kv.v1)
@@ -177,7 +177,7 @@ describe('trie: checkpointing', () => {
     })
 
     it('CP -> V1 -> V2 -> Revert -> Flush() (-> Undefined)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       trie.checkpoint()
       await trie.put(key, kv.v1)
@@ -190,7 +190,7 @@ describe('trie: checkpointing', () => {
     })
 
     it('V1 -> CP -> V2 -> Revert -> Flush() (-> V1)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       await trie.put(key, kv.v1)
       trie.checkpoint()
@@ -202,7 +202,7 @@ describe('trie: checkpointing', () => {
     })
 
     it('V1 -> CP -> V2 -> CP -> V3 -> Commit -> Commit -> Flush() (-> V3)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       await trie.put(key, kv.v1)
       trie.checkpoint()
@@ -217,7 +217,7 @@ describe('trie: checkpointing', () => {
     })
 
     it('V1 -> CP -> V2 -> CP -> V3 -> Commit -> Revert -> Flush() (-> V1)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       await trie.put(key, kv.v1)
       trie.checkpoint()
@@ -232,7 +232,7 @@ describe('trie: checkpointing', () => {
     })
 
     it('V1 -> CP -> V2 -> CP -> V3 -> Revert -> Commit -> Flush() (-> V2)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       await trie.put(key, kv.v1)
       trie.checkpoint()
@@ -247,7 +247,7 @@ describe('trie: checkpointing', () => {
     })
 
     it('V1 -> CP -> V2 -> CP -> V3 -> Revert -> V4 -> Commit -> Flush() (-> V4)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       await trie.put(key, kv.v1)
       trie.checkpoint()
@@ -263,7 +263,7 @@ describe('trie: checkpointing', () => {
     })
 
     it('V1 -> CP -> V2 -> CP -> V3 -> Revert -> V4 -> CP -> V5 -> Commit -> Commit -> Flush() (-> V5)', async () => {
-      const trie = new Trie()
+      const trie = new MerklePatriciaTrie()
 
       await trie.put(key, kv.v1)
       trie.checkpoint()

--- a/packages/trie/test/trie/findPath.spec.ts
+++ b/packages/trie/test/trie/findPath.spec.ts
@@ -1,11 +1,11 @@
 import { randomBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Trie } from '../../src/index.js'
+import { MerklePatriciaTrie } from '../../src/index.js'
 
 describe('TRIE > findPath', async () => {
   const keys = Array.from({ length: 200 }, () => randomBytes(8))
-  const trie = new Trie()
+  const trie = new MerklePatriciaTrie()
   for (const [i, k] of keys.entries()) {
     await trie.put(k, Uint8Array.from([i, i]))
   }
@@ -38,7 +38,7 @@ describe('TRIE > findPath', async () => {
 })
 describe('TRIE (secure) > findPath', async () => {
   const keys = Array.from({ length: 1000 }, () => randomBytes(20))
-  const trie = new Trie({ useKeyHashing: true })
+  const trie = new MerklePatriciaTrie({ useKeyHashing: true })
   for (const [i, k] of keys.entries()) {
     await trie.put(k, Uint8Array.from([i, i]))
   }

--- a/packages/trie/test/trie/prune.spec.ts
+++ b/packages/trie/test/trie/prune.spec.ts
@@ -1,13 +1,13 @@
 import { KECCAK256_RLP, equalsBytes, hexToBytes, randomBytes, utf8ToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Trie, createTrie, isRawNode } from '../../src/index.js'
+import { MerklePatriciaTrie, createTrie, isRawNode } from '../../src/index.js'
 
 import type { BranchNode } from '../../src/index.js'
 
 describe('Pruned trie tests', () => {
   it('should default to not prune the trie', async () => {
-    const trie = new Trie()
+    const trie = new MerklePatriciaTrie()
     const key = utf8ToBytes('test')
     await trie.put(key, utf8ToBytes('1'))
     await trie.put(key, utf8ToBytes('2'))
@@ -20,7 +20,7 @@ describe('Pruned trie tests', () => {
   })
 
   it('should prune simple trie', async () => {
-    const trie = new Trie({ useNodePruning: true })
+    const trie = new MerklePatriciaTrie({ useNodePruning: true })
     const key = utf8ToBytes('test')
     await trie.put(key, utf8ToBytes('1'))
     await trie.put(key, utf8ToBytes('2'))
@@ -33,7 +33,7 @@ describe('Pruned trie tests', () => {
   })
 
   it('should prune simple trie', async () => {
-    const trie = new Trie({ useNodePruning: true })
+    const trie = new MerklePatriciaTrie({ useNodePruning: true })
     const key = utf8ToBytes('test')
     await trie.put(key, utf8ToBytes('1'))
     assert.equal((<any>trie)._db.db._database.size, 1, 'DB size correct')
@@ -46,8 +46,8 @@ describe('Pruned trie tests', () => {
   })
 
   it('should prune trie with depth = 2', async () => {
-    const trie = new Trie({ useNodePruning: true })
-    // Create a Trie with
+    const trie = new MerklePatriciaTrie({ useNodePruning: true })
+    // Create a MerklePatriciaTrie with
     const keys = ['01', '02', '0103', '0104', '0105']
     const values = ['00', '02', '03', '04', '05']
 
@@ -57,7 +57,7 @@ describe('Pruned trie tests', () => {
   })
 
   it('should not prune if the same value is put twice', async () => {
-    const trie = new Trie()
+    const trie = new MerklePatriciaTrie()
     const key = utf8ToBytes('01')
     const value = utf8ToBytes('02')
 
@@ -68,7 +68,7 @@ describe('Pruned trie tests', () => {
   })
 
   it('should not throw if a key is either non-existent or deleted twice', async () => {
-    const trie = new Trie()
+    const trie = new MerklePatriciaTrie()
     const key = utf8ToBytes('01')
     const value = utf8ToBytes('02')
 
@@ -92,7 +92,7 @@ describe('Pruned trie tests', () => {
 
   it('should prune when keys are updated or deleted', async () => {
     for (let testID = 0; testID < 1; testID++) {
-      const trie = new Trie({ useNodePruning: true })
+      const trie = new MerklePatriciaTrie({ useNodePruning: true })
       const keys: Uint8Array[] = []
       for (let i = 0; i < 100; i++) {
         keys.push(randomBytes(32))
@@ -156,7 +156,7 @@ describe('Pruned trie tests', () => {
   it('should successfully delete branch nodes that are <32 bytes length with node pruning', async () => {
     // This test case was added after issue #3333 uncovered a problem with pruning trie paths that reference
     // nodes with their unhashed values (occurs when nodes are less than <32 bytes).
-    const trie = new Trie({
+    const trie = new MerklePatriciaTrie({
       useNodePruning: true,
     })
 
@@ -184,16 +184,16 @@ describe('Pruned trie tests', () => {
   })
 
   it('verifyPrunedIntegrity() => should correctly report unpruned Tries', async () => {
-    // Create empty Trie (is pruned)
-    let trie = new Trie()
+    // Create empty MerklePatriciaTrie (is pruned)
+    let trie = new MerklePatriciaTrie()
     // Create a new value (still is pruned)
     await trie.put(hexToBytes('0xaa'), hexToBytes('0xbb'))
     // Overwrite this value (trie is now not pruned anymore)
     await trie.put(hexToBytes('0xaa'), hexToBytes('0xaa'))
     assert.ok(!(await trie.verifyPrunedIntegrity()), 'trie is not pruned')
 
-    // Create new empty Trie (is pruned)
-    trie = new Trie()
+    // Create new empty MerklePatriciaTrie (is pruned)
+    trie = new MerklePatriciaTrie()
     // Create a new value raw in DB (is not pruned)
     await (<any>trie)._db.db.put(utf8ToBytes('aa'))
     assert.ok(!(await trie.verifyPrunedIntegrity()), 'trie is not pruned')

--- a/packages/trie/test/trie/trie.spec.ts
+++ b/packages/trie/test/trie/trie.spec.ts
@@ -12,15 +12,15 @@ import {
 import { keccak256 } from 'ethereum-cryptography/keccak.js'
 import { assert, describe, it } from 'vitest'
 
-import { ROOT_DB_KEY as BASE_DB_KEY, Trie, createTrie } from '../../src/index.js'
+import { ROOT_DB_KEY as BASE_DB_KEY, MerklePatriciaTrie, createTrie } from '../../src/index.js'
 
 for (const { constructor, defaults, title } of [
   {
-    constructor: Trie,
+    constructor: MerklePatriciaTrie,
     title: 'Trie',
   },
   {
-    constructor: Trie,
+    constructor: MerklePatriciaTrie,
     title: 'SecureTrie',
     defaults: {
       useKeyHashing: true,

--- a/packages/trie/test/util/asyncWalk.spec.ts
+++ b/packages/trie/test/util/asyncWalk.spec.ts
@@ -3,7 +3,7 @@ import { assert, describe, it } from 'vitest'
 
 import {
   LeafNode,
-  Trie,
+  MerklePatriciaTrie,
   createMerkleProof,
   createTrieFromProof,
   verifyTrieProof,
@@ -18,7 +18,7 @@ describe('walk the tries from official tests', async () => {
   const testNames = Object.keys(trieTestData.tests) as (keyof typeof trieTestData.tests)[]
 
   for await (const testName of testNames) {
-    const trie = new Trie()
+    const trie = new MerklePatriciaTrie()
     describe(testName, async () => {
       const inputs = trieTestData.tests[testName].in
       const expect = trieTestData.tests[testName].root
@@ -64,7 +64,7 @@ describe('walk the tries from official tests', async () => {
 })
 
 describe('walk a sparse trie', async () => {
-  const trie = new Trie()
+  const trie = new MerklePatriciaTrie()
   const inputs = trieTestData.tests.jeff.in
   const expect = trieTestData.tests.jeff.root
 

--- a/packages/trie/test/util/log.spec.ts
+++ b/packages/trie/test/util/log.spec.ts
@@ -2,9 +2,9 @@ import { utf8ToBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
 import { createMerkleProof, createTrieFromProof, verifyMerkleProof } from '../../src/index.js'
-import { Trie } from '../../src/trie.js'
+import { MerklePatriciaTrie } from '../../src/trie.js'
 
-describe('Run Trie script with DEBUG enabled', async () => {
+describe('Run MerklePatriciaTrie script with DEBUG enabled', async () => {
   const trie_entries: [string, string | null][] = [
     ['do', 'verb'],
     ['ether', 'wookiedoo'], // cspell:disable-line
@@ -13,7 +13,7 @@ describe('Run Trie script with DEBUG enabled', async () => {
     ['dog', 'puppy'],
   ]
   process.env.DEBUG = 'ethjs'
-  const trie = new Trie({
+  const trie = new MerklePatriciaTrie({
     useRootPersistence: true,
   })
   for (const [key, value] of trie_entries) {

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -7,7 +7,7 @@ import {
 } from '@ethereumjs/block'
 import { ConsensusType, Hardfork } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
-import { Trie } from '@ethereumjs/trie'
+import { MerklePatriciaTrie } from '@ethereumjs/trie'
 import { Blob4844Tx, createMinimal4844TxFromNetworkWrapper } from '@ethereumjs/tx'
 import {
   Address,
@@ -143,7 +143,10 @@ export class BlockBuilder {
    * Calculates and returns the transactionsTrie for the block.
    */
   public async transactionsTrie() {
-    return genTransactionsTrieRoot(this.transactions, new Trie({ common: this.vm.common }))
+    return genTransactionsTrieRoot(
+      this.transactions,
+      new MerklePatriciaTrie({ common: this.vm.common }),
+    )
   }
 
   /**
@@ -165,7 +168,7 @@ export class BlockBuilder {
     if (this.transactionResults.length === 0) {
       return KECCAK256_RLP
     }
-    const receiptTrie = new Trie({ common: this.vm.common })
+    const receiptTrie = new MerklePatriciaTrie({ common: this.vm.common })
     for (const [i, txResult] of this.transactionResults.entries()) {
       const tx = this.transactions[i]
       const encodedReceipt = encodeReceipt(txResult.receipt, tx.type)
@@ -322,7 +325,10 @@ export class BlockBuilder {
 
     const transactionsTrie = await this.transactionsTrie()
     const withdrawalsRoot = this.withdrawals
-      ? await genWithdrawalsTrieRoot(this.withdrawals, new Trie({ common: this.vm.common }))
+      ? await genWithdrawalsTrieRoot(
+          this.withdrawals,
+          new MerklePatriciaTrie({ common: this.vm.common }),
+        )
       : undefined
     const receiptTrie = await this.receiptTrie()
     const logsBloom = this.logsBloom()

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -2,7 +2,7 @@ import { createBlock, genRequestsTrieRoot } from '@ethereumjs/block'
 import { ConsensusType, Hardfork } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
 import { StatelessVerkleStateManager, verifyVerkleStateProof } from '@ethereumjs/statemanager'
-import { Trie } from '@ethereumjs/trie'
+import { MerklePatriciaTrie } from '@ethereumjs/trie'
 import { TransactionType } from '@ethereumjs/tx'
 import {
   Account,
@@ -583,9 +583,9 @@ async function applyTransactions(vm: VM, block: Block, opts: RunBlockOpts) {
   // the total amount of gas used processing these transactions
   let gasUsed = BIGINT_0
 
-  let receiptTrie: Trie | undefined = undefined
+  let receiptTrie: MerklePatriciaTrie | undefined = undefined
   if (block.transactions.length !== 0) {
-    receiptTrie = new Trie({ common: vm.common })
+    receiptTrie = new MerklePatriciaTrie({ common: vm.common })
   }
 
   const receipts: TxReceipt[] = []
@@ -801,7 +801,7 @@ async function _genTxTrie(block: Block) {
   if (block.transactions.length === 0) {
     return KECCAK256_RLP
   }
-  const trie = new Trie({ common: block.common })
+  const trie = new MerklePatriciaTrie({ common: block.common })
   for (const [i, tx] of block.transactions.entries()) {
     await trie.put(RLP.encode(i), tx.serialize())
   }

--- a/packages/vm/test/tester/runners/BlockchainTestsRunner.ts
+++ b/packages/vm/test/tester/runners/BlockchainTestsRunner.ts
@@ -4,7 +4,7 @@ import { ConsensusAlgorithm } from '@ethereumjs/common'
 import { Ethash } from '@ethereumjs/ethash'
 import { RLP } from '@ethereumjs/rlp'
 import { Caches, MerkleStateManager } from '@ethereumjs/statemanager'
-import { Trie } from '@ethereumjs/trie'
+import { MerklePatriciaTrie } from '@ethereumjs/trie'
 import { createTxFromRLP } from '@ethereumjs/tx'
 import {
   MapDB,
@@ -47,7 +47,7 @@ export async function runBlockchainTest(options: any, testData: any, t: tape.Tes
   common.setHardforkBy({ blockNumber: 0 })
 
   let cacheDB = new MapDB()
-  let state = new Trie({ useKeyHashing: true, common })
+  let state = new MerklePatriciaTrie({ useKeyHashing: true, common })
   let stateManager = new MerkleStateManager({
     caches: new Caches(),
     trie: state,

--- a/packages/vm/test/tester/runners/GeneralStateTestsRunner.ts
+++ b/packages/vm/test/tester/runners/GeneralStateTestsRunner.ts
@@ -2,7 +2,7 @@ import { Block } from '@ethereumjs/block'
 import { createBlockchain } from '@ethereumjs/blockchain'
 import { type InterpreterStep } from '@ethereumjs/evm'
 import { Caches, MerkleStateManager } from '@ethereumjs/statemanager'
-import { Trie } from '@ethereumjs/trie'
+import { MerklePatriciaTrie } from '@ethereumjs/trie'
 import {
   Account,
   bytesToHex,
@@ -79,7 +79,7 @@ async function runTestCase(options: any, testData: any, t: tape.Test) {
   // Otherwise mainnet genesis will throw since this has difficulty nonzero
   const genesisBlock = new Block(undefined, undefined, undefined, undefined, { common })
   const blockchain = await createBlockchain({ genesisBlock, common })
-  const state = new Trie({ useKeyHashing: true, common })
+  const state = new MerklePatriciaTrie({ useKeyHashing: true, common })
   const stateManager = new MerkleStateManager({
     caches: new Caches(),
     trie: state,


### PR DESCRIPTION
This PR renames the `Trie` class to `MerklePatriciaTrie`. This aligns with the modularization of state management (i.e. MerkleStateManager & VerkleStateManager) and data structure agnosticism. 

I wasn't sure whether to name it "Tree" or "Trie" and decided to go with what was on the ethereum.org docs: https://ethereum.org/en/developers/docs/data-structures-and-encoding/patricia-merkle-trie/ 