### PR TITLE
Client: (WIP) rework CLI startup logic using RpcConfig (#3983)

### DIFF
--- a/packages/client/bin/cli.ts
+++ b/packages/client/bin/cli.ts
@@ -14,7 +14,7 @@ import { LevelDB } from '../src/execution/level.ts'
 import { generateVKTStateRoot } from '../src/util/vkt.ts'
 
 import { helpRPC, startRPCServers } from './startRPC.ts'
-import { generateClientConfig, getArgs } from './utils.ts'
+import { generateClientConfig, generateRpcConfigs, getArgs } from './utils.ts'
 
 import type * as http from 'http'
 import type { Block, BlockBytes } from '@ethereumjs/block'
@@ -24,6 +24,7 @@ import type { AbstractLevel } from 'abstract-level'
 import type { Server as RPCServer } from 'jayson/promise/index.js'
 import type { Config } from '../src/config.ts'
 import type { Logger } from '../src/logging.ts'
+import type { RpcConfig } from '../src/rpc/config.ts'
 import type { FullEthereumService } from '../src/service/index.ts'
 import type { ClientOpts } from '../src/types.ts'
 import type { RPCArgs } from './startRPC.ts'
@@ -349,8 +350,26 @@ async function run() {
   const { config, customGenesisState, customGenesisStateRoot, metricsServer } =
     await generateClientConfig(args)
 
+  const rpcConfigs = generateRpcConfigs(config, args as RPCArgs)
+
   logger = config.logger
 
+  await startClientAndServers(
+    config,
+    customGenesisState,
+    customGenesisStateRoot,
+    metricsServer,
+    rpcConfigs,
+  )
+}
+
+async function startClientAndServers(
+  config: Config,
+  customGenesisState: GenesisState | undefined,
+  customGenesisStateRoot: Uint8Array<ArrayBufferLike> | undefined,
+  metricsServer: http.Server<typeof http.IncomingMessage, typeof http.ServerResponse> | undefined,
+  rpcConfigs: RpcConfig[],
+) {
   // Do not wait for client to be fully started so that we can hookup SIGINT handling
   // else a SIGINT before may kill the process in unclean manner
   const clientStartPromise = startClient(config, {
@@ -360,7 +379,7 @@ async function run() {
     .then((client) => {
       const servers: (RPCServer | http.Server)[] =
         args.rpc === true || args.rpcEngine === true || args.ws === true
-          ? startRPCServers(client, args as RPCArgs)
+          ? startRPCServers(client, rpcConfigs)
           : []
       if (
         client.config.chainCommon.gteHardfork(Hardfork.Paris) &&

--- a/packages/client/bin/repl.ts
+++ b/packages/client/bin/repl.ts
@@ -3,8 +3,8 @@ import process from 'process'
 
 import { createInlineClient } from '../src/util/index.ts'
 
-import { startRPCServers } from './startRPC.ts'
-import { generateClientConfig, getArgs } from './utils.ts'
+import { type RPCArgs, startRPCServers } from './startRPC.ts'
+import { generateClientConfig, generateRpcConfigs, getArgs } from './utils.ts'
 
 import type { Common, GenesisState } from '@ethereumjs/common'
 import type { Config } from '../src/config.ts'
@@ -24,7 +24,8 @@ const setupClient = async (
     args.dataDir ?? '',
     true,
   )
-  const servers = startRPCServers(client, {
+
+  const rpcArgs: RPCArgs = {
     rpc: true,
     rpcAddr: args.rpcAddr ?? '0.0.0.0',
     rpcPort: args.rpcPort ?? 8545,
@@ -42,7 +43,9 @@ const setupClient = async (
     jwtSecret: '',
     rpcEngineAuth: false,
     rpcCors: '',
-  })
+  }
+
+  const servers = startRPCServers(client, generateRpcConfigs(config, rpcArgs))
 
   return { client, executionRPC: servers[0], engineRPC: servers[1] }
 }

--- a/packages/client/bin/utils.ts
+++ b/packages/client/bin/utils.ts
@@ -49,13 +49,15 @@ import { hideBin } from 'yargs/helpers'
 import { Config, SyncMode } from '../src/config.ts'
 import { getLogger } from '../src/logging.ts'
 import { Event } from '../src/types.ts'
-import { parseMultiaddrs } from '../src/util/index.ts'
+import { MethodConfig, parseJwtSecret, parseMultiaddrs } from '../src/util/index.ts'
 import { setupMetrics } from '../src/util/metrics.ts'
 
 import type { CustomCrypto, GenesisState, GethGenesis } from '@ethereumjs/common'
 import type { Address, PrefixedHexString } from '@ethereumjs/util'
 import type { Logger } from '../src/logging.ts'
+import { RpcConfig } from '../src/rpc/config.ts'
 import type { ClientOpts } from '../src/types.ts'
+import type { RPCArgs } from './startRPC.ts'
 
 export type Account = [address: Address, privateKey: Uint8Array]
 
@@ -895,4 +897,100 @@ export async function generateClientConfig(args: ClientOpts) {
   const customGenesisStateRoot = args.verkleGenesisStateRoot
 
   return { config, customGenesisState, customGenesisStateRoot, metricsServer, common }
+}
+
+export function generateRpcConfigs(config: Config, args: RPCArgs): RpcConfig[] {
+  const servers: RpcConfig[] = []
+
+  const jwtSecret =
+    args.rpcEngine && args.rpcEngineAuth
+      ? parseJwtSecret(config, args.jwtSecret)
+      : new Uint8Array(0)
+
+  // eth/engine shared
+  const withEngineMethods =
+    args.rpcEngine &&
+    args.rpc &&
+    args.rpcEnginePort === args.rpcPort &&
+    args.rpcEngineAddr === args.rpcAddr
+
+  if (args.rpc || args.ws) {
+    const methodConfig = withEngineMethods ? MethodConfig.WithEngine : MethodConfig.WithoutEngine
+
+    if (args.rpc) {
+      servers.push(
+        new RpcConfig({
+          type: 'eth',
+          transport: 'http',
+          methodConfig,
+          address: args.rpcAddr,
+          port: args.rpcPort,
+          engineAuth: withEngineMethods && args.rpcEngineAuth,
+          jwtSecret: withEngineMethods ? jwtSecret : undefined,
+          debug: args.rpcDebug,
+          debugVerbose: args.rpcDebugVerbose,
+          cors: args.rpcCors,
+        }),
+      )
+    }
+
+    if (args.ws) {
+      servers.push(
+        new RpcConfig({
+          type: 'eth',
+          transport: 'ws',
+          methodConfig,
+          address: args.wsAddr,
+          port: args.wsPort,
+          engineAuth: withEngineMethods && args.rpcEngineAuth,
+          jwtSecret: withEngineMethods ? jwtSecret : undefined,
+          debug: args.rpcDebug,
+          debugVerbose: args.rpcDebugVerbose,
+          cors: args.rpcCors,
+        }),
+      )
+    }
+  }
+
+  const engineSeparate =
+    args.rpcEngine &&
+    !(args.rpc && args.rpcPort === args.rpcEnginePort && args.rpcAddr === args.rpcEngineAddr)
+
+  if (engineSeparate) {
+    const methodConfig = MethodConfig.EngineOnly
+
+    servers.push(
+      new RpcConfig({
+        type: 'engine',
+        transport: 'http',
+        methodConfig,
+        address: args.rpcEngineAddr,
+        port: args.rpcEnginePort,
+        engineAuth: args.rpcEngineAuth,
+        jwtSecret,
+        debug: args.rpcDebug,
+        debugVerbose: args.rpcDebugVerbose,
+        cors: args.rpcCors,
+      }),
+    )
+
+    if (args.ws) {
+      servers.push(
+        new RpcConfig({
+          type: 'engine',
+          transport: 'ws',
+          methodConfig,
+          address: args.wsEngineAddr,
+          port: args.wsEnginePort,
+          engineAuth: args.rpcEngineAuth,
+          jwtSecret,
+          debug: args.rpcDebug,
+          debugVerbose: args.rpcDebugVerbose,
+          cors: args.rpcCors,
+        }),
+      )
+    }
+  }
+
+  return servers
 }

--- a/packages/client/src/rpc/config.ts
+++ b/packages/client/src/rpc/config.ts
@@ -1,0 +1,84 @@
+import type { MethodConfig } from '../util/rpc.ts'
+
+export const RPCNamespace = {
+  Eth: 'eth', // untrusted
+  Engine: 'engine', // trusted
+} as const
+
+export type RPCNamespace = (typeof RPCNamespace)[keyof typeof RPCNamespace]
+
+export const RPCTransport = {
+  Ws: 'ws',
+  Http: 'http',
+} as const
+
+export type RPCTransport = (typeof RPCTransport)[keyof typeof RPCTransport]
+
+export class RpcConfig {
+  public static readonly DEFAULT_RPC_ADDR = '0.0.0.0'
+  public static readonly DEFAULT_ENGINE_ADDR = '0.0.0.0'
+  public static readonly DEFAULT_WS_ADDR = '0.0.0.0'
+  public static readonly DEFAULT_WS_ENGINE_ADDR = '0.0.0.0'
+  public static readonly DEFAULT_RPC_PORT = 8545
+  public static readonly DEFAULT_ENGINE_PORT = 8551
+  public static readonly DEFAULT_WS_PORT = 0
+  public static readonly DEFAULT_WS_ENGINE_PORT = 8552
+  public static readonly DEFAULT_RPC_DEBUG = 'eth'
+  public static readonly DEFAULT_RPC_DEBUG_VERBOSE = 'false'
+  public static readonly DEFAULT_HELP_RPC = false
+  public static readonly DEFAULT_RPC_ENGINE_AUTH = false
+  public static readonly DEFAULT_CORS = ''
+  // public static readonly RPC_ETH_MAXPAYLOAD_DEFAULT
+  // public static readonly RPC_ENGINE_MAXPAYLOAD_DEFAULT
+
+  public readonly type: RPCNamespace
+  public readonly transport: RPCTransport
+  public readonly methodConfig: MethodConfig
+  public readonly address: string
+  public readonly port: number
+  public readonly debug: string
+  public readonly debugVerbose: string
+  public readonly jwtSecret: Uint8Array<ArrayBufferLike> | undefined
+  public readonly engineAuth: boolean
+  public readonly cors: string
+
+  constructor(options: {
+    type: RPCNamespace
+    transport: RPCTransport
+    methodConfig: MethodConfig
+    address?: string
+    port?: number
+    jwtSecret: Uint8Array<ArrayBufferLike> | undefined
+    engineAuth?: boolean
+    cors?: string
+    debug?: string
+    debugVerbose?: string
+  }) {
+    this.type = options.type
+    this.transport = options.transport
+    this.methodConfig = options.methodConfig
+    this.address = options.address ?? this.getDefaultAddress(this.type, this.transport)
+    this.port = options.port ?? this.getDefaultPort(this.type, this.transport)
+    this.debug = options.debug ?? RpcConfig.DEFAULT_RPC_DEBUG
+    this.debugVerbose = options.debugVerbose ?? RpcConfig.DEFAULT_RPC_DEBUG_VERBOSE
+    this.cors = options.cors ?? RpcConfig.DEFAULT_CORS
+    this.engineAuth = options.engineAuth ?? RpcConfig.DEFAULT_RPC_ENGINE_AUTH
+    this.jwtSecret = options.jwtSecret
+  }
+
+  getDefaultAddress(type: RPCNamespace, transport: RPCTransport): string {
+    if (type === 'eth') {
+      return transport === 'http' ? RpcConfig.DEFAULT_RPC_ADDR : RpcConfig.DEFAULT_WS_ADDR
+    } else {
+      return transport === 'http' ? RpcConfig.DEFAULT_ENGINE_ADDR : RpcConfig.DEFAULT_WS_ENGINE_ADDR
+    }
+  }
+
+  getDefaultPort(type: RPCNamespace, transport: RPCTransport): number {
+    if (type === 'eth') {
+      return transport === 'http' ? RpcConfig.DEFAULT_RPC_PORT : RpcConfig.DEFAULT_WS_PORT
+    } else {
+      return transport === 'http' ? RpcConfig.DEFAULT_ENGINE_PORT : RpcConfig.DEFAULT_WS_ENGINE_PORT
+    }
+  }
+}

--- a/packages/client/src/util/rpc.ts
+++ b/packages/client/src/util/rpc.ts
@@ -1,5 +1,12 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs'
 import { createServer } from 'http'
 import { inspect } from 'util'
+import {
+  EthereumJSErrorWithoutCode,
+  bytesToUnprefixedHex,
+  hexToBytes,
+  randomBytes,
+} from '@ethereumjs/util'
 import bodyParser from 'body-parser'
 import Connect from 'connect'
 import cors from 'cors'
@@ -8,6 +15,7 @@ import jayson from 'jayson/promise/index.js'
 import { jwt } from '../ext/jwt-simple.ts'
 
 import type { IncomingMessage } from 'connect'
+import type { Config } from '../config.ts'
 import type { TAlgorithm } from '../ext/jwt-simple.ts'
 import type { Logger } from '../logging.ts'
 import type { RPCManager } from '../rpc/index.ts'
@@ -242,4 +250,39 @@ export function createWsRPCServerListener(opts: CreateWSServerOpts): jayson.Http
   })
   // Only return something if a new server was created
   return !opts.httpServer ? httpServer : undefined
+}
+
+export /**
+ * Returns a jwt secret from a provided file path, otherwise saves a randomly generated one to datadir if none already exists
+ */
+function parseJwtSecret(config: Config, jwtFilePath?: string): Uint8Array {
+  let jwtSecret: Uint8Array
+  const defaultJwtPath = `${config.datadir}/jwtsecret`
+  const usedJwtPath = jwtFilePath ?? defaultJwtPath
+
+  // If jwtFilePath is provided, it should exist
+  if (jwtFilePath !== undefined && !existsSync(jwtFilePath)) {
+    throw EthereumJSErrorWithoutCode(`No file exists at provided jwt secret path=${jwtFilePath}`)
+  }
+
+  if (jwtFilePath !== undefined || existsSync(defaultJwtPath)) {
+    const jwtSecretContents = readFileSync(jwtFilePath ?? defaultJwtPath, 'utf-8').trim()
+    const hexPattern = new RegExp(/^(0x|0X)?(?<jwtSecret>[a-fA-F0-9]+)$/, 'g')
+    const jwtSecretHex = hexPattern.exec(jwtSecretContents)?.groups?.jwtSecret
+    if (jwtSecretHex === undefined || jwtSecretHex.length !== 64) {
+      throw Error('Need a valid 256 bit hex encoded secret')
+    }
+    jwtSecret = hexToBytes(`0x${jwtSecretHex}`)
+  } else {
+    const folderExists = existsSync(config.datadir)
+    if (!folderExists) {
+      mkdirSync(config.datadir, { recursive: true })
+    }
+
+    jwtSecret = randomBytes(32)
+    writeFileSync(defaultJwtPath, bytesToUnprefixedHex(jwtSecret), {})
+    config.logger?.info(`New Engine API JWT token created path=${defaultJwtPath}`)
+  }
+  config.logger?.info(`Using Engine API with JWT token authentication path=${usedJwtPath}`)
+  return jwtSecret
 }


### PR DESCRIPTION
This PR starts addressing #3983 by refactoring the client CLI 

### Description

- Introduced a new `RpcConfig` class for RPC endpoints (eth/engine, http/ws)
- Added a `generateRpcConfigs()` func to generate all server configurations from CLI args
- Refactored `startRPCServers()` to use these configs instead of cli args
- Removed repeated logic for creating, starting and logging HTTP/WS servers
- Split the `run()` function to improve testability:
  - `run()` now handles only CLI argument parsing, config generation, and dispatch
  - New `startClientAndServers()` function performs the client and RPC server startup
  - This split improves separation of concerns and makes the CLI flow easier to test

This is still a work in progress — if the current structure looks good to you, I’ll follow up with unit tests for the new helpers and config logic in a separate commit!