### PR TITLE
fix: Explicitly set tsconfigRootDir in ESLint configs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,8 +1,8 @@
+import { dirname } from 'path'
+import { fileURLToPath } from 'url'
 import pluginJs from '@eslint/js'
 import importPlugin from 'eslint-plugin-import'
 import tseslint from 'typescript-eslint'
-import { fileURLToPath } from 'url'
-import { dirname } from 'path'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/binarytree/eslint.config.mjs
+++ b/packages/binarytree/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/block/eslint.config.mjs
+++ b/packages/block/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/blockchain/eslint.config.mjs
+++ b/packages/blockchain/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/client/eslint.config.mjs
+++ b/packages/client/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/common/eslint.config.mjs
+++ b/packages/common/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/devp2p/eslint.config.mjs
+++ b/packages/devp2p/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/e2store/eslint.config.mjs
+++ b/packages/e2store/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/ethash/eslint.config.mjs
+++ b/packages/ethash/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/evm/eslint.config.mjs
+++ b/packages/evm/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/genesis/eslint.config.mjs
+++ b/packages/genesis/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/mpt/eslint.config.mjs
+++ b/packages/mpt/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/rlp/eslint.config.mjs
+++ b/packages/rlp/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/statemanager/eslint.config.mjs
+++ b/packages/statemanager/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/tx/eslint.config.mjs
+++ b/packages/tx/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/util/eslint.config.mjs
+++ b/packages/util/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/vm/eslint.config.mjs
+++ b/packages/vm/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 

--- a/packages/wallet/eslint.config.mjs
+++ b/packages/wallet/eslint.config.mjs
@@ -1,6 +1,6 @@
-import rootConfig from '../../eslint.config.mjs'
-import { fileURLToPath } from 'url'
 import { dirname } from 'path'
+import { fileURLToPath } from 'url'
+import rootConfig from '../../eslint.config.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 


### PR DESCRIPTION
Resolve ESLint parsing error by explicitly setting `tsconfigRootDir` using `__dirname` computed from `import.meta.url` in both root and package-level ESLint configurations. 

This fixes this issue:

```
Parsing error: No tsconfigRootDir was set, and multiple candidate TSConfigRootDirs are present:
 - ..Work/EthereumJS/ethereumjs-monorepo
 - ..Work/EthereumJS/ethereumjs-monorepo/config
You'll need to explicitly set tsconfigRootDir in your parser options.
See: https://typescript-eslint.io/packages/parser/#tsconfigrootdireslint
```