### PR TITLE
Add altair and bellatrix states to era

### DIFF
--- a/config/cspell-ts.json
+++ b/config/cspell-ts.json
@@ -24,6 +24,7 @@
     }
   ],
   "words": [
+    "bytelist",
     "bytestring",
     "binarytree",
     "merkelize",

--- a/package-lock.json
+++ b/package-lock.json
@@ -682,6 +682,14 @@
         "tough-cookie": "^4.1.4"
       }
     },
+    "node_modules/@chainsafe/fast-crc32c": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/fast-crc32c/-/fast-crc32c-4.2.0.tgz",
+      "integrity": "sha512-wbVJ3q1DBuYqs1VGwLe9o5VIDQtxGpSVzr7UY9Hq2SQ283fU6AouII/pwioS9MbiiIK42jDxtY0uLFmTuenb0g==",
+      "optionalDependencies": {
+        "@node-rs/crc32": "^1.10.6"
+      }
+    },
     "node_modules/@chainsafe/is-ip": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.0.2.tgz",
@@ -693,6 +701,30 @@
       "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1"
+      }
+    },
+    "node_modules/@chainsafe/snappy-stream": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@chainsafe/snappy-stream/-/snappy-stream-5.1.2.tgz",
+      "integrity": "sha512-zNhIzEL5k86y6qzXDF6nUIvHGON3SyQK7Vo63jvKyY5AlBJkupVDW8qnbQ9X0vfzw0w79VFYGfv7NXwtb2u4dg==",
+      "dependencies": {
+        "@chainsafe/fast-crc32c": "^4.0.0",
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "buffer-equal": "1.0.0",
+        "buffer-from": "^1.1.1",
+        "snappy": "^6.3.5"
+      }
+    },
+    "node_modules/@chainsafe/snappy-stream/node_modules/snappy": {
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/snappy/-/snappy-6.3.5.tgz",
+      "integrity": "sha512-lonrUtdp1b1uDn1dbwgQbBsb5BbaiLeKq+AGwOk2No+en+VvJThwmtztwulEQsLinRF681pBqib0NUZaizKLIA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.3.1",
+        "nan": "^2.14.1",
+        "prebuild-install": "5.3.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -5036,6 +5068,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
     "node_modules/archiver": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
@@ -5203,6 +5240,48 @@
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
+      "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
+      "deprecated": "This package is no longer supported.",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/are-we-there-yet/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/are-we-there-yet/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/are-we-there-yet/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5545,10 +5624,59 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bintrees": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw=="
+    },
+    "node_modules/bl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/bl/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/bl/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/bl/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/bn.js": {
       "version": "5.2.1",
@@ -5686,6 +5814,20 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "dependencies": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "node_modules/buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+    },
     "node_modules/buffer-crc32": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
@@ -5695,6 +5837,24 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/buffer-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+      "integrity": "sha512-tcBWO2Dl4e7Asr9hTGcpVrCe+F7DubpmqWCTbj4FHLmjqO2hIaC383acQubWtRJhdceqs5uBHs6Es+Sk//RKiQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ=="
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/builtin-modules": {
       "version": "1.1.1",
@@ -5963,6 +6123,11 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
     "node_modules/classic-level": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.4.1.tgz",
@@ -6079,6 +6244,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/color": {
@@ -6269,6 +6442,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+    },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -6296,8 +6474,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "devOptional": true
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -6691,6 +6868,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -6730,6 +6918,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -6863,6 +7059,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -7245,8 +7446,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -8565,6 +8764,14 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
@@ -8782,6 +8989,11 @@
       "dependencies": {
         "moment": "^2.29.1"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -9029,6 +9241,11 @@
         }
       ]
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -9088,6 +9305,65 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
+      "deprecated": "This package is no longer supported.",
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/gauge/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gauge/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gauge/node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gauge/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/geckodriver": {
@@ -9328,6 +9604,11 @@
       "funding": {
         "url": "https://github.com/fisker/git-hooks-list?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "node_modules/gitignore-parser": {
       "version": "0.0.2",
@@ -9584,6 +9865,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "node_modules/hasha": {
       "version": "5.2.2",
@@ -11819,6 +12105,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -11835,7 +12129,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -11847,6 +12140,17 @@
       "devOptional": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/module-error": {
@@ -11998,6 +12302,11 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/nan": {
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ=="
+    },
     "node_modules/nanoid": {
       "version": "3.3.8",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
@@ -12015,6 +12324,11 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "node_modules/napi-macros": {
       "version": "2.2.2",
@@ -12035,6 +12349,22 @@
       "peer": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
+      "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
+      "dependencies": {
+        "semver": "^5.4.1"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/node-addon-api": {
@@ -12136,6 +12466,11 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
     },
+    "node_modules/noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha512-6kM8CLXvuW5crTxsAtva2YLrRrDaiTIkIePWs9moLHqbFWT94WpNFjwS/5dfLfECg5i/lkmw3aoqVidxt23TEQ=="
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -12172,6 +12507,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "deprecated": "This package is no longer supported.",
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -12183,6 +12530,14 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/nyc": {
@@ -12576,7 +12931,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "devOptional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -12643,6 +12997,14 @@
       "resolved": "https://registry.npmjs.org/ordered-binary/-/ordered-binary-1.5.3.tgz",
       "integrity": "sha512-oGFr3T+pYdTGJ+YFEILMpS3es+GiIbs9h/XQrclBXUtd44ey7XwfsMzM31f64I1SQOawDoDr/D823kNCADI8TA==",
       "dev": true
+    },
+    "node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
@@ -13109,6 +13471,124 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.0.tgz",
+      "integrity": "sha512-aaLVANlj4HgZweKttFNUVNRxDukytuIuxeK2boIMHjagNJCiVKWFsKF4tCE3ql3GbrD2tExPQ7/pwtEJcHNZeg==",
+      "dependencies": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^2.0.1",
+        "rc": "^1.2.7",
+        "simple-get": "^2.7.0",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/prebuild-install/node_modules/pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/prebuild-install/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.4.tgz",
+      "integrity": "sha512-u3XczWoYAIVXe5GOKK6+VeWaHjtc47W7hyuTo3+4cNakcCcuDmlkYiiHEsECwTkcI3h1VUgtwBQ54+RvY6cM4w==",
+      "dependencies": {
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs/node_modules/pump": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "dependencies": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -13186,9 +13666,7 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/process-on-spawn": {
       "version": "1.1.0",
@@ -13387,6 +13865,33 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -13973,8 +14478,7 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -14132,8 +14636,36 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.2.tgz",
+      "integrity": "sha512-Ijd/rV5o+mSBBs4F/x9oDPtTx9Zb6X9brmnXvMW4J7IR15ngi9q5xxqWBKU744jTZiaXtxaPL7uHG6vtN8kUkw==",
+      "dependencies": {
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
@@ -15165,6 +15697,11 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -15285,6 +15822,17 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-check": {
@@ -16590,6 +17138,14 @@
       "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
       "dev": true
     },
+    "node_modules/which-pm-runs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.18",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
@@ -16621,6 +17177,40 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wide-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/wide-align/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wide-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -16797,8 +17387,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "devOptional": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -16843,6 +17432,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {
@@ -17260,8 +17857,9 @@
     "packages/era": {
       "name": "@ethereumjs/era",
       "version": "1.0.0-alpha.1",
-      "license": "MPL-2.0",
+      "license": "MIT",
       "dependencies": {
+        "@chainsafe/snappy-stream": "^5.1.2",
         "@ethereumjs/block": "^6.0.0-alpha.1",
         "@ethereumjs/blockchain": "^8.0.0-alpha.1",
         "@ethereumjs/rlp": "^6.0.0-alpha.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2411,214 +2411,6 @@
         "uint8arrays": "^5.0.0"
       }
     },
-    "node_modules/@napi-rs/snappy-android-arm-eabi": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-android-arm-eabi/-/snappy-android-arm-eabi-7.2.2.tgz",
-      "integrity": "sha512-H7DuVkPCK5BlAr1NfSU8bDEN7gYs+R78pSHhDng83QxRnCLmVIZk33ymmIwurmoA1HrdTxbkbuNl+lMvNqnytw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/snappy-android-arm64": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-android-arm64/-/snappy-android-arm64-7.2.2.tgz",
-      "integrity": "sha512-2R/A3qok+nGtpVK8oUMcrIi5OMDckGYNoBLFyli3zp8w6IArPRfg1yOfVUcHvpUDTo9T7LOS1fXgMOoC796eQw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/snappy-darwin-arm64": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-darwin-arm64/-/snappy-darwin-arm64-7.2.2.tgz",
-      "integrity": "sha512-USgArHbfrmdbuq33bD5ssbkPIoT7YCXCRLmZpDS6dMDrx+iM7eD2BecNbOOo7/v1eu6TRmQ0xOzeQ6I/9FIi5g==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/snappy-darwin-x64": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-darwin-x64/-/snappy-darwin-x64-7.2.2.tgz",
-      "integrity": "sha512-0APDu8iO5iT0IJKblk2lH0VpWSl9zOZndZKnBYIc+ei1npw2L5QvuErFOTeTdHBtzvUHASB+9bvgaWnQo4PvTQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/snappy-freebsd-x64": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-freebsd-x64/-/snappy-freebsd-x64-7.2.2.tgz",
-      "integrity": "sha512-mRTCJsuzy0o/B0Hnp9CwNB5V6cOJ4wedDTWEthsdKHSsQlO7WU9W1yP7H3Qv3Ccp/ZfMyrmG98Ad7u7lG58WXA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/snappy-linux-arm-gnueabihf": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-arm-gnueabihf/-/snappy-linux-arm-gnueabihf-7.2.2.tgz",
-      "integrity": "sha512-v1uzm8+6uYjasBPcFkv90VLZ+WhLzr/tnfkZ/iD9mHYiULqkqpRuC8zvc3FZaJy5wLQE9zTDkTJN1IvUcZ+Vcg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/snappy-linux-arm64-gnu": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-arm64-gnu/-/snappy-linux-arm64-gnu-7.2.2.tgz",
-      "integrity": "sha512-LrEMa5pBScs4GXWOn6ZYXfQ72IzoolZw5txqUHVGs8eK4g1HR9HTHhb2oY5ySNaKakG5sOgMsb1rwaEnjhChmQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/snappy-linux-arm64-musl": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-arm64-musl/-/snappy-linux-arm64-musl-7.2.2.tgz",
-      "integrity": "sha512-3orWZo9hUpGQcB+3aTLW7UFDqNCQfbr0+MvV67x8nMNYj5eAeUtMmUE/HxLznHO4eZ1qSqiTwLbVx05/Socdlw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/snappy-linux-x64-gnu": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-x64-gnu/-/snappy-linux-x64-gnu-7.2.2.tgz",
-      "integrity": "sha512-jZt8Jit/HHDcavt80zxEkDpH+R1Ic0ssiVCoueASzMXa7vwPJeF4ZxZyqUw4qeSy7n8UUExomu8G8ZbP6VKhgw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/snappy-linux-x64-musl": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-x64-musl/-/snappy-linux-x64-musl-7.2.2.tgz",
-      "integrity": "sha512-Dh96IXgcZrV39a+Tej/owcd9vr5ihiZ3KRix11rr1v0MWtVb61+H1GXXlz6+Zcx9y8jM1NmOuiIuJwkV4vZ4WA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/snappy-win32-arm64-msvc": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-win32-arm64-msvc/-/snappy-win32-arm64-msvc-7.2.2.tgz",
-      "integrity": "sha512-9No0b3xGbHSWv2wtLEn3MO76Yopn1U2TdemZpCaEgOGccz1V+a/1d16Piz3ofSmnA13HGFz3h9NwZH9EOaIgYA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/snappy-win32-ia32-msvc": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-win32-ia32-msvc/-/snappy-win32-ia32-msvc-7.2.2.tgz",
-      "integrity": "sha512-QiGe+0G86J74Qz1JcHtBwM3OYdTni1hX1PFyLRo3HhQUSpmi13Bzc1En7APn+6Pvo7gkrcy81dObGLDSxFAkQQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/snappy-win32-x64-msvc": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-win32-x64-msvc/-/snappy-win32-x64-msvc-7.2.2.tgz",
-      "integrity": "sha512-a43cyx1nK0daw6BZxVcvDEXxKMFLSBSDTAhsFD0VqSKcC7MGUBMaqyoWUcMiI7LBSz4bxUmxDWKfCYzpEmeb3w==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.6.tgz",
@@ -2672,6 +2464,7 @@
       "resolved": "https://registry.npmjs.org/@node-rs/crc32/-/crc32-1.10.6.tgz",
       "integrity": "sha512-+llXfqt+UzgoDzT9of5vPQPGqTAVCohU74I9zIBkNo5TH6s2P31DFJOGsJQKN207f0GHnYv5pV3wh3BCY/un/A==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 10"
       },
@@ -14737,51 +14530,10 @@
         "npm": ">= 3.0.0"
       }
     },
-    "node_modules/snappy": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/snappy/-/snappy-7.2.2.tgz",
-      "integrity": "sha512-iADMq1kY0v3vJmGTuKcFWSXt15qYUz7wFkArOrsSg0IFfI3nJqIJvK2/ZbEIndg7erIJLtAVX2nSOqPz7DcwbA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "optionalDependencies": {
-        "@napi-rs/snappy-android-arm-eabi": "7.2.2",
-        "@napi-rs/snappy-android-arm64": "7.2.2",
-        "@napi-rs/snappy-darwin-arm64": "7.2.2",
-        "@napi-rs/snappy-darwin-x64": "7.2.2",
-        "@napi-rs/snappy-freebsd-x64": "7.2.2",
-        "@napi-rs/snappy-linux-arm-gnueabihf": "7.2.2",
-        "@napi-rs/snappy-linux-arm64-gnu": "7.2.2",
-        "@napi-rs/snappy-linux-arm64-musl": "7.2.2",
-        "@napi-rs/snappy-linux-x64-gnu": "7.2.2",
-        "@napi-rs/snappy-linux-x64-musl": "7.2.2",
-        "@napi-rs/snappy-win32-arm64-msvc": "7.2.2",
-        "@napi-rs/snappy-win32-ia32-msvc": "7.2.2",
-        "@napi-rs/snappy-win32-x64-msvc": "7.2.2"
-      }
-    },
     "node_modules/snappyjs": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/snappyjs/-/snappyjs-0.6.1.tgz",
       "integrity": "sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg=="
