### PR TITLE
RLP: Move EthereumJSError form util to RLP and start using EthereumJSError in RLP

### DIFF
--- a/config/eslint.config.mjs
+++ b/config/eslint.config.mjs
@@ -157,7 +157,7 @@ export default [
     },
   },
   {
-    files: ['packages/devp2p/src/ext/**', 'packages/client/src/ext/**', 'packages/rlp/**', '**/test/**/*.ts',],
+    files: ['packages/devp2p/src/ext/**', 'packages/client/src/ext/**', '**/test/**/*.ts',],
     rules: {
       'no-restricted-syntax': 'off'
     },

--- a/packages/rlp/eslint.config.mjs
+++ b/packages/rlp/eslint.config.mjs
@@ -12,7 +12,6 @@ export default [
   {
     rules: {
       '@typescript-eslint/no-use-before-define': 'off',
-      'no-restricted-syntax': 'off',
     },
   },
   {

--- a/packages/rlp/src/errors.ts
+++ b/packages/rlp/src/errors.ts
@@ -1,0 +1,57 @@
+/**
+ * Generic EthereumJS error class with metadata attached
+ *
+ * Kudos to https://github.com/ChainSafe/lodestar monorepo
+ * for the inspiration :-)
+ * See: https://github.com/ChainSafe/lodestar/blob/unstable/packages/utils/src/errors.ts
+ */
+export type EthereumJSErrorMetaData = Record<string, string | number | null>
+export type EthereumJSErrorObject = {
+  message: string
+  stack: string
+  className: string
+  type: EthereumJSErrorMetaData
+}
+
+// In order to update all our errors to use `EthereumJSError`, temporarily include the
+// unset error code. All errors throwing this code should be updated to use the relevant
+// error code.
+export const DEFAULT_ERROR_CODE = 'ETHEREUMJS_DEFAULT_ERROR_CODE'
+
+/**
+ * Generic EthereumJS error with attached metadata
+ */
+export class EthereumJSError<T extends { code: string }> extends Error {
+  type: T
+  constructor(type: T, message?: string, stack?: string) {
+    super(message ?? type.code)
+    this.type = type
+    if (stack !== undefined) this.stack = stack
+  }
+
+  getMetadata(): EthereumJSErrorMetaData {
+    return this.type
+  }
+
+  /**
+   * Get the metadata and the stacktrace for the error.
+   */
+  toObject(): EthereumJSErrorObject {
+    return {
+      type: this.getMetadata(),
+      message: this.message ?? '',
+      stack: this.stack ?? '',
+      className: this.constructor.name,
+    }
+  }
+}
+
+/**
+ * @deprecated Use `EthereumJSError` with a set error code instead
+ * @param message Optional error message
+ * @param stack Optional stack trace
+ * @returns
+ */
+export function EthereumJSErrorWithoutCode(message?: string, stack?: string) {
+  return new EthereumJSError({ code: DEFAULT_ERROR_CODE }, message, stack)
+}

--- a/packages/rlp/src/index.ts
+++ b/packages/rlp/src/index.ts
@@ -1,3 +1,5 @@
+export * from './errors.ts'
+
 export type Input = string | number | bigint | Uint8Array | Array<Input> | null | undefined
 
 export type NestedUint8Array = Array<Uint8Array | NestedUint8Array>

--- a/packages/rlp/src/index.ts
+++ b/packages/rlp/src/index.ts
@@ -1,3 +1,5 @@
+import { EthereumJSErrorWithoutCode } from './errors.ts'
+
 export * from './errors.ts'
 
 export type Input = string | number | bigint | Uint8Array | Array<Input> | null | undefined
@@ -15,7 +17,7 @@ export interface Decoded {
  */
 function decodeLength(v: Uint8Array): number {
   if (v[0] === 0) {
-    throw new Error('invalid RLP: extra zeros')
+    throw EthereumJSErrorWithoutCode('invalid RLP: extra zeros')
   }
   return parseHexByte(bytesToHex(v))
 }
@@ -39,7 +41,9 @@ function encodeLength(len: number, offset: number): Uint8Array {
  */
 function safeSlice(input: Uint8Array, start: number, end: number) {
   if (end > input.length) {
-    throw new Error('invalid RLP (safeSlice): end slice of Uint8Array out-of-bounds')
+    throw EthereumJSErrorWithoutCode(
+      'invalid RLP (safeSlice): end slice of Uint8Array out-of-bounds',
+    )
   }
   return input.slice(start, end)
 }
@@ -69,7 +73,9 @@ function _decode(input: Uint8Array): Decoded {
     }
 
     if (length === 2 && data[0] < 0x80) {
-      throw new Error('invalid RLP encoding: invalid prefix, single byte < 0x80 are not prefixed')
+      throw EthereumJSErrorWithoutCode(
+        'invalid RLP encoding: invalid prefix, single byte < 0x80 are not prefixed',
+      )
     }
 
     return {
@@ -81,11 +87,11 @@ function _decode(input: Uint8Array): Decoded {
     // followed by the length, followed by the string
     lLength = firstByte - 0xb6
     if (input.length - 1 < lLength) {
-      throw new Error('invalid RLP: not enough bytes for string length')
+      throw EthereumJSErrorWithoutCode('invalid RLP: not enough bytes for string length')
     }
     length = decodeLength(safeSlice(input, 1, lLength))
     if (length <= 55) {
-      throw new Error('invalid RLP: expected string length to be greater than 55')
+      throw EthereumJSErrorWithoutCode('invalid RLP: expected string length to be greater than 55')
     }
     data = safeSlice(input, lLength, length + lLength)
 
@@ -112,11 +118,11 @@ function _decode(input: Uint8Array): Decoded {
     lLength = firstByte - 0xf6
     length = decodeLength(safeSlice(input, 1, lLength))
     if (length < 56) {
-      throw new Error('invalid RLP: encoded list too short')
+      throw EthereumJSErrorWithoutCode('invalid RLP: encoded list too short')
     }
     const totalLength = lLength + length
     if (totalLength > input.length) {
-      throw new Error('invalid RLP: total length is larger than the data')
+      throw EthereumJSErrorWithoutCode('invalid RLP: total length is larger than the data')
     }
 
     innerRemainder = safeSlice(input, lLength, totalLength)
@@ -146,7 +152,7 @@ function bytesToHex(uint8a: Uint8Array): string {
 
 function parseHexByte(hexByte: string): number {
   const byte = Number.parseInt(hexByte, 16)
-  if (Number.isNaN(byte)) throw new Error('Invalid byte sequence')
+  if (Number.isNaN(byte)) throw EthereumJSErrorWithoutCode('Invalid byte sequence')
   return byte
 }
 
@@ -165,17 +171,21 @@ function asciiToBase16(char: number): number | undefined {
  */
 export function hexToBytes(hex: string): Uint8Array {
   if (hex.slice(0, 2) === '0x') hex = hex.slice(0, 2)
-  if (typeof hex !== 'string') throw new Error('hex string expected, got ' + typeof hex)
+  if (typeof hex !== 'string')
+    throw EthereumJSErrorWithoutCode('hex string expected, got ' + typeof hex)
   const hl = hex.length
   const al = hl / 2
-  if (hl % 2) throw new Error('padded hex string expected, got unpadded hex of length ' + hl)
+  if (hl % 2)
+    throw EthereumJSErrorWithoutCode('padded hex string expected, got unpadded hex of length ' + hl)
   const array = new Uint8Array(al)
   for (let ai = 0, hi = 0; ai < al; ai++, hi += 2) {
     const n1 = asciiToBase16(hex.charCodeAt(hi))
     const n2 = asciiToBase16(hex.charCodeAt(hi + 1))
     if (n1 === undefined || n2 === undefined) {
       const char = hex[hi] + hex[hi + 1]
-      throw new Error('hex string expected, got non-hex character "' + char + '" at index ' + hi)
+      throw EthereumJSErrorWithoutCode(
+        'hex string expected, got non-hex character "' + char + '" at index ' + hi,
+      )
     }
     array[ai] = n1 * 16 + n2
   }
@@ -206,7 +216,7 @@ function utf8ToBytes(utf: string): Uint8Array {
 /** Transform an integer into its hexadecimal value */
 function numberToHex(integer: number | bigint): string {
   if (integer < 0) {
-    throw new Error('Invalid integer as argument, must be unsigned!')
+    throw EthereumJSErrorWithoutCode('Invalid integer as argument, must be unsigned!')
   }
   const hex = integer.toString(16)
   return hex.length % 2 ? `0${hex}` : hex
@@ -250,7 +260,7 @@ function toBytes(v: Input): Uint8Array {
   if (v === null || v === undefined) {
     return Uint8Array.from([])
   }
-  throw new Error('toBytes: received unsupported type ' + typeof v)
+  throw EthereumJSErrorWithoutCode('toBytes: received unsupported type ' + typeof v)
 }
 
 /**
@@ -301,7 +311,7 @@ export function decode(input: Input, stream = false): Uint8Array | NestedUint8Ar
     }
   }
   if (decoded.remainder.length !== 0) {
-    throw new Error('invalid RLP: remainder must be zero')
+    throw EthereumJSErrorWithoutCode('invalid RLP: remainder must be zero')
   }
 
   return decoded.data

--- a/packages/util/src/errors.ts
+++ b/packages/util/src/errors.ts
@@ -1,59 +1,17 @@
-/**
- * Generic EthereumJS error class with metadata attached
- *
- * Kudos to https://github.com/ChainSafe/lodestar monorepo
- * for the inspiration :-)
- * See: https://github.com/ChainSafe/lodestar/blob/unstable/packages/utils/src/errors.ts
- */
-export type EthereumJSErrorMetaData = Record<string, string | number | null>
-export type EthereumJSErrorObject = {
-  message: string
-  stack: string
-  className: string
-  type: EthereumJSErrorMetaData
-}
+import {
+  DEFAULT_ERROR_CODE,
+  EthereumJSError,
+  type EthereumJSErrorMetaData,
+  type EthereumJSErrorObject,
+  EthereumJSErrorWithoutCode,
+} from '@ethereumjs/rlp'
 
-// In order to update all our errors to use `EthereumJSError`, temporarily include the
-// unset error code. All errors throwing this code should be updated to use the relevant
-// error code.
-export const DEFAULT_ERROR_CODE = 'ETHEREUMJS_DEFAULT_ERROR_CODE'
-
-/**
- * Generic EthereumJS error with attached metadata
- */
-export class EthereumJSError<T extends { code: string }> extends Error {
-  type: T
-  constructor(type: T, message?: string, stack?: string) {
-    super(message ?? type.code)
-    this.type = type
-    if (stack !== undefined) this.stack = stack
-  }
-
-  getMetadata(): EthereumJSErrorMetaData {
-    return this.type
-  }
-
-  /**
-   * Get the metadata and the stacktrace for the error.
-   */
-  toObject(): EthereumJSErrorObject {
-    return {
-      type: this.getMetadata(),
-      message: this.message ?? '',
-      stack: this.stack ?? '',
-      className: this.constructor.name,
-    }
-  }
-}
-
-/**
- * @deprecated Use `EthereumJSError` with a set error code instead
- * @param message Optional error message
- * @param stack Optional stack trace
- * @returns
- */
-export function EthereumJSErrorWithoutCode(message?: string, stack?: string) {
-  return new EthereumJSError({ code: DEFAULT_ERROR_CODE }, message, stack)
+export {
+  DEFAULT_ERROR_CODE,
+  EthereumJSError,
+  EthereumJSErrorWithoutCode,
+  type EthereumJSErrorMetaData,
+  type EthereumJSErrorObject,
 }
 
 // Below here: specific monorepo-wide errors (examples and commented out)


### PR DESCRIPTION
This should be minimal impact, definitions of EthereumJSError is now in RLP, and re-exported from util. Also added the linter rules to RLP. 

Let's see if this works. It will slightly increase the RLP package size because we have the EthereumJSError definition but this is (obviously) less impact than making RLP depend on util. 