### PR TITLE
evm: update bls g2 msm price

### DIFF
--- a/packages/evm/src/params.ts
+++ b/packages/evm/src/params.ts
@@ -237,7 +237,7 @@ export const paramsEVM: ParamsDict = {
     bls12381G1AddGas: 375, // Gas cost of a single BLS12-381 G1 addition precompile-call
     bls12381G1MulGas: 12000, // Gas cost of a single BLS12-381 G1 multiplication precompile-call
     bls12381G2AddGas: 600, // Gas cost of a single BLS12-381 G2 addition precompile-call
-    bls12381G2MulGas: 22500, // Gas cost of a single BLS12-381 G2 multiplication precompile-call
+    bls12381G2MulGas: 23000, // Gas cost of a single BLS12-381 G2 multiplication precompile-call
     bls12381PairingBaseGas: 37700, // Base gas cost of BLS12-381 pairing check
     bls12381PairingPerPairGas: 32600, // Per-pair gas cost of BLS12-381 pairing check
     bls12381MapG1Gas: 5500, // Gas cost of BLS12-381 map field element to G1


### PR DESCRIPTION
As discussed on ACD-E 123 the BLS G2 price gets updated such that the formula has no non-integer arithmetic.

Note: this is NOT part of devnet-5, so do not merge (yet)

https://github.com/ethereum/EIPs/pull/9245