### PR TITLE
chore: upgrade chalk beyond 5.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13769,7 +13769,7 @@
         "@scure/base": "^1.2.4",
         "abstract-level": "^3.0.1",
         "body-parser": "^1.20.3",
-        "chalk": "^5.4.1",
+        "chalk": "^5.6.2",
         "connect": "^3.7.0",
         "cors": "^2.8.5",
         "debug": "^4.4.0",
@@ -13813,7 +13813,9 @@
       }
     },
     "packages/client/node_modules/chalk": {
-      "version": "5.4.1",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -13857,7 +13859,7 @@
         "@types/debug": "^4.1.12",
         "@types/k-bucket": "^5.0.4",
         "@types/node": "^22.13.10",
-        "chalk": "^5.4.1",
+        "chalk": "^5.6.2",
         "testdouble": "^3.20.2"
       },
       "engines": {
@@ -13865,7 +13867,9 @@
       }
     },
     "packages/devp2p/node_modules/chalk": {
-      "version": "5.4.1",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -72,7 +72,7 @@
     "@scure/base": "^1.2.4",
     "abstract-level": "^3.0.1",
     "body-parser": "^1.20.3",
-    "chalk": "^5.4.1",
+    "chalk": "^5.6.2",
     "connect": "^3.7.0",
     "cors": "^2.8.5",
     "debug": "^4.4.0",

--- a/packages/devp2p/package.json
+++ b/packages/devp2p/package.json
@@ -82,7 +82,7 @@
     "@types/debug": "^4.1.12",
     "@types/k-bucket": "^5.0.4",
     "@types/node": "^22.13.10",
-    "chalk": "^5.4.1",
+    "chalk": "^5.6.2",
     "testdouble": "^3.20.2"
   },
   "engines": {


### PR DESCRIPTION
Chalk version 5.6.1 is compromised (see https://github.com/chalk/chalk/issues/656) . We were on a version below that, but this PR upgrades it beyond as a safety precaution