### PR TITLE
Add package level `lint:fix` back

### DIFF
--- a/config/eslint.cjs
+++ b/config/eslint.cjs
@@ -149,6 +149,16 @@ module.exports = {
       },
     },
     {
+      files: ['packages/devp2p/**'],
+      rules: {
+        '@typescript-eslint/no-floating-promises': 'off',
+        'no-redeclare': 'off',
+        'no-undef': 'off', // temporary until fixed: 'NodeJS' is not defined
+        'no-console': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+      },
+    },
+    {
       files: ['packages/wallet/**'],
       rules: {
         'github/array-foreach': 'warn',

--- a/config/eslint.cjs
+++ b/config/eslint.cjs
@@ -134,7 +134,7 @@ module.exports = {
       },
     },
     {
-      files: ['**/examples/**/*', '**/benchmarks/*.ts', ],
+      files: ['**/examples/**/*.ts', '**/benchmarks/*.ts', ],
       rules: {
         'implicit-dependencies/no-implicit': 'off',
         'import/no-extraneous-dependencies': 'off',

--- a/config/eslint.cjs
+++ b/config/eslint.cjs
@@ -108,7 +108,6 @@ module.exports = {
     'no-dupe-class-members': 'off',
     'no-extra-semi': 'off',
     'no-redeclare': 'off',
-    'no-undef': 'off',
     'no-unused-vars': 'off',
     'no-var': 'error',
     'object-shorthand': 'error',
@@ -130,7 +129,6 @@ module.exports = {
         'implicit-dependencies/no-implicit': 'off',
         'import/no-extraneous-dependencies': 'off',
         'no-console': 'off',
-        '@typescript-eslint/no-floating-promises': 'warn',
       },
     },
     {

--- a/packages/block/.eslintrc
+++ b/packages/block/.eslintrc
@@ -1,6 +1,0 @@
-{
-  "extends": ["../../config/eslint.cjs"],
-  "parserOptions": {
-    "project": "./tsconfig.lint.json"
-  }
-}

--- a/packages/block/.eslintrc
+++ b/packages/block/.eslintrc
@@ -1,0 +1,6 @@
+{
+  "extends": ["../../config/eslint.cjs"],
+  "parserOptions": {
+    "project": "./tsconfig.lint.json"
+  }
+}

--- a/packages/block/.eslintrc.cjs
+++ b/packages/block/.eslintrc.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  parserOptions: {
+    project: ['./tsconfig.lint.json'],
+  },
+  overrides: [
+    {
+      files: ['examples/**/*'],
+      rules: {
+        'no-console': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+      },
+    },
+  ],
+}

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -31,6 +31,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- block",
     "examples:build": "npx embedme README.md",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -31,6 +31,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- block",
     "examples:build": "npx embedme README.md",
+    "lint:fix": "eslint --fix .",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=../../config/vitest.config.browser.mts",

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -31,7 +31,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- block",
     "examples:build": "npx embedme README.md",
-    "lint:fix": "eslint --fix .",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=../../config/vitest.config.browser.mts",

--- a/packages/block/src/index.ts
+++ b/packages/block/src/index.ts
@@ -1,5 +1,6 @@
 export { Block } from './block/block.js'
 export * from './block/index.js'
+export * from './types.js'
 export * from './consensus/index.js'
 export { type BeaconPayloadJSON, executionPayloadFromBeaconPayload } from './from-beacon-payload.js'
 export * from './header/index.js'
@@ -11,4 +12,3 @@ export {
   valuesArrayToHeaderData,
 } from './helpers.js'
 export * from './params.js'
-export * from './types.js'

--- a/packages/block/src/index.ts
+++ b/packages/block/src/index.ts
@@ -1,6 +1,5 @@
 export { Block } from './block/block.js'
 export * from './block/index.js'
-export * from './types.js'
 export * from './consensus/index.js'
 export { type BeaconPayloadJSON, executionPayloadFromBeaconPayload } from './from-beacon-payload.js'
 export * from './header/index.js'
@@ -12,3 +11,4 @@ export {
   valuesArrayToHeaderData,
 } from './helpers.js'
 export * from './params.js'
+export * from './types.js'

--- a/packages/block/tsconfig.lint.json
+++ b/packages/block/tsconfig.lint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../config/tsconfig.lint.json"
+}

--- a/packages/blockchain/.eslintrc.cjs
+++ b/packages/blockchain/.eslintrc.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  parserOptions: {
+    project: ['./tsconfig.lint.json'],
+  },
+  overrides: [
+    {
+      files: ['examples/**/*'],
+      rules: {
+        'no-console': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+      },
+    },
+  ],
+}

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -31,6 +31,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- blockchain",
     "examples:build": "npx embedme README.md",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -31,6 +31,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- blockchain",
     "examples:build": "npx embedme README.md",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=./vitest.config.browser.mts",

--- a/packages/blockchain/tsconfig.lint.json
+++ b/packages/blockchain/tsconfig.lint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../config/tsconfig.lint.json"
+}

