### PR TITLE
No more unerasable syntax

### DIFF
--- a/.github/workflows/noCompile.yml
+++ b/.github/workflows/noCompile.yml
@@ -1,0 +1,51 @@
+name: Packages examples
+on:
+  workflow_call:
+    inputs:
+      dep-cache-key:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      dep-cache-key:
+        required: false
+        default: 'none'
+      submodule-cache-key:
+        required: false
+        default: 'none'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-examples
+  cancel-in-progress: true
+
+jobs:
+  test-examples:
+    runs-on: ubuntu-latest
+    steps:
+      # We clone the repo and submodules if triggered from work-flow dispatch
+      - if: inputs.submodule-cache-key == 'none'
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
+      - if: inputs.dep-cache-key != 'none' 
+        uses: actions/cache/restore@v4
+        id: dep-cache
+        with:
+          path: ${{github.workspace}}
+          key: ${{ inputs.dep-cache-key }}
+  
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 23
+          cache: 'npm'
+
+      - name: Install Dependencies (if not restored from cache)
+        if: steps.dep-cache.outputs.cache-hit != 'true'
+        run: npm ci     
+        working-directory: ${{ github.workspace }}
+    
+      - run: node --conditions=typescript --experimental-strip-types bin/cli.ts --dev=poa --maxPeers=0
+        working-directory: ${{ github.workspace }}/packages/client

