### PR TITLE
feat(types): implement NumericString type across the monorepo

### DIFF
--- a/packages/block/src/helpers.ts
+++ b/packages/block/src/helpers.ts
@@ -13,13 +13,13 @@ import {
 
 import type { Common } from '@ethereumjs/common'
 import type { TypedTransaction } from '@ethereumjs/tx'
-import type { CLRequest, CLRequestType, PrefixedHexString, Withdrawal } from '@ethereumjs/util'
+import type { CLRequest, CLRequestType, PrefixedHexString, Withdrawal, NumericString } from '@ethereumjs/util'
 import type { BlockHeaderBytes, HeaderData } from './types.ts'
 /**
  * Returns a 0x-prefixed hex number string from a hex string or string integer.
  * @param {string} input string to check, convert, and return
  */
-export const numberToHex = function (input?: string): PrefixedHexString | undefined {
+export const numberToHex = function (input?: string | NumericString): PrefixedHexString | undefined {
   if (input === undefined) return undefined
   if (!isHexString(input)) {
     const regex = new RegExp(/^\d+$/) // test to make sure input contains only digits

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -1,4 +1,4 @@
-import type { BigIntLike, KZG, PrefixedHexString, VerkleCrypto } from '@ethereumjs/util'
+import type { BigIntLike, KZG, PrefixedHexString, VerkleCrypto, NumericString } from '@ethereumjs/util'
 import type { secp256k1 } from 'ethereum-cryptography/secp256k1.js'
 import type { ConsensusAlgorithm, ConsensusType, Hardfork } from './enums.ts'
 
@@ -170,7 +170,7 @@ export type EIPConfig = {
 }
 
 export type ParamsConfig = {
-  [key: string]: number | string | null
+  [key: string]: number | NumericString | null
 }
 
 export type HardforkConfig = {

--- a/packages/evm/src/journal.ts
+++ b/packages/evm/src/journal.ts
@@ -12,11 +12,11 @@ import {
 import debugDefault from 'debug'
 
 import type { Common, StateManagerInterface } from '@ethereumjs/common'
-import type { Account, PrefixedHexString } from '@ethereumjs/util'
+import type { Account, PrefixedHexString, NumericString } from '@ethereumjs/util'
 import type { Debugger } from 'debug'
 
 type AddressString = string
-type SlotString = string
+type SlotString = NumericString
 type WarmSlots = Set<SlotString>
 
 type JournalType = Map<AddressString, WarmSlots>

--- a/packages/util/src/types.ts
+++ b/packages/util/src/types.ts
@@ -65,6 +65,7 @@ export const TypeOutput = {
   BigInt: 1,
   Uint8Array: 2,
   PrefixedHexString: 3,
+  NumericString: 4,
 } as const
 
 export type TypeOutputReturnType = {
@@ -72,6 +73,7 @@ export type TypeOutputReturnType = {
   [TypeOutput.BigInt]: bigint
   [TypeOutput.Uint8Array]: Uint8Array
   [TypeOutput.PrefixedHexString]: PrefixedHexString
+  [TypeOutput.NumericString]: NumericString
 }
 
 /**
@@ -123,6 +125,8 @@ export function toType<T extends TypeOutput>(
     }
     case TypeOutput.PrefixedHexString:
       return bytesToHex(output) as TypeOutputReturnType[T]
+    case TypeOutput.NumericString:
+      return bytesToBigInt(output).toString() as TypeOutputReturnType[T]
     default:
       throw EthereumJSErrorWithoutCode('unknown outputType')
   }

--- a/packages/util/test/types.spec.ts
+++ b/packages/util/test/types.spec.ts
@@ -18,10 +18,12 @@ describe('toType', () => {
     assert.strictEqual(toType(null, TypeOutput.BigInt), null)
     assert.strictEqual(toType(null, TypeOutput.Uint8Array), null)
     assert.strictEqual(toType(null, TypeOutput.PrefixedHexString), null)
+    assert.strictEqual(toType(null, TypeOutput.NumericString), null)
     assert.strictEqual(toType(undefined, TypeOutput.Number), undefined)
     assert.strictEqual(toType(undefined, TypeOutput.BigInt), undefined)
     assert.strictEqual(toType(undefined, TypeOutput.Uint8Array), undefined)
     assert.strictEqual(toType(undefined, TypeOutput.PrefixedHexString), undefined)
+    assert.strictEqual(toType(undefined, TypeOutput.NumericString), undefined)
   })
   it('from Number', () => {
     const num = 1000
@@ -37,6 +39,9 @@ describe('toType', () => {
 
     result = toType(num, TypeOutput.PrefixedHexString)
     assert.strictEqual(result, bytesToHex(bigIntToBytes(BigInt(num))))
+
+    result = toType(num, TypeOutput.NumericString)
+    assert.strictEqual(result, num.toString())
 
     assert.throws(() => {
       const num = Number.MAX_SAFE_INTEGER + 1
@@ -59,6 +64,9 @@ describe('toType', () => {
     result = toType(num, TypeOutput.PrefixedHexString)
     assert.strictEqual(result, bytesToHex(bigIntToBytes(num)))
 
+    result = toType(num, TypeOutput.NumericString)
+    assert.strictEqual(result, num.toString())
+
     const num2 = BigInt(Number.MAX_SAFE_INTEGER) + BigInt(1)
     assert.throws(() => {
       toType(num2, TypeOutput.Number)
@@ -79,6 +87,9 @@ describe('toType', () => {
 
     result = toType(num, TypeOutput.PrefixedHexString)
     assert.strictEqual(result, bytesToHex(num))
+
+    result = toType(num, TypeOutput.NumericString)
+    assert.strictEqual(result, bytesToBigInt(num).toString())
   })
   it('from PrefixedHexString', () => {
     const num = intToHex(1000)
@@ -92,6 +103,9 @@ describe('toType', () => {
 
     result = toType(num, TypeOutput.Uint8Array)
     assert.deepEqual(result, hexToBytes(num))
+
+    result = toType(num, TypeOutput.NumericString)
+    assert.strictEqual(result, bytesToBigInt(hexToBytes(num)).toString())
 
     assert.throws(() => {
       //@ts-expect-error -- Testing invalid input


### PR DESCRIPTION
## Description
This PR implements the NumericString type across the monorepo, following the pattern established with PrefixedHexString. The NumericString type represents string values that contain only numeric characters, providing better type safety and consistency across the codebase.

## Changes
- Added NumericString to TypeOutput and TypeOutputReturnType in `packages/util/src/types.ts`
- Added NumericString handling to the toType function
- Updated ParamsConfig type in `packages/common/src/types.ts` to use NumericString
- Updated SlotString type in `packages/evm/src/journal.ts` to use NumericString
- Updated numberToHex function in `packages/block/src/helpers.ts` to handle NumericString input
- Added comprehensive tests for NumericString type conversions

## Testing
- Added new test cases in `packages/util/test/types.spec.ts` to verify NumericString conversions
- Tests cover conversions from:
  - null/undefined
  - Number
  - BigInt
  - Uint8Array
  - PrefixedHexString

## Related Issues
Closes #3659