### PR TITLE
client: deduplicate produceBlockWith4844Tx

### DIFF
--- a/packages/client/test/rpc/eth/blobBaseFee.spec.ts
+++ b/packages/client/test/rpc/eth/blobBaseFee.spec.ts
@@ -1,93 +1,16 @@
 import { Hardfork } from '@ethereumjs/common'
 import { eip4844GethGenesis } from '@ethereumjs/testdata'
-import { createTx } from '@ethereumjs/tx'
-import {
-  BIGINT_0,
-  BIGINT_256,
-  blobsToCommitments,
-  commitmentsToVersionedHashes,
-  createAddressFromPrivateKey,
-  createZeroAddress,
-  getBlobs,
-  hexToBytes,
-} from '@ethereumjs/util'
-import { buildBlock } from '@ethereumjs/vm'
+import { createAddressFromPrivateKey, hexToBytes } from '@ethereumjs/util'
 import { trustedSetup } from '@paulmillr/trusted-setups/fast-peerdas.js'
 import { KZG as microEthKZG } from 'micro-eth-signer/kzg.js'
 import { assert, describe, it } from 'vitest'
 
-import { getRPCClient, setupChain } from '../helpers.ts'
-
-import type { PrefixedHexString } from '@ethereumjs/util'
-import type { Chain } from '../../../src/blockchain/chain.ts'
-import type { VMExecution } from '../../../src/execution/vmexecution.ts'
+import { getRPCClient, produceBlockWith4844Tx, setupChain } from '../helpers.ts'
 
 const method = 'eth_blobBaseFee'
 const kzg = new microEthKZG(trustedSetup)
 const privateKey = hexToBytes('0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8')
 const accountAddress = createAddressFromPrivateKey(privateKey)
