### PR TITLE
block: use common.getBlobGasSchedule instead of common.param(...)

### DIFF
--- a/packages/block/src/block/block.ts
+++ b/packages/block/src/block/block.ts
@@ -209,7 +209,7 @@ export class Block {
         }
       }
       if (this.common.isActivatedEIP(4844)) {
-        const blobGasLimit = this.common.param('maxBlobGasPerBlock')
+        const blobGasLimit = this.common.getBlobGasSchedule().maxBlobGasPerBlock
         const blobGasPerBlob = this.common.param('blobGasPerBlob')
         if (tx instanceof Blob4844Tx) {
           blobGasUsed += BigInt(tx.numBlobs()) * blobGasPerBlob
@@ -320,7 +320,7 @@ export class Block {
    */
   validateBlobTransactions(parentHeader: BlockHeader) {
     if (this.common.isActivatedEIP(4844)) {
-      const blobGasLimit = this.common.param('maxBlobGasPerBlock')
+      const blobGasLimit = this.common.getBlobGasSchedule().maxBlobGasPerBlock
       const blobGasPerBlob = this.common.param('blobGasPerBlob')
       let blobGasUsed = BIGINT_0
 


### PR DESCRIPTION
Updates blob gas limit lookup in block validation to use the active blob gas schedule (**EIP‑7892**) instead of the legacy `maxBlobGasPerBlock` param.

Replaces `common.param('maxBlobGasPerBlock')` with `common.getBlobGasSchedule().maxBlobGasPerBlock` in `block.ts` to align both transaction validation and blob transaction validation with the active schedule.

Using `getBlobGasSchedule()` **keeps pre‑BPO behavior identical** while correctly applying post‑BPO limits.

