### PR TITLE
More ArrayBuffer Type Assignment Fixes

### DIFF
--- a/packages/devp2p/src/rlpx/ecies.ts
+++ b/packages/devp2p/src/rlpx/ecies.ts
@@ -367,7 +367,7 @@ export class ECIES {
     const bufSize = zfill(intToBytes(size), 3)
     const headerData = RLP.encode([0, 0]) // [capability-id, context-id] (currently unused in spec)
     let header = concatBytes(bufSize, headerData)
-    header = zfill(header, 16, false)
+    header = zfill(header, 16, false) as Uint8Array<ArrayBuffer>
     if (!this._egressAes) return
     header = Uint8Array.from(this._egressAes.update(header))
 

--- a/packages/ethash/src/index.ts
+++ b/packages/ethash/src/index.ts
@@ -200,7 +200,7 @@ export class Ethash {
     let mix = new Uint8Array(this.cache[i % n])
     const mixView = new DataView(mix.buffer)
     mixView.setUint32(0, mixView.getUint32(0, true) ^ i, true)
-    mix = keccak512(mix)
+    mix = keccak512(mix) as Uint8Array<ArrayBuffer>
     for (let j = 0; j < params.DATASET_PARENTS; j++) {
       const cacheIndex = fnv(i ^ j, new DataView(mix.buffer).getUint32((j % r) * 4, true))
       mix = fnvBytes(mix, this.cache[cacheIndex % n])

--- a/packages/evm/src/memory.ts
+++ b/packages/evm/src/memory.ts
@@ -66,10 +66,10 @@ export class Memory {
    * @param size - How many bytes to read
    * @param avoidCopy - Avoid memory copy if possible for performance reasons (optional)
    */
-  read(offset: number, size: number, avoidCopy?: boolean): Uint8Array {
+  read(offset: number, size: number, avoidCopy?: boolean): Uint8Array<ArrayBuffer> {
     this.extend(offset, size)
 
-    const loaded = this._store.subarray(offset, offset + size)
+    const loaded = this._store.subarray(offset, offset + size) as Uint8Array<ArrayBuffer>
     if (avoidCopy === true) {
       return loaded
     }


### PR DESCRIPTION
More errors on nightly like the following (again, I still not dare to re-create package-lock.json due to side effects, but then it would also trickle down to master), see e.g. [this](https://github.com/ethereumjs/ethereumjs-monorepo/actions/runs/17255124263/job/48965310089) run:

<img width="978" height="432" alt="grafik" src="https://github.com/user-attachments/assets/3593f960-70a3-411d-95e0-10f2b4ea5a07" />

I did a bit more research, this is due to a TypeScript 5.9 behavioral change for the `ArrayBuffer` type, see https://devblogs.microsoft.com/typescript/announcing-typescript-5-9-rc/#lib.d.ts-changes.

Bun, others fixed this in a way like https://github.com/oven-sh/bun/pull/21536/files.

Will again admin-merge, working towards a leaner CI setup.