-const produceBlockWith4844Tx = async (
-  execution: VMExecution,
-  chain: Chain,
-  blobsCount: number[],
-) => {
-  // 4844 sample blob
-  const sampleBlob = getBlobs('hello world')
-  const commitment = blobsToCommitments(kzg, sampleBlob)
-  const blobVersionedHash = commitmentsToVersionedHashes(commitment)
-
-  const { vm } = execution
-  const account = await vm.stateManager.getAccount(accountAddress)
-  let nonce = account?.nonce ?? BIGINT_0
-  const parentBlock = await chain.getCanonicalHeadBlock()
-  const vmCopy = await vm.shallowCopy()
-  // Set block's gas used to max
-  const blockBuilder = await buildBlock(vmCopy, {
-    parentBlock,
-    headerData: {
-      timestamp: parentBlock.header.timestamp + BigInt(1),
-    },
-    blockOpts: {
-      calcDifficultyFromHeader: parentBlock.header,
-      putBlockIntoBlockchain: false,
-    },
-  })
-  for (let i = 0; i < blobsCount.length; i++) {
-    const blobVersionedHashes = [] as PrefixedHexString[]
-    const blobs = [] as PrefixedHexString[]
-    const kzgCommitments = [] as PrefixedHexString[]
-    const to = createZeroAddress()
-    if (blobsCount[i] > 0) {
-      for (let blob = 0; blob < blobsCount[i]; blob++) {
-        blobVersionedHashes.push(...blobVersionedHash)
-        blobs.push(...sampleBlob)
-        kzgCommitments.push(...commitment)
-      }
-    }
-    await blockBuilder.addTransaction(
-      createTx(
-        {
-          type: 3,
-          gasLimit: 21000,
-          maxFeePerGas: 0xffffffff,
-          maxPriorityFeePerGas: BIGINT_256,
-          nonce,
-          to,
-          blobVersionedHashes,
-          blobs,
-          kzgCommitments,
-          maxFeePerBlobGas: BigInt(1000),
-        },
-        { common: vmCopy.common },
-      ).sign(privateKey),
-    )
-    nonce++
-  }
-
-  const { block } = await blockBuilder.build()
-  await chain.putBlocks([block], true)
-  await execution.run()
-}
 
 describe(method, () => {
   it('call', async () => {
@@ -114,7 +37,7 @@ describe(method, () => {
     })
 
     for (let i = 0; i < 10; i++) {
-      await produceBlockWith4844Tx(execution, chain, [6])
+      await produceBlockWith4844Tx(execution, chain, [6], accountAddress, privateKey)
     }
     const rpc = getRPCClient(server)
     const res = await rpc.request(method, [])

--- a/packages/client/test/rpc/eth/getFeeHistory.spec.ts
+++ b/packages/client/test/rpc/eth/getFeeHistory.spec.ts
@@ -3,14 +3,9 @@ import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { createTx } from '@ethereumjs/tx'
 import {
   BIGINT_0,
-  BIGINT_256,
   bigIntToHex,
-  blobsToCommitments,
   bytesToBigInt,
-  commitmentsToVersionedHashes,
   createAddressFromPrivateKey,
-  createZeroAddress,
-  getBlobs,
   hexToBytes,
 } from '@ethereumjs/util'
 import { buildBlock } from '@ethereumjs/vm'
@@ -20,7 +15,12 @@ import { assert, describe, it } from 'vitest'
 
 import { eip4844GethGenesis } from '@ethereumjs/testdata'
 import { powData } from '../../testdata/geth-genesis/pow.ts'
-import { getRPCClient, gethGenesisStartLondon, setupChain } from '../helpers.ts'
+import {
+  getRPCClient,
+  gethGenesisStartLondon,
+  produceBlockWith4844Tx,
+  setupChain,
+} from '../helpers.ts'
 
 import type { PrefixedHexString } from '@ethereumjs/util'
 import type { Chain } from '../../../src/blockchain/index.ts'
@@ -112,75 +112,6 @@ const produceBlockWithTx = async (
 
   const { block } = await blockBuilder.build()
   await chain.putBlocks([block], false)
-  await execution.run()
-}
-
-/**
- * This method builds a block on top of the current head block and will insert 4844 txs
- * @param execution
- * @param chain
- * @param blobsCount Array of blob txs to produce. The amount of blobs in here is thus the amount of blobs per tx.
- */
-const produceBlockWith4844Tx = async (
-  execution: VMExecution,
-  chain: Chain,
-  blobsCount: number[],
-) => {
-  // 4844 sample blob
-  const sampleBlob = getBlobs('hello world')
-  const commitment = blobsToCommitments(kzg, sampleBlob)
-  const blobVersionedHash = commitmentsToVersionedHashes(commitment)
-
-  const { vm } = execution
-  const account = await vm.stateManager.getAccount(p4844Address)
-  let nonce = account?.nonce ?? BIGINT_0
-  const parentBlock = await chain.getCanonicalHeadBlock()
-  const vmCopy = await vm.shallowCopy()
-  // Set block's gas used to max
-  const blockBuilder = await buildBlock(vmCopy, {
-    parentBlock,
-    headerData: {
-      timestamp: parentBlock.header.timestamp + BigInt(1),
-    },
-    blockOpts: {
-      calcDifficultyFromHeader: parentBlock.header,
-      putBlockIntoBlockchain: false,
-    },
-  })
-  for (let i = 0; i < blobsCount.length; i++) {
-    const blobVersionedHashes = [] as PrefixedHexString[]
-    const blobs = [] as PrefixedHexString[]
-    const kzgCommitments = [] as PrefixedHexString[]
-    const to = createZeroAddress()
-    if (blobsCount[i] > 0) {
-      for (let blob = 0; blob < blobsCount[i]; blob++) {
-        blobVersionedHashes.push(...blobVersionedHash)
-        blobs.push(...sampleBlob)
-        kzgCommitments.push(...commitment)
-      }
-    }
-    await blockBuilder.addTransaction(
-      createTx(
-        {
-          type: 3,
-          gasLimit: 21000,
-          maxFeePerGas: 0xffffffff,
-          maxPriorityFeePerGas: BIGINT_256,
-          nonce,
-          to,
-          blobVersionedHashes,
-          blobs,
-          kzgCommitments,
-          maxFeePerBlobGas: BigInt(1000),
-        },
-        { common: vmCopy.common },
-      ).sign(privateKey4844),
-    )
-    nonce++
-  }
-
-  const { block } = await blockBuilder.build()
-  await chain.putBlocks([block], true)
   await execution.run()
 }
 
@@ -447,12 +378,12 @@ describe(method, () => {
       // Start cranking up the initial blob gas for some more "realistic" testing
 
       for (let i = 0; i < 10; i++) {
-        await produceBlockWith4844Tx(execution, chain, [6])
+        await produceBlockWith4844Tx(execution, chain, [6], p4844Address, privateKey4844)
       }
 
       // Now for the actual test: create 6 blocks each with a decreasing amount of blobs
       for (let i = 6; i > 0; i--) {
-        await produceBlockWith4844Tx(execution, chain, [i])
+        await produceBlockWith4844Tx(execution, chain, [i], p4844Address, privateKey4844)
       }
 
       const rpc = getRPCClient(server)

--- a/packages/client/test/rpc/helpers.ts
+++ b/packages/client/test/rpc/helpers.ts
@@ -9,16 +9,26 @@ import {
   parseGethGenesisState,
 } from '@ethereumjs/common'
 import { getGenesis } from '@ethereumjs/genesis'
+import { createTx } from '@ethereumjs/tx'
 import {
   Address,
+  BIGINT_0,
   BIGINT_1,
+  BIGINT_256,
   KECCAK256_RLP,
+  type PrefixedHexString,
+  blobsToCommitments,
+  commitmentsToVersionedHashes,
   createAddressFromString,
+  createZeroAddress,
+  getBlobs,
   hexToBytes,
 } from '@ethereumjs/util'
 import { buildBlock } from '@ethereumjs/vm'
+import { trustedSetup } from '@paulmillr/trusted-setups/fast-peerdas.js'
 import { Client, Server as RPCServer } from 'jayson/promise/index.js'
 import { MemoryLevel } from 'memory-level'
+import { KZG as microEthKZG } from 'micro-eth-signer/kzg.js'
 import { assert } from 'vitest'
 
 import { Chain } from '../../src/blockchain/chain.ts'
@@ -364,4 +374,79 @@ export async function testSetup(blockchain: Blockchain, common?: Common) {
   await chain.open()
   await exec.open()
   return exec
+}
+
+const kzg = new microEthKZG(trustedSetup)
+
+/**
+ * This method builds a block on top of the current head block and will insert 4844 txs
+ * @param execution
+ * @param chain
+ * @param blobsCount Array of blob txs to produce. The amount of blobs in here is thus the amount of blobs per tx.
+ * @param accountAddress Address of the account to send the txs from
+ * @param privateKey Private key of the account to sign the txs
+ */
+export const produceBlockWith4844Tx = async (
+  execution: VMExecution,
+  chain: Chain,
+  blobsCount: number[],
+  accountAddress: Address,
+  privateKey: Uint8Array,
+) => {
+  // 4844 sample blob
+  const sampleBlob = getBlobs('hello world')
+  const commitment = blobsToCommitments(kzg, sampleBlob)
+  const blobVersionedHash = commitmentsToVersionedHashes(commitment)
+
+  const { vm } = execution
+  const account = await vm.stateManager.getAccount(accountAddress)
+  let nonce = account?.nonce ?? BIGINT_0
+  const parentBlock = await chain.getCanonicalHeadBlock()
+  const vmCopy = await vm.shallowCopy()
+  // Set block's gas used to max
+  const blockBuilder = await buildBlock(vmCopy, {
+    parentBlock,
+    headerData: {
+      timestamp: parentBlock.header.timestamp + BigInt(1),
+    },
+    blockOpts: {
+      calcDifficultyFromHeader: parentBlock.header,
+      putBlockIntoBlockchain: false,
+    },
+  })
+  for (let i = 0; i < blobsCount.length; i++) {
+    const blobVersionedHashes = [] as PrefixedHexString[]
+    const blobs = [] as PrefixedHexString[]
+    const kzgCommitments = [] as PrefixedHexString[]
+    const to = createZeroAddress()
+    if (blobsCount[i] > 0) {
+      for (let blob = 0; blob < blobsCount[i]; blob++) {
+        blobVersionedHashes.push(...blobVersionedHash)
+        blobs.push(...sampleBlob)
+        kzgCommitments.push(...commitment)
+      }
+    }
+    await blockBuilder.addTransaction(
+      createTx(
+        {
+          type: 3,
+          gasLimit: 21000,
+          maxFeePerGas: 0xffffffff,
+          maxPriorityFeePerGas: BIGINT_256,
+          nonce,
+          to,
+          blobVersionedHashes,
+          blobs,
+          kzgCommitments,
+          maxFeePerBlobGas: BigInt(1000),
+        },
+        { common: vmCopy.common },
+      ).sign(privateKey),
+    )
+    nonce++
+  }
+
+  const { block } = await blockBuilder.build()
+  await chain.putBlocks([block], true)
+  await execution.run()
 }


### PR DESCRIPTION
This PR starts addressing https://github.com/ethereumjs/ethereumjs-monorepo/issues/4093 by consolidating duplicate test utilities

Description
 - deduplicate produceBlockWith4844Tx -> move to helpers.ts with extra params.
 
This is still a work in progress