### PR TITLE
Fix Ethash tests

### DIFF
--- a/packages/ethash/test/miner.spec.ts
+++ b/packages/ethash/test/miner.spec.ts
@@ -75,7 +75,7 @@ describe('Miner', () => {
     const blockMiner = e.getMiner(block)
     const blockSolution = <Block>await blockMiner.mine(-1)
 
-    assert.isTrue(e.verifyPOW(blockSolution))
+    assert.isTrue(await e.verifyPOW(blockSolution))
   }, 60000)
 
   it('Check if it is possible to stop the miner', async () => {


### PR DESCRIPTION
Ethash tests do not run on a PR push, but they do run in the nightly runs which fail https://github.com/ethereumjs/ethereumjs-monorepo/actions/runs/13937007049. The eslint update https://github.com/ethereumjs/ethereumjs-monorepo/commit/5b81492d5fe6f70ab8f597b667beae28162b7b78 has shown that the test has been wrong the entire time: without `await`ing the method, it will return a `Promise`, which is truthy (so `.ok` is fine, which was before the commit/PR above). However, it is not equal to `true` (so `isTrue` will throw) which is why the nightly tests now fail.

The question is: why is this not caught by the linter? It is clearly a floating promise.

To test (this is not done on CI) one can test it locally to `npm run test` in the ethash package.