--- a/packages/client/.eslintignore
+++ b/packages/client/.eslintignore
@@ -1,0 +1,2 @@
+devnets/**/*.ts
+archive/**/*.ts

--- a/packages/client/.eslintrc.cjs
+++ b/packages/client/.eslintrc.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  parserOptions: {
+    project: ['./tsconfig.lint.json'],
+  },
+  overrides: [
+    {
+      files: ['bin/**.ts', 'test/sim/**.ts', 'examples/**/*.ts'],
+      rules: {
+        'no-console': 'off',
+      },
+    },
+  ],
+}

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -34,6 +34,7 @@
     "coverage": "npx vitest --coverage --coverage.include=src --coverage.reporter=lcov run test/* -c=./vitest.config.unit.ts",
     "docs:build": "typedoc --options typedoc.cjs --tsconfig tsconfig.prod.cjs.json",
     "examples": "tsx ../../scripts/examples-runner.ts -- client",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "preinstall": "npm run binWorkaround",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:unit && npm run test:integration",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -34,6 +34,7 @@
     "coverage": "npx vitest --coverage --coverage.include=src --coverage.reporter=lcov run test/* -c=./vitest.config.unit.ts",
     "docs:build": "typedoc --options typedoc.cjs --tsconfig tsconfig.prod.cjs.json",
     "examples": "tsx ../../scripts/examples-runner.ts -- client",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "preinstall": "npm run binWorkaround",
     "prepublishOnly": "../../config/cli/prepublish.sh",

--- a/packages/client/tsconfig.lint.json
+++ b/packages/client/tsconfig.lint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../config/tsconfig.lint.json"
+}

--- a/packages/common/.eslintrc.cjs
+++ b/packages/common/.eslintrc.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  parserOptions: {
+    project: ['./tsconfig.lint.json'],
+  },
+  overrides: [
+    {
+      files: ['examples/**/*'],
+      rules: {
+        'no-console': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+      },
+    },
+  ],
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -44,6 +44,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- common",
     "examples:build": "npx embedme README.md",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -44,6 +44,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- common",
     "examples:build": "npx embedme README.md",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=../../config/vitest.config.browser.mts",

--- a/packages/common/tsconfig.lint.json
+++ b/packages/common/tsconfig.lint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../config/tsconfig.lint.json"
+}

--- a/packages/devp2p/.eslintrc.cjs
+++ b/packages/devp2p/.eslintrc.cjs
@@ -1,0 +1,17 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  rules: {
+    '@typescript-eslint/no-floating-promises': 'off',
+    'no-redeclare': 'off',
+    'no-undef': 'off', // temporary until fixed: 'NodeJS' is not defined
+  },
+  overrides: [
+    {
+      files: ['examples/**/*'],
+      rules: {
+        'no-console': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+      },
+    },
+  ],
+}

--- a/packages/devp2p/.eslintrc.cjs
+++ b/packages/devp2p/.eslintrc.cjs
@@ -1,5 +1,8 @@
 module.exports = {
   extends: '../../config/eslint.cjs',
+  parserOptions: {
+    project: ['./tsconfig.lint.json'],
+  },
   rules: {
     '@typescript-eslint/no-floating-promises': 'off',
     'no-redeclare': 'off',

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -47,6 +47,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- devp2p",
     "examples:build": "npx embedme README.md",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "vitest run",
     "test:node": "npm run test",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -47,6 +47,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- devp2p",
     "examples:build": "npx embedme README.md",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "vitest run",

--- a/packages/devp2p/tsconfig.lint.json
+++ b/packages/devp2p/tsconfig.lint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../config/tsconfig.lint.json"
+}

--- a/packages/ethash/.eslintrc.cjs
+++ b/packages/ethash/.eslintrc.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  parserOptions: {
+    project: ['./tsconfig.lint.json'],
+  },
+  overrides: [
+    {
+      files: ['examples/**/*'],
+      rules: {
+        'no-console': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+      },
+    },
+  ],
+}

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -31,6 +31,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- ethash",
     "examples:build": "npx embedme README.md",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npx vitest run",
     "tsc": "../../config/cli/ts-compile.sh"

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -31,6 +31,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- ethash",
     "examples:build": "npx embedme README.md",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npx vitest run",

