### PR TITLE
evm: verkle updates

### DIFF
--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -317,7 +317,7 @@ export class Common {
     for (const hfChanges of this.HARDFORK_CHANGES) {
       // EIP-referencing HF config (e.g. for berlin)
       if ('eips' in hfChanges[1]) {
-        const hfEIPs = hfChanges[1]['eips'] ?? []
+        const hfEIPs = hfChanges[1].eips ?? []
         for (const eip of hfEIPs) {
           this._mergeWithParamsCache(this._params[eip] ?? {})
         }

--- a/packages/evm/src/opcodes/EIP2929.ts
+++ b/packages/evm/src/opcodes/EIP2929.ts
@@ -31,6 +31,10 @@ export function accessAddressEIP2929(
     // if verkle not activated
     if (chargeGas && !common.isActivatedEIP(6800)) {
       return common.param('coldaccountaccessGas')
+    } else if (chargeGas && common.isActivatedEIP(6800)) {
+      // If Verkle is active, then the warmstoragereadGas should still be charged
+      // This is because otherwise opcodes will have cost 0 (this is thus the base fee)
+      return common.param('warmstoragereadGas')
     }
     // Warm: (selfdestruct beneficiary address reads are not charged when warm)
   } else if (chargeGas && !isSelfdestruct) {

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -166,7 +166,8 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         let charge2929Gas = true
         if (
           common.isActivatedEIP(6800) &&
-          runState.interpreter._evm.getPrecompile(address) === undefined
+          runState.interpreter._evm.getPrecompile(address) === undefined &&
+          !address.equals(createAddressFromStackBigInt(common.param('systemAddress')))
         ) {
           let coldAccessGas = BIGINT_0
           coldAccessGas += runState.env.accessWitness!.readAccountBasicData(address)
@@ -199,7 +200,8 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         let charge2929Gas = true
         if (
           common.isActivatedEIP(6800) &&
-          runState.interpreter._evm.getPrecompile(address) === undefined
+          runState.interpreter._evm.getPrecompile(address) === undefined &&
+          !address.equals(createAddressFromStackBigInt(common.param('systemAddress')))
         ) {
           let coldAccessGas = BIGINT_0
           coldAccessGas += runState.env.accessWitness!.readAccountBasicData(address)
@@ -266,7 +268,11 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         const address = createAddressFromStackBigInt(runState.stack.peek()[0])
         let charge2929Gas = true
 
-        if (common.isActivatedEIP(6800)) {
+        if (
+          common.isActivatedEIP(6800) &&
+          runState.interpreter._evm.getPrecompile(address) === undefined &&
+          !address.equals(createAddressFromStackBigInt(common.param('systemAddress')))
+        ) {
           let coldAccessGas = BIGINT_0
           coldAccessGas += runState.env.accessWitness!.readAccountCodeHash(address)
 
@@ -562,7 +568,6 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           common.isActivatedEIP(6800) &&
           runState.interpreter._evm.getPrecompile(toAddress) === undefined
         ) {
-          // TODO: add check if toAddress is not a precompile
           const coldAccessGas = runState.env.accessWitness!.readAccountBasicData(toAddress)
           if (value !== BIGINT_0) {
             const contractAddress = runState.interpreter.getAddress()
@@ -705,7 +710,6 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           common.isActivatedEIP(6800) &&
           runState.interpreter._evm.getPrecompile(toAddress) === undefined
         ) {
-          // TODO: add check if toAddress is not a precompile
           const coldAccessGas = runState.env.accessWitness!.readAccountBasicData(toAddress)
 
           gas += coldAccessGas
@@ -914,9 +918,11 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         gas += subMemUsage(runState, outOffset, outLength, common)
 
         let charge2929Gas = true
-        if (common.isActivatedEIP(6800)) {
-          const toAddress = createAddressFromStackBigInt(toAddr)
-          // TODO: add check if toAddress is not a precompile
+        const toAddress = createAddressFromStackBigInt(toAddr)
+        if (
+          common.isActivatedEIP(6800) &&
+          runState.interpreter._evm.getPrecompile(toAddress) === undefined
+        ) {
           const coldAccessGas = runState.env.accessWitness!.readAccountBasicData(toAddress)
 
           gas += coldAccessGas

--- a/packages/statemanager/src/statefulVerkleStateManager.ts
+++ b/packages/statemanager/src/statefulVerkleStateManager.ts
@@ -318,7 +318,7 @@ export class StatefulVerkleStateManager implements StateManagerInterface {
       chunkStems[0],
       chunkSuffixes.slice(
         0,
-        codeChunks.length <= VERKLE_CODE_OFFSET ? codeChunks.length : VERKLE_CODE_OFFSET,
+        chunkSuffixes.length <= VERKLE_CODE_OFFSET ? chunkSuffixes.length : VERKLE_CODE_OFFSET,
       ),
       codeChunks.slice(
         0,
@@ -398,13 +398,16 @@ export class StatefulVerkleStateManager implements StateManagerInterface {
     for (let x = 0; x < chunks.length; x++) {
       if (chunks[x] === undefined) throw new Error(`expected code chunk at ID ${x}, got undefined`)
 
+      let lastChunkByteIndex = VERKLE_CODE_CHUNK_SIZE
       // Determine code ending byte (if we're on the last chunk)
-      let sliceEnd = 32
       if (x === chunks.length - 1) {
-        // On the last chunk, the end of the slice is either codeSize (if only one chunk) or codeSize % chunkSize
-        sliceEnd = (x === 0 ? codeSize : codeSize % VERKLE_CODE_CHUNK_SIZE) + 1
+        // On the last chunk, the slice either ends on a partial chunk (if codeSize doesn't exactly fit in full chunks), or a full chunk
+        lastChunkByteIndex = codeSize % VERKLE_CODE_CHUNK_SIZE || VERKLE_CODE_CHUNK_SIZE
       }
-      code.set(chunks[x]!.slice(1, sliceEnd), code.byteOffset + x * VERKLE_CODE_CHUNK_SIZE)
+      code.set(
+        chunks[x]!.slice(1, lastChunkByteIndex + 1),
+        code.byteOffset + x * VERKLE_CODE_CHUNK_SIZE,
+      )
     }
     this._caches?.code?.put(address, code)
 
@@ -598,10 +601,14 @@ export class StatefulVerkleStateManager implements StateManagerInterface {
         // we can only compare the actual code because to compare the first byte would
         // be very tricky and impossible in certain scenarios like when the previous code chunk
         // was not accessed and hence not even provided in the witness
+        // We are left-padding with two zeroes to get a 32-byte length, but these bytes should not be considered reliable
         return bytesToHex(
-          setLengthRight(
-            code.slice(codeOffset, codeOffset + VERKLE_CODE_CHUNK_SIZE),
-            VERKLE_CODE_CHUNK_SIZE,
+          setLengthLeft(
+            setLengthRight(
+              code.slice(codeOffset, codeOffset + VERKLE_CODE_CHUNK_SIZE),
+              VERKLE_CODE_CHUNK_SIZE,
+            ),
+            VERKLE_CODE_CHUNK_SIZE + 1,
           ),
         )
       }
@@ -645,7 +652,7 @@ export class StatefulVerkleStateManager implements StateManagerInterface {
 
       const { chunkKey } = accessedState
       accessedChunks.set(chunkKey, true)
-      const computedValue: PrefixedHexString | null | undefined =
+      let computedValue: PrefixedHexString | null | undefined =
         await this.getComputedValue(accessedState)
       if (computedValue === undefined) {
         this.DEBUG &&
@@ -670,7 +677,7 @@ export class StatefulVerkleStateManager implements StateManagerInterface {
       // if the access type is code, then we can't match the first byte because since the computed value
       // doesn't has the first byte for push data since previous chunk code itself might not be available
       if (accessedState.type === VerkleAccessedStateType.Code) {
-        // computedValue = computedValue !== null ? `0x${computedValue.slice(4)}` : null
+        computedValue = computedValue !== null ? `0x${computedValue.slice(4)}` : null
         canonicalValue = canonicalValue !== null ? `0x${canonicalValue.slice(4)}` : null
       } else if (
         accessedState.type === VerkleAccessedStateType.Storage &&
@@ -680,6 +687,7 @@ export class StatefulVerkleStateManager implements StateManagerInterface {
         canonicalValue = ZEROVALUE
       }
 
+      this._debug(`computed ${computedValue} canonical ${canonicalValue}`)
       if (computedValue !== canonicalValue) {
         if (type === VerkleAccessedStateType.BasicData) {
           this.DEBUG &&

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -275,53 +275,53 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
     }
 
     if (!(vm.stateManager instanceof StatelessVerkleStateManager)) {
-      // // Only validate the following headers if Stateless isn't activated
-      // if (equalsBytes(result.receiptsRoot, block.header.receiptTrie) === false) {
-      //   if (vm.DEBUG) {
-      //     debug(
-      //       `Invalid receiptTrie received=${bytesToHex(result.receiptsRoot)} expected=${bytesToHex(
-      //         block.header.receiptTrie,
-      //       )}`,
-      //     )
-      //   }
-      //   const msg = _errorMsg('invalid receiptTrie', vm, block)
-      //   throw new Error(msg)
-      // }
-      // if (!(equalsBytes(result.bloom.bitvector, block.header.logsBloom) === true)) {
-      //   if (vm.DEBUG) {
-      //     debug(
-      //       `Invalid bloom received=${bytesToHex(result.bloom.bitvector)} expected=${bytesToHex(
-      //         block.header.logsBloom,
-      //       )}`,
-      //     )
-      //   }
-      //   const msg = _errorMsg('invalid bloom', vm, block)
-      //   throw new Error(msg)
-      // }
-      // if (result.gasUsed !== block.header.gasUsed) {
-      //   if (vm.DEBUG) {
-      //     debug(`Invalid gasUsed received=${result.gasUsed} expected=${block.header.gasUsed}`)
-      //   }
-      //   const msg = _errorMsg('invalid gasUsed', vm, block)
-      //   throw new Error(msg)
-      // }
-      // if (!(equalsBytes(stateRoot, block.header.stateRoot) === true)) {
-      //   if (vm.DEBUG) {
-      //     debug(
-      //       `Invalid stateRoot received=${bytesToHex(stateRoot)} expected=${bytesToHex(
-      //         block.header.stateRoot,
-      //       )}`,
-      //     )
-      //   }
-      //   const msg = _errorMsg(
-      //     `invalid block stateRoot, got: ${bytesToHex(stateRoot)}, want: ${bytesToHex(
-      //       block.header.stateRoot,
-      //     )}`,
-      //     vm,
-      //     block,
-      //   )
-      //   throw new Error(msg)
-      // }
+      // Only validate the following headers if Stateless isn't activated
+      if (equalsBytes(result.receiptsRoot, block.header.receiptTrie) === false) {
+        if (vm.DEBUG) {
+          debug(
+            `Invalid receiptTrie received=${bytesToHex(result.receiptsRoot)} expected=${bytesToHex(
+              block.header.receiptTrie,
+            )}`,
+          )
+        }
+        const msg = _errorMsg('invalid receiptTrie', vm, block)
+        throw new Error(msg)
+      }
+      if (!(equalsBytes(result.bloom.bitvector, block.header.logsBloom) === true)) {
+        if (vm.DEBUG) {
+          debug(
+            `Invalid bloom received=${bytesToHex(result.bloom.bitvector)} expected=${bytesToHex(
+              block.header.logsBloom,
+            )}`,
+          )
+        }
+        const msg = _errorMsg('invalid bloom', vm, block)
+        throw new Error(msg)
+      }
+      if (result.gasUsed !== block.header.gasUsed) {
+        if (vm.DEBUG) {
+          debug(`Invalid gasUsed received=${result.gasUsed} expected=${block.header.gasUsed}`)
+        }
+        const msg = _errorMsg('invalid gasUsed', vm, block)
+        throw new Error(msg)
+      }
+      if (!(equalsBytes(stateRoot, block.header.stateRoot) === true)) {
+        if (vm.DEBUG) {
+          debug(
+            `Invalid stateRoot received=${bytesToHex(stateRoot)} expected=${bytesToHex(
+              block.header.stateRoot,
+            )}`,
+          )
+        }
+        const msg = _errorMsg(
+          `invalid block stateRoot, got: ${bytesToHex(stateRoot)}, want: ${bytesToHex(
+            block.header.stateRoot,
+          )}`,
+          vm,
+          block,
+        )
+        throw new Error(msg)
+      }
     }
 
     if (vm.common.isActivatedEIP(6800)) {

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -523,7 +523,7 @@ export async function accumulateParentBlockHash(
   if (!vm.common.isActivatedEIP(2935)) {
     throw new Error('Cannot call `accumulateParentBlockHash`: EIP 2935 is not active')
   }
-  const historyAddress = new Address(bigIntToAddressBytes(vm.common.param('systemAddress')))
+  const historyAddress = new Address(bigIntToAddressBytes(vm.common.param('historyStorageAddress')))
   const historyServeWindow = vm.common.param('historyServeWindow')
 
   // getAccount with historyAddress will throw error as witnesses are not bundled

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -185,7 +185,7 @@ export async function runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
       }
       emitEVMProfile(logs.precompiles, 'Precompile performance')
       emitEVMProfile(logs.opcodes, 'Opcodes performance')
-      ;(<EVM>vm.evm).clearPerformanceLogs()
+        ; (<EVM>vm.evm).clearPerformanceLogs()
     }
   }
 }
@@ -224,8 +224,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   const caller = tx.getSenderAddress()
   if (vm.DEBUG) {
     debug(
-      `New tx run hash=${
-        opts.tx.isSigned() ? bytesToHex(opts.tx.hash()) : 'unsigned'
+      `New tx run hash=${opts.tx.isSigned() ? bytesToHex(opts.tx.hash()) : 'unsigned'
       } sender=${caller}`,
     )
   }
@@ -274,8 +273,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     const baseFeePerGas = block?.header.baseFeePerGas ?? DEFAULT_HEADER.baseFeePerGas!
     if (maxFeePerGas < baseFeePerGas) {
       const msg = _errorMsg(
-        `Transaction's ${
-          'maxFeePerGas' in tx ? 'maxFeePerGas' : 'gasPrice'
+        `Transaction's ${'maxFeePerGas' in tx ? 'maxFeePerGas' : 'gasPrice'
         } (${maxFeePerGas}) is less than the block's baseFeePerGas (${baseFeePerGas})`,
         vm,
         block,
@@ -552,10 +550,8 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
 
   if (vm.DEBUG) {
     debug(
-      `Running tx=${
-        tx.isSigned() ? bytesToHex(tx.hash()) : 'unsigned'
-      } with caller=${caller} gasLimit=${gasLimit} to=${
-        to?.toString() ?? 'none'
+      `Running tx=${tx.isSigned() ? bytesToHex(tx.hash()) : 'unsigned'
+      } with caller=${caller} gasLimit=${gasLimit} to=${to?.toString() ?? 'none'
       } value=${value} data=${short(data)}`,
     )
   }
@@ -593,8 +589,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     const { executionGasUsed, exceptionError, returnValue } = results.execResult
     debug('-'.repeat(100))
     debug(
-      `Received tx execResult: [ executionGasUsed=${executionGasUsed} exceptionError=${
-        exceptionError !== undefined ? `'${exceptionError.error}'` : 'none'
+      `Received tx execResult: [ executionGasUsed=${executionGasUsed} exceptionError=${exceptionError !== undefined ? `'${exceptionError.error}'` : 'none'
       } returnValue=${short(returnValue)} gasRefund=${results.gasRefund ?? 0} ]`,
     )
   }
@@ -661,12 +656,12 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   }
 
   let minerAccount = await state.getAccount(miner)
+  const minerAccountExists = minerAccount !== undefined
   if (minerAccount === undefined) {
     if (vm.common.isActivatedEIP(6800)) {
       if (vm.evm.verkleAccessWitness === undefined) {
         throw Error(`verkleAccessWitness required if verkle (EIP-6800) is activated`)
       }
-      vm.evm.verkleAccessWitness.readAccountHeader(miner)
     }
     minerAccount = new Account()
     // Add the miner account to the system verkle access witness
@@ -678,20 +673,17 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     : results.amountSpent
   minerAccount.balance += results.minerValue
 
-  // If the miner value is zero, revert the access witness as the proof of absence was not necessary.
-  if (results.minerValue === BIGINT_0) {
-    vm.evm.verkleAccessWitness?.revert()
-  } else {
-    vm.evm.verkleAccessWitness?.commit()
-  }
-
   if (vm.common.isActivatedEIP(6800) && results.minerValue !== BIGINT_0) {
     if (vm.evm.verkleAccessWitness === undefined) {
       throw Error(`verkleAccessWitness required if verkle (EIP-6800) is activated`)
     }
-    // use vm utility to build access but the computed gas is not charged and hence free
-    vm.evm.verkleAccessWitness.writeAccountBasicData(miner)
-    vm.evm.verkleAccessWitness.readAccountCodeHash(miner)
+    if (minerAccountExists) {
+      // use vm utility to build access but the computed gas is not charged and hence free
+      vm.evm.verkleAccessWitness.writeAccountBasicData(miner)
+      vm.evm.verkleAccessWitness.readAccountCodeHash(miner)
+    } else {
+      vm.evm.verkleAccessWitness.writeAccountHeader(miner)
+    }
   }
 
   // Put the miner account into the state. If the balance of the miner account remains zero, note that
@@ -804,8 +796,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   await vm._emit('afterTx', event)
   if (vm.DEBUG) {
     debug(
-      `tx run finished hash=${
-        opts.tx.isSigned() ? bytesToHex(opts.tx.hash()) : 'unsigned'
+      `tx run finished hash=${opts.tx.isSigned() ? bytesToHex(opts.tx.hash()) : 'unsigned'
       } sender=${caller}`,
     )
   }
@@ -865,10 +856,8 @@ export async function generateTxReceipt(
   let receipt
   if (vm.DEBUG) {
     debug(
-      `Generate tx receipt transactionType=${
-        tx.type
-      } cumulativeBlockGasUsed=${cumulativeGasUsed} bitvector=${short(baseReceipt.bitvector)} (${
-        baseReceipt.bitvector.length
+      `Generate tx receipt transactionType=${tx.type
+      } cumulativeBlockGasUsed=${cumulativeGasUsed} bitvector=${short(baseReceipt.bitvector)} (${baseReceipt.bitvector.length
       } bytes) logs=${baseReceipt.logs.length}`,
     )
   }

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -669,6 +669,8 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
       vm.evm.verkleAccessWitness.readAccountHeader(miner)
     }
     minerAccount = new Account()
+    // Add the miner account to the system verkle access witness
+    vm.evm.systemVerkleAccessWitness?.writeAccountHeader(miner)
   }
   // add the amount spent on gas to the miner's account
   results.minerValue = vm.common.isActivatedEIP(1559)
@@ -676,7 +678,14 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     : results.amountSpent
   minerAccount.balance += results.minerValue
 
-  if (vm.common.isActivatedEIP(6800)) {
+  // If the miner value is zero, revert the access witness as the proof of absence was not necessary.
+  if (results.minerValue === BIGINT_0) {
+    vm.evm.verkleAccessWitness?.revert()
+  } else {
+    vm.evm.verkleAccessWitness?.commit()
+  }
+
+  if (vm.common.isActivatedEIP(6800) && results.minerValue !== BIGINT_0) {
     if (vm.evm.verkleAccessWitness === undefined) {
       throw Error(`verkleAccessWitness required if verkle (EIP-6800) is activated`)
     }


### PR DESCRIPTION
This PR extracts some Verkle-related updates and fixes from #3716:
- Adds a systemVerkleAccessWiness to the EVM class.
- Adds a codeHash read access when creating a contract (for collision checking)
- Adds conditions that skips some accesses when interacting with system contracts and precompiles, as specified by the EIP-4762 EIP.
- Clarifies and fixes code chunk handling in the statefulVerkleStateManager
- Adjusts some miner/account reward logic so that it uses the systemVerkleAccessWitness and not the tx-level verkleAccessWitness, and skips access witness for miner when reward is 0