### PR TITLE
Add Hoodi DNS Discovery to Client

### DIFF
--- a/packages/client/src/config.ts
+++ b/packages/client/src/config.ts
@@ -725,7 +725,7 @@ export class Config {
    */
   getDnsDiscovery(option: boolean | undefined): boolean {
     if (option !== undefined) return option
-    const dnsNets = ['sepolia', 'holesky']
+    const dnsNets = ['sepolia', 'holesky', 'hoodi']
     return dnsNets.includes(this.chainCommon.chainName())
   }
 }

--- a/packages/common/src/chains.ts
+++ b/packages/common/src/chains.ts
@@ -556,7 +556,9 @@ export const Hoodi: ChainConfig = {
       comment: 'bootnode 3',
     },
   ],
-  dnsNetworks: [],
+  dnsNetworks: [
+    'enrtree://AKA3AM6LPBYEUDMVNU3BSVQJ5AD45Y7YPOHJLEF6W26QOE4VTUDPE@all.hoodi.ethdisco.net',
+  ],
 }
 
 export const Kaustinen6: ChainConfig = {


### PR DESCRIPTION
Small update to add Hoodi DNS discovery to the client, checked [here](https://github.com/ethereum/go-ethereum/blob/77dc1acafaad69e6adc98293541ee49644ed9218/params/bootnodes.go#L99) from Go Ethereum code that a Hoodi DNS server is already up and running.

Also quick debug check indicate things work! 🙂 

<img width="1088" alt="grafik" src="https://github.com/user-attachments/assets/0f0491fa-ae85-48a1-b6cd-5a7931bb4ffc" />
