### PR TITLE
client: add kaustinen6 testnet instructions in client readme

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -216,17 +216,13 @@ Then start the Lodestar client with:
 ./lodestar beacon --network=holesky --jwt-secret=[PATH-TO-JWT-SECRET-FROM-ETHEREUMJS-CLIENT]
 ```
 
-## Testnets
+## Experimental Testnets
 
 The EthereumJS client supports ongoing protocol development efforts, allowing developers and testers to participate in various testnets using the EthereumJS client.
 
-### Running a testnet with EthereumJS/Lodestar
+### Stateless Verkle
 
-To run a testnet, the EthereumJS client has to be run alongside a consensus layer (CL) client. By far the simplest way to run In most scenarios you will want to run the EthereumJS client in a combination with a consensus layer (CL) client.
-
-The most tested combination is to run the client with the [Lodestar](https://github.com/ChainSafe/lodestar) TypeScript CL client. Lodestar provides a [quick-start repository](https://github.com/ChainSafe/lodestar-quickstart) that allows users to get started quickly with minimal configuration.
-
-Taking as an example the Verkle Kaustinen6 testnet, getting the EthereumJS client started alongside the Lodestar consensus client should only require the following commands:
+We are currently supporting the Verkle Kaustinen6 testnet. Getting the EthereumJS client started alongside the Lodestar consensus client should only require the following commands:
 
 Step 1 - Running the EthereumJS client (from the cloned @ethereumjs/client package)
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -226,7 +226,7 @@ To run a testnet, the EthereumJS client has to be run alongside a consensus laye
 
 The most tested combination is to run the client with the [Lodestar](https://github.com/ChainSafe/lodestar) TypeScript CL client. Lodestar provides a [quick-start repository](https://github.com/ChainSafe/lodestar-quickstart) that allows users to get started quickly with minimal configuration.
 
-Taking as an example the Verkle Kaustinen6 testnet, getting the EthereumJS client started alongside the Lodestart consensus client should only require the following commands:
+Taking as an example the Verkle Kaustinen6 testnet, getting the EthereumJS client started alongside the Lodestar consensus client should only require the following commands:
 
 Step 1 - Running the EthereumJS client (from the cloned @ethereumjs/client package)
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -16,6 +16,7 @@
 - [General Usage](#general-usage)
 - [Supported Networks](#supported-networks)
 - [Running with a Consensus Layer (CL) Client](#running-with-a-consensus-layer-cl-client)
+- [Testnets](#testnets)
 - [Custom Chains](#custom-chains)
 - [Custom Network Mining (Beta)](#custom-network-mining-beta)
 - [API](#api)
@@ -214,6 +215,28 @@ Then start the Lodestar client with:
 ```shell
 ./lodestar beacon --network=holesky --jwt-secret=[PATH-TO-JWT-SECRET-FROM-ETHEREUMJS-CLIENT]
 ```
+
+## Testnets
+
+The EthereumJS client supports ongoing protocol development efforts, allowing developers and testers to participate in various testnets using the EthereumJS client.
+
+### Running a testnet with EthereumJS/Lodestar
+
+To run a testnet, the EthereumJS client has to be run alongside a consensus layer (CL) client. By far the simplest way to run In most scenarios you will want to run the EthereumJS client in a combination with a consensus layer (CL) client.
+
+The most tested combination is to run the client with the [Lodestar](https://github.com/ChainSafe/lodestar) TypeScript CL client. Lodestar provides a [quick-start repository](https://github.com/ChainSafe/lodestar-quickstart) that allows users to get started quickly with minimal configuration.
+
+Taking as an example the Verkle Kaustinen6 testnet, getting the EthereumJS client started alongside the Lodestart consensus client should only require the following commands:
+
+Step 1 - Running the EthereumJS client (from the cloned @ethereumjs/client package)
+
+`npm run client:start:ts -- --dataDir /data/k6data --network kaustinen6 --rpcEngine --rpcEngineAuth false --logLevel warn`
+
+Step 2 - Running the Lodestar client (from the cloned Lodestar quick-start repository)
+
+`setup.sh --dataDir k6data --network kaustinen6 --justCL`
+
+The process should be similar for other testnets, and the quick-start repository should provide testnet-specific configuration instructions for the Lodestar consensus layer client.
 
 ## Custom Chains
 


### PR DESCRIPTION
This PR adds a new testnet section to the client readme, with an example of how to run the kaustinen6 testnet. 