### PR TITLE
t8n: do not create empty coinbase account from SpuriousDragon on state.reward == 0

### DIFF
--- a/packages/vm/DEVELOPER.md
+++ b/packages/vm/DEVELOPER.md
@@ -217,3 +217,7 @@ npm run profiling -- mainnetBlocks:10
 and open the link it generates.
 
 For a high-level introduction on flame graphs see e.g. [this](https://blog.codecentric.de/en/2017/09/jvm-fire-using-flame-graphs-analyse-performance/) blog article (the non-Java part).
+
+## T8NTool: fill `execution-spec-tests` tests and write those
+
+The VM has t8ntool (transition-tool) support, see: <https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/vm/test/t8n/README.md>. This tool can be used to create fixtures from the `execution-spec-tests` repo. These fixtures can be consumed by other clients in their test runner (similar to running `npm run test:blockchain` or `npm run test:state` in the VM package). The t8ntool readme also links to a guide on how to write tests to contribute to `execution-spec-tests`.

--- a/packages/vm/test/t8n/README.md
+++ b/packages/vm/test/t8n/README.md
@@ -41,4 +41,4 @@ Processing new transaction...
 
 ## Writing a test in execution-spec-test
 
-This issue comment is a good refernece to write tests, together with an example: <https://github.com/ethereumjs/ethereumjs-monorepo/issues/3666#issuecomment-2349611424>
+This issue comment is a good reference to write tests, together with an example: <https://github.com/ethereumjs/ethereumjs-monorepo/issues/3666#issuecomment-2349611424>

--- a/packages/vm/test/t8n/README.md
+++ b/packages/vm/test/t8n/README.md
@@ -38,3 +38,7 @@ Processing new transaction...
   address: '0x0000000000000000000000000000000000001000'
 }
 ```
+
+## Writing a test in execution-spec-test
+
+This issue comment is a good refernece to write tests, together with an example: <https://github.com/ethereumjs/ethereumjs-monorepo/issues/3666#issuecomment-2349611424>

--- a/packages/vm/test/t8n/t8ntool.ts
+++ b/packages/vm/test/t8n/t8ntool.ts
@@ -113,6 +113,7 @@ export class TransitionTool {
 
     if (args.state.reward !== BigInt(-1)) {
       await rewardAccount(this.vm.evm, block.header.coinbase, args.state.reward, this.vm.common)
+      this.vm.evm.journal.cleanup()
     }
 
     const result = await builder.build()

--- a/packages/vm/test/t8n/t8ntool.ts
+++ b/packages/vm/test/t8n/t8ntool.ts
@@ -113,7 +113,7 @@ export class TransitionTool {
 
     if (args.state.reward !== BigInt(-1)) {
       await rewardAccount(this.vm.evm, block.header.coinbase, args.state.reward, this.vm.common)
-      this.vm.evm.journal.cleanup()
+      await this.vm.evm.journal.cleanup()
     }
 
     const result = await builder.build()


### PR DESCRIPTION
Fixes a bug in t8ntool filler where we create empty coinbase accounts