### PR TITLE
Update 4844 examples to cancun

### DIFF
--- a/packages/block/examples/4844.ts
+++ b/packages/block/examples/4844.ts
@@ -14,6 +14,7 @@ const main = async () => {
     customCrypto: {
       kzg,
     },
+    hardfork: Hardfork.Cancun,
   })
   const blobTx = createBlob4844Tx(
     { blobsData: ['myFirstBlob'], to: createAddressFromPrivateKey(randomBytes(32)) },

--- a/packages/evm/examples/4844.ts
+++ b/packages/evm/examples/4844.ts
@@ -1,3 +1,5 @@
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 
-const common = new Common({ chain: Mainnet, hardfork: Hardfork.Shanghai, eips: [4844] })
+const common = new Common({ chain: Mainnet, hardfork: Hardfork.Cancun })
+
+console.log('is EIP-4844 active?', common.isActivatedEIP(4844))

--- a/packages/tx/examples/blobTx.ts
+++ b/packages/tx/examples/blobTx.ts
@@ -9,8 +9,7 @@ const main = async () => {
   const kzg = new microEthKZG(trustedSetup)
   const common = new Common({
     chain: Mainnet,
-    hardfork: Hardfork.Shanghai,
-    eips: [4844],
+    hardfork: Hardfork.Cancun,
     customCrypto: { kzg },
   })
 

--- a/packages/vm/examples/vmWith4844.ts
+++ b/packages/vm/examples/vmWith4844.ts
@@ -2,7 +2,7 @@ import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { createVM } from '@ethereumjs/vm'
 
 const main = async () => {
-  const common = new Common({ chain: Mainnet, hardfork: Hardfork.Shanghai, eips: [4844] })
+  const common = new Common({ chain: Mainnet, hardfork: Hardfork.Cancun })
   const vm = await createVM({ common })
   console.log(`4844 is active in the VM - ${vm.common.isActivatedEIP(4844)}`)
 }


### PR DESCRIPTION
All of our EIP-4844 examples are still using `shanghai` and manually activating EIP 4844.  This is no longer necessary as of Cancun so this updates the examples accordingly.