### PR TITLE
Limit Coverage to src Folders

### DIFF
--- a/config/vitest.config.coverage.istanbul.mts
+++ b/config/vitest.config.coverage.istanbul.mts
@@ -10,6 +10,7 @@ const config = defineConfig({
       enabled: true,
       all: true,
       include: ['src/**'],
+      reportsDirectory: './coverage/istanbul'
     },
   },
   optimizeDeps: {

--- a/config/vitest.config.coverage.istanbul.mts
+++ b/config/vitest.config.coverage.istanbul.mts
@@ -9,6 +9,7 @@ const config = defineConfig({
       provider: 'istanbul',
       enabled: true,
       all: true,
+      include: ['src/**'],
       reporter: ['html'],
     },
   },

--- a/config/vitest.config.coverage.istanbul.mts
+++ b/config/vitest.config.coverage.istanbul.mts
@@ -10,7 +10,6 @@ const config = defineConfig({
       enabled: true,
       all: true,
       include: ['src/**'],
-      reporter: ['html'],
     },
   },
   optimizeDeps: {

--- a/config/vitest.config.coverage.mts
+++ b/config/vitest.config.coverage.mts
@@ -9,6 +9,7 @@ const config = defineConfig({
       enabled: true,
       all: true,
       include: ['src/**'],
+      reportsDirectory: './coverage/v8',
     },
   },
   optimizeDeps: {

--- a/config/vitest.config.coverage.mts
+++ b/config/vitest.config.coverage.mts
@@ -8,6 +8,7 @@ const config = defineConfig({
       provider: 'v8',
       enabled: true,
       all: true,
+      include: ['src/**'],
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
Small config change to limit coverage reporting to only include the `src` folders from packages. Previously also `examples` and `scripts` had been included, which distorts the overall coverage results (see screenshot).

<img width="927" alt="grafik" src="https://github.com/user-attachments/assets/8cc5296c-4175-418f-b5d6-648ef9e48565" />

After:

<img width="953" alt="grafik" src="https://github.com/user-attachments/assets/1e67501a-d90f-4e34-96a1-b650614a7adf" />
