### PR TITLE
Implement debug_verbosity

### DIFF
--- a/packages/client/src/rpc/modules/debug.ts
+++ b/packages/client/src/rpc/modules/debug.ts
@@ -43,6 +43,14 @@ export interface structLog {
   }
   error: boolean | undefined | null
 }
+
+const logLevels: { [key: number]: string } = {
+  0: 'error',
+  1: 'warn',
+  2: 'info',
+  3: 'debug',
+}
+
 /**
  * Validate tracer opts to ensure only supports opts are provided
  * @param opts a dictionary of {@link tracerOpts}
@@ -85,6 +93,7 @@ const validateTracerConfig = (opts: tracerOpts): tracerOpts => {
  * @memberof module:rpc/modules
  */
 export class Debug {
+  private client: EthereumClient
   private service: FullEthereumService
   private chain: Chain
   private vm: VM
@@ -94,6 +103,7 @@ export class Debug {
    * @param client Client to which the module binds
    */
   constructor(client: EthereumClient, rpcDebug: boolean) {
+    this.client = client
     this.service = client.service as FullEthereumService
     this.chain = this.service.chain
     this.vm = (this.service as FullEthereumService).execution?.vm
@@ -138,6 +148,9 @@ export class Debug {
       1,
       [[validators.hex]],
     )
+    this.verbosity = middleware(callWithStackTrace(this.verbosity.bind(this), this._rpcDebug), 1, [
+      [validators.unsignedInteger],
+    ])
   }
 
   /**
@@ -434,5 +447,14 @@ export class Debug {
     const block = await this.chain.getBlock(blockHash)
     const tx = block.transactions[txIndex]
     return bytesToHex(tx.serialize())
+  }
+  /**
+   * Returns an RLP-encoded block
+   * @param blockOpt Block number or tag
+   */
+  async verbosity(params: [number]) {
+    const [level] = params
+    this.client.config.logger.configure({ level: logLevels[level] })
+    return `level: ${this.client.config.logger.level}`
   }
 }

--- a/packages/client/src/rpc/modules/debug.ts
+++ b/packages/client/src/rpc/modules/debug.ts
@@ -449,8 +449,8 @@ export class Debug {
     return bytesToHex(tx.serialize())
   }
   /**
-   * Returns an RLP-encoded block
-   * @param blockOpt Block number or tag
+   * Sets the verbosity level of the client logger
+   * @param level logger level to use with 0 as the lowest verbosity
    */
   async verbosity(params: [number]) {
     const [level] = params

--- a/packages/client/test/rpc/debug/verbosity.spec.ts
+++ b/packages/client/test/rpc/debug/verbosity.spec.ts
@@ -28,7 +28,7 @@ describe(method, () => {
     // highest level; e.g. be very verbose and show even debug logs
     const levelDebug = 3
     res = await rpc.request(method, [levelDebug])
-    assert.equal(res.result, 'level: debug', 'verbosity level successfully highered')
+    assert.equal(res.result, 'level: debug', 'verbosity level successfully increased')
     assert.equal(client.config.logger.level, logLevels[levelDebug])
   })
 })

--- a/packages/client/test/rpc/debug/verbosity.spec.ts
+++ b/packages/client/test/rpc/debug/verbosity.spec.ts
@@ -4,16 +4,16 @@ import { createClient, createManager, getRPCClient, startRPC } from '../helpers.
 
 const method = 'debug_verbosity'
 
-const logLevels: {[key: number]: string} = {
+const logLevels: { [key: number]: string } = {
   0: 'error',
   1: 'warn',
   2: 'info',
-  3: 'debug'
+  3: 'debug',
 }
 
 describe(method, () => {
   it('works', async () => {
-    const manager = createManager(await createClient({ opened: true, noPeers: true, }))
+    const manager = createManager(await createClient({ opened: true, noPeers: true }))
     const rpc = getRPCClient(startRPC(manager.getMethods()))
     const client = manager['_client']
 
@@ -22,13 +22,13 @@ describe(method, () => {
     // lowest level; e.g. only show errors
     const levelError = 0
     res = await rpc.request(method, [levelError])
-    assert.equal(res.result, 'level: error', 'verbosity level successfully changed')
+    assert.equal(res.result, 'level: error', 'verbosity level successfully lowered')
     assert.equal(client.config.logger.level, logLevels[levelError])
 
     // highest level; e.g. be very verbose and show even debug logs
     const levelDebug = 3
     res = await rpc.request(method, [levelDebug])
-    assert.equal(res.result, 'level: debug', 'verbosity level successfully changed')
+    assert.equal(res.result, 'level: debug', 'verbosity level successfully highered')
     assert.equal(client.config.logger.level, logLevels[levelDebug])
   })
 })

--- a/packages/client/test/rpc/debug/verbosity.spec.ts
+++ b/packages/client/test/rpc/debug/verbosity.spec.ts
@@ -1,0 +1,34 @@
+import { assert, describe, it } from 'vitest'
+
+import { createClient, createManager, getRPCClient, startRPC } from '../helpers.js'
+
+const method = 'debug_verbosity'
+
+const logLevels: {[key: number]: string} = {
+  0: 'error',
+  1: 'warn',
+  2: 'info',
+  3: 'debug'
+}
+
+describe(method, () => {
+  it('works', async () => {
+    const manager = createManager(await createClient({ opened: true, noPeers: true, }))
+    const rpc = getRPCClient(startRPC(manager.getMethods()))
+    const client = manager['_client']
+
+    let res
+
+    // lowest level; e.g. only show errors
+    const levelError = 0
+    res = await rpc.request(method, [levelError])
+    assert.equal(res.result, 'level: error', 'verbosity level successfully changed')
+    assert.equal(client.config.logger.level, logLevels[levelError])
+
+    // highest level; e.g. be very verbose and show even debug logs
+    const levelDebug = 3
+    res = await rpc.request(method, [levelDebug])
+    assert.equal(res.result, 'level: debug', 'verbosity level successfully changed')
+    assert.equal(client.config.logger.level, logLevels[levelDebug])
+  })
+})


### PR DESCRIPTION
This change provides an implementation for debug_verbosity to allow for setting the verbosity level of the client logger as a part of the work being done in #3781  in order to integrate, develop, and provide an ethereumjs repl console. This work also relates to #1114  and increasing JSON-RPC API coverage.