--- a/packages/evm/.eslintrc.cjs
+++ b/packages/evm/.eslintrc.cjs
@@ -1,0 +1,17 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  rules: {
+    '@typescript-eslint/no-use-before-define': 'off',
+    'no-invalid-this': 'off',
+    'no-restricted-syntax': 'off',
+  },
+  overrides: [
+    {
+      files: ['test/util.ts', 'test/tester/**/*.ts', 'examples/**/*.ts'],
+      rules: {
+        'no-console': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+      },
+    },
+  ],
+}

--- a/packages/evm/.eslintrc.cjs
+++ b/packages/evm/.eslintrc.cjs
@@ -1,5 +1,8 @@
 module.exports = {
   extends: '../../config/eslint.cjs',
+  parserOptions: {
+    project: ['./tsconfig.lint.json'],
+  },
   rules: {
     '@typescript-eslint/no-use-before-define': 'off',
     'no-invalid-this': 'off',

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -34,6 +34,7 @@
     "examples": "tsx ../../scripts/examples-runner.ts -- evm",
     "examples:build": "npx embedme README.md",
     "formatTest": "node ./scripts/formatTest",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "profiling": "0x ./benchmarks/run.js profiling",

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -34,6 +34,7 @@
     "examples": "tsx ../../scripts/examples-runner.ts -- evm",
     "examples:build": "npx embedme README.md",
     "formatTest": "node ./scripts/formatTest",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "profiling": "0x ./benchmarks/run.js profiling",
     "test": "npm run test:node && npm run test:browser",

--- a/packages/evm/tsconfig.lint.json
+++ b/packages/evm/tsconfig.lint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../config/tsconfig.lint.json"
+}

--- a/packages/genesis/.eslintrc.cjs
+++ b/packages/genesis/.eslintrc.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  parserOptions: {
+    project: ['./tsconfig.lint.json'],
+  },
+  overrides: [
+    {
+      files: ['examples/**/*'],
+      rules: {
+        'no-console': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+      },
+    },
+  ],
+}

--- a/packages/genesis/package.json
+++ b/packages/genesis/package.json
@@ -43,6 +43,7 @@
     "examples": "tsx ../../scripts/examples-runner.ts -- genesis",
     "examples:build": "npx embedme README.md",
     "docs:build": "typedoc --options typedoc.cjs",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node",
     "test:browser": "npx vitest run --config=../../config/vitest.config.browser.mts",

--- a/packages/genesis/package.json
+++ b/packages/genesis/package.json
@@ -43,6 +43,7 @@
     "examples": "tsx ../../scripts/examples-runner.ts -- genesis",
     "examples:build": "npx embedme README.md",
     "docs:build": "typedoc --options typedoc.cjs",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node",

--- a/packages/genesis/tsconfig.lint.json
+++ b/packages/genesis/tsconfig.lint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../config/tsconfig.lint.json"
+}

--- a/packages/mpt/.eslintrc.cjs
+++ b/packages/mpt/.eslintrc.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  parserOptions: {
+    project: ['./tsconfig.lint.json'],
+  },
+  overrides: [
+    {
+      files: ['benchmarks/*.ts', 'examples/**/*'],
+      rules: {
+        'no-console': 'off',
+      },
+    },
+  ],
+}

--- a/packages/mpt/package.json
+++ b/packages/mpt/package.json
@@ -33,6 +33,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- mpt",
     "examples:build": "npx embedme README.md",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "profiling": "tsc --target ES5 benchmarks/random.ts && 0x benchmarks/random.js",
     "test": "npm run test:node && npm run test:browser",

