### PR TITLE
Use `src/**/*.ts` when developing locally

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -140,7 +140,10 @@ the typescript sources directly without requiring you to recompile packages when
 Vitest is already configured to use the `typescript` entry points so simply specify `npx vitest run-c ../../config/vitest.config.mts test/myTest.spec.ts` 
 when running individual tests.
 
-If running other scripts, you can use `tsx --conditions=typescript myScript.ts` to accomplish the same goal.
+If running typescript scripts from the command line, you can use `tsx --conditions=typescript myScript.ts` to use the typescript sources.
+
+When running code using a bash script, you can set an environment variable `NODE_OPTIONS='--conditions=typescript'` and this will get picked by `tsx`.
+
 ## Documentation
 
 Add `typedoc.js` to a package that extends the generic TypeDoc configuration:

--- a/config/README.md
+++ b/config/README.md
@@ -132,6 +132,15 @@ Use CLI commands above in your `package.json`:
   }
 ```
 
+### Doing cross-package development
+
+All of our packages include a `typescript` entry in the `exports` map under the `esm` key.  This allows `node`/`tsx`/`vitest` to use
+the typescript sources directly without requiring you to recompile packages when you make changes.
+
+Vitest is already configured to use the `typescript` entry points so simply specify `npx vitest run-c ../../config/vitest.config.mts test/myTest.spec.ts` 
+when running individual tests.
+
+If running other scripts, you can use `tsx --conditions=typescript myScript.ts` to accomplish the same goal.
 ## Documentation
 
 Add `typedoc.js` to a package that extends the generic TypeDoc configuration:

--- a/config/vitest.config.mts
+++ b/config/vitest.config.mts
@@ -1,0 +1,10 @@
+import { configDefaults, defineConfig, mergeConfig } from 'vitest/config'
+export default defineConfig({
+  environments: {
+    ssr: {
+      resolve: {
+        conditions: ['typescript'],
+      },
+    },
+  },
+})

--- a/packages/binarytree/package.json
+++ b/packages/binarytree/package.json
@@ -27,7 +27,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "files": ["dist", "src"],
   "scripts": {

--- a/packages/binarytree/package.json
+++ b/packages/binarytree/package.json
@@ -25,10 +25,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "files": ["dist", "src"],
   "scripts": {
@@ -43,7 +45,7 @@
     "lint:fix": "npm run biome:fix && eslint  --fix --config ./eslint.config.mjs .",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node",
-    "test:node": "npx vitest run",
+    "test:node": "npx vitest run -c ../../config/vitest.config.mts",
     "test:browser": "npx vitest run --config=../../config/vitest.config.browser.mts",
     "tsc": "../../config/cli/ts-compile.sh"
   },

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -21,7 +21,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "files": ["dist", "src"],
   "scripts": {

--- a/packages/block/package.json
+++ b/packages/block/package.json
@@ -19,10 +19,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "files": ["dist", "src"],
   "scripts": {
@@ -40,7 +42,7 @@
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=../../config/vitest.config.browser.mts",
-    "test:node": "npx vitest run",
+    "test:node": "npx vitest run -c ../../config/vitest.config.mts",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -19,10 +19,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "files": ["dist", "src"],
   "scripts": {
@@ -40,7 +42,7 @@
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=./vitest.config.browser.mts",
-    "test:node": "npx vitest run",
+    "test:node": "npx vitest run -c ../../config/vitest.config.mts",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/blockchain/package.json
+++ b/packages/blockchain/package.json
@@ -21,7 +21,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "files": ["dist", "src"],
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -44,7 +44,7 @@
     "test": "npm run test:unit && npm run test:integration",
     "test:cli": "npx vitest run -c ../../config/vitest.config.mts ./test/cli/*.spec.ts",
     "test:integration": "npx vitest run -c ../../config/vitest.config.mts ./test/integration/*.spec.ts",
-    "test:unit": "npx vitest run -c ../../config/vitest.config.mts test/*",
+    "test:unit": "npx vitest run -c ./vitest.config.unit.ts",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,7 +27,7 @@
     "build": "npm run build:common && mkdir -p ./src/trustedSetup/ && cp -Rf ./src/trustedSetups ./dist/src/",
     "build:common": "./scripts/ts-build.sh && ./scripts/postBuildFixes.sh",
     "clean": "../../config/cli/clean-package.sh",
-    "client:start:ts": "tsx bin/cli.ts",
+    "client:start:ts": "tsx --conditions=typescript bin/cli.ts",
     "client:start:js": "npm run build && node dist/esm/bin/cli.js",
     "client:start": "npm run client:start:js --",
     "client:start:dev1": "npm run client:start -- --discDns=false --discV4=false --bootnodes",
@@ -42,9 +42,9 @@
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "repl": "npx tsx ./bin/repl.ts --logLevel=error",
     "test": "npm run test:unit && npm run test:integration",
-    "test:cli": "npx vitest run ./test/cli/*.spec.ts",
-    "test:integration": "npx vitest run ./test/integration/*.spec.ts",
-    "test:unit": "npx vitest run test/* -c=./vitest.config.unit.ts",
+    "test:cli": "npx vitest run -c ../../config/vitest.config.mts ./test/cli/*.spec.ts",
+    "test:integration": "npx vitest run -c ../../config/vitest.config.mts ./test/integration/*.spec.ts",
+    "test:unit": "npx vitest run -c ../../config/vitest.config.mts test/*",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/client/vitest.config.unit.ts
+++ b/packages/client/vitest.config.unit.ts
@@ -1,13 +1,17 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig, mergeConfig } from 'vitest/config'
+import baseConfig from '../../config/vitest.config.mts'
 
-export default defineConfig({
-  test: {
-    silent: true,
-    exclude: ['test/integration', 'test/sim', 'test/cli'],
-    testTimeout: 300000,
-    alias: { '@polkadot/util': 'false' },
-    typecheck: {
-      tsconfig: './tsconfig.prod.esm.json',
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      silent: true,
+      exclude: ['test/integration', 'test/sim', 'test/cli'],
+      testTimeout: 300000,
+      alias: { '@polkadot/util': 'false' },
+      typecheck: {
+        tsconfig: './tsconfig.prod.esm.json',
+      },
     },
-  },
-})
+  }),
+)

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -34,7 +34,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "files": ["dist", "src"],
   "scripts": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -32,10 +32,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "files": ["dist", "src"],
   "scripts": {
@@ -53,7 +55,7 @@
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=../../config/vitest.config.browser.mts",
-    "test:node": "npx vitest run",
+    "test:node": "npx vitest run -c ../../config/vitest.config.mts",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -60,6 +60,7 @@ export class Common {
   public events: EventEmitter<CommonEvent>
 
   constructor(opts: CommonOpts) {
+    console.log('hello from common')
     this.events = new EventEmitter<CommonEvent>()
 
     this._chainParams = JSON.parse(JSON.stringify(opts.chain)) // copy

--- a/packages/common/src/common.ts
+++ b/packages/common/src/common.ts
@@ -60,7 +60,6 @@ export class Common {
   public events: EventEmitter<CommonEvent>
 
   constructor(opts: CommonOpts) {
-    console.log('hello from common')
     this.events = new EventEmitter<CommonEvent>()
 
     this._chainParams = JSON.parse(JSON.stringify(opts.chain)) // copy

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -35,10 +35,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "files": ["dist", "src"],
   "scripts": {

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -37,7 +37,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "files": ["dist", "src"],
   "scripts": {

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -56,7 +56,7 @@
     "lint": "npm run biome && eslint --config ./eslint.config.mjs .",
     "lint:fix": "npm run biome:fix && eslint --fix --config ./eslint.config.mjs .",
     "prepublishOnly": "../../config/cli/prepublish.sh",
-    "test": "vitest run",
+    "test": "vitest run -c ../../config/vitest.config.mts",
     "test:node": "npm run test",
     "tsc": "../../config/cli/ts-compile.sh"
   },

--- a/packages/era/package.json
+++ b/packages/era/package.json
@@ -25,10 +25,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "files": ["dist", "src"],
   "scripts": {
@@ -45,7 +47,7 @@
     "lint:fix": "npm run biome:fix && eslint  --fix --config ./eslint.config.mjs .",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node",
-    "test:node": "npx vitest run",
+    "test:node": "npx vitest run -c ../../config/vitest.config.mts",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/era/package.json
+++ b/packages/era/package.json
@@ -27,7 +27,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "files": ["dist", "src"],
   "scripts": {

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -19,10 +19,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "files": ["dist", "src"],
   "scripts": {
@@ -38,7 +40,7 @@
     "lint": "npm run biome && eslint  --config ./eslint.config.mjs .",
     "lint:fix": "npm run biome:fix && eslint  --fix --config ./eslint.config.mjs .",
     "prepublishOnly": "../../config/cli/prepublish.sh",
-    "test": "npx vitest run",
+    "test": "npx vitest run -c ../../config/vitest.config.mts",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -21,7 +21,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "files": ["dist", "src"],
   "scripts": {

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -20,10 +20,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "files": ["dist", "src"],
   "scripts": {
@@ -43,7 +45,7 @@
     "profiling": "0x ./benchmarks/run.js profiling",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=./vitest.config.browser.mts",
-    "test:node": "npx vitest run",
+    "test:node": "npx vitest run -c ../../config/vitest.config.mts",
     "tsc": "../../config/cli/ts-compile.sh",
     "visualize:bundle": "npx vite build --config=./vite.config.bundler.ts --emptyOutDir=false --outDir ."
   },

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -22,7 +22,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "files": ["dist", "src"],
   "scripts": {

--- a/packages/genesis/package.json
+++ b/packages/genesis/package.json
@@ -70,7 +70,7 @@
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node",
     "test:browser": "npx vitest run --config=../../config/vitest.config.browser.mts",
-    "test:node": "vitest run test/*",
+    "test:node": "vitest run test/* -c ../../config/vitest.config.mts",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/genesis/package.json
+++ b/packages/genesis/package.json
@@ -19,23 +19,38 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
     },
     "./holesky": {
-      "import": "./dist/esm/genesisStates/holesky.js",
+      "import": {
+        "typescript": "./dist/esm/genesisStates/holesky.js",
+        "default": "./dist/esm/genesisStates/holesky.js"
+      },
       "require": "./dist/cjs/genesisStates/holesky.js"
     },
     "./hoodi": {
-      "import": "./dist/esm/genesisStates/hoodi.js",
+      "import": {
+        "typescript": "./dist/esm/genesisStates/hoodi.js",
+        "default": "./dist/esm/genesisStates/hoodi.js"
+      },
       "require": "./dist/cjs/genesisStates/hoodi.js"
     },
     "./mainnet": {
-      "import": "./dist/esm/genesisStates/mainnet.js",
+      "import": {
+        "typescript": "./dist/esm/genesisStates/mainnet.js",
+        "default": "./dist/esm/genesisStates/mainnet.js"
+      },
       "require": "./dist/cjs/genesisStates/mainnet.js"
     },
     "./sepolia": {
-      "import": "./dist/esm/genesisStates/sepolia.js",
+      "import": {
+        "typescript": "./dist/esm/genesisStates/sepolia.js",
+        "default": "./dist/esm/genesisStates/sepolia.js"
+      },
       "require": "./dist/cjs/genesisStates/sepolia.js"
     }
   },

--- a/packages/mpt/package.json
+++ b/packages/mpt/package.json
@@ -22,7 +22,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "files": ["dist", "src"],
   "scripts": {

--- a/packages/mpt/package.json
+++ b/packages/mpt/package.json
@@ -20,10 +20,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "files": ["dist", "src"],
   "scripts": {
@@ -43,7 +45,7 @@
     "profiling": "tsc --target ES5 benchmarks/random.ts && 0x benchmarks/random.js",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=./vitest.config.browser.mts",
-    "test:node": "npx vitest run",
+    "test:node": "npx vitest run -c ../../config/vitest.config.mts",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/rlp/package.json
+++ b/packages/rlp/package.json
@@ -29,7 +29,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "bin": {
     "rlp": "bin/rlp.cjs"

--- a/packages/rlp/package.json
+++ b/packages/rlp/package.json
@@ -27,10 +27,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "bin": {
     "rlp": "bin/rlp.cjs"
@@ -52,7 +54,7 @@
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=./vitest.config.browser.mts",
-    "test:node": "npx vitest run",
+    "test:node": "npx vitest run -c ../../config/vitest.config.mts",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "engines": {

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -20,10 +20,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "files": ["dist", "src"],
   "scripts": {
@@ -41,7 +43,7 @@
     "prepublishOnly": "../../config/cli/prepublish.sh && npm run test:node",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=./vitest.config.browser.mts",
-    "test:node": "npx vitest run",
+    "test:node": "npx vitest run -c ../../config/vitest.config.mts",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/statemanager/package.json
+++ b/packages/statemanager/package.json
@@ -22,7 +22,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "files": ["dist", "src"],
   "scripts": {

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -49,7 +49,7 @@
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=./vitest.config.browser.mts",
-    "test:node": "NODE_OPTIONS='--conditions=typescript' vitest run",
+    "test:node": "npx vitest run -c ../../config/vitest.config.mts",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -26,10 +26,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "files": ["dist", "src"],
   "scripts": {
@@ -47,7 +49,7 @@
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=./vitest.config.browser.mts",
-    "test:node": "npx vitest run",
+    "test:node": "NODE_OPTIONS='--conditions=typescript' vitest run",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/tx/package.json
+++ b/packages/tx/package.json
@@ -28,7 +28,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "files": ["dist", "src"],
   "scripts": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -63,10 +63,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "files": ["dist", "src"],
   "scripts": {
@@ -84,7 +86,7 @@
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=../../config/vitest.config.browser.mts",
-    "test:node": "npx vitest run",
+    "test:node": "npx vitest run -c ../../config/vitest.config.mts",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -65,7 +65,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "files": ["dist", "src"],
   "scripts": {

--- a/packages/verkle/package.json
+++ b/packages/verkle/package.json
@@ -27,7 +27,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "files": ["dist", "src"],
   "scripts": {

--- a/packages/verkle/package.json
+++ b/packages/verkle/package.json
@@ -25,10 +25,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "files": ["dist", "src"],
   "scripts": {
@@ -45,7 +47,7 @@
     "lint:fix": "npm run biome:fix && eslint  --fix --config ./eslint.config.mjs .",
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node",
-    "test:node": "npx vitest run",
+    "test:node": "npx vitest run -c ../../config/vitest.config.mts",
     "test:browser": "npx vitest run --config=../../config/vitest.config.browser.mts",
     "tsc": "../../config/cli/ts-compile.sh"
   },

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -45,7 +45,7 @@
     "prepublishOnly": "../../config/cli/prepublish.sh && npm run test:buildIntegrity",
     "profiling": "0x ./benchmarks/run.js profiling",
     "test": "echo \"[INFO] Generic test cmd not used. See package.json for more specific test run cmds.\"",
-    "test:API": "npx vitest run -c ../../config/vitest.config.mts ./test/api/",
+    "test:API": "npx vitest run -c ./vitest.config.ts ./test/api/",
     "test:browser": "npx vitest run --config=./vitest.config.browser.mts",
     "test:blockchain": "npm run tester -- --blockchain",
     "test:blockchain:allForks": "echo 'Chainstart Homestead dao TangerineWhistle SpuriousDragon Byzantium Constantinople Petersburg Istanbul MuirGlacier Berlin London ByzantiumToConstantinopleFixAt5 EIP158ToByzantiumAt5 FrontierToHomesteadAt5 HomesteadToDaoAt5 HomesteadToEIP150At5 BerlinToLondonAt5' | xargs -n1 | xargs -I v1 npm run tester -- --blockchain --fork=v1 --verify-test-amount-alltests",

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -22,7 +22,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "files": ["dist", "src"],
   "scripts": {

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -20,10 +20,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "files": ["dist", "src"],
   "scripts": {
@@ -43,7 +45,7 @@
     "prepublishOnly": "../../config/cli/prepublish.sh && npm run test:buildIntegrity",
     "profiling": "0x ./benchmarks/run.js profiling",
     "test": "echo \"[INFO] Generic test cmd not used. See package.json for more specific test run cmds.\"",
-    "test:API": "npx vitest run ./test/api/",
+    "test:API": "npx vitest run -c ../../config/vitest.config.mts ./test/api/",
     "test:browser": "npx vitest run --config=./vitest.config.browser.mts",
     "test:blockchain": "npm run tester -- --blockchain",
     "test:blockchain:allForks": "echo 'Chainstart Homestead dao TangerineWhistle SpuriousDragon Byzantium Constantinople Petersburg Istanbul MuirGlacier Berlin London ByzantiumToConstantinopleFixAt5 EIP158ToByzantiumAt5 FrontierToHomesteadAt5 HomesteadToDaoAt5 HomesteadToEIP150At5 BerlinToLondonAt5' | xargs -n1 | xargs -I v1 npm run tester -- --blockchain --fork=v1 --verify-test-amount-alltests",
@@ -53,7 +55,7 @@
     "test:state:allForks": "echo 'Chainstart Homestead dao TangerineWhistle SpuriousDragon Byzantium Constantinople Petersburg Istanbul MuirGlacier Berlin London ByzantiumToConstantinopleFixAt5 EIP158ToByzantiumAt5 FrontierToHomesteadAt5 HomesteadToDaoAt5 HomesteadToEIP150At5 BerlinToLondonAt5 Cancun' | xargs -n1 | xargs -I v1 npm run test:state -- --fork=v1 --verify-test-amount-alltests",
     "test:state:selectedForks": "echo 'Homestead TangerineWhistle SpuriousDragon Petersburg Berlin London Cancun' | xargs -n1 | xargs -I v1 npm run test:state -- --fork=v1 --verify-test-amount-alltests",
     "test:state:slow": "npm run test:state -- --runSkipped=slow",
-    "tester": "tsx ./test/tester --stack-size=1500",
+    "tester": "tsx --conditions=typescript ./test/tester --stack-size=1500",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/vm/vitest.config.ts
+++ b/packages/vm/vitest.config.ts
@@ -1,9 +1,13 @@
 import topLevelAwait from 'vite-plugin-top-level-await'
-import { defineConfig } from 'vitest/config'
+import { defineConfig, mergeConfig } from 'vitest/config'
+import baseConfig from '../../config/vitest.config.mts'
 
-export default defineConfig({
-  plugins: [topLevelAwait()],
-  optimizeDeps: {
-    exclude: ['kzg-wasm'],
-  },
-})
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    plugins: [topLevelAwait()],
+    optimizeDeps: {
+      exclude: ['kzg-wasm'],
+    },
+  }),
+)

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -19,10 +19,12 @@
   "module": "dist/esm/index.js",
   "exports": {
     ".": {
-      "import": "./dist/esm/index.js",
+      "import": {
+        "typescript": "./src/index.ts",
+        "default": "./dist/esm/index.js"
+      },
       "require": "./dist/cjs/index.js"
-    },
-    "typescript": "./src/index.ts"
+    }
   },
   "files": ["src", "dist"],
   "scripts": {
@@ -40,7 +42,7 @@
     "prepublishOnly": "../../config/cli/prepublish.sh",
     "test": "npm run test:node && npm run test:browser",
     "test:browser": "npx vitest run --config=../../config/vitest.config.browser.mts",
-    "test:node": "vitest run",
+    "test:node": "npx vitest run -c ../../config/vitest.config.mts",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -21,7 +21,8 @@
     ".": {
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
-    }
+    },
+    "typescript": "./src/index.ts"
   },
   "files": ["src", "dist"],
   "scripts": {


### PR DESCRIPTION
This updates our package.json to provide an entry point at `typescript` that can be specified with a `NODE_OPTIONS="--conditions=typescript"` node option and updates our internal execution scripts and vitest to use these entry points.  This allows us to run our code/tests with sources updated but without having to rebuild all packages when we run code from internal packages.

- Switches the exports map in each `package.json` to this
```json
  "exports": {
    ".": {
      "import": {
        "typescript": "./src/index.ts",
        "default": "./dist/esm/index.js"
      },
      "require": "./dist/cjs/index.js"
    }
  },
```

So that we have a special `typescript` condition that you can specify in `NODE_OPTIONS` as described above.  In doing so, it will then resolve the imports from `src/index.ts` instead of the compiled Javascript code.

- Adds a new configuration file for `vitest` so that it will use the `typescript` condition in the export maps.
- Updates the `npm run...` scripts to use the new `typescript` module resolution specifier.  

The upshot of all this is that when you make changes in a source file, `vitest` and `tsx` can use the typescript code so we no longer need to rebuild packages if we make changes in one package while working in another.  

To run this way with `tsx`, you have to do `tsx --conditions=typescript myscript.ts`.  

Note, if you don't specify anything in the `conditions` flag, tsx/node will continue to resolve from our default import path (so `./dist/esm/index.js`

I didn't make this change to the `cjs` path because we don't develop in a `cjs` environment.