### PR TITLE
Remove `totalDifficulty` from `JSONRPCBlock` type required fields

### DIFF
--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -210,7 +210,6 @@ export interface JSONRPCBlock {
   receiptsRoot: PrefixedHexString // the root of the receipts trie of the block.
   miner: PrefixedHexString // the address of the beneficiary to whom the mining rewards were given.
   difficulty: PrefixedHexString | NumericString // integer of the difficulty for this block. Can be a 0x-prefixed hex string or a string integer
-  totalDifficulty: PrefixedHexString // integer of the total difficulty of the chain until this block.
   extraData: PrefixedHexString // the “extra data” field of this block.
   size: PrefixedHexString // integer the size of this block in bytes.
   gasLimit: PrefixedHexString // the maximum gas allowed in this block.

--- a/packages/block/src/types.ts
+++ b/packages/block/src/types.ts
@@ -210,6 +210,7 @@ export interface JSONRPCBlock {
   receiptsRoot: PrefixedHexString // the root of the receipts trie of the block.
   miner: PrefixedHexString // the address of the beneficiary to whom the mining rewards were given.
   difficulty: PrefixedHexString | NumericString // integer of the difficulty for this block. Can be a 0x-prefixed hex string or a string integer
+  totalDifficulty?: PrefixedHexString // integer of the total difficulty of the chain until this block.
   extraData: PrefixedHexString // the “extra data” field of this block.
   size: PrefixedHexString // integer the size of this block in bytes.
   gasLimit: PrefixedHexString // the maximum gas allowed in this block.


### PR DESCRIPTION
Make `totalDifficulty` field optional in the `JSONRPCBlock` type.

This field is a leftover from pre-merge days and is not even listed as part of the [execution API spec for blocks](https://github.com/ethereum/execution-apis/blob/main/src/schemas/block.yaml) any longer.  We don't use it internally in any of the constructors so there's no reason to require it in the input.