### PR TITLE
packages: add requests hash to genesis block

### DIFF
--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -5,7 +5,7 @@ import {
   BIGINT_1,
   BIGINT_8,
   KECCAK256_RLP,
-  KECCAK256_RLP_RH,
+  SHA256_EMPTY_RH,
   Lock,
   MapDB,
   bigIntToHex,
@@ -1314,7 +1314,7 @@ export class Blockchain implements BlockchainInterface {
       number: 0,
       stateRoot,
       withdrawalsRoot: common.isActivatedEIP(4895) ? KECCAK256_RLP : undefined,
-      requestsHash: common.isActivatedEIP(7685) ? KECCAK256_RLP_RH : undefined,
+      requestsHash: common.isActivatedEIP(7685) ? SHA256_EMPTY_RH : undefined,
     }
     if (common.consensusType() === 'poa') {
       if (common.genesis().extraData) {

--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -5,6 +5,7 @@ import {
   BIGINT_1,
   BIGINT_8,
   KECCAK256_RLP,
+  KECCAK256_RLP_RH,
   Lock,
   MapDB,
   bigIntToHex,
@@ -1313,6 +1314,7 @@ export class Blockchain implements BlockchainInterface {
       number: 0,
       stateRoot,
       withdrawalsRoot: common.isActivatedEIP(4895) ? KECCAK256_RLP : undefined,
+      requestsHash: common.isActivatedEIP(7685) ? KECCAK256_RLP_RH : undefined,
     }
     if (common.consensusType() === 'poa') {
       if (common.genesis().extraData) {

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -52,6 +52,7 @@ export interface GenesisBlockConfig {
   extraData: PrefixedHexString
   baseFeePerGas?: PrefixedHexString
   excessBlobGas?: PrefixedHexString
+  requestsHash?: PrefixedHexString
 }
 
 export interface HardforkTransitionConfig {

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -38,6 +38,7 @@ function parseGethParams(json: any) {
     coinbase,
     baseFeePerGas,
     excessBlobGas,
+    requestsHash,
     extraData: unparsedExtraData,
     nonce: unparsedNonce,
     timestamp: unparsedTimestamp,
@@ -50,6 +51,7 @@ function parseGethParams(json: any) {
     coinbase: PrefixedHexString
     baseFeePerGas: PrefixedHexString
     excessBlobGas: PrefixedHexString
+    requestsHash: PrefixedHexString
     extraData: string
     nonce: string
     timestamp: string
@@ -105,6 +107,7 @@ function parseGethParams(json: any) {
       coinbase,
       baseFeePerGas,
       excessBlobGas,
+      requestsHash,
     },
     hardfork: undefined as string | undefined,
     hardforks: [] as ConfigHardfork[],

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -68,6 +68,17 @@ export const KECCAK256_RLP = hexToBytes(KECCAK256_RLP_S)
 export const SHA256_NULL = sha256(new Uint8Array())
 
 /**
+ * Keccak-256 hash of the RLP of an empty requests hash
+ */
+export const KECCAK256_RLP_RH_S =
+  '0x6036c41849da9c076ed79654d434017387a88fb833c2856b32e18218b3341c5f'
+
+/**
+ * Keccak-256 hash of the RLP of an empty requests hash
+ */
+export const KECCAK256_RLP_RH = hexToBytes(KECCAK256_RLP_RH_S)
+
+/**
  *  RLP encoded empty string
  */
 export const RLP_EMPTY_STRING = Uint8Array.from([0x80])

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -70,13 +70,7 @@ export const SHA256_NULL = sha256(new Uint8Array())
 /**
  * Keccak-256 hash of the RLP of an empty requests hash
  */
-export const KECCAK256_RLP_RH_S =
-  export const SHA256_EMPTY_RH_S = sha256(new Uint8Array([0, 1, 2]))
-
-/**
- * Keccak-256 hash of the RLP of an empty requests hash
- */
-export const SHA256_EMPTY_RH = hexToBytes(SHA256_EMPTY_RH_S)
+export const SHA256_EMPTY_RH = sha256(new Uint8Array([0, 1, 2]))
 
 /**
  *  RLP encoded empty string

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -71,7 +71,7 @@ export const SHA256_NULL = sha256(new Uint8Array())
  * Keccak-256 hash of the RLP of an empty requests hash
  */
 export const KECCAK256_RLP_RH_S =
-  '0x6036c41849da9c076ed79654d434017387a88fb833c2856b32e18218b3341c5f'
+  export const SHA256_EMPTY_RH_S = sha256(new Uint8Array([0, 1, 2]))
 
 /**
  * Keccak-256 hash of the RLP of an empty requests hash

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -68,7 +68,7 @@ export const KECCAK256_RLP = hexToBytes(KECCAK256_RLP_S)
 export const SHA256_NULL = sha256(new Uint8Array())
 
 /**
- * Keccak-256 hash of the RLP of an empty requests hash
+ * SHA-256 hash of the RLP of an empty requests hash
  */
 export const SHA256_EMPTY_RH = sha256(new Uint8Array([0, 1, 2]))
 

--- a/packages/util/src/constants.ts
+++ b/packages/util/src/constants.ts
@@ -76,7 +76,7 @@ export const KECCAK256_RLP_RH_S =
 /**
  * Keccak-256 hash of the RLP of an empty requests hash
  */
-export const KECCAK256_RLP_RH = hexToBytes(KECCAK256_RLP_RH_S)
+export const SHA256_EMPTY_RH = hexToBytes(SHA256_EMPTY_RH_S)
 
 /**
  *  RLP encoded empty string


### PR DESCRIPTION
# Description
Adds the request hash to the genesis block to enable running tests on hive: `consume engine` and `consume rlp`.

## Reproduce Hive Passes

Using the following hive branch [spencer-tb@prague-devnet-4-ethjs](https://github.com/spencer-tb/hive/tree/prague-devnet-4-ethjs) run either of:
```bash
./hive --sim 'ethereum/eest/consume-block-rlp' --client-file configs/prague.yaml --docker.output --client ethereumjs --docker.nocache .
./hive --sim 'ethereum/eest/consume-engine' --client-file configs/prague.yaml --docker.output --client ethereumjs --docker.nocache .
```

## Empty Requests Hash

Note the keccak256 of the empty requests should account for the type prefixing, hence why:
```
KECCAK256_RLP_RH == 0x6036c41849da9c076ed79654d434017387a88fb833c2856b32e18218b3341c5f
```
and not the default `0x56e8...`.