### PR TITLE
chore: add osaka hf to utils

### DIFF
--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -180,6 +180,7 @@ function parseGethParams(json: any) {
     [Hardfork.Shanghai]: { name: 'shanghaiTime', postMerge: true, isTimestamp: true },
     [Hardfork.Cancun]: { name: 'cancunTime', postMerge: true, isTimestamp: true },
     [Hardfork.Prague]: { name: 'pragueTime', postMerge: true, isTimestamp: true },
+    [Hardfork.Osaka]: { name: 'osakaTime', postMerge: true, isTimestamp: true },
     [Hardfork.Verkle]: { name: 'verkleTime', postMerge: true, isTimestamp: true },
   }
 


### PR DESCRIPTION
## 🗒️ Description

Adds the Osaka hard fork to `common/utils`. Required to run `consume engine` EOF tests in hive.