### PR TITLE
Fix `lint-staged` script

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  '*.{js,json,md,ts}': 'npx @biomejs/biome check --write',
+  '*.{js,json,md,ts}': 'npx @biomejs/biome check --write --no-errors-on-unmatched',
 }


### PR DESCRIPTION
This fixes an error condition in the `lint-staged` precommit git hook so that biome doesn't throw an error if it doesn't find any files to check.