### PR TITLE
Update 4844 docs

### DIFF
--- a/packages/tx/examples/blobTx.ts
+++ b/packages/tx/examples/blobTx.ts
@@ -1,7 +1,7 @@
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import type { BlobEIP4844TxData } from '@ethereumjs/tx'
 import { createBlob4844Tx } from '@ethereumjs/tx'
-import { bytesToHex } from '@ethereumjs/util'
+import { bytesToHex, randomBytes } from '@ethereumjs/util'
 import { trustedSetup } from '@paulmillr/trusted-setups/fast.js'
 import { KZG as microEthKZG } from 'micro-eth-signer/kzg'
 
@@ -34,6 +34,10 @@ const main = async () => {
   const tx = createBlob4844Tx(txData, { common })
 
   console.log(bytesToHex(tx.hash())) //0x3c3e7c5e09c250d2200bcc3530f4a9088d7e3fb4ea3f4fccfd09f535a3539e84
+
+  // To send a transaction via RPC, you can something like this:
+  // const rawTx = tx.sign(privateKeyBytes).serializeNetworkWrapper()
+  // myRPCClient.request('eth_sendRawTransaction', [rawTx]) // submits a transaction via RPC
 }
 
 void main()

--- a/packages/tx/src/4844/tx.ts
+++ b/packages/tx/src/4844/tx.ts
@@ -317,7 +317,9 @@ export class Blob4844Tx implements TransactionInterface<typeof TransactionType.B
   }
 
   /**
-   * @returns the serialized form of a blob transaction in the network wrapper format (used for gossipping mempool transactions over devp2p)
+   * @returns the serialized form of a blob transaction in the network wrapper format
+   * This format is used for gossipping mempool transactions over devp2p or when
+   * submitting a transaction via RPC.
    */
   serializeNetworkWrapper(): Uint8Array {
     if (


### PR DESCRIPTION
This adds a few notes on how to serialize 4844 transactions for the most common use case (i.e. when we are constructing a blob txn for submission via JSON-RPC)