### PR TITLE
block: use child common in EIP-7918 reserve price check

### DIFF
--- a/packages/block/src/header/header.ts
+++ b/packages/block/src/header/header.ts
@@ -576,7 +576,7 @@ export class BlockHeader {
       const blobBaseCost = childCommon.param('blobBaseCost')
       const gasPerBlob = childCommon.param('blobGasPerBlob')
       const baseFee = this.baseFeePerGas ?? BIGINT_0
-      const blobFee = this.getBlobGasPrice()
+      const blobFee = computeBlobGasPrice(excessBlobGas, childCommon)
 
       if (blobBaseCost * baseFee > gasPerBlob * blobFee) {
         const increase = (blobGasUsed * (maxPerBlock - targetPerBlock)) / maxPerBlock


### PR DESCRIPTION
- Aligns `EIP-7918` **reserve-price check** with spec by computing `base_fee_per_blob_gas(parent)` using the *current* (child) block’s `blob schedule`, via `computeBlobGasPrice(excessBlobGas, childCommon)` in `calcNextExcessBlobGas`
- Ensures fork-transition correctness by applying the *new* blobSchedule when evaluating the reserve-price condition for the parent header.

The EIP-7918 spec explicitly defines the reserve-price condition inside `calc_excess_blob_gas(parent)` as:

```
if BLOB_BASE_COST * parent.base_fee_per_gas > GAS_PER_BLOB * get_base_fee_per_blob_gas(parent):
    return parent.excess_blob_gas + parent.blob_gas_used * (blobSchedule.max - blobSchedule.target) // blobSchedule.max
else:
    return parent.excess_blob_gas + parent.blob_gas_used - target_blob_gas
```
and clarifies that “the current block’s blobSchedule is used during processing” and that in the first block after a fork the new `blobSchedule` must be used in both `get_base_fee_per_blob_gas(parent)` and `calc_excess_blob_gas()` 