### PR TITLE
Use `inlineclient` in miner integration tests

### DIFF
--- a/packages/client/test/integration/miner.spec.ts
+++ b/packages/client/test/integration/miner.spec.ts
@@ -1,121 +1,119 @@
-import { CliqueConsensus, createBlockchain } from '@ethereumjs/blockchain'
+import { Hardfork, createCommonFromGethGenesis } from '@ethereumjs/common'
 import {
-  Common,
-  ConsensusAlgorithm,
-  ConsensusType,
-  Goerli,
-  Hardfork,
-  createCustomCommon,
-} from '@ethereumjs/common'
-import { Address, hexToBytes } from '@ethereumjs/util'
+  Address,
+  bytesToHex,
+  concatBytes,
+  hexToBytes,
+  parseGethGenesisState,
+} from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
-import { Chain } from '../../src/blockchain/index.js'
 import { Config } from '../../src/config.js'
-import { FullEthereumService } from '../../src/service/index.js'
+import { getLogger } from '../../src/logging.js'
 import { Event } from '../../src/types.js'
+import { parseMultiaddrs } from '../../src/util/parse.js'
+import { createInlineClient } from '../sim/simutils.js'
 
-import { MockServer } from './mocks/mockserver.js'
-import { destroy, setup } from './util.js'
+import type { EthereumClient } from '../../src/index.js'
 
