### PR TITLE
util: remove unnecessary empty array assignment

### DIFF
--- a/packages/client/src/util/vkt.ts
+++ b/packages/client/src/util/vkt.ts
@@ -19,7 +19,7 @@ export async function generateVKTStateRoot(genesisState: GenesisState, common: C
   for (const addressStr of Object.keys(genesisState)) {
     const addrState = genesisState[addressStr]
     let nonce, balance, code
-    let storage: StoragePair[] | undefined = []
+    let storage: StoragePair[] | undefined
     if (Array.isArray(addrState)) {
       ;[balance, code, storage, nonce] = addrState
     } else {


### PR DESCRIPTION
This PR removes an unnecessary empty array initialization that was pointed out by @jochem-brouwer  in https://github.com/ethereumjs/ethereumjs-monorepo/pull/3973#discussion_r2041248173 but that had not addressed before the PR got merged. 