--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -349,7 +349,7 @@ async function run() {
   const { config, customGenesisState, customGenesisStateRoot, metricsServer } =
     await generateClientConfig(args)
 
-  logger = config.logger
+  logger = <any>config.logger
 
   // Do not wait for client to be fully started so that we can hookup SIGINT handling
   // else a SIGINT before may kill the process in unclean manner

--- a/packages/client/examples/noCompile.sh
+++ b/packages/client/examples/noCompile.sh
@@ -1,0 +1,20 @@
+# Create a named pipe for output monitoring
+tmpfile=$(mktemp)
+trap 'rm -f $tmpfile' EXIT
+
+# Run the command and capture its PID
+node --conditions=typescript --experimental-strip-types bin/cli.ts --dev=poa --executeBlocks=0 2>&1 | { 
+  pid=$PPID  # Parent process ID
+  while IFS= read -r line; do
+    echo "$line"
+    if [[ "$line" == *"Error starting client value"* ]]; then
+      kill -INT $pid
+      exit 1
+    fi
+    if [[ "$line" == *"ERR_INVALID_TYPESCRIPT_SYNTAX"* ]]; then
+      # For this error, also kill the process with SIGINT and exit with error code
+      kill -INT $pid
+      exit 2
+    fi
+  done
+}

--- a/packages/client/src/net/peer/peer.ts
+++ b/packages/client/src/net/peer/peer.ts
@@ -170,12 +170,12 @@ export abstract class Peer extends EventEmitter {
 
       await bound!.handshake(sender)
 
-      this.eth = <BoundEthProtocol>bound
+      this.eth = bound as BoundEthProtocol
     } else if (protocol.name === 'snap') {
       bound = new BoundSnapProtocol(boundOpts)
       if (sender.status === undefined) throw Error('Snap can only be bound on handshaked peer')
 
-      this.snap = <BoundSnapProtocol>bound
+      this.snap = bound as BoundSnapProtocol
     } else {
       throw EthereumJSErrorWithoutCode(`addProtocol: ${protocol.name} protocol not supported`)
     }

--- a/packages/client/src/sync/fetcher/fetcher.ts
+++ b/packages/client/src/sync/fetcher/fetcher.ts
@@ -483,7 +483,7 @@ export abstract class Fetcher<JobTask, JobResult, StorageItem> extends Readable 
         many: { chunk: Job<JobTask, JobResult, StorageItem>; encoding: string }[],
         cb: Function,
       ) => {
-        const items = (<Job<JobTask, JobResult, StorageItem>[]>[]).concat(
+        const items = ([] as Job<JobTask, JobResult, StorageItem>[]).concat(
           ...many.map(
             (x: { chunk: Job<JobTask, JobResult, StorageItem>; encoding: string }) => x.chunk,
           ),

--- a/packages/client/test/sync/beaconsync.spec.ts
+++ b/packages/client/test/sync/beaconsync.spec.ts
@@ -120,7 +120,7 @@ describe('[BeaconSynchronizer]', async () => {
     /// @ts-expect-error -- Assigning simpler config for testing
     sync.pool = { peers }
     sync['forceSync'] = true
-    assert.equal(await sync.best(), <any>peers[1], 'found best')
+    assert.equal(await sync.best(), peers[1] as any, 'found best')
     await sync.stop()
     await sync.close()
   })

--- a/packages/client/test/sync/fetcher/fetcher.spec.ts
+++ b/packages/client/test/sync/fetcher/fetcher.spec.ts
@@ -76,7 +76,7 @@ describe('should handle expiration', async () => {
     })
 
     fetcher['in'].insert(job as any)
-    ;(<any>fetcher)['_readableState'] = []
+    ;(fetcher as any)['_readableState'] = []
     fetcher['running'] = true
     fetcher['total'] = 10
     fetcher.next()

--- a/packages/ethash/src/index.ts
+++ b/packages/ethash/src/index.ts
@@ -93,12 +93,12 @@ export class Miner {
 
     if (solution) {
       if (this.block) {
-        const data = <BlockData>this.block.toJSON()
+        const data = this.block.toJSON() as BlockData
         data.header!.mixHash = solution.mixHash
         data.header!.nonce = solution.nonce
         return createBlock(data, { common: this.block.common })
       } else {
-        const data = <HeaderData>this.blockHeader.toJSON()
+        const data = this.blockHeader.toJSON() as HeaderData
         data.mixHash = solution.mixHash
         data.nonce = solution.nonce
         return createBlockHeader(data, { common: this.blockHeader.common })

--- a/packages/ethash/test/miner.spec.ts
+++ b/packages/ethash/test/miner.spec.ts
@@ -65,7 +65,7 @@ describe('Miner', () => {
       { common },
     )
     const miner = e.getMiner(block.header)
-    const solution = <BlockHeader>await miner.mine(-1)
+    const solution = (await miner.mine(-1)) as BlockHeader
 
     assert.isTrue(
       await e.verifyPOW(createBlock({ header: solution.toJSON() }, { common })),
@@ -73,7 +73,7 @@ describe('Miner', () => {
     )
 
     const blockMiner = e.getMiner(block)
-    const blockSolution = <Block>await blockMiner.mine(-1)
+    const blockSolution = (await blockMiner.mine(-1)) as Block
 
     assert.isTrue(await e.verifyPOW(blockSolution))
   }, 60000)
@@ -129,13 +129,13 @@ describe('Miner', () => {
     )
 
     const miner = e.getMiner(block.header)
-    const solution = <BlockHeader>await miner.mine(-1)
+    const solution = (await miner.mine(-1)) as BlockHeader
 
     assert.equal(solution.common.hardfork(), Hardfork.Petersburg, 'hardfork did not change')
     assert.equal(solution.common.chainName(), 'mainnet', 'chain name did not change')
 
     const blockMiner = e.getMiner(block)
-    const blockSolution = <Block>await blockMiner.mine(-1)
+    const blockSolution = (await blockMiner.mine(-1)) as Block
 
     assert.equal(blockSolution.common.hardfork(), Hardfork.Petersburg, 'hardfork did not change')
     assert.equal(blockSolution.common.chainName(), 'mainnet', 'chain name did not change')

--- a/packages/evm/test/eips/eof-header-validation.spec.ts
+++ b/packages/evm/test/eips/eof-header-validation.spec.ts
@@ -41,7 +41,7 @@ await new Promise<void>((resolve, reject) => {
     }
     const name = path.parse(fileName).name
     describe(`EOF Header validation tests - ${name}`, async () => {
-      const testData = JSON.parse(<string>content)
+      const testData = JSON.parse(content as string)
       const evm = await getEVM()
       for (const key in testData) {
         it(`Test ${key}`, () => {

--- a/packages/tx/test/eip1559.spec.ts
+++ b/packages/tx/test/eip1559.spec.ts
@@ -55,7 +55,7 @@ describe('[FeeMarket1559Tx]', () => {
         if (
           !(
             value === 'chainId' &&
-            ((typeof testCase === 'number' && isNaN(<number>testCase)) || testCase === false)
+            ((typeof testCase === 'number' && isNaN(testCase)) || testCase === false)
           )
         ) {
           txData[value] = testCase

--- a/packages/tx/test/typedTxsAndEIP2930.spec.ts
+++ b/packages/tx/test/typedTxsAndEIP2930.spec.ts
@@ -149,7 +149,7 @@ describe('[AccessList2930Tx / FeeMarket1559Tx] -> EIP-2930 Compatibility', () =>
         if (
           !(
             value === 'chainId' &&
-            ((typeof testCase === 'number' && isNaN(<number>testCase)) || testCase === false)
+            ((typeof testCase === 'number' && isNaN(testCase)) || testCase === false)
           )
         ) {
           txData[value] = testCase

--- a/packages/util/test/account.spec.ts
+++ b/packages/util/test/account.spec.ts
@@ -323,7 +323,7 @@ describe('Utility Functions', () => {
     pubKey =
       '0x3a443d8381a6798a70c6ff9304bdc8cb0163c23211d11628fae52ef9e0dca11a001cf066d56a8156fc201cd5df8a36ef694eecd258903fca7086c1fae7441e1d' as any
     try {
-      isValidPublic((<unknown>pubKey) as Uint8Array)
+      isValidPublic(pubKey as Uint8Array)
     } catch (err: any) {
       assert.isTrue(
         err.message.includes('This method only supports Uint8Array'),
@@ -372,7 +372,7 @@ describe('Utility Functions', () => {
 
     assert.throws(
       function () {
-        importPublic((<unknown>pubKey) as Uint8Array)
+        importPublic(pubKey as unknown as Uint8Array)
       },
       undefined,
       undefined,
@@ -462,7 +462,7 @@ describe('Utility Functions', () => {
 
     privateKey = '0xea54bdc52d163f88c93ab0615782cf718a2efb9e51a7989aab1b08067e9c1c5f' as any
     try {
-      privateToPublic((<unknown>privateKey) as Uint8Array)
+      privateToPublic(privateKey as Uint8Array)
     } catch (err: any) {
       assert.isTrue(
         err.message.includes('This method only supports Uint8Array'),
@@ -563,7 +563,7 @@ describe('Utility Functions', () => {
     assert.throws(
       function () {
         generateAddress2(
-          (<unknown>address) as Uint8Array,
+          address as unknown as Uint8Array,
           hexToBytes(salt as PrefixedHexString),
           hexToBytes(initCode as PrefixedHexString),
         )
@@ -577,7 +577,7 @@ describe('Utility Functions', () => {
       function () {
         generateAddress2(
           hexToBytes(address as PrefixedHexString),
-          (<unknown>salt) as Uint8Array,
+          salt as unknown as Uint8Array,
           hexToBytes(initCode as PrefixedHexString),
         )
       },
@@ -591,7 +591,7 @@ describe('Utility Functions', () => {
         generateAddress2(
           hexToBytes(address as PrefixedHexString),
           hexToBytes(salt as PrefixedHexString),
-          (<unknown>initCode) as Uint8Array,
+          initCode as unknown as Uint8Array,
         )
       },
       undefined,

--- a/packages/util/test/bytes.spec.ts
+++ b/packages/util/test/bytes.spec.ts
@@ -77,7 +77,7 @@ describe('unpadArray', () => {
   })
   it('should throw if input is not an Array', () => {
     assert.throws(function () {
-      unpadArray((<unknown>toBytes([0, 0, 0, 1])) as number[])
+      unpadArray(toBytes([0, 0, 0, 1]) as unknown as number[])
     })
   })
 })

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -393,7 +393,7 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
   if (enableProfiler) {
     // eslint-disable-next-line no-console
     console.timeEnd(entireBlockLabel)
-    const logs = (<EVM>vm.evm).getPerformanceLogs()
+    const logs = (vm.evm as EVM).getPerformanceLogs()
     if (logs.precompiles.length === 0 && logs.opcodes.length === 0) {
       // eslint-disable-next-line no-console
       console.log('No block txs with precompile or opcode execution.')
@@ -401,7 +401,7 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
 
     emitEVMProfile(logs.precompiles, 'Precompile performance')
     emitEVMProfile(logs.opcodes, 'Opcodes performance')
-    ;(<EVM>vm.evm).clearPerformanceLogs()
+    ;(vm.evm as EVM).clearPerformanceLogs()
   }
 
   return results

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -149,7 +149,7 @@ export async function runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
       throw EthereumJSErrorWithoutCode(msg)
     }
 
-    const castedTx = <AccessList2930Tx>opts.tx
+    const castedTx = opts.tx as AccessList2930Tx
 
     for (const accessListItem of castedTx.accessList) {
       const [addressBytes, slotBytesList] = accessListItem
@@ -183,14 +183,14 @@ export async function runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     if (enableProfiler) {
       // eslint-disable-next-line no-console
       console.timeEnd(entireTxLabel)
-      const logs = (<EVM>vm.evm).getPerformanceLogs()
+      const logs = (vm.evm as EVM).getPerformanceLogs()
       if (logs.precompiles.length === 0 && logs.opcodes.length === 0) {
         // eslint-disable-next-line no-console
         console.log('No precompile or opcode execution.')
       }
       emitEVMProfile(logs.precompiles, 'Precompile performance')
       emitEVMProfile(logs.opcodes, 'Opcodes performance')
-      ;(<EVM>vm.evm).clearPerformanceLogs()
+      ;(vm.evm as EVM).clearPerformanceLogs()
     }
   }
 }
@@ -449,10 +449,10 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     gasPrice = inclusionFeePerGas + baseFee
   } else {
     // Have to cast as legacy tx since EIP1559 tx does not have gas price
-    gasPrice = (<LegacyTx>tx).gasPrice
+    gasPrice = (tx as LegacyTx).gasPrice
     if (vm.common.isActivatedEIP(1559)) {
       const baseFee = block?.header.baseFeePerGas ?? DEFAULT_HEADER.baseFeePerGas!
-      inclusionFeePerGas = (<LegacyTx>tx).gasPrice - baseFee
+      inclusionFeePerGas = (tx as LegacyTx).gasPrice - baseFee
     }
   }
 
@@ -476,7 +476,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
 
   if (tx.supports(Capability.EIP7702EOACode)) {
     // Add contract code for authority tuples provided by EIP 7702 tx
-    const authorizationList = (<EIP7702CompatibleTx>tx).authorizationList
+    const authorizationList = (tx as EIP7702CompatibleTx).authorizationList
     for (let i = 0; i < authorizationList.length; i++) {
       // Authority tuple validation
       const data = authorizationList[i]

--- a/packages/vm/test/api/muirGlacier/index.spec.ts
+++ b/packages/vm/test/api/muirGlacier/index.spec.ts
@@ -2,6 +2,7 @@ import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { KECCAK256_RLP } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
+import type { MerkleStateManager } from '@ethereumjs/statemanager'
 import { createVM } from '../../../src/index.ts'
 
 describe('General MuirGlacier VM tests', () => {
@@ -9,6 +10,10 @@ describe('General MuirGlacier VM tests', () => {
     const common = new Common({ chain: Mainnet, hardfork: Hardfork.MuirGlacier })
     const vm = await createVM({ common })
     assert.isDefined(vm.stateManager)
-    assert.deepEqual((<any>vm.stateManager)._trie.root(), KECCAK256_RLP, 'it has default trie')
+    assert.deepEqual(
+      (vm.stateManager as MerkleStateManager)['_trie'].root(),
+      KECCAK256_RLP,
+      'it has default trie',
+    )
   })
 })

--- a/packages/vm/test/api/runTx.spec.ts
+++ b/packages/vm/test/api/runTx.spec.ts
@@ -598,7 +598,7 @@ describe('runTx() -> API return values', () => {
       } else {
         assert.equal(
           res.amountSpent,
-          res.totalGasSpent * (<LegacyTx>tx).gasPrice,
+          res.totalGasSpent * (tx as LegacyTx).gasPrice,
           `runTx result -> amountSpent -> gasUsed * gasPrice (${txType.name})`,
         )
       }

--- a/packages/vm/test/t8n/stateTracker.ts
+++ b/packages/vm/test/t8n/stateTracker.ts
@@ -48,7 +48,7 @@ export class StateTracker {
     vm.stateManager.putStorage = async function (...args: [Address, Uint8Array, Uint8Array]) {
       const address = args[0]
       const key = args[1]
-      self['addStorage'](address.toString(), <PrefixedHexString>bytesToHex(key))
+      self['addStorage'](address.toString(), bytesToHex(key))
       return originalPutStorage.apply(this, args)
     }
   }
@@ -90,7 +90,7 @@ export class StateTracker {
       outputAlloc[addressString].storage = outputAlloc[addressString].storage ?? {}
 
       for (const key of storage) {
-        const keyBytes = hexToBytes(<PrefixedHexString>key)
+        const keyBytes = hexToBytes(key)
         let storageKeyTrimmed = bytesToHex(unpadBytes(keyBytes))
         if (storageKeyTrimmed === '0x') {
           storageKeyTrimmed = '0x00'

--- a/packages/vm/test/t8n/t8ntool.ts
+++ b/packages/vm/test/t8n/t8ntool.ts
@@ -43,7 +43,7 @@ function getBlockchain(inputEnv: T8NEnv) {
       if (Number(key) === number) {
         return {
           hash() {
-            return hexToBytes(<PrefixedHexString>inputEnv.blockHashes[key])
+            return hexToBytes(inputEnv.blockHashes[key])
           },
         }
       }
@@ -154,7 +154,7 @@ export class TransitionTool {
     const parentBlock = createBlock({ header: parentBlockHeader }, { common: this.common })
 
     const headerData = block.header.toJSON()
-    headerData.difficulty = <PrefixedHexString>this.inputEnv.parentDifficulty
+    headerData.difficulty = this.inputEnv.parentDifficulty as PrefixedHexString
 
     const builder = await buildBlock(this.vm, {
       parentBlock,

--- a/packages/vm/test/util.ts
+++ b/packages/vm/test/util.ts
@@ -269,7 +269,7 @@ export async function verifyPostConditions(state: any, testData: any, t: tape.Te
         const promise = verifyAccountPostConditions(state, address, account, testData, t)
         queue.push(promise)
       } else {
-        t.comment('invalid account in the trie: ' + <string>key)
+        t.comment('invalid account in the trie: ' + key)
       }
     })
 
@@ -364,9 +364,9 @@ export function makeBlockHeader(data: any, opts?: BlockOptions) {
   }
   if (opts?.common && opts.common.gteHardfork('paris')) {
     headerData['mixHash'] = setLengthLeft(
-      <Uint8Array>toType(currentRandom, TypeOutput.Uint8Array)!,
+      toType(currentRandom, TypeOutput.Uint8Array)!,
       32,
-    )
+    ) as Uint8Array
     headerData['difficulty'] = 0
   }
   if (opts?.common && opts.common.gteHardfork('cancun')) {


### PR DESCRIPTION
This removes all remaining non-`erasableSyntax` from the monorepo to allow us to run typescript without a build step.  

- Replaces remaining `<someType>someVariable` syntax with `someVariable as someType`
- Adds a new CI job that starts the client in dev mode using node 23