-    },
-    "node_modules/snappystream": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/snappystream/-/snappystream-2.1.1.tgz",
-      "integrity": "sha512-VaQhOYlyrrqmEmTdYW6rR6nKyQFbJ1DfX9U7P1NZafFh5RkoM1aSrizfP5BOB1h+9kwVk0pQV+OgZAK7S48PWw==",
-      "license": "MIT",
-      "dependencies": {
-        "@node-rs/crc32": "^1.7.2",
-        "snappy": "^7.2.2"
-      },
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/socks": {
       "version": "2.8.4",
@@ -17865,10 +17617,8 @@
         "@ethereumjs/rlp": "^6.0.0-alpha.1",
         "@ethereumjs/util": "^10.0.0-alpha.1",
         "level": "^8.0.0",
-        "micro-eth-signer": "^0.13.3",
-        "snappystream": "^2.1.1"
+        "micro-eth-signer": "^0.13.3"
       },
-      "devDependencies": {},
       "engines": {
         "node": ">=18"
       }

--- a/packages/era/README.md
+++ b/packages/era/README.md
@@ -25,7 +25,7 @@ All helpers are re-exported from the root level and deep imports are not necessa
 import { formatEntry } from "@ethereumjs/era";
 ```
 
-#### Export History as Era1
+### Export History as Era1
 
 Export history in epochs of 8192 blocks as Era1 files
 
@@ -39,7 +39,7 @@ const epoch = 0;
 await exportEpochAsEra1(epoch, dataDir);
 ```
 
