### PR TITLE
Spec test runner: improve error message

### DIFF
--- a/packages/vm/test/tester/executionSpecBlockchain.test.ts
+++ b/packages/vm/test/tester/executionSpecBlockchain.test.ts
@@ -104,7 +104,7 @@ export async function runBlockchainTestCase(
       t.notExists(expectException, `Should have thrown with: ${expectException}`)
     } catch (e: any) {
       if (e.message.includes(`Should have thrown`) === true) {
-        t.notExists(expectException, `Should have thrown with: ${expectException}`)
+        throw e
       }
       // Check if the block failed due to an expected exception
       t.exists(


### PR DESCRIPTION
This PR fixes a flaw in the execution spec blockchain test runner that produced misleading error messages.  

Tests that fail due to successfully processing a block with an `expectedException` field should fail with a `Should have thrown with...` message.  Since this was inside of a **try/catch**, that error was absorbed into another check, producing a nested and misleading error message.

This fixes the condition to actually fail with the correct "Should have thrown with..." message, allowing better test debugging.