### PR TITLE
Add EIP-7594 PeerDAS Max Blob Limit for Txs

### DIFF
--- a/packages/common/src/gethGenesis.ts
+++ b/packages/common/src/gethGenesis.ts
@@ -28,6 +28,7 @@ export interface GethGenesisConfig {
   shanghaiTime?: number
   cancunTime?: number
   pragueTime?: number
+  osakaTime?: number
   verkleTime?: number
   terminalTotalDifficulty?: number
   terminalTotalDifficultyPassed?: boolean

--- a/packages/testdata/src/gethGenesis/eip4844GethGenesis.ts
+++ b/packages/testdata/src/gethGenesis/eip4844GethGenesis.ts
@@ -17,6 +17,8 @@ export const eip4844GethGenesis: GethGenesis = {
     mergeForkBlock: 0,
     shanghaiTime: 0,
     cancunTime: 0,
+    pragueTime: 0,
+    osakaTime: 0,
     clique: {
       blockperiodseconds: 5,
       epochlength: 30000,

--- a/packages/tx/src/4844/tx.ts
+++ b/packages/tx/src/4844/tx.ts
@@ -187,10 +187,26 @@ export class Blob4844Tx implements TransactionInterface<typeof TransactionType.B
       }
     }
 
+    // EIP-7594 PeerDAS: Limit of 6 blobs per transaction
+    if (this.common.isActivatedEIP(7594)) {
+      const maxBlobsPerTx = this.common.param('maxBlobsPerTx')
+      if (this.blobVersionedHashes.length > maxBlobsPerTx) {
+        const msg = Legacy.errorMsg(
+          this,
+          `tx can contain at most ${maxBlobsPerTx} blobs (EIP-7594)`,
+        )
+        throw EthereumJSErrorWithoutCode(msg)
+      }
+    }
+
+    // "Old" limit (superseeded by EIP-7594 starting with Osaka)
     const limitBlobsPerTx =
       this.common.param('maxBlobGasPerBlock') / this.common.param('blobGasPerBlob')
     if (this.blobVersionedHashes.length > limitBlobsPerTx) {
-      const msg = Legacy.errorMsg(this, `tx can contain at most ${limitBlobsPerTx} blobs`)
+      const msg = Legacy.errorMsg(
+        this,
+        `tx can contain at most ${limitBlobsPerTx} blobs (maxBlobGasPerBlock/blobGasPerBlob)`,
+      )
       throw EthereumJSErrorWithoutCode(msg)
     } else if (this.blobVersionedHashes.length === 0) {
       const msg = Legacy.errorMsg(this, `tx should contain at least one blob`)

--- a/packages/tx/src/params.ts
+++ b/packages/tx/src/params.ts
@@ -46,6 +46,12 @@ export const paramsTx: ParamsDict = {
     maxBlobGasPerBlock: 786432, // The max blob gas allowable per block
   },
   /**
+   * PeerDAS - Peer Data Availability Sampling
+   */
+  7594: {
+    maxBlobsPerTx: 6, // Max number of blobs per tx
+  },
+  /**
    * Increase calldata cost to reduce maximum block size
    */
   7623: {

--- a/packages/tx/test/eip4844.spec.ts
+++ b/packages/tx/test/eip4844.spec.ts
@@ -37,7 +37,7 @@ const kzg = new microEthKZG(trustedSetup)
 describe('EIP4844 addSignature tests', () => {
   const common = createCommonFromGethGenesis(eip4844GethGenesis, {
     chain: 'customChain',
-    hardfork: Hardfork.Cancun,
+    hardfork: Hardfork.Prague,
     customCrypto: { kzg },
   })
 
@@ -214,7 +214,7 @@ describe('fromTxData using from a json', () => {
 })
 
 describe('EIP4844 constructor tests - invalid scenarios', () => {
-  const common = createCommonFromGethGenesis(eip4844GethGenesis, {
+  let common = createCommonFromGethGenesis(eip4844GethGenesis, {
     chain: 'customChain',
     hardfork: Hardfork.Cancun,
     customCrypto: { kzg },
@@ -232,8 +232,12 @@ describe('EIP4844 constructor tests - invalid scenarios', () => {
     const invalidVersionHash = {
       blobVersionedHashes: [concatBytes(new Uint8Array([3]), randomBytes(31))],
     }
-    const tooManyBlobs = {
+    const tooManyBlobs7 = {
       blobVersionedHashes: [
+        concatBytes(new Uint8Array([1]), randomBytes(31)),
+        concatBytes(new Uint8Array([1]), randomBytes(31)),
+        concatBytes(new Uint8Array([1]), randomBytes(31)),
+        concatBytes(new Uint8Array([1]), randomBytes(31)),
         concatBytes(new Uint8Array([1]), randomBytes(31)),
         concatBytes(new Uint8Array([1]), randomBytes(31)),
         concatBytes(new Uint8Array([1]), randomBytes(31)),
@@ -256,10 +260,25 @@ describe('EIP4844 constructor tests - invalid scenarios', () => {
       )
     }
     try {
-      createBlob4844Tx({ ...baseTxData, ...tooManyBlobs }, { common })
+      createBlob4844Tx({ ...baseTxData, ...tooManyBlobs7 }, { common })
     } catch (err: any) {
       assert.isTrue(
-        err.message.includes('tx can contain at most'),
+        err.message.includes('tx can contain at most 6 blobs (maxBlobGasPerBlock/blobGasPerBlob)'),
+        'throws on too many versioned hashes',
+      )
+    }
+
+    common = createCommonFromGethGenesis(eip4844GethGenesis, {
+      chain: 'customChain',
+      hardfork: Hardfork.Cancun,
+      eips: [7594],
+      customCrypto: { kzg },
+    })
+    try {
+      createBlob4844Tx({ ...baseTxData, ...tooManyBlobs7 }, { common })
+    } catch (err: any) {
+      assert.isTrue(
+        err.message.includes('tx can contain at most 6 blobs (EIP-7594)'),
         'throws on too many versioned hashes',
       )
     }


### PR DESCRIPTION
This adds the PeerDAS blob per tx limit from [here](https://github.com/ethereum/EIPs/commit/cf1a3edbdd400eb85e0819dd36c20206b0bde5be) fixing the remaining failing Osaka state tests.

PR also fixes a false positive test for the former max blob per tx case (test cases tx blobs were at 3 and so the `catch` block was simply not reached and so test was passing for the wrong reason (we should rework the test setup here)).

Ready for review/merge.