### PR TITLE
EIP-7702: unpad bytes in case of hex-string "0x0" inputs for authorization list fields

### DIFF
--- a/config/cspell-ts.json
+++ b/config/cspell-ts.json
@@ -24,6 +24,7 @@
     }
   ],
   "words": [
+    "unpadding",
     "prehash",
     "viem",
     "immediates",

--- a/packages/tx/test/eip7702.spec.ts
+++ b/packages/tx/test/eip7702.spec.ts
@@ -131,12 +131,33 @@ describe('[EOACode7702Transaction]', () => {
     }, 'leading zeros in chainId should be normalized and accepted')
 
     // '0x0' should be treated as zero (empty bytes after unpadding)
-    assert.doesNotThrow(() => {
-      createEOACode7702Tx(getTxData({ chainId: '0x0' }), { common })
-    }, 'chainId 0x0 should be normalized to empty bytes and accepted')
+    const txWithZeroChainId = createEOACode7702Tx(getTxData({ chainId: '0x0' }), { common })
+    assert.strictEqual(
+      txWithZeroChainId.authorizationList[0][0].length,
+      0,
+      'chainId 0x0 should be normalized to empty bytes',
+    )
 
-    assert.doesNotThrow(() => {
-      createEOACode7702Tx(getTxData({ yParity: '0x0' }), { common })
-    }, 'yParity 0x0 should be normalized to empty bytes and accepted')
+    const txWithZeroYParity = createEOACode7702Tx(getTxData({ yParity: '0x0' }), { common })
+    assert.strictEqual(
+      txWithZeroYParity.authorizationList[0][3].length,
+      0,
+      'yParity 0x0 should be normalized to empty bytes',
+    )
+
+    // Verify that leading zeros are normalized correctly
+    const txWithPaddedNonce = createEOACode7702Tx(getTxData({ nonce: '0x0001' }), { common })
+    assert.deepEqual(
+      txWithPaddedNonce.authorizationList[0][2],
+      new Uint8Array([1]),
+      'nonce 0x0001 should be normalized to [1]',
+    )
+
+    const txWithPaddedChainId = createEOACode7702Tx(getTxData({ chainId: '0x0001' }), { common })
+    assert.deepEqual(
+      txWithPaddedChainId.authorizationList[0][0],
+      new Uint8Array([1]),
+      'chainId 0x0001 should be normalized to [1]',
+    )
   })
 })

--- a/packages/util/src/authorization.ts
+++ b/packages/util/src/authorization.ts
@@ -63,12 +63,12 @@ export function eoaCode7702AuthorizationListJSONItemToBytes(
   }
 
   return [
-    hexToBytes(authorizationList.chainId),
-    hexToBytes(authorizationList.address),
-    hexToBytes(authorizationList.nonce),
-    hexToBytes(authorizationList.yParity),
-    hexToBytes(authorizationList.r),
-    hexToBytes(authorizationList.s),
+    unpadBytes(hexToBytes(authorizationList.chainId)),
+    unpadBytes(hexToBytes(authorizationList.address)),
+    unpadBytes(hexToBytes(authorizationList.nonce)),
+    unpadBytes(hexToBytes(authorizationList.yParity)),
+    unpadBytes(hexToBytes(authorizationList.r)),
+    unpadBytes(hexToBytes(authorizationList.s)),
   ]
 }
 
@@ -78,7 +78,7 @@ function unsignedAuthorizationListToBytes(input: EOACode7702AuthorizationListIte
   const chainId = hexToBytes(chainIdHex)
   const address = setLengthLeft(hexToBytes(addressHex), 20)
   const nonce = hexToBytes(nonceHex)
-  return [chainId, address, nonce]
+  return [chainId, address, nonce].map(unpadBytes)
 }
 
 /**
@@ -151,9 +151,9 @@ export function eoaCode7702SignAuthorization(
     : unsignedAuthorizationListToBytes(input)
 
   return [
-    chainId,
-    address,
-    nonce,
+    unpadBytes(chainId),
+    unpadBytes(address),
+    unpadBytes(nonce),
     bigIntToUnpaddedBytes(BigInt(signed.recovery!)),
     bigIntToUnpaddedBytes(signed.r),
     bigIntToUnpaddedBytes(signed.s),
@@ -166,7 +166,7 @@ export function eoaCode7702RecoverAuthority(
   const inputBytes = Array.isArray(input)
     ? input
     : eoaCode7702AuthorizationListJSONItemToBytes(input)
-  const [chainId, address, nonce, yParity, r, s] = inputBytes
+  const [chainId, address, nonce, yParity, r, s] = inputBytes.map(unpadBytes)
   const msgHash = eoaCode7702AuthorizationHashedMessageToSign([chainId, address, nonce])
   const pubKey = ecrecover(msgHash, bytesToBigInt(yParity), r, s)
   return new Address(publicToAddress(pubKey))

--- a/packages/util/test/bytes.spec.ts
+++ b/packages/util/test/bytes.spec.ts
@@ -68,6 +68,22 @@ describe('unpadBytes', () => {
       unpadBytes((<unknown>'0000000006600') as Uint8Array)
     })
   })
+  it('should correctly unpad 0x0', () => {
+    const bytes = hexToBytes('0x0')
+    assert.deepEqual(bytes, new Uint8Array([0]), 'hexToBytes("0x0") should return [0]')
+
+    const unpadded = unpadBytes(bytes)
+    assert.deepEqual(unpadded, new Uint8Array(0), 'unpadBytes should return empty array for 0x0')
+    assert.strictEqual(unpadded.length, 0, 'unpadded result should have length 0')
+
+    const result = unpadBytes(hexToBytes('0x0'))
+    assert.deepEqual(
+      result,
+      new Uint8Array(0),
+      'unpadBytes(hexToBytes("0x0")) should return empty array',
+    )
+    assert.strictEqual(bytesToHex(result), '0x', 'empty bytes should convert to "0x" hex string')
+  })
 })
 
 describe('unpadArray', () => {


### PR DESCRIPTION
Closes https://github.com/ethereumjs/ethereumjs-monorepo/issues/4057

CC @yann300 

The problem here is:

```
> util.hexToBytes("0x0")
Uint8Array(1) [ 0 ]
```

This decodes the "0x0" JSON fields of a transaction to 1-byte-length 0x00. This is invalid for 7702 txs, these fields should be unpadded. I added it to all cases  of the 7702 logic. 

TODO: tests