### PR TITLE
Use interfaces for VKT/BST backed statemanagers in `evm`/`vm`

### DIFF
--- a/packages/client/src/execution/vmexecution.ts
+++ b/packages/client/src/execution/vmexecution.ts
@@ -230,7 +230,10 @@ export class VMExecution extends Execution {
   }
 
   async transitionToVerkle(merkleStateRoot: Uint8Array, assignToVM: boolean = true): Promise<void> {
-    if (typeof this.vm.stateManager.initVerkleExecutionWitness === 'function') {
+    if (
+      'initVerkleExecutionWitness' in this.vm.stateManager &&
+      typeof this.vm.stateManager.initVerkleExecutionWitness === 'function'
+    ) {
       return
     }
 
@@ -430,6 +433,7 @@ export class VMExecution extends Execution {
           }
 
           const needsStatelessExecution =
+            'initVerkleExecutionWitness' in this.vm.stateManager &&
             typeof this.vm.stateManager.initVerkleExecutionWitness === 'function'
           if (needsStatelessExecution && block.executionWitness === undefined) {
             throw Error(`Verkle blocks need executionWitness for stateless execution`)
@@ -691,6 +695,7 @@ export class VMExecution extends Execution {
                   }
                   if (
                     (!this.config.execCommon.gteHardfork(Hardfork.Verkle) &&
+                      'initVerkleExecutionWitness' in this.vm.stateManager &&
                       typeof this.vm.stateManager.initVerkleExecutionWitness === 'function') ||
                     (this.config.execCommon.gteHardfork(Hardfork.Verkle) &&
                       this.vm.stateManager instanceof MerkleStateManager)

--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -226,17 +226,6 @@ export interface StateManagerInterface {
     clear(): void
   }
   generateCanonicalGenesis?(initState: any): Promise<void> // TODO make input more typesafe
-  initVerkleExecutionWitness?(
-    blockNum: bigint,
-    executionWitness?: VerkleExecutionWitness | null,
-  ): void
-  verifyVerklePostState?(accessWitness: VerkleAccessWitnessInterface): Promise<boolean>
-  initBinaryTreeExecutionWitness?(
-    blockNum: bigint,
-    executionWitness?: BinaryTreeExecutionWitness | null,
-  ): void
-  verifyBinaryTreePostState?(accessWitness: BinaryTreeAccessWitnessInterface): Promise<boolean>
-  checkChunkWitnessPresent?(contract: Address, programCounter: number): Promise<boolean>
   getAppliedKey?(address: Uint8Array): Uint8Array // only for preimages
 
   /*
@@ -244,4 +233,22 @@ export interface StateManagerInterface {
    */
   clearCaches(): void
   shallowCopy(downlevelCaches?: boolean): StateManagerInterface
+}
+
+export interface VerkleStateManagerInterface extends StateManagerInterface {
+  initVerkleExecutionWitness(
+    blockNum: bigint,
+    executionWitness?: VerkleExecutionWitness | null,
+  ): void
+  verifyPostState(accessWitness: VerkleAccessWitnessInterface): Promise<boolean>
+  checkChunkWitnessPresent?(contract: Address, programCounter: number): Promise<boolean>
+}
+
+export interface BinaryStateManagerInterface extends StateManagerInterface {
+  initBinaryTreeExecutionWitness(
+    blockNum: bigint,
+    executionWitness?: BinaryTreeExecutionWitness | null,
+  ): void
+  verifyBinaryTreePostState?(accessWitness: BinaryTreeAccessWitnessInterface): Promise<boolean>
+  checkChunkWitnessPresent?(contract: Address, programCounter: number): Promise<boolean>
 }

--- a/packages/evm/src/binaryTreeAccessWitness.ts
+++ b/packages/evm/src/binaryTreeAccessWitness.ts
@@ -1,5 +1,6 @@
 import type {
   AccessEventFlags,
+  BinaryStateManagerInterface,
   BinaryTreeAccessWitnessInterface,
   BinaryTreeAccessedState,
   BinaryTreeAccessedStateWithAddress,
@@ -29,7 +30,6 @@ import { ChunkCache } from './chunkCache.ts'
 import { StemCache } from './stemCache.ts'
 
 import type { BinaryTree } from '@ethereumjs/binarytree'
-import type { StatefulBinaryTreeStateManager } from '@ethereumjs/statemanager'
 import type { Address, BinaryTreeExecutionWitness, PrefixedHexString } from '@ethereumjs/util'
 
 const debug = debugDefault('evm:binaryTree:aw')
@@ -389,11 +389,11 @@ export class BinaryTreeAccessWitness implements BinaryTreeAccessWitnessInterface
  * @returns The generated binary tree execution witness
  */
 export const generateBinaryExecutionWitness = async (
-  stateManager: StatefulBinaryTreeStateManager,
+  stateManager: BinaryStateManagerInterface,
   accessWitness: BinaryTreeAccessWitness,
   parentStateRoot: Uint8Array,
 ): Promise<BinaryTreeExecutionWitness> => {
-  const tree = stateManager['_tree'] as BinaryTree
+  const tree = (stateManager as any)['_tree'] as BinaryTree
   await tree['_lock'].acquire()
   const postStateRoot = await stateManager.getStateRoot()
   const ew: BinaryTreeExecutionWitness = {

--- a/packages/evm/src/verkleAccessWitness.ts
+++ b/packages/evm/src/verkleAccessWitness.ts
@@ -28,8 +28,8 @@ import type {
   VerkleAccessWitnessInterface,
   VerkleAccessedState,
   VerkleAccessedStateWithAddress,
+  VerkleStateManagerInterface,
 } from '@ethereumjs/common'
-import type { StatefulVerkleStateManager } from '@ethereumjs/statemanager'
 import type {
   Address,
   PrefixedHexString,
@@ -398,11 +398,11 @@ export class VerkleAccessWitness implements VerkleAccessWitnessInterface {
  * Note: This does not provide the verkle proof, which is not implemented
  */
 export const generateExecutionWitness = async (
-  stateManager: StatefulVerkleStateManager,
+  stateManager: VerkleStateManagerInterface,
   accessWitness: VerkleAccessWitness,
   parentStateRoot: Uint8Array,
 ): Promise<VerkleExecutionWitness> => {
-  const trie = stateManager['_trie'] as VerkleTree
+  const trie = (stateManager as any)['_trie'] as VerkleTree
   await trie['_lock'].acquire()
   const postStateRoot = await stateManager.getStateRoot()
   const ew: VerkleExecutionWitness = {

--- a/packages/evm/vite.config.bundler.ts
+++ b/packages/evm/vite.config.bundler.ts
@@ -11,7 +11,7 @@ export default defineConfig({
       treeshake: 'safest',
     },
     lib: {
-      entry: './src/',
+      entry: '../vm/examples/runTx.ts',
       name: '@ethereumjs/evm',
       fileName: (format) => `ethereumjs-evm-bundle.${format}.js`,
       // only build for es

--- a/packages/statemanager/src/proof/verkle.ts
+++ b/packages/statemanager/src/proof/verkle.ts
@@ -2,11 +2,10 @@ import { EthereumJSErrorWithoutCode, verifyVerkleProof } from '@ethereumjs/util'
 
 import type { VerkleStateManagerInterface } from '@ethereumjs/common'
 import type { Address } from '@ethereumjs/util'
-import type { Proof } from '../index.ts'
-import type { StatelessVerkleStateManager } from '../statelessVerkleStateManager.ts'
+import type { Proof, StatelessVerkleStateManager } from '../index.ts'
 
 export function getVerkleStateProof(
-  sm: StatelessVerkleStateManager,
+  sm: VerkleStateManagerInterface,
   _: Address,
   __: Uint8Array[] = [],
 ): Promise<Proof> {

--- a/packages/statemanager/src/proof/verkle.ts
+++ b/packages/statemanager/src/proof/verkle.ts
@@ -1,5 +1,6 @@
 import { EthereumJSErrorWithoutCode, verifyVerkleProof } from '@ethereumjs/util'
 
+import type { VerkleStateManagerInterface } from '@ethereumjs/common'
 import type { Address } from '@ethereumjs/util'
 import type { Proof } from '../index.ts'
 import type { StatelessVerkleStateManager } from '../statelessVerkleStateManager.ts'
@@ -16,11 +17,12 @@ export function getVerkleStateProof(
  * @param {Uint8Array} stateRoot - The stateRoot to verify the executionWitness against
  * @returns {boolean} - Returns true if the executionWitness matches the provided stateRoot, otherwise false
  */
-export function verifyVerkleStateProof(sm: StatelessVerkleStateManager): boolean {
-  if (sm['_executionWitness'] === undefined) {
-    sm['DEBUG'] && sm['_debug']('Missing executionWitness')
+export function verifyVerkleStateProof(sm: VerkleStateManagerInterface): boolean {
+  const stateManager = sm as StatelessVerkleStateManager
+  if (stateManager['_executionWitness'] === undefined) {
+    stateManager['DEBUG'] && stateManager['_debug']('Missing executionWitness')
     return false
   }
 
-  return verifyVerkleProof(sm.verkleCrypto, sm['_executionWitness'])
+  return verifyVerkleProof(stateManager.verkleCrypto, stateManager['_executionWitness'])
 }

--- a/packages/statemanager/src/statefulBinaryTreeStateManager.ts
+++ b/packages/statemanager/src/statefulBinaryTreeStateManager.ts
@@ -42,6 +42,7 @@ import { modifyAccountFields } from './util.ts'
 
 import type {
   AccountFields,
+  BinaryStateManagerInterface,
   BinaryTreeAccessWitnessInterface,
   BinaryTreeAccessedStateWithAddress,
   GenesisState,
@@ -55,7 +56,7 @@ import type { Caches } from './cache/caches.ts'
 import type { BinaryTreeState, StatefulBinaryTreeStateManagerOpts } from './types.ts'
 
 const ZEROVALUE = '0x0000000000000000000000000000000000000000000000000000000000000000'
-export class StatefulBinaryTreeStateManager implements StateManagerInterface {
+export class StatefulBinaryTreeStateManager implements BinaryStateManagerInterface {
   protected _debug: Debugger
   protected _caches?: Caches
 

--- a/packages/statemanager/src/statefulVerkleStateManager.ts
+++ b/packages/statemanager/src/statefulVerkleStateManager.ts
@@ -54,13 +54,14 @@ import type {
   StorageRange,
   VerkleAccessWitnessInterface,
   VerkleAccessedStateWithAddress,
+  VerkleStateManagerInterface,
 } from '@ethereumjs/common'
 import type { Debugger } from 'debug'
 import type { Caches } from './cache/caches.ts'
 import type { StatefulVerkleStateManagerOpts, VerkleState } from './types.ts'
 
 const ZEROVALUE = '0x0000000000000000000000000000000000000000000000000000000000000000'
-export class StatefulVerkleStateManager implements StateManagerInterface {
+export class StatefulVerkleStateManager implements VerkleStateManagerInterface {
   protected _debug: Debugger
   protected _caches?: Caches
 

--- a/packages/statemanager/src/statelessVerkleStateManager.ts
+++ b/packages/statemanager/src/statelessVerkleStateManager.ts
@@ -31,9 +31,9 @@ import { modifyAccountFields } from './util.ts'
 import type {
   AccountFields,
   Common,
-  StateManagerInterface,
   VerkleAccessWitnessInterface,
   VerkleAccessedStateWithAddress,
+  VerkleStateManagerInterface,
 } from '@ethereumjs/common'
 import type {
   Address,
@@ -66,7 +66,7 @@ const ZEROVALUE = '0x00000000000000000000000000000000000000000000000000000000000
  * to fetch data requested by the the VM.
  *
  */
-export class StatelessVerkleStateManager implements StateManagerInterface {
+export class StatelessVerkleStateManager implements VerkleStateManagerInterface {
   _cachedStateRoot?: Uint8Array
 
   originalStorageCache: OriginalStorageCache

--- a/packages/vm/src/vm.ts
+++ b/packages/vm/src/vm.ts
@@ -4,7 +4,12 @@ import { EventEmitter } from 'eventemitter3'
 import { createVM } from './constructors.ts'
 import { paramsVM } from './params.ts'
 
-import type { Common, StateManagerInterface } from '@ethereumjs/common'
+import type {
+  BinaryStateManagerInterface,
+  Common,
+  StateManagerInterface,
+  VerkleStateManagerInterface,
+} from '@ethereumjs/common'
 import type { EVMInterface, EVMMockBlockchainInterface } from '@ethereumjs/evm'
 import type { BigIntLike } from '@ethereumjs/util'
 import type { VMEvent, VMOpts } from './types.ts'
@@ -17,7 +22,10 @@ export class VM {
   /**
    * The StateManager used by the VM
    */
-  readonly stateManager: StateManagerInterface
+  readonly stateManager:
+    | StateManagerInterface
+    | VerkleStateManagerInterface
+    | BinaryStateManagerInterface
 
   /**
    * The blockchain the VM operates on


### PR DESCRIPTION
This is an attempt to replace the direct references to the verkle and binary tree backed `StateManagers` in `evm`/`vm` in the interest of improving tree shakeability since we shouldn't need to bundle all of our state managers in a simple app devotes to say, simulating transactions on the MPT.