### PR TITLE
mpt: refactor, comment and simplify MPT class 

### DIFF
--- a/packages/mpt/src/types.ts
+++ b/packages/mpt/src/types.ts
@@ -36,7 +36,7 @@ export interface Path {
 }
 
 export type FoundNodeFunction = (
-  nodeRef: Uint8Array,
+  nodeRef: NodeReferenceOrRawMPTNode,
   node: MPTNode | null,
   key: Nibbles,
   walkController: WalkController,


### PR DESCRIPTION
This PR refactors, comments and simplifies the MPT class and some underlying files so that it's more approachable and underestandable, following in line with this old PR #2962 .

- Extracted shared logic – Added _getDbKey() for key-prefix handling and _createPruneDeleteOps() for prune deletes to remove duplication in put/del.
- Simplified _updateNode – Moved the leaf “exact match” check into _isMatchingLeafUpdate() and clarified the three update paths (leaf update, branch insert, path divergence).
- Refactored _deleteNode – Simplified collapseBranchWithOneChild (was processBranchMPTNode) so the parent-handling branches are clearer and correct for both null and undefined.
- Documentation and structure – Added JSDoc and section markers, commented findPath node handlers, and explained saveStack, _formatNode, and the delete flow.
- Small cleanups – Fixed put debug to log the value instead of the key, dropped redundant === true, simplified debug output, and