### PR TITLE
test: fix RlpxPeer mock for Vitest 4

### DIFF
--- a/packages/client/test/net/peer/rlpxpeer.spec.ts
+++ b/packages/client/test/net/peer/rlpxpeer.spec.ts
@@ -7,16 +7,19 @@ import { Event } from '../../../src/types.ts'
 describe('[RlpxPeer]', async () => {
   vi.mock('@ethereumjs/devp2p', async () => {
     const devp2p = await vi.importActual<any>('@ethereumjs/devp2p')
-    const RLPx = vi.fn().mockImplementation(() => {
-      return {
-        events: new EventEmitter(),
-        connect: vi.fn(),
+
+    // Create a proper constructor mock for RLPx
+    class RLPxMock {
+      events = new EventEmitter()
+      connect = vi.fn()
+      constructor() {
+        // Constructor can be empty, properties are initialized above
       }
-    })
+    }
 
     return {
       ...devp2p,
-      RLPx,
+      RLPx: RLPxMock,
     }
   })
 


### PR DESCRIPTION
Vitest 4 requires mocks used with 'new' to be proper constructors. Changed RLPx mock from a function returning an object to a class.