### PR TITLE
common: improve ugly method

### DIFF
--- a/packages/client/src/sync/fullsync.ts
+++ b/packages/client/src/sync/fullsync.ts
@@ -250,7 +250,6 @@ export class FullSynchronizer extends Synchronizer {
     if (nextHFBlockNum !== null) {
       const remaining = nextHFBlockNum - last
       if (remaining <= BigInt(10000)) {
-        // TODO: Do something about super-ugly nextHardforkBlockOrTimestamp() method
         const nextHF = this.config.chainCommon.getHardforkBy({ blockNumber: nextHFBlockNum })
         attentionHF = `${nextHF} HF in ${remaining} blocks`
       }


### PR DESCRIPTION
Responding to a TODO found in `client/sync/fullsync.ts` regarding `common.nextHardforkBlockOrTimestamp`

> // TODO: Do something about super-ugly nextHardforkBlockOrTimestamp() method

---- 

This PR attempts to make this method a bit less ugly with:

- simplified logic
- more explicit merge hf handling
- more consistent type handling
- improved documentation