### PR TITLE
vm: Fix BlockBuilder bug

### DIFF
--- a/packages/tx/src/4844/constructors.ts
+++ b/packages/tx/src/4844/constructors.ts
@@ -22,7 +22,7 @@ import { paramsTx } from '../params.ts'
 import { TransactionType } from '../types.ts'
 import { accessListBytesToJSON } from '../util/access.ts'
 
-import { Blob4844Tx, NetworkWrapperType } from './tx.ts'
+import { Blob4844Tx, NetworkWrapperType, validateBlob4844TxForkConstraints } from './tx.ts'
 
 import type { KZG, PrefixedHexString } from '@ethereumjs/util'
 import type {
@@ -382,6 +382,12 @@ export function createBlob4844TxFromSerializedNetworkWrapper(
   ) {
     throw Error(`Invalid networkWrapperVersion=${networkWrapperVersionInt}`)
   }
+
+  validateBlob4844TxForkConstraints({
+    blobVersionedHashes: decodedTx.blobVersionedHashes,
+    common: commonCopy,
+    networkWrapperVersion: networkWrapperVersionInt,
+  })
 
   validateBlobTransactionNetworkWrapper(
     networkWrapperVersionInt,

--- a/packages/tx/src/4844/tx.ts
+++ b/packages/tx/src/4844/tx.ts
@@ -17,6 +17,7 @@ import * as EIP1559 from '../capabilities/eip1559.ts'
 import * as EIP2718 from '../capabilities/eip2718.ts'
 import * as EIP2930 from '../capabilities/eip2930.ts'
 import * as Legacy from '../capabilities/legacy.ts'
+import { paramsTx } from '../params.ts'
 import { TransactionType, isAccessList } from '../types.ts'
 import { accessListBytesToJSON, accessListJSONToBytes } from '../util/access.ts'
 import {
@@ -30,7 +31,7 @@ import {
 import { createBlob4844Tx } from './constructors.ts'
 
 import type { Common } from '@ethereumjs/common'
-import type { Address, PrefixedHexString } from '@ethereumjs/util'
+import type { Address, BytesLike, PrefixedHexString } from '@ethereumjs/util'
 import type {
   AccessListBytes,
   TxData as AllTypesTxData,
@@ -50,6 +51,60 @@ export const NetworkWrapperType = {
   EIP7594: 1,
 } as const
 export type NetworkWrapperType = (typeof NetworkWrapperType)[keyof typeof NetworkWrapperType]
+
+const validateNetworkWrapperVersion = (
+  common: Common,
+  networkWrapperVersion?: NetworkWrapperType,
+) => {
+  if (networkWrapperVersion === undefined) {
+    return
+  }
+
+  switch (networkWrapperVersion) {
+    case NetworkWrapperType.EIP7594:
+      if (!common.isActivatedEIP(7594)) {
+        throw EthereumJSErrorWithoutCode(
+          'EIP-7594 not enabled on Common for EIP-7594 network wrapper version',
+        )
+      }
+      break
+
+    case NetworkWrapperType.EIP4844:
+      if (common.isActivatedEIP(7594)) {
+        throw EthereumJSErrorWithoutCode(
+          'EIP-7594 is active on Common for EIP-4844 network wrapper version',
+        )
+      }
+      break
+
+    default: {
+      const _exhaustiveCheck: never = networkWrapperVersion
+      throw EthereumJSErrorWithoutCode(`Invalid networkWrapperVersion=${_exhaustiveCheck}`)
+    }
+  }
+}
+
+export const validateBlob4844TxForkConstraints = ({
+  blobVersionedHashes,
+  common,
+  errorBuilder,
+  networkWrapperVersion,
+}: {
+  blobVersionedHashes: BytesLike[]
+  common: Common
+  errorBuilder?: (message: string) => string
+  networkWrapperVersion?: NetworkWrapperType
+}) => {
+  validateNetworkWrapperVersion(common, networkWrapperVersion)
+
+  if (common.isActivatedEIP(7594)) {
+    const maxBlobsPerTx = common.param('maxBlobsPerTx')
+    if (blobVersionedHashes.length > maxBlobsPerTx) {
+      const message = `${blobVersionedHashes.length} blobs exceeds max ${maxBlobsPerTx} blobs per tx (EIP-7594)`
+      throw EthereumJSErrorWithoutCode(errorBuilder !== undefined ? errorBuilder(message) : message)
+    }
+  }
+}
 
 /**
  * Typed transaction with a new gas fee market mechanism for transactions that include "blobs" of data
@@ -121,33 +176,16 @@ export class Blob4844Tx implements TransactionInterface<typeof TransactionType.B
     // Check networkWrapperVersion early, before sharedConstructor, to ensure proper error ordering
     // This validation needs to happen before EIP-7825 gas limit checks
     const common = getCommon(opts.common)
+    common.updateParams(opts.params ?? paramsTx)
     const networkWrapperVersion =
       txData.networkWrapperVersion !== undefined
         ? (bytesToInt(toBytes(txData.networkWrapperVersion)) as NetworkWrapperType)
         : undefined
-
-    if (networkWrapperVersion !== undefined) {
-      switch (networkWrapperVersion) {
-        case NetworkWrapperType.EIP7594:
-          if (!common.isActivatedEIP(7594)) {
-            throw EthereumJSErrorWithoutCode(
-              'EIP-7594 not enabled on Common for EIP-7594 network wrapper version',
-            )
-          }
-          break
-
-        case NetworkWrapperType.EIP4844:
-          if (common.isActivatedEIP(7594)) {
-            throw EthereumJSErrorWithoutCode(
-              'EIP-7594 is active on Common for EIP-4844 network wrapper version',
-            )
-          }
-          break
-
-        default:
-          throw EthereumJSErrorWithoutCode(`Invalid networkWrapperVersion=${networkWrapperVersion}`)
-      }
-    }
+    validateBlob4844TxForkConstraints({
+      blobVersionedHashes: txData.blobVersionedHashes ?? [],
+      common,
+      networkWrapperVersion,
+    })
 
     sharedConstructor(this, { ...txData, type: TransactionType.BlobEIP4844 }, opts)
     const {
@@ -243,17 +281,12 @@ export class Blob4844Tx implements TransactionInterface<typeof TransactionType.B
       throw EthereumJSErrorWithoutCode(msg)
     }
 
-    // EIP-7594 PeerDAS: Limit of 6 blobs per transaction
-    if (this.common.isActivatedEIP(7594)) {
-      const maxBlobsPerTx = this.common.param('maxBlobsPerTx')
-      if (this.blobVersionedHashes.length > maxBlobsPerTx) {
-        const msg = Legacy.errorMsg(
-          this,
-          `${this.blobVersionedHashes.length} blobs exceeds max ${maxBlobsPerTx} blobs per tx (EIP-7594)`,
-        )
-        throw EthereumJSErrorWithoutCode(msg)
-      }
-    }
+    validateBlob4844TxForkConstraints({
+      blobVersionedHashes: this.blobVersionedHashes,
+      common: this.common,
+      errorBuilder: (message) => Legacy.errorMsg(this, message),
+      networkWrapperVersion,
+    })
     if (this.blobVersionedHashes.length === 0) {
       const msg = Legacy.errorMsg(this, `tx should contain at least one blob`)
       throw EthereumJSErrorWithoutCode(msg)

--- a/packages/tx/test/eip7594.spec.ts
+++ b/packages/tx/test/eip7594.spec.ts
@@ -199,7 +199,41 @@ describe('Network wrapper tests', () => {
         ),
       ).toThrowError(/EIP-7594 is active on Common for EIP-4844 network wrapper version/)
     }
-  }, 40_000)
+  }, 60_000)
+
+  it('should reject an EIP-7594 network wrapper on a pre-7594 common during deserialization', async () => {
+    for (const kzg of kzgs) {
+      const blobs = [...getBlobs('hello world'), ...getBlobs('hello world')]
+      const commitments = blobsToCommitments(kzg.lib, blobs)
+      const blobVersionedHashes = commitmentsToVersionedHashes(commitments)
+      const cellProofs = blobsToCellProofs(kzg.lib, blobs)
+      const preOsakaCommon = createCommonFromGethGenesis(osakaGethGenesis.osakaGenesis, {
+        chain: 'customChain',
+        hardfork: Hardfork.Prague,
+        customCrypto: { kzg: kzg.lib },
+      })
+
+      const serialized = createBlob4844Tx(
+        {
+          networkWrapperVersion: 1,
+          blobVersionedHashes,
+          blobs,
+          kzgCommitments: commitments,
+          kzgProofs: cellProofs,
+          maxFeePerBlobGas: 100000000n,
+          gasLimit: 0xffffffn,
+          to: randomBytes(20),
+        },
+        { common: kzg.common },
+      ).serializeNetworkWrapper()
+
+      expect(() =>
+        createBlob4844TxFromSerializedNetworkWrapper(serialized, {
+          common: preOsakaCommon,
+        }),
+      ).toThrowError(/EIP-7594 not enabled on Common for EIP-7594 network wrapper version/)
+    }
+  }, 60_000)
 
   it('should work with all data provided', async () => {
     for (const kzg of kzgs) {
@@ -369,7 +403,7 @@ describe('Network wrapper tests', () => {
         'throws when kzg proof cant be verified',
       )
     }
-  }, 40_000)
+  }, 60_000)
 
   it('should calculate the correct cell proofs', async () => {
     for (const kzg of kzgs) {

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -239,7 +239,7 @@ export class BlockBuilder {
     const previousTransactionCount = this.transactions.length
     const previousTransactionResultCount = this.transactionResults.length
 
-    await this.vm.evm.journal.checkpoint()
+    await this.vm.stateManager.checkpoint()
 
     try {
       // According to the Yellow Paper, a transaction's gas limit
@@ -314,7 +314,7 @@ export class BlockBuilder {
       this.gasUsed += result.totalGasSpent
       this._minerValue += result.minerValue
 
-      await this.vm.evm.journal.commit()
+      await this.vm.stateManager.commit()
 
       return result
     } catch (error) {
@@ -323,7 +323,7 @@ export class BlockBuilder {
       this._minerValue = previousMinerValue
       this.transactions.length = previousTransactionCount
       this.transactionResults.length = previousTransactionResultCount
-      await this.vm.evm.journal.revert()
+      await this.vm.stateManager.revert()
       throw error
     }
   }

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -233,79 +233,99 @@ export class BlockBuilder {
       this.checkpointed = true
     }
 
-    // According to the Yellow Paper, a transaction's gas limit
-    // cannot be greater than the remaining gas in the block
-    const blockGasLimit = toType(this.headerData.gasLimit, TypeOutput.BigInt)
+    const previousBlobGasUsed = this.blobGasUsed
+    const previousGasUsed = this.gasUsed
+    const previousMinerValue = this._minerValue
+    const previousTransactionCount = this.transactions.length
+    const previousTransactionResultCount = this.transactionResults.length
 
-    const blobGasPerBlob = this.vm.common.param('blobGasPerBlob')
+    await this.vm.evm.journal.checkpoint()
 
-    const blockGasRemaining = blockGasLimit - this.gasUsed
-    if (tx.gasLimit > blockGasRemaining) {
-      throw EthereumJSErrorWithoutCode(
-        'tx has a higher gas limit than the remaining gas in the block',
-      )
-    }
-    let blobGasUsed = undefined
-    if (tx instanceof Blob4844Tx) {
-      const { maxBlobGasPerBlock: blobGasLimit } = this.vm.common.getBlobGasSchedule()
-      if (
-        tx.networkWrapperVersion === NetworkWrapperType.EIP4844 &&
-        this.vm.common.isActivatedEIP(7594)
-      ) {
-        throw Error('eip4844 blob transaction for eip7594 activated fork')
-      } else if (
-        tx.networkWrapperVersion === NetworkWrapperType.EIP7594 &&
-        !this.vm.common.isActivatedEIP(7594)
-      ) {
-        throw Error('eip7594 blob transaction but eip not yet activated')
+    try {
+      // According to the Yellow Paper, a transaction's gas limit
+      // cannot be greater than the remaining gas in the block
+      const blockGasLimit = toType(this.headerData.gasLimit, TypeOutput.BigInt)
+
+      const blobGasPerBlob = this.vm.common.param('blobGasPerBlob')
+
+      const blockGasRemaining = blockGasLimit - this.gasUsed
+      if (tx.gasLimit > blockGasRemaining) {
+        throw EthereumJSErrorWithoutCode(
+          'tx has a higher gas limit than the remaining gas in the block',
+        )
       }
-
-      if (this.blockOpts.common?.isActivatedEIP(4844) === false) {
-        throw Error('eip4844 not activated yet for adding a blob transaction')
-      }
-      const blobTx = tx as Blob4844Tx
-
-      // Guard against the case if a tx came into the pool without blobs i.e. network wrapper payload
-      if (blobTx.blobs === undefined) {
-        // TODO: verify if we want this, do we want to allow the block builder to accept blob txs without the actual blobs?
-        // (these must have at least one `blobVersionedHashes`, this is verified at tx-level)
-        if (allowNoBlobs !== true) {
-          throw EthereumJSErrorWithoutCode('blobs missing for 4844 transaction')
+      let blobGasUsed = undefined
+      let txToAdd = tx
+      let nextBlobGasUsed = this.blobGasUsed
+      if (tx instanceof Blob4844Tx) {
+        const { maxBlobGasPerBlock: blobGasLimit } = this.vm.common.getBlobGasSchedule()
+        if (
+          tx.networkWrapperVersion === NetworkWrapperType.EIP4844 &&
+          this.vm.common.isActivatedEIP(7594)
+        ) {
+          throw Error('eip4844 blob transaction for eip7594 activated fork')
+        } else if (
+          tx.networkWrapperVersion === NetworkWrapperType.EIP7594 &&
+          !this.vm.common.isActivatedEIP(7594)
+        ) {
+          throw Error('eip7594 blob transaction but eip not yet activated')
         }
+
+        if (this.blockOpts.common?.isActivatedEIP(4844) === false) {
+          throw Error('eip4844 not activated yet for adding a blob transaction')
+        }
+        const blobTx = tx as Blob4844Tx
+
+        // Guard against the case if a tx came into the pool without blobs i.e. network wrapper payload
+        if (blobTx.blobs === undefined) {
+          // TODO: verify if we want this, do we want to allow the block builder to accept blob txs without the actual blobs?
+          // (these must have at least one `blobVersionedHashes`, this is verified at tx-level)
+          if (allowNoBlobs !== true) {
+            throw EthereumJSErrorWithoutCode('blobs missing for 4844 transaction')
+          }
+        }
+
+        const blobGasDelta = BigInt(blobTx.numBlobs()) * blobGasPerBlob
+        if (this.blobGasUsed + blobGasDelta > blobGasLimit) {
+          throw EthereumJSErrorWithoutCode('block blob gas limit reached')
+        }
+
+        blobGasUsed = this.blobGasUsed
+        txToAdd = createMinimal4844TxFromNetworkWrapper(blobTx, {
+          common: this.blockOpts.common,
+        })
+        nextBlobGasUsed = this.blobGasUsed + blobGasDelta
+      }
+      const header = {
+        ...this.headerData,
+        gasUsed: this.gasUsed,
+        // correct excessBlobGas should already part of headerData used above
+        blobGasUsed,
       }
 
-      if (this.blobGasUsed + BigInt(blobTx.numBlobs()) * blobGasPerBlob > blobGasLimit) {
-        throw EthereumJSErrorWithoutCode('block blob gas limit reached')
-      }
+      const blockData = { header, transactions: this.transactions }
+      const block = createBlock(blockData, this.blockOpts)
 
-      blobGasUsed = this.blobGasUsed
+      const result = await runTx(this.vm, { tx, block, skipHardForkValidation })
+
+      this.blobGasUsed = nextBlobGasUsed
+      this.transactions.push(txToAdd)
+      this.transactionResults.push(result)
+      this.gasUsed += result.totalGasSpent
+      this._minerValue += result.minerValue
+
+      await this.vm.evm.journal.commit()
+
+      return result
+    } catch (error) {
+      this.blobGasUsed = previousBlobGasUsed
+      this.gasUsed = previousGasUsed
+      this._minerValue = previousMinerValue
+      this.transactions.length = previousTransactionCount
+      this.transactionResults.length = previousTransactionResultCount
+      await this.vm.evm.journal.revert()
+      throw error
     }
-    const header = {
-      ...this.headerData,
-      gasUsed: this.gasUsed,
-      // correct excessBlobGas should already part of headerData used above
-      blobGasUsed,
-    }
-
-    const blockData = { header, transactions: this.transactions }
-    const block = createBlock(blockData, this.blockOpts)
-
-    const result = await runTx(this.vm, { tx, block, skipHardForkValidation })
-
-    // If tx is a blob transaction, remove blobs/kzg commitments before adding to block per EIP-4844
-    if (tx instanceof Blob4844Tx) {
-      const txData = tx as Blob4844Tx
-      this.blobGasUsed += BigInt(txData.blobVersionedHashes.length) * blobGasPerBlob
-      tx = createMinimal4844TxFromNetworkWrapper(txData, {
-        common: this.blockOpts.common,
-      })
-    }
-    this.transactions.push(tx)
-    this.transactionResults.push(result)
-    this.gasUsed += result.totalGasSpent
-    this._minerValue += result.minerValue
-
-    return result
   }
 
   /**

--- a/packages/vm/test/api/buildBlock.spec.ts
+++ b/packages/vm/test/api/buildBlock.spec.ts
@@ -118,9 +118,7 @@ describe('BlockBuilder', () => {
         throw new Error('synthetic bookkeeping failure')
       }) as typeof transactions.push
 
-      await expect(blockBuilder.addTransaction(tx)).rejects.toThrow(
-        /synthetic bookkeeping failure/,
-      )
+      await expect(blockBuilder.addTransaction(tx)).rejects.toThrow(/synthetic bookkeeping failure/)
     } finally {
       transactions.push = originalPush
     }

--- a/packages/vm/test/api/buildBlock.spec.ts
+++ b/packages/vm/test/api/buildBlock.spec.ts
@@ -19,11 +19,11 @@ import { concatBytes, createAccount, createZeroAddress } from '@ethereumjs/util'
 import { assert, describe, expect, it } from 'vitest'
 
 import { buildBlock, createVM, runBlock } from '../../src/index.ts'
-
 import { setBalance } from './utils.ts'
 
 import type { Blockchain, ConsensusDict } from '@ethereumjs/blockchain'
 import { SIGNER_A } from '@ethereumjs/testdata'
+import type { TypedTransaction } from '@ethereumjs/tx'
 
 describe('BlockBuilder', () => {
   it('should build a valid block', async () => {
@@ -89,6 +89,53 @@ describe('BlockBuilder', () => {
       0,
       'should have the correct number of tx receipts',
     )
+  })
+
+  it('should revert builder state if post-run bookkeeping fails', async () => {
+    const common = new Common({ chain: Mainnet, hardfork: Hardfork.Istanbul })
+    const genesisBlock = createBlock({ header: { gasLimit: 50000 } }, { common })
+    const blockchain = await createBlockchain({ genesisBlock, common, validateConsensus: false })
+    const vm = await createVM({ common, blockchain })
+
+    await setBalance(vm, SIGNER_A.address)
+
+    const blockBuilder = await buildBlock(vm, {
+      parentBlock: genesisBlock,
+      blockOpts: { calcDifficultyFromHeader: genesisBlock.header, freeze: false },
+    })
+    const originalStateRoot = await vm.stateManager.getStateRoot()
+
+    const transactions = (blockBuilder as any).transactions as TypedTransaction[]
+    const originalPush = transactions.push.bind(transactions)
+    transactions.push = (() => {
+      throw new Error('synthetic bookkeeping failure')
+    }) as typeof transactions.push
+
+    const tx = createLegacyTx(
+      { to: createZeroAddress(), value: 1000, gasLimit: 21000, gasPrice: 1 },
+      { common, freeze: false },
+    ).sign(SIGNER_A.privateKey)
+
+    await expect(blockBuilder.addTransaction(tx)).rejects.toThrow(/synthetic bookkeeping failure/)
+
+    transactions.push = originalPush
+
+    assert.strictEqual(blockBuilder.gasUsed, 0n, 'gas used should be rolled back')
+    assert.strictEqual(blockBuilder.minerValue, 0n, 'miner value should be rolled back')
+    assert.strictEqual(blockBuilder.transactionReceipts.length, 0, 'receipts should be rolled back')
+    assert.deepEqual(
+      await vm.stateManager.getStateRoot(),
+      originalStateRoot,
+      'state root should be rolled back',
+    )
+
+    const { block } = await blockBuilder.build()
+    assert.strictEqual(
+      block.transactions.length,
+      0,
+      'failed tx should not be included in the block',
+    )
+    assert.strictEqual(block.header.gasUsed, 0n, 'failed tx should not affect block gas accounting')
   })
 
   it('should correctly seal a PoW block', async () => {

--- a/packages/vm/test/api/buildBlock.spec.ts
+++ b/packages/vm/test/api/buildBlock.spec.ts
@@ -107,18 +107,23 @@ describe('BlockBuilder', () => {
 
     const transactions = (blockBuilder as any).transactions as TypedTransaction[]
     const originalPush = transactions.push.bind(transactions)
-    transactions.push = (() => {
-      throw new Error('synthetic bookkeeping failure')
-    }) as typeof transactions.push
 
     const tx = createLegacyTx(
       { to: createZeroAddress(), value: 1000, gasLimit: 21000, gasPrice: 1 },
       { common, freeze: false },
     ).sign(SIGNER_A.privateKey)
 
-    await expect(blockBuilder.addTransaction(tx)).rejects.toThrow(/synthetic bookkeeping failure/)
+    try {
+      transactions.push = (() => {
+        throw new Error('synthetic bookkeeping failure')
+      }) as typeof transactions.push
 
-    transactions.push = originalPush
+      await expect(blockBuilder.addTransaction(tx)).rejects.toThrow(
+        /synthetic bookkeeping failure/,
+      )
+    } finally {
+      transactions.push = originalPush
+    }
 
     assert.strictEqual(blockBuilder.gasUsed, 0n, 'gas used should be rolled back')
     assert.strictEqual(blockBuilder.minerValue, 0n, 'miner value should be rolled back')


### PR DESCRIPTION
Implemented the fix for #4271.

I was able to reproduce the user's sceanario and confirm that the issue is valid.

The current BlockBuilder flow does `runTx(...)`, then mutates builder accounting, then reconstructs the minimal blob tx.

That means a throw from minimal tx reconstruction can happen after execution has already committed into the builder journal and after `blobGasUsed` has been mutated, but before the tx/result arrays and `gasUsed` are updated.

The decode path in `4844/constructors.ts` also constructs the tx first and only later assigns `decodedTx.networkWrapperVersion = networkWrapperVersionInt`, so the constructor checks in `tx.ts` do not run against the wire wrapper version during initial decode.

Fix: 

In packages/tx/src/4844/tx.ts and packages/tx/src/4844/constructors.ts, I factored the fork-sensitive blob checks into a shared validator and now run that validation during network-wrapper deserialization before mutating the decoded tx. That closes the split-validation gap where a wrapper_version = 1 payload could be decoded under a pre-7594 Common and only fail later.

In `packages/vm/src/buildBlock.ts`, `BlockBuilder.addTransaction()` is now atomic at the builder level. It creates a nested checkpoint per transaction attempt, precomputes the minimal blob tx before execution, and restores builder counters/arrays on any error. That prevents partial state, `blobGasUsed`, and tx bookkeeping from diverging if something throws mid-flow.