### PR TITLE
docs: update wallet README.md to correct the link for Wallet's API

### DIFF
--- a/packages/wallet/README.md
+++ b/packages/wallet/README.md
@@ -28,7 +28,7 @@ Features not supported:
 
 ## Wallet API
 
-For information about the Wallet's API, please go to [./docs/classes/wallet.md](./docs/classes/wallet.md).
+For information about the Wallet's API, please go to [./docs/classes/Wallet.md](./docs/classes/Wallet.md).
 
 You can import the `Wallet` class like this
 


### PR DESCRIPTION
Link typo at: [master/packages/wallet/README.md#L31](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/wallet/README.md?plain=1#L31)