### PR TITLE
Change typecasting to `as type` format

### DIFF
--- a/packages/binarytree/src/db/checkpoint.ts
+++ b/packages/binarytree/src/db/checkpoint.ts
@@ -165,7 +165,7 @@ export class CheckpointDB implements DB {
       value !== undefined
         ? value instanceof Uint8Array
           ? value
-          : unprefixedHexToBytes(<string>value)
+          : unprefixedHexToBytes(value as string)
         : undefined
     this._cache?.set(keyHex, returnValue)
     if (this.hasCheckpoints()) {
@@ -250,7 +250,7 @@ export class CheckpointDB implements DB {
         }
         this._stats.db.writes += 1
         if (op.type === 'put' && this.valueEncoding === ValueEncoding.String) {
-          convertedOp.value = bytesToUnprefixedHex(<Uint8Array>convertedOp.value)
+          convertedOp.value = bytesToUnprefixedHex(convertedOp.value as Uint8Array)
         }
         return convertedOp
       })

--- a/packages/block/src/block/block.ts
+++ b/packages/block/src/block/block.ts
@@ -158,7 +158,7 @@ export class Block {
    * Returns a Array of the raw Bytes Arrays of this block, in order.
    */
   raw(): BlockBytes {
-    const bytesArray = <BlockBytes>[
+    const bytesArray = [
       this.header.raw(),
       this.transactions.map((tx) =>
         tx.supports(Capability.EIP2718TypedTransaction) ? tx.serialize() : tx.raw(),
@@ -174,7 +174,7 @@ export class Block {
       const executionWitnessBytes = RLP.encode(JSON.stringify(this.executionWitness))
       bytesArray.push(executionWitnessBytes as any)
     }
-    return bytesArray
+    return bytesArray as BlockBytes
   }
 
   /**

--- a/packages/mpt/src/db/checkpointDB.ts
+++ b/packages/mpt/src/db/checkpointDB.ts
@@ -165,7 +165,7 @@ export class CheckpointDB implements DB {
       value !== undefined
         ? value instanceof Uint8Array
           ? value
-          : unprefixedHexToBytes(<string>value)
+          : unprefixedHexToBytes(value as string)
         : undefined
     this._cache?.set(keyHex, returnValue)
     if (this.hasCheckpoints()) {
@@ -250,7 +250,7 @@ export class CheckpointDB implements DB {
         }
         this._stats.db.writes += 1
         if (op.type === 'put' && this.valueEncoding === ValueEncoding.String) {
-          convertedOp.value = bytesToUnprefixedHex(<Uint8Array>convertedOp.value)
+          convertedOp.value = bytesToUnprefixedHex(convertedOp.value as Uint8Array)
         }
         return convertedOp
       })

--- a/packages/mpt/src/mpt.ts
+++ b/packages/mpt/src/mpt.ts
@@ -333,7 +333,7 @@ export class MerklePatriciaTrie {
     let progress = 0
     for (let i = 0; i < partialPath.stack.length - 1; i++) {
       stack[i] = partialPath.stack[i]
-      progress += stack[i] instanceof BranchMPTNode ? 1 : (<ExtensionMPTNode>stack[i]).keyLength()
+      progress += stack[i] instanceof BranchMPTNode ? 1 : (stack[i] as ExtensionMPTNode).keyLength()
     }
     this.DEBUG && this.debug(`Target (${targetKey.length}): [${targetKey}]`, ['find_path'])
     let result: Path | null = null

--- a/packages/tx/src/1559/tx.ts
+++ b/packages/tx/src/1559/tx.ts
@@ -351,7 +351,7 @@ export class FeeMarket1559Tx
   }
 
   sign(privateKey: Uint8Array, extraEntropy: Uint8Array | boolean = false): FeeMarket1559Tx {
-    return <FeeMarket1559Tx>Legacy.sign(this, privateKey, extraEntropy)
+    return Legacy.sign(this, privateKey, extraEntropy) as FeeMarket1559Tx
   }
 
   public isSigned(): boolean {

--- a/packages/tx/src/2930/tx.ts
+++ b/packages/tx/src/2930/tx.ts
@@ -325,7 +325,7 @@ export class AccessList2930Tx
   }
 
   sign(privateKey: Uint8Array, extraEntropy: Uint8Array | boolean = false): AccessList2930Tx {
-    return <AccessList2930Tx>Legacy.sign(this, privateKey, extraEntropy)
+    return Legacy.sign(this, privateKey, extraEntropy) as AccessList2930Tx
   }
 
   isSigned(): boolean {

--- a/packages/tx/src/4844/tx.ts
+++ b/packages/tx/src/4844/tx.ts
@@ -441,7 +441,7 @@ export class Blob4844Tx implements TransactionInterface<typeof TransactionType.B
   }
 
   sign(privateKey: Uint8Array, extraEntropy: Uint8Array | boolean = false): Blob4844Tx {
-    return <Blob4844Tx>Legacy.sign(this, privateKey, extraEntropy)
+    return Legacy.sign(this, privateKey, extraEntropy) as Blob4844Tx
   }
 
   public isSigned(): boolean {

--- a/packages/tx/src/7702/tx.ts
+++ b/packages/tx/src/7702/tx.ts
@@ -391,7 +391,7 @@ export class EOACode7702Tx implements TransactionInterface<typeof TransactionTyp
   }
 
   sign(privateKey: Uint8Array, extraEntropy: Uint8Array | boolean = false): EOACode7702Tx {
-    return <EOACode7702Tx>Legacy.sign(this, privateKey, extraEntropy)
+    return Legacy.sign(this, privateKey, extraEntropy) as EOACode7702Tx
   }
 
   public isSigned(): boolean {

--- a/packages/tx/src/legacy/tx.ts
+++ b/packages/tx/src/legacy/tx.ts
@@ -397,7 +397,7 @@ export class LegacyTx implements TransactionInterface<typeof TransactionType.Leg
   }
 
   sign(privateKey: Uint8Array, extraEntropy: Uint8Array | boolean = false): LegacyTx {
-    return <LegacyTx>Legacy.sign(this, privateKey, extraEntropy)
+    return Legacy.sign(this, privateKey, extraEntropy) as LegacyTx
   }
 
   /**

--- a/packages/util/src/withdrawal.ts
+++ b/packages/util/src/withdrawal.ts
@@ -44,7 +44,7 @@ export function withdrawalToBytesArray(withdrawal: Withdrawal | WithdrawalData):
       ? new Uint8Array()
       : toType(validatorIndex, TypeOutput.Uint8Array)
   const addressBytes =
-    address instanceof Address ? (<Address>address).bytes : toType(address, TypeOutput.Uint8Array)
+    address instanceof Address ? address.bytes : toType(address, TypeOutput.Uint8Array)
 
   const amountBytes =
     toType(amount, TypeOutput.BigInt) === BIGINT_0


### PR DESCRIPTION
Cleans up some more type casting that used the `<Type>SomeVariable` format instead of `SomeVariable as Type`.

Node 23 `remove-experimental-types` wa complaining.

To test, go to `devp2p` and run `node --conditions=typescript --experimental-strip-types examples/peer-communication.ts` on master and then this branch to confirm that it breaks on master and not here.