### PR TITLE
evm: upgrade noble curves to 1.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17674,7 +17674,7 @@
         "@ethereumjs/statemanager": "^10.0.0-rc.1",
         "@ethereumjs/util": "^10.0.0-rc.1",
         "@ethereumjs/verkle": "^10.0.0-dev-rc.1",
-        "@noble/curves": "^1.8.2",
+        "@noble/curves": "^1.9.0",
         "@types/debug": "^4.1.12",
         "debug": "^4.4.0",
         "ethereum-cryptography": "^3.1.0",
@@ -17703,12 +17703,12 @@
       }
     },
     "packages/evm/node_modules/@noble/curves": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.2.tgz",
-      "integrity": "sha512-vnI7V6lFNe0tLAuJMu+2sX+FcL14TaCWy1qiczg1VwRmPrpQCdq5ESXQMqUc2tluRNf6irBXrWbl1mGN8uaU/g==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.0.tgz",
+      "integrity": "sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "1.7.2"
+        "@noble/hashes": "1.8.0"
       },
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -17718,9 +17718,9 @@
       }
     },
     "packages/evm/node_modules/@noble/hashes": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.2.tgz",
-      "integrity": "sha512-biZ0NUSxyjLLqo6KxEJ1b+C2NAx0wtDoFvCaXHGgUkeHzf3Xc1xKumFKREuT7f7DARNZ/slvYUwFG6B0f2b6hQ==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"

--- a/packages/evm/package.json
+++ b/packages/evm/package.json
@@ -59,7 +59,7 @@
     "@ethereumjs/statemanager": "^10.0.0-rc.1",
     "@ethereumjs/util": "^10.0.0-rc.1",
     "@ethereumjs/verkle": "^10.0.0-dev-rc.1",
-    "@noble/curves": "^1.8.2",
+    "@noble/curves": "^1.9.0",
     "@types/debug": "^4.1.12",
     "debug": "^4.4.0",
     "ethereum-cryptography": "^3.1.0",

--- a/packages/evm/src/precompiles/10-bls12-map-fp-to-g1.ts
+++ b/packages/evm/src/precompiles/10-bls12-map-fp-to-g1.ts
@@ -44,18 +44,6 @@ export async function precompile10(opts: PrecompileInput): Promise<ExecResult> {
     if (opts._debug !== undefined) {
       opts._debug(`${pName} failed: ${e.message}`)
     }
-    // noble‑curves throws this for inputs that map to the point at infinity
-    if (e.message === 'bad point: ZERO') {
-      // return two zeroed field elements (x & y), each the same length as the input
-      const zeroPoint = new Uint8Array(opts.data.length * 2)
-      if (opts._debug !== undefined) {
-        opts._debug(`${pName} mapping to ZERO point, returning zero-filled output`)
-      }
-      return {
-        executionGasUsed: gasUsed,
-        returnValue: zeroPoint,
-      }
-    }
     return EVMErrorResult(e, opts.gasLimit)
   }
 


### PR DESCRIPTION
This PR upgrades noble to 1.9.0, removing the need to manually catch the zero-point error since it now implements the expected behavior. 