### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/block-build.yml
+++ b/.github/workflows/block-build.yml
@@ -34,7 +34,7 @@ jobs:
     steps:     
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/blockchain-build.yml
+++ b/.github/workflows/blockchain-build.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)  
       - uses: actions/cache/restore@v4

--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/cache/restore@v4
         id: dep-cache

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - if: inputs.dep-cache-key != 'none' 
         uses: actions/cache/restore@v4
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
     steps:
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none' 

--- a/.github/workflows/common-build.yml
+++ b/.github/workflows/common-build.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none' 

--- a/.github/workflows/devp2p-build.yml
+++ b/.github/workflows/devp2p-build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none' 

--- a/.github/workflows/evm-build.yml
+++ b/.github/workflows/evm-build.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none' 

--- a/.github/workflows/lockfile.yml
+++ b/.github/workflows/lockfile.yml
@@ -12,7 +12,7 @@ jobs:
   root:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v2
         id: changes
         with:

--- a/.github/workflows/mpt-build.yml
+++ b/.github/workflows/mpt-build.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'

--- a/.github/workflows/noCompile.yml
+++ b/.github/workflows/noCompile.yml
@@ -23,7 +23,7 @@ jobs:
       DEP_CACHE_KEY: ${{ github.event_name == 'push' && 'none' || inputs.dep-cache-key }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: env.DEP_CACHE_KEY != 'none'
         uses: actions/cache/restore@v4

--- a/.github/workflows/node-versions.yml
+++ b/.github/workflows/node-versions.yml
@@ -12,7 +12,7 @@ jobs:
         node-version: [20, 22]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/rlp-ethash-genesis-wallet-build.yml
+++ b/.github/workflows/rlp-ethash-genesis-wallet-build.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none' 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -12,7 +12,7 @@ jobs:
   run-spellcheck-cspell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/statemanager-build.yml
+++ b/.github/workflows/statemanager-build.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none' 

--- a/.github/workflows/tx-build.yml
+++ b/.github/workflows/tx-build.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none' 

--- a/.github/workflows/util-build.yml
+++ b/.github/workflows/util-build.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none' 

--- a/.github/workflows/verkle-build.yml
+++ b/.github/workflows/verkle-build.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none' 

--- a/.github/workflows/vm-build.yml
+++ b/.github/workflows/vm-build.yml
@@ -16,7 +16,7 @@ jobs:
   test-vm-state:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -42,7 +42,7 @@ jobs:
   test-vm-blockchain:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/vm-nightly-test.yml
+++ b/.github/workflows/vm-nightly-test.yml
@@ -15,7 +15,7 @@ jobs:
   test-vm-api:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v4
         with:
@@ -36,7 +36,7 @@ jobs:
   test-vm-state:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -58,7 +58,7 @@ jobs:
   test-vm-blockchain:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -81,7 +81,7 @@ jobs:
   test-vm-slow:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
 

--- a/.github/workflows/vm-pr.yml
+++ b/.github/workflows/vm-pr.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -83,7 +83,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -143,7 +143,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -199,7 +199,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -266,7 +266,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
 
@@ -305,7 +305,7 @@ jobs:
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
       - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none' 


### PR DESCRIPTION
Updates actions/checkout@v4 to actions/checkout@v5 across CI workflows.

Upgrade to actions/checkout@v5 for improved performance and stability.

Reference:
Latest version: https://github.com/actions/checkout/releases/tag/v5.0.0