### PR TITLE
EVM: add EIP-7823 (modexp Precompile Upper Bounds)

### DIFF
--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -471,6 +471,14 @@ export const eipsDict: EIPsDict = {
     requiredEIPs: [2718, 2929, 2930],
   },
   /**
+   * Description : Set upper bounds for MODEXP
+   * URL         : https://eips.ethereum.org/EIPS/eip-7823
+   * Status      : Review
+   */
+  7823: {
+    minimumHardfork: Hardfork.Byzantium,
+  },
+  /**
    * Description : Use historical block hashes saved in state for BLOCKHASH
    * URL         : https://eips.ethereum.org/EIPS/eip-7709
    * Status      : Final

--- a/packages/common/src/hardforks.ts
+++ b/packages/common/src/hardforks.ts
@@ -153,7 +153,7 @@ export const hardforksDict: HardforksDict = {
     eips: [1153, 4844, 4788, 5656, 6780, 7516],
   },
   /**
-   * Description: Next feature hardfork after cancun
+   * Description: Next feature hardfork after cancun including EIP-7702 account abstraction + other EIPs
    * URL        : https://eips.ethereum.org/EIPS/eip-7600
    * Status     : Final
    */
@@ -161,12 +161,12 @@ export const hardforksDict: HardforksDict = {
     eips: [2537, 2935, 6110, 7002, 7251, 7623, 7685, 7691, 7702],
   },
   /**
-   * Description: Next feature hardfork after prague, internally used for peerdas/EOF testing/implementation (incomplete/experimental)
+   * Description: Next feature hardfork after prague (headliner: PeerDAS)
    * URL        : https://eips.ethereum.org/EIPS/eip-7607
    * Status     : Draft
    */
   osaka: {
-    eips: [7594, 7883],
+    eips: [7594, 7823, 7883],
   },
   /**
    * Description: Next feature hardfork after osaka, internally used for verkle testing/implementation (incomplete/experimental)

--- a/packages/evm/src/precompiles/05-modexp.ts
+++ b/packages/evm/src/precompiles/05-modexp.ts
@@ -30,9 +30,10 @@ const BIGINT_500 = BigInt(500)
 const BIGINT_1024 = BigInt(1024)
 const BIGINT_3072 = BigInt(3072)
 const BIGINT_199680 = BigInt(199680)
+const BIGINT_2147483647 = BigInt(2147483647)
 
 const maxInt = BigInt(Number.MAX_SAFE_INTEGER)
-const maxSize = BigInt(2147483647) // @ethereumjs/util setLengthRight limitation
+const maxSize = BIGINT_2147483647 // @ethereumjs/util setLengthRight limitation
 
 function multiplicationComplexity(x: bigint): bigint {
   let fac1

--- a/packages/evm/src/precompiles/05-modexp.ts
+++ b/packages/evm/src/precompiles/05-modexp.ts
@@ -33,7 +33,6 @@ const BIGINT_199680 = BigInt(199680)
 const BIGINT_2147483647 = BigInt(2147483647)
 
 const maxInt = BigInt(Number.MAX_SAFE_INTEGER)
-const maxSize = BIGINT_2147483647 // @ethereumjs/util setLengthRight limitation
 
 function multiplicationComplexity(x: bigint): bigint {
   let fac1
@@ -158,16 +157,18 @@ export function precompile05(opts: PrecompileInput): ExecResult {
     }
   }
 
+  const maxSize = BIGINT_2147483647 // @ethereumjs/util setLengthRight limitation
+
   if (bLen > maxSize || eLen > maxSize || mLen > maxSize) {
     if (opts._debug !== undefined) {
-      opts._debug(`${pName} failed: OOG`)
+      opts._debug(`${pName} failed: one or more modexp precompile input values too large`)
     }
     return OOGResult(opts.gasLimit)
   }
 
   if (mEnd > maxInt) {
     if (opts._debug !== undefined) {
-      opts._debug(`${pName} failed: OOG`)
+      opts._debug(`${pName} failed: total modexp precompile input too large`)
     }
     return OOGResult(opts.gasLimit)
   }


### PR DESCRIPTION
Implements [EIP-7823](https://eips.ethereum.org/EIPS/eip-7823) being included in the [Osaka](https://eips.ethereum.org/EIPS/eip-7607) hardfork.

Have decided to not take in #4070, wanted to change a few things and it was easier to start over.

Will also not include additional tests, wouldn't want to take the time to modify the setup from #4070 and the tests included in the official suite should be enough for now.