### PR TITLE
client: docs link to kaustinen6 ref

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -232,6 +232,8 @@ Step 2 - Running the Lodestar client (from the cloned Lodestar quick-start repos
 
 `setup.sh --dataDir k6data --network kaustinen6 --justCL`
 
+Additional information on the Kaustinen6 testnet can be retrieve from this page: https://verkle-gen-devnet-6.ethpandaops.io/
+
 The process should be similar for other testnets, and the quick-start repository should provide testnet-specific configuration instructions for the Lodestar consensus layer client.
 
 ## Custom Chains


### PR DESCRIPTION
This adds a Kaustinen6 reference to the client verkle docs section 