### PR TITLE
Client: fix version logging and hive block imports

### DIFF
--- a/packages/blockchain/src/blockchain.ts
+++ b/packages/blockchain/src/blockchain.ts
@@ -7,6 +7,7 @@ import {
   KECCAK256_RLP,
   Lock,
   MapDB,
+  SHA256_NULL,
   bigIntToHex,
   bytesToHex,
   bytesToUnprefixedHex,
@@ -26,7 +27,6 @@ import {
 } from './db/helpers.js'
 import { DBManager } from './db/manager.js'
 import { DBTarget } from './db/operation.js'
-import { SHA256_EMPTY_RH } from './helpers.js'
 
 import type {
   BlockchainEvent,
@@ -1320,7 +1320,7 @@ export class Blockchain implements BlockchainInterface {
       number: 0,
       stateRoot,
       withdrawalsRoot: common.isActivatedEIP(4895) ? KECCAK256_RLP : undefined,
-      requestsHash: common.isActivatedEIP(7685) ? SHA256_EMPTY_RH : undefined,
+      requestsHash: common.isActivatedEIP(7685) ? SHA256_NULL : undefined,
     }
     if (common.consensusType() === 'poa') {
       if (common.genesis().extraData) {

--- a/packages/blockchain/src/helpers.ts
+++ b/packages/blockchain/src/helpers.ts
@@ -1,6 +1,6 @@
 import { ChainGenesis } from '@ethereumjs/common'
 import { genesisMPTStateRoot } from '@ethereumjs/mpt'
-import { type GenesisState, hexToBytes } from '@ethereumjs/util'
+import { type GenesisState } from '@ethereumjs/util'
 
 import type { Chain, Common } from '@ethereumjs/common'
 
@@ -40,21 +40,3 @@ export async function getGenesisStateRoot(chainId: Chain, common: Common): Promi
   const chainGenesis = ChainGenesis[chainId]
   return chainGenesis !== undefined ? chainGenesis.stateRoot : genGenesisStateRoot({}, common)
 }
-
-/* 
-The code below calculates the empty requests hash as of devnet-4 for EIP 7685
-Note: it is not possible to calculate this directly in the blockchain package,
-this introduces the `ethereum-cryptography` dependency.
-
-// Used to calculate the empty requests hash
-const z0 = sha256(new Uint8Array([0]))
-const z1 = sha256(new Uint8Array([1]))
-const z2 = sha256(new Uint8Array([2]))
-
-export const SHA256_EMPTY_RH = sha256(concatBytes(z0, z1, z2))
-
-*/
-
-export const SHA256_EMPTY_RH = hexToBytes(
-  '0x6036c41849da9c076ed79654d434017387a88fb833c2856b32e18218b3341c5f',
-)

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -236,7 +236,7 @@ async function startClient(
           blocks.push(block)
           buf = RLP.decode(buf.remainder, true)
           config.logger.info(
-            `Preloading block hash=0x${short(bytesToHex(block.header.hash()))} number=${
+            `Preloading block hash=${short(bytesToHex(block.header.hash()))} number=${
               block.header.number
             }`,
           )

--- a/packages/client/src/util/index.ts
+++ b/packages/client/src/util/index.ts
@@ -2,9 +2,9 @@
  * @module util
  */
 import { bytesToHex } from '@ethereumjs/util'
-import { readFileSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 import { platform } from 'os'
-import { dirname } from 'path'
+import { dirname, join as joinPath } from 'path'
 import { fileURLToPath } from 'url'
 
 export * from './inclineClient.js'
@@ -24,8 +24,33 @@ export function short(bytes: Uint8Array | string): string {
   return str
 }
 
-export function getPackageJSON(): { version: string } {
-  return JSON.parse(readFileSync(__dirname + '/../../package.json', 'utf-8'))
+export function getPackageJSON() {
+  // Find the package.json by checking the current directory and then
+  // moving up a directory each time until package.json is found,
+  // or we are at the root directory.
+  let currentDir = __dirname
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const packageJsonPath = joinPath(currentDir, 'package.json')
+    if (existsSync(packageJsonPath)) {
+      // Read package.json contents
+      const parsedJSON = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
+
+      // Verify that the package.json contains the version
+      if (parsedJSON.version !== undefined) {
+        return parsedJSON
+      }
+      // If it does not contain the version, then keep moving to upper directories until a version is found
+    }
+    const parentDir = dirname(currentDir)
+    // If we've reached the root directory, stop searching
+    if (parentDir === currentDir) {
+      // No package.json found
+      return {}
+    }
+    currentDir = parentDir // Move up one directory
+  }
 }
 
 export function getClientVersion() {


### PR DESCRIPTION
When running `./hive --sim rpc --sim.limit rpc-compat --client ethereumjs --docker.output ethereumjs`, the `rpc-compat` tests it is noticed that the initial blocks fail to import and the client immediately exits. This PR will fix this problem. It also fixes finding the correct package.json file to extract the client version.

The main change is in the blockchain package, which now correctly sets the default value of the requestsHash in case it is not provided for the genesis block. If this is not done (or the incorrect value is used), the blockhash of the genesis block will be different and therefore the blockchain is configured to run a different chain.