### PR TITLE
fix: nightly node tests

### DIFF
--- a/packages/ethash/package.json
+++ b/packages/ethash/package.json
@@ -44,7 +44,7 @@
     "spellcheck": "npm run spellcheck:ts && npm run spellcheck:md",
     "spellcheck:ts": "npx cspell --gitignore -c ../../config/cspell-ts.json \"./**/*.ts\" --cache --show-suggestions --show-context",
     "spellcheck:md": "npx cspell --gitignore -c ../../config/cspell-md.json \"**.md\" --cache --show-suggestions --show-context",
-    "test": "npx vitest run -c ../../config/vitest.config.mts",
+    "test": "npx vitest run -c ./vite.config.ts",
     "tsc": "../../config/cli/ts-compile.sh"
   },
   "dependencies": {


### PR DESCRIPTION
This PR fixes #4005 by adjusting the ethash npm run test script so that it consider the global timeout specified in the ethash package.

This seems to be the culprit for both node20 and node22 (aside from some irregular client tests failing)