### PR TITLE
evm: consistent error message names

### DIFF
--- a/packages/evm/src/eof/container.ts
+++ b/packages/evm/src/eof/container.ts
@@ -22,7 +22,7 @@ import {
   TYPE_MIN,
   VERSION,
 } from './constants.ts'
-import { EOFError, validationError } from './errors.ts'
+import { EOFErrorMessage, validationError } from './errors.ts'
 import { ContainerSectionType, verifyCode } from './verify.ts'
 
 import type { EVM } from '../evm.ts'
@@ -64,7 +64,7 @@ class StreamReader {
   readBytes(amount: number, errorStr?: string) {
     const end = this.ptr + amount
     if (end > this.data.length) {
-      validationError(EOFError.OUT_OF_BOUNDS, this.ptr, errorStr)
+      validationError(EOFErrorMessage.OUT_OF_BOUNDS, this.ptr, errorStr)
     }
     const ptr = this.ptr
     this.ptr += amount
@@ -78,7 +78,7 @@ class StreamReader {
    */
   readUint(errorStr?: string) {
     if (this.ptr >= this.data.length) {
-      validationError(EOFError.OUT_OF_BOUNDS, this.ptr, errorStr)
+      validationError(EOFErrorMessage.OUT_OF_BOUNDS, this.ptr, errorStr)
     }
     return this.data[this.ptr++]
   }
@@ -91,7 +91,7 @@ class StreamReader {
    */
   verifyUint(expect: number, errorStr?: string) {
     if (this.readUint() !== expect) {
-      validationError(EOFError.VERIFY_UINT, this.ptr - 1, errorStr)
+      validationError(EOFErrorMessage.VERIFY_UINT, this.ptr - 1, errorStr)
     }
   }
 
@@ -103,7 +103,7 @@ class StreamReader {
   readUint16(errorStr?: string) {
     const end = this.ptr + 2
     if (end > this.data.length) {
-      validationError(EOFError.OUT_OF_BOUNDS, this.ptr, errorStr)
+      validationError(EOFErrorMessage.OUT_OF_BOUNDS, this.ptr, errorStr)
     }
     const ptr = this.ptr
     this.ptr += 2
@@ -155,20 +155,20 @@ class EOFHeader {
     }
     const stream = new StreamReader(input)
     // Verify that the header starts with 0xEF0001
-    stream.verifyUint(FORMAT, EOFError.FORMAT)
-    stream.verifyUint(MAGIC, EOFError.MAGIC)
-    stream.verifyUint(VERSION, EOFError.VERSION)
+    stream.verifyUint(FORMAT, EOFErrorMessage.FORMAT)
+    stream.verifyUint(MAGIC, EOFErrorMessage.MAGIC)
+    stream.verifyUint(VERSION, EOFErrorMessage.VERSION)
     if (input.length < 15) {
       throw EthereumJSErrorWithoutCode('err: container size less than minimum valid size')
     }
     // Verify that the types section is present and its length is valid
-    stream.verifyUint(KIND_TYPE, EOFError.KIND_TYPE)
-    const typeSize = stream.readUint16(EOFError.TYPE_SIZE)
+    stream.verifyUint(KIND_TYPE, EOFErrorMessage.KIND_TYPE)
+    const typeSize = stream.readUint16(EOFErrorMessage.TYPE_SIZE)
     if (typeSize < TYPE_MIN) {
-      validationError(EOFError.INVALID_TYPE_SIZE, typeSize)
+      validationError(EOFErrorMessage.INVALID_TYPE_SIZE, typeSize)
     }
     if (typeSize % TYPE_DIVISOR !== 0) {
-      validationError(EOFError.INVALID_TYPE_SIZE, typeSize)
+      validationError(EOFErrorMessage.INVALID_TYPE_SIZE, typeSize)
     }
     if (typeSize > TYPE_MAX) {
       throw EthereumJSErrorWithoutCode(
@@ -176,20 +176,20 @@ class EOFHeader {
       )
     }
     // Verify that the code section is present and its size is valid
-    stream.verifyUint(KIND_CODE, EOFError.KIND_CODE)
-    const codeSize = stream.readUint16(EOFError.CODE_SIZE)
+    stream.verifyUint(KIND_CODE, EOFErrorMessage.KIND_CODE)
+    const codeSize = stream.readUint16(EOFErrorMessage.CODE_SIZE)
     if (codeSize < CODE_MIN) {
-      validationError(EOFError.MIN_CODE_SECTIONS)
+      validationError(EOFErrorMessage.MIN_CODE_SECTIONS)
     }
     if (codeSize !== typeSize / TYPE_DIVISOR) {
-      validationError(EOFError.TYPE_SECTIONS, typeSize / TYPE_DIVISOR, codeSize)
+      validationError(EOFErrorMessage.TYPE_SECTIONS, typeSize / TYPE_DIVISOR, codeSize)
     }
     // Read the actual code sizes in the code section and verify that each section has the minimum size
     const codeSizes = []
     for (let i = 0; i < codeSize; i++) {
-      const codeSectionSize = stream.readUint16(EOFError.CODE_SECTION)
+      const codeSectionSize = stream.readUint16(EOFErrorMessage.CODE_SECTION)
       if (codeSectionSize < CODE_SIZE_MIN) {
-        validationError(EOFError.CODE_SECTION_SIZE)
+        validationError(EOFErrorMessage.CODE_SECTION_SIZE)
       }
       codeSizes.push(codeSectionSize)
     }
@@ -199,21 +199,21 @@ class EOFHeader {
     const containerSizes: number[] = []
     if (nextSection === KIND_CONTAINER) {
       // The optional container section is present, validate that the size is within bounds
-      const containerSectionSize = stream.readUint16(EOFError.CONTAINER_SIZE)
+      const containerSectionSize = stream.readUint16(EOFErrorMessage.CONTAINER_SIZE)
 
       if (containerSectionSize < CONTAINER_MIN) {
-        validationError(EOFError.CONTAINER_SECTION_SIZE)
+        validationError(EOFErrorMessage.CONTAINER_SECTION_SIZE)
       }
       if (containerSectionSize > CONTAINER_MAX) {
-        validationError(EOFError.CONTAINER_SECTION_SIZE)
+        validationError(EOFErrorMessage.CONTAINER_SECTION_SIZE)
       }
 
       // Read the actual container sections and validate that each section has the minimum size
       for (let i = 0; i < containerSectionSize; i++) {
-        const containerSize = stream.readUint16(EOFError.CONTAINER_SECTION)
+        const containerSize = stream.readUint16(EOFErrorMessage.CONTAINER_SECTION)
 
         if (containerSize < CONTAINER_SIZE_MIN) {
-          validationError(EOFError.CONTAINER_SECTION_MIN)
+          validationError(EOFErrorMessage.CONTAINER_SECTION_MIN)
         }
 
         containerSizes.push(containerSize)
@@ -224,15 +224,15 @@ class EOFHeader {
 
     // Verify that the next section is of the data type
     if (nextSection !== KIND_DATA) {
-      validationError(EOFError.KIND_DATA)
+      validationError(EOFErrorMessage.KIND_DATA)
     }
 
     this.dataSizePtr = stream.getPtr()
 
-    const dataSize = stream.readUint16(EOFError.DATA_SIZE)
+    const dataSize = stream.readUint16(EOFErrorMessage.DATA_SIZE)
 
     // Verify that the header ends with the TERMINATOR byte
-    stream.verifyUint(TERMINATOR, EOFError.TERMINATOR)
+    stream.verifyUint(TERMINATOR, EOFErrorMessage.TERMINATOR)
 
     // Write all values to the header object
     this.typeSize = typeSize
@@ -327,25 +327,25 @@ class EOFBody {
     const typeSections: TypeSection[] = []
     // Read and parse each type section, and validate that the type section values are within valid bounds
     for (let i = 0; i < header.typeSize / 4; i++) {
-      const inputs = stream.readUint(EOFError.INPUTS)
-      const outputs = stream.readUint(EOFError.OUTPUTS)
-      const maxStackHeight = stream.readUint16(EOFError.MAX_STACK_HEIGHT)
+      const inputs = stream.readUint(EOFErrorMessage.INPUTS)
+      const outputs = stream.readUint(EOFErrorMessage.OUTPUTS)
+      const maxStackHeight = stream.readUint16(EOFErrorMessage.MAX_STACK_HEIGHT)
       if (i === 0) {
         if (inputs !== 0) {
-          validationError(EOFError.CODE0_INPUTS)
+          validationError(EOFErrorMessage.CODE0_INPUTS)
         }
         if (outputs !== 0x80) {
-          validationError(EOFError.CODE0_OUTPUTS)
+          validationError(EOFErrorMessage.CODE0_OUTPUTS)
         }
       }
       if (inputs > INPUTS_MAX) {
-        validationError(EOFError.MAX_INPUTS, i, inputs)
+        validationError(EOFErrorMessage.MAX_INPUTS, i, inputs)
       }
       if (outputs > OUTPUTS_MAX) {
-        validationError(EOFError.MAX_OUTPUTS, i, outputs)
+        validationError(EOFErrorMessage.MAX_OUTPUTS, i, outputs)
       }
       if (maxStackHeight > MAX_STACK_HEIGHT) {
-        validationError(EOFError.MAX_STACK_HEIGHT_LIMIT, i, maxStackHeight)
+        validationError(EOFErrorMessage.MAX_STACK_HEIGHT_LIMIT, i, maxStackHeight)
       }
       typeSections.push({
         inputs,
@@ -361,7 +361,7 @@ class EOFBody {
         const code = stream.readBytes(codeSize)
         codes.push(code)
       } catch {
-        validationError(EOFError.CODE_SECTION, i)
+        validationError(EOFErrorMessage.CODE_SECTION, i)
       }
     }
     // Write the entire code section to the entireCodeSection
@@ -374,7 +374,7 @@ class EOFBody {
         const container = stream.readBytes(containerSize)
         containers.push(container)
       } catch {
-        validationError(EOFError.CONTAINER_SECTION, i)
+        validationError(EOFErrorMessage.CONTAINER_SECTION, i)
       }
     }
 
@@ -386,12 +386,12 @@ class EOFBody {
 
     // Edge case: deployment code validation
     if (eofMode !== EOFContainerMode.Initmode && !dataSectionAllowedSmaller) {
-      dataSection = stream.readBytes(header.dataSize, EOFError.DATA_SECTION)
+      dataSection = stream.readBytes(header.dataSize, EOFErrorMessage.DATA_SECTION)
 
       if (eofMode === EOFContainerMode.Default) {
         if (!stream.isAtEnd()) {
           // If there are dangling bytes in default container mode, this is invalid
-          validationError(EOFError.DANGLING_BYTES)
+          validationError(EOFErrorMessage.DANGLING_BYTES)
         }
       } else {
         // Tx init mode: the remaining bytes (if any) are used as CALLDATA in the EVM, in case of a Tx init
@@ -401,7 +401,7 @@ class EOFBody {
       dataSection = stream.readRemainder()
 
       if (dataSection.length > header.dataSize) {
-        validationError(EOFError.DANGLING_BYTES)
+        validationError(EOFErrorMessage.DANGLING_BYTES)
       }
     }
 

--- a/packages/evm/src/eof/errors.ts
+++ b/packages/evm/src/eof/errors.ts
@@ -1,8 +1,8 @@
 import { EthereumJSErrorWithoutCode } from '@ethereumjs/util'
 
-export type EOFError = (typeof EOFError)[keyof typeof EOFError]
+export type EOFErrorMessage = (typeof EOFErrorMessage)[keyof typeof EOFErrorMessage]
 
-export const EOFError = {
+export const EOFErrorMessage = {
   OUT_OF_BOUNDS: 'Trying to read out of bounds',
   VERIFY_UINT: 'Uint does not match expected value ',
   VERIFY_BYTES: 'Bytes do not match expected value',
@@ -67,137 +67,145 @@ export const EOFError = {
   INVALID_RETURN_CONTRACT_DATA_SIZE: 'invalid RETURNCONTRACT: data size lower than expected',
 } as const
 
-export function validationErrorMsg(type: EOFError, ...args: any) {
+export function validationErrorMsg(type: EOFErrorMessage, ...args: any) {
   switch (type) {
-    case EOFError.OUT_OF_BOUNDS: {
-      return EOFError.OUT_OF_BOUNDS + ` at pos: ${args[0]}: ${args[1]}`
+    case EOFErrorMessage.OUT_OF_BOUNDS: {
+      return EOFErrorMessage.OUT_OF_BOUNDS + ` at pos: ${args[0]}: ${args[1]}`
     }
-    case EOFError.VERIFY_BYTES: {
-      return EOFError.VERIFY_BYTES + ` at pos: ${args[0]}: ${args[1]}`
+    case EOFErrorMessage.VERIFY_BYTES: {
+      return EOFErrorMessage.VERIFY_BYTES + ` at pos: ${args[0]}: ${args[1]}`
     }
-    case EOFError.VERIFY_UINT: {
-      return EOFError.VERIFY_UINT + `at pos: ${args[0]}: ${args[1]}`
+    case EOFErrorMessage.VERIFY_UINT: {
+      return EOFErrorMessage.VERIFY_UINT + `at pos: ${args[0]}: ${args[1]}`
     }
-    case EOFError.TYPE_SIZE: {
-      return EOFError.TYPE_SIZE + args[0]
+    case EOFErrorMessage.TYPE_SIZE: {
+      return EOFErrorMessage.TYPE_SIZE + args[0]
     }
-    case EOFError.INVALID_TYPE_SIZE: {
-      return EOFError.INVALID_TYPE_SIZE + args[0]
+    case EOFErrorMessage.INVALID_TYPE_SIZE: {
+      return EOFErrorMessage.INVALID_TYPE_SIZE + args[0]
     }
-    case EOFError.INVALID_CODE_SIZE: {
-      return EOFError.INVALID_CODE_SIZE + args[0]
+    case EOFErrorMessage.INVALID_CODE_SIZE: {
+      return EOFErrorMessage.INVALID_CODE_SIZE + args[0]
     }
-    case EOFError.INPUTS: {
-      return `${EOFError.INPUTS} - typeSection ${args[0]}`
+    case EOFErrorMessage.INPUTS: {
+      return `${EOFErrorMessage.INPUTS} - typeSection ${args[0]}`
     }
-    case EOFError.OUTPUTS: {
-      return `${EOFError.OUTPUTS} - typeSection ${args[0]}`
+    case EOFErrorMessage.OUTPUTS: {
+      return `${EOFErrorMessage.OUTPUTS} - typeSection ${args[0]}`
     }
-    case EOFError.CODE0_INPUTS: {
+    case EOFErrorMessage.CODE0_INPUTS: {
       return `first code section should have 0 inputs`
     }
-    case EOFError.CODE0_OUTPUTS: {
+    case EOFErrorMessage.CODE0_OUTPUTS: {
       return `first code section should have 0 outputs`
     }
-    case EOFError.MAX_INPUTS: {
-      return EOFError.MAX_INPUTS + `${args[1]} - code section ${args[0]}`
+    case EOFErrorMessage.MAX_INPUTS: {
+      return EOFErrorMessage.MAX_INPUTS + `${args[1]} - code section ${args[0]}`
     }
-    case EOFError.MAX_OUTPUTS: {
-      return EOFError.MAX_OUTPUTS + `${args[1]} - code section ${args[0]}`
+    case EOFErrorMessage.MAX_OUTPUTS: {
+      return EOFErrorMessage.MAX_OUTPUTS + `${args[1]} - code section ${args[0]}`
     }
-    case EOFError.CODE_SECTION: {
+    case EOFErrorMessage.CODE_SECTION: {
       return `expected code: codeSection ${args[0]}: `
     }
-    case EOFError.DATA_SECTION: {
-      return EOFError.DATA_SECTION
+    case EOFErrorMessage.DATA_SECTION: {
+      return EOFErrorMessage.DATA_SECTION
     }
-    case EOFError.MAX_STACK_HEIGHT: {
-      return `${EOFError.MAX_STACK_HEIGHT} - typeSection ${args[0]}: `
+    case EOFErrorMessage.MAX_STACK_HEIGHT: {
+      return `${EOFErrorMessage.MAX_STACK_HEIGHT} - typeSection ${args[0]}: `
     }
-    case EOFError.MAX_STACK_HEIGHT_LIMIT: {
-      return `${EOFError.MAX_STACK_HEIGHT_LIMIT}, got: ${args[1]} - typeSection ${args[0]}`
+    case EOFErrorMessage.MAX_STACK_HEIGHT_LIMIT: {
+      return `${EOFErrorMessage.MAX_STACK_HEIGHT_LIMIT}, got: ${args[1]} - typeSection ${args[0]}`
     }
-    case EOFError.DANGLING_BYTES: {
-      return EOFError.DANGLING_BYTES
+    case EOFErrorMessage.DANGLING_BYTES: {
+      return EOFErrorMessage.DANGLING_BYTES
     }
     default: {
       return type
     }
   }
 }
-export function validationError(type: EOFError, ...args: any): never {
+export function validationError(type: EOFErrorMessage, ...args: any): never {
   switch (type) {
-    case EOFError.OUT_OF_BOUNDS: {
+    case EOFErrorMessage.OUT_OF_BOUNDS: {
       const pos = args[0]
       if (pos === 0 || pos === 2 || pos === 3 || pos === 6) {
         throw EthereumJSErrorWithoutCode(args[1])
       }
-      throw EthereumJSErrorWithoutCode(EOFError.OUT_OF_BOUNDS + ` `)
+      throw EthereumJSErrorWithoutCode(EOFErrorMessage.OUT_OF_BOUNDS + ` `)
     }
-    case EOFError.VERIFY_BYTES: {
+    case EOFErrorMessage.VERIFY_BYTES: {
       const pos = args[0]
       if (pos === 0 || pos === 2 || pos === 3 || pos === 6) {
         throw EthereumJSErrorWithoutCode(args[1])
       }
-      throw EthereumJSErrorWithoutCode(EOFError.VERIFY_BYTES + ` at pos: ${args[0]}: ${args[1]}`)
+      throw EthereumJSErrorWithoutCode(
+        EOFErrorMessage.VERIFY_BYTES + ` at pos: ${args[0]}: ${args[1]}`,
+      )
     }
-    case EOFError.VERIFY_UINT: {
+    case EOFErrorMessage.VERIFY_UINT: {
       const pos = args[0]
       if (pos === 0 || pos === 2 || pos === 3 || pos === 6 || pos === 18) {
         throw EthereumJSErrorWithoutCode(args[1])
       }
-      throw EthereumJSErrorWithoutCode(EOFError.VERIFY_UINT + `at pos: ${args[0]}: ${args[1]}`)
-    }
-    case EOFError.TYPE_SIZE: {
-      throw EthereumJSErrorWithoutCode(EOFError.TYPE_SIZE + args[0])
-    }
-    case EOFError.TYPE_SECTIONS: {
       throw EthereumJSErrorWithoutCode(
-        `${EOFError.TYPE_SECTIONS} (types ${args[0]} code ${args[1]})`,
+        EOFErrorMessage.VERIFY_UINT + `at pos: ${args[0]}: ${args[1]}`,
       )
     }
-    case EOFError.INVALID_TYPE_SIZE: {
-      throw EthereumJSErrorWithoutCode(EOFError.INVALID_TYPE_SIZE)
+    case EOFErrorMessage.TYPE_SIZE: {
+      throw EthereumJSErrorWithoutCode(EOFErrorMessage.TYPE_SIZE + args[0])
     }
-    case EOFError.INVALID_CODE_SIZE: {
-      throw EthereumJSErrorWithoutCode(EOFError.INVALID_CODE_SIZE + args[0])
+    case EOFErrorMessage.TYPE_SECTIONS: {
+      throw EthereumJSErrorWithoutCode(
+        `${EOFErrorMessage.TYPE_SECTIONS} (types ${args[0]} code ${args[1]})`,
+      )
     }
-    case EOFError.INPUTS: {
-      throw EthereumJSErrorWithoutCode(`${EOFError.INPUTS} - typeSection ${args[0]}`)
+    case EOFErrorMessage.INVALID_TYPE_SIZE: {
+      throw EthereumJSErrorWithoutCode(EOFErrorMessage.INVALID_TYPE_SIZE)
     }
-    case EOFError.OUTPUTS: {
-      throw EthereumJSErrorWithoutCode(`${EOFError.OUTPUTS} - typeSection ${args[0]}`)
+    case EOFErrorMessage.INVALID_CODE_SIZE: {
+      throw EthereumJSErrorWithoutCode(EOFErrorMessage.INVALID_CODE_SIZE + args[0])
     }
-    case EOFError.CODE0_INPUTS: {
+    case EOFErrorMessage.INPUTS: {
+      throw EthereumJSErrorWithoutCode(`${EOFErrorMessage.INPUTS} - typeSection ${args[0]}`)
+    }
+    case EOFErrorMessage.OUTPUTS: {
+      throw EthereumJSErrorWithoutCode(`${EOFErrorMessage.OUTPUTS} - typeSection ${args[0]}`)
+    }
+    case EOFErrorMessage.CODE0_INPUTS: {
       throw EthereumJSErrorWithoutCode(`first code section should have 0 inputs`)
     }
-    case EOFError.CODE0_OUTPUTS: {
+    case EOFErrorMessage.CODE0_OUTPUTS: {
       throw EthereumJSErrorWithoutCode(`first code section should have 0 outputs`)
     }
-    case EOFError.MAX_INPUTS: {
-      throw EthereumJSErrorWithoutCode(EOFError.MAX_INPUTS + `${args[1]} - code section ${args[0]}`)
-    }
-    case EOFError.MAX_OUTPUTS: {
+    case EOFErrorMessage.MAX_INPUTS: {
       throw EthereumJSErrorWithoutCode(
-        EOFError.MAX_OUTPUTS + `${args[1]} - code section ${args[0]}`,
+        EOFErrorMessage.MAX_INPUTS + `${args[1]} - code section ${args[0]}`,
       )
     }
-    case EOFError.CODE_SECTION: {
+    case EOFErrorMessage.MAX_OUTPUTS: {
+      throw EthereumJSErrorWithoutCode(
+        EOFErrorMessage.MAX_OUTPUTS + `${args[1]} - code section ${args[0]}`,
+      )
+    }
+    case EOFErrorMessage.CODE_SECTION: {
       throw EthereumJSErrorWithoutCode(`expected code: codeSection ${args[0]}: `)
     }
-    case EOFError.DATA_SECTION: {
-      throw EthereumJSErrorWithoutCode(EOFError.DATA_SECTION)
+    case EOFErrorMessage.DATA_SECTION: {
+      throw EthereumJSErrorWithoutCode(EOFErrorMessage.DATA_SECTION)
     }
-    case EOFError.MAX_STACK_HEIGHT: {
-      throw EthereumJSErrorWithoutCode(`${EOFError.MAX_STACK_HEIGHT} - typeSection ${args[0]}: `)
-    }
-    case EOFError.MAX_STACK_HEIGHT_LIMIT: {
+    case EOFErrorMessage.MAX_STACK_HEIGHT: {
       throw EthereumJSErrorWithoutCode(
-        `${EOFError.MAX_STACK_HEIGHT_LIMIT}, got: ${args[1]} - typeSection ${args[0]}`,
+        `${EOFErrorMessage.MAX_STACK_HEIGHT} - typeSection ${args[0]}: `,
       )
     }
-    case EOFError.DANGLING_BYTES: {
-      throw EthereumJSErrorWithoutCode(EOFError.DANGLING_BYTES)
+    case EOFErrorMessage.MAX_STACK_HEIGHT_LIMIT: {
+      throw EthereumJSErrorWithoutCode(
+        `${EOFErrorMessage.MAX_STACK_HEIGHT_LIMIT}, got: ${args[1]} - typeSection ${args[0]}`,
+      )
+    }
+    case EOFErrorMessage.DANGLING_BYTES: {
+      throw EthereumJSErrorWithoutCode(EOFErrorMessage.DANGLING_BYTES)
     }
     default: {
       throw EthereumJSErrorWithoutCode(type)

--- a/packages/evm/src/errors.ts
+++ b/packages/evm/src/errors.ts
@@ -1,8 +1,8 @@
-export type EVMErrorType = (typeof EVMErrorMessages)[keyof typeof EVMErrorMessages]
+export type EVMErrorType = (typeof EVMErrorMessage)[keyof typeof EVMErrorMessage]
 
 export const EVMErrorTypeString = 'EVMError'
 
-const EVMErrorMessages = {
+const EVMErrorMessage = {
   OUT_OF_GAS: 'out of gas',
   CODESTORE_OUT_OF_GAS: 'code store out of gas',
   CODESIZE_EXCEEDS_MAXIMUM: 'code size to deposit exceeds maximum code size',
@@ -36,7 +36,7 @@ const EVMErrorMessages = {
 export class EVMError {
   error: EVMErrorType
   errorType: string
-  static errorMessages: Record<keyof typeof EVMErrorMessages, EVMErrorType> = EVMErrorMessages
+  static errorMessages: Record<keyof typeof EVMErrorMessage, EVMErrorType> = EVMErrorMessage
 
   constructor(error: EVMErrorType) {
     this.error = error

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -29,7 +29,7 @@ import {
 import { keccak256 } from 'ethereum-cryptography/keccak.js'
 
 import { EOFContainer, EOFContainerMode } from '../eof/container.ts'
-import { EOFError } from '../eof/errors.ts'
+import { EOFErrorMessage } from '../eof/errors.ts'
 import { EOFBYTES, EOFHASH, isEOF } from '../eof/util.ts'
 import { EVMError } from '../errors.ts'
 
@@ -1135,10 +1135,10 @@ export const handlers: Map<number, OpHandler> = new Map([
       const stackItems = runState.stack.length
       const typeSection = runState.env.eof!.container.body.typeSections[sectionTarget]
       if (stackItems > 1024 - typeSection.maxStackHeight + typeSection.inputs) {
-        trap(EOFError.STACK_OVERFLOW)
+        trap(EOFErrorMessage.STACK_OVERFLOW)
       }
       if (runState.env.eof!.eofRunState.returnStack.length >= 1024) {
-        trap(EOFError.RETURN_STACK_OVERFLOW)
+        trap(EOFErrorMessage.RETURN_STACK_OVERFLOW)
       }
       runState.env.eof?.eofRunState.returnStack.push(runState.programCounter + 2)
 
@@ -1157,7 +1157,7 @@ export const handlers: Map<number, OpHandler> = new Map([
       const newPc = runState.env.eof!.eofRunState.returnStack.pop()
       if (newPc === undefined) {
         // This should NEVER happen since it is validated that functions either terminate (the call frame) or return
-        trap(EOFError.RETF_NO_RETURN)
+        trap(EOFErrorMessage.RETF_NO_RETURN)
       }
       runState.programCounter = newPc!
     },
@@ -1179,10 +1179,10 @@ export const handlers: Map<number, OpHandler> = new Map([
       const stackItems = runState.stack.length
       const typeSection = runState.env.eof!.container.body.typeSections[sectionTarget]
       if (stackItems > 1024 - typeSection.maxStackHeight + typeSection.inputs) {
-        trap(EOFError.STACK_OVERFLOW)
+        trap(EOFErrorMessage.STACK_OVERFLOW)
       }
       /*if (runState.env.eof!.eofRunState.returnStack.length >= 1024) {
-        trap(EOFError.ReturnStackOverflow)
+        trap(EOFErrorMessage.ReturnStackOverflow)
       }
       runState.env.eof?.eofRunState.returnStack.push(runState.programCounter + 2)*/
 
@@ -1310,7 +1310,7 @@ export const handlers: Map<number, OpHandler> = new Map([
         const actualSectionSize = preDeployDataSectionSize + Number(auxDataSize)
 
         if (actualSectionSize < originalDataSize) {
-          trap(EOFError.INVALID_RETURN_CONTRACT_DATA_SIZE)
+          trap(EOFErrorMessage.INVALID_RETURN_CONTRACT_DATA_SIZE)
         }
 
         if (actualSectionSize > 0xffff) {

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -11,7 +11,7 @@ import {
   setLengthLeft,
 } from '@ethereumjs/util'
 
-import { EOFError } from '../eof/errors.ts'
+import { EOFErrorMessage } from '../eof/errors.ts'
 import { EVMError } from '../errors.ts'
 import { DELEGATION_7702_FLAG } from '../types.ts'
 
@@ -793,7 +793,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         // Check if the target address > 20 bytes
         if (toAddr > EXTCALL_TARGET_MAX) {
-          trap(EOFError.INVALID_EXTCALL_TARGET)
+          trap(EOFErrorMessage.INVALID_EXTCALL_TARGET)
         }
 
         // Charge for memory expansion
@@ -860,7 +860,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         // Check if the target address > 20 bytes
         if (toAddr > EXTCALL_TARGET_MAX) {
-          trap(EOFError.INVALID_EXTCALL_TARGET)
+          trap(EOFErrorMessage.INVALID_EXTCALL_TARGET)
         }
 
         // Charge for memory expansion
@@ -964,7 +964,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         // Check if the target address > 20 bytes
         if (toAddr > EXTCALL_TARGET_MAX) {
-          trap(EOFError.INVALID_EXTCALL_TARGET)
+          trap(EOFErrorMessage.INVALID_EXTCALL_TARGET)
         }
 
         // Charge for memory expansion


### PR DESCRIPTION
This PR:

- Makes the EVMErrorMessage singular (EVMErrorMessages -> EVMErrorMessage)
- Renames EOFError to EOFErrorMessage to be consistnet with the above. 

The convention would then be: 
- Error messages live under an enum-like const/type that is named `XYZErrorMessage`
- Error classes or wrappers are named `XYZError` (e.g. EVMError)
- These error classes may have a message property that is then typed as `XYZErrorMessage`

