### PR TITLE
Fix 7702 gas calculation

### DIFF
--- a/packages/tx/src/capabilities/eip2930.ts
+++ b/packages/tx/src/capabilities/eip2930.ts
@@ -7,7 +7,8 @@ import type { EIP2930CompatibleTx } from '../types.ts'
  * The amount of gas paid for the data in this tx
  */
 export function getDataGas(tx: EIP2930CompatibleTx): bigint {
-  return Legacy.getDataGas(tx, BigInt(getAccessListDataGas(tx)))
+  const eip2930Gas = BigInt(getAccessListDataGas(tx))
+  return Legacy.getDataGas(tx) + eip2930Gas
 }
 
 /**

--- a/packages/tx/src/capabilities/eip7702.ts
+++ b/packages/tx/src/capabilities/eip7702.ts
@@ -1,5 +1,4 @@
 import * as EIP2930 from './eip2930.ts'
-import * as Legacy from './legacy.ts'
 
 import {
   EthereumJSErrorWithoutCode,
@@ -14,11 +13,11 @@ import type { EIP7702CompatibleTx } from '../types.ts'
  * The amount of gas paid for the data in this tx
  */
 export function getDataGas(tx: EIP7702CompatibleTx): bigint {
-  const eip2930Cost = BigInt(EIP2930.getDataGas(tx))
+  const eip2930Cost = EIP2930.getDataGas(tx)
   const eip7702Cost = BigInt(
     tx.authorizationList.length * Number(tx.common.param('perEmptyAccountCost')),
   )
-  return Legacy.getDataGas(tx, eip2930Cost + eip7702Cost)
+  return eip2930Cost + eip7702Cost
 }
 
 /**

--- a/packages/tx/src/capabilities/legacy.ts
+++ b/packages/tx/src/capabilities/legacy.ts
@@ -33,7 +33,7 @@ export function isSigned(tx: LegacyTxInterface): boolean {
 /**
  * The amount of gas paid for the data in this tx
  */
-export function getDataGas(tx: LegacyTxInterface, extraCost?: bigint): bigint {
+export function getDataGas(tx: LegacyTxInterface): bigint {
   if (tx.cache.dataFee && tx.cache.dataFee.hardfork === tx.common.hardfork()) {
     return tx.cache.dataFee.value
   }
@@ -41,7 +41,7 @@ export function getDataGas(tx: LegacyTxInterface, extraCost?: bigint): bigint {
   const txDataZero = tx.common.param('txDataZeroGas')
   const txDataNonZero = tx.common.param('txDataNonZeroGas')
 
-  let cost = extraCost ?? BIGINT_0
+  let cost = BIGINT_0
   for (let i = 0; i < tx.data.length; i++) {
     tx.data[i] === 0 ? (cost += txDataZero) : (cost += txDataNonZero)
   }


### PR DESCRIPTION
This PR fixes the gas calculation in 7702. 

It also removes the `extraCost` param from the legacy `getDataGas`, this param has no use, one can just add the `extraCost` to whatever the method returns. 

This PR now passes https://github.com/ethereum/execution-spec-tests/releases/tag/pectra-devnet-6%40v1.0.0

Side note: we need a CI job or a tool which allows us to run these tests on the CI. The CI currently does not run the latest Prague tests.