### PR TITLE
EIP 7702 authority list signing utilities

### DIFF
--- a/packages/tx/examples/setEOATx.ts
+++ b/packages/tx/examples/setEOATx.ts
@@ -1,0 +1,49 @@
+/**
+ * This example shows how to initialize an EIP-7702 (Set EOA account code) transaction
+ * WARNING: do NOT try this or sign this with any keys which have any value on any network
+ * This is for educational purposes only.
+ */
+
+// This example will show how to self-delegate a fresh EOA account to the address `0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+// In the same transaction, it will also delegate another account to address `0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`
+// It will self-delegate. Note that in a 7702-tx, you are free to include any authorization item.
+// If the authorization item is valid (it has the correct nonce, and matches the chainId (or the chainId is 0))
+// then it will delegate the code of the account **who signed that authorization item** to the address in that authority item
+import {
+  authorizationListBytesItemToJSON,
+  createEOACode7702Tx,
+  signAuthorization,
+} from '@ethereumjs/tx'
+import { Address, privateToAddress } from '@ethereumjs/util'
+
+const privateKey = new Uint8Array(32).fill(0x20)
+const privateKeyOther = new Uint8Array(32).fill(0x99)
+
+const myAddress = new Address(privateToAddress(privateKey))
+
+const unsignedAuthorizationListItemSelf = {
+  chainId: '0x1337', // This delegation will only work on the chain with chainId 0x1337
+  address: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  nonce: '0x01', // Since we are self-delegating we need account for the nonce being bumped of the account
+}
+const signedSelf = signAuthorization(unsignedAuthorizationListItemSelf, privateKey)
+// To convert the bytes array to a human-readable form, use `authorizationListBytesItemToJSON`
+console.log(authorizationListBytesItemToJSON(signedSelf))
+
+const unsignedAuthorizationListItemOther = {
+  chainId: '0x', // The chainId 0 is special: this authorization will work on any chain which supports EIP-7702
+  address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  nonce: '0x',
+}
+const signedOther = signAuthorization(unsignedAuthorizationListItemOther, privateKeyOther)
+
+const authorizationList = [signedSelf, signedOther]
+
+const unsignedTx = createEOACode7702Tx({
+  authorizationList,
+  to: myAddress, // Call into self, so call as own address into `0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`
+})
+
+const signed = unsignedTx.sign(privateKey)
+
+console.log(signed.toJSON())

--- a/packages/tx/src/7702/tx.ts
+++ b/packages/tx/src/7702/tx.ts
@@ -39,8 +39,8 @@ import type {
 } from '../types.ts'
 import { accessListBytesToJSON, accessListJSONToBytes } from '../util/access.ts'
 import {
-  authorizationListBytesToJSON,
-  authorizationListJSONToBytes,
+  authorizationListBytesItemToJSON,
+  authorizationListJSONItemToBytes,
 } from '../util/authorization.ts'
 
 export type TxData = AllTypesTxData[typeof TransactionType.EOACodeEIP7702]
@@ -125,7 +125,7 @@ export class EOACode7702Tx implements TransactionInterface<typeof TransactionTyp
 
     // Populate the authority list fields
     this.authorizationList = isAuthorizationList(authorizationList)
-      ? authorizationListJSONToBytes(authorizationList)
+      ? authorizationList.map((item) => authorizationListJSONItemToBytes(item))
       : authorizationList
     // Verify the authority list format.
     EIP7702.verifyAuthorizationList(this)
