### PR TITLE
BAL transition bug fix

### DIFF
--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -77,9 +77,6 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
     // eslint-disable-next-line no-console
     console.time(entireBlockLabel)
   }
-  if (vm.common.isActivatedEIP(7928)) {
-    vm.evm.blockLevelAccessList = createBlockLevelAccessList()
-  }
   const stateManager = vm.stateManager
 
   const { root } = opts
@@ -112,6 +109,10 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
       blockNumber: block.header.number,
       timestamp: block.header.timestamp,
     })
+  }
+
+  if (vm.common.isActivatedEIP(7928)) {
+    vm.evm.blockLevelAccessList = createBlockLevelAccessList()
   }
 
   if (vm.DEBUG) {


### PR DESCRIPTION
Issue:

`runBlock` initializes **BAL** before calling `setHardforkBy`

At the transition into Amsterdam, this will activate EIP-7928 for the rest of `runBlock`, but `evm.blockLevelAccessList` will be undefined.

Fix:

Move the initialization to after `setHardforkBy`.