### PR TITLE
Fix outdated hardware wallet signing example

### DIFF
--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -456,9 +456,6 @@ const transport = await TransportNodeHid.default.open()
 const eth = new Eth.default(transport)
 const common = new Common({ chain: Sepolia })
 
-let tx: LegacyTx | FeeMarket1559Tx
-let unsignedTx: Uint8Array[] | Uint8Array
-let signedTx: typeof tx
 // Signing with the first key of the derivation path
 const bip32Path = "44'/60'/0'/0/0"
 
@@ -485,23 +482,23 @@ const eip1559TxData: FeeMarketEIP1559TxData = {
 
 const run = async () => {
     // Signing a legacy tx
-    tx = createLegacyTx(legacyTxData, { common })
-    unsignedTx = tx.getMessageToSign()
+    const tx1 = createLegacyTx(legacyTxData, { common })
+    const unsignedTx1 = tx1.getMessageToSign()
     // Ledger signTransaction API expects it to be serialized
     // Ledger returns unprefixed hex strings without 0x for v, r, s values
-    let { v, r, s } = await eth.signTransaction(bip32Path, bytesToHex(RLP.encode(unsignedTx)).slice(2), null)
-    let signedTx: LegacyTx | FeeMarket1559Tx = tx.addSignature(BigInt(`0x${v}`), BigInt(`0x${r}`), BigInt(`0x${s}`))
-    let from = signedTx.getSenderAddress().toString()
-    console.log(`signedTx: ${bytesToHex(tx.serialize())}\nfrom: ${from}`)
+    const { v, r, s } = await eth.signTransaction(bip32Path, bytesToHex(RLP.encode(unsignedTx1)).slice(2), null)
+    const signedTx1 = tx1.addSignature(BigInt(`0x${v}`), BigInt(`0x${r}`), BigInt(`0x${s}`))
+    const from = signedTx1.getSenderAddress().toString()
+    console.log(`signedTx: ${bytesToHex(tx1.serialize())}\nfrom: ${from}`)
 
     // Signing a 1559 tx
-    tx = createFeeMarket1559Tx(eip1559TxData, { common })
+    const tx2 = createFeeMarket1559Tx(eip1559TxData, { common })
     // Ledger returns unprefixed hex strings without 0x for v, r, s values
-    unsignedTx = tx.getMessageToSign()
-        ; ({ v, r, s } = await eth.signTransaction(bip32Path, bytesToHex(unsignedTx).slice(2), null))
-    signedTx = tx.addSignature(BigInt(`0x${v}`), BigInt(`0x${r}`), BigInt(`0x${s}`))
-    from = signedTx.getSenderAddress().toString()
-    console.log(`signedTx: ${bytesToHex(tx.serialize())}\nfrom: ${from}`)
+    const unsignedTx2 = tx2.getMessageToSign()
+    const { v2, r2, s2 } = await eth.signTransaction(bip32Path, bytesToHex(unsignedTx2).slice(2), null)
+    const signedTx2 = tx2.addSignature(BigInt(`0x${v2}`), BigInt(`0x${r2}`), BigInt(`0x${s2}`))
+    const from2 = signedTx2.getSenderAddress().toString()
+    console.log(`signedTx: ${bytesToHex(tx2.serialize())}\nfrom: ${from2}`)
 }
 
 run()

--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -478,9 +478,6 @@ const eip1559TxData: FeeMarketEIP1559TxData = {
     nonce: '0x00',
     to: '0xcccccccccccccccccccccccccccccccccccccccc',
     value: '0x0186a0',
-    v: '0x01',
-    r: '0xafb6e247b1c490e284053c87ab5f6b59e219d51f743f7a4d83e400782bc7e4b9',
-    s: '0x479a268e0e0acd4de3f1e28e4fac2a6b32a4195e8dfa9d19147abe8807aa6f64',
     accessList: [],
     type: '0x02',
 }

--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -441,65 +441,67 @@ To sign a tx with a hardware or external wallet use `tx.getMessageToSign()` to r
 
 A legacy transaction will return a Buffer list of the values, and a Typed Transaction ([EIP-2718](https://eips.ethereum.org/EIPS/eip-2718)) will return the serialized output.
 
-Here is an example of signing txs with `@ledgerhq/hw-app-eth` as of `v6.5.0`:
-
+Here is an example of signing txs with `@ledgerhq/hw-app-eth` with `v6.45.4` and `@ledgerhq/hw-transport-node-hid` with `v6.29.5`:
 ```ts
-import { Chain, Common } from '@ethereumjs/common'
-import { createLegacyTx, createFeeMarket1559Tx } from '@ethereumjs/tx'
+// examples/ledgerSigner.mts
+
+import { Chain, Common, Sepolia } from '@ethereumjs/common'
+import { createLegacyTx, createFeeMarket1559Tx, type LegacyTx, type FeeMarket1559Tx, type LegacyTxData, type FeeMarketEIP1559TxData } from '@ethereumjs/tx'
 import { bytesToHex } from '@ethereumjs/util'
 import { RLP } from '@ethereumjs/rlp'
 import Eth from '@ledgerhq/hw-app-eth'
+import TransportNodeHid from '@ledgerhq/hw-transport-node-hid'
 
-const eth = new Eth(transport)
-const common = new Common({ chain: Chain.Sepolia })
+const transport = await TransportNodeHid.default.open()
+const eth = new Eth.default(transport)
+const common = new Common({ chain: Sepolia })
 
-let tx: LegacyTransaction | FeeMarketEIP1559Transaction
+let tx: LegacyTx | FeeMarket1559Tx
 let unsignedTx: Uint8Array[] | Uint8Array
 let signedTx: typeof tx
 const bip32Path = "44'/60'/0'/0/0"
 
 const legacyTxData: LegacyTxData = {
-  nonce: '0x0',
-  gasPrice: '0x09184e72a000',
-  gasLimit: '0x2710',
-  to: '0x0000000000000000000000000000000000000000',
-  value: '0x00',
-  data: '0x7f7465737432000000000000000000000000000000000000000000000000000000600057',
+    nonce: '0x0',
+    gasPrice: '0x09184e72a000',
+    gasLimit: '0x2710',
+    to: '0x0000000000000000000000000000000000000000',
+    value: '0x00',
+    data: '0x7f7465737432000000000000000000000000000000000000000000000000000000600057',
 }
 
 const eip1559TxData: FeeMarketEIP1559TxData = {
-  data: '0x1a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
-  gasLimit: '0x02625a00',
-  maxPriorityFeePerGas: '0x01',
-  maxFeePerGas: '0xff',
-  nonce: '0x00',
-  to: '0xcccccccccccccccccccccccccccccccccccccccc',
-  value: '0x0186a0',
-  v: '0x01',
-  r: '0xafb6e247b1c490e284053c87ab5f6b59e219d51f743f7a4d83e400782bc7e4b9',
-  s: '0x479a268e0e0acd4de3f1e28e4fac2a6b32a4195e8dfa9d19147abe8807aa6f64',
-  chainId: '0x01',
-  accessList: [],
-  type: '0x02',
+    data: '0x1a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+    gasLimit: '0x02625a00',
+    maxPriorityFeePerGas: '0x01',
+    maxFeePerGas: '0xff',
+    nonce: '0x00',
+    to: '0xcccccccccccccccccccccccccccccccccccccccc',
+    value: '0x0186a0',
+    v: '0x01',
+    r: '0xafb6e247b1c490e284053c87ab5f6b59e219d51f743f7a4d83e400782bc7e4b9',
+    s: '0x479a268e0e0acd4de3f1e28e4fac2a6b32a4195e8dfa9d19147abe8807aa6f64',
+    accessList: [],
+    type: '0x02',
 }
 
 const run = async () => {
-  // Signing a legacy tx
-  let tx = createLegacyTx(legacyTxData, { common })
-  unsignedTx = tx.getMessageToSign()
-  // ledger signTransaction API expects it to be serialized
-  let { v, r, s } = await eth.signTransaction(bip32Path, RLP.encode(unsignedTx))
-  tx.addSignature(v, r, s, true)
-  let from = tx.getSenderAddress().toString()
-  console.log(`signedTx: ${bytesToHex(tx.serialize())}\nfrom: ${from}`)
+    // Signing a legacy tx
+    tx = createLegacyTx(legacyTxData, { common })
+    unsignedTx = tx.getMessageToSign()
+    // ledger signTransaction API expects it to be serialized
+    let { v, r, s } = await eth.signTransaction(bip32Path, bytesToHex(RLP.encode(unsignedTx)).slice(2), null)
+    let signedTx: LegacyTx | FeeMarket1559Tx = tx.addSignature(BigInt(`0x${v}`), BigInt(`0x${r}`), BigInt(`0x${s}`))
+    let from = signedTx.getSenderAddress().toString()
+    console.log(`signedTx: ${bytesToHex(tx.serialize())}\nfrom: ${from}`)
 
-  // Signing a 1559 tx
-  tx = createFeeMarket1559Tx(eip1559TxData, { common })
-  unsignedTx = tx.getMessageToSign()
-  ;({ v, r, s } = await eth.signTransaction(bip32Path, unsignedTx)) // this syntax is: object destructuring - assignment without declaration
-  tx.addSignature(v, r, s)
-  from = tx.getSenderAddress().toString()
-  console.log(`signedTx: ${bytesToHex(tx.serialize())}\nfrom: ${from}`)
+    // Signing a 1559 tx
+    tx = createFeeMarket1559Tx(eip1559TxData, { common })
+    unsignedTx = tx.getMessageToSign()
+        ; ({ v, r, s } = await eth.signTransaction(bip32Path, bytesToHex(unsignedTx).slice(2), null))
+    signedTx = tx.addSignature(BigInt(`0x${v}`), BigInt(`0x${r}`), BigInt(`0x${s}`))
+    from = signedTx.getSenderAddress().toString()
+    console.log(`signedTx: ${bytesToHex(tx.serialize())}\nfrom: ${from}`)
 }
 
 run()

--- a/packages/tx/README.md
+++ b/packages/tx/README.md
@@ -459,6 +459,7 @@ const common = new Common({ chain: Sepolia })
 let tx: LegacyTx | FeeMarket1559Tx
 let unsignedTx: Uint8Array[] | Uint8Array
 let signedTx: typeof tx
+// Signing with the first key of the derivation path
 const bip32Path = "44'/60'/0'/0/0"
 
 const legacyTxData: LegacyTxData = {
@@ -486,7 +487,8 @@ const run = async () => {
     // Signing a legacy tx
     tx = createLegacyTx(legacyTxData, { common })
     unsignedTx = tx.getMessageToSign()
-    // ledger signTransaction API expects it to be serialized
+    // Ledger signTransaction API expects it to be serialized
+    // Ledger returns unprefixed hex strings without 0x for v, r, s values
     let { v, r, s } = await eth.signTransaction(bip32Path, bytesToHex(RLP.encode(unsignedTx)).slice(2), null)
     let signedTx: LegacyTx | FeeMarket1559Tx = tx.addSignature(BigInt(`0x${v}`), BigInt(`0x${r}`), BigInt(`0x${s}`))
     let from = signedTx.getSenderAddress().toString()
@@ -494,6 +496,7 @@ const run = async () => {
 
     // Signing a 1559 tx
     tx = createFeeMarket1559Tx(eip1559TxData, { common })
+    // Ledger returns unprefixed hex strings without 0x for v, r, s values
     unsignedTx = tx.getMessageToSign()
         ; ({ v, r, s } = await eth.signTransaction(bip32Path, bytesToHex(unsignedTx).slice(2), null))
     signedTx = tx.addSignature(BigInt(`0x${v}`), BigInt(`0x${r}`), BigInt(`0x${s}`))

--- a/packages/tx/examples/ledgerSigner.mts
+++ b/packages/tx/examples/ledgerSigner.mts
@@ -1,7 +1,12 @@
-import { Chain, Common, Sepolia } from '@ethereumjs/common'
-import { createLegacyTx, createFeeMarket1559Tx, type LegacyTx, type FeeMarket1559Tx, type LegacyTxData, type FeeMarketEIP1559TxData } from '@ethereumjs/tx'
-import { bytesToHex } from '@ethereumjs/util'
+import { Common, Sepolia } from '@ethereumjs/common'
 import { RLP } from '@ethereumjs/rlp'
+import {
+  type FeeMarketEIP1559TxData,
+  type LegacyTxData,
+  createFeeMarket1559Tx,
+  createLegacyTx,
+} from '@ethereumjs/tx'
+import { bytesToHex } from '@ethereumjs/util'
 import Eth from '@ledgerhq/hw-app-eth'
 import TransportNodeHid from '@ledgerhq/hw-transport-node-hid'
 
@@ -13,45 +18,53 @@ const common = new Common({ chain: Sepolia })
 const bip32Path = "44'/60'/0'/0/0"
 
 const legacyTxData: LegacyTxData = {
-    nonce: '0x0',
-    gasPrice: '0x09184e72a000',
-    gasLimit: '0x2710',
-    to: '0x0000000000000000000000000000000000000000',
-    value: '0x00',
-    data: '0x7f7465737432000000000000000000000000000000000000000000000000000000600057',
+  nonce: '0x0',
+  gasPrice: '0x09184e72a000',
+  gasLimit: '0x2710',
+  to: '0x0000000000000000000000000000000000000000',
+  value: '0x00',
+  data: '0x7f7465737432000000000000000000000000000000000000000000000000000000600057',
 }
 
 const eip1559TxData: FeeMarketEIP1559TxData = {
-    data: '0x1a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
-    gasLimit: '0x02625a00',
-    maxPriorityFeePerGas: '0x01',
-    maxFeePerGas: '0xff',
-    nonce: '0x00',
-    to: '0xcccccccccccccccccccccccccccccccccccccccc',
-    value: '0x0186a0',
-    accessList: [],
-    type: '0x02',
+  data: '0x1a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+  gasLimit: '0x02625a00',
+  maxPriorityFeePerGas: '0x01',
+  maxFeePerGas: '0xff',
+  nonce: '0x00',
+  to: '0xcccccccccccccccccccccccccccccccccccccccc',
+  value: '0x0186a0',
+  accessList: [],
+  type: '0x02',
 }
 
 const run = async () => {
-    // Signing a legacy tx
-    const tx1 = createLegacyTx(legacyTxData, { common })
-    const unsignedTx1 = tx1.getMessageToSign()
-    // Ledger signTransaction API expects it to be serialized
-    // Ledger returns unprefixed hex strings without 0x for v, r, s values
-    const { v, r, s } = await eth.signTransaction(bip32Path, bytesToHex(RLP.encode(unsignedTx1)).slice(2), null)
-    const signedTx1 = tx1.addSignature(BigInt(`0x${v}`), BigInt(`0x${r}`), BigInt(`0x${s}`))
-    const from = signedTx1.getSenderAddress().toString()
-    console.log(`signedTx: ${bytesToHex(tx1.serialize())}\nfrom: ${from}`)
+  // Signing a legacy tx
+  const tx1 = createLegacyTx(legacyTxData, { common })
+  const unsignedTx1 = tx1.getMessageToSign()
+  // Ledger signTransaction API expects it to be serialized
+  // Ledger returns unprefixed hex strings without 0x for v, r, s values
+  const { v, r, s } = await eth.signTransaction(
+    bip32Path,
+    bytesToHex(RLP.encode(unsignedTx1)).slice(2),
+    null,
+  )
+  const signedTx1 = tx1.addSignature(BigInt(`0x${v}`), BigInt(`0x${r}`), BigInt(`0x${s}`))
+  const from = signedTx1.getSenderAddress().toString()
+  console.log(`signedTx: ${bytesToHex(tx1.serialize())}\nfrom: ${from}`)
 
-    // Signing a 1559 tx
-    const tx2 = createFeeMarket1559Tx(eip1559TxData, { common })
-    // Ledger returns unprefixed hex strings without 0x for v, r, s values
-    const unsignedTx2 = tx2.getMessageToSign()
-    const { v2, r2, s2 } = await eth.signTransaction(bip32Path, bytesToHex(unsignedTx2).slice(2), null)
-    const signedTx2 = tx2.addSignature(BigInt(`0x${v2}`), BigInt(`0x${r2}`), BigInt(`0x${s2}`))
-    const from2 = signedTx2.getSenderAddress().toString()
-    console.log(`signedTx: ${bytesToHex(tx2.serialize())}\nfrom: ${from2}`)
+  // Signing a 1559 tx
+  const tx2 = createFeeMarket1559Tx(eip1559TxData, { common })
+  // Ledger returns unprefixed hex strings without 0x for v, r, s values
+  const unsignedTx2 = tx2.getMessageToSign()
+  const { v2, r2, s2 } = await eth.signTransaction(
+    bip32Path,
+    bytesToHex(unsignedTx2).slice(2),
+    null,
+  )
+  const signedTx2 = tx2.addSignature(BigInt(`0x${v2}`), BigInt(`0x${r2}`), BigInt(`0x${s2}`))
+  const from2 = signedTx2.getSenderAddress().toString()
+  console.log(`signedTx: ${bytesToHex(tx2.serialize())}\nfrom: ${from2}`)
 }
 
 run()

--- a/packages/tx/examples/ledgerSigner.mts
+++ b/packages/tx/examples/ledgerSigner.mts
@@ -1,0 +1,60 @@
+import { Chain, Common, Sepolia } from '@ethereumjs/common'
+import { createLegacyTx, createFeeMarket1559Tx, type LegacyTx, type FeeMarket1559Tx, type LegacyTxData, type FeeMarketEIP1559TxData } from '@ethereumjs/tx'
+import { bytesToHex } from '@ethereumjs/util'
+import { RLP } from '@ethereumjs/rlp'
+import Eth from '@ledgerhq/hw-app-eth'
+import TransportNodeHid from '@ledgerhq/hw-transport-node-hid'
+
+const transport = await TransportNodeHid.default.open()
+const eth = new Eth.default(transport)
+const common = new Common({ chain: Sepolia })
+
+let tx: LegacyTx | FeeMarket1559Tx
+let unsignedTx: Uint8Array[] | Uint8Array
+let signedTx: typeof tx
+const bip32Path = "44'/60'/0'/0/0"
+
+const legacyTxData: LegacyTxData = {
+    nonce: '0x0',
+    gasPrice: '0x09184e72a000',
+    gasLimit: '0x2710',
+    to: '0x0000000000000000000000000000000000000000',
+    value: '0x00',
+    data: '0x7f7465737432000000000000000000000000000000000000000000000000000000600057',
+}
+
+const eip1559TxData: FeeMarketEIP1559TxData = {
+    data: '0x1a8451e600000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
+    gasLimit: '0x02625a00',
+    maxPriorityFeePerGas: '0x01',
+    maxFeePerGas: '0xff',
+    nonce: '0x00',
+    to: '0xcccccccccccccccccccccccccccccccccccccccc',
+    value: '0x0186a0',
+    v: '0x01',
+    r: '0xafb6e247b1c490e284053c87ab5f6b59e219d51f743f7a4d83e400782bc7e4b9',
+    s: '0x479a268e0e0acd4de3f1e28e4fac2a6b32a4195e8dfa9d19147abe8807aa6f64',
+    accessList: [],
+    type: '0x02',
+}
+
+const run = async () => {
+    // Signing a legacy tx
+    tx = createLegacyTx(legacyTxData, { common })
+    unsignedTx = tx.getMessageToSign()
+    // ledger signTransaction API expects it to be serialized
+    let { v, r, s } = await eth.signTransaction(bip32Path, bytesToHex(RLP.encode(unsignedTx)).slice(2), null)
+    let signedTx: LegacyTx | FeeMarket1559Tx = tx.addSignature(BigInt(`0x${v}`), BigInt(`0x${r}`), BigInt(`0x${s}`))
+    let from = signedTx.getSenderAddress().toString()
+    console.log(`signedTx: ${bytesToHex(tx.serialize())}\nfrom: ${from}`)
+
+    // Signing a 1559 tx
+    tx = createFeeMarket1559Tx(eip1559TxData, { common })
+    unsignedTx = tx.getMessageToSign()
+        ; ({ v, r, s } = await eth.signTransaction(bip32Path, bytesToHex(unsignedTx).slice(2), null))
+    signedTx = tx.addSignature(BigInt(`0x${v}`), BigInt(`0x${r}`), BigInt(`0x${s}`))
+    from = signedTx.getSenderAddress().toString()
+    console.log(`signedTx: ${bytesToHex(tx.serialize())}\nfrom: ${from}`)
+}
+
+run()

--- a/packages/tx/examples/ledgerSigner.mts
+++ b/packages/tx/examples/ledgerSigner.mts
@@ -9,9 +9,6 @@ const transport = await TransportNodeHid.default.open()
 const eth = new Eth.default(transport)
 const common = new Common({ chain: Sepolia })
 
-let tx: LegacyTx | FeeMarket1559Tx
-let unsignedTx: Uint8Array[] | Uint8Array
-let signedTx: typeof tx
 // Signing with the first key of the derivation path
 const bip32Path = "44'/60'/0'/0/0"
 
@@ -38,23 +35,23 @@ const eip1559TxData: FeeMarketEIP1559TxData = {
 
 const run = async () => {
     // Signing a legacy tx
-    tx = createLegacyTx(legacyTxData, { common })
-    unsignedTx = tx.getMessageToSign()
+    const tx1 = createLegacyTx(legacyTxData, { common })
+    const unsignedTx1 = tx1.getMessageToSign()
     // Ledger signTransaction API expects it to be serialized
     // Ledger returns unprefixed hex strings without 0x for v, r, s values
-    let { v, r, s } = await eth.signTransaction(bip32Path, bytesToHex(RLP.encode(unsignedTx)).slice(2), null)
-    let signedTx: LegacyTx | FeeMarket1559Tx = tx.addSignature(BigInt(`0x${v}`), BigInt(`0x${r}`), BigInt(`0x${s}`))
-    let from = signedTx.getSenderAddress().toString()
-    console.log(`signedTx: ${bytesToHex(tx.serialize())}\nfrom: ${from}`)
+    const { v, r, s } = await eth.signTransaction(bip32Path, bytesToHex(RLP.encode(unsignedTx1)).slice(2), null)
+    const signedTx1 = tx1.addSignature(BigInt(`0x${v}`), BigInt(`0x${r}`), BigInt(`0x${s}`))
+    const from = signedTx1.getSenderAddress().toString()
+    console.log(`signedTx: ${bytesToHex(tx1.serialize())}\nfrom: ${from}`)
 
     // Signing a 1559 tx
-    tx = createFeeMarket1559Tx(eip1559TxData, { common })
+    const tx2 = createFeeMarket1559Tx(eip1559TxData, { common })
     // Ledger returns unprefixed hex strings without 0x for v, r, s values
-    unsignedTx = tx.getMessageToSign()
-        ; ({ v, r, s } = await eth.signTransaction(bip32Path, bytesToHex(unsignedTx).slice(2), null))
-    signedTx = tx.addSignature(BigInt(`0x${v}`), BigInt(`0x${r}`), BigInt(`0x${s}`))
-    from = signedTx.getSenderAddress().toString()
-    console.log(`signedTx: ${bytesToHex(tx.serialize())}\nfrom: ${from}`)
+    const unsignedTx2 = tx2.getMessageToSign()
+    const { v2, r2, s2 } = await eth.signTransaction(bip32Path, bytesToHex(unsignedTx2).slice(2), null)
+    const signedTx2 = tx2.addSignature(BigInt(`0x${v2}`), BigInt(`0x${r2}`), BigInt(`0x${s2}`))
+    const from2 = signedTx2.getSenderAddress().toString()
+    console.log(`signedTx: ${bytesToHex(tx2.serialize())}\nfrom: ${from2}`)
 }
 
 run()


### PR DESCRIPTION
Updates the "Signing with a hardware or external wallet" example in the tx package documentation to use the current API.
Fixes #3989
