### PR TITLE
Add Units class for conversions

### DIFF
--- a/packages/util/src/units.ts
+++ b/packages/util/src/units.ts
@@ -18,3 +18,21 @@ export function formatBigDecimal(
   const zerosPostDecimal = String(maxDecimalFactor).length - 1 - String(fraction).length
   return `${full}.${'0'.repeat(zerosPostDecimal)}${fraction}`
 }
+
+export class Units {
+  static ether(amount: number | bigint): bigint {
+    if (typeof amount === 'number' && !Number.isInteger(amount)) {
+      throw new Error('Input must be an integer number')
+    }
+    const weiPerEther = BigInt(10 ** 18)
+    return BigInt(amount) * weiPerEther
+  }
+
+  static gwei(amount: number | bigint): bigint {
+    if (typeof amount === 'number' && !Number.isInteger(amount)) {
+      throw new Error('Input must be an integer number')
+    }
+    const weiPerGwei = BigInt(10 ** 9)
+    return BigInt(amount) * weiPerGwei
+  }
+}

--- a/packages/util/src/units.ts
+++ b/packages/util/src/units.ts
@@ -1,6 +1,9 @@
 import { BIGINT_0, BIGINT_1 } from './constants.js'
+
 /** Easy conversion from Gwei to wei */
 export const GWEI_TO_WEI = BigInt(1000000000)
+export const WEI_TO_EITHER = BigInt(10 ** 18)
+export const WIE_TO_GWEI = BigInt(10 ** 9)
 
 export function formatBigDecimal(
   numerator: bigint,
@@ -20,19 +23,22 @@ export function formatBigDecimal(
 }
 
 export class Units {
-  static ether(amount: number | bigint): bigint {
+  static validateInput(amount: number | bigint): void {
     if (typeof amount === 'number' && !Number.isInteger(amount)) {
       throw new Error('Input must be an integer number')
     }
-    const weiPerEther = BigInt(10 ** 18)
-    return BigInt(amount) * weiPerEther
+    if (BigInt(amount) < 0) {
+      throw new Error('Input must be a positive number')
+    }
+  }
+
+  static ether(amount: number | bigint): bigint {
+    Units.validateInput(amount)
+    return BigInt(amount) * WEI_TO_EITHER
   }
 
   static gwei(amount: number | bigint): bigint {
-    if (typeof amount === 'number' && !Number.isInteger(amount)) {
-      throw new Error('Input must be an integer number')
-    }
-    const weiPerGwei = BigInt(10 ** 9)
-    return BigInt(amount) * weiPerGwei
+    Units.validateInput(amount)
+    return BigInt(amount) * WIE_TO_GWEI
   }
 }

--- a/packages/util/src/units.ts
+++ b/packages/util/src/units.ts
@@ -32,11 +32,23 @@ export class Units {
     }
   }
 
+  /**
+   * Convert a number or bigint input of ether to wei
+   *
+   * @param {number | bigint} amount amount of units of ether to convert to wei
+   * @returns {bigint} amount of units in wei
+   */
   static ether(amount: number | bigint): bigint {
     Units.validateInput(amount)
     return BigInt(amount) * WEI_TO_EITHER
   }
 
+  /**
+   * Convert a number or bigint input of gwei to wei
+   *
+   * @param amount amount of units of gwei to convert to wei
+   * @returns {bigint} amount of units in wei
+   */
   static gwei(amount: number | bigint): bigint {
     Units.validateInput(amount)
     return BigInt(amount) * WIE_TO_GWEI

--- a/packages/util/test/units.spec.ts
+++ b/packages/util/test/units.spec.ts
@@ -39,9 +39,15 @@ describe('Units', () => {
     })
 
     it('should throw error when a non-integer number is used', () => {
-      assert.throw(function () {
+      assert.throws(() => {
         Units.ether(0.5)
-      })
+      }, 'Input must be an integer number')
+    })
+
+    it('should throw error when a negative number is used', () => {
+      assert.throws(() => {
+        Units.ether(-1)
+      }, 'Input must be a positive number')
     })
 
     it('should convert a bigint amount of ether to wei', () => {
@@ -69,7 +75,13 @@ describe('Units', () => {
     it('should throw error when a non-integer number is used', () => {
       assert.throws(function () {
         Units.gwei(0.5)
-      })
+      }, 'Input must be an integer number')
+    })
+
+    it('should throw error when a negative number is used', () => {
+      assert.throws(() => {
+        Units.ether(-1)
+      }, 'Input must be a positive number')
     })
 
     it('should convert a bigint amount of gwei to wei', () => {

--- a/packages/util/test/units.spec.ts
+++ b/packages/util/test/units.spec.ts
@@ -1,6 +1,6 @@
 import { assert, describe, it } from 'vitest'
 
-import { formatBigDecimal } from '../src/index.js'
+import { Units, formatBigDecimal } from '../src/index.js'
 
 describe('formatBigDecimal', function () {
   const testCases: [bigint, bigint, bigint, string][] = [
@@ -19,4 +19,62 @@ describe('formatBigDecimal', function () {
       assert.equal(formatBigDecimal(numerator, denominator, decimalFactor), expectedString)
     })
   }
+})
+
+describe('Units', () => {
+  describe('ether()', () => {
+    it('should convert 1 ether to wei', () => {
+      const result = Units.ether(1)
+      assert.equal(result, BigInt(10 ** 18))
+    })
+
+    it('should convert 0 ether to wei', () => {
+      const result = Units.ether(0)
+      assert.equal(result, BigInt(0))
+    })
+
+    it('should convert a large number of ether to wei', () => {
+      const result = Units.ether(1000000)
+      assert.equal(result, BigInt(1000000) * BigInt(10 ** 18))
+    })
+
+    it('should throw error when a non-integer number is used', () => {
+      assert.throw(function () {
+        Units.ether(0.5)
+      })
+    })
+
+    it('should convert a bigint amount of ether to wei', () => {
+      const result = Units.ether(BigInt(2))
+      assert.equal(result, BigInt(2) * BigInt(10 ** 18))
+    })
+  })
+
+  describe('gwei()', () => {
+    it('should convert 1 gwei to wei', () => {
+      const result = Units.gwei(1)
+      assert.equal(result, BigInt(10 ** 9))
+    })
+
+    it('should convert 0 gwei to wei', () => {
+      const result = Units.gwei(0)
+      assert.equal(result, BigInt(0))
+    })
+
+    it('should convert a large number of gwei to wei', () => {
+      const result = Units.gwei(1000000)
+      assert.equal(result, BigInt(1000000) * BigInt(10 ** 9))
+    })
+
+    it('should throw error when a non-integer number is used', () => {
+      assert.throws(function () {
+        Units.gwei(0.5)
+      })
+    })
+
+    it('should convert a bigint amount of gwei to wei', () => {
+      const result = Units.gwei(BigInt(2))
+      assert.equal(result, BigInt(2) * BigInt(10 ** 9))
+    })
+  })
 })


### PR DESCRIPTION
This change adds a `Units` class in the `util` package with two conversion functions in it:
```
  static ether(amount: number | bigint): bigint 
  static gwei(amount: number | bigint): bigint
```
Also see #1397, most importantly [this](https://github.com/ethereumjs/ethereumjs-monorepo/issues/1397#issuecomment-2401861664) comment for more details.