--- a/packages/mpt/package.json
+++ b/packages/mpt/package.json
@@ -33,6 +33,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- mpt",
     "examples:build": "npx embedme README.md",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "profiling": "tsc --target ES5 benchmarks/random.ts && 0x benchmarks/random.js",

--- a/packages/mpt/tsconfig.lint.json
+++ b/packages/mpt/tsconfig.lint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../config/tsconfig.lint.json"
+}

--- a/packages/rlp/.eslintrc.cjs
+++ b/packages/rlp/.eslintrc.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  rules: {
+    '@typescript-eslint/no-use-before-define': 'off',
+  },
+  overrides: [
+    {
+      files: ['examples/**/*'],
+      rules: {
+        'no-console': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+      },
+    },
+  ],
+}

--- a/packages/rlp/package.json
+++ b/packages/rlp/package.json
@@ -43,6 +43,7 @@
     "coverage": "npx vitest --coverage --coverage.include=src run",
     "examples": "tsx ../../scripts/examples-runner.ts -- rlp",
     "examples:build": "npx embedme README.md",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=./vitest.config.browser.mts",

--- a/packages/rlp/package.json
+++ b/packages/rlp/package.json
@@ -43,6 +43,7 @@
     "coverage": "npx vitest --coverage --coverage.include=src run",
     "examples": "tsx ../../scripts/examples-runner.ts -- rlp",
     "examples:build": "npx embedme README.md",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",

--- a/packages/rlp/tsconfig.lint.json
+++ b/packages/rlp/tsconfig.lint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../config/tsconfig.lint.json"
+}

--- a/packages/statemanager/.eslintrc.cjs
+++ b/packages/statemanager/.eslintrc.cjs
@@ -1,0 +1,17 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  rules: {
+    '@typescript-eslint/no-use-before-define': 'off',
+    'no-invalid-this': 'off',
+    'no-restricted-syntax': 'off',
+  },
+  overrides: [
+    {
+      files: ['examples/**/*'],
+      rules: {
+        'no-console': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+      },
+    },
+  ],
+}

--- a/packages/statemanager/.eslintrc.cjs
+++ b/packages/statemanager/.eslintrc.cjs
@@ -1,5 +1,8 @@
 module.exports = {
   extends: '../../config/eslint.cjs',
+  parserOptions: {
+    project: ['./tsconfig.lint.json'],
+  },
   rules: {
     '@typescript-eslint/no-use-before-define': 'off',
     'no-invalid-this': 'off',

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -32,6 +32,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- statemanager",
     "examples:build": "npx embedme README.md",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh && npm run test:node",
     "test": "npm run test:node && npm run test:browser",

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -32,6 +32,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- statemanager",
     "examples:build": "npx embedme README.md",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh && npm run test:node",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=./vitest.config.browser.mts",

--- a/packages/statemanager/tsconfig.lint.json
+++ b/packages/statemanager/tsconfig.lint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../config/tsconfig.lint.json"
+}

--- a/packages/tx/.eslintrc.cjs
+++ b/packages/tx/.eslintrc.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  parserOptions: {
+    project: ['./tsconfig.lint.json'],
+  },
+  overrides: [
+    {
+      files: ['examples/**/*'],
+      rules: {
+        'no-console': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+      },
+    },
+  ],
+}

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -38,6 +38,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- tx",
     "examples:build": "npx embedme README.md",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -38,6 +38,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- tx",
     "examples:build": "npx embedme README.md",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=./vitest.config.browser.mts",

--- a/packages/tx/tsconfig.lint.json
+++ b/packages/tx/tsconfig.lint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../config/tsconfig.lint.json"
+}

--- a/packages/util/.eslintrc.cjs
+++ b/packages/util/.eslintrc.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  parserOptions: {
+    project: ['./tsconfig.lint.json'],
+  },
+  overrides: [
+    {
+      files: ['examples/**/*'],
+      rules: {
+        'no-console': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+      },
+    },
+  ],
+}

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -75,6 +75,7 @@
     "docs:build": "npx typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- util",
     "examples:build": "npx embedme README.md",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=../../config/vitest.config.browser.mts",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -75,6 +75,7 @@
     "docs:build": "npx typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- util",
     "examples:build": "npx embedme README.md",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",

--- a/packages/util/tsconfig.lint.json
+++ b/packages/util/tsconfig.lint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../config/tsconfig.lint.json"
+}

