### PR TITLE
Turn static-build workflow into four separater workflows with explicit package names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,9 +150,30 @@ jobs:
     with:
       dep-cache-key: ${{ needs.build.outputs.dep-cache-key }}
 
-  static:
+  ethash:
     needs: build
-    uses: ./.github/workflows/static-build.yml
+    uses: ./.github/workflows/ethash-build.yml
+    secrets: inherit
+    with:
+      dep-cache-key: ${{ needs.build.outputs.dep-cache-key }}
+
+  genesis:
+    needs: build
+    uses: ./.github/workflows/genesis-build.yml
+    secrets: inherit
+    with:
+      dep-cache-key: ${{ needs.build.outputs.dep-cache-key }}
+      
+  rlp:
+    needs: build
+    uses: ./.github/workflows/rlp-build.yml
+    secrets: inherit
+    with:
+      dep-cache-key: ${{ needs.build.outputs.dep-cache-key }}
+
+  wallet:
+    needs: build
+    uses: ./.github/workflows/wallet-build.yml
     secrets: inherit
     with:
       dep-cache-key: ${{ needs.build.outputs.dep-cache-key }}

--- a/.github/workflows/ethash-build.yml
+++ b/.github/workflows/ethash-build.yml
@@ -1,4 +1,4 @@
-name: Static Packages Build
+name: Ethash Packages Build
 on:
   workflow_call:
     inputs:
@@ -17,11 +17,11 @@ env:
   cwd: ${{github.workspace}}/packages/rlp # This doesn't appear to matter since code coverage finds all of the reports
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-static
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-ethash
   cancel-in-progress: true
 
 jobs:
-  test-static:
+  test-ethash:
     runs-on: ubuntu-latest
 
     steps:
@@ -48,25 +48,14 @@ jobs:
         run: npm ci     
         working-directory: ${{ github.workspace }}
 
-      # Run coverage for rlp
-      - run: npm run coverage
-        working-directory: ${{ github.workspace }}/packages/rlp
-
-      # Run coverage for genesis
-      - run: npm run coverage
-        working-directory: ${{ github.workspace }}/packages/genesis
-
       # Run coverage for ethash
       - run: npm run coverage
         working-directory: ${{ github.workspace }}/packages/ethash
 
-      # Run coverage for wallet
-      - run: npm run coverage
-        working-directory: ${{ github.workspace }}/packages/wallet
-        # Upload code coverage for all jobs
+      # Upload code coverage for all jobs
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ env.cwd }}/coverage/lcov.info
-          flags: static
+          flags: ethash
 

--- a/.github/workflows/ethash-build.yml
+++ b/.github/workflows/ethash-build.yml
@@ -14,7 +14,7 @@ on:
         required: false
 
 env:
-  cwd: ${{github.workspace}}/packages/rlp # This doesn't appear to matter since code coverage finds all of the reports
+  cwd: ${{github.workspace}}/packages/ethash # This doesn't appear to matter since code coverage finds all of the reports
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-ethash

--- a/.github/workflows/genesis-build.yml
+++ b/.github/workflows/genesis-build.yml
@@ -1,0 +1,61 @@
+name: Genesis Packages Build
+on:
+  workflow_call:
+    inputs:
+      dep-cache-key:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      dep-cache-key:
+        required: false
+        default: 'none'
+      submodule-cache-key:
+        required: false
+
+env:
+  cwd: ${{github.workspace}}/packages/rlp # This doesn't appear to matter since code coverage finds all of the reports
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-genesis
+  cancel-in-progress: true
+
+jobs:
+  test-genesis:
+    runs-on: ubuntu-latest
+
+    steps:
+      # We clone the repo and submodules if triggered from work-flow dispatch
+      - if: inputs.submodule-cache-key == 'none'
+        uses: actions/checkout@v4
+
+      # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
+      - if: inputs.dep-cache-key != 'none' 
+        uses: actions/cache/restore@v4
+        id: dep-cache
+        with:
+          path: ${{github.workspace}}
+          key: ${{ inputs.dep-cache-key }}
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install Dependencies (if not restored from cache)
+        if: steps.dep-cache.outputs.cache-hit != 'true'
+        run: npm ci     
+        working-directory: ${{ github.workspace }}
+
+      # Run coverage for genesis
+      - run: npm run coverage
+        working-directory: ${{ github.workspace }}/packages/genesis
+
+      # Upload code coverage for all jobs
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ env.cwd }}/coverage/lcov.info
+          flags: genesis
+

