### PR TITLE
Pass filename or partial path to execution-spec-tests loader

### DIFF
--- a/packages/vm/test/tester/executionSpecBlockchain.test.ts
+++ b/packages/vm/test/tester/executionSpecBlockchain.test.ts
@@ -1,6 +1,5 @@
 import { assert, describe, it } from 'vitest'
 
-import fs from 'fs'
 import path from 'path'
 
 import type { Block } from '@ethereumjs/block'
@@ -22,22 +21,18 @@ import { createCommonForFork, loadExecutionSpecFixtures } from './executionSpecT
 
 const customFixturesPath = process.env.TEST_PATH ?? '../execution-spec-tests'
 const fixturesPath = path.resolve(customFixturesPath)
-
-console.log(`Using execution-spec blockchain tests from: ${fixturesPath}`)
+const resolvedNote = path.isAbsolute(customFixturesPath) ? '' : ` (resolved: ${fixturesPath})`
+console.log(`Using execution-spec blockchain tests from: ${customFixturesPath}${resolvedNote}`)
 
 // Create KZG instance once at the top level (expensive operation)
 const kzg = new microEthKZG(trustedSetup)
 
-if (fs.existsSync(fixturesPath) === false) {
-  describe('Execution-spec blockchain tests', () => {
-    it.skip(`fixtures not found at ${fixturesPath}`, () => {})
-  })
-} else {
-  const fixtures = loadExecutionSpecFixtures(fixturesPath, 'blockchain_tests')
+{
+  const fixtures = loadExecutionSpecFixtures(customFixturesPath, 'blockchain_tests')
 
   describe('Execution-spec blockchain tests', () => {
     if (fixtures.length === 0) {
-      it.skip(`no execution-spec blockchain fixtures found under ${fixturesPath}`, () => {})
+      it.skip(`no execution-spec blockchain fixtures found for ${customFixturesPath}`, () => {})
       return
     }
 

--- a/packages/vm/test/tester/executionSpecState.test.ts
+++ b/packages/vm/test/tester/executionSpecState.test.ts
@@ -1,6 +1,5 @@
 import { assert, describe, it } from 'vitest'
 
-import fs from 'fs'
 import path from 'path'
 
 import { Common, Mainnet } from '@ethereumjs/common'
@@ -14,22 +13,18 @@ import { loadExecutionSpecFixtures, parseTest } from './executionSpecTestLoader.
 
 const customFixturesPath = process.env.TEST_PATH ?? '../execution-spec-tests'
 const fixturesPath = path.resolve(customFixturesPath)
-
-console.log(`Using execution-spec state tests from: ${fixturesPath}`)
+const resolvedNote = path.isAbsolute(customFixturesPath) ? '' : ` (resolved: ${fixturesPath})`
+console.log(`Using execution-spec state tests from: ${customFixturesPath}${resolvedNote}`)
 
 // Create KZG instance once at the top level (expensive operation)
 const kzg = new microEthKZG(trustedSetup)
 
-if (fs.existsSync(fixturesPath) === false) {
-  describe('Execution-spec state tests', () => {
-    it.skip(`fixtures not found at ${fixturesPath}`, () => {})
-  })
-} else {
-  const fixtures = loadExecutionSpecFixtures(fixturesPath, 'state_tests')
+{
+  const fixtures = loadExecutionSpecFixtures(customFixturesPath, 'state_tests')
 
   describe('Execution-spec state tests', () => {
     if (fixtures.length === 0) {
-      it.skip(`no execution-spec state fixtures found under ${fixturesPath}`, () => {})
+      it.skip(`no execution-spec state fixtures found for ${customFixturesPath}`, () => {})
       return
     }
 


### PR DESCRIPTION
This updates the test fixture loading logic for the execution-spec-tests runner.

Previously `TEST_PATH` needed to be a full path to a directory of test fixtures: 
`TEST_PATH=../execution-spec-tests/dev/blockchain_tests/amsterdam/eip7928_block_level_access_lists`


### Partial Paths
Now `TEST_PATH` can simply be a partial path, and the test loader will find it in the `execution-spec-tests` submodule directory.

`TEST_PATH=eip7928_block_level_access_lists` 

### Filename 
Now `TEST_PATH` can also be a single filename with full or partial path:

`TEST_PATH=../execution-spec-tests/dev/blockchain_tests/amsterdam/eip7928_block_level_access_lists/test_bal_4788_empty_block.json`
or simply
`TEST_PATH=test_bal_4788_empty_block.json`
will run a single test fixture file.

** Note that multiple directories or files with the same name will all be discovered if using a partial path **

----

This is intended to improve the developer experience while working with `execution-spec-tests` both by allowing the running of single test fixture files instead of whole directories, and reducing the need to include the full path in the `TEST_PATH` variable.