### PR TITLE
Update `ethereum-cryptography`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2341,9 +2341,9 @@
       }
     },
     "node_modules/@noble/ciphers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.0.0.tgz",
-      "integrity": "sha512-wH5EHOmLi0rEazphPbecAzmjd12I6/Yv/SiHdkA9LSycsQk7RuuTp7am5/o62qYr0RScE7Pc9icXGBbsr6cesA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.2.1.tgz",
+      "integrity": "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==",
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2949,50 +2949,70 @@
       ]
     },
     "node_modules/@scure/base": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.1.tgz",
-      "integrity": "sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
+      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.5.0.tgz",
-      "integrity": "sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.2.tgz",
+      "integrity": "sha512-t96EPDMbtGgtb7onKKqxRLfE5g05k7uHnHRM2xdE6BP/ZmxaLtPek4J4KfVn/90IQNrU1IOAqMgiDtUdtbe3nw==",
       "dependencies": {
-        "@noble/curves": "~1.6.0",
-        "@noble/hashes": "~1.5.0",
-        "@scure/base": "~1.1.7"
+        "@noble/curves": "~1.8.1",
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.2"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@scure/bip32/node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "dependencies": {
+        "@noble/hashes": "1.7.1"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
-      "integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
+      "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
       "dependencies": {
-        "@noble/hashes": "~1.5.0",
-        "@scure/base": "~1.1.8"
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.4"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@scure/bip39/node_modules/@scure/base": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
-      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -7833,19 +7853,44 @@
       }
     },
     "node_modules/ethereum-cryptography": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-3.0.0.tgz",
-      "integrity": "sha512-Ij7U9OgVZc4MAui8BttPCEaWUrAXy+eo2IbVfIxZyfzfFxMQrbIWXRUbrsRBqRrIhJ75T8P+KQRKpKTaG0Du8Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-3.1.0.tgz",
+      "integrity": "sha512-ZqHd92eOIH9RExpBUOgzpAgflyFv9/+Ca39G8V+oCjJPGjJUihQcG/Gl67I/Xn2HGS87dgnrCG3kb1jNClLi6g==",
       "dependencies": {
-        "@noble/ciphers": "1.0.0",
-        "@noble/curves": "1.6.0",
-        "@noble/hashes": "1.5.0",
-        "@scure/bip32": "1.5.0",
-        "@scure/bip39": "1.4.0"
+        "@noble/ciphers": "1.2.1",
+        "@noble/curves": "1.8.1",
+        "@noble/hashes": "1.7.1",
+        "@scure/bip32": "1.6.2",
+        "@scure/bip39": "1.5.4"
       },
       "engines": {
         "node": "^14.21.3 || >=16",
         "npm": ">=9"
+      }
+    },
+    "node_modules/ethereum-cryptography/node_modules/@noble/curves": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "dependencies": {
+        "@noble/hashes": "1.7.1"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethereum-cryptography/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/ethers": {
@@ -16426,7 +16471,7 @@
         "@ethereumjs/rlp": "^6.0.0-alpha.1",
         "@ethereumjs/tx": "^6.0.0-alpha.1",
         "@ethereumjs/util": "^10.0.0-alpha.1",
-        "ethereum-cryptography": "^3.0.0"
+        "ethereum-cryptography": "^3.1.0"
       },
       "devDependencies": {
         "@paulmillr/trusted-setups": "^0.1.2",
@@ -16487,7 +16532,7 @@
         "connect": "^3.7.0",
         "cors": "^2.8.5",
         "debug": "^4.3.3",
-        "ethereum-cryptography": "^3.0.0",
+        "ethereum-cryptography": "^3.1.0",
         "eventemitter3": "^5.0.1",
         "jayson": "^4.0.0",
         "level": "^8.0.0",
@@ -16617,7 +16662,7 @@
         "@ethereumjs/util": "^10.0.0-alpha.1",
         "@scure/base": "^1.1.7",
         "debug": "^4.3.3",
-        "ethereum-cryptography": "^3.0.0",
+        "ethereum-cryptography": "^3.1.0",
         "eventemitter3": "^5.0.1",
         "lru-cache": "10.1.0",
         "scanf": "1.1.2",
@@ -16654,7 +16699,7 @@
         "@ethereumjs/rlp": "^6.0.0-alpha.1",
         "@ethereumjs/util": "^10.0.0-alpha.1",
         "bigint-crypto-utils": "^3.2.2",
-        "ethereum-cryptography": "^3.0.0"
+        "ethereum-cryptography": "^3.1.0"
       },
       "devDependencies": {
         "@ethereumjs/common": "^5.0.0-alpha.1"
@@ -16671,9 +16716,10 @@
         "@ethereumjs/common": "^5.0.0-alpha.1",
         "@ethereumjs/statemanager": "^3.0.0-alpha.1",
         "@ethereumjs/util": "^10.0.0-alpha.1",
+        "@noble/curves": "^1.8.1",
         "@types/debug": "^4.1.9",
         "debug": "^4.3.3",
-        "ethereum-cryptography": "^3.0.0",
+        "ethereum-cryptography": "^3.1.0",
         "eventemitter3": "^5.0.1"
       },
       "devDependencies": {
@@ -16699,6 +16745,31 @@
         "node": ">=18"
       }
     },
