### PR TITLE
genesis: remove mpt devdep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17627,9 +17627,6 @@
         "@ethereumjs/common": "^4.4.0",
         "@ethereumjs/util": "^9.1.0"
       },
-      "devDependencies": {
-        "@ethereumjs/mpt": "^6.2.2"
-      },
       "engines": {
         "node": ">=18"
       }

--- a/packages/genesis/package.json
+++ b/packages/genesis/package.json
@@ -64,8 +64,5 @@
   },
   "engines": {
     "node": ">=18"
-  },
-  "devDependencies": {
-    "@ethereumjs/mpt": "^6.2.2"
   }
 }

--- a/packages/genesis/test/index.spec.ts
+++ b/packages/genesis/test/index.spec.ts
@@ -1,6 +1,4 @@
 import { Chain, ChainGenesis } from '@ethereumjs/common'
-import { genesisMPTStateRoot } from '@ethereumjs/mpt'
-import { bytesToHex, equalsBytes } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
 import { getGenesis } from '../src/index.js'
@@ -12,20 +10,12 @@ describe('genesis test', () => {
       // Kaustinen can have an empty genesis state since verkle blocks contain their pre-state
       if (Number(chainId) === Chain.Kaustinen6) continue
 
-      const { name, stateRoot: expectedRoot } = ChainGenesis[chainId as unknown as Chain]
+      const { name } = ChainGenesis[chainId as unknown as Chain]
 
       const genesisState = getGenesis(Number(chainId))
       assert.ok(
         genesisState !== undefined,
         `network=${name} chainId=${chainId} genesis should be found`,
-      )
-
-      const stateRoot = await genesisMPTStateRoot(genesisState!)
-      assert.ok(
-        equalsBytes(expectedRoot, stateRoot),
-        `network=${name} chainId=${chainId} stateRoot should match expected=${bytesToHex(
-          expectedRoot,
-        )} actual=${bytesToHex(stateRoot)}`,
       )
     }
   })


### PR DESCRIPTION
This PR removes the mpt dev dependency from the genesis package.json. It was only used for one check in a test, and it leads to a circular dependency that was spotted by @holgerd77 . If we want to do that root check, we can always port some tests over to another package, but I suspect that this sort of very common stateRoot check is covered by many other tests already. 