### PR TITLE
Force resolution of `@noble/curves` and `hashes`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "root",
   "private": true,
   "workspaces": ["packages/*"],
+  "overrides": {
+    "@noble/curves": "1.9.x",
+    "@noble/hashes": "1.8.x"
+  },
   "scripts": {
     "biome": "npx @biomejs/biome check",
     "biome:fix": "npx @biomejs/biome check --write",


### PR DESCRIPTION
Forces `npm` to resolve `@noble/curves` and `@noble/hashes` to latest versions and dedup old versions being used by dev dependencies.