### PR TITLE
util/tx: change ecsign to not add 27 to `v` value

### DIFF
--- a/packages/block/src/consensus/clique.ts
+++ b/packages/block/src/consensus/clique.ts
@@ -153,7 +153,7 @@ export function generateCliqueBlockExtraData(
 
   const ecSignFunction = header.common.customCrypto?.ecsign ?? ecsign
   const signature = ecSignFunction(cliqueSigHash(header), cliqueSigner)
-  const signatureB = concatBytes(signature.r, signature.s, bigIntToBytes(signature.v - BIGINT_27))
+  const signatureB = concatBytes(signature.r, signature.s, bigIntToBytes(signature.v))
 
   const extraDataWithoutSeal = header.extraData.subarray(
     0,

--- a/packages/client/bin/utils.ts
+++ b/packages/client/bin/utils.ts
@@ -15,7 +15,6 @@ import {
   getPresetChainConfig,
 } from '@ethereumjs/common'
 import {
-  BIGINT_2,
   EthereumJSErrorWithoutCode,
   bytesToHex,
   calculateSigRecovery,
@@ -648,23 +647,15 @@ export async function generateClientConfig(args: ClientOpts) {
         ),
       ).slice(1)
     cryptoFunctions.sha256 = wasmSha256
-    cryptoFunctions.ecsign = (
-      msg: Uint8Array,
-      pk: Uint8Array,
-      ecSignOpts: { chainId?: bigint } = {},
-    ) => {
+    cryptoFunctions.ecsign = (msg: Uint8Array, pk: Uint8Array) => {
       if (msg.length < 32) {
         // WASM errors with `unreachable` if we try to pass in less than 32 bytes in the message
         throw EthereumJSErrorWithoutCode('message length must be 32 bytes or greater')
       }
-      const { chainId } = ecSignOpts
       const buf = secp256k1Sign(msg, pk)
       const r = buf.slice(0, 32)
       const s = buf.slice(32, 64)
-      const v =
-        chainId === undefined
-          ? BigInt(buf[64] + 27)
-          : BigInt(buf[64] + 35) + BigInt(chainId) * BIGINT_2
+      const v = BigInt(buf[64])
 
       return { r, s, v }
     }

--- a/packages/client/test/util/wasmCrypto.spec.ts
+++ b/packages/client/test/util/wasmCrypto.spec.ts
@@ -1,7 +1,6 @@
 import { Common, Mainnet } from '@ethereumjs/common'
 import { createLegacyTx } from '@ethereumjs/tx'
 import {
-  BIGINT_2,
   bytesToHex,
   calculateSigRecovery,
   concatBytes,
@@ -66,7 +65,7 @@ describe('WASM crypto tests', () => {
   })
 
   it('should compute the same signature whether js or WASM signature used', async () => {
-    const wasmSign = (msg: Uint8Array, pk: Uint8Array, chainId?: bigint) => {
+    const wasmSign = (msg: Uint8Array, pk: Uint8Array) => {
       if (msg.length < 32) {
         // WASM errors with `unreachable` if we try to pass in less than 32 bytes in the message
         throw new Error('message length must be 32 bytes or greater')
@@ -74,10 +73,7 @@ describe('WASM crypto tests', () => {
       const buf = secp256k1Sign(msg, pk)
       const r = buf.slice(0, 32)
       const s = buf.slice(32, 64)
-      const v =
-        chainId === undefined
-          ? BigInt(buf[64] + 27)
-          : BigInt(buf[64] + 35) + BigInt(chainId) * BIGINT_2
+      const v = BigInt(buf[64])
 
       return { r, s, v }
     }

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -94,7 +94,7 @@ export interface CustomCrypto {
   ecsign?: (
     msg: Uint8Array,
     pk: Uint8Array,
-    ecSignOpts?: { chainId?: bigint; extraEntropy?: Uint8Array | boolean },
+    ecSignOpts?: { extraEntropy?: Uint8Array | boolean },
   ) => ECDSASignature
   ecdsaSign?: (msg: Uint8Array, pk: Uint8Array) => { signature: Uint8Array; recid: number }
   ecdsaRecover?: (sig: Uint8Array, recId: number, hash: Uint8Array) => Uint8Array

--- a/packages/common/test/customCrypto.spec.ts
+++ b/packages/common/test/customCrypto.spec.ts
@@ -24,13 +24,9 @@ describe('[Common]: Custom Crypto', () => {
     return msg
   }
 
-  const customEcSign = (
-    _msg: Uint8Array,
-    _pk: Uint8Array,
-    ecSignOpts?: { chainId?: bigint; extraEntropy?: Uint8Array | boolean },
-  ): ECDSASignature => {
+  const customEcSign = (_msg: Uint8Array, _pk: Uint8Array): ECDSASignature => {
     return {
-      v: ecSignOpts?.chainId ?? 27n,
+      v: 0n,
       r: Uint8Array.from([0, 1, 2, 3]),
       s: Uint8Array.from([0, 1, 2, 3]),
     }
@@ -85,7 +81,6 @@ describe('[Common]: Custom Crypto', () => {
       ecsign: customEcSign,
     }
     const c = new Common({ chain: Mainnet, customCrypto })
-    assert.equal(c.customCrypto.ecsign!(randomBytes(32), randomBytes(32), { chainId: 0n }).v, 0n)
-    assert.equal(c.customCrypto.ecsign!(randomBytes(32), randomBytes(32)).v, 27n)
+    assert.equal(c.customCrypto.ecsign!(randomBytes(32), randomBytes(32)).v, 0n)
   })
 })

--- a/packages/tx/CHANGELOG.md
+++ b/packages/tx/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 10.x.x - UNPUBLISHED
+
+Update transaction test runner to correctly report tests and fix edge case of invalid 7702 txs with nested lists inside the authority list, PR[3942](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3942)
+
 ## 10.0.0-rc.1 - 2025-03-24
 
 This is the first (and likely the last) round of `RC` releases for the upcoming breaking releases, following the `alpha` releases from October 2024. The releases are somewhat delayed (sorry for that), but final releases can now be expected very very soon, to be released once the Ethereum [Pectra](https://eips.ethereum.org/EIPS/eip-7600) hardfork is scheduled for mainnet and all EIPs are fully finalized. Pectra will then also be the default hardfork setting for all EthereumJS libraries.

--- a/packages/tx/src/1559/tx.ts
+++ b/packages/tx/src/1559/tx.ts
@@ -1,6 +1,5 @@
 import {
   BIGINT_0,
-  BIGINT_27,
   EthereumJSErrorWithoutCode,
   MAX_INTEGER,
   bigIntToHex,
@@ -295,12 +294,7 @@ export class FeeMarket1559Tx
     return Legacy.getSenderPublicKey(this)
   }
 
-  addSignature(
-    v: bigint,
-    r: Uint8Array | bigint,
-    s: Uint8Array | bigint,
-    convertV: boolean = false,
-  ): FeeMarket1559Tx {
+  addSignature(v: bigint, r: Uint8Array | bigint, s: Uint8Array | bigint): FeeMarket1559Tx {
     r = toBytes(r)
     s = toBytes(s)
     const opts = { ...this.txOptions, common: this.common }
@@ -316,7 +310,7 @@ export class FeeMarket1559Tx
         value: this.value,
         data: this.data,
         accessList: this.accessList,
-        v: convertV ? v - BIGINT_27 : v, // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
+        v,
         r: bytesToBigInt(r),
         s: bytesToBigInt(s),
       },

--- a/packages/tx/src/2930/tx.ts
+++ b/packages/tx/src/2930/tx.ts
@@ -1,5 +1,4 @@
 import {
-  BIGINT_27,
   EthereumJSErrorWithoutCode,
   MAX_INTEGER,
   bigIntToHex,
@@ -271,12 +270,7 @@ export class AccessList2930Tx
     return Legacy.getSenderPublicKey(this)
   }
 
-  addSignature(
-    v: bigint,
-    r: Uint8Array | bigint,
-    s: Uint8Array | bigint,
-    convertV: boolean = false,
-  ): AccessList2930Tx {
+  addSignature(v: bigint, r: Uint8Array | bigint, s: Uint8Array | bigint): AccessList2930Tx {
     r = toBytes(r)
     s = toBytes(s)
     const opts = { ...this.txOptions, common: this.common }
@@ -291,7 +285,7 @@ export class AccessList2930Tx
         value: this.value,
         data: this.data,
         accessList: this.accessList,
-        v: convertV ? v - BIGINT_27 : v, // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
+        v,
         r: bytesToBigInt(r),
         s: bytesToBigInt(s),
       },

--- a/packages/tx/src/4844/tx.ts
+++ b/packages/tx/src/4844/tx.ts
@@ -1,6 +1,5 @@
 import {
   BIGINT_0,
-  BIGINT_27,
   EthereumJSErrorWithoutCode,
   MAX_INTEGER,
   TypeOutput,
@@ -396,12 +395,7 @@ export class Blob4844Tx implements TransactionInterface<typeof TransactionType.B
     }
   }
 
-  addSignature(
-    v: bigint,
-    r: Uint8Array | bigint,
-    s: Uint8Array | bigint,
-    convertV: boolean = false,
-  ): Blob4844Tx {
+  addSignature(v: bigint, r: Uint8Array | bigint, s: Uint8Array | bigint): Blob4844Tx {
     r = toBytes(r)
     s = toBytes(s)
     const opts = { ...this.txOptions, common: this.common }
@@ -417,7 +411,7 @@ export class Blob4844Tx implements TransactionInterface<typeof TransactionType.B
         value: this.value,
         data: this.data,
         accessList: this.accessList,
-        v: convertV ? v - BIGINT_27 : v, // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
+        v,
         r: bytesToBigInt(r),
         s: bytesToBigInt(s),
         maxFeePerBlobGas: this.maxFeePerBlobGas,

--- a/packages/tx/src/7702/tx.ts
+++ b/packages/tx/src/7702/tx.ts
@@ -1,6 +1,5 @@
 import {
   BIGINT_0,
-  BIGINT_27,
   EthereumJSErrorWithoutCode,
   MAX_INTEGER,
   bigIntToHex,
@@ -329,12 +328,7 @@ export class EOACode7702Tx implements TransactionInterface<typeof TransactionTyp
     return Legacy.getSenderPublicKey(this)
   }
 
-  addSignature(
-    v: bigint,
-    r: Uint8Array | bigint,
-    s: Uint8Array | bigint,
-    convertV: boolean = false,
-  ): EOACode7702Tx {
+  addSignature(v: bigint, r: Uint8Array | bigint, s: Uint8Array | bigint): EOACode7702Tx {
     r = toBytes(r)
     s = toBytes(s)
     const opts = { ...this.txOptions, common: this.common }
@@ -351,7 +345,7 @@ export class EOACode7702Tx implements TransactionInterface<typeof TransactionTyp
         data: this.data,
         accessList: this.accessList,
         authorizationList: this.authorizationList,
-        v: convertV ? v - BIGINT_27 : v, // This looks extremely hacky: @ethereumjs/util actually adds 27 to the value, the recovery bit is either 0 or 1.
+        v,
         r: bytesToBigInt(r),
         s: bytesToBigInt(s),
       },

--- a/packages/tx/src/legacy/tx.ts
+++ b/packages/tx/src/legacy/tx.ts
@@ -1,7 +1,6 @@
 import { RLP } from '@ethereumjs/rlp'
 import {
   BIGINT_2,
-  BIGINT_8,
   EthereumJSErrorWithoutCode,
   MAX_INTEGER,
   bigIntToHex,
@@ -336,12 +335,19 @@ export class LegacyTx implements TransactionInterface<typeof TransactionType.Leg
     v: bigint,
     r: Uint8Array | bigint,
     s: Uint8Array | bigint,
+    // convertV is `true` when called from `sign`
+    // This is used to convert the `v` output from `ecsign` (0 or 1) to the values used for legacy txs:
+    // 27 or 28 for non-EIP-155 protected txs
+    // 35 or 36 + chainId * 2 for EIP-155 protected txs
+    // See: https://eips.ethereum.org/EIPS/eip-155
     convertV: boolean = false,
   ): LegacyTx {
     r = toBytes(r)
     s = toBytes(s)
     if (convertV && this.supports(Capability.EIP155ReplayProtection)) {
-      v += this.common.chainId() * BIGINT_2 + BIGINT_8
+      v += BigInt(35) + this.common.chainId() * BIGINT_2
+    } else if (convertV) {
+      v += BigInt(27)
     }
 
     const opts = { ...this.txOptions, common: this.common }

--- a/packages/tx/src/util/authorization.ts
+++ b/packages/tx/src/util/authorization.ts
@@ -137,8 +137,7 @@ export function signAuthorization(
     chainId,
     address,
     nonce,
-    // Note: @ethereumjs/util ecsign adds 27 to the `v` (recovery bit / yParity) value, so we subtract it here
-    bigIntToUnpaddedBytes(signed.v - BigInt(27)),
+    bigIntToUnpaddedBytes(signed.v),
     unpadBytes(signed.r),
     unpadBytes(signed.s),
   ]

--- a/packages/tx/test/eip1559.spec.ts
+++ b/packages/tx/test/eip1559.spec.ts
@@ -149,7 +149,7 @@ describe('[FeeMarket1559Tx]', () => {
     const { v, r, s } = ecsign(msgHash, privKey, { extraEntropy: false })
 
     const signedTx = tx.sign(privKey)
-    const addSignatureTx = tx.addSignature(v, r, s, true)
+    const addSignatureTx = tx.addSignature(v, r, s)
 
     assert.deepEqual(signedTx.toJSON(), addSignatureTx.toJSON())
   })
@@ -163,7 +163,7 @@ describe('[FeeMarket1559Tx]', () => {
 
     assert.throws(() => {
       // This will throw, since we now try to set either v=27 or v=28
-      tx.addSignature(v, r, s, false)
+      tx.addSignature(v + BigInt(27), r, s)
     })
   })
 

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -70,7 +70,7 @@ describe('EIP4844 addSignature tests', () => {
     const { v, r, s } = ecsign(msgHash, privKey)
 
     const signedTx = tx.sign(privKey)
-    const addSignatureTx = tx.addSignature(v, r, s, true)
+    const addSignatureTx = tx.addSignature(v, r, s)
 
     assert.deepEqual(signedTx.toJSON(), addSignatureTx.toJSON())
   })
@@ -90,7 +90,7 @@ describe('EIP4844 addSignature tests', () => {
 
     assert.throws(() => {
       // This will throw, since we now try to set either v=27 or v=28
-      tx.addSignature(v, r, s, false)
+      tx.addSignature(v + BigInt(27), r, s)
     })
   })
 })

--- a/packages/tx/test/typedTxsAndEIP2930.spec.ts
+++ b/packages/tx/test/typedTxsAndEIP2930.spec.ts
@@ -405,7 +405,7 @@ describe('[AccessList2930Tx / FeeMarket1559Tx] -> EIP-2930 Compatibility', () =>
     const { v, r, s } = ecsign(msgHash, privKey)
 
     const signedTx = tx.sign(privKey)
-    const addSignatureTx = tx.addSignature(v, r, s, true)
+    const addSignatureTx = tx.addSignature(v, r, s)
 
     assert.deepEqual(signedTx.toJSON(), addSignatureTx.toJSON())
   })
@@ -419,7 +419,7 @@ describe('[AccessList2930Tx / FeeMarket1559Tx] -> EIP-2930 Compatibility', () =>
 
     assert.throws(() => {
       // This will throw, since we now try to set either v=27 or v=28
-      tx.addSignature(v, r, s, false)
+      tx.addSignature(v + BigInt(27), r, s)
     })
   })
 

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 (modification: no type change headlines) and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 10.x.x - UNPUBLISHED
+
+- Does not add `27` to the recovery bit `v` value of `ecsign`. Also removes the `chainId` option from extra options, PR [3941](https://github.com/ethereumjs/ethereumjs-monorepo/pull/3941)
+
 ## 10.0.0-rc.1 - 2025-03-24
 
 This is the first (and likely the last) round of `RC` releases for the upcoming breaking releases, following the `alpha` releases from October 2024. The releases are somewhat delayed (sorry for that), but final releases can now be expected very very soon, to be released once the Ethereum [Pectra](https://eips.ethereum.org/EIPS/eip-7600) hardfork is scheduled for mainnet and all EIPs are fully finalized. Pectra will then also be the default hardfork setting for all EthereumJS libraries.

--- a/packages/util/test/signature.spec.ts
+++ b/packages/util/test/signature.spec.ts
@@ -7,7 +7,6 @@ import {
   equalsBytes,
   fromRPCSig,
   hashPersonalMessage,
-  hexToBigInt,
   hexToBytes,
   isValidSignature,
   privateToPublic,
@@ -40,52 +39,7 @@ describe('ecsign', () => {
       sig.s,
       hexToBytes('0x129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66'),
     )
-    assert.equal(sig.v, BigInt(27))
-  })
-
-  it('should produce a deterministic signature for Ropsten testnet', () => {
-    const sig = ecsign(ecHash, ecPrivKey, { chainId })
-    assert.deepEqual(
-      sig.r,
-      hexToBytes('0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9'),
-    )
-    assert.deepEqual(
-      sig.s,
-      hexToBytes('0x129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66'),
-    )
-    assert.equal(sig.v, BigInt(41))
-  })
-
-  it('should produce a deterministic signature for chainId=150', () => {
-    const expectedSigR = hexToBytes(
-      '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9',
-    )
-    const expectedSigS = hexToBytes(
-      '0x129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66',
-    )
-
-    const sig = ecsign(ecHash, ecPrivKey, { chainId: BigInt(150) })
-    assert.deepEqual(sig.r, expectedSigR)
-    assert.deepEqual(sig.s, expectedSigS)
-    assert.equal(sig.v, BigInt(150 * 2 + 35))
-  })
-
-  it('should produce a deterministic signature for a high number chainId greater than MAX_SAFE_INTEGER', () => {
-    const chainIDBigInt = hexToBigInt('0x796f6c6f763378')
-    assert.isTrue(chainIDBigInt > BigInt(Number.MAX_SAFE_INTEGER))
-
-    const expectedSigR = hexToBytes(
-      '0x99e71a99cb2270b8cac5254f9e99b6210c6c10224a1579cf389ef88b20a1abe9',
-    )
-    const expectedSigS = hexToBytes(
-      '0x129ff05af364204442bdb53ab6f18a99ab48acc9326fa689f228040429e3ca66',
-    )
-    const expectedSigV = BigInt('68361967398315795')
-
-    const sigBuffer = ecsign(ecHash, ecPrivKey, { chainId: chainIDBigInt })
-    assert.deepEqual(sigBuffer.r, expectedSigR)
-    assert.deepEqual(sigBuffer.s, expectedSigS)
-    assert.equal(sigBuffer.v, expectedSigV)
+    assert.equal(sig.v, BigInt(0))
   })
 
   it('should produce hedged signatures (extraEntropy=true)', () => {
@@ -95,8 +49,7 @@ describe('ecsign', () => {
   })
 
   it('should produce hedged signatures by default (with provided chainID)', () => {
-    const chainId = BigInt(1337)
-    const sigOpts = { extraEntropy: true, chainId }
+    const sigOpts = { extraEntropy: true }
     const sig = ecsign(ecHash, ecPrivKey, sigOpts)
     const sig2 = ecsign(ecHash, ecPrivKey, sigOpts)
     assert.isFalse(sigCmp(sig, sig2), 'chain id: signatures should be hedged and thus different')
@@ -108,15 +61,6 @@ describe('ecsign', () => {
     const sig = ecsign(ecHash, ecPrivKey, sigOpts)
     const sig2 = ecsign(ecHash, ecPrivKey, sigOpts)
     assert.isTrue(sigCmp(sig, sig2), 'no chain id: signatures should be deterministic')
-  })
-
-  it('should produce deterministic signatures with set extraEntropy (with provided chainID)', () => {
-    const extraEntropy = bigIntToBytes(BigInt(13371337))
-    const chainId = BigInt(1337)
-    const sigOpts = { extraEntropy, chainId }
-    const sig = ecsign(ecHash, ecPrivKey, sigOpts)
-    const sig2 = ecsign(ecHash, ecPrivKey, sigOpts)
-    assert.isTrue(sigCmp(sig, sig2), 'chain id: signatures should be deterministic')
   })
 })
 

--- a/packages/vm/test/api/EIPs/eip-7702.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-7702.spec.ts
@@ -67,7 +67,7 @@ function getAuthorizationListItem(opts: GetAuthListOpts): AuthorizationListBytes
     chainIdBytes,
     addressBytes,
     nonceBytes,
-    bigIntToUnpaddedBytes(signed.v - BigInt(27)),
+    bigIntToUnpaddedBytes(signed.v),
     unpadBytes(signed.r),
     unpadBytes(signed.s),
   ]

--- a/packages/vm/test/api/runBlock.spec.ts
+++ b/packages/vm/test/api/runBlock.spec.ts
@@ -627,7 +627,7 @@ describe('runBlock() -> tx types', async () => {
       const msgToSign = keccak256(concatBytes(new Uint8Array([5]), rlpdMsg))
       const signed = ecsign(msgToSign, pkey)
 
-      const yParity = signed.v === BigInt(27) ? new Uint8Array() : new Uint8Array([1])
+      const yParity = signed.v === BigInt(0) ? new Uint8Array() : new Uint8Array([1])
 
       return [
         chainIdBytes,


### PR DESCRIPTION
Updates `@ethereumjs/util` `ecsign` method:

- Does not add 27 anymore to the recovery bit. This is a weird quirk from legacy txs where the recovery bit (unprotected) is 27 or 28
- Remove the `chainId` property of ecsign (this is used nowhere in our libraries, the place where it *could* have been used is the tx package: legacy txs with EIP-155 protection. It is handled within the package already (so util does not take care of this logic))
