### PR TITLE
Fix VM Nightly CI

### DIFF
--- a/packages/util/src/bytes.ts
+++ b/packages/util/src/bytes.ts
@@ -428,10 +428,10 @@ export const randomBytes = (length: number): Uint8Array => {
  * @returns {Uint8Array} one Uint8Array with all the elements of the original set
  * works like `Buffer.concat`
  */
-export const concatBytes = (...arrays: Uint8Array[]): Uint8Array => {
-  if (arrays.length === 1) return arrays[0]
+export const concatBytes = (...arrays: Uint8Array[]): Uint8Array<ArrayBuffer> => {
+  if (arrays.length === 1) return arrays[0] as Uint8Array<ArrayBuffer>
   const length = arrays.reduce((a, arr) => a + arr.length, 0)
-  const result = new Uint8Array(length)
+  const result = new Uint8Array(length) as Uint8Array<ArrayBuffer>
   for (let i = 0, pad = 0; i < arrays.length; i++) {
     const arr = arrays[i]
     result.set(arr, pad)


### PR DESCRIPTION
This fixes the VM nightly tests like [this](https://github.com/ethereumjs/ethereumjs-monorepo/actions/runs/17225705048/job/48869724463) to have the nightly tests running reliably and so to prepare for moving more test runs over to nightly.

The `package-lock.json` file is updated as well since this was necessary to re-trigger the error locally, indicating that the error was prevented on PRs still due to the cache not yet taking in the latest version from ESLint (so but it would have propagated to PRs anyhow at some point).

Will admin merge, a quick look would nevertheless be nice!