### PR TITLE
common: add 5 bpo hardforks for blobSchedule specification

### DIFF
--- a/packages/common/src/enums.ts
+++ b/packages/common/src/enums.ts
@@ -86,6 +86,11 @@ export const Hardfork = {
   Prague: 'prague',
   Osaka: 'osaka',
   Verkle: 'verkle',
+  Bpo1: 'bpo1',
+  Bpo2: 'bpo2',
+  Bpo3: 'bpo3',
+  Bpo4: 'bpo4',
+  Bpo5: 'bpo5',
 } as const
 
 export type ConsensusType = (typeof ConsensusType)[keyof typeof ConsensusType]

--- a/packages/common/src/hardforks.ts
+++ b/packages/common/src/hardforks.ts
@@ -176,4 +176,44 @@ export const hardforksDict: HardforksDict = {
   verkle: {
     eips: [7709, 4762, 6800],
   },
+  /**
+   * Description: HF to update the blob target, max and updateFraction
+   * URL        : https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/bpo1.md
+   * Status     : Experimental
+   */
+  bpo1: {
+    eips: [],
+  },
+  /**
+   * Description: HF to update the blob target, max and updateFraction
+   * URL        : https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/bpo2.md
+   * Status     : Experimental
+   */
+  bpo2: {
+    eips: [],
+  },
+  /**
+   * Description: HF to update the blob target, max and updateFraction
+   * URL        : https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/bpo3.md
+   * Status     : Experimental
+   */
+  bpo3: {
+    eips: [],
+  },
+  /**
+   * Description: HF to update the blob target, max and updateFraction
+   * URL        : https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/bpo4.md
+   * Status     : Experimental
+   */
+  bpo4: {
+    eips: [],
+  },
+  /**
+   * Description: HF to update the blob target, max and updateFraction
+   * URL        : https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/bpo5.md
+   * Status     : Experimental
+   */
+  bpo5: {
+    eips: [],
+  },
 }

--- a/packages/common/src/utils.ts
+++ b/packages/common/src/utils.ts
@@ -168,6 +168,11 @@ function parseGethParams(gethGenesis: GethGenesis) {
     [Hardfork.Prague]: { name: 'pragueTime', postMerge: true, isTimestamp: true },
     [Hardfork.Osaka]: { name: 'osakaTime', postMerge: true, isTimestamp: true },
     [Hardfork.Verkle]: { name: 'verkleTime', postMerge: true, isTimestamp: true },
+    [Hardfork.Bpo1]: { name: 'bpo1Time', postMerge: true, isTimestamp: true },
+    [Hardfork.Bpo2]: { name: 'bpo2Time', postMerge: true, isTimestamp: true },
+    [Hardfork.Bpo3]: { name: 'bpo3Time', postMerge: true, isTimestamp: true },
+    [Hardfork.Bpo4]: { name: 'bpo4Time', postMerge: true, isTimestamp: true },
+    [Hardfork.Bpo5]: { name: 'bpo5Time', postMerge: true, isTimestamp: true },
   }
 
   // forkMapRev is the map from config field name to Hardfork

--- a/packages/common/test/gethGenesis.spec.ts
+++ b/packages/common/test/gethGenesis.spec.ts
@@ -170,8 +170,20 @@ describe('[Utils/Parse]', () => {
           max: 91,
           baseFeeUpdateFraction: 13338477,
         },
+        bpo1: {
+          target: 71,
+          max: 101,
+          baseFeeUpdateFraction: 23338477,
+        },
+        bpo2: {
+          target: 81,
+          max: 111,
+          baseFeeUpdateFraction: 33338477,
+        },
       },
       pragueTime: 1736942378,
+      bpo1Time: 1736942478,
+      bpo2Time: 1736942578,
     }
     Object.assign(customData.config, customConfigData)
 
@@ -202,7 +214,19 @@ describe('[Utils/Parse]', () => {
         Hardfork.Prague,
         blobGasPerBlob * BigInt(customConfigData.blobSchedule.prague.target),
         blobGasPerBlob * BigInt(customConfigData.blobSchedule.prague.max),
-        13338477,
+        customConfigData.blobSchedule.prague.baseFeeUpdateFraction,
+      ],
+      [
+        Hardfork.Bpo1,
+        blobGasPerBlob * BigInt(customConfigData.blobSchedule.bpo1.target),
+        blobGasPerBlob * BigInt(customConfigData.blobSchedule.bpo1.max),
+        customConfigData.blobSchedule.bpo1.baseFeeUpdateFraction,
+      ],
+      [
+        Hardfork.Bpo2,
+        blobGasPerBlob * BigInt(customConfigData.blobSchedule.bpo2.target),
+        blobGasPerBlob * BigInt(customConfigData.blobSchedule.bpo2.max),
+        customConfigData.blobSchedule.bpo2.baseFeeUpdateFraction,
       ],
     ]
     for (const [testHf, testTarget, testMax, testUpdateFraction] of testCases) {

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -153,6 +153,11 @@ export class EVM implements EVMInterface {
     Hardfork.Prague,
     Hardfork.Osaka,
     Hardfork.Verkle,
+    Hardfork.Bpo1,
+    Hardfork.Bpo2,
+    Hardfork.Bpo3,
+    Hardfork.Bpo4,
+    Hardfork.Bpo5,
   ]
   protected _tx?: {
     gasPrice: bigint


### PR DESCRIPTION
### context

do we want to add static bpo hardforks or inject them dynamically?

so:
1. have bpo1, bpo2,..bpo5 hardforks added in code and populate/update their dicts. this will allow configuring blobschedule for these hardforks for devnets,

2. inject bpo1, bpo2... hardforks based on parsing the blobschedule (and then we also maintain a default blobschedule objects in our chains as well which we use to inject these hardforks)

### rationals 

so ethereumjs view is:

1. if its a normal fork treatment affecting forkid then we will add 5 bpo forks statically to the code (and we will add more later when the need arises).,

2. if its not a normal fork treatment, then we will allow dynamic specification of bpos in blobsschedule

### this PR

since it seems that there is desire for changing forkid with bpo forks, and 1. is simpler to implement and we can add more bpo forks later as necessary,

this PRs add static 5 bpo forks that can be configured using blobSchedule in geth genesis, and for known chains (mainnet, hoodi etc) through `HardforksDict` (when the params for these known chains are decided)

TODO
 - [x] add a testcase for blobschedlue for these forks