### PR TITLE
Add T9N (TransactionTool) test consumption 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17760,10 +17760,102 @@
         "@types/node-dir": "^0.0.34",
         "micro-eth-signer": "^0.11.0",
         "minimist": "^1.2.0",
-        "node-dir": "^0.1.16"
+        "node-dir": "^0.1.16",
+        "yargs": "^17.7.1"
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "packages/tx/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/tx/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/tx/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "packages/tx/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/tx/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/tx/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/tx/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/tx/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/util": {

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -65,7 +65,8 @@
     "@paulmillr/trusted-setups": "^0.1.2",
     "micro-eth-signer": "^0.11.0",
     "minimist": "^1.2.0",
-    "node-dir": "^0.1.16"
+    "node-dir": "^0.1.16",
+    "yargs": "^17.7.1"
   },
   "engines": {
     "node": ">=18"

--- a/packages/tx/test/t9n.spec.ts
+++ b/packages/tx/test/t9n.spec.ts
@@ -1,0 +1,128 @@
+import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
+import { bytesToHex, hexToBigInt, hexToBytes } from '@ethereumjs/util'
+import * as fs from 'fs'
+import path from 'path'
+import { assert, describe, it } from 'vitest'
+import * as yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+
+import { createTxFromRLP } from '../src/transactionFactory.js'
+
+import type { PrefixedHexString } from '@ethereumjs/util'
+
+type T9NArgs = {
+  dir: string
+}
+
+type T9NTestResult =
+  | {
+      exception: undefined
+      intrinsicGas: PrefixedHexString
+      sender: PrefixedHexString
+      hash: PrefixedHexString
+    }
+  | {
+      exception: string
+      intrinsicGas: undefined
+      sender: undefined
+      hash: undefined
+    }
+
+type T9NTest = {
+  txbytes: string
+  result: {
+    [fork: string]: T9NTestResult
+  }
+}
+
+const forkMap: { [key: string]: string } = {
+  Frontier: Hardfork.Chainstart,
+  EIP150: Hardfork.TangerineWhistle,
+  EIP158: Hardfork.SpuriousDragon,
+  ConstantinopleFix: Hardfork.Petersburg,
+}
+
+const args: T9NArgs = yargs
+  .default(hideBin(process.argv))
+  .parserConfiguration({
+    'dot-notation': false,
+  })
+  .option('dir', {
+    describe: 'Directory to road t9n tests from',
+    default: '../ethereum-tests/TransactionTests',
+    string: true,
+  }).argv as T9NArgs
+
+function getFork(fork: string) {
+  const f = forkMap[fork] ?? fork
+  // Normalize fork name to work with common (lowercase first character)
+  return f[0].toLowerCase() + f.substring(1)
+}
+
+function runTests(filePath: string) {
+  if (path.extname(filePath) === '.json') {
+    const fname = path.parse(filePath).name
+
+    describe(fname, async () => {
+      const testsRaw: string = await new Promise((resolve, reject) => {
+        fs.readFile(filePath, 'utf8', (err, data) => {
+          if (err) {
+            reject(err)
+          }
+          resolve(data)
+        })
+      })
+
+      const tests: { [testName: string]: T9NTest } = JSON.parse(testsRaw)
+
+      // eslint-disable-next-line no-restricted-syntax
+      for (const testName in tests) {
+        const test = tests[testName]
+        const txBytes = hexToBytes(test.txbytes)
+        // eslint-disable-next-line no-restricted-syntax
+        for (const fork in test.result) {
+          it(`${testName} [${getFork(fork)}]`, () => {
+            const common = new Common({ chain: Mainnet, hardfork: getFork(fork) })
+            const result = test.result[fork]
+
+            try {
+              const tx = createTxFromRLP(txBytes, { common })
+              if (result.exception !== undefined) {
+                assert.fail('RLP is invalid, but decoding succeeded')
+              } else {
+                assert.equal(bytesToHex(tx.hash()), result.hash!, 'correct hash')
+                assert.equal(
+                  tx.getIntrinsicGas(),
+                  hexToBigInt(result.intrinsicGas),
+                  'correct intrinsic gas',
+                )
+                assert.equal(tx.getSenderAddress().toString(), result.sender, 'correct sender')
+              }
+            } catch (e: any) {
+              if (result.exception === undefined) {
+                assert.fail('RLP is valid, but decoding failed')
+              } else {
+                assert.ok(true, 'RLP decoding successfully failed')
+              }
+            }
+          })
+        }
+      }
+    })
+  }
+}
+
+function recursiveLoad(dir: string) {
+  // eslint-disable-next-line github/array-foreach
+  fs.readdirSync(dir).forEach((file) => {
+    const fullName = dir + '/' + file
+    const stat = fs.statSync(fullName)
+    if (stat.isFile()) {
+      runTests(fullName)
+    } else if (stat.isDirectory()) {
+      recursiveLoad(fullName)
+    }
+  })
+}
+
+recursiveLoad(args.dir)


### PR DESCRIPTION
This PR adds T9N test support, to decode tx rlps and then verify:

- the sender
- the hash
- the intrinsic gas (the minimal gas limit the tx has to pay, covering data fee / access lists / tx base fee (21k in most cases, higher when creating contracts))

Or:

- If the RLP is invalid, the tx creation aborts

Runs tests of `ethereum-tests/TransactionTests`.

This currently only allows to consume the tests, not to fill them.

See: https://github.com/ethereum/go-ethereum/tree/master/cmd/evm#transaction-tool