--- a/packages/verkle/.eslintrc.cjs
+++ b/packages/verkle/.eslintrc.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  parserOptions: {
+    project: ['./tsconfig.lint.json'],
+  },
+  ignorePatterns: ['src/rust-verkle-wasm/rust_verkle_wasm.js', '**/vendor/*.js'],
+  overrides: [
+    {
+      files: ['benchmarks/*.ts', 'examples/*.ts'],
+      rules: {
+        'no-console': 'off',
+      },
+    },
+  ],
+}

--- a/packages/verkle/package.json
+++ b/packages/verkle/package.json
@@ -37,6 +37,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- verkle",
     "examples:build": "npx embedme README.md",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node",
     "test:node": "npx vitest run",

--- a/packages/verkle/package.json
+++ b/packages/verkle/package.json
@@ -37,6 +37,7 @@
     "docs:build": "typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- verkle",
     "examples:build": "npx embedme README.md",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node",

--- a/packages/verkle/tsconfig.lint.json
+++ b/packages/verkle/tsconfig.lint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../config/tsconfig.lint.json"
+}

--- a/packages/vm/.eslintrc.cjs
+++ b/packages/vm/.eslintrc.cjs
@@ -1,0 +1,19 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  parserOptions: {
+    project: ['./tsconfig.lint.json'],
+  },
+  rules: {
+    '@typescript-eslint/no-use-before-define': 'off',
+    'no-invalid-this': 'off',
+    'no-restricted-syntax': 'off',
+  },
+  overrides: [
+    {
+      files: ['test/util.ts', 'test/tester/**/*.ts', 'examples/**/*.ts'],
+      rules: {
+        'no-console': 'off',
+      },
+    },
+  ],
+}

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -36,6 +36,7 @@
     "examples": "tsx ../../scripts/examples-runner.ts -- vm",
     "examples:build": "npx embedme README.md",
     "formatTest": "node ./scripts/formatTest",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh && npm run test:buildIntegrity",
     "profiling": "0x ./benchmarks/run.js profiling",
     "test": "echo \"[INFO] Generic test cmd not used. See package.json for more specific test run cmds.\"",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -36,6 +36,7 @@
     "examples": "tsx ../../scripts/examples-runner.ts -- vm",
     "examples:build": "npx embedme README.md",
     "formatTest": "node ./scripts/formatTest",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh && npm run test:buildIntegrity",
     "profiling": "0x ./benchmarks/run.js profiling",

--- a/packages/vm/tsconfig.lint.json
+++ b/packages/vm/tsconfig.lint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../config/tsconfig.lint.json"
+}

--- a/packages/wallet/.eslintrc.cjs
+++ b/packages/wallet/.eslintrc.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  extends: '../../config/eslint.cjs',
+  parserOptions: {
+    project: ['./tsconfig.lint.json'],
+  },
+  overrides: [
+    {
+      files: ['test/index.spec.ts', 'examples/**/*'],
+      rules: {
+        'github/array-foreach': 'warn',
+        'no-prototype-builtins': 'warn',
+        'no-console': 'off',
+      },
+    },
+  ],
+}

--- a/packages/wallet/.prettierignore
+++ b/packages/wallet/.prettierignore
@@ -1,7 +1,0 @@
-node_modules
-.vscode
-package.json
-dist
-.nyc_output
-test/testdata
-docs

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -31,6 +31,7 @@
     "docs:build": "npx typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- wallet",
     "examples:build": "npx embedme README.md",
+    "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=../../config/vitest.config.browser.mts",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -31,6 +31,7 @@
     "docs:build": "npx typedoc --options typedoc.cjs",
     "examples": "tsx ../../scripts/examples-runner.ts -- wallet",
     "examples:build": "npx embedme README.md",
+    "lint": "eslint --config .eslintrc.cjs . --ext .js,.ts",
     "lint:fix": "eslint --fix --config .eslintrc.cjs . --ext .js,.ts",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",

--- a/packages/wallet/tsconfig.lint.json
+++ b/packages/wallet/tsconfig.lint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../config/tsconfig.lint.json"
+}


### PR DESCRIPTION
By request, this re-introduces package level `lint` and `lint:fix` npm scripts.  These will not run under normal circumstances but can be used to do package level linting.