-import type { ConsensusDict } from '@ethereumjs/blockchain'
-
-// Schedule london at 0 and also unset any past scheduled timestamp hardforks that might collide with test
-const hardforks = new Common({ chain: Goerli })
-  .hardforks()
-  .map((h) =>
-    h.name === Hardfork.London
-      ? { ...h, block: 0, timestamp: undefined }
-      : { ...h, timestamp: undefined },
-  )
-const common = createCustomCommon(
-  {
-    hardforks,
-    consensus: {
-      type: ConsensusType.ProofOfAuthority,
-      algorithm: ConsensusAlgorithm.Clique,
-      clique: {
-        period: 1, // use 1s period for quicker test execution
-        epoch: 30000,
-      },
+async function setupDevnet(prefundAddress: Address) {
+  const addr = prefundAddress.toString().slice(2)
+  const consensusConfig = {
+    clique: {
+      period: 1,
+      epoch: 30000,
     },
-  },
-  Goerli,
-  { hardfork: Hardfork.London },
-)
+  }
+  const defaultChainData = {
+    config: {
+      chainId: 123456,
+      homesteadBlock: 0,
+      eip150Block: 0,
+      eip150Hash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+      eip155Block: 0,
+      eip158Block: 0,
+      byzantiumBlock: 0,
+      constantinopleBlock: 0,
+      petersburgBlock: 0,
+      istanbulBlock: 0,
+      berlinBlock: 0,
+      londonBlock: 0,
+      ...consensusConfig,
+    },
+    nonce: '0x0',
+    timestamp: '0x614b3731',
+    gasLimit: '0x47b760',
+    difficulty: '0x1',
+    mixHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    coinbase: '0x0000000000000000000000000000000000000000',
+    number: '0x0',
+    gasUsed: '0x0',
+    parentHash: '0x0000000000000000000000000000000000000000000000000000000000000000',
+    baseFeePerGas: 7,
+  }
+  const extraData = concatBytes(new Uint8Array(32), prefundAddress.toBytes(), new Uint8Array(65))
+
+  const chainData = {
+    ...defaultChainData,
+    extraData: bytesToHex(extraData),
+    alloc: { [addr]: { balance: '0x10000000000000000000' } },
+  }
+
+  const common = createCommonFromGethGenesis(chainData, {
+    chain: 'devnet',
+    hardfork: Hardfork.London,
+  })
+  const customGenesisState = parseGethGenesisState(chainData)
+  return { common, customGenesisState }
+}
+
 const accounts: [Address, Uint8Array][] = [
   [
     new Address(hexToBytes('0x0b90087d864e82a284dca15923f3776de6bb016f')),
     hexToBytes('0x64bf9cc30328b0e42387b3c82c614e6386259136235e20c1357bd11cdee86993'),
   ],
 ]
-async function minerSetup(): Promise<[MockServer, FullEthereumService]> {
-  const config = new Config({ common, accountCache: 10000, storageCache: 1000 })
-  const server = new MockServer({ config }) as any
 
-  const consensusDict: ConsensusDict = {}
-  consensusDict[ConsensusAlgorithm.Clique] = new CliqueConsensus()
-  const blockchain = await createBlockchain({
+async function minerSetup(): Promise<EthereumClient[]> {
+  const { common, customGenesisState } = await setupDevnet(accounts[0][0])
+  const config1 = new Config({
     common,
-    validateBlocks: false,
-    validateConsensus: false,
-    consensusDict,
-  })
-  ;(blockchain.consensus as CliqueConsensus).cliqueActiveSigners = () => [accounts[0][0]] // stub
-  const chain = await Chain.create({ config, blockchain })
-  const serviceConfig = new Config({
-    common,
-    server,
+    accountCache: 10000,
+    storageCache: 1000,
     mine: true,
     accounts,
+    logger: getLogger({ logLevel: 'debug' }),
   })
-  // attach chain to centralized event bus
-  ;(chain.config as any).events = serviceConfig.events
-  const service = new FullEthereumService({
-    config: serviceConfig,
-    chain,
+
+  const miner = await createInlineClient(config1, common, customGenesisState, '', true)
+
+  const config2 = new Config({
+    common,
+    accountCache: 10000,
+    storageCache: 1000,
+    bootnodes: parseMultiaddrs(miner.config.server!.getRlpxInfo().enode as string),
+    accounts,
+    logger: getLogger({ logLevel: 'info' }),
+    port: 30304,
+    mine: false,
   })
-  service.execution.run = async () => 1 // stub
-  await service.open()
-  await server.start()
-  await service.start()
-  return [server, service]
+
+  const follower = await createInlineClient(config2, common, customGenesisState, '', true)
+  return [miner, follower]
 }
 
 describe('should mine blocks while a peer stays connected to tip of chain', () => {
-  it(
-    'should work',
-    async () => {
-      const [server, service] = await minerSetup()
-      const [remoteServer, remoteService] = await setup({
-        location: '127.0.0.2',
-        height: 0,
-        common,
-      })
-      ;(remoteService.chain.blockchain.consensus as CliqueConsensus).cliqueActiveSigners = () => [
-        accounts[0][0],
-      ] // stub
-      ;(remoteService as FullEthereumService).execution.run = async () => 1 // stub
-      await server.discover('remotePeer1', '127.0.0.2')
-      const targetHeight = BigInt(5)
-      await new Promise((resolve) => {
-        remoteService.config.events.on(Event.SYNC_SYNCHRONIZED, async (chainHeight) => {
-          if (chainHeight === targetHeight) {
-            assert.equal(
-              remoteService.chain.blocks.height,
-              targetHeight,
-              'synced blocks successfully',
-            )
+  it('should work', async () => {
+    const [follower] = await minerSetup()
 
-            await destroy(server, service)
-            await destroy(remoteServer, remoteService)
-            resolve(undefined)
-
-            void remoteService.synchronizer!.start()
-          }
-        })
+    const targetHeight = BigInt(5)
+    await new Promise((resolve) => {
+      follower.config.events.on(Event.SYNC_SYNCHRONIZED, (chainHeight) => {
+        if (chainHeight === targetHeight) {
+          assert.equal(follower.chain.blocks.height, targetHeight, 'synced blocks successfully')
+          resolve(undefined)
+        }
       })
-    },
-    { timeout: 25000 },
-  )
+    })
+  }, 60000)
 })

--- a/packages/client/test/sim/simutils.ts
+++ b/packages/client/test/sim/simutils.ts
@@ -1,5 +1,6 @@
 import { executionPayloadFromBeaconPayload } from '@ethereumjs/block'
-import { createBlockchain } from '@ethereumjs/blockchain'
+import { CliqueConsensus, createBlockchain } from '@ethereumjs/blockchain'
+import { type Common, ConsensusAlgorithm } from '@ethereumjs/common'
 import { createBlob4844Tx, createFeeMarket1559Tx } from '@ethereumjs/tx'
 import {
   BIGINT_1,
@@ -15,6 +16,7 @@ import {
 import { trustedSetup } from '@paulmillr/trusted-setups/fast.js'
 import * as fs from 'fs/promises'
 import { Level } from 'level'
+import { MemoryLevel } from 'memory-level'
 import { KZG as microEthKZG } from 'micro-eth-signer/kzg'
 import { execSync, spawn } from 'node:child_process'
 import * as net from 'node:net'
@@ -26,9 +28,9 @@ import { LevelDB } from '../../src/execution/level.js'
 import { RPCManager } from '../../src/rpc/index.js'
 import { Event } from '../../src/types.js'
 
-import type { Common } from '@ethereumjs/common'
+import type { ConsensusDict } from '@ethereumjs/blockchain'
 import type { TransactionType, TxData, TxOptions } from '@ethereumjs/tx'
-import type { PrefixedHexString } from '@ethereumjs/util'
+import type { GenesisState, PrefixedHexString } from '@ethereumjs/util'
 import type { ChildProcessWithoutNullStreams } from 'child_process'
 import type { Client } from 'jayson/promise'
 const kzg = new microEthKZG(trustedSetup)
@@ -429,28 +431,47 @@ export const runBlobTxsFromFile = async (client: Client, path: string) => {
 }
 
 export async function createInlineClient(
-  config: any,
-  common: any,
-  customGenesisState: any,
-  datadir: any = Config.DATADIR_DEFAULT,
+  config: Config,
+  common: Common,
+  customGenesisState: GenesisState,
+  datadir: string = Config.DATADIR_DEFAULT,
+  memoryDB: boolean = false,
 ) {
-  const chainDB = new Level<string | Uint8Array, string | Uint8Array>(
-    `${datadir}/${common.chainName()}/chainDB`,
-  )
-  const stateDB = new Level<string | Uint8Array, string | Uint8Array>(
-    `${datadir}/${common.chainName()}/stateDB`,
-  )
-  const metaDB = new Level<string | Uint8Array, string | Uint8Array>(
-    `${datadir}/${common.chainName()}/metaDB`,
-  )
+  let chainDB
+  let stateDB
+  let metaDB
+  if (memoryDB) {
+    chainDB = new MemoryLevel<string | Uint8Array, string | Uint8Array>()
+    stateDB = new MemoryLevel<string | Uint8Array, string | Uint8Array>()
+    metaDB = new MemoryLevel<string | Uint8Array, string | Uint8Array>()
+  } else {
+    chainDB = new Level<string | Uint8Array, string | Uint8Array>(
+      `${datadir}/${common.chainName()}/chainDB`,
+    )
 
+    stateDB = new Level<string | Uint8Array, string | Uint8Array>(
+      `${datadir}/${common.chainName()}/stateDB`,
+    )
+    metaDB = new Level<string | Uint8Array, string | Uint8Array>(
+      `${datadir}/${common.chainName()}/metaDB`,
+    )
+  }
+  let validateConsensus = false
+  const consensusDict: ConsensusDict = {}
+  if (customGenesisState !== undefined) {
+    if (config.chainCommon.consensusAlgorithm() === ConsensusAlgorithm.Clique) {
+      consensusDict[ConsensusAlgorithm.Clique] = new CliqueConsensus()
+      validateConsensus = true
+    }
+  }
   const blockchain = await createBlockchain({
     db: new LevelDB(chainDB),
     genesisState: customGenesisState,
     common: config.chainCommon,
     hardforkByHeadBlockNumber: true,
     validateBlocks: true,
-    validateConsensus: false,
+    validateConsensus,
+    consensusDict,
   })
   config.chainCommon.setForkHashes(blockchain.genesisBlock.hash())
   const inlineClient = await EthereumClient.create({


### PR DESCRIPTION
Cleanup item from #3750

This replaces the current `miner` integration test with one that uses the inline client setup from the `test/sim/simutils` instead of complicated mocks.