-#### Read Era1 file
+### Read Era1 file
 
 `readERA1` returns an async iterator of block tuples (header + body + receipts + totalDifficulty)
 
@@ -72,6 +72,26 @@ for await (const blockTuple of blocks) {
 const headerRecords = await getHeaderRecords(era1File);
 const epochAccumulator = EpochAccumulator.encode(headerRecords);
 const epochAccumulatorRoot = EpochAccumulator.merkleRoot(headerRecords);
+```
+
+### Read Era file
+
+```ts
+import { readBeaconState } from "@ethereumjs/era";
+
+const eraFile = readBinaryFile(PATH_TO_ERA_FILE);
+
+// Extract BeaconState
+const state = await readBeaconState(eraFile);
+console.log(state.slot)
+
+// Read Beacon Blocks from era file
+let count = 0
+for await (const block of readBlocksFromEra(eraFile)) {
+  console.log(block.message.slot)
+  count++
+  if (count > 10) break
+}
 ```
 
 ## EthereumJS

--- a/packages/era/package.json
+++ b/packages/era/package.json
@@ -47,15 +47,14 @@
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {
-    "level": "^8.0.0",
+    "@chainsafe/snappy-stream": "^5.1.2",
     "@ethereumjs/block": "^6.0.0-alpha.1",
     "@ethereumjs/blockchain": "^8.0.0-alpha.1",
     "@ethereumjs/rlp": "^6.0.0-alpha.1",
-    "micro-eth-signer": "^0.13.3",
-    "snappystream": "^2.1.1",
-    "@ethereumjs/util": "^10.0.0-alpha.1"
+    "@ethereumjs/util": "^10.0.0-alpha.1",
+    "level": "^8.0.0",
+    "micro-eth-signer": "^0.13.3"
   },
-  "devDependencies": {},
   "engines": {
     "node": ">=18"
   }

--- a/packages/era/src/e2store.ts
+++ b/packages/era/src/e2store.ts
@@ -23,6 +23,7 @@ export async function parseEntry(entry: e2StoreEntry) {
     case bytesToHex(Era1Types.CompressedReceipts):
       data = RLP.decode(decompressed)
       break
+    case bytesToHex(Era1Types.Version):
     case bytesToHex(Era1Types.AccumulatorRoot):
     case bytesToHex(EraTypes.CompressedBeaconState):
     case bytesToHex(EraTypes.CompressedSignedBeaconBlockType):

--- a/packages/era/src/era.ts
+++ b/packages/era/src/era.ts
@@ -136,8 +136,9 @@ export async function* readBlocksFromEra(eraFile: Uint8Array) {
       const block = await readBeaconBlock(eraFile, x)
       yield block
     } catch (err) {
+      // TODO: we need to check for empty slots (basically where the next offset is the same as the current one)
+      // and skip them
       console.log(err)
-      throw err
       // noop - we skip empty slots
     }
   }

--- a/packages/era/src/era.ts
+++ b/packages/era/src/era.ts
@@ -94,7 +94,7 @@ export const readBeaconState = async (eraData: Uint8Array) => {
  *
  * @param eraData a bytestring representing an era file
  * @returns a decompressed SignedBeaconBlock object of the same time as returned by {@link ssz.ETH2_TYPES.SignedBeaconBlock}
- * @throws if SignedBeaconBlock cannot be found
+ * @throws if SignedBeaconBlock is not found when reading an entry
  */
 export const readBeaconBlock = async (eraData: Uint8Array, offset: number) => {
   const indices = getEraIndexes(eraData)

--- a/packages/era/src/era.ts
+++ b/packages/era/src/era.ts
@@ -1,7 +1,13 @@
 import { equalsBytes } from '@ethereumjs/util'
 import * as ssz from 'micro-eth-signer/ssz'
 
-import { EraTypes, parseEntry, readEntry } from './index.js'
+import {
+  AltairBeaconState,
+  BellatrixBeaconState,
+  EraTypes,
+  parseEntry,
+  readEntry,
+} from './index.js'
 
 import type { SlotIndex } from './index.js'
 
@@ -59,7 +65,7 @@ export const getEraIndexes = (
  * @returns a BeaconState object of the same time as returned by {@link ssz.ETH2_TYPES.BeaconState}
  * @throws if BeaconState cannot be found
  */
-export const readBeaconState = async (eraData: Uint8Array) => {
+export const readBeaconState = async (eraData: Uint8Array, fork: string) => {
   const indices = getEraIndexes(eraData)
   const stateEntry = readEntry(
     eraData.slice(indices.stateSlotIndex.recordStart + indices.stateSlotIndex.slotOffsets[0]),
@@ -68,7 +74,14 @@ export const readBeaconState = async (eraData: Uint8Array) => {
   if (equalsBytes(stateEntry.type, EraTypes.CompressedBeaconState) === false) {
     throw new Error(`expected CompressedBeaconState type, got ${stateEntry.type}`)
   }
-  return ssz.ETH2_TYPES.BeaconState.decode(data.data as Uint8Array)
+  switch (fork) {
+    case 'bellatrix':
+      return BellatrixBeaconState.decode(data.data as Uint8Array)
+    case 'altair':
+      return AltairBeaconState.decode(data.data as Uint8Array)
+    default:
+      return ssz.ETH2_TYPES.BeaconState.decode(data.data as Uint8Array)
+  }
 }
 
 /**

--- a/packages/era/src/snappy.ts
+++ b/packages/era/src/snappy.ts
@@ -54,33 +54,21 @@ export async function decompressData(compressedData: Uint8Array) {
   })
 
   stream.push(compressedData)
+
   const data: Uint8Array = await new Promise((resolve, reject) => {
     unsnappy.on('data', (data: Uint8Array) => {
-      try {
-        destroy()
-        resolve(data)
-        // eslint-disable-next-line
-      } catch {}
+      destroy()
+      resolve(data)
     })
     unsnappy.on('end', (data: any) => {
-      try {
-        destroy()
-        resolve(data)
-      } catch (err: any) {
-        destroy()
-        reject(`unable to deserialize data with reason - ${err.message}`)
-      }
+      destroy()
+      resolve(data)
     })
     unsnappy.on('close', (data: any) => {
-      try {
-        destroy()
-        resolve(data)
-      } catch (err: any) {
-        destroy()
-        reject(`unable to deserialize data with reason - ${err.message}`)
-      }
+      destroy()
+      data !== undefined ? resolve(data) : reject('no data received')
     })
-    stream.pipe(unsnappy)
+    stream.pipe(unsnappy, { end: true })
   })
   return data
 }

--- a/packages/era/src/snappy.ts
+++ b/packages/era/src/snappy.ts
@@ -1,6 +1,6 @@
-import { SnappyStream, UnsnappyStream } from 'snappystream'
-import { Duplex, Writable } from 'stream'
-
+import snappyStream from '@chainsafe/snappy-stream'
+import { concatBytes } from '@ethereumjs/util'
+import { Writable } from 'stream'
 /**
  * Compress data using snappy
  * @param uncompressedData
@@ -16,7 +16,7 @@ export async function compressData(uncompressedData: Uint8Array): Promise<Uint8A
       },
     })
 
-    const compress = new SnappyStream()
+    const compress = snappyStream.createCompressStream()
 
     compress.on('error', reject)
     writableStream.on('error', reject)
@@ -33,42 +33,29 @@ export async function compressData(uncompressedData: Uint8Array): Promise<Uint8A
 
     compress.pipe(writableStream)
 
-    compress.end(uncompressedData)
+    compress.write(uncompressedData)
+    compress.end()
   })
 }
 
 export async function decompressData(compressedData: Uint8Array) {
-  const unsnappy = new UnsnappyStream()
-  const stream = new Duplex()
+  const unsnappy = snappyStream.createUncompressStream({ asBuffer: true })
   const destroy = () => {
     unsnappy.destroy()
-    stream.destroy()
   }
-  stream.on('error', (err) => {
-    if (err.message.includes('_read() method is not implemented')) {
-      // ignore errors about unimplemented methods
-      return
-    } else {
-      throw err
-    }
-  })
 
-  stream.push(compressedData)
-
-  const data: Uint8Array = await new Promise((resolve, reject) => {
+  const data: Uint8Array = await new Promise((resolve) => {
+    const chunks: Uint8Array[] = []
     unsnappy.on('data', (data: Uint8Array) => {
-      destroy()
-      resolve(data)
+      chunks.push(data)
     })
-    unsnappy.on('end', (data: any) => {
+
+    unsnappy.on('end', () => {
       destroy()
-      resolve(data)
+      resolve(concatBytes(...chunks))
     })
-    unsnappy.on('close', (data: any) => {
-      destroy()
-      data !== undefined ? resolve(data) : reject('no data received')
-    })
-    stream.pipe(unsnappy, { end: true })
+    unsnappy.write(compressedData)
+    unsnappy.end()
   })
   return data
 }

--- a/packages/era/src/types.ts
+++ b/packages/era/src/types.ts
@@ -62,7 +62,14 @@ const EPOCHS_PER_SLASHINGS_VECTOR = 8192
 const JUSTIFICATION_BITS_LENGTH = 4
 const BYTES_PER_LOGS_BLOOM = 256
 const MAX_EXTRA_DATA_BYTES = 32
+const MAX_DEPOSITS = 16
+const MAX_PROPOSER_SLASHINGS = 16
+const MAX_ATTESTER_SLASHINGS = 2
+const MAX_VOLUNTARY_EXITS = 16
+const MAX_ATTESTATIONS = 128
+const MAX_BLS_TO_EXECUTION_CHANGES = 16
 
+/** Capella Types */
 export const CapellaExecutionPayloadHeader = ssz.container({
   parent_hash: ssz.ETH2_TYPES.Hash32,
   fee_recipient: ssz.ETH2_TYPES.ExecutionAddress,
@@ -81,21 +88,33 @@ export const CapellaExecutionPayloadHeader = ssz.container({
   withdrawals_root: ssz.ETH2_TYPES.Root,
 })
 
-export const BellatrixExecutionPayloadHeader = ssz.container({
-  parent_hash: ssz.ETH2_TYPES.Hash32,
-  fee_recipient: ssz.ETH2_TYPES.ExecutionAddress,
-  state_root: ssz.ETH2_TYPES.Bytes32,
-  receipts_root: ssz.ETH2_TYPES.Bytes32,
-  logs_bloom: ssz.bytevector(BYTES_PER_LOGS_BLOOM),
-  prev_randao: ssz.ETH2_TYPES.Bytes32,
-  block_number: ssz.uint64,
-  gas_limit: ssz.uint64,
-  gas_used: ssz.uint64,
-  timestamp: ssz.uint64,
-  extra_data: ssz.bytelist(MAX_EXTRA_DATA_BYTES),
-  base_fee_per_gas: ssz.uint256,
-  block_hash: ssz.ETH2_TYPES.Hash32,
-  transactions_root: ssz.ETH2_TYPES.Root,
+const CapellaBeaconBlockBody = ssz.container({
+  randao_reveal: ssz.ETH2_TYPES.BLSSignature,
+  eth1_data: ssz.ETH2_TYPES.Eth1Data,
+  graffiti: ssz.ETH2_TYPES.Bytes32,
+  proposer_slashings: ssz.list(MAX_PROPOSER_SLASHINGS, ssz.ETH2_TYPES.ProposerSlashing),
+  attester_slashings: ssz.list(MAX_ATTESTER_SLASHINGS, ssz.ETH2_TYPES.AttesterSlashing),
+  attestations: ssz.list(MAX_ATTESTATIONS, ssz.ETH2_TYPES.Attestation),
+  deposits: ssz.list(MAX_DEPOSITS, ssz.ETH2_TYPES.Deposit),
+  voluntary_exits: ssz.list(MAX_VOLUNTARY_EXITS, ssz.ETH2_TYPES.SignedVoluntaryExit),
+  sync_aggregate: ssz.ETH2_TYPES.SyncAggregate,
+  execution_payload: CapellaExecutionPayloadHeader,
+  bls_to_execution_changes: ssz.list(
+    MAX_BLS_TO_EXECUTION_CHANGES,
+    ssz.ETH2_TYPES.SignedBLSToExecutionChange,
+  ),
+})
+export const CapellaBeaconBlock = ssz.container({
+  slot: ssz.ETH2_TYPES.Slot,
+  proposer_index: ssz.ETH2_TYPES.ValidatorIndex,
+  parent_root: ssz.ETH2_TYPES.Root,
+  state_root: ssz.ETH2_TYPES.Root,
+  body: CapellaBeaconBlockBody,
+})
+
+export const CapellaSignedBeaconBlock = ssz.container({
+  message: CapellaBeaconBlock,
+  signature: ssz.ETH2_TYPES.BLSSignature,
 })
 
 export const CapellaBeaconState = ssz.container({
@@ -138,6 +157,53 @@ export const CapellaBeaconState = ssz.container({
   historical_summaries: ssz.list(HISTORICAL_ROOTS_LIMIT, ssz.ETH2_TYPES.HistoricalSummary),
 })
 
+/** Bellatrix Types */
+export const BellatrixExecutionPayloadHeader = ssz.container({
+  parent_hash: ssz.ETH2_TYPES.Hash32,
+  fee_recipient: ssz.ETH2_TYPES.ExecutionAddress,
+  state_root: ssz.ETH2_TYPES.Bytes32,
+  receipts_root: ssz.ETH2_TYPES.Bytes32,
+  logs_bloom: ssz.bytevector(BYTES_PER_LOGS_BLOOM),
+  prev_randao: ssz.ETH2_TYPES.Bytes32,
+  block_number: ssz.uint64,
+  gas_limit: ssz.uint64,
+  gas_used: ssz.uint64,
+  timestamp: ssz.uint64,
+  extra_data: ssz.bytelist(MAX_EXTRA_DATA_BYTES),
+  base_fee_per_gas: ssz.uint256,
+  block_hash: ssz.ETH2_TYPES.Hash32,
+  transactions_root: ssz.ETH2_TYPES.Root,
+})
+
+const BellatrixBeaconBlockBody = ssz.container({
+  randao_reveal: ssz.ETH2_TYPES.BLSSignature,
+  eth1_data: ssz.ETH2_TYPES.Eth1Data,
+  graffiti: ssz.ETH2_TYPES.Bytes32,
+  proposer_slashings: ssz.list(MAX_PROPOSER_SLASHINGS, ssz.ETH2_TYPES.ProposerSlashing),
+  attester_slashings: ssz.list(MAX_ATTESTER_SLASHINGS, ssz.ETH2_TYPES.AttesterSlashing),
+  attestations: ssz.list(MAX_ATTESTATIONS, ssz.ETH2_TYPES.Attestation),
+  deposits: ssz.list(MAX_DEPOSITS, ssz.ETH2_TYPES.Deposit),
+  voluntary_exits: ssz.list(MAX_VOLUNTARY_EXITS, ssz.ETH2_TYPES.SignedVoluntaryExit),
+  sync_aggregate: ssz.ETH2_TYPES.SyncAggregate,
+  execution_payload: BellatrixExecutionPayloadHeader,
+  bls_to_execution_changes: ssz.list(
+    MAX_BLS_TO_EXECUTION_CHANGES,
+    ssz.ETH2_TYPES.SignedBLSToExecutionChange,
+  ),
+})
+export const BellatrixBeaconBlock = ssz.container({
+  slot: ssz.ETH2_TYPES.Slot,
+  proposer_index: ssz.ETH2_TYPES.ValidatorIndex,
+  parent_root: ssz.ETH2_TYPES.Root,
+  state_root: ssz.ETH2_TYPES.Root,
+  body: BellatrixBeaconBlockBody,
+})
+
+export const BellatrixSignedBeaconBlock = ssz.container({
+  message: BellatrixBeaconBlock,
+  signature: ssz.ETH2_TYPES.BLSSignature,
+})
+
 export const BellatrixBeaconState = ssz.container({
   genesis_time: ssz.uint64,
   genesis_validators_root: ssz.ETH2_TYPES.Root,
@@ -173,6 +239,31 @@ export const BellatrixBeaconState = ssz.container({
   current_sync_committee: ssz.ETH2_TYPES.SyncCommittee,
   next_sync_committee: ssz.ETH2_TYPES.SyncCommittee,
   latest_execution_payload_header: BellatrixExecutionPayloadHeader,
+})
+
+/** Altair Types */
+const AltairBeaconBlockBody = ssz.container({
+  randao_reveal: ssz.ETH2_TYPES.BLSSignature,
+  eth1_data: ssz.ETH2_TYPES.Eth1Data,
+  graffiti: ssz.ETH2_TYPES.Bytes32,
+  proposer_slashings: ssz.list(MAX_PROPOSER_SLASHINGS, ssz.ETH2_TYPES.ProposerSlashing),
+  attester_slashings: ssz.list(MAX_ATTESTER_SLASHINGS, ssz.ETH2_TYPES.AttesterSlashing),
+  attestations: ssz.list(MAX_ATTESTATIONS, ssz.ETH2_TYPES.Attestation),
+  deposits: ssz.list(MAX_DEPOSITS, ssz.ETH2_TYPES.Deposit),
+  voluntary_exits: ssz.list(MAX_VOLUNTARY_EXITS, ssz.ETH2_TYPES.SignedVoluntaryExit),
+  sync_aggregate: ssz.ETH2_TYPES.SyncAggregate,
+})
+export const AltairBeaconBlock = ssz.container({
+  slot: ssz.ETH2_TYPES.Slot,
+  proposer_index: ssz.ETH2_TYPES.ValidatorIndex,
+  parent_root: ssz.ETH2_TYPES.Root,
+  state_root: ssz.ETH2_TYPES.Root,
+  body: AltairBeaconBlockBody,
+})
+
+export const AltairSignedBeaconBlock = ssz.container({
+  message: AltairBeaconBlock,
+  signature: ssz.ETH2_TYPES.BLSSignature,
 })
 
 export const AltairBeaconState = ssz.container({
@@ -211,6 +302,29 @@ export const AltairBeaconState = ssz.container({
   next_sync_committee: ssz.ETH2_TYPES.SyncCommittee,
 })
 
+/** Phase0 Types */
+const Phase0BeaconBlockBody = ssz.container({
+  randao_reveal: ssz.ETH2_TYPES.BLSSignature,
+  eth1_data: ssz.ETH2_TYPES.Eth1Data,
+  graffiti: ssz.ETH2_TYPES.Bytes32,
+  proposer_slashings: ssz.list(MAX_PROPOSER_SLASHINGS, ssz.ETH2_TYPES.ProposerSlashing),
+  attester_slashings: ssz.list(MAX_ATTESTER_SLASHINGS, ssz.ETH2_TYPES.AttesterSlashing),
+  attestations: ssz.list(MAX_ATTESTATIONS, ssz.ETH2_TYPES.Attestation),
+  deposits: ssz.list(MAX_DEPOSITS, ssz.ETH2_TYPES.Deposit),
+  voluntary_exits: ssz.list(MAX_VOLUNTARY_EXITS, ssz.ETH2_TYPES.SignedVoluntaryExit),
+})
+export const Phase0BeaconBlock = ssz.container({
+  slot: ssz.ETH2_TYPES.Slot,
+  proposer_index: ssz.ETH2_TYPES.ValidatorIndex,
+  parent_root: ssz.ETH2_TYPES.Root,
+  state_root: ssz.ETH2_TYPES.Root,
+  body: Phase0BeaconBlockBody,
+})
+
+export const Phase0SignedBeaconBlock = ssz.container({
+  message: Phase0BeaconBlock,
+  signature: ssz.ETH2_TYPES.BLSSignature,
+})
 export const Phase0BeaconState = ssz.container({
   genesis_time: ssz.uint64,
   genesis_validators_root: ssz.ETH2_TYPES.Root,

--- a/packages/era/src/types.ts
+++ b/packages/era/src/types.ts
@@ -44,6 +44,14 @@ export type SlotIndex = {
 }
 
 /** Consensus Layer Constants */
+export enum ForkSlots {
+  Phase0 = 0,
+  Altair = 2375680,
+  Bellatrix = 4700013,
+  Capella = 6209536,
+  Deneb = 8626176,
+}
+
 const SLOTS_PER_HISTORICAL_ROOT = 8192
 const HISTORICAL_ROOTS_LIMIT = 16777216
 const SLOTS_PER_EPOCH = 32
@@ -52,6 +60,83 @@ const EPOCHS_PER_HISTORICAL_VECTOR = 65536
 const EPOCHS_PER_ETH1_VOTING_PERIOD = 64
 const EPOCHS_PER_SLASHINGS_VECTOR = 8192
 const JUSTIFICATION_BITS_LENGTH = 4
+const BYTES_PER_LOGS_BLOOM = 256
+const MAX_EXTRA_DATA_BYTES = 32
+
+export const CapellaExecutionPayloadHeader = ssz.container({
+  parent_hash: ssz.ETH2_TYPES.Hash32,
+  fee_recipient: ssz.ETH2_TYPES.ExecutionAddress,
+  state_root: ssz.ETH2_TYPES.Bytes32,
+  receipts_root: ssz.ETH2_TYPES.Bytes32,
+  logs_bloom: ssz.bytevector(BYTES_PER_LOGS_BLOOM),
+  prev_randao: ssz.ETH2_TYPES.Bytes32,
+  block_number: ssz.uint64,
+  gas_limit: ssz.uint64,
+  gas_used: ssz.uint64,
+  timestamp: ssz.uint64,
+  extra_data: ssz.bytelist(MAX_EXTRA_DATA_BYTES),
+  base_fee_per_gas: ssz.uint256,
+  block_hash: ssz.ETH2_TYPES.Hash32,
+  transactions_root: ssz.ETH2_TYPES.Root,
+  withdrawals_root: ssz.ETH2_TYPES.Root,
+})
+
+export const BellatrixExecutionPayloadHeader = ssz.container({
+  parent_hash: ssz.ETH2_TYPES.Hash32,
+  fee_recipient: ssz.ETH2_TYPES.ExecutionAddress,
+  state_root: ssz.ETH2_TYPES.Bytes32,
+  receipts_root: ssz.ETH2_TYPES.Bytes32,
+  logs_bloom: ssz.bytevector(BYTES_PER_LOGS_BLOOM),
+  prev_randao: ssz.ETH2_TYPES.Bytes32,
+  block_number: ssz.uint64,
+  gas_limit: ssz.uint64,
+  gas_used: ssz.uint64,
+  timestamp: ssz.uint64,
+  extra_data: ssz.bytelist(MAX_EXTRA_DATA_BYTES),
+  base_fee_per_gas: ssz.uint256,
+  block_hash: ssz.ETH2_TYPES.Hash32,
+  transactions_root: ssz.ETH2_TYPES.Root,
+})
+
+export const CapellaBeaconState = ssz.container({
+  genesis_time: ssz.uint64,
+  genesis_validators_root: ssz.ETH2_TYPES.Root,
+  slot: ssz.ETH2_TYPES.Slot,
+  fork: ssz.ETH2_TYPES.Fork,
+  latest_block_header: ssz.ETH2_TYPES.BeaconBlockHeader,
+  block_roots: ssz.vector(SLOTS_PER_HISTORICAL_ROOT, ssz.ETH2_TYPES.Root),
+  state_roots: ssz.vector(SLOTS_PER_HISTORICAL_ROOT, ssz.ETH2_TYPES.Root),
+  historical_roots: ssz.list(HISTORICAL_ROOTS_LIMIT, ssz.ETH2_TYPES.Root),
+  eth1_data: ssz.ETH2_TYPES.Eth1Data,
+  eth1_data_votes: ssz.list(
+    EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH,
+    ssz.ETH2_TYPES.Eth1Data,
+  ),
+  eth1_deposit_index: ssz.uint64,
+  validators: ssz.list(VALIDATOR_REGISTRY_LIMIT, ssz.ETH2_TYPES.Validator),
+  balances: ssz.list(VALIDATOR_REGISTRY_LIMIT, ssz.ETH2_TYPES.Gwei),
+  randao_mixes: ssz.vector(EPOCHS_PER_HISTORICAL_VECTOR, ssz.ETH2_TYPES.Bytes32),
+  slashings: ssz.vector(EPOCHS_PER_SLASHINGS_VECTOR, ssz.ETH2_TYPES.Gwei),
+  previous_epoch_participation: ssz.list(
+    VALIDATOR_REGISTRY_LIMIT,
+    ssz.ETH2_TYPES.ParticipationFlags,
+  ),
+  current_epoch_participation: ssz.list(
+    VALIDATOR_REGISTRY_LIMIT,
+    ssz.ETH2_TYPES.ParticipationFlags,
+  ),
+  justification_bits: ssz.bitvector(JUSTIFICATION_BITS_LENGTH),
+  previous_justified_checkpoint: ssz.ETH2_TYPES.Checkpoint,
+  current_justified_checkpoint: ssz.ETH2_TYPES.Checkpoint,
+  finalized_checkpoint: ssz.ETH2_TYPES.Checkpoint,
+  inactivity_scores: ssz.list(VALIDATOR_REGISTRY_LIMIT, ssz.uint64),
+  current_sync_committee: ssz.ETH2_TYPES.SyncCommittee,
+  next_sync_committee: ssz.ETH2_TYPES.SyncCommittee,
+  latest_execution_payload_header: CapellaExecutionPayloadHeader,
+  next_withdrawal_index: ssz.uint64,
+  next_withdrawal_validator_index: ssz.uint64,
+  historical_summaries: ssz.list(HISTORICAL_ROOTS_LIMIT, ssz.ETH2_TYPES.HistoricalSummary),
+})
 
 export const BellatrixBeaconState = ssz.container({
   genesis_time: ssz.uint64,
@@ -87,7 +172,7 @@ export const BellatrixBeaconState = ssz.container({
   inactivity_scores: ssz.list(VALIDATOR_REGISTRY_LIMIT, ssz.uint64),
   current_sync_committee: ssz.ETH2_TYPES.SyncCommittee,
   next_sync_committee: ssz.ETH2_TYPES.SyncCommittee,
-  latest_execution_payload_header: ssz.ETH2_TYPES.ExecutionPayloadHeader,
+  latest_execution_payload_header: BellatrixExecutionPayloadHeader,
 })
 
 export const AltairBeaconState = ssz.container({
@@ -124,4 +209,37 @@ export const AltairBeaconState = ssz.container({
   inactivity_scores: ssz.list(VALIDATOR_REGISTRY_LIMIT, ssz.uint64),
   current_sync_committee: ssz.ETH2_TYPES.SyncCommittee,
   next_sync_committee: ssz.ETH2_TYPES.SyncCommittee,
+})
+
+export const Phase0BeaconState = ssz.container({
+  genesis_time: ssz.uint64,
+  genesis_validators_root: ssz.ETH2_TYPES.Root,
+  slot: ssz.ETH2_TYPES.Slot,
+  fork: ssz.ETH2_TYPES.Fork,
+  latest_block_header: ssz.ETH2_TYPES.BeaconBlockHeader,
+  block_roots: ssz.vector(SLOTS_PER_HISTORICAL_ROOT, ssz.ETH2_TYPES.Root),
+  state_roots: ssz.vector(SLOTS_PER_HISTORICAL_ROOT, ssz.ETH2_TYPES.Root),
+  historical_roots: ssz.list(HISTORICAL_ROOTS_LIMIT, ssz.ETH2_TYPES.Root),
+  eth1_data: ssz.ETH2_TYPES.Eth1Data,
+  eth1_data_votes: ssz.list(
+    EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH,
+    ssz.ETH2_TYPES.Eth1Data,
+  ),
+  eth1_deposit_index: ssz.uint64,
+  validators: ssz.list(VALIDATOR_REGISTRY_LIMIT, ssz.ETH2_TYPES.Validator),
+  balances: ssz.list(VALIDATOR_REGISTRY_LIMIT, ssz.ETH2_TYPES.Gwei),
+  randao_mixes: ssz.vector(EPOCHS_PER_HISTORICAL_VECTOR, ssz.ETH2_TYPES.Bytes32),
+  slashings: ssz.vector(EPOCHS_PER_SLASHINGS_VECTOR, ssz.ETH2_TYPES.Gwei),
+  previous_epoch_participation: ssz.list(
+    VALIDATOR_REGISTRY_LIMIT,
+    ssz.ETH2_TYPES.ParticipationFlags,
+  ),
+  current_epoch_participation: ssz.list(
+    VALIDATOR_REGISTRY_LIMIT,
+    ssz.ETH2_TYPES.ParticipationFlags,
+  ),
+  justification_bits: ssz.bitvector(JUSTIFICATION_BITS_LENGTH),
+  previous_justified_checkpoint: ssz.ETH2_TYPES.Checkpoint,
+  current_justified_checkpoint: ssz.ETH2_TYPES.Checkpoint,
+  finalized_checkpoint: ssz.ETH2_TYPES.Checkpoint,
 })

--- a/packages/era/src/types.ts
+++ b/packages/era/src/types.ts
@@ -42,3 +42,86 @@ export type SlotIndex = {
   recordStart: number
   slotOffsets: number[]
 }
+
+/** Consensus Layer Constants */
+const SLOTS_PER_HISTORICAL_ROOT = 8192
+const HISTORICAL_ROOTS_LIMIT = 16777216
+const SLOTS_PER_EPOCH = 32
+const VALIDATOR_REGISTRY_LIMIT = 1099511627776
+const EPOCHS_PER_HISTORICAL_VECTOR = 65536
+const EPOCHS_PER_ETH1_VOTING_PERIOD = 64
+const EPOCHS_PER_SLASHINGS_VECTOR = 8192
+const JUSTIFICATION_BITS_LENGTH = 4
+
+export const BellatrixBeaconState = ssz.container({
+  genesis_time: ssz.uint64,
+  genesis_validators_root: ssz.ETH2_TYPES.Root,
+  slot: ssz.ETH2_TYPES.Slot,
+  fork: ssz.ETH2_TYPES.Fork,
+  latest_block_header: ssz.ETH2_TYPES.BeaconBlockHeader,
+  block_roots: ssz.vector(SLOTS_PER_HISTORICAL_ROOT, ssz.ETH2_TYPES.Root),
+  state_roots: ssz.vector(SLOTS_PER_HISTORICAL_ROOT, ssz.ETH2_TYPES.Root),
+  historical_roots: ssz.list(HISTORICAL_ROOTS_LIMIT, ssz.ETH2_TYPES.Root),
+  eth1_data: ssz.ETH2_TYPES.Eth1Data,
+  eth1_data_votes: ssz.list(
+    EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH,
+    ssz.ETH2_TYPES.Eth1Data,
+  ),
+  eth1_deposit_index: ssz.uint64,
+  validators: ssz.list(VALIDATOR_REGISTRY_LIMIT, ssz.ETH2_TYPES.Validator),
+  balances: ssz.list(VALIDATOR_REGISTRY_LIMIT, ssz.ETH2_TYPES.Gwei),
+  randao_mixes: ssz.vector(EPOCHS_PER_HISTORICAL_VECTOR, ssz.ETH2_TYPES.Bytes32),
+  slashings: ssz.vector(EPOCHS_PER_SLASHINGS_VECTOR, ssz.ETH2_TYPES.Gwei),
+  previous_epoch_participation: ssz.list(
+    VALIDATOR_REGISTRY_LIMIT,
+    ssz.ETH2_TYPES.ParticipationFlags,
+  ),
+  current_epoch_participation: ssz.list(
+    VALIDATOR_REGISTRY_LIMIT,
+    ssz.ETH2_TYPES.ParticipationFlags,
+  ),
+  justification_bits: ssz.bitvector(JUSTIFICATION_BITS_LENGTH),
+  previous_justified_checkpoint: ssz.ETH2_TYPES.Checkpoint,
+  current_justified_checkpoint: ssz.ETH2_TYPES.Checkpoint,
+  finalized_checkpoint: ssz.ETH2_TYPES.Checkpoint,
+  inactivity_scores: ssz.list(VALIDATOR_REGISTRY_LIMIT, ssz.uint64),
+  current_sync_committee: ssz.ETH2_TYPES.SyncCommittee,
+  next_sync_committee: ssz.ETH2_TYPES.SyncCommittee,
+  latest_execution_payload_header: ssz.ETH2_TYPES.ExecutionPayloadHeader,
+})
+
+export const AltairBeaconState = ssz.container({
+  genesis_time: ssz.uint64,
+  genesis_validators_root: ssz.ETH2_TYPES.Root,
+  slot: ssz.ETH2_TYPES.Slot,
+  fork: ssz.ETH2_TYPES.Fork,
+  latest_block_header: ssz.ETH2_TYPES.BeaconBlockHeader,
+  block_roots: ssz.vector(SLOTS_PER_HISTORICAL_ROOT, ssz.ETH2_TYPES.Root),
+  state_roots: ssz.vector(SLOTS_PER_HISTORICAL_ROOT, ssz.ETH2_TYPES.Root),
+  historical_roots: ssz.list(HISTORICAL_ROOTS_LIMIT, ssz.ETH2_TYPES.Root),
+  eth1_data: ssz.ETH2_TYPES.Eth1Data,
+  eth1_data_votes: ssz.list(
+    EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH,
+    ssz.ETH2_TYPES.Eth1Data,
+  ),
+  eth1_deposit_index: ssz.uint64,
+  validators: ssz.list(VALIDATOR_REGISTRY_LIMIT, ssz.ETH2_TYPES.Validator),
+  balances: ssz.list(VALIDATOR_REGISTRY_LIMIT, ssz.ETH2_TYPES.Gwei),
+  randao_mixes: ssz.vector(EPOCHS_PER_HISTORICAL_VECTOR, ssz.ETH2_TYPES.Bytes32),
+  slashings: ssz.vector(EPOCHS_PER_SLASHINGS_VECTOR, ssz.ETH2_TYPES.Gwei),
+  previous_epoch_participation: ssz.list(
+    VALIDATOR_REGISTRY_LIMIT,
+    ssz.ETH2_TYPES.ParticipationFlags,
+  ),
+  current_epoch_participation: ssz.list(
+    VALIDATOR_REGISTRY_LIMIT,
+    ssz.ETH2_TYPES.ParticipationFlags,
+  ),
+  justification_bits: ssz.bitvector(JUSTIFICATION_BITS_LENGTH),
+  previous_justified_checkpoint: ssz.ETH2_TYPES.Checkpoint,
+  current_justified_checkpoint: ssz.ETH2_TYPES.Checkpoint,
+  finalized_checkpoint: ssz.ETH2_TYPES.Checkpoint,
+  inactivity_scores: ssz.list(VALIDATOR_REGISTRY_LIMIT, ssz.uint64),
+  current_sync_committee: ssz.ETH2_TYPES.SyncCommittee,
+  next_sync_committee: ssz.ETH2_TYPES.SyncCommittee,
+})

--- a/packages/era/src/types/snappy-stream.d.ts
+++ b/packages/era/src/types/snappy-stream.d.ts
@@ -1,0 +1,11 @@
+declare module '@chainsafe/snappy-stream' {
+  import type { Writable } from 'stream'
+  export function createCompressStream(): Writable
+  export function createUncompressStream(options?: { asBuffer: boolean }): Writable
+  const snappyStream: {
+    createCompressStream: typeof createCompressStream
+    createUncompressStream: typeof createUncompressStream
+  }
+  // eslint-disable-next-line import/no-default-export
+  export default snappyStream
+}

--- a/packages/era/test/era.spec.ts
+++ b/packages/era/test/era.spec.ts
@@ -61,8 +61,16 @@ describe.skip('it should be able to extract beacon objects from an era file', ()
   }, 30000)
   it('should extract the beacon state for Capella state', async () => {
     // https://mainnet.era.nimbus.team/mainnet-00780-bb546fec.era
-    const data = readBinaryFile(__dirname + '/mainnet-00780-bb546fec.era')
+    const data = readBinaryFile(__dirname + '/mainnet-00001-40cf2f3c.era')
     const state = await readBeaconState(data)
+    assert.equal(Number(state.slot), 8192)
+    let count = 0
+
+    for await (const _block of readBlocksFromEra(data)) {
+      count++
+      if (count > 10) break
+    }
+
     assert.equal(Number(state.slot), 6389760)
   }, 30000)
 })

--- a/packages/era/test/era.spec.ts
+++ b/packages/era/test/era.spec.ts
@@ -39,17 +39,29 @@ describe.skip('it should be able to extract beacon objects from an era file', ()
   })
 })
 
-describe('it should be able to extract beacon objects from an era file', () => {
+describe.skip('it should be able to extract beacon objects from an era file', () => {
+  it('should extract the beacon state for Phase0 state', async () => {
+    // https://mainnet.era.nimbus.team/mainnet-00265-1468e348.era
+    const data = readBinaryFile(__dirname + '/mainnet-00265-1468e348.era')
+    const state = await readBeaconState(data)
+    assert.equal(Number(state.slot), 2170880)
+  }, 30000)
   it('should extract the beacon state for Altair state', async () => {
     // https://mainnet.era.nimbus.team/mainnet-00291-5cffd097.era
     const data = readBinaryFile(__dirname + '/mainnet-00291-5cffd097.era')
-    const state = await readBeaconState(data, 'altair')
+    const state = await readBeaconState(data)
     assert.equal(Number(state.slot), 2383872)
   }, 30000)
   it('should extract the beacon state for Bellatrix state', async () => {
     // https://mainnet.era.nimbus.team/mainnet-00600-e031a37d.era
     const data = readBinaryFile(__dirname + '/mainnet-00600-e031a37d.era')
-    const state = await readBeaconState(data, 'bellatrix')
-    assert.equal(Number(state.slot), 2383872)
+    const state = await readBeaconState(data)
+    assert.equal(Number(state.slot), 4915200)
+  }, 30000)
+  it('should extract the beacon state for Capella state', async () => {
+    // https://mainnet.era.nimbus.team/mainnet-00780-bb546fec.era
+    const data = readBinaryFile(__dirname + '/mainnet-00780-bb546fec.era')
+    const state = await readBeaconState(data)
+    assert.equal(Number(state.slot), 6389760)
   }, 30000)
 })

--- a/packages/era/test/era.spec.ts
+++ b/packages/era/test/era.spec.ts
@@ -16,7 +16,7 @@ describe.skip('it should be able to extract beacon objects from an era file', ()
     assert.equal(slotIndex.startSlot, 10969088)
   })
   it('should extract the beacon state', async () => {
-    const state = await readBeaconState(data)
+    const state = await readBeaconState(data, 'deneb')
     assert.equal(Number(state.slot), 10969088)
   }, 30000)
   it('should read a block from the era file and decompress it', async () => {
@@ -37,4 +37,19 @@ describe.skip('it should be able to extract beacon objects from an era file', ()
       assert.equal(block, undefined)
     }
   })
+})
+
+describe('it should be able to extract beacon objects from an era file', () => {
+  it('should extract the beacon state for Altair state', async () => {
+    // https://mainnet.era.nimbus.team/mainnet-00291-5cffd097.era
+    const data = readBinaryFile(__dirname + '/mainnet-00291-5cffd097.era')
+    const state = await readBeaconState(data, 'altair')
+    assert.equal(Number(state.slot), 2383872)
+  }, 30000)
+  it('should extract the beacon state for Bellatrix state', async () => {
+    // https://mainnet.era.nimbus.team/mainnet-00600-e031a37d.era
+    const data = readBinaryFile(__dirname + '/mainnet-00600-e031a37d.era')
+    const state = await readBeaconState(data, 'bellatrix')
+    assert.equal(Number(state.slot), 2383872)
+  }, 30000)
 })

--- a/packages/era/test/era.spec.ts
+++ b/packages/era/test/era.spec.ts
@@ -59,18 +59,17 @@ describe.skip('it should be able to extract beacon objects from an era file', ()
     const state = await readBeaconState(data)
     assert.equal(Number(state.slot), 4915200)
   }, 30000)
-  it('should extract the beacon state for Capella state', async () => {
+  it('should extract the beacon state and blocks for Capella state', async () => {
     // https://mainnet.era.nimbus.team/mainnet-00780-bb546fec.era
-    const data = readBinaryFile(__dirname + '/mainnet-00001-40cf2f3c.era')
+    const data = readBinaryFile(__dirname + '/mainnet-00780-bb546fec.era')
     const state = await readBeaconState(data)
-    assert.equal(Number(state.slot), 8192)
+    assert.equal(Number(state.slot), 6389760)
+
     let count = 0
 
     for await (const _block of readBlocksFromEra(data)) {
       count++
       if (count > 10) break
     }
-
-    assert.equal(Number(state.slot), 6389760)
   }, 30000)
 })

--- a/packages/era/test/era.spec.ts
+++ b/packages/era/test/era.spec.ts
@@ -16,7 +16,7 @@ describe.skip('it should be able to extract beacon objects from an era file', ()
     assert.equal(slotIndex.startSlot, 10969088)
   })
   it('should extract the beacon state', async () => {
-    const state = await readBeaconState(data, 'deneb')
+    const state = await readBeaconState(data)
     assert.equal(Number(state.slot), 10969088)
   }, 30000)
   it('should read a block from the era file and decompress it', async () => {
@@ -32,6 +32,7 @@ describe.skip('it should be able to extract beacon objects from an era file', ()
     }
   }, 30000)
   it('reads no blocks from the genesis era file', async () => {
+    // https://mainnet.era.nimbus.team/mainnet-00000-4b363db9.era
     const data = new Uint8Array(readFileSync(__dirname + '/mainnet-00000-4b363db9.era'))
     for await (const block of readBlocksFromEra(data)) {
       assert.equal(block, undefined)


### PR DESCRIPTION
Adds SSZ types for `Phase0`,  `Altair`, `Bellatrix`, and `Capella`  `BeaconState` types to `era` package to support the various Beacon State objects across forks.

Also, updates the README.md with basic usage for the `era` file format
