### PR TITLE
Fix broken Node Nightly CI jobs

### DIFF
--- a/.github/workflows/node-versions.yml
+++ b/.github/workflows/node-versions.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/packages/client/test/rpc/websocket.spec.ts
+++ b/packages/client/test/rpc/websocket.spec.ts
@@ -54,7 +54,7 @@ describe('JSON-RPC call', () => {
         resolve(undefined)
       })
     })
-  }, 30000)
+  })
 
   it('server without any auth headers', async () => {
     const server = startRPC({}, { wsServer: true })

--- a/packages/client/test/rpc/websocket.spec.ts
+++ b/packages/client/test/rpc/websocket.spec.ts
@@ -39,17 +39,19 @@ describe('JSON-RPC call', () => {
     }
   })
 
-  it('auth protected server without any auth headers', async () => {
+  it.only('auth protected server without any auth headers', async () => {
     const server = startRPC({}, { wsServer: true }, { jwtSecret })
     server.listen(1236, 'localhost')
-    const rpc = Client.websocket({
-      url: 'ws://localhost:1236/',
-    })
 
     await new Promise((resolve) => {
-      ;(rpc as any).ws.on('error', async (err: any) => {
+      const socket = new WebSocket('ws://localhost:1236', undefined, {})
+      socket.onerror = (err) => {
         assert.ok(err.message.includes('401'), 'Unauthorized')
         resolve(undefined)
+      }
+      const _rpc = Client.websocket({
+        // @ts-ignore -- see above test
+        ws: socket,
       })
     })
   })

--- a/packages/client/test/rpc/websocket.spec.ts
+++ b/packages/client/test/rpc/websocket.spec.ts
@@ -49,7 +49,7 @@ describe('JSON-RPC call', () => {
         assert.ok(err.message.includes('401'), 'Unauthorized')
         resolve(undefined)
       }
-      const _rpc = Client.websocket({
+      Client.websocket({
         // @ts-ignore -- see above test
         ws: socket,
       })

--- a/packages/client/test/rpc/websocket.spec.ts
+++ b/packages/client/test/rpc/websocket.spec.ts
@@ -28,14 +28,12 @@ describe('JSON-RPC call', () => {
       //@ts-ignore -- `isomorphic-ws` types aren't perfectly mapped to jayson.WebSocketClient but works fine for this test
       ws: socket,
     })
+    while ((rpc as any).ws.readyState !== WebSocket.OPEN) {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
     try {
-      await new Promise((resolve) => {
-        ;(rpc as any).ws.on('open', async () => {
-          const res = await rpc.request('METHOD_DOES_NOT_EXIST', ['0x1', true])
-          assert.equal(res.error.code, METHOD_NOT_FOUND)
-          resolve(undefined)
-        })
-      })
+      const res = await rpc.request('METHOD_DOES_NOT_EXIST', ['0x1', true])
+      assert.equal(res.error.code, METHOD_NOT_FOUND)
     } catch (err: any) {
       assert.fail(err)
     }
@@ -62,14 +60,12 @@ describe('JSON-RPC call', () => {
     const rpc = Client.websocket({
       url: 'ws://localhost:12345/',
     })
+    while ((rpc as any).ws.readyState !== WebSocket.OPEN) {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
     try {
-      await new Promise((resolve) => {
-        ;(rpc as any).ws.on('open', async () => {
-          const res = await rpc.request('METHOD_DOES_NOT_EXIST', ['0x1', true])
-          assert.equal(res.error.code, METHOD_NOT_FOUND)
-          resolve(undefined)
-        })
-      })
+      const res = await rpc.request('METHOD_DOES_NOT_EXIST', ['0x1', true])
+      assert.equal(res.error.code, METHOD_NOT_FOUND)
     } catch (err: any) {
       assert.fail(err)
     }

--- a/packages/client/test/rpc/websocket.spec.ts
+++ b/packages/client/test/rpc/websocket.spec.ts
@@ -39,7 +39,7 @@ describe('JSON-RPC call', () => {
     }
   })
 
-  it.only('auth protected server without any auth headers', async () => {
+  it('auth protected server without any auth headers', async () => {
     const server = startRPC({}, { wsServer: true }, { jwtSecret })
     server.listen(1236, 'localhost')
 


### PR DESCRIPTION
This removes Node 18 from the Node versions run by the Node Nightly ci jobs (since only 18 is failing and it's been deprecated and we no longer officially support it).

Also rewrites `client/test/rpc/websocket.spec.ts` so the test should be less flaky.