### PR TITLE
Replace `ethers` with `viem` in vm examples/tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4938,6 +4938,28 @@
         "node": ">=16.5.0"
       }
     },
+    "node_modules/abitype": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
+      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.22.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -10555,6 +10577,22 @@
         "ws": "*"
       }
     },
+    "node_modules/isows": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
+      "integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -12885,6 +12923,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.9.tgz",
+      "integrity": "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/p-defer": {
@@ -16322,6 +16390,37 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/viem": {
+      "version": "2.27.2",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.27.2.tgz",
+      "integrity": "sha512-VwsB+RswcflbwBNPMvzTHuafDA51iT8v4SuIFcudTP2skmxcdodbgoOLP4dYELVnCzcedxoSJDOeext4V3zdnA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.8.1",
+        "@noble/hashes": "1.7.1",
+        "@scure/bip32": "1.6.2",
+        "@scure/bip39": "1.5.4",
+        "abitype": "1.0.8",
+        "isows": "1.0.6",
+        "ox": "0.6.9",
+        "ws": "8.18.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vite": {
       "version": "6.3.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.2.tgz",
@@ -17906,7 +18005,6 @@
         "@types/minimist": "^1.2.5",
         "@types/node-dir": "^0.0.37",
         "benchmark": "^2.1.4",
-        "ethers": "^6.13.5",
         "mcl-wasm": "^1.8.0",
         "micro-eth-signer": "^0.14.0",
         "minimist": "^1.2.8",
@@ -17914,6 +18012,7 @@
         "nyc": "^17.1.0",
         "solc": "^0.8.28",
         "tape": "^5.9.0",
+        "viem": "^2.27.2",
         "yargs": "^17.7.2"
       },
       "engines": {

--- a/packages/vm/examples/helpers/tx-builder.ts
+++ b/packages/vm/examples/helpers/tx-builder.ts
@@ -1,36 +1,4 @@
-import { AbiCoder, Interface } from 'ethers' // cspell:disable-line
-
 import type { LegacyTxData } from '@ethereumjs/tx'
-
-export const encodeFunction = (
-  method: string,
-  params?: {
-    types: any[]
-    values: unknown[]
-  },
-): string => {
-  const parameters = params?.types ?? []
-  const methodWithParameters = `function ${method}(${parameters.join(',')})`
-  const signatureHash = new Interface([methodWithParameters]).getFunction(method)?.selector
-  const encodedArgs = new AbiCoder().encode(parameters, params?.values ?? [])
-
-  return signatureHash + encodedArgs.slice(2)
-}
-
-export const encodeDeployment = (
-  bytecode: string,
-  params?: {
-    types: any[]
-    values: unknown[]
-  },
-) => {
-  const deploymentData = '0x' + bytecode
-  if (params) {
-    const argumentsEncoded = new AbiCoder().encode(params.types, params.values)
-    return deploymentData + argumentsEncoded.slice(2)
-  }
-  return deploymentData
-}
 
 export const buildTransaction = (data: Partial<LegacyTxData>): LegacyTxData => {
   const defaultData: Partial<LegacyTxData> = {

--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -75,13 +75,13 @@
   "devDependencies": {
     "@ethereumjs/blockchain": "^10.0.0-rc.1",
     "@ethereumjs/ethash": "^10.0.0-rc.1",
+    "@ethereumjs/testdata": "1.0.0",
     "@paulmillr/trusted-setups": "^0.1.2",
     "@types/benchmark": "^2.1.5",
     "@types/core-js": "^2.5.8",
     "@types/minimist": "^1.2.5",
     "@types/node-dir": "^0.0.37",
     "benchmark": "^2.1.4",
-    "ethers": "^6.13.5",
     "mcl-wasm": "^1.8.0",
     "micro-eth-signer": "^0.14.0",
     "minimist": "^1.2.8",
@@ -89,8 +89,8 @@
     "nyc": "^17.1.0",
     "solc": "^0.8.28",
     "tape": "^5.9.0",
-    "yargs": "^17.7.2",
-    "@ethereumjs/testdata": "1.0.0"
+    "viem": "^2.27.2",
+    "yargs": "^17.7.2"
   },
   "engines": {
     "node": ">=18"

--- a/packages/vm/test/api/customChain.spec.ts
+++ b/packages/vm/test/api/customChain.spec.ts
@@ -9,7 +9,7 @@ import {
   createAddressFromString,
   hexToBytes,
 } from '@ethereumjs/util'
-import { Interface } from 'ethers'
+import { encodeFunctionData } from 'viem'
 import { assert, describe, it } from 'vitest'
 
 import { createVM, runTx } from '../../src/index.ts'
@@ -96,7 +96,12 @@ describe('VM initialized with custom state', () => {
     common.setHardfork(Hardfork.London)
     const vm = await createVM({ blockchain, common })
     await vm.stateManager.generateCanonicalGenesis!(genesisState)
-    const calldata = new Interface(['function retrieve()']).getFunction('retrieve')!.selector
+    const calldata = encodeFunctionData({
+      abi: [
+        { type: 'function', name: 'retrieve', inputs: [], outputs: [], stateMutability: 'view' },
+      ],
+      functionName: 'retrieve',
+    })
 
     const callResult = await vm.evm.runCall({
       to: createAddressFromString(contractAddress),


### PR DESCRIPTION
`ethers` currently is using an older version of `@noble/hashes` (v1.3.2) which is causing some duplication of versions of `@noble/hashes` in our monorepo.

`ethers` is only being used in `vm` for some ABI encoding/decoding utilities so this replaces it with `viem` which has no dependencies and provides basically drop-in replacements for those tools.

Note, the robots wrote the actual translations of these functions and I reviewed/edited/tightened things up.