--- a/.github/workflows/genesis-build.yml
+++ b/.github/workflows/genesis-build.yml
@@ -14,7 +14,7 @@ on:
         required: false
 
 env:
-  cwd: ${{github.workspace}}/packages/rlp # This doesn't appear to matter since code coverage finds all of the reports
+  cwd: ${{github.workspace}}/packages/genesis # This doesn't appear to matter since code coverage finds all of the reports
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-genesis

--- a/.github/workflows/rlp-build.yml
+++ b/.github/workflows/rlp-build.yml
@@ -1,0 +1,61 @@
+name: Rlp Packages Build
+on:
+  workflow_call:
+    inputs:
+      dep-cache-key:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      dep-cache-key:
+        required: false
+        default: 'none'
+      submodule-cache-key:
+        required: false
+
+env:
+  cwd: ${{github.workspace}}/packages/rlp # This doesn't appear to matter since code coverage finds all of the reports
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-rlp
+  cancel-in-progress: true
+
+jobs:
+  test-rlp:
+    runs-on: ubuntu-latest
+
+    steps:
+      # We clone the repo and submodules if triggered from work-flow dispatch
+      - if: inputs.submodule-cache-key == 'none'
+        uses: actions/checkout@v4
+
+      # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
+      - if: inputs.dep-cache-key != 'none' 
+        uses: actions/cache/restore@v4
+        id: dep-cache
+        with:
+          path: ${{github.workspace}}
+          key: ${{ inputs.dep-cache-key }}
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install Dependencies (if not restored from cache)
+        if: steps.dep-cache.outputs.cache-hit != 'true'
+        run: npm ci     
+        working-directory: ${{ github.workspace }}
+
+      # Run coverage for rlp
+      - run: npm run coverage
+        working-directory: ${{ github.workspace }}/packages/rlp
+
+      # Upload code coverage for all jobs
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ env.cwd }}/coverage/lcov.info
+          flags: rlp
+

--- a/.github/workflows/wallet-build.yml
+++ b/.github/workflows/wallet-build.yml
@@ -1,0 +1,61 @@
+name: Wallet Packages Build
+on:
+  workflow_call:
+    inputs:
+      dep-cache-key:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      dep-cache-key:
+        required: false
+        default: 'none'
+      submodule-cache-key:
+        required: false
+
+env:
+  cwd: ${{github.workspace}}/packages/rlp # This doesn't appear to matter since code coverage finds all of the reports
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-wallet
+  cancel-in-progress: true
+
+jobs:
+  test-wallet:
+    runs-on: ubuntu-latest
+
+    steps:
+      # We clone the repo and submodules if triggered from work-flow dispatch
+      - if: inputs.submodule-cache-key == 'none'
+        uses: actions/checkout@v4
+
+      # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
+      - if: inputs.dep-cache-key != 'none' 
+        uses: actions/cache/restore@v4
+        id: dep-cache
+        with:
+          path: ${{github.workspace}}
+          key: ${{ inputs.dep-cache-key }}
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install Dependencies (if not restored from cache)
+        if: steps.dep-cache.outputs.cache-hit != 'true'
+        run: npm ci     
+        working-directory: ${{ github.workspace }}
+
+      # Run coverage for wallet
+      - run: npm run coverage
+        working-directory: ${{ github.workspace }}/packages/wallet
+
+      # Upload code coverage for all jobs
+      - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ env.cwd }}/coverage/lcov.info
+          flags: wallet
+

--- a/.github/workflows/wallet-build.yml
+++ b/.github/workflows/wallet-build.yml
@@ -14,7 +14,7 @@ on:
         required: false
 
 env:
-  cwd: ${{github.workspace}}/packages/rlp # This doesn't appear to matter since code coverage finds all of the reports
+  cwd: ${{github.workspace}}/packages/wallet # This doesn't appear to matter since code coverage finds all of the reports
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-wallet


### PR DESCRIPTION
This change removes the `static-build` workflow and creates four separate workflows: `genesis-build`, `ethash-build`, `wallet-build`, and `rlp-build`.