### PR TITLE
Skip t9n in browser

### DIFF
--- a/packages/tx/vitest.config.browser.mts
+++ b/packages/tx/vitest.config.browser.mts
@@ -12,7 +12,8 @@ export default mergeConfig(
         // default export for minimist
         // wrong ethereum-tests path reference (../ is stripped)
         'test/transactionRunner.spec.ts',
-        'test/eip4844.spec.ts'
+        'test/eip4844.spec.ts',
+        'test/t9n.spec.ts'
       ],
     }
   }))


### PR DESCRIPTION
Adds an edit to the `tx` browser test config to skip `t9n` tests in browser and fix browser tests **again**