### PR TITLE
Further troubleshoot current codecov CI issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  push:
+    branches: [master]
+    tags: ['*']
   workflow_dispatch:
 
 env:

--- a/.github/workflows/devp2p-build.yml
+++ b/.github/workflows/devp2p-build.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ${{ github.workspace }}/packages/devp2p/coverage/lcov.info
+          files: ${{ env.cwd }}/coverage/lcov.info
           flags: devp2p
 
 

--- a/.github/workflows/devp2p-build.yml
+++ b/.github/workflows/devp2p-build.yml
@@ -14,6 +14,13 @@ on:
         required: false
         default: 'none'
 
+env:
+  cwd: ${{github.workspace}}/packages/mpt
+
+defaults:
+  run:
+    working-directory: packages/mpt
+    
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-devp2p
   cancel-in-progress: true

--- a/.github/workflows/devp2p-build.yml
+++ b/.github/workflows/devp2p-build.yml
@@ -15,12 +15,12 @@ on:
         default: 'none'
 
 env:
-  cwd: ${{github.workspace}}/packages/mpt
+  cwd: ${{github.workspace}}/packages/devp2p
 
 defaults:
   run:
-    working-directory: packages/mpt
-    
+    working-directory: packages/devp2p
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-devp2p
   cancel-in-progress: true

--- a/.github/workflows/devp2p-build.yml
+++ b/.github/workflows/devp2p-build.yml
@@ -17,10 +17,6 @@ on:
 env:
   cwd: ${{github.workspace}}/packages/devp2p
 
-defaults:
-  run:
-    working-directory: packages/devp2p
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-devp2p
   cancel-in-progress: true


### PR DESCRIPTION
This change is a followup on #3376 and looks into remaining codecov issues:
- [ ] The master branch isn't having coverage pushed/calculated/visualized, so I'll see if this is just a misconfig or something
- [ ] Some packages (devp2p, wallet, genesis, client) aren't having their coverage files uploaded? Or, atleast they're not showing up on codecov at the moment, so I'll triage and followup here.
- [ ] As mentions by @jochem-brouwer, most of the coverage diffs seem to not be calculates/reported (https://github.com/ethereumjs/ethereumjs-monorepo/pull/3376#issuecomment-2406199634).
- [ ] `rlp` and `ethash` packages are uploading coverage reports, but their reports are erroring out as unusable. I remember working on this before and opening a codecov ticket on it too (in the codecov official repo) that didn't get much activity, but will look into and followup on this on as well.