### PR TITLE
chore: handling of zero point in bls point mapping G2

### DIFF
--- a/packages/evm/src/precompiles/11-bls12-map-fp2-to-g2.ts
+++ b/packages/evm/src/precompiles/11-bls12-map-fp2-to-g2.ts
@@ -47,6 +47,18 @@ export async function precompile11(opts: PrecompileInput): Promise<ExecResult> {
     if (opts._debug !== undefined) {
       opts._debug(`${pName} failed: ${e.message}`)
     }
+    // noble‑curves throws this for inputs that map to the point at infinity
+    if (e.message === 'bad point: ZERO') {
+      // return two zeroed field elements (x & y), each the same length as the input
+      const zeroPoint = new Uint8Array(opts.data.length * 2)
+      if (opts._debug !== undefined) {
+        opts._debug(`${pName} mapping to ZERO point, returning zero-filled output`)
+      }
+      return {
+        executionGasUsed: gasUsed,
+        returnValue: zeroPoint,
+      }
+    }
     return EvmErrorResult(e, opts.gasLimit)
   }
 


### PR DESCRIPTION
This addresses the issue that was flared up in #3979 and addressed in #3985 for bls point mapping G1 but for the G2 mapping. 