### PR TITLE
Rename static build ci job

### DIFF
--- a/.github/workflows/static-build.yml
+++ b/.github/workflows/static-build.yml
@@ -1,4 +1,4 @@
-name: Static Packages Build
+name: RLP/Ethash/Genesis/Wallet Build
 on:
   workflow_call:
     inputs:

--- a/packages/ethash/README.md
+++ b/packages/ethash/README.md
@@ -124,7 +124,7 @@ See our organizational [documentation](https://ethereumjs.readthedocs.io) for an
 [ethash-npm-link]: https://www.npmjs.org/package/@ethereumjs/ethash
 [ethash-issues-badge]: https://img.shields.io/github/issues/ethereumjs/ethereumjs-monorepo/package:%20ethash?label=issues
 [ethash-issues-link]: https://github.com/ethereumjs/ethereumjs-monorepo/issues?q=is%3Aopen+is%3Aissue+label%3A"package%3A+ethash"
-[ethash-actions-badge]: https://github.com/ethereumjs/ethereumjs-monorepo/workflows/Ethash/badge.svg
+[ethash-actions-badge]: https://github.com/ethereumjs/ethereumjs-monorepo/actions/workflows/static-build.yml/badge.svg
 [ethash-actions-link]: https://github.com/ethereumjs/ethereumjs-monorepo/actions?query=workflow%3A%22Ethash%22
 [ethash-coverage-badge]: https://codecov.io/gh/ethereumjs/ethereumjs-monorepo/branch/master/graph/badge.svg?flag=ethash
 [ethash-coverage-link]: https://codecov.io/gh/ethereumjs/ethereumjs-monorepo/tree/master/packages/ethash

--- a/packages/genesis/README.md
+++ b/packages/genesis/README.md
@@ -61,7 +61,7 @@ See our organizational [documentation](https://ethereumjs.readthedocs.io) for an
 [genesis-npm-link]: https://www.npmjs.com/package/@ethereumjs/genesis
 [genesis-issues-badge]: https://img.shields.io/github/issues/ethereumjs/ethereumjs-monorepo/package:%20genesis?label=issues
 [genesis-issues-link]: https://github.com/ethereumjs/ethereumjs-monorepo/issues?q=is%3Aopen+is%3Aissue+label%3A"package%3A+genesis"
-[genesis-actions-badge]: https://github.com/ethereumjs/ethereumjs-monorepo/workflows/Genesis/badge.svg
+[genesis-actions-badge]: https://github.com/ethereumjs/ethereumjs-monorepo/actions/workflows/static-build.yml/badge.svg
 [genesis-actions-link]: https://github.com/ethereumjs/ethereumjs-monorepo/actions?query=workflow%3A%22Genesis%22
 [genesis-coverage-badge]: https://codecov.io/gh/ethereumjs/ethereumjs-monorepo/branch/master/graph/badge.svg?flag=genesis
 [genesis-coverage-link]: https://codecov.io/gh/ethereumjs/ethereumjs-monorepo/tree/master/packages/genesis

--- a/packages/rlp/README.md
+++ b/packages/rlp/README.md
@@ -82,7 +82,7 @@ See our organizational [documentation](https://ethereumjs.readthedocs.io) for an
 [rlp-npm-link]: https://www.npmjs.com/package/@ethereumjs/rlp
 [rlp-issues-badge]: https://img.shields.io/github/issues/ethereumjs/ethereumjs-monorepo/package:%20rlp?label=issues
 [rlp-issues-link]: https://github.com/ethereumjs/ethereumjs-monorepo/issues?q=is%3Aopen+is%3Aissue+label%3A"package%3A+rlp"
-[rlp-actions-badge]: https://github.com/ethereumjs/ethereumjs-monorepo/workflows/rlp/badge.svg
+[rlp-actions-badge]: https://github.com/ethereumjs/ethereumjs-monorepo/actions/workflows/static-build.yml/badge.svg
 [rlp-actions-link]: https://github.com/ethereumjs/ethereumjs-monorepo/actions?query=workflow%3A%22rlp%22
 [rlp-coverage-badge]: https://codecov.io/gh/ethereumjs/ethereumjs-monorepo/branch/master/graph/badge.svg?flag=rlp
 [rlp-coverage-link]: https://codecov.io/gh/ethereumjs/ethereumjs-monorepo/tree/master/packages/rlp

--- a/packages/wallet/README.md
+++ b/packages/wallet/README.md
@@ -171,7 +171,7 @@ MIT License
 
 Copyright (C) 2016 Alex Beregszaszi
 
-[actions-badge]: https://github.com/ethereumjs/ethereumjs-monorepo/workflows/Build/badge.svg
+[actions-badge]: https://github.com/ethereumjs/ethereumjs-monorepo/actions/workflows/static-build.yml/badge.svg
 [actions-link]: https://github.com/ethereumjs/ethereumjs-monorepo/actions
 [coverage-badge]: https://img.shields.io/coveralls/ethereumjs/ethereumjs-wallet.svg
 [coverage-link]: https://coveralls.io/r/ethereumjs/ethereumjs-wallet


### PR DESCRIPTION
This change:
* Renames the static-build workflow to include all packages being covered
* Fixes all action badge links