### PR TITLE
update bundle size script

### DIFF
--- a/scripts/bundle-size.mjs
+++ b/scripts/bundle-size.mjs
@@ -28,6 +28,8 @@ function resolveExportTarget(target) {
   if (typeof target !== 'object') return null
   if (target.import?.default) return target.import.default
   if (typeof target.import === 'string') return target.import
+  if (target.default?.default) return target.default.default
+  if (typeof target.default === 'string') return target.default
   return null
 }
 


### PR DESCRIPTION
This improves upon the `bundle-size` script.  This script is run during CI on pull requests, and reports changes in the bundled size of each package, helping to show the impact of proposed code changes.

The current script accomplished this by measuring the size of each package's `dist/` directory.  This provided a good look the the published footprint of each package, but did not accurately describe "bundled size" as intended.  Type mappings and other build artifacts were included, and the effects of tree-shaking were ignored with this method.

For example, adding code comments increased the reported package sizes.  In reality, comments are removed during bundling, so this should not have added to the size.


The updated script analyzes "minified", tree-shaken bundle sizes for packages in the monorepo.

1. Package discovery: Scans packages/ and reads each package.json.
2. Entry point resolution: Uses resolveEntry() to pick the entry:
  * Checks exports['.'] first (supports nested import.default)
  * Falls back to module or main
  * Only handles the root export (.)
3. Internal package mapping: Builds a map of workspace package names to paths.
4. Bundling: Uses esbuild to:
  * Bundle the entry point
  * Mark non-internal dependencies as external
  * Minify and tree-shake
  * Target Node.js ESM (platform: 'node', format: 'esm')
5. Size calculation: Gzips the minified bundle and records the byte count.
6. Comparison: Compares current sizes to a baseline JSON and outputs a markdown table.


Instructions: 

Baseline generation: `--output=file.json` saves current sizes.
Comparison: `--baseline=file.json` compares and prints a markdown table.

