### PR TITLE
Remove unused params from common

### DIFF
--- a/packages/block/src/params.ts
+++ b/packages/block/src/params.ts
@@ -17,8 +17,6 @@ export const paramsBlock: ParamsDict = {
     minimumDifficulty: 131072, // The minimum that the difficulty may ever be
     difficultyBoundDivisor: 2048, // The bound divisor of the difficulty, used in the update calculations
     durationLimit: 13, // The decision boundary on the blocktime duration used to determine whether difficulty should go up or not
-    epochDuration: 30000, // Duration between proof-of-work epochs
-    timebombPeriod: 100000, // Exponential difficulty timebomb period
     difficultyBombDelay: 0, // the amount of blocks to delay the difficulty bomb with
   },
   /**
@@ -75,7 +73,6 @@ export const paramsBlock: ParamsDict = {
     maxBlobGasPerBlock: 786432, // The max blob gas allowable per block
     blobGasPriceUpdateFraction: 3338477, // The denominator used in the exponential when calculating a blob gas price
     // gasPrices
-    simplePerBlobGas: 12000, // The basic gas fee for each blob
     minBlobGas: 1, // The minimum fee per blob gas
   },
   /**

--- a/packages/evm/src/params.ts
+++ b/packages/evm/src/params.ts
@@ -99,7 +99,6 @@ export const paramsEVM: ParamsDict = {
     prevrandaoGas: 0, // TODO: these below 0-gas additions might also point to non-clean implementations in the code base
     // evm
     stackLimit: 1024, // Maximum size of VM stack allowed
-    callCreateDepth: 1024, // Maximum depth of call/create stack
   },
   /**
 .  * Homestead HF Meta EIP

--- a/packages/evm/src/precompiles/0b-bls12-g1add.ts
+++ b/packages/evm/src/precompiles/0b-bls12-g1add.ts
@@ -16,7 +16,7 @@ export async function precompile0b(opts: PrecompileInput): Promise<ExecResult> {
   const bls = (<any>opts._EVM)._bls! as EVMBLSInterface
 
   // note: the gas used is constant; even if the input is incorrect.
-  const gasUsed = opts.common.paramByEIP('bls12381G1AddGas', 2537) ?? BigInt(0)
+  const gasUsed = opts.common.param('bls12381G1AddGas') ?? BigInt(0)
   if (!gasLimitCheck(opts, gasUsed, pName)) {
     return OOGResult(opts.gasLimit)
   }

--- a/packages/evm/src/precompiles/0c-bls12-g1msm.ts
+++ b/packages/evm/src/precompiles/0c-bls12-g1msm.ts
@@ -32,7 +32,7 @@ export async function precompile0c(opts: PrecompileInput): Promise<ExecResult> {
   // on this eventually to be "floored" pair number should happen before the input length modulo
   // validation (same for g2msm)
   const numPairs = Math.floor(inputData.length / 160)
-  const gasUsedPerPair = opts.common.paramByEIP('bls12381G1MulGas', 2537) ?? BigInt(0)
+  const gasUsedPerPair = opts.common.param('bls12381G1MulGas') ?? BigInt(0)
   const gasUsed = msmGasUsed(numPairs, gasUsedPerPair, BLS_GAS_DISCOUNT_PAIRS_G1)
 
   if (!gasLimitCheck(opts, gasUsed, pName)) {

--- a/packages/evm/src/precompiles/0d-bls12-g2add.ts
+++ b/packages/evm/src/precompiles/0d-bls12-g2add.ts
@@ -16,7 +16,7 @@ export async function precompile0d(opts: PrecompileInput): Promise<ExecResult> {
   const bls = (<any>opts._EVM)._bls! as EVMBLSInterface
 
   // note: the gas used is constant; even if the input is incorrect.
-  const gasUsed = opts.common.paramByEIP('bls12381G2AddGas', 2537) ?? BigInt(0)
+  const gasUsed = opts.common.param('bls12381G2AddGas') ?? BigInt(0)
   if (!gasLimitCheck(opts, gasUsed, pName)) {
     return OOGResult(opts.gasLimit)
   }

--- a/packages/evm/src/precompiles/0e-bls12-g2msm.ts
+++ b/packages/evm/src/precompiles/0e-bls12-g2msm.ts
@@ -27,7 +27,7 @@ export async function precompile0e(opts: PrecompileInput): Promise<ExecResult> {
   }
 
   const numPairs = Math.floor(opts.data.length / 288)
-  const gasUsedPerPair = opts.common.paramByEIP('bls12381G2MulGas', 2537) ?? BigInt(0)
+  const gasUsedPerPair = opts.common.param('bls12381G2MulGas') ?? BigInt(0)
   const gasUsed = msmGasUsed(numPairs, gasUsedPerPair, BLS_GAS_DISCOUNT_PAIRS_G2)
 
   if (!gasLimitCheck(opts, gasUsed, pName)) {

--- a/packages/evm/src/precompiles/0f-bls12-pairing.ts
+++ b/packages/evm/src/precompiles/0f-bls12-pairing.ts
@@ -15,7 +15,7 @@ export async function precompile0f(opts: PrecompileInput): Promise<ExecResult> {
   const pName = getPrecompileName('11')
   const bls = (<any>opts._EVM)._bls! as EVMBLSInterface
 
-  const baseGas = opts.common.paramByEIP('bls12381PairingBaseGas', 2537) ?? BigInt(0)
+  const baseGas = opts.common.param('bls12381PairingBaseGas') ?? BigInt(0)
 
   // TODO: confirm that this is not a thing for the other precompiles
   if (opts.data.length === 0) {
@@ -25,7 +25,7 @@ export async function precompile0f(opts: PrecompileInput): Promise<ExecResult> {
     return EvmErrorResult(new EvmError(ERROR.BLS_12_381_INPUT_EMPTY), opts.gasLimit)
   }
 
-  const gasUsedPerPair = opts.common.paramByEIP('bls12381PairingPerPairGas', 2537) ?? BigInt(0)
+  const gasUsedPerPair = opts.common.param('bls12381PairingPerPairGas') ?? BigInt(0)
 
   // TODO: For this precompile it is the only exception that the length check is placed before the
   // gas check. I will keep it there to not side-change the existing implementation, but we should

--- a/packages/evm/src/precompiles/10-bls12-map-fp-to-g1.ts
+++ b/packages/evm/src/precompiles/10-bls12-map-fp-to-g1.ts
@@ -16,7 +16,7 @@ export async function precompile10(opts: PrecompileInput): Promise<ExecResult> {
   const bls = (<any>opts._EVM)._bls! as EVMBLSInterface
 
   // note: the gas used is constant; even if the input is incorrect.
-  const gasUsed = opts.common.paramByEIP('bls12381MapG1Gas', 2537) ?? BigInt(0)
+  const gasUsed = opts.common.param('bls12381MapG1Gas') ?? BigInt(0)
   if (!gasLimitCheck(opts, gasUsed, pName)) {
     return OOGResult(opts.gasLimit)
   }

--- a/packages/evm/src/precompiles/11-bls12-map-fp2-to-g2.ts
+++ b/packages/evm/src/precompiles/11-bls12-map-fp2-to-g2.ts
@@ -16,7 +16,7 @@ export async function precompile11(opts: PrecompileInput): Promise<ExecResult> {
   const bls = (<any>opts._EVM)._bls! as EVMBLSInterface
 
   // note: the gas used is constant; even if the input is incorrect.
-  const gasUsed = opts.common.paramByEIP('bls12381MapG2Gas', 2537) ?? BigInt(0)
+  const gasUsed = opts.common.param('bls12381MapG2Gas') ?? BigInt(0)
   if (!gasLimitCheck(opts, gasUsed, pName)) {
     return OOGResult(opts.gasLimit)
   }


### PR DESCRIPTION
(mini cleanup PR)

Besides cleaning up, this PR also ensures dynamic gas values for 2537 are read from common, not specifically pointing to EIP-2537 (for future possible price updates)

I noticed that some params in common appear to be unused. CoPilot helped me, had to tweak the script but got this:

```bash
# Step 1: List all parameters
grep -ohP '(\w+):' packages/*/src/params.ts | sed 's/:$//' | sort | uniq > all_params.txt

# Step 2: Search for usage
grep -r -ohP "param\('\K[^']+" packages/**/src --include \*.ts | sort | uniq > used_params.txt

# Step 3: Identify unused parameters
comm -23 all_params.txt used_params.txt > unused_params.txt

# Output the unused parameters
cat unused_params.txt
```

Note: this outputs a lot of `*Gas`, these are still used, but EVM indexes those by `opcode.name + "Gas"` and not explicit hardcoded strings. 

NOTE: this also gives false positives, since this does not check the `paramByEIP`