### PR TITLE
docs: update outdated GeneralStateTests link

### DIFF
--- a/packages/vm/DEVELOPER.md
+++ b/packages/vm/DEVELOPER.md
@@ -132,7 +132,7 @@ Blockchain tests support `--debug` to verify the postState:
 
 `tsx ./test/tester --blockchain --debug --test='ZeroValue_SELFDESTRUCT_ToOneStorageKey_OOGRevert_d0g0v0_EIP158'`
 
-All/most State tests are replicated as Blockchain tests in a `GeneralStateTests` [sub directory](https://github.com/ethereum/tests/tree/develop/BlockchainTests/GeneralStateTests) in the Ethereum tests repo, so for debugging single test cases the Blockchain test version of the State test can be used.
+All/most State tests are replicated as Blockchain tests in a `GeneralStateTests` [sub directory](https://github.com/ethereum/tests/tree/develop/docs/test_types/TestStructures/GeneralStateTests) in the Ethereum tests repo, so for debugging single test cases the Blockchain test version of the State test can be used.
 
 #### Comparing Stack Traces
 


### PR DESCRIPTION
Nothing fancy just fixed a outdated link:
https://github.com/ethereum/tests/tree/develop/BlockchainTests/GeneralStateTests - outdated
https://github.com/ethereum/tests/tree/develop/docs/test_types/TestStructures/GeneralStateTests - new