### PR TITLE
Common: Add Mainnet Prague Timestamp & ForkHash

### DIFF
--- a/packages/common/src/chains.ts
+++ b/packages/common/src/chains.ts
@@ -117,6 +117,7 @@ export const Mainnet: ChainConfig = {
       name: 'prague',
       block: null,
       timestamp: '1746612311',
+      forkHash: '0xc376cf8b',
     },
     {
       name: 'osaka',

--- a/packages/common/src/chains.ts
+++ b/packages/common/src/chains.ts
@@ -116,8 +116,7 @@ export const Mainnet: ChainConfig = {
     {
       name: 'prague',
       block: null,
-      // Note: Prague is not yet scheduled for Mainnet.
-      // Timestamp will be added once it is scheduled.
+      timestamp: '1746612311',
     },
     {
       name: 'osaka',


### PR DESCRIPTION
Small PR to add the Prague hardfork timestamp from [EIP-6700](https://eips.ethereum.org/EIPS/eip-7600) and the fork hash, before we forget before releases. 🙂 

Fork hash has been taken from a Nethermind [PR](https://github.com/NethermindEth/nethermind/pull/8502/files) and confirmed with the following code:

```ts
c = new Common({ chain: Mainnet })
const fh = c.forkHash(Hardfork.Prague, hexToBytes('0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3'))
console.log(fh)
```

Ready for review and merge.