### PR TITLE
evm: simplify verkle access witness methods

### DIFF
--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -102,41 +102,16 @@ export interface VerkleAccessWitnessInterface {
   accesses(): Generator<VerkleAccessedStateWithAddress>
   rawAccesses(): Generator<RawVerkleAccessedState>
   debugWitnessCost(): void
-  touchAndChargeProofOfAbsence(address: Address): bigint
-  touchAndChargeMessageCall(address: Address): bigint
-  touchAndChargeValueTransfer(target: Address): bigint
-  touchAndChargeContractCreateInit(address: Address): bigint
-  touchAndChargeContractCreateCompleted(address: Address): bigint
-  touchTxOriginAndComputeGas(origin: Address): bigint
-  touchTxTargetAndComputeGas(target: Address, { sendsValue }: { sendsValue?: boolean }): bigint
-  touchCodeChunksRangeOnReadAndComputeGas(contract: Address, startPc: number, endPc: number): bigint
-  touchCodeChunksRangeOnWriteAndComputeGas(
-    contract: Address,
-    startPc: number,
-    endPc: number,
-  ): bigint
-  touchAddressOnWriteAndComputeGas(
-    address: Address,
-    treeIndex: number | bigint,
-    subIndex: number | Uint8Array,
-  ): bigint
-  touchAddressOnReadAndComputeGas(
-    address: Address,
-    treeIndex: number | bigint,
-    subIndex: number | Uint8Array,
-  ): bigint
-  touchAddressAndComputeGas(
-    address: Address,
-    treeIndex: number | bigint,
-    subIndex: number | Uint8Array,
-    { isWrite }: { isWrite?: boolean },
-  ): bigint
-  touchAddress(
-    address: Address,
-    treeIndex: number | bigint,
-    subIndex: number | Uint8Array,
-    { isWrite }: { isWrite?: boolean },
-  ): AccessEventFlags
+  readAccountBasicData(address: Address): bigint
+  writeAccountBasicData(address: Address): bigint
+  readAccountCodeHash(address: Address): bigint
+  writeAccountCodeHash(address: Address): bigint
+  readAccountHeader(address: Address): bigint
+  writeAccountHeader(address: Address): bigint
+  readAccountCodeChunks(contract: Address, startPc: number, endPc: number): bigint
+  writeAccountCodeChunks(contract: Address, startPc: number, endPc: number): bigint
+  readAccountStorage(contract: Address, storageSlot: bigint): bigint
+  writeAccountStorage(contract: Address, storageSlot: bigint): bigint
   merge(accessWitness: VerkleAccessWitnessInterface): void
   commit(): void
   revert(): void

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -386,12 +386,11 @@ export class Interpreter {
 
       if (this.common.isActivatedEIP(6800) && this._env.chargeCodeAccesses === true) {
         const contract = this._runState.interpreter.getAddress()
-        const statelessGas =
-          this._runState.env.accessWitness!.touchCodeChunksRangeOnReadAndComputeGas(
-            contract,
-            this._runState.programCounter,
-            this._runState.programCounter,
-          )
+        const statelessGas = this._runState.env.accessWitness!.readAccountCodeChunks(
+          contract,
+          this._runState.programCounter,
+          this._runState.programCounter,
+        )
         gas += statelessGas
         debugGas(`codechunk accessed statelessGas=${statelessGas} (-> ${gas})`)
       }

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -24,7 +24,6 @@ import {
   bytesToInt,
   concatBytes,
   equalsBytes,
-  getVerkleTreeIndicesForStorageSlot,
   setLengthLeft,
 } from '@ethereumjs/util'
 import { keccak256 } from 'ethereum-cryptography/keccak.js'
@@ -667,12 +666,10 @@ export const handlers: Map<number, OpHandler> = new Map([
         const key = setLengthLeft(bigIntToBytes(number % historyServeWindow), 32)
 
         if (common.isActivatedEIP(6800)) {
-          const { treeIndex, subIndex } = getVerkleTreeIndicesForStorageSlot(number)
           // create witnesses and charge gas
-          const statelessGas = runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
+          const statelessGas = runState.env.accessWitness!.readAccountStorage(
             historyAddress,
-            treeIndex,
-            subIndex,
+            number,
           )
           runState.interpreter.useGas(statelessGas, `BLOCKHASH`)
         }
@@ -959,7 +956,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         const contract = runState.interpreter.getAddress()
         const startOffset = Math.min(runState.code.length, runState.programCounter + 1)
         const endOffset = Math.min(runState.code.length, startOffset + numToPush - 1)
-        const statelessGas = runState.env.accessWitness!.touchCodeChunksRangeOnReadAndComputeGas(
+        const statelessGas = runState.env.accessWitness!.readAccountCodeChunks(
           contract,
           startOffset,
           endOffset,

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -6,11 +6,8 @@ import {
   BIGINT_31,
   BIGINT_32,
   BIGINT_64,
-  VERKLE_BASIC_DATA_LEAF_KEY,
-  VERKLE_CODE_HASH_LEAF_KEY,
   bigIntToBytes,
   equalsBytes,
-  getVerkleTreeIndicesForStorageSlot,
   setLengthLeft,
 } from '@ethereumjs/util'
 
@@ -106,11 +103,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         const address = createAddressFromStackBigInt(runState.stack.peek()[0])
         let charge2929Gas = true
         if (common.isActivatedEIP(6800)) {
-          const coldAccessGas = runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-            address,
-            0,
-            VERKLE_BASIC_DATA_LEAF_KEY,
-          )
+          const coldAccessGas = runState.env.accessWitness!.readAccountBasicData(address)
 
           gas += coldAccessGas
           charge2929Gas = coldAccessGas === BIGINT_0
@@ -154,7 +147,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
               codeEnd = codeSize
             }
 
-            gas += runState.env.accessWitness!.touchCodeChunksRangeOnReadAndComputeGas(
+            gas += runState.env.accessWitness!.readAccountCodeChunks(
               contract,
               Number(_codeOffset),
               Number(codeEnd),
@@ -176,11 +169,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           runState.interpreter._evm.getPrecompile(address) === undefined
         ) {
           let coldAccessGas = BIGINT_0
-          coldAccessGas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-            address,
-            0,
-            VERKLE_BASIC_DATA_LEAF_KEY,
-          )
+          coldAccessGas += runState.env.accessWitness!.readAccountBasicData(address)
 
           gas += coldAccessGas
           // if cold access gas has been charged 2929 gas shouldn't be charged
@@ -213,11 +202,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           runState.interpreter._evm.getPrecompile(address) === undefined
         ) {
           let coldAccessGas = BIGINT_0
-          coldAccessGas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-            address,
-            0,
-            VERKLE_BASIC_DATA_LEAF_KEY,
-          )
+          coldAccessGas += runState.env.accessWitness!.readAccountBasicData(address)
 
           gas += coldAccessGas
           // if cold access gas has been charged 2929 gas shouldn't be charged
@@ -242,7 +227,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
               codeEnd = codeSize
             }
 
-            gas += runState.env.accessWitness!.touchCodeChunksRangeOnReadAndComputeGas(
+            gas += runState.env.accessWitness!.readAccountCodeChunks(
               address,
               Number(_codeOffset),
               Number(codeEnd),
@@ -283,11 +268,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         if (common.isActivatedEIP(6800)) {
           let coldAccessGas = BIGINT_0
-          coldAccessGas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-            address,
-            0,
-            VERKLE_CODE_HASH_LEAF_KEY,
-          )
+          coldAccessGas += runState.env.accessWitness!.readAccountCodeHash(address)
 
           gas += coldAccessGas
           charge2929Gas = coldAccessGas === BIGINT_0
@@ -341,12 +322,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         let charge2929Gas = true
         if (common.isActivatedEIP(6800)) {
           const address = runState.interpreter.getAddress()
-          const { treeIndex, subIndex } = getVerkleTreeIndicesForStorageSlot(key)
-          const coldAccessGas = runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-            address,
-            treeIndex,
-            subIndex,
-          )
+          const coldAccessGas = runState.env.accessWitness!.readAccountStorage(address, key)
 
           gas += coldAccessGas
           charge2929Gas = coldAccessGas === BIGINT_0
@@ -409,12 +385,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         let charge2929Gas = true
         if (common.isActivatedEIP(6800)) {
           const contract = runState.interpreter.getAddress()
-          const { treeIndex, subIndex } = getVerkleTreeIndicesForStorageSlot(key)
-          const coldAccessGas = runState.env.accessWitness!.touchAddressOnWriteAndComputeGas(
-            contract,
-            treeIndex,
-            subIndex,
-          )
+          const coldAccessGas = runState.env.accessWitness!.writeAccountStorage(contract, key)
 
           gas += coldAccessGas
           charge2929Gas = coldAccessGas === BIGINT_0
@@ -592,15 +563,11 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           runState.interpreter._evm.getPrecompile(toAddress) === undefined
         ) {
           // TODO: add check if toAddress is not a precompile
-          const coldAccessGas = runState.env.accessWitness!.touchAndChargeMessageCall(toAddress)
+          const coldAccessGas = runState.env.accessWitness!.readAccountBasicData(toAddress)
           if (value !== BIGINT_0) {
             const contractAddress = runState.interpreter.getAddress()
-            gas += runState.env.accessWitness!.touchAddressOnWriteAndComputeGas(
-              contractAddress,
-              0,
-              VERKLE_BASIC_DATA_LEAF_KEY,
-            )
-            gas += runState.env.accessWitness!.touchAndChargeValueTransfer(toAddress)
+            gas += runState.env.accessWitness!.writeAccountBasicData(contractAddress)
+            gas += runState.env.accessWitness!.writeAccountBasicData(toAddress)
           }
 
           gas += coldAccessGas
@@ -674,7 +641,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           common.isActivatedEIP(6800) &&
           runState.interpreter._evm.getPrecompile(toAddress) === undefined
         ) {
-          const coldAccessGas = runState.env.accessWitness!.touchAndChargeMessageCall(toAddress)
+          const coldAccessGas = runState.env.accessWitness!.readAccountBasicData(toAddress)
 
           gas += coldAccessGas
           charge2929Gas = coldAccessGas === BIGINT_0
@@ -739,7 +706,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           runState.interpreter._evm.getPrecompile(toAddress) === undefined
         ) {
           // TODO: add check if toAddress is not a precompile
-          const coldAccessGas = runState.env.accessWitness!.touchAndChargeMessageCall(toAddress)
+          const coldAccessGas = runState.env.accessWitness!.readAccountBasicData(toAddress)
 
           gas += coldAccessGas
           charge2929Gas = coldAccessGas === BIGINT_0
@@ -950,7 +917,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         if (common.isActivatedEIP(6800)) {
           const toAddress = createAddressFromStackBigInt(toAddr)
           // TODO: add check if toAddress is not a precompile
-          const coldAccessGas = runState.env.accessWitness!.touchAndChargeMessageCall(toAddress)
+          const coldAccessGas = runState.env.accessWitness!.readAccountBasicData(toAddress)
 
           gas += coldAccessGas
           charge2929Gas = coldAccessGas === BIGINT_0
@@ -1085,32 +1052,16 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         let selfDestructToCharge2929Gas = true
         if (common.isActivatedEIP(6800)) {
-          gas += runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-            contractAddress,
-            0,
-            VERKLE_BASIC_DATA_LEAF_KEY,
-          )
+          gas += runState.env.accessWitness!.readAccountBasicData(contractAddress)
           if (balance > BIGINT_0) {
-            gas += runState.env.accessWitness!.touchAddressOnWriteAndComputeGas(
-              contractAddress,
-              0,
-              VERKLE_BASIC_DATA_LEAF_KEY,
-            )
+            gas += runState.env.accessWitness!.writeAccountBasicData(contractAddress)
           }
 
           let selfDestructToColdAccessGas =
-            runState.env.accessWitness!.touchAddressOnReadAndComputeGas(
-              selfdestructToAddress,
-              0,
-              VERKLE_BASIC_DATA_LEAF_KEY,
-            )
+            runState.env.accessWitness!.readAccountBasicData(selfdestructToAddress)
           if (balance > BIGINT_0) {
             selfDestructToColdAccessGas +=
-              runState.env.accessWitness!.touchAddressOnWriteAndComputeGas(
-                selfdestructToAddress,
-                0,
-                VERKLE_BASIC_DATA_LEAF_KEY,
-              )
+              runState.env.accessWitness!.writeAccountBasicData(selfdestructToAddress)
           }
 
           gas += selfDestructToColdAccessGas

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -666,7 +666,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
       if (vm.evm.verkleAccessWitness === undefined) {
         throw Error(`verkleAccessWitness required if verkle (EIP-6800) is activated`)
       }
-      vm.evm.verkleAccessWitness.touchAndChargeProofOfAbsence(miner)
+      vm.evm.verkleAccessWitness.readAccountHeader(miner)
     }
     minerAccount = new Account()
   }
@@ -681,9 +681,8 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
       throw Error(`verkleAccessWitness required if verkle (EIP-6800) is activated`)
     }
     // use vm utility to build access but the computed gas is not charged and hence free
-    vm.evm.verkleAccessWitness.touchTxTargetAndComputeGas(miner, {
-      sendsValue: true,
-    })
+    vm.evm.verkleAccessWitness.writeAccountBasicData(miner)
+    vm.evm.verkleAccessWitness.readAccountCodeHash(miner)
   }
 
   // Put the miner account into the state. If the balance of the miner account remains zero, note that


### PR DESCRIPTION
This PR aims to simplify the verkle access witness method interface by focusing on the actual explicit actions (read/writing different parts of an account) rather than abstract methods (like "create a contract"). This ends up with DRY-er code and makes it eaiser to parse what is going on. 