@@ -364,7 +364,9 @@ export class EOACode7702Tx implements TransactionInterface<typeof TransactionTyp
    */
   toJSON(): JSONTx {
     const accessListJSON = accessListBytesToJSON(this.accessList)
-    const authorizationList = authorizationListBytesToJSON(this.authorizationList)
+    const authorizationList = this.authorizationList.map((item) =>
+      authorizationListBytesItemToJSON(item),
+    )
 
     const baseJSON = getBaseJSON(this)
 

--- a/packages/tx/src/constants.ts
+++ b/packages/tx/src/constants.ts
@@ -1,4 +1,6 @@
-/** EIP4844 constants */
+/** EIP-4844 constants */
+
+import { hexToBytes } from '@ethereumjs/util'
 
 export const MAX_CALLDATA_SIZE = 16777216 // 2 ** 24
 export const MAX_ACCESS_LIST_SIZE = 16777216 // 2 ** 24
@@ -6,3 +8,7 @@ export const MAX_VERSIONED_HASHES_LIST_SIZE = 16777216 // 2 ** 24
 export const MAX_TX_WRAP_KZG_COMMITMENTS = 16777216 // 2 ** 24
 export const FIELD_ELEMENTS_PER_BLOB = 4096 // This is also in the Common 4844 parameters but needed here since types can't access Common params
 export const BYTES_PER_FIELD_ELEMENT = 32
+
+/** EIP-7702 constants */
+
+export const AUTHORITY_SIGNING_MAGIC = hexToBytes('0x05')

--- a/packages/tx/src/index.ts
+++ b/packages/tx/src/index.ts
@@ -20,6 +20,4 @@ export {
 export * from './types.ts'
 
 // Utils
-export * from './util/general.ts'
-export * from './util/access.ts'
-export * from './util/authorization.ts'
+export * from './util/index.ts'

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -609,14 +609,17 @@ export type AccessList = AccessListItem[]
 /**
  * Authorization list types
  */
-export type AuthorizationListItem = {
+export type AuthorizationListItemUnsigned = {
   chainId: PrefixedHexString
   address: PrefixedHexString
   nonce: PrefixedHexString
+}
+
+export type AuthorizationListItem = {
   yParity: PrefixedHexString
   r: PrefixedHexString
   s: PrefixedHexString
-}
+} & AuthorizationListItemUnsigned
 
 // Tuple of [chain_id, address, [nonce], y_parity, r, s]
 export type AuthorizationListBytesItem = [
@@ -629,3 +632,5 @@ export type AuthorizationListBytesItem = [
 ]
 export type AuthorizationListBytes = AuthorizationListBytesItem[]
 export type AuthorizationList = AuthorizationListItem[]
+
+export type AuthorizationListBytesItemUnsigned = [Uint8Array, Uint8Array, Uint8Array]

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -610,15 +610,17 @@ export type AccessList = AccessListItem[]
  * Authorization list types
  */
 export type AuthorizationListItemUnsigned = {
-  chainId: PrefixedHexString
-  address: PrefixedHexString
-  nonce: PrefixedHexString
+  // Note: these are `PrefixedHexString`s
+  chainId: string
+  address: string
+  nonce: string
 }
 
 export type AuthorizationListItem = {
-  yParity: PrefixedHexString
-  r: PrefixedHexString
-  s: PrefixedHexString
+  // Note: these are `PrefixedHexString`s
+  yParity: string
+  r: string
+  s: string
 } & AuthorizationListItemUnsigned
 
 // Tuple of [chain_id, address, [nonce], y_parity, r, s]

--- a/packages/tx/src/util/authorization.ts
+++ b/packages/tx/src/util/authorization.ts
@@ -133,7 +133,8 @@ export function signAuthorization(
     chainId,
     address,
     nonce,
-    bigIntToUnpaddedBytes(signed.v),
+    // Note: @ethereumjs/util ecsign adds 27 to the `v` (recovery bit / yParity) value, so we subtract it here
+    bigIntToUnpaddedBytes(signed.v - BigInt(27)),
     unpadBytes(signed.r),
     unpadBytes(signed.s),
   ]

--- a/packages/tx/src/util/authorization.ts
+++ b/packages/tx/src/util/authorization.ts
@@ -7,6 +7,7 @@ import {
   bigIntToUnpaddedBytes,
   bytesToBigInt,
   bytesToHex,
+  concatBytes,
   ecrecover,
   ecsign,
   hexToBytes,
@@ -94,10 +95,13 @@ export function authorizationMessageToSign(
     if (address.length !== 20) {
       throw EthereumJSErrorWithoutCode('Cannot sign authority: address length should be 20 bytes')
     }
-    return RLP.encode([AUTHORITY_SIGNING_MAGIC, unpadBytes(chainId), address, unpadBytes(nonce)])
+    return concatBytes(
+      AUTHORITY_SIGNING_MAGIC,
+      RLP.encode([unpadBytes(chainId), address, unpadBytes(nonce)]),
+    )
   } else {
     const [chainId, address, nonce] = unsignedAuthorizationListToBytes(input)
-    return RLP.encode([AUTHORITY_SIGNING_MAGIC, chainId, address, nonce])
+    return concatBytes(AUTHORITY_SIGNING_MAGIC, RLP.encode([chainId, address, nonce]))
   }
 }
 

--- a/packages/tx/src/util/authorization.ts
+++ b/packages/tx/src/util/authorization.ts
@@ -126,7 +126,7 @@ export function authorizationHashedMessageToSign(
 export function signAuthorization(
   input: AuthorizationListItemUnsigned | AuthorizationListBytesItemUnsigned,
   privateKey: Uint8Array,
-) {
+): AuthorizationListBytesItem {
   const msgHash = authorizationHashedMessageToSign(input)
   const signed = ecsign(msgHash, privateKey)
   const [chainId, address, nonce] = Array.isArray(input)

--- a/packages/tx/src/util/index.ts
+++ b/packages/tx/src/util/index.ts
@@ -1,3 +1,4 @@
+// Do not add `./internal.ts`, this will export the internal helpers also at package level
 export * from './general.ts'
 export * from './access.ts'
 export * from './authorization.ts'

--- a/packages/tx/test/util/authorization.spec.ts
+++ b/packages/tx/test/util/authorization.spec.ts
@@ -1,0 +1,106 @@
+import { RLP } from '@ethereumjs/rlp'
+import {
+  Address,
+  type PrefixedHexString,
+  concatBytes,
+  equalsBytes,
+  hexToBytes,
+} from '@ethereumjs/util'
+import { keccak256 } from 'ethereum-cryptography/keccak'
+import { assert, describe, it } from 'vitest'
+import { AUTHORITY_SIGNING_MAGIC } from '../../src/constants.ts'
+import {
+  type AuthorizationListBytesItemUnsigned,
+  type AuthorizationListItem,
+  type AuthorizationListItemUnsigned,
+  authorizationHashedMessageToSign,
+  authorizationListBytesItemToJSON,
+  authorizationListJSONItemToBytes,
+  authorizationMessageToSign,
+  recoverAuthority,
+  signAuthorization,
+} from '../../src/index.ts'
+
+// Taken from execution-spec-tests (tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_address_from_set_code)
+const SAMPLE_AUTH = {
+  chainId: '0x',
+  address: '0x0000000000000000000000000000000000001000',
+  nonce: '0x',
+  yParity: '0x',
+  r: '0xdbcff17ff6c249f13b334fa86bcbaa1afd9f566ca9b06e4ea5fab9bdde9a9202',
+  s: '0x5c34c9d8af5b20e4a425fc1daf2d9d484576857eaf1629145b4686bac733868e',
+}
+// RLP-encoded bytes of above sample
+const EXPECTED_RLP_BYTES = hexToBytes(
+  '0xf85a809400000000000000000000000000000000000010008080a0dbcff17ff6c249f13b334fa86bcbaa1afd9f566ca9b06e4ea5fab9bdde9a9202a05c34c9d8af5b20e4a425fc1daf2d9d484576857eaf1629145b4686bac733868e',
+)
+
+// Taken from execution-spec-tests (`TestAddress`)
+const PRIVATE_KEY = hexToBytes('0x45A915E4D060149EB4365960E6A7A45F334393093061116B197E3240065FF2D8')
+const EXPECTED_SIGNER = new Address(hexToBytes('0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b'))
+
+describe('Authorization lists', () => {
+  const item = authorizationListJSONItemToBytes(SAMPLE_AUTH as AuthorizationListItem)
+  const [chainId, address, nonce] = item
+  const unsignedBytesItem: AuthorizationListBytesItemUnsigned = [chainId, address, nonce]
+  const unsignedJSONItem: AuthorizationListItemUnsigned = {
+    chainId: SAMPLE_AUTH.chainId as PrefixedHexString,
+    address: SAMPLE_AUTH.address as PrefixedHexString,
+    nonce: SAMPLE_AUTH.nonce as PrefixedHexString,
+  }
+
+  it('authorizationMessageToSign() / authorizationHashedMessageToSign()', () => {
+    const expected = concatBytes(AUTHORITY_SIGNING_MAGIC, RLP.encode([chainId, address, nonce]))
+
+    assert.isTrue(
+      equalsBytes(authorizationMessageToSign(unsignedBytesItem), expected),
+      'msg to sign ok: bytes',
+    )
+    assert.isTrue(
+      equalsBytes(authorizationMessageToSign(unsignedJSONItem), expected),
+      'msg to sign ok: json',
+    )
+
+    const expectedHash = keccak256(expected)
+    assert.isTrue(
+      equalsBytes(authorizationHashedMessageToSign(unsignedBytesItem), expectedHash),
+      'hashed msg to sign ok: bytes',
+    )
+    assert.isTrue(
+      equalsBytes(authorizationHashedMessageToSign(unsignedJSONItem), expectedHash),
+      'hashed msg to sign ok: json',
+    )
+
+    assert.throws(
+      () => {
+        authorizationMessageToSign([new Uint8Array(), new Uint8Array(19), new Uint8Array()])
+      },
+      undefined,
+      undefined,
+      'throws on address not 20 bytes',
+    )
+  })
+
+  it('sign() / recoverAuthority()', () => {
+    const signedFromBytes = signAuthorization(unsignedBytesItem, PRIVATE_KEY)
+    const signedFromJSON = signAuthorization(unsignedJSONItem, PRIVATE_KEY)
+
+    const signedFromBytesRLP = RLP.encode(signedFromBytes)
+    const signedFromJSONRLP = RLP.encode(signedFromJSON)
+
+    assert.isTrue(equalsBytes(signedFromBytesRLP, EXPECTED_RLP_BYTES), 'signed ok: bytes')
+    assert.isTrue(equalsBytes(signedFromJSONRLP, EXPECTED_RLP_BYTES), 'signed ok: json')
+
+    assert.deepEqual(
+      authorizationListBytesItemToJSON(signedFromBytes),
+      SAMPLE_AUTH,
+      'json conversion matches expected json',
+    )
+
+    const recoveredBytesAddress = recoverAuthority(signedFromBytes)
+    const recoveredJSONAddress = recoverAuthority(SAMPLE_AUTH as AuthorizationListItem)
+
+    assert.isTrue(EXPECTED_SIGNER.equals(recoveredBytesAddress), 'bytes: recovered corerct signer')
+    assert.isTrue(EXPECTED_SIGNER.equals(recoveredJSONAddress), 'json: recovered corerct signer')
+  })
+})

--- a/packages/tx/test/util/authorization.spec.ts
+++ b/packages/tx/test/util/authorization.spec.ts
@@ -85,11 +85,11 @@ describe('Authorization lists', () => {
     const signedFromBytes = signAuthorization(unsignedBytesItem, PRIVATE_KEY)
     const signedFromJSON = signAuthorization(unsignedJSONItem, PRIVATE_KEY)
 
-    const signedFromBytesRLP = RLP.encode(signedFromBytes)
-    const signedFromJSONRLP = RLP.encode(signedFromJSON)
+    const signedFromBytes_RLP = RLP.encode(signedFromBytes)
+    const signedFromJSON_RLP = RLP.encode(signedFromJSON)
 
-    assert.isTrue(equalsBytes(signedFromBytesRLP, EXPECTED_RLP_BYTES), 'signed ok: bytes')
-    assert.isTrue(equalsBytes(signedFromJSONRLP, EXPECTED_RLP_BYTES), 'signed ok: json')
+    assert.isTrue(equalsBytes(signedFromBytes_RLP, EXPECTED_RLP_BYTES), 'signed ok: bytes')
+    assert.isTrue(equalsBytes(signedFromJSON_RLP, EXPECTED_RLP_BYTES), 'signed ok: json')
 
     assert.deepEqual(
       authorizationListBytesItemToJSON(signedFromBytes),
@@ -100,7 +100,7 @@ describe('Authorization lists', () => {
     const recoveredBytesAddress = recoverAuthority(signedFromBytes)
     const recoveredJSONAddress = recoverAuthority(SAMPLE_AUTH as AuthorizationListItem)
 
-    assert.isTrue(EXPECTED_SIGNER.equals(recoveredBytesAddress), 'bytes: recovered corerct signer')
-    assert.isTrue(EXPECTED_SIGNER.equals(recoveredJSONAddress), 'json: recovered corerct signer')
+    assert.isTrue(EXPECTED_SIGNER.equals(recoveredBytesAddress), 'bytes: recovered correct signer')
+    assert.isTrue(EXPECTED_SIGNER.equals(recoveredJSONAddress), 'json: recovered correct signer')
   })
 })

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -1,13 +1,12 @@
 import { cliqueSigner, createBlockHeader } from '@ethereumjs/block'
 import { ConsensusType, Hardfork } from '@ethereumjs/common'
 import { BinaryTreeAccessWitness, type EVM, VerkleAccessWitness } from '@ethereumjs/evm'
-import { RLP } from '@ethereumjs/rlp'
 import {
   StatefulBinaryTreeStateManager,
   StatefulVerkleStateManager,
   StatelessVerkleStateManager,
 } from '@ethereumjs/statemanager'
-import { Capability, isBlob4844Tx } from '@ethereumjs/tx'
+import { Capability, isBlob4844Tx, recoverAuthority } from '@ethereumjs/tx'
 import {
   Account,
   Address,
@@ -22,14 +21,11 @@ import {
   bytesToHex,
   bytesToUnprefixedHex,
   concatBytes,
-  ecrecover,
   equalsBytes,
   hexToBytes,
-  publicToAddress,
   short,
 } from '@ethereumjs/util'
 import debugDefault from 'debug'
-import { keccak256 } from 'ethereum-cryptography/keccak.js'
 
 import { Bloom } from './bloom/index.ts'
 import { emitEVMProfile } from './emitEVMProfile.ts'
@@ -481,7 +477,6 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   if (tx.supports(Capability.EIP7702EOACode)) {
     // Add contract code for authority tuples provided by EIP 7702 tx
     const authorizationList = (<EIP7702CompatibleTx>tx).authorizationList
-    const MAGIC = new Uint8Array([5])
     for (let i = 0; i < authorizationList.length; i++) {
       // Authority tuple validation
       const data = authorizationList[i]
@@ -512,19 +507,14 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
         continue
       }
 
-      const r = data[4]
-
-      const rlpdSignedMessage = RLP.encode([chainId, address, nonce])
-      const toSign = keccak256(concatBytes(MAGIC, rlpdSignedMessage))
-      let pubKey
+      // Address to set code to
+      let authority
       try {
-        pubKey = ecrecover(toSign, yParity, r, s)
+        authority = recoverAuthority(data)
       } catch {
         // Invalid signature, continue
         continue
       }
-      // Address to set code to
-      const authority = new Address(publicToAddress(pubKey))
       const accountMaybeUndefined = await vm.stateManager.getAccount(authority)
       const accountExists = accountMaybeUndefined !== undefined
       const account = accountMaybeUndefined ?? new Account()


### PR DESCRIPTION
Closes #3929

WIP

TODO:

- [x] Integrate these utility methods in `vm/runTx`
- [x] Add example to show how to init a 7702 tx
- [x] Add tests
- [x] Change `authorizationListJSONToBytes` to no work on `authorizationListItem[]` but instead work on `authorizationListItem`, because now there is this awkward `authorizationListJSONToBytes([item])[0]` to convert an element. Also for Bytes -> JSON
- [x] Add https://github.com/ethereumjs/ethereumjs-monorepo/pull/3890#discussion_r2010801841