### PR TITLE
Small devp2p Namespace Addition Fix

### DIFF
--- a/packages/devp2p/src/util.ts
+++ b/packages/devp2p/src/util.ts
@@ -12,7 +12,9 @@ import { secp256k1 } from 'ethereum-cryptography/secp256k1.js'
 
 import type { EthStatusMsg } from './protocol/eth.ts'
 
-export const devp2pDebug = debug('devp2p:#')
+// Do not use :# here, no logging without subnamespace occurring and current code structure
+// otherwise creates loggers like `devp2p:#:eth`
+export const devp2pDebug = debug('devp2p')
 
 export function genPrivateKey(): Uint8Array {
   const privateKey = secp256k1.utils.randomPrivateKey()


### PR DESCRIPTION
We recently added this `#` for the part of the logger namespace where the package name is used to log the more generic things (so e.g., have `evm` as a namespace, `evm:gas`, then we changed `evm` -> `evm:#), to avoid side effects and allow for easier log filtering (use `evm:#` to just filter for the generic stuff).

For `devp2p` this `#` accidentally also trickled down when subloggers were appended, e.g.:

![grafik](https://github.com/user-attachments/assets/30c77f9c-9bb2-48eb-b3ee-0ef74e3e985b)

This PR fixes this. Ready for merge!

![grafik](https://github.com/user-attachments/assets/c3841a68-65d2-4c4f-a4be-8544fb27ccc0)
