### PR TITLE
 evm: add expected error messages to EOF validation test failures 

### DIFF
--- a/packages/evm/src/eof/container.ts
+++ b/packages/evm/src/eof/container.ts
@@ -151,7 +151,7 @@ class EOFHeader {
    */
   constructor(input: Uint8Array) {
     if (input.length > MAX_HEADER_SIZE) {
-      throw EthereumJSErrorWithoutCode('err: container size more than maximum valid size')
+      validationError(EOFErrorMessage.CONTAINER_SIZE_MAX)
     }
     const stream = new StreamReader(input)
     // Verify that the header starts with 0xEF0001
@@ -159,7 +159,7 @@ class EOFHeader {
     stream.verifyUint(MAGIC, EOFErrorMessage.MAGIC)
     stream.verifyUint(VERSION, EOFErrorMessage.VERSION)
     if (input.length < 15) {
-      throw EthereumJSErrorWithoutCode('err: container size less than minimum valid size')
+      validationError(EOFErrorMessage.CONTAINER_SIZE_MIN)
     }
     // Verify that the types section is present and its length is valid
     stream.verifyUint(KIND_TYPE, EOFErrorMessage.KIND_TYPE)
@@ -171,9 +171,7 @@ class EOFHeader {
       validationError(EOFErrorMessage.INVALID_TYPE_SIZE, typeSize)
     }
     if (typeSize > TYPE_MAX) {
-      throw EthereumJSErrorWithoutCode(
-        `err: number of code sections must not exceed 1024 (got ${typeSize})`,
-      )
+      validationError(EOFErrorMessage.TYPE_SIZE_MAX)
     }
     // Verify that the code section is present and its size is valid
     stream.verifyUint(KIND_CODE, EOFErrorMessage.KIND_CODE)

--- a/packages/evm/src/eof/errors.ts
+++ b/packages/evm/src/eof/errors.ts
@@ -1,5 +1,3 @@
-import { EthereumJSErrorWithoutCode } from '@ethereumjs/util'
-
 export type EOFErrorMessage = (typeof EOFErrorMessage)[keyof typeof EOFErrorMessage]
 
 export const EOFErrorMessage = {
@@ -65,7 +63,20 @@ export const EOFErrorMessage = {
   RETURN_STACK_OVERFLOW: 'Return stack overflow',
   INVALID_EXTCALL_TARGET: 'invalid extcall target: address > 20 bytes',
   INVALID_RETURN_CONTRACT_DATA_SIZE: 'invalid RETURNCONTRACT: data size lower than expected',
+  CONTAINER_SIZE_MIN: 'err: container size less than minimum valid size',
+  CONTAINER_SIZE_MAX: 'err: container size more than maximum valid size',
+  TYPE_SIZE_MAX: 'type size exceeds limit',
 } as const
+
+export class EOFValidationError extends Error {
+  public readonly code: string
+
+  constructor(type: EOFErrorMessage, message: string) {
+    super(message)
+    this.name = 'EOFValidationError'
+    this.code = type
+  }
+}
 
 export function validationErrorMsg(type: EOFErrorMessage, ...args: any) {
   switch (type) {
@@ -130,85 +141,95 @@ export function validationError(type: EOFErrorMessage, ...args: any): never {
     case EOFErrorMessage.OUT_OF_BOUNDS: {
       const pos = args[0]
       if (pos === 0 || pos === 2 || pos === 3 || pos === 6) {
-        throw EthereumJSErrorWithoutCode(args[1])
+        const actualType = args[1] as EOFErrorMessage
+        throw new EOFValidationError(actualType, actualType)
       }
-      throw EthereumJSErrorWithoutCode(EOFErrorMessage.OUT_OF_BOUNDS + ` `)
+      throw new EOFValidationError(type, EOFErrorMessage.OUT_OF_BOUNDS + ` `)
     }
     case EOFErrorMessage.VERIFY_BYTES: {
       const pos = args[0]
       if (pos === 0 || pos === 2 || pos === 3 || pos === 6) {
-        throw EthereumJSErrorWithoutCode(args[1])
+        const actualType = args[1] as EOFErrorMessage
+        throw new EOFValidationError(actualType, actualType)
       }
-      throw EthereumJSErrorWithoutCode(
+      throw new EOFValidationError(
+        type,
         EOFErrorMessage.VERIFY_BYTES + ` at pos: ${args[0]}: ${args[1]}`,
       )
     }
     case EOFErrorMessage.VERIFY_UINT: {
       const pos = args[0]
       if (pos === 0 || pos === 2 || pos === 3 || pos === 6 || pos === 18) {
-        throw EthereumJSErrorWithoutCode(args[1])
+        const actualType = args[1] as EOFErrorMessage
+        throw new EOFValidationError(actualType, actualType)
       }
-      throw EthereumJSErrorWithoutCode(
+      throw new EOFValidationError(
+        type,
         EOFErrorMessage.VERIFY_UINT + `at pos: ${args[0]}: ${args[1]}`,
       )
     }
     case EOFErrorMessage.TYPE_SIZE: {
-      throw EthereumJSErrorWithoutCode(EOFErrorMessage.TYPE_SIZE + args[0])
+      throw new EOFValidationError(type, EOFErrorMessage.TYPE_SIZE + args[0])
     }
     case EOFErrorMessage.TYPE_SECTIONS: {
-      throw EthereumJSErrorWithoutCode(
+      throw new EOFValidationError(
+        type,
         `${EOFErrorMessage.TYPE_SECTIONS} (types ${args[0]} code ${args[1]})`,
       )
     }
     case EOFErrorMessage.INVALID_TYPE_SIZE: {
-      throw EthereumJSErrorWithoutCode(EOFErrorMessage.INVALID_TYPE_SIZE)
+      throw new EOFValidationError(type, EOFErrorMessage.INVALID_TYPE_SIZE)
     }
     case EOFErrorMessage.INVALID_CODE_SIZE: {
-      throw EthereumJSErrorWithoutCode(EOFErrorMessage.INVALID_CODE_SIZE + args[0])
+      throw new EOFValidationError(type, EOFErrorMessage.INVALID_CODE_SIZE + args[0])
     }
     case EOFErrorMessage.INPUTS: {
-      throw EthereumJSErrorWithoutCode(`${EOFErrorMessage.INPUTS} - typeSection ${args[0]}`)
+      throw new EOFValidationError(type, `${EOFErrorMessage.INPUTS} - typeSection ${args[0]}`)
     }
     case EOFErrorMessage.OUTPUTS: {
-      throw EthereumJSErrorWithoutCode(`${EOFErrorMessage.OUTPUTS} - typeSection ${args[0]}`)
+      throw new EOFValidationError(type, `${EOFErrorMessage.OUTPUTS} - typeSection ${args[0]}`)
     }
     case EOFErrorMessage.CODE0_INPUTS: {
-      throw EthereumJSErrorWithoutCode(`first code section should have 0 inputs`)
+      throw new EOFValidationError(type, `first code section should have 0 inputs`)
     }
     case EOFErrorMessage.CODE0_OUTPUTS: {
-      throw EthereumJSErrorWithoutCode(`first code section should have 0 outputs`)
+      throw new EOFValidationError(type, `first code section should have 0 outputs`)
     }
     case EOFErrorMessage.MAX_INPUTS: {
-      throw EthereumJSErrorWithoutCode(
+      throw new EOFValidationError(
+        type,
         EOFErrorMessage.MAX_INPUTS + `${args[1]} - code section ${args[0]}`,
       )
     }
     case EOFErrorMessage.MAX_OUTPUTS: {
-      throw EthereumJSErrorWithoutCode(
+      throw new EOFValidationError(
+        type,
         EOFErrorMessage.MAX_OUTPUTS + `${args[1]} - code section ${args[0]}`,
       )
     }
     case EOFErrorMessage.CODE_SECTION: {
-      throw EthereumJSErrorWithoutCode(`expected code: codeSection ${args[0]}: `)
+      throw new EOFValidationError(type, `expected code: codeSection ${args[0]}: `)
     }
     case EOFErrorMessage.DATA_SECTION: {
-      throw EthereumJSErrorWithoutCode(EOFErrorMessage.DATA_SECTION)
+      throw new EOFValidationError(type, EOFErrorMessage.DATA_SECTION)
     }
     case EOFErrorMessage.MAX_STACK_HEIGHT: {
-      throw EthereumJSErrorWithoutCode(
+      throw new EOFValidationError(
+        type,
         `${EOFErrorMessage.MAX_STACK_HEIGHT} - typeSection ${args[0]}: `,
       )
     }
     case EOFErrorMessage.MAX_STACK_HEIGHT_LIMIT: {
-      throw EthereumJSErrorWithoutCode(
+      throw new EOFValidationError(
+        type,
         `${EOFErrorMessage.MAX_STACK_HEIGHT_LIMIT}, got: ${args[1]} - typeSection ${args[0]}`,
       )
     }
     case EOFErrorMessage.DANGLING_BYTES: {
-      throw EthereumJSErrorWithoutCode(EOFErrorMessage.DANGLING_BYTES)
+      throw new EOFValidationError(type, EOFErrorMessage.DANGLING_BYTES)
     }
     default: {
-      throw EthereumJSErrorWithoutCode(type)
+      throw new EOFValidationError(type, type)
     }
   }
 }

--- a/packages/evm/src/eof/verify.ts
+++ b/packages/evm/src/eof/verify.ts
@@ -208,6 +208,10 @@ function validateOpcodes(
       const minStackCurrent = stackHeightMin[ptr]
       const maxStackCurrent = stackHeightMax[ptr]
 
+      if (stackDelta[opcode] === undefined) {
+        validationError(EOFErrorMessage.INVALID_OPCODE)
+      }
+
       const opcodeInputs = stackDelta[opcode].inputs
       const opcodeOutputs = stackDelta[opcode].outputs
 

--- a/packages/evm/src/index.ts
+++ b/packages/evm/src/index.ts
@@ -1,4 +1,5 @@
 import { EOFContainer, validateEOF } from './eof/container.ts'
+import { EOFValidationError } from './eof/errors.ts'
 import { EVMError } from './errors.ts'
 import { EVM } from './evm.ts'
 import { Message } from './message.ts'
@@ -45,6 +46,7 @@ export type {
 
 export {
   EOFContainer,
+  EOFValidationError,
   EVM,
   EVMError,
   EVMMockBlockchain,


### PR DESCRIPTION
When an EOF validation test should fail but doesn't throw, now shows: `Should have failed because of: <expected_error>`.

Also adds `EOFValidationError` class to distinguish EOF validation errors from other exceptions, and optional mismatch logging via `EOF_VERBOSE_ERRORS` env var.

Question: Is the env var approach enough for reviewing error mismatches, or should we add something more #3874?