### PR TITLE
vm: externalize header field validation

### DIFF
--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -221,7 +221,7 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
   } else {
     try {
       // Only validate header fields if Stateless isn't activated
-      await validateHeaderFields(vm, block, result, requestsHash, stateRoot, debug)
+      validateHeaderFields(vm, block, result, requestsHash, stateRoot, debug)
 
       // Validate binary tree post-state if activated
       if (vm.common.isActivatedEIP(7864)) {

--- a/packages/vm/src/validateHeaderFields.ts
+++ b/packages/vm/src/validateHeaderFields.ts
@@ -17,7 +17,7 @@ const formatErrorMessage = (field: string, headerValue: string, resultsValue: st
  * @param stateRoot - Post execution state root.
  * @param debug - Debug function.
  */
-export async function validateHeaderFields(
+export function validateHeaderFields(
   vm: VM,
   block: Block,
   result: ApplyBlockResult,


### PR DESCRIPTION
This PR externalizes the header field validation conditionals from `vm.runBlock` into a new fuction: `validateHeaderFields` exported from `validateHeaderFields.ts`.

Also modifies the error reporting to include all mismatches.  Previously `runBlock` would fail at the first header field mismatch.  Often this meant a `invalid receiptsRoot` error thrown, when in reality, multiple header fields were probably mismatched.

The new function will check all of the header fields, and report the full list of mismatched fields.  