### PR TITLE
mpt: benchmark unrolled-nbl-hashes-sha3 for keccak256 speedup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,6 @@
       "version": "7.28.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -627,8 +626,7 @@
     "node_modules/@cspell/dict-css": {
       "version": "4.0.18",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-dart": {
       "version": "2.3.1",
@@ -728,14 +726,12 @@
     "node_modules/@cspell/dict-html": {
       "version": "4.0.12",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-html-symbol-entities": {
       "version": "4.0.4",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-java": {
       "version": "5.0.12",
@@ -879,8 +875,7 @@
     "node_modules/@cspell/dict-typescript": {
       "version": "3.2.3",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@cspell/dict-vue": {
       "version": "3.0.5",
@@ -1858,7 +1853,6 @@
     "node_modules/@polkadot/util": {
       "version": "13.5.7",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@polkadot/x-bigint": "13.5.7",
         "@polkadot/x-global": "13.5.7",
@@ -1954,7 +1948,6 @@
     "node_modules/@polkadot/wasm-util": {
       "version": "7.5.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.7.0"
       },
@@ -2940,7 +2933,6 @@
       "version": "8.46.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -3128,7 +3120,6 @@
       "integrity": "sha512-OWN4ZgOIV2+T9cR4qfoajtjZDFoxcLa6qUpgDkviXZFUNkZ7XTVKvL/16X+gz5dtpqdZwXf3m0qIj72Ge/vytw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/mocker": "4.0.9",
         "@vitest/utils": "4.0.9",
@@ -3152,7 +3143,6 @@
       "integrity": "sha512-ayr0vCxvJIvodzfUTVzifFMT3bmcMeKzEWoPt7mtgrZsqJhMbYaftifuBZRQeF/glogsVr+jhtIePHw6g+0YRQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/browser": "4.0.9",
         "@vitest/mocker": "4.0.9",
@@ -3330,7 +3320,6 @@
       "integrity": "sha512-6HV2HHl9aRJ09TlYj/WAQxaa797Ezb5u0LpgabthlASAUAWKgw/W1DSPX7t848mMZmIUvzZgnUHGIylAoYHP0w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.9",
         "fflate": "^0.8.2",
@@ -3440,7 +3429,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3825,7 +3813,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -4963,7 +4950,6 @@
       "version": "9.37.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6893,7 +6879,6 @@
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },
@@ -8125,6 +8110,7 @@
       "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.56.1"
       },
@@ -8144,6 +8130,7 @@
       "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -8162,6 +8149,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -8447,7 +8435,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9275,7 +9262,6 @@
       "version": "4.20.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -9386,7 +9372,6 @@
       "version": "0.28.14",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.12.0",
         "lunr": "^2.3.9",
@@ -9420,7 +9405,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9505,6 +9489,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/unrolled-nbl-hashes-sha3": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/unrolled-nbl-hashes-sha3/-/unrolled-nbl-hashes-sha3-0.1.1.tgz",
+      "integrity": "sha512-/ysXyrVCw6LDpkn1EvcDEi11NHg45ShbwCjx3NeuALO8lZCWBdI2uZ3h453xAdDIid9sicmhc0Wv5hNZ6XXbhA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -9626,7 +9617,6 @@
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -9724,7 +9714,6 @@
       "integrity": "sha512-E0Ja2AX4th+CG33yAFRC+d1wFx2pzU5r6HtG6LiPSE04flaE0qB6YyjSw9ZcpJAtVPfsvZGtJlKWZpuW7EHRxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.9",
         "@vitest/mocker": "4.0.9",
@@ -10024,7 +10013,6 @@
       "version": "8.18.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10603,7 +10591,8 @@
         "level": "^9.0.0",
         "lmdb": "^3.2.6",
         "memory-level": "^3.0.0",
-        "micro-bmark": "0.4.0"
+        "micro-bmark": "0.4.0",
+        "unrolled-nbl-hashes-sha3": "^0.1.1"
       },
       "engines": {
         "node": ">=20"

--- a/packages/mpt/benchmarks/index.ts
+++ b/packages/mpt/benchmarks/index.ts
@@ -1,6 +1,13 @@
 import { MapDB } from '@ethereumjs/util'
+import { keccak_256 as nobleKeccak } from '@noble/hashes/sha3.js'
+import { keccak_256 as unrolledKeccak } from 'unrolled-nbl-hashes-sha3'
 import { LevelDB } from './engines/level'
 import { createSuite } from './suite'
 
-createSuite(new MapDB())
-createSuite(new LevelDB())
+// Run with noble keccak (baseline)
+createSuite(new MapDB(), nobleKeccak, '[noble] ')
+createSuite(new LevelDB(), nobleKeccak, '[noble] ')
+
+// Run with unrolled keccak
+createSuite(new MapDB(), unrolledKeccak, '[unrolled] ')
+createSuite(new LevelDB(), unrolledKeccak, '[unrolled] ')

--- a/packages/mpt/benchmarks/keccak.ts
+++ b/packages/mpt/benchmarks/keccak.ts
@@ -1,0 +1,30 @@
+import { keccak_256 as nobleKeccak } from '@noble/hashes/sha3.js'
+//@ts-expect-error - package has no types...
+import { mark } from 'micro-bmark' // cspell:disable-line
+import { keccak_256 as unrolledKeccak } from 'unrolled-nbl-hashes-sha3'
+
+const ITERATIONS = 50000
+
+async function main() {
+  for (const size of [32, 100, 500, 2000]) {
+    const input = new Uint8Array(size)
+    for (let i = 0; i < size; i++) input[i] = i & 0xff
+
+    await mark(`noble keccak256 (${size} bytes)`, ITERATIONS, () => {
+      nobleKeccak(input)
+    })
+
+    await mark(`unrolled keccak256 (${size} bytes)`, ITERATIONS, () => {
+      unrolledKeccak(input)
+    })
+  }
+
+  // Verify output equivalence
+  const testInput = new Uint8Array([1, 2, 3, 4, 5])
+  const nobleResult = nobleKeccak(testInput)
+  const unrolledResult = unrolledKeccak(testInput)
+  const match = nobleResult.every((b: number, i: number) => b === unrolledResult[i])
+  console.log(`\nOutput equivalence check: ${match ? 'PASS' : 'FAIL'}`)
+}
+
+main()

--- a/packages/mpt/benchmarks/suite.ts
+++ b/packages/mpt/benchmarks/suite.ts
@@ -1,20 +1,23 @@
 import { keccak_256 } from '@noble/hashes/sha3.js'
 //@ts-expect-error - package has no types...
-import { logMem, mark, run } from 'micro-bmark' // cspell:disable-line
+import { mark, utils } from 'micro-bmark' // cspell:disable-line
 
 import { MerklePatriciaTrie } from '../dist/cjs/index.js'
 import { keys } from './keys'
 
 import type { DB } from '@ethereumjs/util'
 
-export function createSuite(db: DB<string, string>) {
-  const trie = new MerklePatriciaTrie({ db })
-  const checkpointTrie = new MerklePatriciaTrie({ db })
+export function createSuite(
+  db: DB<string, string>,
+  hashFn: (msg: Uint8Array) => Uint8Array = keccak_256,
+  label: string = '',
+) {
+  const trie = new MerklePatriciaTrie({ db, useKeyHashingFunction: hashFn })
+  const checkpointTrie = new MerklePatriciaTrie({ db, useKeyHashingFunction: hashFn })
 
   const ROUNDS = 1000
   const KEY_SIZE = 32
-
-  run(async () => {
+  ;(async () => {
     // random.ts
     // Test ID is defined as: `pair_count`-`era_size`-`key_size`-`value_type`
     // where value_type = symmetric ? 'mir' : 'ran'
@@ -27,11 +30,11 @@ export function createSuite(db: DB<string, string>) {
       ['1k-1k-32-ran', 1000, false],
       ['1k-1k-32-mir', 1000, true],
     ]) {
-      await mark(title, async () => {
+      await mark(`${label}${title}`, async () => {
         let key = new Uint8Array(KEY_SIZE)
 
         for (let i = 0; i <= ROUNDS; i++) {
-          key = keccak_256(key)
+          key = hashFn(key)
 
           if (symmetric) {
             await trie.put(key, key)
@@ -49,13 +52,13 @@ export function createSuite(db: DB<string, string>) {
     // References:
     // https://gist.github.com/heikoheiko/0fa2b322560ba7794f22/
     for (const samples of [100, 500, 1000, 5000]) {
-      await mark(`Checkpointing: ${samples} iterations`, samples, async (i: number) => {
+      await mark(`${label}Checkpointing: ${samples} iterations`, samples, async (i: number) => {
         checkpointTrie.checkpoint()
         await checkpointTrie.put(keys[i], keys[i])
         await checkpointTrie.commit()
       })
     }
 
-    logMem()
-  })
+    utils.logMem()
+  })()
 }

--- a/packages/mpt/package.json
+++ b/packages/mpt/package.json
@@ -67,7 +67,8 @@
     "level": "^9.0.0",
     "lmdb": "^3.2.6",
     "memory-level": "^3.0.0",
-    "micro-bmark": "0.4.0"
+    "micro-bmark": "0.4.0",
+    "unrolled-nbl-hashes-sha3": "^0.1.1"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary

- Adds standalone keccak256 microbenchmark comparing `@noble/hashes` vs `unrolled-nbl-hashes-sha3` (ref #3227)
- Extends MPT benchmark suite to accept a configurable hash function for side-by-side trie-level comparison
- Fixes `micro-bmark` import compatibility (`logMem` → `utils.logMem`, removes non-exported `run`)

## Benchmark Results

### Raw keccak256 throughput

| Input Size | @noble/hashes | unrolled-nbl-hashes-sha3 | Speedup |
|---|---|---|---|
| 32 bytes | 37,738 ops/s | 151,653 ops/s | **4.0x** |
| 100 bytes | 36,903 ops/s | 201,085 ops/s | **5.4x** |
| 500 bytes | 9,523 ops/s | 62,123 ops/s | **6.5x** |
| 2000 bytes | 2,497 ops/s | 17,301 ops/s | **6.9x** |

### MPT trie-level benchmarks

No measurable difference at trie level — DB I/O and RLP encoding dominate