### PR TITLE
client: fix new tsx behavior which overwrites (?) fields of subclasses

### DIFF
--- a/packages/client/src/sync/fetcher/fetcher.ts
+++ b/packages/client/src/sync/fetcher/fetcher.ts
@@ -65,11 +65,6 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
   protected destroyWhenDone: boolean // Destroy the fetcher once we are finished processing each task.
   syncErrored?: Error
 
-  private _readableState?: {
-    // This property is inherited from Readable. We only need `length`.
-    length: number
-  }
-
   private writer: Writable | null = null
 
   /**
@@ -352,10 +347,13 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
       return false
     }
     const jobStr = this.jobStr(job)
-    if (this._readableState === undefined || this._readableState!.length > this.maxQueue) {
+    if (
+      (<any>this)._readableState === undefined ||
+      (<any>this)._readableState!.length > this.maxQueue
+    ) {
       this.DEBUG &&
         this.debug(
-          `Readable state length=${this._readableState!.length} exceeds max queue size=${
+          `Readable state length=${(<any>this)._readableState!.length} exceeds max queue size=${
             this.maxQueue
           }, skip job ${jobStr} execution.`,
         )

--- a/packages/client/src/sync/fetcher/fetcher.ts
+++ b/packages/client/src/sync/fetcher/fetcher.ts
@@ -348,12 +348,12 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
     }
     const jobStr = this.jobStr(job)
     if (
-      (<any>this)._readableState === undefined ||
-      (<any>this)._readableState!.length > this.maxQueue
+      (this as any)._readableState === undefined ||
+      (this as any)._readableState!.length > this.maxQueue
     ) {
       this.DEBUG &&
         this.debug(
-          `Readable state length=${(<any>this)._readableState!.length} exceeds max queue size=${
+          `Readable state length=${(this as any)._readableState!.length} exceeds max queue size=${
             this.maxQueue
           }, skip job ${jobStr} execution.`,
         )

--- a/packages/client/test/sync/fetcher/fetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/fetcher.spec.ts
@@ -76,7 +76,7 @@ describe('should handle expiration', async () => {
     })
 
     fetcher['in'].insert(job as any)
-    fetcher['_readableState'] = []
+    ;(<any>fetcher)['_readableState'] = []
     fetcher['running'] = true
     fetcher['total'] = 10
     fetcher.next()


### PR DESCRIPTION
At the RC releases PR https://github.com/ethereumjs/ethereumjs-monorepo/pull/3886 which only updated package.jsons, changelogs, readmes and package-lock, for some reason when running client in `tsx` mode (so `npm run client:start:ts`) the Fetcher `client/src/sync/fetcher/fetcher.ts` would throw:

```
TypeError: Cannot read properties of undefined (reading 'pipes')
    at Readable.pipe (node:internal/streams/readable:670:13)
    at BlockFetcher.write (/home/jochem/Documents/ejs/ethereumjs-monorepo/packages/client/src/sync/fetcher/fetcher.ts:500:8)
    at BlockFetcher._fetch (/home/jochem/Documents/ejs/ethereumjs-monorepo/packages/client/src/sync/fetcher/fetcher.ts:519:12)
    at BlockFetcher.fetch (/home/jochem/Documents/ejs/ethereumjs-monorepo/packages/client/src/sync/fetcher/fetcher.ts:552:32)
    at BlockFetcher.blockingFetch (/home/jochem/Documents/ejs/ethereumjs-monorepo/packages/client/src/sync/fetcher/fetcher.ts:558:55)
    at FullSynchronizer.syncWithFetcher (/home/jochem/Documents/ejs/ethereumjs-monorepo/packages/client/src/sync/sync.ts:149:29)
    at FullSynchronizer.sync (/home/jochem/Documents/ejs/ethereumjs-monorepo/packages/client/src/sync/sync.ts:184:17)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at FullSynchronizer.start (/home/jochem/Documents/ejs/ethereumjs-monorepo/packages/client/src/sync/sync.ts:125:9)
[03-28|10:21:28] ERROR Received sync error, stopping sync and clearing fetcher: Cannot read properties of undefined (reading 'pipes')
```

This does NOT happen when running in `npm run client:start:js`. It also does not happen if you attach a debugger, `tsx --inspect-brk bin/cli.ts`

For some reason the RC releases have changed something in the specific tsx run. I think it would take the field `_readableState` which is marked as `private` on the `Fetcher` and somehow overwrite this value in the constructor of the Fetcher. This breaks the entire Readable object. The workaround (for now) is to cast `this` as `any` and query the fields which we need (should likely find a way to get the same result but not reading private properties of Readable).

This fix allows the client to start syncing!

I still do not know what the `npm run client:start:ts` (this runs `tsx bin/cli.ts`) does different than if I attach a debugger. How come the end result is different? Without this change, in the constructor of Fetcher, log `console.log(this)` after `super(` and one will see that almost the entire object is empty instead of having an initialized Readable :thinking: 