### PR TITLE
Include request type byte in t8n response

### DIFF
--- a/packages/vm/test/t8n/t8ntool.ts
+++ b/packages/vm/test/t8n/t8ntool.ts
@@ -309,7 +309,7 @@ export class TransitionTool {
       output.requests = []
       for (const request of requests) {
         if (request.bytes.length > 1) {
-          output.requests.push(bytesToHex(request.bytes.slice(1)))
+          output.requests.push(bytesToHex(request.bytes))
         }
       }
     }


### PR DESCRIPTION
At some point we changed from not expecting the request byte from the t8n to expecting it, this is current EELS behavior.

This changes fixes test filling for all EIP-7685 and related EIPs tests in EEST.