### PR TITLE
Fixed typos and grammatical errors in files 

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -60,7 +60,7 @@ Use CLI commands above in your `package.json`:
 
 ### Getting the most out of linting
 
-This lint package is used as git pre-push hook on with the help of [Husky](https://www.npmjs.com/package/husky).
+This lint package is used as git pre-push hook with the help of [Husky](https://www.npmjs.com/package/husky).
 
 ## Coverage
 

--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -25,7 +25,7 @@ This package provides the core Ethereum Virtual Machine (EVM) implementation whi
 
 ### Basic
 
-With the v2 release (Summer 2023) the EVM/VM packages have been further decoupled and it now possible to run the EVM package in isolation with reasonable defaults.
+With the v2 release (Summer 2023) the EVM/VM packages have been further decoupled and it is now possible to run the EVM package in isolation with reasonable defaults.
 
 The following is the simplest example for an EVM instantiation:
 

--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -119,7 +119,7 @@ This library supports the blob transaction type introduced with [EIP-4844](https
 
 ##### Usage
 
-See the following code snipped for an example on how to instantiate (using the `c-kzg` module for our KZG dependency).
+See the following code snippet for an example on how to instantiate (using the `c-kzg` module for our KZG dependency).
 
 ```ts
 // ./examples/blobTx.ts

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -246,7 +246,7 @@ Read the [API docs](docs/).
 
 ### Upgrade Helpers in bytes-Module
 
-Depending on the extend of `Buffer` usage within your own libraries and other planning considerations, there are the two upgrade options to do the switch to `Uint8Array` yourself or keep `Buffer` and do transitions for input and output values.
+Depending on the extent of `Buffer` usage within your own libraries and other planning considerations, there are the two upgrade options to do the switch to `Uint8Array` yourself or keep `Buffer` and do transitions for input and output values.
 
 We have updated the `@ethereumjs/util` `bytes` module with helpers for the most common conversions:
 

--- a/packages/vm/CHANGELOG.md
+++ b/packages/vm/CHANGELOG.md
@@ -1116,7 +1116,7 @@ New:
 invalid receiptTrie (vm hf=berlin -> block number=1 hash=0x8e368301586b53e30c58dd4734de4b3d6e17db837eb3fbde8cc0036bc7752d9a hf=berlin baseFeePerGas=none txs=1 uncles=0)
 ```
 
-The extended errors give substantial more object and chain context and should ease debugging.
+The extended errors give substantially more object and chain context and should ease debugging.
 
 **Potentially breaking**: Attention! If you do react on errors in your code and do exact error matching (`error.message === 'invalid transaction trie'`) things will break. Please make sure to do error comparisons with something like `error.message.includes('invalid transaction trie')` instead. This should generally be the pattern used for all error message comparisons and is assured to be future proof on all error messages (we won't change the core text in non-breaking releases).
 

--- a/packages/vm/DEVELOPER.md
+++ b/packages/vm/DEVELOPER.md
@@ -128,7 +128,7 @@ If the label is removed, the extended tests will not run anymore.
 
 For state tests you can use the `--jsontrace` flag to output opcode trace information.
 
-Blockchain tests support `--debug` to verify the postState:
+Blockchain tests support `--debug` to verify the post state:
 
 `tsx ./test/tester --blockchain --debug --test='ZeroValue_SELFDESTRUCT_ToOneStorageKey_OOGRevert_d0g0v0_EIP158'`
 


### PR DESCRIPTION
config/README.md:
on with -> with

packages/evm/README.md:
it now -> it is now

packages/tx/README.md:
snipped-> snippet

packages/util/README.md
extend-> extent

packages/vm/CHANGELOG.md:
substantial -> substantially

packages/vm/DEVELOPER.md:
postState -> post state
