### PR TITLE
Fix/err

### DIFF
--- a/packages/blockchain/docs/classes/CliqueConsensus.md
+++ b/packages/blockchain/docs/classes/CliqueConsensus.md
@@ -238,7 +238,7 @@ ___
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `param` | [`ConsensusOptions`](../interfaces/ConsensusOptions.md) | dictionary containin a [Blockchain](Blockchain.md) object  Note: this method must be called before consensus checks are used or type errors will occur |
+| `param` | [`ConsensusOptions`](../interfaces/ConsensusOptions.md) | dictionary containing a [Blockchain](Blockchain.md) object  Note: this method must be called before consensus checks are used or type errors will occur |
 
 #### Returns
 

--- a/packages/client/devnets/4844-interop/prysm/generate_genesis.sh
+++ b/packages/client/devnets/4844-interop/prysm/generate_genesis.sh
@@ -3,7 +3,7 @@ CONFIGDIR=$(pwd)
 PRYSMDIR=$1
 GENESIS=$(($(date +%s) + 30)) # 120s until genesis, feel free to increase this to give you more time to everything
 
-# The following are configureable too but you have to make sure they align.
+# The following are configurable too but you have to make sure they align.
 # Take SECONDS_PER_SLOT * SLOTS_PER_EPOCH * CAPELLA_FORK_EPOCH for SHANGHAI
 # Take SECONDS_PER_SLOT * SLOTS_PER_EPOCH * EIP4844_FORK_EPOCH for CANCUN
 SHANGHAI=$(($GENESIS + 144))

--- a/packages/statemanager/docs/classes/DefaultStateManager.md
+++ b/packages/statemanager/docs/classes/DefaultStateManager.md
@@ -710,7 +710,7 @@ This means in particular:
 1. For caches instantiated as an LRU cache type
 the copy() method will instantiate with an ORDERED_MAP cache
 instead, since copied instantances are mostly used in
-short-term usage contexts and LRU cache instantation would create
+short-term usage contexts and LRU cache instantiation would create
 a large overhead here.
 2. The underlying trie object is initialized with 0 cache size
 


### PR DESCRIPTION
# Fix: Corrected typos across files

## Changes
- `packages\statemanager\docs\classes\DefaultStateManager.md:713`: "instantation" corrected to "instantiation".
- `packages\blockchain\docs\classes\CliqueConsensus.md:241`: "containin" corrected to "containing".
- `packages\client\devnets\4844-interop\prysm\generate_genesis.sh:6`: "configureable" corrected to "configurable".

## Reason
- Ensured proper spelling for better documentation quality and code clarity.
