### PR TITLE
valueBoundaryCheck chores

### DIFF
--- a/packages/tx/src/1559/tx.ts
+++ b/packages/tx/src/1559/tx.ts
@@ -13,7 +13,7 @@ import * as EIP2718 from '../capabilities/eip2718.ts'
 import * as EIP2930 from '../capabilities/eip2930.ts'
 import * as Legacy from '../capabilities/legacy.ts'
 import { TransactionType, isAccessList } from '../types.ts'
-import { getBaseJSON, sharedConstructor, valueBoundaryCheck } from '../util/internal.ts'
+import { getBaseJSON, sharedConstructor, valueOverflowCheck } from '../util/internal.ts'
 
 import { createFeeMarket1559Tx } from './constructors.ts'
 
@@ -109,7 +109,7 @@ export class FeeMarket1559Tx
     this.maxFeePerGas = bytesToBigInt(toBytes(maxFeePerGas))
     this.maxPriorityFeePerGas = bytesToBigInt(toBytes(maxPriorityFeePerGas))
 
-    valueBoundaryCheck({
+    valueOverflowCheck({
       maxFeePerGas: this.maxFeePerGas,
       maxPriorityFeePerGas: this.maxPriorityFeePerGas,
     })

--- a/packages/tx/src/2930/tx.ts
+++ b/packages/tx/src/2930/tx.ts
@@ -11,7 +11,7 @@ import * as EIP2718 from '../capabilities/eip2718.ts'
 import * as EIP2930 from '../capabilities/eip2930.ts'
 import * as Legacy from '../capabilities/legacy.ts'
 import { TransactionType, isAccessList } from '../types.ts'
-import { getBaseJSON, sharedConstructor, valueBoundaryCheck } from '../util/internal.ts'
+import { getBaseJSON, sharedConstructor, valueOverflowCheck } from '../util/internal.ts'
 
 import { createAccessList2930Tx } from './constructors.ts'
 
@@ -105,7 +105,7 @@ export class AccessList2930Tx
 
     this.gasPrice = bytesToBigInt(toBytes(gasPrice))
 
-    valueBoundaryCheck({ gasPrice: this.gasPrice })
+    valueOverflowCheck({ gasPrice: this.gasPrice })
 
     if (this.gasPrice * this.gasLimit > MAX_INTEGER) {
       const msg = Legacy.errorMsg(this, 'gasLimit * gasPrice cannot exceed MAX_INTEGER')

--- a/packages/tx/src/4844/tx.ts
+++ b/packages/tx/src/4844/tx.ts
@@ -21,7 +21,7 @@ import {
   getBaseJSON,
   sharedConstructor,
   validateNotArray,
-  valueBoundaryCheck,
+  valueOverflowCheck,
 } from '../util/internal.ts'
 
 import { createBlob4844Tx } from './constructors.ts'
@@ -130,7 +130,7 @@ export class Blob4844Tx implements TransactionInterface<typeof TransactionType.B
     this.maxFeePerGas = bytesToBigInt(toBytes(maxFeePerGas))
     this.maxPriorityFeePerGas = bytesToBigInt(toBytes(maxPriorityFeePerGas))
 
-    valueBoundaryCheck({
+    valueOverflowCheck({
       maxFeePerGas: this.maxFeePerGas,
       maxPriorityFeePerGas: this.maxPriorityFeePerGas,
     })

--- a/packages/tx/src/7702/tx.ts
+++ b/packages/tx/src/7702/tx.ts
@@ -22,7 +22,7 @@ import {
   getBaseJSON,
   sharedConstructor,
   validateNotArray,
-  valueBoundaryCheck,
+  valueOverflowCheck,
 } from '../util/internal.ts'
 
 import { createEOACode7702Tx } from './constructors.ts'
@@ -131,7 +131,7 @@ export class EOACode7702Tx implements TransactionInterface<typeof TransactionTyp
     this.maxFeePerGas = bytesToBigInt(toBytes(maxFeePerGas))
     this.maxPriorityFeePerGas = bytesToBigInt(toBytes(maxPriorityFeePerGas))
 
-    valueBoundaryCheck({
+    valueOverflowCheck({
       maxFeePerGas: this.maxFeePerGas,
       maxPriorityFeePerGas: this.maxPriorityFeePerGas,
     })

--- a/packages/tx/src/legacy/tx.ts
+++ b/packages/tx/src/legacy/tx.ts
@@ -15,7 +15,7 @@ import { keccak256 } from 'ethereum-cryptography/keccak.js'
 import * as Legacy from '../capabilities/legacy.ts'
 import { paramsTx } from '../index.ts'
 import { Capability, TransactionType } from '../types.ts'
-import { getBaseJSON, sharedConstructor, valueBoundaryCheck } from '../util/internal.ts'
+import { getBaseJSON, sharedConstructor, valueOverflowCheck } from '../util/internal.ts'
 
 import { createLegacyTx } from './constructors.ts'
 
@@ -124,7 +124,7 @@ export class LegacyTx implements TransactionInterface<typeof TransactionType.Leg
     sharedConstructor(this, txData, opts)
 
     this.gasPrice = bytesToBigInt(toBytes(txData.gasPrice))
-    valueBoundaryCheck({ gasPrice: this.gasPrice })
+    valueOverflowCheck({ gasPrice: this.gasPrice })
 
     // Everything from BaseTransaction done here
     this.common.updateParams(opts.params ?? paramsTx) // TODO should this move higher?

--- a/packages/tx/src/util/internal.ts
+++ b/packages/tx/src/util/internal.ts
@@ -63,9 +63,9 @@ function checkMaxInitCodeSize(common: Common, length: number) {
  * Validates that an object with BigInt values cannot exceed the specified bit limit.
  * @param values Object containing string keys and BigInt values
  * @param bits Number of bits to check (64 or 256)
- * @param cannotEqual Pass true if the number also cannot equal one less the maximum value
+ * @param cannotEqual Pass true if the number also cannot equal one less than the maximum value
  */
-export function valueBoundaryCheck(
+export function valueOverflowCheck(
   // TODO: better method name
   values: { [key: string]: bigint | undefined },
   bits = 256,
@@ -155,13 +155,13 @@ export function sharedConstructor(
   // Start validating the data
 
   // Validate value/r/s
-  valueBoundaryCheck({ value: tx.value, r: tx.r, s: tx.s })
+  valueOverflowCheck({ value: tx.value, r: tx.r, s: tx.s })
 
   // geth limits gasLimit to 2^64-1
-  valueBoundaryCheck({ gasLimit: tx.gasLimit }, 64)
+  valueOverflowCheck({ gasLimit: tx.gasLimit }, 64)
 
   // EIP-2681 limits nonce to 2^64-1 (cannot equal 2^64-1)
-  valueBoundaryCheck({ nonce: tx.nonce }, 64, true)
+  valueOverflowCheck({ nonce: tx.nonce }, 64, true)
 
   const createContract = tx.to === undefined || tx.to === null
   const allowUnlimitedInitCodeSize = opts.allowUnlimitedInitCodeSize ?? false

--- a/packages/tx/src/util/internal.ts
+++ b/packages/tx/src/util/internal.ts
@@ -66,7 +66,6 @@ function checkMaxInitCodeSize(common: Common, length: number) {
  * @param cannotEqual Pass true if the number also cannot equal one less than the maximum value
  */
 export function valueOverflowCheck(
-  // TODO: better method name
   values: { [key: string]: bigint | undefined },
   bits = 256,
   cannotEqual = false,

--- a/packages/tx/test/base.spec.ts
+++ b/packages/tx/test/base.spec.ts
@@ -1,7 +1,5 @@
 import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import {
-  MAX_INTEGER,
-  MAX_UINT64,
   SECP256K1_ORDER,
   bytesToBigInt,
   equalsBytes,
@@ -28,7 +26,6 @@ import {
   createLegacyTxFromRLP,
   paramsTx,
 } from '../src/index.ts'
-import { valueBoundaryCheck } from '../src/util/internal.ts'
 
 import { eip1559TxsData } from './testData/eip1559txs.ts'
 import { eip2930TxsData } from './testData/eip2930txs.ts'
@@ -442,46 +439,5 @@ describe('[BaseTransaction]', () => {
     assert.strictEqual(tx.gasPrice, bytesToBigInt(bufferZero))
     assert.strictEqual(tx.gasLimit, bytesToBigInt(bufferZero))
     assert.strictEqual(tx.nonce, bytesToBigInt(bufferZero))
-  })
-
-  // TODO: move this to a different file (not part of base transaction anymore)
-  it('valueBoundaryCheck()', () => {
-    try {
-      valueBoundaryCheck({ a: MAX_INTEGER }, 256, true)
-    } catch (err: any) {
-      assert.isTrue(
-        err.message.includes('equal or exceed MAX_INTEGER'),
-        'throws when value equals or exceeds MAX_INTEGER',
-      )
-    }
-    try {
-      valueBoundaryCheck({ a: MAX_INTEGER + BigInt(1) }, 256, false)
-    } catch (err: any) {
-      assert.isTrue(
-        err.message.includes('exceed MAX_INTEGER'),
-        'throws when value exceeds MAX_INTEGER',
-      )
-    }
-    try {
-      valueBoundaryCheck({ a: BigInt(0) }, 100, false)
-    } catch (err: any) {
-      assert.isTrue(
-        err.message.includes('unimplemented bits value'),
-        'throws when bits value other than 64 or 256 provided',
-      )
-    }
-    try {
-      valueBoundaryCheck({ a: MAX_UINT64 + BigInt(1) }, 64, false)
-    } catch (err: any) {
-      assert.isTrue(err.message.includes('2^64'), 'throws when 64 bit integer exceeds MAX_UINT64')
-    }
-    try {
-      valueBoundaryCheck({ a: MAX_UINT64 }, 64, true)
-    } catch (err: any) {
-      assert.isTrue(
-        err.message.includes('2^64'),
-        'throws when 64 bit integer equals or exceeds MAX_UINT64',
-      )
-    }
   })
 })

--- a/packages/tx/test/util.spec.ts
+++ b/packages/tx/test/util.spec.ts
@@ -1,0 +1,46 @@
+import { MAX_INTEGER, MAX_UINT64 } from '@ethereumjs/util'
+import { assert, describe, it } from 'vitest'
+
+import { valueOverflowCheck } from '../src/util/internal.ts'
+
+describe('Helper methods should be correct', () => {
+  it('valueBoundaryCheck()', () => {
+    try {
+      valueOverflowCheck({ a: MAX_INTEGER }, 256, true)
+    } catch (err: any) {
+      assert.isTrue(
+        err.message.includes('equal or exceed MAX_INTEGER'),
+        'throws when value equals or exceeds MAX_INTEGER',
+      )
+    }
+    try {
+      valueOverflowCheck({ a: MAX_INTEGER + BigInt(1) }, 256, false)
+    } catch (err: any) {
+      assert.isTrue(
+        err.message.includes('exceed MAX_INTEGER'),
+        'throws when value exceeds MAX_INTEGER',
+      )
+    }
+    try {
+      valueOverflowCheck({ a: BigInt(0) }, 100, false)
+    } catch (err: any) {
+      assert.isTrue(
+        err.message.includes('unimplemented bits value'),
+        'throws when bits value other than 64 or 256 provided',
+      )
+    }
+    try {
+      valueOverflowCheck({ a: MAX_UINT64 + BigInt(1) }, 64, false)
+    } catch (err: any) {
+      assert.isTrue(err.message.includes('2^64'), 'throws when 64 bit integer exceeds MAX_UINT64')
+    }
+    try {
+      valueOverflowCheck({ a: MAX_UINT64 }, 64, true)
+    } catch (err: any) {
+      assert.isTrue(
+        err.message.includes('2^64'),
+        'throws when 64 bit integer equals or exceeds MAX_UINT64',
+      )
+    }
+  })
+})


### PR DESCRIPTION
This change addresses two `TODO`s from the codebase:
* Move the test for `valueBoundaryCheck()` from `base.spec.ts` which should hold tests that test the base transaction functionality, into a more appropriately named file, `util.spec.ts` for the helper function being tested
* Improve the method name by making it more specific