### PR TITLE
client: fix getpayloadv4 to return execution requests as well on retry

### DIFF
--- a/config/cspell-ts.json
+++ b/config/cspell-ts.json
@@ -639,6 +639,7 @@
     "bytevector",
     "blobschedule",
     "hoodi",
-    "peerdas"
+    "peerdas",
+    "getpayload"
   ]
 }

--- a/packages/client/src/miner/pendingBlock.ts
+++ b/packages/client/src/miner/pendingBlock.ts
@@ -64,6 +64,7 @@ export class PendingBlock {
 
   pendingPayloads: Map<string, BlockBuilder> = new Map()
   blobsBundles: Map<string, BlobsBundle> = new Map()
+  executionRequests: Map<string, CLRequest<CLRequestType>[]> = new Map()
 
   private skipHardForkValidation?: boolean
 
@@ -232,6 +233,7 @@ export class PendingBlock {
     // Remove from pendingPayloads
     this.pendingPayloads.delete(payloadId)
     this.blobsBundles.delete(payloadId)
+    this.executionRequests.delete(payloadId)
   }
 
   /**
@@ -262,6 +264,7 @@ export class PendingBlock {
         builder.transactionReceipts,
         builder.minerValue,
         this.blobsBundles.get(payloadId),
+        this.executionRequests.get(payloadId),
       ]
     }
     const { vm, headerData } = builder as unknown as { vm: VM; headerData: HeaderData }
@@ -293,6 +296,9 @@ export class PendingBlock {
     const { skippedByAddErrors, blobTxs } = await this.addTransactions(builder, txs)
 
     const { block, requests } = await builder.build()
+    if (requests !== undefined) {
+      this.executionRequests.set(payloadId, requests)
+    }
 
     // Construct blobs bundle
     const blobs = block.common.isActivatedEIP(4844)

--- a/packages/client/test/rpc/engine/newPayloadV4.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV4.spec.ts
@@ -201,8 +201,17 @@ describe(`${method}: call with executionPayloadV4`, () => {
     await service.txPool.add(depositTx, true)
 
     res = await rpc.request('engine_getPayloadV4', [payloadId])
-    const { executionPayload, executionRequests } = res.result
+    const getPayloadResult = res.result
+    // recall getpayloadv4 to verify if all of cached payload is returned
+    res = await rpc.request('engine_getPayloadV4', [payloadId])
+    const getPayloadRetryResult = res.result
+    const hasAllKeys = Object.keys(getPayloadResult).reduce(
+      (acc, key) => acc && Object.keys(getPayloadRetryResult).includes(key),
+      true,
+    )
+    assert(hasAllKeys === true, 'all cached data should be returned on retry')
 
+    const { executionPayload, executionRequests } = getPayloadResult
     assert.strictEqual(
       executionRequests?.length,
       1,

--- a/packages/client/test/rpc/engine/newPayloadV4.spec.ts
+++ b/packages/client/test/rpc/engine/newPayloadV4.spec.ts
@@ -202,7 +202,7 @@ describe(`${method}: call with executionPayloadV4`, () => {
 
     res = await rpc.request('engine_getPayloadV4', [payloadId])
     const getPayloadResult = res.result
-    // recall getpayloadv4 to verify if all of cached payload is returned
+    // recall getpayload to verify if all of cached payload is returned
     res = await rpc.request('engine_getPayloadV4', [payloadId])
     const getPayloadRetryResult = res.result
     const hasAllKeys = Object.keys(getPayloadResult).reduce(


### PR DESCRIPTION
while debugging peerdas lighthouse was doing getpayload retries which was returning incomplete response on retry
