### PR TITLE
EIP-7883 Fixes

### DIFF
--- a/packages/evm/src/precompiles/05-modexp.ts
+++ b/packages/evm/src/precompiles/05-modexp.ts
@@ -130,9 +130,7 @@ export function precompile05(opts: PrecompileInput): ExecResult {
   if (opts.common.isActivatedEIP(2565)) {
     const words = (maxLen + BIGINT_7) / BIGINT_8
     if (opts.common.isActivatedEIP(7883)) {
-      gasUsed =
-        (adjustedELen * (maxLen > BIGINT_32 ? BIGINT_2 * words * words : words * words)) /
-        Gquaddivisor
+      gasUsed = adjustedELen * (maxLen > BIGINT_32 ? BIGINT_2 * words * words : BIGINT_16)
       if (gasUsed < BIGINT_500) {
         gasUsed = BIGINT_500
       }

--- a/packages/evm/src/precompiles/05-modexp.ts
+++ b/packages/evm/src/precompiles/05-modexp.ts
@@ -134,7 +134,8 @@ export function precompile05(opts: PrecompileInput): ExecResult {
 
   if (opts.common.isActivatedEIP(7883)) {
     const wordsSquared = multiplicationComplexityEIP2565(maxLen)
-    gasUsed = (adjustedELen * (maxLen > 32 ? 2n * wordsSquared : wordsSquared)) / Gquaddivisor
+    gasUsed =
+      (adjustedELen * (maxLen > BIGINT_32 ? BIGINT_2 * wordsSquared : wordsSquared)) / Gquaddivisor
     if (gasUsed < BIGINT_500) {
       gasUsed = BIGINT_500
     }

--- a/packages/evm/src/precompiles/05-modexp.ts
+++ b/packages/evm/src/precompiles/05-modexp.ts
@@ -132,21 +132,25 @@ export function precompile05(opts: PrecompileInput): ExecResult {
   const mStart = eEnd
   const mEnd = mStart + mLen
 
-  if (opts.common.isActivatedEIP(7883)) {
+  if (opts.common.isActivatedEIP(2565)) {
     const wordsSquared = multiplicationComplexityEIP2565(maxLen)
-    gasUsed =
-      (adjustedELen * (maxLen > BIGINT_32 ? BIGINT_2 * wordsSquared : wordsSquared)) / Gquaddivisor
-    if (gasUsed < BIGINT_500) {
-      gasUsed = BIGINT_500
-    }
-  } else if (opts.common.isActivatedEIP(2565)) {
-    gasUsed = (adjustedELen * multiplicationComplexityEIP2565(maxLen)) / Gquaddivisor
-    if (gasUsed < BIGINT_200) {
-      gasUsed = BIGINT_200
+    if (opts.common.isActivatedEIP(7883)) {
+      gasUsed =
+        (adjustedELen * (maxLen > BIGINT_32 ? BIGINT_2 * wordsSquared : wordsSquared)) /
+        Gquaddivisor
+      if (gasUsed < BIGINT_500) {
+        gasUsed = BIGINT_500
+      }
+    } else {
+      gasUsed = (adjustedELen * wordsSquared) / Gquaddivisor
+      if (gasUsed < BIGINT_200) {
+        gasUsed = BIGINT_200
+      }
     }
   } else {
     gasUsed = (adjustedELen * multiplicationComplexity(maxLen)) / Gquaddivisor
   }
+
   if (!gasLimitCheck(opts, gasUsed, pName)) {
     return OOGResult(opts.gasLimit)
   }

--- a/packages/evm/src/precompiles/05-modexp.ts
+++ b/packages/evm/src/precompiles/05-modexp.ts
@@ -52,11 +52,6 @@ function multiplicationComplexity(x: bigint): bigint {
   }
 }
 
-function multiplicationComplexityEIP2565(x: bigint): bigint {
-  const words = (x + BIGINT_7) / BIGINT_8
-  return words * words
-}
-
 function getAdjustedExponentLength(data: Uint8Array, opts: PrecompileInput): bigint {
   let expBytesStart
   try {
@@ -133,16 +128,16 @@ export function precompile05(opts: PrecompileInput): ExecResult {
   const mEnd = mStart + mLen
 
   if (opts.common.isActivatedEIP(2565)) {
-    const wordsSquared = multiplicationComplexityEIP2565(maxLen)
+    const words = (maxLen + BIGINT_7) / BIGINT_8
     if (opts.common.isActivatedEIP(7883)) {
       gasUsed =
-        (adjustedELen * (maxLen > BIGINT_32 ? BIGINT_2 * wordsSquared : wordsSquared)) /
+        (adjustedELen * (maxLen > BIGINT_32 ? BIGINT_2 * words * words : words * words)) /
         Gquaddivisor
       if (gasUsed < BIGINT_500) {
         gasUsed = BIGINT_500
       }
     } else {
-      gasUsed = (adjustedELen * wordsSquared) / Gquaddivisor
+      gasUsed = (adjustedELen * words * words) / Gquaddivisor
       if (gasUsed < BIGINT_200) {
         gasUsed = BIGINT_200
       }


### PR DESCRIPTION
Follow-up on #4071 

The gas cost formula update for [EIP-7883](https://eips.ethereum.org/EIPS/eip-7883) was not yet fully correct (or there was an EIP update in between, not sure, but anyhow).

This PR applies two fixes and a few simplifications/clean-ups. This fixes the remaining 70 failing tests from the EEST Osaka tests.

(best to review commit-by-commit)