### PR TITLE
vm: EIP-7976 (calldata floor cost)

### DIFF
--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -576,4 +576,13 @@ export const eipsDict: EIPsDict = {
     minimumHardfork: Hardfork.Cancun,
     requiredEIPs: [],
   },
+  /**
+   * Description : Increase calldata floor cost
+   * URL         : https://eips.ethereum.org/EIPS/eip-7976
+   * Status      : Draft
+   */
+  7976: {
+    minimumHardfork: Hardfork.Chainstart,
+    requiredEIPs: [7623],
+  },
 }

--- a/packages/common/src/hardforks.ts
+++ b/packages/common/src/hardforks.ts
@@ -200,6 +200,6 @@ export const hardforksDict: HardforksDict = {
    * Status     : Draft (implementation incomplete + spec still moving!)
    */
   amsterdam: {
-    eips: [7708, 7843, 7778, 7928, 8024],
+    eips: [7708, 7843, 7778, 7928, 7976, 8024],
   },
 }

--- a/packages/tx/src/capabilities/legacy.ts
+++ b/packages/tx/src/capabilities/legacy.ts
@@ -212,8 +212,13 @@ export function getValidationErrors(tx: LegacyTxInterface): string[] {
   let intrinsicGas = tx.getIntrinsicGas()
   if (tx.common.isActivatedEIP(7623)) {
     let tokens = 0
-    for (let i = 0; i < tx.data.length; i++) {
-      tokens += tx.data[i] === 0 ? 1 : 4
+    if (tx.common.isActivatedEIP(7976)) {
+      // EIP-7976: uniform 4 tokens per byte regardless of zero/non-zero
+      tokens = tx.data.length * 4
+    } else {
+      for (let i = 0; i < tx.data.length; i++) {
+        tokens += tx.data[i] === 0 ? 1 : 4
+      }
     }
     const floorCost =
       tx.common.param('txGas') + tx.common.param('totalCostFloorPerToken') * BigInt(tokens)

--- a/packages/tx/src/params.ts
+++ b/packages/tx/src/params.ts
@@ -78,4 +78,10 @@ export const paramsTx: ParamsDict = {
   7825: {
     maxTransactionGasLimit: 16777216, // Maximum gas limit for a single transaction (2^24)
   },
+  /**
+   * Increase calldata floor cost (uniform 64 gas/byte floor)
+   */
+  7976: {
+    totalCostFloorPerToken: 16,
+  },
 }

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -554,8 +554,13 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   if (vm.common.isActivatedEIP(7623)) {
     // Tx should at least cover the floor price for tx data
     let tokens = 0
-    for (let i = 0; i < tx.data.length; i++) {
-      tokens += tx.data[i] === 0 ? 1 : 4
+    if (vm.common.isActivatedEIP(7976)) {
+      // EIP-7976: uniform 4 tokens per byte regardless of zero/non-zero
+      tokens = tx.data.length * 4
+    } else {
+      for (let i = 0; i < tx.data.length; i++) {
+        tokens += tx.data[i] === 0 ? 1 : 4
+      }
     }
     floorCost =
       tx.common.param('txGas') + tx.common.param('totalCostFloorPerToken') * BigInt(tokens)

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -910,7 +910,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // EIP-7778: block-level gas accounting does not subtract tx refunds.
   // For pre-7778 forks this equals the amount paid by the sender.
   results.blockGasSpent = vm.common.isActivatedEIP(7778)
-    ? bigIntMax(totalGasSpentBeforeRefund, floorCost)
+    ? bigIntMax(results.totalGasSpent, floorCost)
     : results.totalGasSpent
 
   results.amountSpent = results.totalGasSpent * gasPrice


### PR DESCRIPTION
## Summary

Initial scaffolding for [EIP-7976](https://eips.ethereum.org/EIPS/eip-7976) (Increase calldata floor cost) — included in the upcoming Amsterdam hardfork.

**Brings test failures down from 1475 to 1394 in the est-dev-blockchain v5.7. tests.** 

### Done
- Register EIP-7976 in `common` (eips, hardforks). Added to the Amsterdam EIP list.
- Add `totalCostFloorPerToken: 16` param under EIP-7976 (raised from EIP-7623's 10).
- Update floor-cost computation in both `vm/runTx.ts` and `tx/capabilities/legacy.ts` to use the EIP-7976 uniform 4 tokens/byte formula when active (vs EIP-7623's 1/4 tokens for zero/non-zero bytes).
- Switch EIP-7778 block-level gas accounting to use post-refund `totalGasSpent` (matches the v570 `full_gas_consumption` and `eip_mainnet` fixtures, where the floor binds only after refunds are subtracted). The earlier pre-refund formula was off by the refund amount in cases where the floor barely binds.

### Status
- Existing Prague + Osaka EIP-7623 stable-state tests: **972 / 972 pass** (no regression).
- New v570 `eip7976_increase_calldata_floor_cost` blockchain fixtures: substantial number passing, including all `execution_gas/full_gas_consumption` cases (12/12) and most `eip_mainnet` cases. A material subset (notably `additional_coverage/test_authorization_list_intrinsic_gas` and several `transaction_validity_type_4` cases) still fail