### PR TITLE
Monorepo: Simplify coverage Command & Reactivate Reporting

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -40,7 +40,7 @@
     "client:start": "npm run client:start:js --",
     "client:start:dev1": "npm run client:start -- --discDns=false --discV4=false --bootnodes",
     "client:start:dev2": "npm run client:start -- --discDns=false --discV4=false --port=30304 --dataDir=datadir-dev2",
-    "coverage": "c8 --all --reporter=lcov --reporter=text npm run test:unit",
+    "coverage": "npx vitest --coverage --coverage.include=src --coverage.reporter=lcov run test/* -c=./vitest.config.unit.ts",
     "docs:build": "typedoc --options typedoc.cjs --tsconfig tsconfig.prod.cjs.json",
     "examples": "tsx ../../scripts/examples-runner.ts -- client",
     "lint": "../../config/cli/lint.sh",

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "../../config/cli/coverage.sh",
+    "coverage": "npx vitest --coverage --coverage.include=src --coverage.reporter=lcov run",
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- ethash",
     "examples:build": "npx embedme README.md",

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -34,7 +34,7 @@
   "scripts": {
     "build": "../../config/cli/ts-build.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "npx vitest --coverage --coverage.include=src --coverage.reporter=lcov run",
+    "coverage": "npx vitest --coverage --coverage.include=src --coverage.reporter=lcov run test/*",
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- ethash",
     "examples:build": "npx embedme README.md",

--- a/packages/rlp/package.json
+++ b/packages/rlp/package.json
@@ -47,7 +47,7 @@
     "build": "../../config/cli/ts-build.sh node",
     "build:benchmarks": "npm run build && tsc -p tsconfig.benchmarks.json",
     "clean": "../../config/cli/clean-package.sh",
-    "coverage": "c8 --all --reporter=lcov --reporter=text npm run test:node",
+    "coverage": "npx vitest --coverage --coverage.include=src run",
     "examples": "tsx ../../scripts/examples-runner.ts -- rlp",
     "examples:build": "npx embedme README.md",
     "lint": "../../config/cli/lint.sh",


### PR DESCRIPTION
This simplifies the coverage runs by removing the c8 tool usage and directly use the in-build vitest coverage functionality.

Beside being simpler goal is to reactivate coverage reporting for certain packages.