+    "packages/evm/node_modules/@noble/curves": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "dependencies": {
+        "@noble/hashes": "1.7.1"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/evm/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "packages/genesis": {
       "name": "@ethereumjs/genesis",
       "version": "0.3.0-alpha.1",
@@ -16719,7 +16790,7 @@
         "@ethereumjs/rlp": "^6.0.0-alpha.1",
         "@ethereumjs/util": "^10.0.0-alpha.1",
         "debug": "^4.3.4",
-        "ethereum-cryptography": "^3.0.0",
+        "ethereum-cryptography": "^3.1.0",
         "lru-cache": "10.1.0"
       },
       "devDependencies": {
@@ -16764,7 +16835,7 @@
         "@ethereumjs/verkle": "^0.2.0-alpha.1",
         "@js-sdsl/ordered-map": "^4.4.2",
         "debug": "^4.3.3",
-        "ethereum-cryptography": "^3.0.0",
+        "ethereum-cryptography": "^3.1.0",
         "lru-cache": "10.1.0"
       },
       "devDependencies": {
@@ -16781,7 +16852,7 @@
         "@ethereumjs/common": "^5.0.0-alpha.1",
         "@ethereumjs/rlp": "^6.0.0-alpha.1",
         "@ethereumjs/util": "^10.0.0-alpha.1",
-        "ethereum-cryptography": "^3.0.0"
+        "ethereum-cryptography": "^3.1.0"
       },
       "devDependencies": {
         "@paulmillr/trusted-setups": "^0.1.2",
@@ -16802,7 +16873,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@ethereumjs/rlp": "^6.0.0-alpha.1",
-        "ethereum-cryptography": "^3.0.0"
+        "ethereum-cryptography": "^3.1.0"
       },
       "devDependencies": {
         "@paulmillr/trusted-setups": "^0.1.2",
@@ -16853,7 +16924,7 @@
         "@ethereumjs/util": "^10.0.0-alpha.1",
         "@ethereumjs/verkle": "^0.2.0-alpha.1",
         "debug": "^4.3.3",
-        "ethereum-cryptography": "^3.0.0",
+        "ethereum-cryptography": "^3.1.0",
         "eventemitter3": "^5.0.1"
       },
       "devDependencies": {
@@ -16886,7 +16957,7 @@
       "dependencies": {
         "@ethereumjs/util": "^10.0.0-alpha.1",
         "@scure/base": "^1.1.7",
-        "ethereum-cryptography": "^3.0.0",
+        "ethereum-cryptography": "^3.1.0",
         "js-md5": "^0.8.3",
         "uuid": "^9.0.1"
       },

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -47,7 +47,7 @@
     "@ethereumjs/mpt": "^7.0.0-alpha.1",
     "@ethereumjs/tx": "^6.0.0-alpha.1",
     "@ethereumjs/util": "^10.0.0-alpha.1",
-    "ethereum-cryptography": "^3.0.0"
+    "ethereum-cryptography": "^3.1.0"
   },
   "devDependencies": {
     "@paulmillr/trusted-setups": "^0.1.2",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -72,7 +72,7 @@
     "connect": "^3.7.0",
     "cors": "^2.8.5",
     "debug": "^4.3.3",
-    "ethereum-cryptography": "^3.0.0",
+    "ethereum-cryptography": "^3.1.0",
     "eventemitter3": "^5.0.1",
     "jayson": "^4.0.0",
     "level": "^8.0.0",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -62,7 +62,7 @@
     "@ethereumjs/util": "^10.0.0-alpha.1",
     "@scure/base": "^1.1.7",
     "debug": "^4.3.3",
-    "ethereum-cryptography": "^3.0.0",
+    "ethereum-cryptography": "^3.1.0",
     "eventemitter3": "^5.0.1",
     "lru-cache": "10.1.0",
     "scanf": "1.1.2",

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -44,7 +44,7 @@
     "@ethereumjs/rlp": "^6.0.0-alpha.1",
     "@ethereumjs/util": "^10.0.0-alpha.1",
     "bigint-crypto-utils": "^3.2.2",
-    "ethereum-cryptography": "^3.0.0"
+    "ethereum-cryptography": "^3.1.0"
   },
   "devDependencies": {
     "@ethereumjs/common": "^5.0.0-alpha.1"

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -49,9 +49,10 @@
     "@ethereumjs/common": "^5.0.0-alpha.1",
     "@ethereumjs/statemanager": "^3.0.0-alpha.1",
     "@ethereumjs/util": "^10.0.0-alpha.1",
+    "@noble/curves": "^1.8.1",
     "@types/debug": "^4.1.9",
     "debug": "^4.3.3",
-    "ethereum-cryptography": "^3.0.0",
+    "ethereum-cryptography": "^3.1.0",
     "eventemitter3": "^5.0.1"
   },
   "devDependencies": {

--- a/packages/evm/src/precompiles/bls12_381/noble.ts
+++ b/packages/evm/src/precompiles/bls12_381/noble.ts
@@ -6,7 +6,7 @@ import {
   equalsBytes,
   setLengthLeft,
 } from '@ethereumjs/util'
-import { bls12_381 } from 'ethereum-cryptography/bls.js'
+import { bls12_381 } from '@noble/curves/bls12-381'
 
 import { ERROR, EvmError } from '../../exceptions.js'
 
@@ -58,7 +58,7 @@ function BLS12_381_ToFp2Point(fpXCoordinate: Uint8Array, fpYCoordinate: Uint8Arr
  * @returns Noble G1 point
  */
 function BLS12_381_ToG1Point(input: Uint8Array, verifyOrder = true) {
-  if (equalsBytes(input, BLS_G1_INFINITY_POINT_BYTES)) {
+  if (equalsBytes(input, BLS_G1_INFINITY_POINT_BYTES) === true) {
     return G1_ZERO
   }
 
@@ -96,7 +96,7 @@ function BLS12_381_FromG1Point(input: AffinePoint<bigint>): Uint8Array {
  * @returns Noble G2 point
  */
 function BLS12_381_ToG2Point(input: Uint8Array, verifyOrder = true) {
-  if (equalsBytes(input, BLS_G2_INFINITY_POINT_BYTES)) {
+  if (equalsBytes(input, BLS_G2_INFINITY_POINT_BYTES) === true) {
     return G2_ZERO
   }
 

--- a/packages/evm/src/precompiles/bls12_381/noble.ts
+++ b/packages/evm/src/precompiles/bls12_381/noble.ts
@@ -21,17 +21,8 @@ import {
 } from './constants.js'
 
 import type { EVMBLSInterface } from '../../types.js'
-
-// Copied from @noble/curves/bls12-381 (only local declaration)
-type Fp2 = {
-  c0: bigint
-  c1: bigint
-}
-// Copied from @noble/curves/abstract/curve.ts (not exported in ethereum-cryptography)
-type AffinePoint<T> = {
-  x: T
-  y: T
-} & { z?: never; t?: never }
+import type { Fp2 } from '@noble/curves/abstract/tower'
+import type { AffinePoint } from '@noble/curves/abstract/weierstrass'
 
 const G1_ZERO = bls12_381.G1.ProjectivePoint.ZERO
 const G2_ZERO = bls12_381.G2.ProjectivePoint.ZERO

--- a/packages/evm/src/precompiles/bn254/noble.ts
+++ b/packages/evm/src/precompiles/bn254/noble.ts
@@ -12,6 +12,7 @@ import { bn254 } from '@noble/curves/bn254'
 import { ERROR, EvmError } from '../../exceptions.js'
 
 import type { EVMBN254Interface } from '../../types.js'
+import type { AffinePoint } from '@noble/curves/abstract/weierstrass'
 
 const G1_INFINITY_POINT_BYTES = new Uint8Array(64)
 const G2_INFINITY_POINT_BYTES = new Uint8Array(128)
@@ -21,12 +22,6 @@ const G2_POINT_BYTE_LENGTH = 128
 
 const ZERO_BUFFER = new Uint8Array(32)
 const ONE_BUFFER = concatBytes(new Uint8Array(31), hexToBytes('0x01'))
-
-// Copied from @noble/curves/abstract/curve.ts (not exported in ethereum-cryptography)
-export type AffinePoint<T> = {
-  x: T
-  y: T
-} & { z?: never; t?: never }
 
 /**
  * Converts an Uint8Array to a Noble G1 point.

--- a/packages/evm/src/precompiles/bn254/noble.ts
+++ b/packages/evm/src/precompiles/bn254/noble.ts
@@ -7,7 +7,7 @@ import {
   hexToBytes,
   setLengthLeft,
 } from '@ethereumjs/util'
-import { bn254 } from 'ethereum-cryptography/bn.js'
+import { bn254 } from '@noble/curves/bn254'
 
 import { ERROR, EvmError } from '../../exceptions.js'
 
@@ -34,7 +34,7 @@ export type AffinePoint<T> = {
  * @returns Noble G1 point
  */
 function toG1Point(input: Uint8Array) {
-  if (equalsBytes(input, G1_INFINITY_POINT_BYTES)) {
+  if (equalsBytes(input, G1_INFINITY_POINT_BYTES) === true) {
     return bn254.G1.ProjectivePoint.ZERO
   }
 
@@ -88,7 +88,7 @@ function toFp2Point(fpXCoordinate: Uint8Array, fpYCoordinate: Uint8Array) {
  * @returns Noble G2 point
  */
 function toG2Point(input: Uint8Array) {
-  if (equalsBytes(input, G2_INFINITY_POINT_BYTES)) {
+  if (equalsBytes(input, G2_INFINITY_POINT_BYTES) === true) {
     return bn254.G2.ProjectivePoint.ZERO
   }
 

--- a/packages/mpt/package.json
+++ b/packages/mpt/package.json
@@ -49,7 +49,7 @@
     "@ethereumjs/util": "^10.0.0-alpha.1",
     "debug": "^4.3.4",
     "lru-cache": "10.1.0",
-    "ethereum-cryptography": "^3.0.0"
+    "ethereum-cryptography": "^3.1.0"
   },
   "devDependencies": {
     "@ethereumjs/genesis": "^0.3.0-alpha.1",

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -50,7 +50,7 @@
     "@ethereumjs/verkle": "^0.2.0-alpha.1",
     "@js-sdsl/ordered-map": "^4.4.2",
     "debug": "^4.3.3",
-    "ethereum-cryptography": "^3.0.0",
+    "ethereum-cryptography": "^3.1.0",
     "lru-cache": "10.1.0"
   },
   "devDependencies": {

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -52,7 +52,7 @@
     "@ethereumjs/common": "^5.0.0-alpha.1",
     "@ethereumjs/rlp": "^6.0.0-alpha.1",
     "@ethereumjs/util": "^10.0.0-alpha.1",
-    "ethereum-cryptography": "^3.0.0"
+    "ethereum-cryptography": "^3.1.0"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.0",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -87,7 +87,7 @@
   },
   "dependencies": {
     "@ethereumjs/rlp": "^6.0.0-alpha.1",
-    "ethereum-cryptography": "^3.0.0"
+    "ethereum-cryptography": "^3.1.0"
   },
   "devDependencies": {
     "@paulmillr/trusted-setups": "^0.1.2",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -66,7 +66,7 @@
     "@ethereumjs/util": "^10.0.0-alpha.1",
     "@ethereumjs/verkle": "^0.2.0-alpha.1",
     "debug": "^4.3.3",
-    "ethereum-cryptography": "^3.0.0",
+    "ethereum-cryptography": "^3.1.0",
     "eventemitter3": "^5.0.1"
   },
   "devDependencies": {

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@ethereumjs/util": "^10.0.0-alpha.1",
     "@scure/base": "^1.1.7",
-    "ethereum-cryptography": "^3.0.0",
+    "ethereum-cryptography": "^3.1.0",
     "js-md5": "^0.8.3",
     "uuid": "^9.0.1"
   },


### PR DESCRIPTION
This updates `ethereum-cryptography` to the latest version and also does some code clean-up related to removing some types that were duplicated from `@noble/curves` but not re-exported by `eth-crypto` in `evm`.

Fixes #3855 