### PR TITLE
chore: default test est dev blockchain to v5

### DIFF
--- a/packages/vm/package.json
+++ b/packages/vm/package.json
@@ -57,7 +57,7 @@
     "test:est:stable:state": "TEST_PATH=../execution-spec-tests/stable/state_tests npx vitest run test/tester/executionSpecState.test.ts",
     "test:est:stable:blockchain": "TEST_PATH=../execution-spec-tests/stable/blockchain_tests npx vitest run test/tester/executionSpecBlockchain.test.ts",
     "test:est:dev:state": "TEST_PATH=../execution-spec-tests/dev/state_tests npx vitest run test/tester/executionSpecState.test.ts",
-    "test:est:dev:blockchain": "npm run test:est:dev:blockchain:v200",
+    "test:est:dev:blockchain": "npm run test:est:dev:blockchain:v500",
     "test:est:dev:blockchain:v500": "TEST_PATH=../execution-spec-tests/dev/blockchain_tests/amsterdam/v500_mixed_with_other_eips npx vitest run test/tester/executionSpecBlockchain.test.ts",
     "test:est:dev:blockchain:v301": "TEST_PATH=../execution-spec-tests/dev/blockchain_tests/amsterdam/v301_single_bal_no_bal_defs npx vitest run test/tester/executionSpecBlockchain.test.ts",
     "test:est:dev:blockchain:v200": "TEST_PATH=../execution-spec-tests/dev/blockchain_tests/amsterdam/v200_bal_defs_somewhat_outdated npx vitest run test/tester/executionSpecBlockchain.test.ts",


### PR DESCRIPTION
This PR updates the CI so that it uses the v5 version of the EEST dev blockchain test, so that they match what are now working on (#4238 ). It's now easier to directly check how much a PR contributes to test coverage:

<img width="684" height="530" alt="image" src="https://github.com/user-attachments/assets/6e4bfa2f-1fcc-4e6f-90eb-5fe5d23315e2" />
