### PR TITLE
Implement EIP-7981: Increase Access List Cost

### DIFF
--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -585,4 +585,13 @@ export const eipsDict: EIPsDict = {
     minimumHardfork: Hardfork.Chainstart,
     requiredEIPs: [7623],
   },
+  /**
+   * Description : Access list data pricing
+   * URL         : https://eips.ethereum.org/EIPS/eip-7981
+   * Status      : Draft
+   */
+  7981: {
+    minimumHardfork: Hardfork.Amsterdam,
+    requiredEIPs: [2930, 7976],
+  },
 }

--- a/packages/common/src/hardforks.ts
+++ b/packages/common/src/hardforks.ts
@@ -200,6 +200,6 @@ export const hardforksDict: HardforksDict = {
    * Status     : Draft (implementation incomplete + spec still moving!)
    */
   amsterdam: {
-    eips: [7708, 7843, 7778, 7928, 7976, 8024],
+    eips: [7708, 7843, 7778, 7928, 7976, 7981, 8024],
   },
 }

--- a/packages/tx/src/capabilities/eip2930.ts
+++ b/packages/tx/src/capabilities/eip2930.ts
@@ -22,7 +22,16 @@ function getAccessListDataGas(tx: EIP2930CompatibleTx): number {
   const totalSlots = accessList.reduce((sum, item) => sum + item[1].length, 0)
   const addresses = accessList.length
 
-  return addresses * Number(accessListAddressCost) + totalSlots * Number(accessListStorageKeyCost)
+  let cost =
+    addresses * Number(accessListAddressCost) + totalSlots * Number(accessListStorageKeyCost)
+
+  // EIP-7981: add floor cost for access list bytes (20 bytes/address + 32 bytes/slot, 4 tokens/byte)
+  if (common.isActivatedEIP(7981)) {
+    const accessListBytes = addresses * 20 + totalSlots * 32
+    cost += Number(common.param('totalCostFloorPerToken')) * accessListBytes * 4
+  }
+
+  return cost
 }
 
 /**

--- a/packages/tx/src/capabilities/eip2930.ts
+++ b/packages/tx/src/capabilities/eip2930.ts
@@ -7,28 +7,26 @@ import type { EIP2930CompatibleTx } from '../types.ts'
  * The amount of gas paid for the data in this tx
  */
 export function getDataGas(tx: EIP2930CompatibleTx): bigint {
-  const eip2930Gas = BigInt(getAccessListDataGas(tx))
-  return Legacy.getDataGas(tx) + eip2930Gas
+  return Legacy.getDataGas(tx) + getAccessListDataGas(tx)
 }
 
 /**
  * Calculates the data gas cost for the access list of a tx
  */
-function getAccessListDataGas(tx: EIP2930CompatibleTx): number {
+function getAccessListDataGas(tx: EIP2930CompatibleTx): bigint {
   const { common, accessList } = tx
   const accessListStorageKeyCost = common.param('accessListStorageKeyGas')
   const accessListAddressCost = common.param('accessListAddressGas')
 
-  const totalSlots = accessList.reduce((sum, item) => sum + item[1].length, 0)
-  const addresses = accessList.length
+  const totalSlots = accessList.reduce((sum, item) => sum + BigInt(item[1].length), 0n)
+  const addresses = BigInt(accessList.length)
 
-  let cost =
-    addresses * Number(accessListAddressCost) + totalSlots * Number(accessListStorageKeyCost)
+  let cost = addresses * accessListAddressCost + totalSlots * accessListStorageKeyCost
 
   // EIP-7981: add floor cost for access list bytes (20 bytes/address + 32 bytes/slot, 4 tokens/byte)
   if (common.isActivatedEIP(7981)) {
-    const accessListBytes = addresses * 20 + totalSlots * 32
-    cost += Number(common.param('totalCostFloorPerToken')) * accessListBytes * 4
+    const accessListBytes = addresses * 20n + totalSlots * 32n
+    cost += common.param('totalCostFloorPerToken') * accessListBytes * 4n
   }
 
   return cost

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -562,6 +562,12 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
         tokens += tx.data[i] === 0 ? 1 : 4
       }
     }
+    // EIP-7981: include access list bytes in floor token count (20 bytes/address + 32 bytes/slot)
+    if (vm.common.isActivatedEIP(7981) && 'accessList' in tx) {
+      const accessList = tx.accessList
+      const totalSlots = accessList.reduce((sum: number, item) => sum + item[1].length, 0)
+      tokens += (accessList.length * 20 + totalSlots * 32) * 4
+    }
     floorCost =
       tx.common.param('txGas') + tx.common.param('totalCostFloorPerToken') * BigInt(tokens)
   }
@@ -570,7 +576,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   const minGasLimit = bigIntMax(intrinsicGas, floorCost)
   if (gasLimit < minGasLimit) {
     const msg = _errorMsg(
-      `tx gas limit ${Number(gasLimit)} is lower than the minimum gas limit of ${Number(
+      `INTRINSIC_GAS_TOO_LOW: tx gas limit ${Number(gasLimit)} is lower than the minimum gas limit of ${Number(
         minGasLimit,
       )}`,
       vm,

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -563,8 +563,8 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
       }
     }
     // EIP-7981: include access list bytes in floor token count (20 bytes/address + 32 bytes/slot)
-    if (vm.common.isActivatedEIP(7981) && 'accessList' in tx) {
-      const accessList = tx.accessList
+    if (vm.common.isActivatedEIP(7981) && tx.supports(Capability.EIP2930AccessLists)) {
+      const accessList = (tx as AccessList2930Tx).accessList
       const totalSlots = accessList.reduce((sum: number, item) => sum + item[1].length, 0)
       tokens += (accessList.length * 20 + totalSlots * 32) * 4
     }

--- a/packages/vm/test/tester/executionSpecBlockchain.test.ts
+++ b/packages/vm/test/tester/executionSpecBlockchain.test.ts
@@ -255,7 +255,7 @@ const exceptionMessages: Record<string, RegExp> = {
     /Transaction's maxFeePerBlobGas \d+\) is less than block blobGasPrice \(\d+\)/,
   'TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS': /tx unable to pay base fee/,
   'TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST': /gasLimit is too low/,
-  'TransactionException.INTRINSIC_GAS_TOO_LOW': /gasLimit is too low/,
+  'TransactionException.INTRINSIC_GAS_TOO_LOW': /gasLimit is too low|INTRINSIC_GAS_TOO_LOW/,
   'TransactionException.NONCE_MISMATCH_TOO_LOW': /the tx doesn't have the correct nonce/,
   'TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS':
     /maxFeePerGas cannot be less than maxPriorityFeePerGas/,


### PR DESCRIPTION
`common`:
- Added EIP-7981 entry to `eips.ts`
- Added 7981 to `Amsterdam` hardfork EIP list

`tx`:
- Updated `getAccessListDataGas` to add the floor cost to the intrinsic gas when EIP-7981 is active

`vm`:
- Extended the floor cost calculation (EIP-7623 block) to also count access list bytes as floor tokens when EIP-7981 is active.



Testing:
 - 79/105 tests passing in `v570_mixed_with_other_eips/eip7981_increase_access_list_cost`
  - All tests for tx type 1, 2, and 3 pass
  - Test for Type 4 tx failing
    - The Type 4 test fixtures likely rely on eip-8037 to pass.

- Brings total test failures in v570 down to 886 from 1394