### PR TITLE
docs: cleanup

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -35,7 +35,7 @@ The EthereumJS project uses [npm workspaces](https://docs.npmjs.com/cli/v7/using
 - `/packages` - Contains all EthereumJS packages
 - `/config` - Shared configuration files and scripts
 - `packages/ethereum-tests` - Git submodule with Ethereum test vectors (legacy)
-- `packages/execution-spec-tests-fixtures` - Git submodule with selected Ethereum test vectors
+- `packages/execution-spec-tests` - Git submodule with selected execution-spec-tests fixtures
 
 ### Scripts
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Below you can find a list of the active packages included in this repository.
 | [@ethereumjs/block][block-package]               | [![NPM Package][block-npm-badge]][block-npm-link]               | [![Block Issues][block-issues-badge]][block-issues-link]                      | [![Actions Status][block-actions-badge]][block-actions-link]               | [![Code Coverage][block-coverage-badge]][block-coverage-link]               |
 | [@ethereumjs/blockchain][blockchain-package]     | [![NPM Package][blockchain-npm-badge]][blockchain-npm-link]     | [![Blockchain Issues][blockchain-issues-badge]][blockchain-issues-link]       | [![Actions Status][blockchain-actions-badge]][blockchain-actions-link]     | [![Code Coverage][blockchain-coverage-badge]][blockchain-coverage-link]     |
 | [@ethereumjs/common][common-package]             | [![NPM Package][common-npm-badge]][common-npm-link]             | [![Common Issues][common-issues-badge]][common-issues-link]                   | [![Actions Status][common-actions-badge]][common-actions-link]             | [![Code Coverage][common-coverage-badge]][common-coverage-link]             |
+| [@ethereumjs/e2store][e2store-package]           | [![NPM Package][e2store-npm-badge]][e2store-npm-link]           | [![E2store Issues][e2store-issues-badge]][e2store-issues-link]                | -                                                                          | -                                                                           |
 | [@ethereumjs/evm][evm-package]                   | [![NPM Package][evm-npm-badge]][evm-npm-link]                   | [![EVM Issues][evm-issues-badge]][evm-issues-link]                            | [![Actions Status][evm-actions-badge]][evm-actions-link]                   | [![Code Coverage][evm-coverage-badge]][evm-coverage-link]                   |
 | [@ethereumjs/genesis][genesis-package]           | [![NPM Package][genesis-npm-badge]][genesis-npm-link]           | [![Genesis Issues][genesis-issues-badge]][genesis-issues-link]                | [![Actions Status][genesis-actions-badge]][genesis-actions-link]           | [![Code Coverage][genesis-coverage-badge]][genesis-coverage-link]           |
 | [@ethereumjs/mpt][mpt-package]                   | [![NPM Package][mpt-npm-badge]][mpt-npm-link]                   | [![MPT Issues][mpt-issues-badge]][mpt-issues-link]                            | [![Actions Status][mpt-actions-badge]][mpt-actions-link]                   | [![Code Coverage][mpt-coverage-badge]][mpt-coverage-link]                   |
@@ -62,8 +63,8 @@ If you're new to the EthereumJS monorepo, this section will help you get up and 
 
 ### Prerequisites
 
-- Node.js (v18 or higher)
-- npm (v8 or higher)
+- Node.js (v20 or higher)
+- npm (v9 or higher)
 - Git
 
 ### Initial Setup
@@ -148,6 +149,10 @@ To inspect code related to a specific package version, refer to the [tags](https
    tx --> client
    vm --> client
    rlp --> util
+   rlp --> e2store
+   util --> e2store
+   block --> e2store
+   blockchain --> e2store
    statemanager --> evm
    statemanager --> vm
    statemanager --> client
@@ -228,6 +233,12 @@ Most packages are [MPL-2.0](<https://tldrlegal.com/license/mozilla-public-licens
 [devp2p-actions-link]: https://github.com/ethereumjs/ethereumjs-monorepo/actions?query=workflow%3A%22Devp2p%22
 [devp2p-coverage-badge]: https://codecov.io/gh/ethereumjs/ethereumjs-monorepo/branch/master/graph/badge.svg?flag=devp2p
 [devp2p-coverage-link]: https://codecov.io/gh/ethereumjs/ethereumjs-monorepo/tree/master/packages/devp2p
+
+[e2store-package]: ./packages/e2store
+[e2store-npm-badge]: https://img.shields.io/npm/v/@ethereumjs/e2store.svg
+[e2store-npm-link]: https://www.npmjs.com/package/@ethereumjs/e2store
+[e2store-issues-badge]: https://img.shields.io/github/issues/ethereumjs/ethereumjs-monorepo/package:%20e2store?label=issues
+[e2store-issues-link]: https://github.com/ethereumjs/ethereumjs-monorepo/issues?q=is%3Aopen+is%3Aissue+label%3A"package%3A+e2store"
 
 [ethash-package]: ./packages/ethash
 [ethash-npm-badge]: https://img.shields.io/npm/v/@ethereumjs/ethash.svg

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -216,13 +216,11 @@ Then start the Lodestar client with:
 
 ## Research & Development
 
-### Verkle/Stateless
+### Stateless
 
-We are active in verkle/stateless research for some time, the [Stateless Implementers Calls](https://github.com/ethereum/pm/issues?q=is%3Aissue%20state%3Aopen%20label%3AStateless) serve as a good entrypoint to grasp what is going on and have some references to current work and testnets.
+We have been active in stateless research for some time, the [Stateless Implementers Calls](https://github.com/ethereum/pm/issues?q=is%3Aissue%20state%3Aopen%20label%3AStateless) serve as a good entrypoint to grasp what is going on and have some references to current work and testnets.
 
-The [verkle-devnets](https://github.com/ethpandaops/verkle-devnets) repository hosts configuration for joining the ongoing testnet efforts.
-
-In the monorepo we have experimental [verkle](./../verkle/) and [binary](./../binarytree/) tree implementations and have integrated both into our [state manager](./../statemanager/) (abstraction of Ethereum state access). All verkle/stateless code gets merged into the `master` branch. In the client there are dedicated flags for stateless execution, see `--help` flag for reference.
+In the monorepo we have an experimental [binary tree](./../binarytree/) implementation that is integrated into our [state manager](./../statemanager/) (abstraction of Ethereum state access).
 
 ### PeerDAS
 
@@ -296,30 +294,6 @@ Some useful commands to start with are (assuming a Kurtosis "enclave" called "hi
 Logs/shell can be directly accessed through the docker UI for containers, also available through Kurtosis though:
 
 - `kurtosis service logs -f spooky-sea el-1-ethereumjs-lighthouse`
-
-### Manual Testnet Setup (Verkle Example)
-
-This is an example how to using the EthereumJS client to manually join a research network.
-
-We currently support the Kaustinen7 testnet, both with stateless and stateful execution. We will be proactively supporting upcoming testnets as they launch. 
-
-Step 1 - Running the EthereumJS client (from the cloned @ethereumjs/client package)
-
-For stateless execution: 
-
-`npm run client:start:ts -- --rpc --gethGenesis=./devnets/kaustinen7/genesis.json --dataDir=datadir/kaust7 --rpcEngine --rpcEngineAuth=false --statelessVerkle=true`
-
-For stateful execution:
-
-`npm run client:start:ts -- --rpc --gethGenesis=./devnets/kaustinen7/genesis.json --dataDir=datadir/kaust7 --rpcEngine --rpcEngineAuth=false --statefulVerkle=true`
-
-Step 2 - Running the Lodestar client (from the cloned Lodestar quick-start repository)
-
-`./setup.sh --network kaustinen7 --dataDir kaust --justCL`
-
-Additional information on the Kaustinen7 testnet can be retrieve from this page: https://verkle-gen-devnet-7.ethpandaops.io/
-
-The process should be similar for other testnets, and the quick-start repository should provide testnet-specific configuration instructions for the Lodestar consensus layer client.
 
 ## Custom Chains
 

--- a/packages/statemanager/DEVELOPER.md
+++ b/packages/statemanager/DEVELOPER.md
@@ -19,12 +19,10 @@ The following initial logger is currently available:
 
 | Logger                          | Description                                              |
 | ------------------------------- | -------------------------------------------------------- |
-| `statemanager:merkle`           | Operations happening on the `MerkleStateManager`         |
-| `statemanager:rpc`              | Operations happening on the `RPCStateManager`            |
-| `statemanager:verkle:stateful`  | Operations happening on the `StatefulVerkleStateManager` |
-| `statemanager:verkle:stateless` | Operations accessing verkle witnesses                    |
-| `statemanager:verkle:aw`        | Operations accessing verkle witnesses                    |
-| `statemanager:cache`            | Operations accessing statemanager caches                 |
+| `statemanager:merkle`           | Operations happening on the `MerkleStateManager`              |
+| `statemanager:rpc`              | Operations happening on the `RPCStateManager`                 |
+| `statemanager:binarytree`       | Operations happening on the `StatefulBinaryTreeStateManager`  |
+| `statemanager:cache`            | Operations accessing statemanager caches                      |
 | `statemanager:cache:code`       | Operations accessing statemanager code cache             |
 | `statemanager:cache:account`    | Operations accessing statemanager account cache          |
 | `statemanager:cache:storage`    | Operations accessing statemanager storage cache          |

--- a/packages/statemanager/README.md
+++ b/packages/statemanager/README.md
@@ -25,7 +25,7 @@
 - [MerkleStateManager](#merklestatemanager)
 - [SimpleStateManager](#simplestatemanager)
 - [RPCStateManager](#rpcstatemanager)
-- [Verkle (experimental)](#verkle-state-managers-experimental)
+- [Binary Tree (experimental)](#binary-tree-experimental)
 - [Browser](#browser)
 - [API](#api)
 - [Development](#development)
@@ -52,8 +52,7 @@ This library includes several different implementations that all implement the `
 - [`SimpleStateManager`](./src/simpleStateManager.ts) -a minimally functional (and dependency minimized) version of the state manager suitable for most basic EVM bytecode operations
 - [`MerkleStateManager`](./src/stateManager.ts) - a Merkle-Patricia Trie-based `MerkleStateManager` implementation that is used by the `@ethereumjs/client` and `@ethereumjs/vm`
 - [`RPCStateManager`](./src/rpcStateManager.ts) - a light-weight implementation that sources state and history data from an external JSON-RPC provider
-- [`StatefulVerkleStateManager`](./src/statefulVerkleStateManager.ts) - an experimental implementation of a stateful verkle state manager
-- [`StatelessVerkleStateManager`](./src/statelessVerkleStateManager.ts) - an experimental implementation of a "stateless" state manager that uses Verkle proofs to provide necessary state access for processing verkle-trie based blocks
+- [`StatefulBinaryTreeStateManager`](./src/statefulBinaryTreeStateManager.ts) - an experimental implementation of a stateful binary tree state manager
 
 It also includes a checkpoint/revert/commit mechanism to either persist or revert state changes and provides a sophisticated caching mechanism under the hood to reduce the need reading state accesses from disk.
 
@@ -271,11 +270,9 @@ Note: Failing to provide the `RPCBlockChain` instance when instantiating the EVM
 
 Refer to [this test script](./test/rpcStateManager.spec.ts) for complete examples of running transactions and blocks in the `vm` with data sourced from a provider.
 
-## Verkle (experimental)
+## Binary Tree (experimental)
 
-There are two new verkle related state managers integrated into the code base. These state managers are very experimental and meant to be used for connecting to early [Verkle Tree](https://eips.ethereum.org/EIPS/eip-6800) test networks (Kaustinen). These state managers are not yet sufficiently tested and APIs are not yet stable and it therefore should not be used in production.
-
-See [PRs around Verkle](https://github.com/search?q=repo%3Aethereumjs%2Fethereumjs-monorepo+verkle&type=pullrequests) in our monorepo for an entrypoint if you are interested in our current Verkle related work.
+The `StatefulBinaryTreeStateManager` is an experimental state manager built on top of the [binary tree](../binarytree/) implementation, intended for stateless-Ethereum research and early test networks. It is not yet sufficiently tested and its APIs are not yet stable; it should not be used in production.
 
 ## Browser
 

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -27,7 +27,6 @@
 - [Module: [request]](#module-request)
 - [Module: [signature]](#module-signature)
 - [Module: [types]](#module-types)
-- [Module: [verkle]](#module-verkle)
 - [Module: [withdrawal]](#module-withdrawal)
 - [Browser](#browser)
 - [API](#api)


### PR DESCRIPTION
## Summary

General docs cleanup as suggested by #3946

- **Add `e2store` to root [README.md](./README.md)**: included in the mermaid relationships diagram (with edges from its deps `rlp`/`util`/`block`/`blockchain`) and added as an Active package row. Issue mention of "era" interpreted as `@ethereumjs/e2store`.
- **Bump prerequisites**: root README now states Node v20+ / npm v9+ to match the actual `engines` field in every package's `package.json`.
- **Fix stale submodule path** in root [DEVELOPER.md](./DEVELOPER.md): `execution-spec-tests-fixtures` → `execution-spec-tests` (the on-disk path).
- **Remove dead verkle references** across [util](./packages/util/README.md), [client](./packages/client/README.md) and [statemanager](./packages/statemanager/README.md) READMEs. The `@ethereumjs/verkle` package was removed in #4145; the README still pointed to a deleted directory, ToC entries for non-existent modules, and obsolete CLI flags (`--statelessVerkle` / `--statefulVerkle`) that no longer exist in the client.
- **Replace dead debug namespaces**: `statemanager:verkle:{stateful,stateless,aw}` are gone from `src/`; replaced with the live `statemanager:binarytree`.

The other items from the issue are already done on `master`:
- `config/E2E_TESTING.md`, `config/MONOREPO.md` and `config/README.md` were consolidated/removed in #3951 and #4079.
- No `verdaccio` references remain anywhere in markdown.
- `binarytree` is already in the mermaid diagram.

## Follow-ups (not in this PR)

1. **`e2store` CI workflow**: there is no `.github/workflows/e2store-build.yml`, so the Actions/Coverage badge cells are intentionally rendered as `-`. Worth adding a workflow before final release, plus a definitive Active vs Deprecated decision (the package's own README still has a "Considered for deprecation" banner).
2. **`util/README.md` ToC drift**: several modules in `src/` (`bal`, `binaryTree`, `authorization`, `blobs`, `lock`, `tasks`, `units`, `env`, `errors`, `helpers`, `provider`) are missing from the ToC. Out of scope here but easy follow-up.