### PR TITLE
Convert `StatelessVerkleStateManager` usage to type in `vm`

### DIFF
--- a/packages/statemanager/src/statefulVerkleStateManager.ts
+++ b/packages/statemanager/src/statefulVerkleStateManager.ts
@@ -711,7 +711,7 @@ export class StatefulVerkleStateManager implements StateManagerInterface {
 
     const verifyPassed = postFailures === 0
     this.DEBUG &&
-      this._debug(`verifyPostState verifyPassed=${verifyPassed} postFailures=${postFailures}`)
+      this._debug(`verifyVerklePostState verifyPassed=${verifyPassed} postFailures=${postFailures}`)
 
     return verifyPassed
   }

--- a/packages/statemanager/src/statefulVerkleStateManager.ts
+++ b/packages/statemanager/src/statefulVerkleStateManager.ts
@@ -622,6 +622,7 @@ export class StatefulVerkleStateManager implements StateManagerInterface {
   }
 
   // Verifies that the witness post-state matches the computed post-state
+  // NOTE: Do not rename this method as we check for this function name in the VM to verify we're using a StatefulVerkleStateManager
   async verifyPostState(accessWitness: VerkleAccessWitnessInterface): Promise<boolean> {
     // track what all chunks were accessed so as to compare in the end if any chunks were missed
     // in access while comparing against the provided poststate in the execution witness

--- a/packages/statemanager/src/statelessVerkleStateManager.ts
+++ b/packages/statemanager/src/statelessVerkleStateManager.ts
@@ -499,6 +499,7 @@ export class StatelessVerkleStateManager implements StateManagerInterface {
   }
 
   // Verifies that the witness post-state matches the computed post-state
+  // NOTE: Do not rename this method as we check for this function name in the VM to verify we're using a StatelessVerkleStateManager
   verifyPostState(accessWitness: VerkleAccessWitnessInterface): Promise<boolean> {
     // track what all chunks were accessed so as to compare in the end if any chunks were missed
     // in access while comparing against the provided poststate in the execution witness

--- a/packages/statemanager/src/statelessVerkleStateManager.ts
+++ b/packages/statemanager/src/statelessVerkleStateManager.ts
@@ -572,7 +572,7 @@ export class StatelessVerkleStateManager implements StateManagerInterface {
 
     const verifyPassed = postFailures === 0
     this.DEBUG &&
-      this._debug(`verifyPostState verifyPassed=${verifyPassed} postFailures=${postFailures}`)
+      this._debug(`verifyVerklePostState verifyPassed=${verifyPassed} postFailures=${postFailures}`)
 
     // This is async so the stateful variant can use the same interface method
     return Promise.resolve(verifyPassed)

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -160,8 +160,8 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
     // Populate the execution witness
     stateManager.initVerkleExecutionWitness!(block.header.number, block.executionWitness)
 
-    // Check if statemanager is a Verkle State Manager (stateless and stateful both have verifyPostState)
-    if ('verifyPostState' in stateManager) {
+    // Check if statemanager is a Verkle State Manager (stateless and stateful both have verifyVerklePostState)
+    if ('verifyVerklePostState' in stateManager) {
       // Update the stateRoot cache
       await stateManager.setStateRoot(block.header.stateRoot)
       if (verifyVerkleStateProof(stateManager as StatelessVerkleStateManager) === true) {
@@ -275,7 +275,7 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
     }
 
     // Check if statemanager is a StatelessVerkleStateManager by checking for a method only on StatelessVerkleStateManager API
-    if (!('verifyPostState' in vm.stateManager)) {
+    if (!('verifyVerklePostState' in vm.stateManager)) {
       // Only validate the following headers if Stateless isn't activated
       if (equalsBytes(result.receiptsRoot, block.header.receiptTrie) === false) {
         if (vm.DEBUG) {

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -160,6 +160,7 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
     // Populate the execution witness
     stateManager.initVerkleExecutionWitness!(block.header.number, block.executionWitness)
 
+    // Check if statemanager is a Verkle State Manager (stateless and stateful both have verifyPostState)
     if ('verifyPostState' in stateManager) {
       // Update the stateRoot cache
       await stateManager.setStateRoot(block.header.stateRoot)
@@ -273,6 +274,7 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
       }
     }
 
+    // Check if statemanager is a StatelessVerkleStateManager by checking for a method only on StatelessVerkleStateManager API
     if (!('verifyPostState' in vm.stateManager)) {
       // Only validate the following headers if Stateless isn't activated
       if (equalsBytes(result.receiptsRoot, block.header.receiptTrie) === false) {

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -3,7 +3,7 @@ import { ConsensusType, Hardfork } from '@ethereumjs/common'
 import { type EVM, type EVMInterface, VerkleAccessWitness } from '@ethereumjs/evm'
 import { MerklePatriciaTrie } from '@ethereumjs/mpt'
 import { RLP } from '@ethereumjs/rlp'
-import { StatelessVerkleStateManager, verifyVerkleStateProof } from '@ethereumjs/statemanager'
+import { type StatelessVerkleStateManager, verifyVerkleStateProof } from '@ethereumjs/statemanager'
 import { TransactionType } from '@ethereumjs/tx'
 import {
   Account,
@@ -160,10 +160,10 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
     // Populate the execution witness
     stateManager.initVerkleExecutionWitness!(block.header.number, block.executionWitness)
 
-    if (stateManager instanceof StatelessVerkleStateManager) {
+    if ('verifyPostState' in stateManager) {
       // Update the stateRoot cache
       await stateManager.setStateRoot(block.header.stateRoot)
-      if (verifyVerkleStateProof(stateManager) === true) {
+      if (verifyVerkleStateProof(stateManager as StatelessVerkleStateManager) === true) {
         if (vm.DEBUG) {
           debug(`Verkle proof verification succeeded`)
         }
@@ -273,7 +273,7 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
       }
     }
 
-    if (!(vm.stateManager instanceof StatelessVerkleStateManager)) {
+    if (!('verifyPostState' in vm.stateManager)) {
       // Only validate the following headers if Stateless isn't activated
       if (equalsBytes(result.receiptsRoot, block.header.receiptTrie) === false) {
         if (vm.DEBUG) {

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -205,7 +205,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     }
 
     // Check if statemanager is a Verkle State Manager (stateless and stateful both have verifyPostState)
-    if (!('verifyPostState' in vm.stateManager) && !('verifyPostState' in vm.stateManager)) {
+    if (!('verifyPostState' in vm.stateManager)) {
       throw EthereumJSErrorWithoutCode(`Verkle State Manager needed for execution of verkle blocks`)
     }
     stateAccesses = vm.evm.verkleAccessWitness

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -204,8 +204,8 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
       throw Error(`Verkle access witness needed for execution of verkle blocks`)
     }
 
-    // Check if statemanager is a Verkle State Manager (stateless and stateful both have verifyPostState)
-    if (!('verifyPostState' in vm.stateManager)) {
+    // Check if statemanager is a Verkle State Manager (stateless and stateful both have verifyVerklePostState)
+    if (!('verifyVerklePostState' in vm.stateManager)) {
       throw EthereumJSErrorWithoutCode(`Verkle State Manager needed for execution of verkle blocks`)
     }
     stateAccesses = vm.evm.verkleAccessWitness

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -2,9 +2,8 @@ import { cliqueSigner, createBlockHeader } from '@ethereumjs/block'
 import { ConsensusType, Hardfork } from '@ethereumjs/common'
 import { BinaryTreeAccessWitness, type EVM, VerkleAccessWitness } from '@ethereumjs/evm'
 import {
-  StatefulBinaryTreeStateManager,
-  StatefulVerkleStateManager,
-  StatelessVerkleStateManager,
+  type StatefulVerkleStateManager,
+  type StatelessVerkleStateManager,
 } from '@ethereumjs/statemanager'
 import { Capability, isBlob4844Tx, recoverAuthority } from '@ethereumjs/tx'
 import {
@@ -205,20 +204,20 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
       throw Error(`Verkle access witness needed for execution of verkle blocks`)
     }
 
-    if (
-      !(vm.stateManager instanceof StatefulVerkleStateManager) &&
-      !(vm.stateManager instanceof StatelessVerkleStateManager)
-    ) {
+    if (!('verifyPostState' in vm.stateManager) && !('verifyPostState' in vm.stateManager)) {
       throw EthereumJSErrorWithoutCode(`Verkle State Manager needed for execution of verkle blocks`)
     }
     stateAccesses = vm.evm.verkleAccessWitness
-    txAccesses = new VerkleAccessWitness({ verkleCrypto: vm.stateManager.verkleCrypto })
+    txAccesses = new VerkleAccessWitness({
+      verkleCrypto: (vm.stateManager as StatelessVerkleStateManager | StatefulVerkleStateManager)
+        .verkleCrypto,
+    })
   } else if (vm.common.isActivatedEIP(7864)) {
     if (vm.evm.binaryTreeAccessWitness === undefined) {
       throw Error(`Binary tree access witness needed for execution of binary tree blocks`)
     }
 
-    if (!(vm.stateManager instanceof StatefulBinaryTreeStateManager)) {
+    if (!('verifyBinaryPostState' in vm.stateManager)) {
       throw EthereumJSErrorWithoutCode(
         `Binary tree State Manager needed for execution of binary tree blocks`,
       )

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -204,6 +204,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
       throw Error(`Verkle access witness needed for execution of verkle blocks`)
     }
 
+    // Check if statemanager is a Verkle State Manager (stateless and stateful both have verifyPostState)
     if (!('verifyPostState' in vm.stateManager) && !('verifyPostState' in vm.stateManager)) {
       throw EthereumJSErrorWithoutCode(`Verkle State Manager needed for execution of verkle blocks`)
     }
@@ -217,6 +218,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
       throw Error(`Binary tree access witness needed for execution of binary tree blocks`)
     }
 
+    // Check if statemanager is a BinaryTreeStateManager by checking for a method only on BinaryTreeStateManager API
     if (!('verifyBinaryPostState' in vm.stateManager)) {
       throw EthereumJSErrorWithoutCode(
         `Binary tree State Manager needed for execution of binary tree blocks`,


### PR DESCRIPTION
This modifies our usage of `StatelessVerkleStateManager` in `vm` to import it only as a type so it does not get included in a bundle where the `StatelessVerkleStateManager` isn't actually used