### PR TITLE
typo fix Update CHANGELOG.md

### DIFF
--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -1011,7 +1011,7 @@ Source files from the `src` folder are now included in the distribution build, s
 
 This release comes with significant library usability improvements by allowing a tx instantiation more independently from the `Common` library. This was reported and requested by Web3.js (thanks to @gregthegreek for giving some guidance on the discussion) and others, since they needed the possibility of a tx instantiation in unknown contexts where the chain or HF state is somewhat unclear.
 
-So we've decided to do the following tweaks to the libray:
+So we've decided to do the following tweaks to the library:
 
 ### New Rules for Internal Default HF Setting
 


### PR DESCRIPTION
# Typo Fix in `CHANGELOG.md`

**Author**: @pinkflower32  
**Branch**: `pinkflower32:fix-typo`  
**Base**: `ethereumjs:master`  

## Description
This pull request fixes a typo in the `CHANGELOG.md` file. Specifically, the word "libray" has been corrected to "library" for improved accuracy and clarity.

## Changes
- Corrected the typo: replaced "libray" with "library."

