### PR TITLE
StateManager: add name property to interface

### DIFF
--- a/packages/common/src/interfaces.ts
+++ b/packages/common/src/interfaces.ts
@@ -175,6 +175,7 @@ export interface VerkleAccessWitnessInterface {
  *
  */
 export interface StateManagerInterface {
+  name?: string
   /*
    * Core Access Functionality
    */

--- a/packages/statemanager/src/merkleStateManager.ts
+++ b/packages/statemanager/src/merkleStateManager.ts
@@ -59,6 +59,7 @@ export const CODEHASH_PREFIX = utf8ToBytes('c')
  * for many basic use cases.
  */
 export class MerkleStateManager implements StateManagerInterface {
+  name = 'MERKLE'
   protected _debug: Debugger
   protected _caches?: Caches
 

--- a/packages/statemanager/src/proof/verkle.ts
+++ b/packages/statemanager/src/proof/verkle.ts
@@ -1,8 +1,9 @@
 import { EthereumJSErrorWithoutCode, verifyVerkleProof } from '@ethereumjs/util'
 
+import type { StateManagerInterface } from '@ethereumjs/common'
 import type { Address } from '@ethereumjs/util'
 import type { Proof } from '../index.ts'
-import type { StatelessVerkleStateManager } from '../statelessVerkleStateManager.ts'
+import { StatelessVerkleStateManager } from '../statelessVerkleStateManager.ts'
 
 export function getVerkleStateProof(
   sm: StatelessVerkleStateManager,
@@ -16,7 +17,10 @@ export function getVerkleStateProof(
  * @param {Uint8Array} stateRoot - The stateRoot to verify the executionWitness against
  * @returns {boolean} - Returns true if the executionWitness matches the provided stateRoot, otherwise false
  */
-export function verifyVerkleStateProof(sm: StatelessVerkleStateManager): boolean {
+export function verifyVerkleStateProof(sm: StateManagerInterface): boolean {
+  if (!(sm instanceof StatelessVerkleStateManager)) {
+    throw new Error('StatelessVerkleStateManager expected')
+  }
   if (sm['_executionWitness'] === undefined) {
     sm['DEBUG'] && sm['_debug']('Missing executionWitness')
     return false

--- a/packages/statemanager/src/proof/verkle.ts
+++ b/packages/statemanager/src/proof/verkle.ts
@@ -19,7 +19,7 @@ export function getVerkleStateProof(
  */
 export function verifyVerkleStateProof(sm: StateManagerInterface): boolean {
   if (!(sm instanceof StatelessVerkleStateManager)) {
-    throw new Error('StatelessVerkleStateManager expected')
+    throw EthereumJSErrorWithoutCode('StatelessVerkleStateManager expected')
   }
   if (sm['_executionWitness'] === undefined) {
     sm['DEBUG'] && sm['_debug']('Missing executionWitness')

--- a/packages/statemanager/src/rpcStateManager.ts
+++ b/packages/statemanager/src/rpcStateManager.ts
@@ -27,6 +27,7 @@ import type { RPCStateManagerOpts } from './index.ts'
 const KECCAK256_RLP_EMPTY_ACCOUNT = RLP.encode(new Account().serialize()).slice(2)
 
 export class RPCStateManager implements StateManagerInterface {
+  name = 'RPC'
   protected _provider: string
   protected _caches: Caches
   protected _blockTag: string

--- a/packages/statemanager/src/simpleStateManager.ts
+++ b/packages/statemanager/src/simpleStateManager.ts
@@ -24,6 +24,7 @@ import type { SimpleStateManagerOpts } from './index.ts'
  * have a look at the [`@ethereumjs/statemanager` package docs](https://github.com/ethereumjs/ethereumjs-monorepo/blob/master/packages/statemanager/docs/README.md).
  */
 export class SimpleStateManager implements StateManagerInterface {
+  name = 'SIMPLE'
   public accountStack: Map<PrefixedHexString, Account | undefined>[] = []
   public codeStack: Map<PrefixedHexString, Uint8Array>[] = []
   public storageStack: Map<string, Uint8Array>[] = []

--- a/packages/statemanager/src/statefulBinaryTreeStateManager.ts
+++ b/packages/statemanager/src/statefulBinaryTreeStateManager.ts
@@ -56,6 +56,7 @@ import type { BinaryTreeState, StatefulBinaryTreeStateManagerOpts } from './type
 
 const ZEROVALUE = '0x0000000000000000000000000000000000000000000000000000000000000000'
 export class StatefulBinaryTreeStateManager implements StateManagerInterface {
+  name = 'BINARY_STATEFUL'
   protected _debug: Debugger
   protected _caches?: Caches
 

--- a/packages/statemanager/src/statefulVerkleStateManager.ts
+++ b/packages/statemanager/src/statefulVerkleStateManager.ts
@@ -61,6 +61,7 @@ import type { StatefulVerkleStateManagerOpts, VerkleState } from './types.ts'
 
 const ZEROVALUE = '0x0000000000000000000000000000000000000000000000000000000000000000'
 export class StatefulVerkleStateManager implements StateManagerInterface {
+  name = 'VERKLE_STATEFUL'
   protected _debug: Debugger
   protected _caches?: Caches
 

--- a/packages/statemanager/src/statelessVerkleStateManager.ts
+++ b/packages/statemanager/src/statelessVerkleStateManager.ts
@@ -67,6 +67,7 @@ const ZEROVALUE = '0x00000000000000000000000000000000000000000000000000000000000
  *
  */
 export class StatelessVerkleStateManager implements StateManagerInterface {
+  name = 'VERKLE_STATELESS'
   _cachedStateRoot?: Uint8Array
 
   originalStorageCache: OriginalStorageCache

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -3,7 +3,7 @@ import { ConsensusType, Hardfork } from '@ethereumjs/common'
 import { type EVM, type EVMInterface, VerkleAccessWitness } from '@ethereumjs/evm'
 import { MerklePatriciaTrie } from '@ethereumjs/mpt'
 import { RLP } from '@ethereumjs/rlp'
-import { StatelessVerkleStateManager, verifyVerkleStateProof } from '@ethereumjs/statemanager'
+import { verifyVerkleStateProof } from '@ethereumjs/statemanager'
 import { TransactionType } from '@ethereumjs/tx'
 import {
   Account,
@@ -160,7 +160,7 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
     // Populate the execution witness
     stateManager.initVerkleExecutionWitness!(block.header.number, block.executionWitness)
 
-    if (stateManager instanceof StatelessVerkleStateManager) {
+    if (stateManager.name === 'VERKLE_STATELESS') {
       // Update the stateRoot cache
       await stateManager.setStateRoot(block.header.stateRoot)
       if (verifyVerkleStateProof(stateManager) === true) {
@@ -273,7 +273,7 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
       }
     }
 
-    if (!(vm.stateManager instanceof StatelessVerkleStateManager)) {
+    if (!(vm.stateManager.name === 'VERKLE_STATELESS')) {
       // Only validate the following headers if Stateless isn't activated
       if (equalsBytes(result.receiptsRoot, block.header.receiptTrie) === false) {
         if (vm.DEBUG) {


### PR DESCRIPTION
Implements solution suggested in #4017

Adds `name` property to `StateManagerInterface`

e.g.
```ts
// StatelessVerkleStateManager
statemanager.name = 'VERKLE_STATELESS`
```

This allows replacing conditionals like:
 `if (vm.stateManager instanceof StatelessVerkleStateManager)` 
with 
`if (vm.stateManager.name === 'VERKLE_STATELESS')`

----

For the purpose of tree-shaking / bundle size reduction, this allows us to remove the import of state manager classes into `vm/runBlock.ts` and `vm/runTx.ts`.

One additional change was made to allow this.
In `statemanager/src/proof/verkle.ts`:
The `sm` parameter was changed to `StateManagerInterface`, and the function now checks internally that the input is the correct class.