### PR TITLE
Binary Tree cleanup

### DIFF
--- a/packages/binarytree/src/binaryTree.ts
+++ b/packages/binarytree/src/binaryTree.ts
@@ -468,6 +468,7 @@ export class BinaryTree {
           matchingKeyLength === keyInBits.length &&
           equalsBits(keyInBits, childNode.path) === true
         ) {
+          // We found the sought node
           this.DEBUG &&
             this.debug(
               `Path ${bytesToHex(keyInBytes)} - found full path to node ${bytesToHex(
@@ -479,7 +480,7 @@ export class BinaryTree {
           result.remaining = []
           return result
         }
-        // Otherwise, record the unmatched tail of the key.
+        // We didn't find the sought node so record the unmatched tail of the key.
         result.remaining = keyInBits.slice(matchingKeyLength)
         result.stack.push([decodedNode, childNode.path])
         return result
@@ -575,11 +576,19 @@ export class BinaryTree {
 
   /**
    * Creates a proof from a tree and key that can be verified using {@link BinaryTree.verifyBinaryProof}.
-   * @param key
+   * @param key a 32 byte binary tree key (31 byte stem + 1 byte suffix)
    */
   async createBinaryProof(key: Uint8Array): Promise<Uint8Array[]> {
-    const { stack } = await this.findPath(key)
+    this.DEBUG && this.debug(`creating proof for ${bytesToHex(key)}`, ['create_proof'])
+    // We only use the stem (i.e. the first 31 bytes) to find the path to the node
+
+    const { node, stack } = await this.findPath(key.slice(0, 31))
     const proof = stack.map(([node, _]) => node.serialize())
+    if (node !== null) {
+      // If node is found, add node to proof
+      proof.push(node.serialize())
+    }
+
     return proof
   }
 

--- a/packages/binarytree/src/binaryTree.ts
+++ b/packages/binarytree/src/binaryTree.ts
@@ -444,11 +444,6 @@ export class BinaryTree {
     // The root is an internal node. Determine the branch to follow using the first bit of the key
     let childNode = rootNode.getChild(keyInBits[0])
 
-    // If no child exists on that branch, return what we have.
-    if (childNode === null) {
-      this.DEBUG && this.debug(`Partial Path ${keyInBits[0]} - found no child.`, ['find_path'])
-      return result
-    }
     let finished = false
     while (!finished) {
       if (childNode === null) break
@@ -584,7 +579,8 @@ export class BinaryTree {
    */
   async createBinaryProof(key: Uint8Array): Promise<Uint8Array[]> {
     const { stack } = await this.findPath(key)
-    return stack.map(([node, _]) => node.serialize())
+    const proof = stack.map(([node, _]) => node.serialize())
+    return proof
   }
 
   /**

--- a/packages/evm/src/binaryTreeAccessWitness.ts
+++ b/packages/evm/src/binaryTreeAccessWitness.ts
@@ -31,7 +31,7 @@ import type { BinaryTreeAccessedState, RawBinaryTreeAccessedState } from '@ether
 import type { StatefulBinaryTreeStateManager } from '@ethereumjs/statemanager'
 import type { Address, BinaryTreeExecutionWitness, PrefixedHexString } from '@ethereumjs/util'
 
-const debug = debugDefault('evm:verkle:aw')
+const debug = debugDefault('evm:binaryTree:aw')
 
 /**
  * Tree key constants.
@@ -44,7 +44,7 @@ const WitnessChunkFillCost = BigInt(6200)
 
 // read is a default access event if stem or chunk is present
 export type BinaryStemAccessEvent = { write?: boolean }
-// chunk fill access event was not charged in verkle testnets, not sure if it will be charged in binary
+
 export type BinaryChunkAccessEvent = BinaryStemAccessEvent & { fill?: boolean }
 
 // Since stem is hashed, it is useful to maintain the reverse relationship
@@ -324,7 +324,7 @@ export class BinaryTreeAccessWitness implements BinaryTreeAccessWitnessInterface
   }
 
   debugWitnessCost(): void {
-    // Calculate the aggregate gas cost for verkle access witness per type
+    // Calculate the aggregate gas cost for binary access witness per type
     let stemReads = 0,
       stemWrites = 0,
       chunkReads = 0,
@@ -385,9 +385,7 @@ export class BinaryTreeAccessWitness implements BinaryTreeAccessWitnessInterface
  * @param stateManager - The state manager containing the state to generate the witness for.
  * @param accessWitness - The access witness containing the accessed states.
  * @param parentStateRoot - The parent state root (i.e. prestate root) to generate the witness for.
- * @returns The generated verkle execution witness
- *
- * Note: This does not provide the verkle proof, which is not implemented
+ * @returns The generated binary tree execution witness
  */
 export const generateBinaryExecutionWitness = async (
   stateManager: StatefulBinaryTreeStateManager,

--- a/packages/evm/src/binaryTreeAccessWitness.ts
+++ b/packages/evm/src/binaryTreeAccessWitness.ts
@@ -43,14 +43,14 @@ const WitnessChunkWriteCost = BigInt(500)
 const WitnessChunkFillCost = BigInt(6200)
 
 // read is a default access event if stem or chunk is present
-export type StemAccessEvent = { write?: boolean }
+export type BinaryStemAccessEvent = { write?: boolean }
 // chunk fill access event was not charged in verkle testnets, not sure if it will be charged in binary
-export type ChunkAccessEvent = StemAccessEvent & { fill?: boolean }
+export type BinaryChunkAccessEvent = BinaryStemAccessEvent & { fill?: boolean }
 
 // Since stem is hashed, it is useful to maintain the reverse relationship
-export type StemMeta = { address: Address; treeIndex: number | bigint }
+export type BinaryStemMeta = { address: Address; treeIndex: number | bigint }
 
-export function decodeAccessedState(
+export function decodeBinaryAccessState(
   treeIndex: number | bigint,
   chunkIndex: number,
 ): BinaryTreeAccessedState {
@@ -89,19 +89,19 @@ export function decodeAccessedState(
 }
 
 export class BinaryTreeAccessWitness implements BinaryTreeAccessWitnessInterface {
-  stems: Map<PrefixedHexString, StemAccessEvent & StemMeta>
-  chunks: Map<PrefixedHexString, ChunkAccessEvent>
+  stems: Map<PrefixedHexString, BinaryStemAccessEvent & BinaryStemMeta>
+  chunks: Map<PrefixedHexString, BinaryChunkAccessEvent>
   stemCache: StemCache = new StemCache()
   chunkCache: ChunkCache = new ChunkCache()
   hashFunction: (msg: Uint8Array) => Uint8Array
   constructor(opts: {
     hashFunction: (msg: Uint8Array) => Uint8Array
-    stems?: Map<PrefixedHexString, StemAccessEvent & StemMeta>
-    chunks?: Map<PrefixedHexString, ChunkAccessEvent>
+    stems?: Map<PrefixedHexString, BinaryStemAccessEvent & BinaryStemMeta>
+    chunks?: Map<PrefixedHexString, BinaryChunkAccessEvent>
   }) {
     this.hashFunction = opts.hashFunction
-    this.stems = opts.stems ?? new Map<PrefixedHexString, StemAccessEvent & StemMeta>()
-    this.chunks = opts.chunks ?? new Map<PrefixedHexString, ChunkAccessEvent>()
+    this.stems = opts.stems ?? new Map<PrefixedHexString, BinaryStemAccessEvent & BinaryStemMeta>()
+    this.chunks = opts.chunks ?? new Map<PrefixedHexString, BinaryChunkAccessEvent>()
   }
 
   readAccountBasicData(address: Address): bigint {
@@ -374,7 +374,7 @@ export class BinaryTreeAccessWitness implements BinaryTreeAccessWitnessInterface
   *accesses(): Generator<BinaryTreeAccessedStateWithAddress> {
     for (const rawAccess of this.rawAccesses()) {
       const { address, treeIndex, chunkIndex, chunkKey } = rawAccess
-      const accessedState = decodeAccessedState(treeIndex, chunkIndex)
+      const accessedState = decodeBinaryAccessState(treeIndex, chunkIndex)
       yield { ...accessedState, address, chunkKey }
     }
   }
@@ -389,7 +389,7 @@ export class BinaryTreeAccessWitness implements BinaryTreeAccessWitnessInterface
  *
  * Note: This does not provide the verkle proof, which is not implemented
  */
-export const generateExecutionWitness = async (
+export const generateBinaryExecutionWitness = async (
   stateManager: StatefulBinaryTreeStateManager,
   accessWitness: BinaryTreeAccessWitness,
   parentStateRoot: Uint8Array,

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -270,7 +270,7 @@ export class EVM implements EVMInterface {
 
     if (this.common.isActivatedEIP(6800) || this.common.isActivatedEIP(7864)) {
       if (message.accessWitness === undefined) {
-        throw EthereumJSErrorWithoutCode('accessWitness is required for EIP-6800')
+        throw EthereumJSErrorWithoutCode('accessWitness is required for EIP-6800 & EIP-7864')
       }
       const sendsValue = message.value !== BIGINT_0
       if (message.depth === 0) {

--- a/packages/evm/src/index.ts
+++ b/packages/evm/src/index.ts
@@ -59,6 +59,7 @@ export {
   validateEOF,
 }
 
+export * from './binaryTreeAccessWitness.js'
 export * from './constructors.js'
 export * from './params.js'
 export * from './verkleAccessWitness.js'

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -37,6 +37,7 @@ import type {
   Log,
 } from './types.js'
 import type {
+  BinaryTreeAccessWitnessInterface,
   Common,
   StateManagerInterface,
   VerkleAccessWitnessInterface,
@@ -84,7 +85,7 @@ export interface Env {
   eof?: EOFEnv /* Optional EOF environment in case of EOF execution */
   blobVersionedHashes: PrefixedHexString[] /** Versioned hashes for blob transactions */
   createdAddresses?: Set<string>
-  accessWitness?: VerkleAccessWitnessInterface
+  accessWitness?: VerkleAccessWitnessInterface | BinaryTreeAccessWitnessInterface
   chargeCodeAccesses?: boolean
 }
 
@@ -305,7 +306,7 @@ export class Interpreter {
       // chunk in the witness, and throw appropriate error to distinguish from an actual invalid opcode
       if (
         opCode === 0xfe &&
-        this.common.isActivatedEIP(6800) &&
+        (this.common.isActivatedEIP(6800) || this.common.isActivatedEIP(7864)) &&
         // is this a code loaded from state using witnesses
         this._runState.env.chargeCodeAccesses === true
       ) {
@@ -386,7 +387,10 @@ export class Interpreter {
         await this._runStepHook(gas, this.getGasLeft())
       }
 
-      if (this.common.isActivatedEIP(6800) && this._env.chargeCodeAccesses === true) {
+      if (
+        (this.common.isActivatedEIP(6800) || this.common.isActivatedEIP(7864)) &&
+        this._env.chargeCodeAccesses === true
+      ) {
         const contract = this._runState.interpreter.getAddress()
         const statelessGas = this._runState.env.accessWitness!.readAccountCodeChunks(
           contract,

--- a/packages/evm/src/message.ts
+++ b/packages/evm/src/message.ts
@@ -2,7 +2,10 @@ import { BIGINT_0, EthereumJSErrorWithoutCode, createZeroAddress } from '@ethere
 
 import type { PrecompileFunc } from './precompiles/index.js'
 import type { EOFEnv } from './types.js'
-import type { VerkleAccessWitnessInterface } from '@ethereumjs/common'
+import type {
+  BinaryTreeAccessWitnessInterface,
+  VerkleAccessWitnessInterface,
+} from '@ethereumjs/common'
 import type { Address, PrefixedHexString } from '@ethereumjs/util'
 
 const defaults = {
@@ -40,7 +43,7 @@ interface MessageOpts {
   delegatecall?: boolean
   gasRefund?: bigint
   blobVersionedHashes?: PrefixedHexString[]
-  accessWitness?: VerkleAccessWitnessInterface
+  accessWitness?: VerkleAccessWitnessInterface | BinaryTreeAccessWitnessInterface
 }
 
 export class Message {
@@ -73,7 +76,7 @@ export class Message {
    * List of versioned hashes if message is a blob transaction in the outer VM
    */
   blobVersionedHashes?: PrefixedHexString[]
-  accessWitness?: VerkleAccessWitnessInterface
+  accessWitness?: VerkleAccessWitnessInterface | BinaryTreeAccessWitnessInterface
 
   constructor(opts: MessageOpts) {
     this.to = opts.to

--- a/packages/evm/src/opcodes/EIP2929.ts
+++ b/packages/evm/src/opcodes/EIP2929.ts
@@ -29,9 +29,9 @@ export function accessAddressEIP2929(
     // CREATE, CREATE2 opcodes have the address warmed for free.
     // selfdestruct beneficiary address reads are charged an *additional* cold access
     // if verkle not activated
-    if (chargeGas && !common.isActivatedEIP(6800)) {
+    if (chargeGas && (!common.isActivatedEIP(6800) || !common.isActivatedEIP(7864))) {
       return common.param('coldaccountaccessGas')
-    } else if (chargeGas && common.isActivatedEIP(6800)) {
+    } else if (chargeGas && (common.isActivatedEIP(6800) || common.isActivatedEIP(7864))) {
       // If Verkle is active, then the warmstoragereadGas should still be charged
       // This is because otherwise opcodes will have cost 0 (this is thus the base fee)
       return common.param('warmstoragereadGas')
@@ -66,10 +66,13 @@ export function accessStorageEIP2929(
   // Cold (SLOAD and SSTORE)
   if (slotIsCold) {
     runState.interpreter.journal.addWarmedStorage(address, key)
-    if (chargeGas && !common.isActivatedEIP(6800)) {
+    if (chargeGas && (!common.isActivatedEIP(6800) || !common.isActivatedEIP(7864))) {
       return common.param('coldsloadGas')
     }
-  } else if (chargeGas && (!isSstore || common.isActivatedEIP(6800))) {
+  } else if (
+    chargeGas &&
+    (!isSstore || common.isActivatedEIP(6800) || common.isActivatedEIP(7864))
+  ) {
     return common.param('warmstoragereadGas')
   }
   return BIGINT_0

--- a/packages/evm/src/opcodes/EIP2929.ts
+++ b/packages/evm/src/opcodes/EIP2929.ts
@@ -29,7 +29,7 @@ export function accessAddressEIP2929(
     // CREATE, CREATE2 opcodes have the address warmed for free.
     // selfdestruct beneficiary address reads are charged an *additional* cold access
     // if verkle not activated
-    if (chargeGas && (!common.isActivatedEIP(6800) || !common.isActivatedEIP(7864))) {
+    if (chargeGas && !(common.isActivatedEIP(6800) || common.isActivatedEIP(7864))) {
       return common.param('coldaccountaccessGas')
     } else if (chargeGas && (common.isActivatedEIP(6800) || common.isActivatedEIP(7864))) {
       // If Verkle is active, then the warmstoragereadGas should still be charged
@@ -66,7 +66,7 @@ export function accessStorageEIP2929(
   // Cold (SLOAD and SSTORE)
   if (slotIsCold) {
     runState.interpreter.journal.addWarmedStorage(address, key)
-    if (chargeGas && (!common.isActivatedEIP(6800) || !common.isActivatedEIP(7864))) {
+    if (chargeGas && !(common.isActivatedEIP(6800) || common.isActivatedEIP(7864))) {
       return common.param('coldsloadGas')
     }
   } else if (

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -633,7 +633,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         const historyServeWindow = common.param('historyServeWindow')
         const key = setLengthLeft(bigIntToBytes(number % historyServeWindow), 32)
 
-        if (common.isActivatedEIP(6800)) {
+        if (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) {
           // create witnesses and charge gas
           const statelessGas = runState.env.accessWitness!.readAccountStorage(
             historyAddress,
@@ -920,7 +920,10 @@ export const handlers: Map<number, OpHandler> = new Map([
     function (runState, common) {
       const numToPush = runState.opCode - 0x5f
 
-      if (common.isActivatedEIP(6800) && runState.env.chargeCodeAccesses === true) {
+      if (
+        (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) &&
+        runState.env.chargeCodeAccesses === true
+      ) {
         const contract = runState.interpreter.getAddress()
         const startOffset = Math.min(runState.code.length, runState.programCounter + 1)
         const endOffset = Math.min(runState.code.length, startOffset + numToPush - 1)

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -102,7 +102,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
       async function (runState, gas, common): Promise<bigint> {
         const address = createAddressFromStackBigInt(runState.stack.peek()[0])
         let charge2929Gas = true
-        if (common.isActivatedEIP(6800)) {
+        if (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) {
           const coldAccessGas = runState.env.accessWitness!.readAccountBasicData(address)
 
           gas += coldAccessGas
@@ -139,7 +139,10 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         if (dataLength !== BIGINT_0) {
           gas += common.param('copyGas') * divCeil(dataLength, BIGINT_32)
 
-          if (common.isActivatedEIP(6800) && runState.env.chargeCodeAccesses === true) {
+          if (
+            (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) &&
+            runState.env.chargeCodeAccesses === true
+          ) {
             const contract = runState.interpreter.getAddress()
             let codeEnd = _codeOffset + dataLength
             const codeSize = runState.interpreter.getCodeSize()
@@ -165,7 +168,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         let charge2929Gas = true
         if (
-          common.isActivatedEIP(6800) &&
+          (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) &&
           runState.interpreter._evm.getPrecompile(address) === undefined &&
           !address.equals(createAddressFromStackBigInt(common.param('systemAddress')))
         ) {
@@ -195,7 +198,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         let charge2929Gas = true
         if (
-          common.isActivatedEIP(6800) &&
+          (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) &&
           runState.interpreter._evm.getPrecompile(address) === undefined &&
           !address.equals(createAddressFromStackBigInt(common.param('systemAddress')))
         ) {
@@ -214,7 +217,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         if (dataLength !== BIGINT_0) {
           gas += common.param('copyGas') * divCeil(dataLength, BIGINT_32)
 
-          if (common.isActivatedEIP(6800)) {
+          if (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) {
             let codeEnd = _codeOffset + dataLength
             const codeSize = BigInt((await runState.stateManager.getCode(address)).length)
             if (codeEnd > codeSize) {
@@ -261,7 +264,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         let charge2929Gas = true
 
         if (
-          common.isActivatedEIP(6800) &&
+          (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) &&
           runState.interpreter._evm.getPrecompile(address) === undefined &&
           !address.equals(createAddressFromStackBigInt(common.param('systemAddress')))
         ) {
@@ -314,7 +317,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         const keyBuf = setLengthLeft(bigIntToBytes(key), 32)
 
         let charge2929Gas = true
-        if (common.isActivatedEIP(6800)) {
+        if (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) {
           const address = runState.interpreter.getAddress()
           const coldAccessGas = runState.env.accessWitness!.readAccountStorage(address, key)
 
@@ -362,7 +365,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
             common,
           )
         } else if (common.gteHardfork(Hardfork.Istanbul)) {
-          if (!common.isActivatedEIP(6800)) {
+          if (!common.isActivatedEIP(6800) && !common.isActivatedEIP(7864)) {
             gas += updateSstoreGasEIP2200(
               runState,
               currentStorage,
@@ -377,7 +380,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         }
 
         let charge2929Gas = true
-        if (common.isActivatedEIP(6800)) {
+        if (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) {
           const contract = runState.interpreter.getAddress()
           const coldAccessGas = runState.env.accessWitness!.writeAccountStorage(contract, key)
 
@@ -553,7 +556,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         let charge2929Gas = true
         if (
-          common.isActivatedEIP(6800) &&
+          (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) &&
           runState.interpreter._evm.getPrecompile(toAddress) === undefined
         ) {
           const coldAccessGas = runState.env.accessWitness!.readAccountBasicData(toAddress)
@@ -575,7 +578,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           gas += await eip7702GasCost(runState, common, toAddress, charge2929Gas)
         }
 
-        if (value !== BIGINT_0 && !common.isActivatedEIP(6800)) {
+        if (value !== BIGINT_0 && !common.isActivatedEIP(6800) && !common.isActivatedEIP(7864)) {
           gas += common.param('callValueTransferGas')
         }
 
@@ -631,7 +634,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         let charge2929Gas = true
         if (
-          common.isActivatedEIP(6800) &&
+          (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) &&
           runState.interpreter._evm.getPrecompile(toAddress) === undefined
         ) {
           const coldAccessGas = runState.env.accessWitness!.readAccountBasicData(toAddress)
@@ -695,7 +698,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         let charge2929Gas = true
         if (
-          common.isActivatedEIP(6800) &&
+          (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) &&
           runState.interpreter._evm.getPrecompile(toAddress) === undefined
         ) {
           const coldAccessGas = runState.env.accessWitness!.readAccountBasicData(toAddress)
@@ -908,7 +911,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         let charge2929Gas = true
         const toAddress = createAddressFromStackBigInt(toAddr)
         if (
-          common.isActivatedEIP(6800) &&
+          (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) &&
           runState.interpreter._evm.getPrecompile(toAddress) === undefined
         ) {
           const coldAccessGas = runState.env.accessWitness!.readAccountBasicData(toAddress)
@@ -1045,7 +1048,10 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         }
 
         let selfDestructToCharge2929Gas = true
-        if (common.isActivatedEIP(6800)) {
+        if (
+          (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) &&
+          runState.env.chargeCodeAccesses === true
+        ) {
           gas += runState.env.accessWitness!.readAccountBasicData(contractAddress)
           if (balance > BIGINT_0) {
             gas += runState.env.accessWitness!.writeAccountBasicData(contractAddress)

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -1,3 +1,4 @@
+import type { BinaryTreeAccessWitness } from './binaryTreeAccessWitness.js'
 import type { EOFContainer } from './eof/container.js'
 import type { EvmError } from './exceptions.js'
 import type { InterpreterStep, RunState } from './interpreter.js'
@@ -6,6 +7,7 @@ import type { AsyncDynamicGasHandler, SyncDynamicGasHandler } from './opcodes/ga
 import type { OpHandler } from './opcodes/index.js'
 import type { CustomPrecompile } from './precompiles/index.js'
 import type { PrecompileFunc } from './precompiles/types.js'
+import type { VerkleAccessWitness } from './verkleAccessWitness.js'
 import type {
   BinaryTreeAccessWitnessInterface,
   Common,
@@ -167,10 +169,10 @@ export interface EVMInterface {
   runCall(opts: EVMRunCallOpts): Promise<EVMResult>
   runCode(opts: EVMRunCodeOpts): Promise<ExecResult>
   events?: EventEmitter<EVMEvent>
-  verkleAccessWitness?: VerkleAccessWitnessInterface
-  systemVerkleAccessWitness?: VerkleAccessWitnessInterface
-  binaryTreeAccessWitness?: BinaryTreeAccessWitnessInterface
-  systemBinaryTreeAccessWitness?: BinaryTreeAccessWitnessInterface
+  verkleAccessWitness?: VerkleAccessWitness
+  systemVerkleAccessWitness?: VerkleAccessWitness
+  binaryTreeAccessWitness?: BinaryTreeAccessWitness
+  systemBinaryTreeAccessWitness?: BinaryTreeAccessWitness
 }
 
 export type EVMProfilerOpts = {

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -129,7 +129,7 @@ export interface EVMRunCallOpts extends EVMRunOpts {
    */
   message?: Message
 
-  accessWitness?: VerkleAccessWitnessInterface
+  accessWitness?: VerkleAccessWitnessInterface | BinaryTreeAccessWitnessInterface
 }
 
 interface NewContractEvent {

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -580,7 +580,7 @@ export async function accumulateParentBlockHash(
       vm.evm.systemVerkleAccessWitness.writeAccountStorage(historyAddress, ringKey)
     } else if (vm.common.isActivatedEIP(7864)) {
       if (vm.evm.systemBinaryTreeAccessWitness === undefined) {
-        throw Error(`binaryTreeAccessWitness required if binary tree (EIP-7864) is activated`)
+        throw Error(`systemBinaryTreeAccessWitness required if binary tree (EIP-7864) is activated`)
       }
       // Add to system binary tree access witness so that it doesn't warm up tx accesses
       vm.evm.systemBinaryTreeAccessWitness.writeAccountStorage(historyAddress, ringKey)
@@ -800,7 +800,7 @@ export async function rewardAccount(
     }
     if (common.isActivatedEIP(7864) === true && reward !== BIGINT_0) {
       if (evm.systemBinaryTreeAccessWitness === undefined) {
-        throw Error(`binaryTreeAccessWitness required if binary tree (EIP-7864) is activated`)
+        throw Error(`systemBinaryTreeAccessWitness required if binary tree (EIP-7864) is activated`)
       }
       evm.systemBinaryTreeAccessWitness.writeAccountHeader(address)
     }
@@ -819,7 +819,7 @@ export async function rewardAccount(
   }
   if (common.isActivatedEIP(7864) === true && reward !== BIGINT_0) {
     if (evm.systemBinaryTreeAccessWitness === undefined) {
-      throw Error(`binaryTreeAccessWitness required if binary tree (EIP-7864) is activated`)
+      throw Error(`systemBinaryTreeAccessWitness required if binary tree (EIP-7864) is activated`)
     }
     evm.systemBinaryTreeAccessWitness.writeAccountBasicData(address)
     evm.systemBinaryTreeAccessWitness.readAccountCodeHash(address)

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -46,11 +46,7 @@ import type {
 } from './types.js'
 import type { VM } from './vm.js'
 import type { Block } from '@ethereumjs/block'
-import type {
-  BinaryTreeAccessWitnessInterface,
-  Common,
-  VerkleAccessWitnessInterface,
-} from '@ethereumjs/common'
+import type { Common } from '@ethereumjs/common'
 import type {
   AccessList,
   AccessList2930Tx,

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -203,8 +203,8 @@ export async function runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
 async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   const state = vm.stateManager
 
-  let stateAccesses: VerkleAccessWitnessInterface | BinaryTreeAccessWitnessInterface | undefined
-  let txAccesses: VerkleAccessWitnessInterface | BinaryTreeAccessWitnessInterface | undefined
+  let stateAccesses: VerkleAccessWitness | BinaryTreeAccessWitness | undefined
+  let txAccesses: VerkleAccessWitness | BinaryTreeAccessWitness | undefined
   if (vm.common.isActivatedEIP(6800)) {
     if (vm.evm.verkleAccessWitness === undefined) {
       throw Error(`Verkle access witness needed for execution of verkle blocks`)
@@ -230,7 +230,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     }
     stateAccesses = vm.evm.binaryTreeAccessWitness
     txAccesses = new BinaryTreeAccessWitness({
-      hashFunction: (vm.evm.binaryTreeAccessWitness as BinaryTreeAccessWitness).hashFunction,
+      hashFunction: vm.evm.binaryTreeAccessWitness.hashFunction,
     })
   }
 
@@ -610,9 +610,9 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   })) as RunTxResult
 
   if (vm.common.isActivatedEIP(6800)) {
-    stateAccesses?.merge(
-      txAccesses! as VerkleAccessWitnessInterface & BinaryTreeAccessWitnessInterface,
-    )
+    ;(stateAccesses as VerkleAccessWitness)?.merge(txAccesses! as VerkleAccessWitness)
+  } else if (vm.common.isActivatedEIP(7864)) {
+    ;(stateAccesses as BinaryTreeAccessWitness)?.merge(txAccesses! as BinaryTreeAccessWitness)
   }
 
   if (enableProfiler) {


### PR DESCRIPTION
Various fixes related `binarytree` and `StatefulBinaryStateManager`
 
- Updated `evm`/`vm` to use the correct state manager if EIP 7864 is active
- Add `BinaryTreeAccessWitness` as optional property on `EVM`
- Fix bug in `createBinaryProof` where the whole key (instead of just the stem) was being passed to `findPath`