### PR TITLE
Add basic Cursor AI .cursorignore File

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,3 @@
+node_modules/
+packages/ethereum-tests/
+*bundle*.js


### PR DESCRIPTION
This PR adds a basic Cursor [.cursorignore](https://docs.cursor.com/en/context/ignore-files) file which exludes large code parts (mainly the `ethereum-tests` submodule directory) to allow Cursor for sufficiently performant code base indexing, this now takes < 5 min first time for the whole monorepo codebase.

Indexing gives Cursor a better understanding of the code base and provides better results on AI prompts.

I have purposefully left the new `execution-spec-tests` submodule directory in since I think this might be helpful for Cursor as context since there is mainly "the current stuff" integrated. 😄