### PR TITLE
Tx: fix transaction tester

### DIFF
--- a/packages/tx/src/capabilities/eip7702.ts
+++ b/packages/tx/src/capabilities/eip7702.ts
@@ -36,6 +36,17 @@ export function verifyAuthorizationList(tx: EIP7702CompatibleTx) {
         'Invalid EIP-7702 transaction: authorization list item should have 6 elements',
       )
     }
+
+    for (const member of item) {
+      // This checks if the `member` is a list, not bytes
+      // This checks that the authority list does not have any embedded lists in it
+      if (Array.isArray(member)) {
+        throw EthereumJSErrorWithoutCode(
+          'Invalid EIP-7702 transaction: authority list element is a list, not bytes',
+        )
+      }
+    }
+
     const [chainId, address, nonce, yParity, r, s] = item
 
     validateNoLeadingZeroes({ yParity, r, s, nonce, chainId })

--- a/packages/tx/test/transactionRunner.spec.ts
+++ b/packages/tx/test/transactionRunner.spec.ts
@@ -62,11 +62,11 @@ describe('TransactionTests', async () => {
       testName: string,
       testData: OfficialTransactionTestData,
     ) => {
-      it(testName, () => {
-        for (const forkName of forkNames) {
-          if (testData.result[forkName] === undefined) {
-            continue
-          }
+      for (const forkName of forkNames) {
+        if (testData.result[forkName] === undefined) {
+          continue
+        }
+        it(`${testName} - [${forkName}]`, () => {
           const forkTestData = testData.result[forkName]
           const shouldBeInvalid = forkTestData.exception !== undefined
 
@@ -103,8 +103,8 @@ describe('TransactionTests', async () => {
             assert.isTrue(senderIsCorrect, 'sender is correct')
             assert.isTrue(hashIsCorrect, 'hash is correct')
           }
-        }
-      }, 120000)
+        }, 120000)
+      }
     },
     fileFilterRegex,
     undefined,


### PR DESCRIPTION
Our current transaction tester is wrong, it passes tests where it should fail. This updates the test runner.

Here are also some txs to test for 7702 (generated with EEST). To run, place the contents of this zip in `ethereum-tests` and then change the lines in `transactionRunner.spec.ts` from

```
    fileFilterRegex,
    undefined,
    'TransactionTests',
  )
```

to

```
    fileFilterRegex,
    undefined,
    'txs',
  )
```


[txs.zip](https://github.com/user-attachments/files/19480417/txs.zip)
