### PR TITLE
Implement admin_addPeer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1544,121 +1544,6 @@
       "resolved": "packages/statemanager",
       "link": true
     },
-    "node_modules/@ethereumjs/trie": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/trie/-/trie-6.2.1.tgz",
-      "integrity": "sha512-MguABMVi/dPtgagK+SuY57rpXFP+Ghr2x+pBDy+e3VmMqUY+WGzFu1QWjBb5/iJ7lINk4CI2Uwsih07Nu9sTSg==",
-      "dev": true,
-      "dependencies": {
-        "@ethereumjs/rlp": "^5.0.2",
-        "@ethereumjs/util": "^9.1.0",
-        "@types/readable-stream": "^2.3.13",
-        "debug": "^4.3.4",
-        "ethereum-cryptography": "^2.2.1",
-        "lru-cache": "10.1.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ethereumjs/trie/node_modules/@ethereumjs/rlp": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
-      "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
-      "dev": true,
-      "bin": {
-        "rlp": "bin/rlp.cjs"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ethereumjs/trie/node_modules/@ethereumjs/util": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.1.0.tgz",
-      "integrity": "sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==",
-      "dev": true,
-      "dependencies": {
-        "@ethereumjs/rlp": "^5.0.2",
-        "ethereum-cryptography": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ethereumjs/trie/node_modules/@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
-      "dev": true,
-      "dependencies": {
-        "@noble/hashes": "1.4.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ethereumjs/trie/node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ethereumjs/trie/node_modules/@scure/bip32": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
-      "dev": true,
-      "dependencies": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ethereumjs/trie/node_modules/@scure/bip39": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
-      "dev": true,
-      "dependencies": {
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ethereumjs/trie/node_modules/ethereum-cryptography": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
-      "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
-      "dev": true,
-      "dependencies": {
-        "@noble/curves": "1.4.2",
-        "@noble/hashes": "1.4.0",
-        "@scure/bip32": "1.4.0",
-        "@scure/bip39": "1.3.0"
-      }
-    },
-    "node_modules/@ethereumjs/trie/node_modules/lru-cache": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
-      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
-      "dev": true,
-      "engines": {
-        "node": "14 || >=16.14"
-      }
-    },
     "node_modules/@ethereumjs/tx": {
       "resolved": "packages/tx",
       "link": true
@@ -3570,22 +3455,6 @@
       "version": "6.9.16",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.16.tgz",
       "integrity": "sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==",
-      "dev": true
-    },
-    "node_modules/@types/readable-stream": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
-      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/@types/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
     "node_modules/@types/rollup-plugin-visualizer": {
@@ -17951,7 +17820,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/@ethereumjs/block/-/block-5.3.0.tgz",
       "integrity": "sha512-cyphdEB/ywIERqWLRHdAS6muTkAcd6BibMOp6XmGbeWgvtIhe4ArxcMDI78MVstJzT/faihvRI4rKQKy+MpdKQ==",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "@ethereumjs/common": "^4.4.0",
         "@ethereumjs/rlp": "^5.0.2",
@@ -17968,7 +17837,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-4.4.0.tgz",
       "integrity": "sha512-Fy5hMqF6GsE6DpYTyqdDIJPJgUtDn4dL120zKw+Pswuo+iLyBsEYuSyzMw6NVzD2vDzcBG9fE4+qX4X2bPc97w==",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "@ethereumjs/util": "^9.1.0"
       }
@@ -17977,7 +17846,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-5.0.2.tgz",
       "integrity": "sha512-DziebCdg4JpGlEqEdGgXmjqcFoJi+JGulUXwEjsZGAscAQ7MyD/7LE/GVCP29vEQxKc7AAwjT3A2ywHp2xfoCA==",
-      "dev": true,
+      "extraneous": true,
       "bin": {
         "rlp": "bin/rlp.cjs"
       },
@@ -17989,7 +17858,7 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-5.4.0.tgz",
       "integrity": "sha512-SCHnK7m/AouZ7nyoR0MEXw1OO/tQojSbp88t8oxhwes5iZkZCtfFdUrJaiIb72qIpH2FVw6s1k1uP7LXuH7PsA==",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "@ethereumjs/common": "^4.4.0",
         "@ethereumjs/rlp": "^5.0.2",
@@ -18004,7 +17873,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-9.1.0.tgz",
       "integrity": "sha512-XBEKsYqLGXLah9PNJbgdkigthkG7TAGvlD/sH12beMXEyHDyigfcbdvHhmLyDWgDyOJn4QwiQUaF7yeuhnjdog==",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
         "ethereum-cryptography": "^2.2.1"
@@ -18017,63 +17886,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz",
       "integrity": "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==",
-      "dev": true,
+      "extraneous": true,
       "dependencies": {
         "@noble/curves": "1.4.2",
         "@noble/hashes": "1.4.0",
         "@scure/bip32": "1.4.0",
         "@scure/bip39": "1.3.0"
-      }
-    },
-    "packages/vm/node_modules/@noble/curves": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz",
-      "integrity": "sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==",
-      "dev": true,
-      "dependencies": {
-        "@noble/hashes": "1.4.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/vm/node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/vm/node_modules/@scure/bip32": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.4.0.tgz",
-      "integrity": "sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==",
-      "dev": true,
-      "dependencies": {
-        "@noble/curves": "~1.4.0",
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/vm/node_modules/@scure/bip39": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
-      "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
-      "dev": true,
-      "dependencies": {
-        "@noble/hashes": "~1.4.0",
-        "@scure/base": "~1.1.6"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "packages/wallet": {

--- a/packages/client/src/rpc/modules/admin.ts
+++ b/packages/client/src/rpc/modules/admin.ts
@@ -1,5 +1,7 @@
 import { bytesToHex } from '@ethereumjs/util'
 
+import { Config } from '../../index.js'
+import { RlpxPeer } from '../../net/peer/rlpxpeer.js'
 import { getClientVersion } from '../../util/index.js'
 import { INTERNAL_ERROR } from '../error-code.js'
 import { callWithStackTrace } from '../helpers.js'
@@ -7,7 +9,6 @@ import { middleware, validators } from '../validation.js'
 
 import type { Chain } from '../../blockchain/index.js'
 import type { EthereumClient } from '../../client.js'
-import type { RlpxPeer } from '../../net/peer/rlpxpeer.js'
 import type { RlpxServer } from '../../net/server/rlpxserver.js'
 import type { FullEthereumService } from '../../service/index.js'
 
@@ -122,7 +123,13 @@ export class Admin {
     let peerInfo
     try {
       peerInfo = await dpt!.addPeer(params[0])
-      await server.connect(bytesToHex(peerInfo.id!))
+      const rlpxPeer = new RlpxPeer({
+        config: new Config(),
+        id: bytesToHex(peerInfo.id!),
+        host: peerInfo.address!,
+        port: peerInfo.tcpPort as number,
+      })
+      service.pool.add(rlpxPeer)
     } catch (err: any) {
       throw {
         code: INTERNAL_ERROR,

--- a/packages/client/src/rpc/modules/admin.ts
+++ b/packages/client/src/rpc/modules/admin.ts
@@ -1,12 +1,14 @@
 import { bytesToHex } from '@ethereumjs/util'
 
 import { getClientVersion } from '../../util/index.js'
+import { INTERNAL_ERROR } from '../error-code.js'
 import { callWithStackTrace } from '../helpers.js'
-import { middleware } from '../validation.js'
+import { middleware, validators } from '../validation.js'
 
 import type { Chain } from '../../blockchain/index.js'
 import type { EthereumClient } from '../../client.js'
 import type { RlpxPeer } from '../../net/peer/rlpxpeer.js'
+import type { RlpxServer } from '../../net/server/rlpxserver.js'
 import type { FullEthereumService } from '../../service/index.js'
 
 /**
@@ -30,6 +32,15 @@ export class Admin {
 
     this.nodeInfo = middleware(callWithStackTrace(this.nodeInfo.bind(this), this._rpcDebug), 0, [])
     this.peers = middleware(callWithStackTrace(this.peers.bind(this), this._rpcDebug), 0, [])
+    this.addPeer = middleware(callWithStackTrace(this.addPeer.bind(this), this._rpcDebug), 1, [
+      [
+        validators.object({
+          address: validators.ipv4Address,
+          udpPort: validators.unsignedInteger,
+          tcpPort: validators.unsignedInteger,
+        }),
+      ],
+    ])
   }
 
   /**
@@ -96,5 +107,30 @@ export class Admin {
         },
       }
     })
+  }
+
+  /**
+   * Attempts to add a peer to client service peer pool using the RLPx server address and port
+   * e.g. `.admin_addPeer [{"address": "127.0.0.1", "tcpPort": 30303, "udpPort": 30303}]`
+   * @param params An object containing an address, tcpPort, and udpPort for target server to connect to
+   */
+  async addPeer(params: [string]) {
+    const service = this._client.service as any as FullEthereumService
+    const server = service.pool.config.server as RlpxServer
+    const dpt = server.dpt
+
+    let peerInfo
+    try {
+      peerInfo = await dpt.addPeer(params[0])
+      await server.connect(peerInfo.id)
+    } catch (err) {
+      throw {
+        code: INTERNAL_ERROR,
+        message: `failed to add peer: ${JSON.stringify(params)}`,
+        stack: err.stack,
+      }
+    }
+
+    return peerInfo !== undefined
   }
 }

--- a/packages/client/src/rpc/modules/admin.ts
+++ b/packages/client/src/rpc/modules/admin.ts
@@ -114,20 +114,20 @@ export class Admin {
    * e.g. `.admin_addPeer [{"address": "127.0.0.1", "tcpPort": 30303, "udpPort": 30303}]`
    * @param params An object containing an address, tcpPort, and udpPort for target server to connect to
    */
-  async addPeer(params: [string]) {
+  async addPeer(params: [Object]) {
     const service = this._client.service as any as FullEthereumService
     const server = service.pool.config.server as RlpxServer
     const dpt = server.dpt
 
     let peerInfo
     try {
-      peerInfo = await dpt.addPeer(params[0])
-      await server.connect(peerInfo.id)
-    } catch (err) {
+      peerInfo = await dpt!.addPeer(params[0])
+      await server.connect(bytesToHex(peerInfo.id!))
+    } catch (err: any) {
       throw {
         code: INTERNAL_ERROR,
         message: `failed to add peer: ${JSON.stringify(params)}`,
-        stack: err.stack,
+        stack: err?.stack,
       }
     }
 

--- a/packages/client/src/rpc/validation.ts
+++ b/packages/client/src/rpc/validation.ts
@@ -307,11 +307,29 @@ export const validators = {
   },
 
   /**
+   * bool validator to check if type is valid ipv4 address
+   * @param params parameters of method
+   * @param index index of parameter
+   */
+  get ipv4Address() {
+    // regex from https://stackoverflow.com/questions/5284147/validating-ipv4-addresses-with-regexp
+    const ipv4Regex = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$/
+
+    return (params: any[], index: number) => {
+      if (!ipv4Regex.test(params[index])) {
+        return {
+          code: INVALID_PARAMS,
+          message: `invalid argument ${index}: argument is not ipv4 address`,
+        }
+      }
+    }
+  },
+
+  /**
    * number validator to check if type is integer
    * @param params parameters of method
    * @param index index of parameter
    */
-
   get integer() {
     return (params: any[], index: number) => {
       if (!Number.isInteger(params[index])) {

--- a/packages/client/test/rpc/admin/addPeer.spec.ts
+++ b/packages/client/test/rpc/admin/addPeer.spec.ts
@@ -1,0 +1,48 @@
+import { DPT } from '@ethereumjs/devp2p'
+import { hexToBytes } from 'ethereum-cryptography/utils'
+import { assert, describe, it } from 'vitest'
+
+import { Config } from '../../../src/index.js'
+import { PeerPool } from '../../../src/net/peerpool.js'
+import { RlpxServer } from '../../../src/net/server/index.js'
+import { createClient, createManager, getRPCClient, startRPC } from '../helpers.js'
+
+const method = 'admin_addPeer'
+const localEndpointInfo = { address: '0.0.0.0', tcpPort: 30303 }
+const peerPort = 30304
+const privateKey = 'dc6457099f127cf0bac78de8b297df04951281909db4f58b43def7c7151e765d'
+const privateKeyBytes = hexToBytes(privateKey)
+
+describe(method, () => {
+  it('works', async () => {
+    const localPeerClient = await createClient({ opened: true, noPeers: true })
+    const remotePeerClient = await createClient({ opened: true, noPeers: true })
+    const rpc = getRPCClient(startRPC(createManager(localPeerClient).getMethods()))
+    const dpt = new DPT(privateKeyBytes, {
+      endpoint: localEndpointInfo,
+    })
+
+    localPeerClient.service.pool = new PeerPool({
+      config: new Config({ accountCache: 10000, storageCache: 1000 }),
+    })
+    ;(localPeerClient.service.pool.config.server.dpt as any) = dpt
+
+    const remoteConfig = new Config({ accountCache: 10000, storageCache: 1000, port: peerPort })
+    const remoteServer = new RlpxServer({
+      config: remoteConfig,
+      key: privateKey,
+    })
+    await remoteServer.start()
+    ;(remotePeerClient.service.pool.config as any) = {
+      server: remoteServer,
+    }
+
+    const addPeerResponse = await rpc.request('admin_addPeer', [
+      { address: '0.0.0.0', tcpPort: peerPort, udpPort: peerPort },
+    ])
+    assert.equal(addPeerResponse.result, true, 'admin_addPeer successfully adds peer')
+
+    const peersResponse = await rpc.request('admin_peers', [])
+    assert.equal(peersResponse.result.length, 1, 'added peer is visible')
+  })
+})

--- a/packages/client/test/rpc/admin/addPeer.spec.ts
+++ b/packages/client/test/rpc/admin/addPeer.spec.ts
@@ -25,6 +25,7 @@ describe(method, () => {
     localPeerClient.service.pool = new PeerPool({
       config: new Config({ accountCache: 10000, storageCache: 1000 }),
     })
+    //@ts-ignore
     ;(localPeerClient.service.pool.config.server.dpt as any) = dpt
 
     const remoteConfig = new Config({ accountCache: 10000, storageCache: 1000, port: peerPort })

--- a/packages/client/test/rpc/admin/addPeer.spec.ts
+++ b/packages/client/test/rpc/admin/addPeer.spec.ts
@@ -41,9 +41,11 @@ describe(method, () => {
     const addPeerResponse = await rpc.request('admin_addPeer', [
       { address: '0.0.0.0', tcpPort: peerPort, udpPort: peerPort },
     ])
+
     assert.equal(addPeerResponse.result, true, 'admin_addPeer successfully adds peer')
 
     const peersResponse = await rpc.request('admin_peers', [])
     assert.equal(peersResponse.result.length, 1, 'added peer is visible')
+    assert.equal(localPeerClient.service.pool.peers.length, 1, 'added peer is visible in peer pool')
   })
 })


### PR DESCRIPTION
This change provides an implementation for `admin_addPeer` as a part of the work being done in #3781 in order to integrate, develop, and provide an ethereumjs repl console. This work also relates to #1114 and increasing JSON-RPC API coverage.