### PR TITLE
feat: EIP-8037 (State Creation Gas Cost Increase) 

### DIFF
--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -594,4 +594,13 @@ export const eipsDict: EIPsDict = {
     minimumHardfork: Hardfork.Amsterdam,
     requiredEIPs: [2930, 7976],
   },
+  /**
+   * Description : State Creation Gas Cost Increase
+   * URL         : https://eips.ethereum.org/EIPS/eip-8037
+   * Status      : Draft
+   */
+  8037: {
+    minimumHardfork: Hardfork.Amsterdam,
+    requiredEIPs: [2780, 6780, 7702, 7825, 7976, 7981],
+  },
 }

--- a/packages/common/src/hardforks.ts
+++ b/packages/common/src/hardforks.ts
@@ -200,6 +200,6 @@ export const hardforksDict: HardforksDict = {
    * Status     : Draft (implementation incomplete + spec still moving!)
    */
   amsterdam: {
-    eips: [7708, 7843, 7778, 7928, 7976, 7981, 8024],
+    eips: [7708, 7843, 7778, 7928, 7976, 7981, 8024, 8037],
   },
 }

--- a/packages/evm/src/eip8037.ts
+++ b/packages/evm/src/eip8037.ts
@@ -1,0 +1,50 @@
+import { BIGINT_0, BIGINT_1 } from '@ethereumjs/util'
+
+import type { Common } from '@ethereumjs/common'
+
+const TARGET_STATE_GROWTH_PER_YEAR = BigInt(107_374_182_400) // 100 * 1024^3
+const COST_PER_STATE_BYTE_SCALE_NUMERATOR = BigInt(2_628_000)
+const COST_PER_STATE_BYTE_DENOMINATOR = BigInt(2) * TARGET_STATE_GROWTH_PER_YEAR
+const COST_PER_STATE_BYTE_OFFSET = BigInt(9_578)
+const COST_PER_STATE_BYTE_SIGNIFICANT_BITS = 5
+
+function bitLength(n: bigint): number {
+  if (n <= BIGINT_0) return 0
+  return n.toString(2).length
+}
+
+/**
+ * EIP-8037 cost-per-state-byte, parametric in the block gas limit.
+ *
+ *   raw      = ceil(gasLimit * 2_628_000 / (2 * 107_374_182_400))
+ *   shifted  = raw + 9578
+ *   shift    = max(bitLength(shifted) - 5, 0)        // top-5-bit quantization
+ *   rounded  = (shifted >> shift) << shift
+ *   result   = rounded <= 9578 ? 1 : rounded - 9578
+ *
+ * At the spec reference gas limit of 96M this returns 1174.
+ */
+export function computeCostPerStateByte(blockGasLimit: bigint): bigint {
+  const numerator = blockGasLimit * COST_PER_STATE_BYTE_SCALE_NUMERATOR
+  // ceil division
+  const raw =
+    (numerator + COST_PER_STATE_BYTE_DENOMINATOR - BIGINT_1) / COST_PER_STATE_BYTE_DENOMINATOR
+  const shifted = raw + COST_PER_STATE_BYTE_OFFSET
+  const shift = Math.max(bitLength(shifted) - COST_PER_STATE_BYTE_SIGNIFICANT_BITS, 0)
+  const rounded = (shifted >> BigInt(shift)) << BigInt(shift)
+  if (rounded <= COST_PER_STATE_BYTE_OFFSET) return BIGINT_1
+  return rounded - COST_PER_STATE_BYTE_OFFSET
+}
+
+/**
+ * Returns the active cost-per-state-byte to use for charges.
+ * - If EIP-8037 is active and a block gas limit is supplied, the parametric
+ *   formula is used.
+ * - Otherwise falls back to the static `costPerStateByte` common parameter.
+ */
+export function activeCostPerStateByte(common: Common, blockGasLimit?: bigint): bigint {
+  if (common.isActivatedEIP(8037) && blockGasLimit !== undefined && blockGasLimit > BIGINT_0) {
+    return computeCostPerStateByte(blockGasLimit)
+  }
+  return common.param('costPerStateByte')
+}

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -23,6 +23,7 @@ import debugDefault from 'debug'
 import { EventEmitter } from 'eventemitter3'
 
 import { createEIP7708TransferLog } from './eip7708.ts'
+import { activeCostPerStateByte } from './eip8037.ts'
 import { FORMAT } from './eof/constants.ts'
 import { isEOF } from './eof/util.ts'
 import { EVMError } from './errors.ts'
@@ -238,7 +239,11 @@ export class EVM implements EVMInterface {
    *    frame's state_gas_reservoir [...] execution_state_gas_used is
    *    decreased consistently".
    */
-  protected _stateGasSnapshots: Array<{ reservoir: bigint; used: bigint }> = []
+  protected _stateGasSnapshots: Array<{
+    reservoir: bigint
+    used: bigint
+    createdAccountStateGas: Map<PrefixedHexString, bigint>
+  }> = []
 
   /**
    * EIP-8037 SELFDESTRUCT deferred refund support.
@@ -546,16 +551,40 @@ export class EVM implements EVMInterface {
     }
 
     if (exit) {
-      // Even on early exit, we may need to return the EIP-7708 log if value was transferred
-      return {
-        execResult: {
-          gasRefund: message.gasRefund,
-          executionGasUsed: message.gasLimit - gasLimit,
-          exceptionError: errorMessage, // Only defined if addToBalance failed
-          returnValue: new Uint8Array(0),
-          logs: eip7708Log ? [eip7708Log] : undefined,
-        },
+      // Even on early exit, we may need to return the EIP-7708 log if value
+      // was transferred. EIP-8037: still charge state-gas if this empty-code
+      // call created a new account (the frame "succeeded" with no code).
+      const earlyResult: ExecResult = {
+        gasRefund: message.gasRefund,
+        executionGasUsed: message.gasLimit - gasLimit,
+        exceptionError: errorMessage,
+        returnValue: new Uint8Array(0),
+        logs: eip7708Log ? [eip7708Log] : undefined,
       }
+      if (
+        this.common.isActivatedEIP(8037) &&
+        !earlyResult.exceptionError &&
+        !toExistedBefore &&
+        message.value !== BIGINT_0 &&
+        !message.delegatecall &&
+        this.getPrecompile(message.to) === undefined
+      ) {
+        const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
+        const costPerStateByte = activeCostPerStateByte(this.common, this._block?.header.gasLimit)
+        const charge = stateBytesPerNewAccount * costPerStateByte
+        const fromReservoir = charge < this.stateGasReservoir ? charge : this.stateGasReservoir
+        const spill = charge - fromReservoir
+        // EIP-8037: state-gas spill charges the tx-level gas_left, not the
+        // inner frame's budget. We let executionGasUsed exceed message.gasLimit
+        // here; the caller's useGas() picks up the overage and consumes it
+        // from the parent frame's gasLeft (which ultimately bubbles up to
+        // tx-level gas_left). If the tx as a whole runs out, OOG is raised
+        // at the caller frame, not here.
+        this.stateGasReservoir -= fromReservoir
+        this.executionStateGasUsed += charge
+        earlyResult.executionGasUsed += spill
+      }
+      return { execResult: earlyResult }
     }
 
     let result: ExecResult
@@ -624,20 +653,17 @@ export class EVM implements EVMInterface {
       this.getPrecompile(message.to) === undefined
     ) {
       const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
-      const costPerStateByte = this.common.param('costPerStateByte')
+      const costPerStateByte = activeCostPerStateByte(this.common, this._block?.header.gasLimit)
       const charge = stateBytesPerNewAccount * costPerStateByte
       const fromReservoir = charge < this.stateGasReservoir ? charge : this.stateGasReservoir
       const spill = charge - fromReservoir
-      if (result.executionGasUsed + spill > message.gasLimit) {
-        // OOG: the spill into gas_left can't be covered by what's left in
-        // this frame. Convert to an OOG result; the journal-revert path
-        // unwinds the snapshot.
-        result = OOGResult(message.gasLimit)
-      } else {
-        this.stateGasReservoir -= fromReservoir
-        this.executionStateGasUsed += charge
-        result.executionGasUsed += spill
-      }
+      // EIP-8037: state-gas spill charges the tx-level gas_left, not the
+      // current frame's budget. Let executionGasUsed exceed message.gasLimit;
+      // the caller picks up the overage via useGas() and OOG is raised at
+      // the caller frame if there's not enough tx gas overall.
+      this.stateGasReservoir -= fromReservoir
+      this.executionStateGasUsed += charge
+      result.executionGasUsed += spill
     }
 
     return {
@@ -871,7 +897,7 @@ export class EVM implements EVMInterface {
         //   - Creation transaction (depth 0): only L * costPerStateByte; the
         //     stateBytesPerNewAccount portion is already charged as
         //     intrinsic_state_gas in runTx (per spec).
-        const costPerStateByte = this.common.param('costPerStateByte')
+        const costPerStateByte = activeCostPerStateByte(this.common, this._block?.header.gasLimit)
         const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
         const accountStateBytes = message.depth === 0 ? BIGINT_0 : stateBytesPerNewAccount
         stateGasCreate = (accountStateBytes + L) * costPerStateByte
@@ -972,7 +998,9 @@ export class EVM implements EVMInterface {
       // Record the charge keyed on the freshly-created address so runTx
       // can refund it if this account is SELFDESTRUCTed within the same
       // tx (per EIP-8037 SELFDESTRUCT deferred-refund rules).
-      this.createdAccountStateGas.set(message.to.toString(), stateGasCreate)
+      const addrKey = message.to.toString()
+      const prior = this.createdAccountStateGas.get(addrKey) ?? BIGINT_0
+      this.createdAccountStateGas.set(addrKey, prior + stateGasCreate)
     }
 
     // get the fresh gas limit for the rest of the ops
@@ -1253,6 +1281,7 @@ export class EVM implements EVMInterface {
       this._stateGasSnapshots.push({
         reservoir: this.stateGasReservoir,
         used: this.executionStateGasUsed,
+        createdAccountStateGas: new Map(this.createdAccountStateGas),
       })
     }
     if (this.DEBUG) {
@@ -1320,6 +1349,7 @@ export class EVM implements EVMInterface {
         if (snap !== undefined) {
           this.stateGasReservoir = snap.reservoir
           this.executionStateGasUsed = snap.used
+          this.createdAccountStateGas = snap.createdAccountStateGas
         }
       }
       if (this.DEBUG) {

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -229,6 +229,29 @@ export class EVM implements EVMInterface {
   public stateGasReservoir: bigint = BIGINT_0
   /** EIP-8037 cumulative state-gas used by the current transaction. */
   public executionStateGasUsed: bigint = BIGINT_0
+  /**
+   * EIP-8037 per-frame state-gas snapshots. Pushed on each message-level
+   * journal.checkpoint() and popped on commit (drop) or revert / exceptional
+   * halt (restore). Restoring on revert refunds all state-gas charges and
+   * undoes all reservoir refills made within the reverted frame, per spec:
+   *   "all state-gas charged on the child frame is refunded to the parent
+   *    frame's state_gas_reservoir [...] execution_state_gas_used is
+   *    decreased consistently".
+   */
+  protected _stateGasSnapshots: Array<{ reservoir: bigint; used: bigint }> = []
+
+  /**
+   * EIP-8037 SELFDESTRUCT deferred refund support.
+   * Per-address record of the state-gas charged for account creation
+   * (stateBytesPerNewAccount × costPerStateByte) plus code deposit
+   * (L × costPerStateByte) at successful CREATE/CREATE2 frame exit.
+   * Reset at the start of each tx and consulted by runTx to refund
+   * state-gas for accounts that were both created and SELFDESTRUCTed
+   * in the same tx (per EIP-6780 + EIP-8037).
+   * Storage-slot state-gas is not tracked here yet; that is a separate
+   * follow-up.
+   */
+  public createdAccountStateGas: Map<PrefixedHexString, bigint> = new Map()
 
   protected readonly _customOpcodes?: CustomOpcode[]
   protected readonly _customPrecompiles?: CustomPrecompile[]
@@ -440,6 +463,11 @@ export class EVM implements EVMInterface {
 
     // Load `to` account
     let toAccount = await this.stateManager.getAccount(message.to)
+    // EIP-8037: capture whether the destination account existed before this
+    // call frame, used below to decide whether to charge new-account state
+    // gas on successful frame exit. Empty accounts are treated as
+    // non-existent (matches the existing callNewAccountGas trigger).
+    const toExistedBefore = toAccount !== undefined && !toAccount.isEmpty()
     if (!toAccount) {
       if (this.common.isActivatedEIP(6800) || this.common.isActivatedEIP(7864)) {
         const absenceProofAccessGas = message.accessWitness!.readAccountHeader(message.to)
@@ -577,6 +605,40 @@ export class EVM implements EVMInterface {
     }
 
     result.executionGasUsed += message.gasLimit - gasLimit
+
+    // EIP-8037: charge state-gas on successful CALL frame exit when this
+    // call created a new account (non-existent or empty `to` + non-zero
+    // value transfer). On revert / exceptional halt the snapshot mechanism
+    // restores the reservoir, so we only charge on success.
+    // Precompile addresses are excluded: they are code-only entities, not
+    // real account state. Funding a precompile via CALL-with-value does not
+    // create a new "stored" account, so no state-gas charge applies (this
+    // matches the behavior the network's other clients exhibit; without the
+    // skip we regress test_bal_precompile_funded and similar fixtures).
+    if (
+      this.common.isActivatedEIP(8037) &&
+      !result.exceptionError &&
+      !toExistedBefore &&
+      message.value !== BIGINT_0 &&
+      !message.delegatecall &&
+      this.getPrecompile(message.to) === undefined
+    ) {
+      const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
+      const costPerStateByte = this.common.param('costPerStateByte')
+      const charge = stateBytesPerNewAccount * costPerStateByte
+      const fromReservoir = charge < this.stateGasReservoir ? charge : this.stateGasReservoir
+      const spill = charge - fromReservoir
+      if (result.executionGasUsed + spill > message.gasLimit) {
+        // OOG: the spill into gas_left can't be covered by what's left in
+        // this frame. Convert to an OOG result; the journal-revert path
+        // unwinds the snapshot.
+        result = OOGResult(message.gasLimit)
+      } else {
+        this.stateGasReservoir -= fromReservoir
+        this.executionStateGasUsed += charge
+        result.executionGasUsed += spill
+      }
+    }
 
     return {
       execResult: result,
@@ -792,9 +854,37 @@ export class EVM implements EVMInterface {
     // fee for size of the return value
     let totalGas = result.executionGasUsed
     let returnFee = BIGINT_0
+    // EIP-8037 state-gas charge for the new account + code deposit. Computed
+    // here (so failure modes can refund), applied below once the success
+    // branch confirms there is enough total gas to cover regular + state.
+    let stateGasCreate = BIGINT_0
+    let stateGasFromReservoir = BIGINT_0
+    let stateGasSpillToGasLeft = BIGINT_0
     if (!result.exceptionError && !this.common.isActivatedEIP(6800)) {
-      returnFee = BigInt(result.returnValue.length) * BigInt(this.common.param('createDataGas'))
-      totalGas = totalGas + returnFee
+      if (this.common.isActivatedEIP(8037)) {
+        // Regular code-deposit cost: 6 * ceil(L / 32) hash words
+        const L = BigInt(result.returnValue.length)
+        const words = (L + BigInt(31)) / BigInt(32)
+        returnFee = words * this.common.param('codeDepositHashWordGas')
+        // State-gas:
+        //   - CREATE/CREATE2 opcode (depth > 0): (stateBytesPerNewAccount + L) * costPerStateByte
+        //   - Creation transaction (depth 0): only L * costPerStateByte; the
+        //     stateBytesPerNewAccount portion is already charged as
+        //     intrinsic_state_gas in runTx (per spec).
+        const costPerStateByte = this.common.param('costPerStateByte')
+        const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
+        const accountStateBytes = message.depth === 0 ? BIGINT_0 : stateBytesPerNewAccount
+        stateGasCreate = (accountStateBytes + L) * costPerStateByte
+        // Tentatively split the state-gas across the reservoir and the
+        // remaining gas in this CREATE frame. Don't mutate evm.* yet — we
+        // commit only if totalGas (including spill) <= message.gasLimit.
+        stateGasFromReservoir =
+          stateGasCreate < this.stateGasReservoir ? stateGasCreate : this.stateGasReservoir
+        stateGasSpillToGasLeft = stateGasCreate - stateGasFromReservoir
+      } else {
+        returnFee = BigInt(result.returnValue.length) * BigInt(this.common.param('createDataGas'))
+      }
+      totalGas = totalGas + returnFee + stateGasSpillToGasLeft
       if (this.DEBUG) {
         debugGas(`Add return value size fee (${returnFee} to gas used (-> ${totalGas}))`)
       }
@@ -812,6 +902,7 @@ export class EVM implements EVMInterface {
 
     // If enough gas and allowed code size
     let CodestoreOOG = false
+    let createSucceeded = false
     if (totalGas <= message.gasLimit && (this.allowUnlimitedContractSize || allowedCodeSize)) {
       if (this.common.isActivatedEIP(3541) && result.returnValue[0] === FORMAT) {
         if (!this.common.isActivatedEIP(3540)) {
@@ -829,9 +920,11 @@ export class EVM implements EVMInterface {
         } else {
           // 3541 is active and current runtime mode is EOF
           result.executionGasUsed = totalGas
+          createSucceeded = true
         }
       } else {
         result.executionGasUsed = totalGas
+        createSucceeded = true
       }
     } else {
       if (this.common.gteHardfork(Hardfork.Homestead)) {
@@ -865,6 +958,21 @@ export class EVM implements EVMInterface {
           result = { ...result, ...OOGResult(message.gasLimit) }
         }
       }
+    }
+
+    // EIP-8037: commit state-gas accounting now that the success / failure
+    // branch has been chosen. On success the reservoir is debited and
+    // execution_state_gas_used is incremented. On failure the tentative
+    // values are dropped (the journal-revert snapshot will also restore the
+    // reservoir to its frame-entry value, so even any in-frame charges from
+    // the body — e.g. SSTORE — are unwound).
+    if (this.common.isActivatedEIP(8037) && createSucceeded && stateGasCreate > BIGINT_0) {
+      this.stateGasReservoir -= stateGasFromReservoir
+      this.executionStateGasUsed += stateGasCreate
+      // Record the charge keyed on the freshly-created address so runTx
+      // can refund it if this account is SELFDESTRUCTed within the same
+      // tx (per EIP-8037 SELFDESTRUCT deferred-refund rules).
+      this.createdAccountStateGas.set(message.to.toString(), stateGasCreate)
     }
 
     // get the fresh gas limit for the rest of the ops
@@ -1139,6 +1247,14 @@ export class EVM implements EVMInterface {
     }
     await this.journal.checkpoint()
     if (this.common.isActivatedEIP(1153)) this.transientStorage.checkpoint()
+    if (this.common.isActivatedEIP(8037)) {
+      // EIP-8037: snapshot reservoir + cumulative state-gas used at frame
+      // entry so revert / exceptional halt can restore them.
+      this._stateGasSnapshots.push({
+        reservoir: this.stateGasReservoir,
+        used: this.executionStateGasUsed,
+      })
+    }
     if (this.DEBUG) {
       debug('-'.repeat(100))
       debug(`message checkpoint`)
@@ -1196,6 +1312,16 @@ export class EVM implements EVMInterface {
       if (this.common.isActivatedEIP(7928)) {
         this.blockLevelAccessList?.revert()
       }
+      if (this.common.isActivatedEIP(8037)) {
+        // EIP-8037: restore reservoir + cumulative state-gas used to their
+        // values at frame entry, refunding any state-gas charged during the
+        // reverted frame and undoing any in-frame reservoir refills.
+        const snap = this._stateGasSnapshots.pop()
+        if (snap !== undefined) {
+          this.stateGasReservoir = snap.reservoir
+          this.executionStateGasUsed = snap.used
+        }
+      }
       if (this.DEBUG) {
         debug(`message checkpoint reverted`)
       }
@@ -1204,6 +1330,11 @@ export class EVM implements EVMInterface {
       if (this.common.isActivatedEIP(1153)) this.transientStorage.commit()
       if (this.common.isActivatedEIP(7928)) {
         this.blockLevelAccessList?.commit()
+      }
+      if (this.common.isActivatedEIP(8037)) {
+        // EIP-8037: drop the frame's snapshot; current reservoir / used
+        // values flow up to the parent frame.
+        this._stateGasSnapshots.pop()
       }
       if (this.DEBUG) {
         debug(`message checkpoint committed`)

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -216,6 +216,20 @@ export class EVM implements EVMInterface {
 
   public readonly blockLevelAccessList?: BlockLevelAccessList
 
+  /**
+   * EIP-8037 transaction-level state-gas reservoir.
+   * Holds gas paid by the user that exceeds the EIP-7825 regular-gas budget
+   * and is reserved exclusively for state-creation charges. State-gas charges
+   * draw from `stateGasReservoir` first; once exhausted, they fall through to
+   * the regular `gasLeft`. Refunds (revert / exceptional halt / SELFDESTRUCT
+   * of same-tx-created accounts) refill it.
+   * Initialized by runTx at the start of each transaction; 0 when EIP-8037 is
+   * inactive.
+   */
+  public stateGasReservoir: bigint = BIGINT_0
+  /** EIP-8037 cumulative state-gas used by the current transaction. */
+  public executionStateGasUsed: bigint = BIGINT_0
+
   protected readonly _customOpcodes?: CustomOpcode[]
   protected readonly _customPrecompiles?: CustomPrecompile[]
 

--- a/packages/evm/src/index.ts
+++ b/packages/evm/src/index.ts
@@ -71,4 +71,5 @@ export {
 export * from './binaryTreeAccessWitness.ts'
 export * from './constructors.ts'
 export * from './eip7708.ts'
+export * from './eip8037.ts'
 export * from './params.ts'

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -657,6 +657,59 @@ export class Interpreter {
   }
 
   /**
+   * EIP-8037: Charge state-gas. Draws from the per-tx state-gas reservoir
+   * first; if the reservoir is exhausted, the remainder is taken from the
+   * regular `gasLeft` (which may OOG). Increments `execution_state_gas_used`
+   * by the full charged amount.
+   * @param amount - Amount of state gas to charge
+   * @param context - Usage context for debugging
+   * @throws if both pools combined are insufficient (out of gas)
+   */
+  chargeStateGas(amount: bigint, context?: string): void {
+    if (amount === BIGINT_0) return
+    const evm = this._evm
+    let remaining = amount
+    if (evm.stateGasReservoir > BIGINT_0) {
+      const fromReservoir = remaining < evm.stateGasReservoir ? remaining : evm.stateGasReservoir
+      evm.stateGasReservoir -= fromReservoir
+      remaining -= fromReservoir
+    }
+    if (remaining > BIGINT_0) {
+      this.useGas(
+        remaining,
+        context !== undefined ? `state-gas spill: ${context}` : 'state-gas spill',
+      )
+    }
+    evm.executionStateGasUsed += amount
+    if (evm.DEBUG) {
+      debugGas(
+        `${context !== undefined ? context + ': ' : ''}charged ${amount} state gas (reservoir=${evm.stateGasReservoir}, executionStateGasUsed=${evm.executionStateGasUsed}, gasLeft=${this._runState.gasLeft})`,
+      )
+    }
+  }
+
+  /**
+   * EIP-8037: Refill the state-gas reservoir, e.g. on revert / exceptional
+   * halt or on SSTORE clear-back-to-zero where the slot was zero at tx start.
+   * Increments `stateGasReservoir` and decrements `execution_state_gas_used`
+   * by the same amount. Refills always go to the reservoir, regardless of
+   * whether the original charge spilled to gas_left.
+   * @param amount - Amount of state gas to refill
+   * @param context - Usage context for debugging
+   */
+  refillStateGasReservoir(amount: bigint, context?: string): void {
+    if (amount === BIGINT_0) return
+    const evm = this._evm
+    evm.stateGasReservoir += amount
+    evm.executionStateGasUsed -= amount
+    if (evm.DEBUG) {
+      debugGas(
+        `${context !== undefined ? context + ': ' : ''}refilled ${amount} state gas (reservoir=${evm.stateGasReservoir}, executionStateGasUsed=${evm.executionStateGasUsed})`,
+      )
+    }
+  }
+
+  /**
    * Reduces amount of gas to be refunded by a positive value.
    * @param amount - Amount to subtract from gas refunds
    * @param context - Usage context for debugging

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -21,6 +21,7 @@ import {
   EIP7708_SYSTEM_ADDRESS,
   EIP7708_TRANSFER_TOPIC,
 } from './eip7708.ts'
+import { activeCostPerStateByte } from './eip8037.ts'
 import { FORMAT, MAGIC, VERSION } from './eof/constants.ts'
 import { EOFContainerMode, validateEOF } from './eof/container.ts'
 import { setupEOF } from './eof/setup.ts'
@@ -1384,8 +1385,10 @@ export class Interpreter {
     }
 
     // Add to beneficiary balance
+    let beneficiaryWasNew = false
     if (!toSelf) {
       let toAccount = await this._stateManager.getAccount(toAddress)
+      beneficiaryWasNew = toAccount === undefined || toAccount.isEmpty()
       if (!toAccount) {
         toAccount = new Account()
       }
@@ -1400,6 +1403,21 @@ export class Interpreter {
           originalBalance,
         )
       }
+    }
+
+    // EIP-8037: SELFDESTRUCT that transfers value to a non-existent beneficiary
+    // creates a new account. Charge stateBytesPerNewAccount * costPerStateByte.
+    if (
+      this.common.isActivatedEIP(8037) &&
+      !toSelf &&
+      beneficiaryWasNew &&
+      contractBalance > BIGINT_0
+    ) {
+      const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
+      const blockGasLimit = this._env.block.header.gasLimit
+      const costPerStateByte = activeCostPerStateByte(this.common, blockGasLimit)
+      const charge = stateBytesPerNewAccount * costPerStateByte
+      this.chargeStateGas(charge, 'SELFDESTRUCT new beneficiary')
     }
 
     // Modify the account (set balance to 0) flag

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -843,7 +843,40 @@ export const handlers: Map<number, OpHandler> = new Map([
         value = bigIntToBytes(val)
       }
 
+      // EIP-8037: state-gas accounting at the end of SSTORE (per the spec
+      // table). State-gas adjustments only happen when the slot was zero at
+      // the start of the transaction:
+      //   original=0, current=0, new!=0  -> charge stateBytesPerStorageSet * costPerStateByte
+      //   original=0, current!=0, new=0  -> refill stateBytesPerStorageSet * costPerStateByte
+      //   all other (original, current, new) triplets: no adjustment
+      // NB: the regular-gas `sstoreSetGas` (2900 under 8037, was 20000) is
+      // still charged in the dynamic gas function above; this only meters
+      // the state-gas dimension.
+      const common = runState.interpreter._evm.common
+      let originalIsZero = false
+      let currentIsZero = false
+      const newIsZero = val === BIGINT_0
+      if (common.isActivatedEIP(8037)) {
+        const current = await runState.interpreter.storageLoad(keyBuf, false, false)
+        const original = await runState.interpreter.storageLoad(keyBuf, true, false)
+        currentIsZero = current.length === 0
+        originalIsZero = original.length === 0
+      }
+
       await runState.interpreter.storageStore(keyBuf, value)
+
+      if (common.isActivatedEIP(8037) && originalIsZero) {
+        const stateBytes = common.param('stateBytesPerStorageSet')
+        const costPerStateByte = common.param('costPerStateByte')
+        const amount = stateBytes * costPerStateByte
+        if (currentIsZero && !newIsZero) {
+          // 0 -> 0 -> nonzero: new slot, charge state gas
+          runState.interpreter.chargeStateGas(amount, 'SSTORE')
+        } else if (!currentIsZero && newIsZero) {
+          // 0 -> nonzero -> 0: clearing a slot created in this tx, refill reservoir
+          runState.interpreter.refillStateGasReservoir(amount, 'SSTORE clear')
+        }
+      }
     },
   ],
   // 0x56: JUMP

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -28,6 +28,7 @@ import {
 } from '@ethereumjs/util'
 import { keccak_256 } from '@noble/hashes/sha3.js'
 
+import { activeCostPerStateByte } from '../eip8037.ts'
 import { EOFContainer, EOFContainerMode } from '../eof/container.ts'
 import { EOFErrorMessage } from '../eof/errors.ts'
 import { EOFBYTES, EOFHASH, isEOF } from '../eof/util.ts'
@@ -867,14 +868,27 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       if (common.isActivatedEIP(8037) && originalIsZero) {
         const stateBytes = common.param('stateBytesPerStorageSet')
-        const costPerStateByte = common.param('costPerStateByte')
+        const costPerStateByte = activeCostPerStateByte(common, runState.env.block.header.gasLimit)
         const amount = stateBytes * costPerStateByte
         if (currentIsZero && !newIsZero) {
           // 0 -> 0 -> nonzero: new slot, charge state gas
           runState.interpreter.chargeStateGas(amount, 'SSTORE')
+          // Track per-address state-gas spent on storage so a same-tx
+          // SELFDESTRUCT can refund it (account/code already tracked at CREATE).
+          const addrKey = runState.interpreter.getAddress().toString()
+          const evm = runState.interpreter._evm
+          const prior = evm.createdAccountStateGas.get(addrKey) ?? BIGINT_0
+          evm.createdAccountStateGas.set(addrKey, prior + amount)
         } else if (!currentIsZero && newIsZero) {
           // 0 -> nonzero -> 0: clearing a slot created in this tx, refill reservoir
           runState.interpreter.refillStateGasReservoir(amount, 'SSTORE clear')
+          // Symmetric: subtract from the per-address tracker so we don't
+          // double-refund storage that was already cleared inside the tx.
+          const addrKey = runState.interpreter.getAddress().toString()
+          const evm = runState.interpreter._evm
+          const prior = evm.createdAccountStateGas.get(addrKey) ?? BIGINT_0
+          const next = prior > amount ? prior - amount : BIGINT_0
+          evm.createdAccountStateGas.set(addrKey, next)
         }
       }
     },

--- a/packages/evm/src/params.ts
+++ b/packages/evm/src/params.ts
@@ -410,4 +410,24 @@ export const paramsEVM: ParamsDict = {
     // gasPrices
     clzGas: 5, // Base fee of the CLZ opcode (matching MUL as per EIP-7939)
   },
+  /**
+   * State Creation Gas Cost Increase
+   * Regular-gas portions of the state-creation cost overrides per the EIP-8037 parameter table,
+   * plus the new state-gas constants. State-gas charges are derived from these constants and
+   * applied via the reservoir model (see runTx / interpreter).
+   */
+  8037: {
+    // Regular-gas overrides (state portion is metered separately)
+    sstoreSetGas: 2900, // SSTORE 0->nonzero: regular gas (down from 20000); state portion = stateBytesPerStorageSet * costPerStateByte
+    createGas: 9000, // CREATE / CREATE2 base regular gas (down from 32000); state portion = (stateBytesPerNewAccount + L) * costPerStateByte
+    callNewAccountGas: 0, // CALL* to non-existent: regular gas (down from 25000); state portion = stateBytesPerNewAccount * costPerStateByte
+    createDataGas: 0, // Per-byte regular cost of code deposit (down from 200); replaced by costPerStateByte state-gas plus a per-word hash cost (see codeDepositHashWordGas)
+    codeDepositHashWordGas: 6, // Per 32-byte word regular hash cost on contract creation (6 * ceil(L/32))
+    // New state-gas constants (used to compute state-gas charges)
+    costPerStateByte: 1174, // Cost per state byte
+    stateBytesPerStorageSet: 32, // Bytes accounted per new storage slot
+    stateBytesPerNewAccount: 112, // Bytes accounted per newly created account
+    stateBytesPerAuthBase: 23, // Bytes accounted per EIP-7702 authorization base
+    systemMaxSstoresPerCall: 16, // Reservoir headroom for system contract calls
+  },
 }

--- a/packages/evm/src/params.ts
+++ b/packages/evm/src/params.ts
@@ -419,6 +419,8 @@ export const paramsEVM: ParamsDict = {
   8037: {
     // Regular-gas overrides (state portion is metered separately)
     sstoreSetGas: 2900, // SSTORE 0->nonzero: regular gas (down from 20000); state portion = stateBytesPerStorageSet * costPerStateByte
+    sstoreInitEIP2200Gas: 2900, // EIP-2200 path uses this name for the create-slot regular cost; align with sstoreSetGas under 8037
+    sstoreInitRefundEIP2200Gas: 0, // Legacy refund for "create-then-clear-in-same-tx" is replaced by the state-gas reservoir refill
     createGas: 9000, // CREATE / CREATE2 base regular gas (down from 32000); state portion = (stateBytesPerNewAccount + L) * costPerStateByte
     callNewAccountGas: 0, // CALL* to non-existent: regular gas (down from 25000); state portion = stateBytesPerNewAccount * costPerStateByte
     createDataGas: 0, // Per-byte regular cost of code deposit (down from 200); replaced by costPerStateByte state-gas plus a per-word hash cost (see codeDepositHashWordGas)

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -183,6 +183,10 @@ export interface EVMInterface {
   binaryTreeAccessWitness?: BinaryTreeAccessWitness
   systemBinaryTreeAccessWitness?: BinaryTreeAccessWitness
   blockLevelAccessList?: BlockLevelAccessList
+  /** EIP-8037: per-tx state-gas reservoir (set by runTx, read/written by opcodes). */
+  stateGasReservoir: bigint
+  /** EIP-8037: per-tx cumulative state-gas used. */
+  executionStateGasUsed: bigint
 }
 
 export type EVMProfilerOpts = {

--- a/packages/tx/src/params.ts
+++ b/packages/tx/src/params.ts
@@ -85,12 +85,14 @@ export const paramsTx: ParamsDict = {
     totalCostFloorPerToken: 16,
   },
   /**
-   * State Creation Gas Cost Increase — EIP-7702 regular-gas overrides.
-   * State-gas portion of the authorization base/empty-account cost is computed
-   * separately from the EIP-8037 constants (see evm params block).
+   * State Creation Gas Cost Increase — tx-level regular-gas overrides.
+   * State-gas portion of the authorization base/empty-account cost and the
+   * creation-tx state cost are computed separately from the EIP-8037
+   * constants (see evm params block).
    */
   8037: {
     perAuthBaseGas: 7500, // Regular gas per authorization (down from 12500); state portion = stateBytesPerAuthBase * costPerStateByte
     perEmptyAccountCost: 0, // Regular gas for empty authority (down from 25000); state portion = stateBytesPerNewAccount * costPerStateByte (refunded if authority is non-empty)
+    txCreationGas: 9000, // Regular gas for a creation tx (down from 32000); state portion = stateBytesPerNewAccount * costPerStateByte
   },
 }

--- a/packages/tx/src/params.ts
+++ b/packages/tx/src/params.ts
@@ -84,4 +84,13 @@ export const paramsTx: ParamsDict = {
   7976: {
     totalCostFloorPerToken: 16,
   },
+  /**
+   * State Creation Gas Cost Increase — EIP-7702 regular-gas overrides.
+   * State-gas portion of the authorization base/empty-account cost is computed
+   * separately from the EIP-8037 constants (see evm params block).
+   */
+  8037: {
+    perAuthBaseGas: 7500, // Regular gas per authorization (down from 12500); state portion = stateBytesPerAuthBase * costPerStateByte
+    perEmptyAccountCost: 0, // Regular gas for empty authority (down from 25000); state portion = stateBytesPerNewAccount * costPerStateByte (refunded if authority is non-empty)
+  },
 }

--- a/packages/tx/src/util/internal.ts
+++ b/packages/tx/src/util/internal.ts
@@ -181,8 +181,13 @@ export function sharedConstructor(
   // EIP-2681 limits nonce to 2^64-1 (cannot equal 2^64-1)
   valueOverflowCheck({ nonce: tx.nonce }, 64, true)
 
-  // EIP-7825: Transaction Gas Limit Cap
-  if (tx.common.isActivatedEIP(7825)) {
+  // EIP-7825: Transaction Gas Limit Cap.
+  // Under EIP-8037 the cap applies to the regular-gas dimension only (state-gas
+  // is capped solely by tx.gas), so the tx-level total-gas-limit cap is lifted
+  // here. The runTx-level validation enforces
+  // `max(intrinsic_regular_gas, calldata_floor_gas_cost) <= TX_MAX_GAS_LIMIT`
+  // instead.
+  if (tx.common.isActivatedEIP(7825) && !tx.common.isActivatedEIP(8037)) {
     const maxGasLimit = tx.common.param('maxTransactionGasLimit')
     if (tx.gasLimit > maxGasLimit) {
       throw EthereumJSErrorWithoutCode(

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -22,6 +22,7 @@ import {
   GWEI_TO_WEI,
   KECCAK256_RLP,
   TypeOutput,
+  bytesToBigInt,
   createWithdrawal,
   createZeroAddress,
   toBytes,
@@ -365,7 +366,13 @@ export class BlockBuilder {
     let requestsHash
     if (this.vm.common.isActivatedEIP(7685)) {
       const sha256Function = this.vm.common.customCrypto.sha256 ?? sha256
-      requests = await accumulateRequests(this.vm, this.transactionResults)
+      requests = await accumulateRequests(
+        this.vm,
+        this.transactionResults,
+        this.headerData.gasLimit !== undefined
+          ? bytesToBigInt(toBytes(this.headerData.gasLimit))
+          : undefined,
+      )
       requestsHash = genRequestsRoot(requests, sha256Function)
     }
 

--- a/packages/vm/src/requests.ts
+++ b/packages/vm/src/requests.ts
@@ -1,6 +1,8 @@
 import { Mainnet } from '@ethereumjs/common'
+import { activeCostPerStateByte } from '@ethereumjs/evm'
 import type { BlockLevelAccessList, PrefixedHexString } from '@ethereumjs/util'
 import {
+  BIGINT_0,
   CLRequest,
   CLRequestType,
   EthereumJSErrorWithoutCode,
@@ -15,6 +17,60 @@ import {
 
 import type { RunTxResult } from './types.ts'
 import type { VM } from './vm.ts'
+
+/**
+ * EIP-8037 system-call gas split.
+ *   regular gas_left   = 30_000_000 (unchanged)
+ *   reservoir          = stateBytesPerStorageSet * costPerStateByte(blockGasLimit) * 16
+ *
+ * Returns the regular gas portion (passed to runCall) and the reservoir
+ * portion (set on vm.evm before the call). The block argument is required
+ * under 8037 so costPerStateByte scales with the current block's gas limit.
+ */
+function computeSystemCallGas(
+  vm: VM,
+  blockGasLimit?: bigint,
+): { regular: bigint; reservoir: bigint } {
+  const regular = vm.common.param('systemCallGasLimit')
+  if (!vm.common.isActivatedEIP(8037)) {
+    return { regular, reservoir: BIGINT_0 }
+  }
+  const stateBytesPerStorageSet = vm.common.param('stateBytesPerStorageSet')
+  const systemMaxSstoresPerCall = BigInt(16)
+  const costPerStateByte = activeCostPerStateByte(vm.common, blockGasLimit)
+  const reservoir = stateBytesPerStorageSet * costPerStateByte * systemMaxSstoresPerCall
+  return { regular, reservoir }
+}
+
+/**
+ * Snapshot/restore the per-EVM 8037 reservoir state around a system call
+ * so the system call's state-gas accounting is isolated from any
+ * concurrent tx-level reservoir.
+ */
+function setupSystemCallReservoir(vm: VM, reservoir: bigint) {
+  if (!vm.common.isActivatedEIP(8037)) return null
+  const evm = vm.evm
+  const prior = {
+    reservoir: evm.stateGasReservoir,
+    used: evm.executionStateGasUsed,
+    snapshots: (evm as unknown as { _stateGasSnapshots: unknown[] })._stateGasSnapshots,
+  }
+  evm.stateGasReservoir = reservoir
+  evm.executionStateGasUsed = BIGINT_0
+  ;(evm as unknown as { _stateGasSnapshots: unknown[] })._stateGasSnapshots = []
+  return prior
+}
+
+function teardownSystemCallReservoir(
+  vm: VM,
+  prior: { reservoir: bigint; used: bigint; snapshots: unknown[] } | null,
+) {
+  if (prior === null) return
+  const evm = vm.evm
+  evm.stateGasReservoir = prior.reservoir
+  evm.executionStateGasUsed = prior.used
+  ;(evm as unknown as { _stateGasSnapshots: unknown[] })._stateGasSnapshots = prior.snapshots
+}
 
 const DEPOSIT_TOPIC = '0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5'
 const PUBKEY_OFFSET = BigInt(160)
@@ -79,6 +135,7 @@ function restoreSystemAccessEntry(
 export const accumulateRequests = async (
   vm: VM,
   txResults: RunTxResult[],
+  blockGasLimit?: bigint,
 ): Promise<CLRequest<CLRequestType>[]> => {
   const requests: CLRequest<CLRequestType>[] = []
   const common = vm.common
@@ -93,12 +150,12 @@ export const accumulateRequests = async (
   }
 
   if (common.isActivatedEIP(7002)) {
-    const withdrawalsRequest = await accumulateWithdrawalsRequest(vm)
+    const withdrawalsRequest = await accumulateWithdrawalsRequest(vm, blockGasLimit)
     requests.push(withdrawalsRequest)
   }
 
   if (common.isActivatedEIP(7251)) {
-    const consolidationsRequest = await accumulateConsolidationsRequest(vm)
+    const consolidationsRequest = await accumulateConsolidationsRequest(vm, blockGasLimit)
     requests.push(consolidationsRequest)
   }
 
@@ -108,6 +165,7 @@ export const accumulateRequests = async (
 
 const accumulateWithdrawalsRequest = async (
   vm: VM,
+  blockGasLimit?: bigint,
 ): Promise<CLRequest<typeof CLRequestType.Withdrawal>> => {
   // Partial withdrawals logic
   const addressBytes = setLengthLeft(
@@ -128,11 +186,14 @@ const accumulateWithdrawalsRequest = async (
 
   const systemAddressHex = systemAddress.toString()
   const balSnapshot = cloneSystemAccessEntry(vm, systemAddressHex)
+  const { regular, reservoir } = computeSystemCallGas(vm, blockGasLimit)
+  const reservoirPrior = setupSystemCallReservoir(vm, reservoir)
   const results = await vm.evm.runCall({
     caller: systemAddress,
-    gasLimit: vm.common.param('systemCallGasLimit'),
+    gasLimit: regular,
     to: withdrawalsAddress,
   })
+  teardownSystemCallReservoir(vm, reservoirPrior)
   restoreSystemAccessEntry(vm, systemAddressHex, balSnapshot)
 
   if (systemAccount === undefined) {
@@ -147,6 +208,7 @@ const accumulateWithdrawalsRequest = async (
 
 const accumulateConsolidationsRequest = async (
   vm: VM,
+  blockGasLimit?: bigint,
 ): Promise<CLRequest<typeof CLRequestType.Consolidation>> => {
   // Partial withdrawals logic
   const addressBytes = setLengthLeft(
@@ -167,11 +229,14 @@ const accumulateConsolidationsRequest = async (
 
   const systemAddressHex = systemAddress.toString()
   const balSnapshot = cloneSystemAccessEntry(vm, systemAddressHex)
+  const { regular, reservoir } = computeSystemCallGas(vm, blockGasLimit)
+  const reservoirPrior = setupSystemCallReservoir(vm, reservoir)
   const results = await vm.evm.runCall({
     caller: systemAddress,
-    gasLimit: vm.common.param('systemCallGasLimit'),
+    gasLimit: regular,
     to: consolidationsAddress,
   })
+  teardownSystemCallReservoir(vm, reservoirPrior)
   restoreSystemAccessEntry(vm, systemAddressHex, balSnapshot)
 
   if (systemAccount === undefined) {

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -609,8 +609,14 @@ async function applyTransactions(vm: VM, block: Block, opts: RunBlockOpts) {
   }
 
   const bloom = new Bloom(undefined, vm.common)
-  // Block header gas accounting (EIP-7778: no refund subtraction)
+  // Block header gas accounting (EIP-7778: no refund subtraction).
+  // Under EIP-8037 this is the bottleneck of two dimensions:
+  //   gas_used = max(block_regular_gas_used, block_state_gas_used)
+  // tracked via blockRegularGasUsed / blockStateGasUsed below.
   let gasUsed = BIGINT_0
+  // EIP-8037 per-dimension accumulators
+  let blockRegularGasUsed = BIGINT_0
+  let blockStateGasUsed = BIGINT_0
   // Receipt cumulative gas accounting (keeps tx refund subtraction semantics)
   let receiptGasUsed = BIGINT_0
 
@@ -637,10 +643,32 @@ async function applyTransactions(vm: VM, block: Block, opts: RunBlockOpts) {
       )
     }
 
-    const gasLimitIsHigherThanBlock = block.header.gasLimit < tx.gasLimit + gasUsed
-    if (gasLimitIsHigherThanBlock) {
-      const msg = _errorMsg('tx has a higher gas limit than the block', vm, block)
-      throw EthereumJSErrorWithoutCode(msg)
+    // EIP-8037 pre-execution check (spec):
+    //   min(TX_MAX_GAS_LIMIT, tx.gas) <= regular_gas_available
+    //   tx.gas <= state_gas_available
+    // where *_available = block.gas_limit - block_*_gas_used.
+    // Pre-EIP-8037 keeps the original check (`tx.gasLimit + gasUsed <= block.gasLimit`).
+    if (vm.common.isActivatedEIP(8037)) {
+      const txMax = tx.common.param('maxTransactionGasLimit')
+      const regularAvailable =
+        block.header.gasLimit > blockRegularGasUsed
+          ? block.header.gasLimit - blockRegularGasUsed
+          : BIGINT_0
+      const stateAvailable =
+        block.header.gasLimit > blockStateGasUsed
+          ? block.header.gasLimit - blockStateGasUsed
+          : BIGINT_0
+      const txRegularBound = tx.gasLimit < txMax ? tx.gasLimit : txMax
+      if (txRegularBound > regularAvailable || tx.gasLimit > stateAvailable) {
+        const msg = _errorMsg('tx has a higher gas limit than the block', vm, block)
+        throw EthereumJSErrorWithoutCode(msg)
+      }
+    } else {
+      const gasLimitIsHigherThanBlock = block.header.gasLimit < tx.gasLimit + gasUsed
+      if (gasLimitIsHigherThanBlock) {
+        const msg = _errorMsg('tx has a higher gas limit than the block', vm, block)
+        throw EthereumJSErrorWithoutCode(msg)
+      }
     }
 
     // Run the tx through the VM
@@ -660,8 +688,22 @@ async function applyTransactions(vm: VM, block: Block, opts: RunBlockOpts) {
       debug('-'.repeat(100))
     }
 
-    // Add to total block gas usage
-    gasUsed += txRes.blockGasSpent
+    // Add to total block gas usage.
+    // Pre-EIP-8037: single-dimension accumulator (blockGasSpent already
+    // applies the EIP-7623 calldata floor and respects EIP-7778's no-refund
+    // semantics).
+    // EIP-8037: track regular and state dimensions independently and use
+    // their max as the block's gas_used. tx_regular_gas/tx_state_gas come
+    // from runTx; the calldata floor applies to the regular dimension.
+    if (vm.common.isActivatedEIP(8037) && txRes.txRegularGas !== undefined) {
+      const txRegular =
+        txRes.txRegularGas > txRes.blockGasSpent ? txRes.txRegularGas : txRes.blockGasSpent
+      blockRegularGasUsed += txRegular
+      blockStateGasUsed += txRes.txStateGas ?? BIGINT_0
+      gasUsed = blockRegularGasUsed > blockStateGasUsed ? blockRegularGasUsed : blockStateGasUsed
+    } else {
+      gasUsed += txRes.blockGasSpent
+    }
     receiptGasUsed += txRes.totalGasSpent
     if (vm.DEBUG) {
       debug(`Add tx gas used (${txRes.blockGasSpent}) to total block gas usage (-> ${gasUsed})`)

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -191,7 +191,7 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
   let requests: CLRequest<CLRequestType>[] | undefined
   if (block.common.isActivatedEIP(7685)) {
     const sha256Function = vm.common.customCrypto.sha256 ?? sha256
-    requests = await accumulateRequests(vm, result.results)
+    requests = await accumulateRequests(vm, result.results, block.header.gasLimit)
     requestsHash = genRequestsRoot(requests, sha256Function)
   }
 
@@ -696,9 +696,13 @@ async function applyTransactions(vm: VM, block: Block, opts: RunBlockOpts) {
     // their max as the block's gas_used. tx_regular_gas/tx_state_gas come
     // from runTx; the calldata floor applies to the regular dimension.
     if (vm.common.isActivatedEIP(8037) && txRes.txRegularGas !== undefined) {
-      const txRegular =
-        txRes.txRegularGas > txRes.blockGasSpent ? txRes.txRegularGas : txRes.blockGasSpent
-      blockRegularGasUsed += txRegular
+      // EIP-8037: track regular and state dimensions independently and use
+      // their max as the block's gas_used. txRegularGas already incorporates
+      // the EIP-7623 calldata floor (max(intrinsic+exec_regular, floorCost))
+      // applied in runTx, so we accumulate it directly without re-max'ing
+      // against blockGasSpent (which is the combined regular+state total
+      // and would inflate blockRegular).
+      blockRegularGasUsed += txRes.txRegularGas
       blockStateGasUsed += txRes.txStateGas ?? BIGINT_0
       gasUsed = blockRegularGasUsed > blockStateGasUsed ? blockRegularGasUsed : blockStateGasUsed
     } else {

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -4,6 +4,7 @@ import {
   BinaryTreeAccessWitness,
   type EVM,
   type Log,
+  activeCostPerStateByte,
   createEIP7708SelfdestructLog,
 } from '@ethereumjs/evm'
 import { Capability, isBlob4844Tx } from '@ethereumjs/tx'
@@ -89,8 +90,10 @@ async function processAuthorizationList(
   tx: EIP7702CompatibleTx,
   caller: Address,
   initialGasRefund: bigint,
-): Promise<bigint> {
+  block: Block | undefined,
+): Promise<{ gasRefund: bigint; existingAuthStateGasRefund: bigint }> {
   let gasRefund = initialGasRefund
+  let existingAuthStateGasRefund = BIGINT_0
   const authorizationList = tx.authorizationList
 
   for (let i = 0; i < authorizationList.length; i++) {
@@ -176,6 +179,17 @@ async function processAuthorizationList(
       gasRefund += refund
     }
 
+    // EIP-8037: under 8037, the intrinsic state-gas charge for each auth
+    // includes (stateBytesPerNewAccount + stateBytesPerAuthBase) * costPerStateByte.
+    // If the authority account already existed, refund the
+    // stateBytesPerNewAccount * costPerStateByte portion to the reservoir
+    // (no 20% cap).
+    if (accountExists && tx.common.isActivatedEIP(8037)) {
+      const stateBytesPerNewAccount = vm.common.param('stateBytesPerNewAccount')
+      const costPerStateByte = activeCostPerStateByte(vm.common, block?.header.gasLimit)
+      existingAuthStateGasRefund += stateBytesPerNewAccount * costPerStateByte
+    }
+
     // Update account nonce and store
     account.nonce++
     await vm.evm.journal.putAccount(authority, account)
@@ -219,7 +233,7 @@ async function processAuthorizationList(
     }
   }
 
-  return gasRefund
+  return { gasRefund, existingAuthStateGasRefund }
 }
 
 /**
@@ -588,7 +602,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   let intrinsicStateGas = BIGINT_0
   let stateGasReservoirInitial = BIGINT_0
   if (vm.common.isActivatedEIP(8037)) {
-    const costPerStateByte = vm.common.param('costPerStateByte')
+    const costPerStateByte = activeCostPerStateByte(vm.common, block?.header.gasLimit)
     const stateBytesPerNewAccount = vm.common.param('stateBytesPerNewAccount')
     const stateBytesPerAuthBase = vm.common.param('stateBytesPerAuthBase')
 
@@ -878,8 +892,17 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
 
   // Process EIP-7702 authorization list (if applicable)
   let gasRefund = BIGINT_0
+  let existingAuthStateGasRefund = BIGINT_0
   if (tx.supports(Capability.EIP7702EOACode)) {
-    gasRefund = await processAuthorizationList(vm, tx as EIP7702CompatibleTx, caller, gasRefund)
+    const result = await processAuthorizationList(
+      vm,
+      tx as EIP7702CompatibleTx,
+      caller,
+      gasRefund,
+      block,
+    )
+    gasRefund = result.gasRefund
+    existingAuthStateGasRefund = result.existingAuthStateGasRefund
   }
 
   if (vm.DEBUG) {
@@ -910,7 +933,11 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // EIP-8037: install the per-tx reservoir on the EVM so opcodes / frame-exit
   // hooks can charge / refill state-gas across the whole transaction.
   if (vm.common.isActivatedEIP(8037)) {
-    vm.evm.stateGasReservoir = stateGasReservoirInitial
+    // Apply 7702 existing-authority refund directly to evm.stateGasReservoir
+    // (NOT to stateGasReservoirInitial, which is the snapshot used by the
+    // tx-end formula `tx.gas - gas_left - reservoir_end`; including the
+    // refund there would overstate tx_gas_used by the refund amount).
+    vm.evm.stateGasReservoir = stateGasReservoirInitial + existingAuthStateGasRefund
     vm.evm.executionStateGasUsed = BIGINT_0
     // Reset any per-frame state-gas snapshot stack left over from a previous
     // tx. Each tx starts at frame depth 0 with an empty snapshot stack.
@@ -1013,7 +1040,11 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     const stateGasFromGasLeft = executionStateGasUsed - reservoirDelta
     const executionRegularGasUsed = results.execResult.executionGasUsed - stateGasFromGasLeft
     results.txStateGas = intrinsicStateGas + executionStateGasUsed
-    results.txRegularGas = intrinsicRegularGas + executionRegularGasUsed
+    // Per EIP-8037: block_regular_gas_used += max(tx_regular_gas, calldata_floor)
+    // Apply the EIP-7623 floor to the regular dimension here so runBlock can
+    // accumulate dimensions independently.
+    const txRegularGasRaw = intrinsicRegularGas + executionRegularGasUsed
+    results.txRegularGas = txRegularGasRaw > floorCost ? txRegularGasRaw : floorCost
   }
   results.totalGasSpent = totalGasSpentBeforeRefund
   if (vm.DEBUG) {

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -912,6 +912,13 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   if (vm.common.isActivatedEIP(8037)) {
     vm.evm.stateGasReservoir = stateGasReservoirInitial
     vm.evm.executionStateGasUsed = BIGINT_0
+    // Reset any per-frame state-gas snapshot stack left over from a previous
+    // tx. Each tx starts at frame depth 0 with an empty snapshot stack.
+    ;(vm.evm as unknown as { _stateGasSnapshots: unknown[] })._stateGasSnapshots = []
+    // Reset the per-tx record of state-gas charged for newly-created
+    // accounts, used for the SELFDESTRUCT deferred refund.
+    ;(vm.evm as unknown as { createdAccountStateGas: Map<string, bigint> }).createdAccountStateGas =
+      new Map()
   }
 
   const results = (await vm.evm.runCall({
@@ -956,6 +963,32 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // ===========================
   // RESULTS: Gas and Balances
   // ===========================
+  // EIP-8037 SELFDESTRUCT deferred refund: for any address that was both
+  // created in this tx and SELFDESTRUCTed during it, refund the state-gas
+  // charged at CREATE time (account + code deposit). These refunds go
+  // directly to the reservoir and decrement execution_state_gas_used by
+  // the same amount, and are NOT subject to the 20% refund cap.
+  // (Storage-slot state-gas tracking per-account is a separate follow-up;
+  // this covers the pure account+code-deposit refund cases that otherwise
+  // regress vs the parent branch.)
+  if (vm.common.isActivatedEIP(8037)) {
+    const sd = results.execResult.selfdestruct
+    const created = results.execResult.createdAddresses
+    const map = (vm.evm as unknown as { createdAccountStateGas: Map<string, bigint> })
+      .createdAccountStateGas
+    if (sd !== undefined && created !== undefined && map.size > 0) {
+      for (const addr of sd.keys()) {
+        if (created.has(addr)) {
+          const charge = map.get(addr)
+          if (charge !== undefined && charge > BIGINT_0) {
+            vm.evm.stateGasReservoir += charge
+            vm.evm.executionStateGasUsed -= charge
+          }
+        }
+      }
+    }
+  }
+
   // Calculate tx gas used before refund processing.
   // Pre-EIP-8037: tx_gas_used = intrinsic + executionGasUsed.
   // EIP-8037: tx_gas_used_before_refund = tx.gas - gas_left - state_gas_reservoir

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -638,7 +638,22 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     //   regular_gas_budget = TX_MAX_GAS_LIMIT - intrinsic_regular_gas
     //   gas_left           = min(regular_gas_budget, execution_gas)
     //   reservoir          = execution_gas - gas_left
-    const txMaxGasLimit = vm.common.param('maxTransactionGasLimit')
+    // EIP-7825 cap applies only to the regular-gas dimension under 8037:
+    //   max(intrinsic_regular_gas, calldata_floor_gas_cost) <= TX_MAX_GAS_LIMIT.
+    // (tx.common is used because `maxTransactionGasLimit` lives in the tx
+    // params block, which is merged into tx.common but may not be merged into
+    // vm.common in all configurations.)
+    const txMaxGasLimit = tx.common.param('maxTransactionGasLimit')
+    const regularCapCheck = bigIntMax(intrinsicRegularGas, floorCost)
+    if (regularCapCheck > txMaxGasLimit) {
+      const msg = _errorMsg(
+        `Transaction intrinsic regular gas ${regularCapCheck} exceeds the EIP-7825 cap (${txMaxGasLimit})`,
+        vm,
+        block,
+        tx,
+      )
+      throw EthereumJSErrorWithoutCode(msg)
+    }
     const executionGas = gasLimit - totalIntrinsic
     const regularBudget =
       txMaxGasLimit > intrinsicRegularGas ? txMaxGasLimit - intrinsicRegularGas : BIGINT_0

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -166,7 +166,12 @@ async function processAuthorizationList(
     }
 
     // Calculate gas refund for existing accounts
-    if (accountExists) {
+    // EIP-8037: under 8037, the existing-authority refund is moved to the
+    // state-gas reservoir (refund of stateBytesPerNewAccount × costPerStateByte), and is
+    // applied during authorization processing in a follow-up step. Skip the
+    // legacy regular-gas refund here to avoid producing a negative refund
+    // (under 8037 perEmptyAccountCost = 0, perAuthBaseGas = 7500).
+    if (accountExists && !tx.common.isActivatedEIP(8037)) {
       const refund = tx.common.param('perEmptyAccountCost') - tx.common.param('perAuthBaseGas')
       gasRefund += refund
     }
@@ -572,8 +577,50 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
       tx.common.param('txGas') + tx.common.param('totalCostFloorPerToken') * BigInt(tokens)
   }
 
+  // ===========================
+  // EIP-8037: split intrinsic gas into regular + state and initialize the
+  // transaction-level state-gas reservoir. The reservoir holds gas paid by
+  // the user that exceeds the EIP-7825 regular-gas budget; it is reserved
+  // for state-creation charges and is plumbed onto the EVM instance so
+  // child frames can draw from / refill it across the whole transaction.
+  // ===========================
+  let intrinsicRegularGas = intrinsicGas
+  let intrinsicStateGas = BIGINT_0
+  let stateGasReservoirInitial = BIGINT_0
+  if (vm.common.isActivatedEIP(8037)) {
+    const costPerStateByte = vm.common.param('costPerStateByte')
+    const stateBytesPerNewAccount = vm.common.param('stateBytesPerNewAccount')
+    const stateBytesPerAuthBase = vm.common.param('stateBytesPerAuthBase')
+
+    // 7702 intrinsic correction: getDataGas adds (authCount * perEmptyAccountCost)
+    // to the regular intrinsic, but under EIP-8037 perEmptyAccountCost = 0 and
+    // the regular per-auth cost is perAuthBaseGas instead. Add the missing
+    // regular per-auth amount here.
+    let authCount = 0
+    if (tx.type === 4 /* EOACode7702Tx */) {
+      authCount = (tx as EIP7702CompatibleTx).authorizationList.length
+      intrinsicRegularGas += BigInt(authCount) * tx.common.param('perAuthBaseGas')
+    }
+
+    // intrinsic_state_gas = creation tx state portion + per-auth state portion
+    let isCreate = false
+    try {
+      isCreate = tx.toCreationAddress()
+    } catch {
+      isCreate = false
+    }
+    if (isCreate) {
+      intrinsicStateGas += stateBytesPerNewAccount * costPerStateByte
+    }
+    if (authCount > 0) {
+      intrinsicStateGas +=
+        BigInt(authCount) * (stateBytesPerNewAccount + stateBytesPerAuthBase) * costPerStateByte
+    }
+  }
+  const totalIntrinsic = intrinsicRegularGas + intrinsicStateGas
+
   let gasLimit = tx.gasLimit
-  const minGasLimit = bigIntMax(intrinsicGas, floorCost)
+  const minGasLimit = bigIntMax(totalIntrinsic, floorCost)
   if (gasLimit < minGasLimit) {
     const msg = _errorMsg(
       `INTRINSIC_GAS_TOO_LOW: tx gas limit ${Number(gasLimit)} is lower than the minimum gas limit of ${Number(
@@ -585,7 +632,22 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     )
     throw EthereumJSErrorWithoutCode(msg)
   }
-  gasLimit -= intrinsicGas
+  if (vm.common.isActivatedEIP(8037)) {
+    // EIP-8037 reservoir formula:
+    //   execution_gas      = tx.gas - intrinsic_gas
+    //   regular_gas_budget = TX_MAX_GAS_LIMIT - intrinsic_regular_gas
+    //   gas_left           = min(regular_gas_budget, execution_gas)
+    //   reservoir          = execution_gas - gas_left
+    const txMaxGasLimit = vm.common.param('maxTransactionGasLimit')
+    const executionGas = gasLimit - totalIntrinsic
+    const regularBudget =
+      txMaxGasLimit > intrinsicRegularGas ? txMaxGasLimit - intrinsicRegularGas : BIGINT_0
+    const gasLeft = executionGas < regularBudget ? executionGas : regularBudget
+    stateGasReservoirInitial = executionGas - gasLeft
+    gasLimit = gasLeft
+  } else {
+    gasLimit -= intrinsicGas
+  }
   if (vm.DEBUG) {
     debugGas(`Subtracting base fee (${intrinsicGas}) from gasLimit (-> ${gasLimit})`)
   }
@@ -830,6 +892,13 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     )
   }
 
+  // EIP-8037: install the per-tx reservoir on the EVM so opcodes / frame-exit
+  // hooks can charge / refill state-gas across the whole transaction.
+  if (vm.common.isActivatedEIP(8037)) {
+    vm.evm.stateGasReservoir = stateGasReservoirInitial
+    vm.evm.executionStateGasUsed = BIGINT_0
+  }
+
   const results = (await vm.evm.runCall({
     block,
     gasPrice,
@@ -872,8 +941,20 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // ===========================
   // RESULTS: Gas and Balances
   // ===========================
-  // Calculate tx gas used before refund processing
-  const totalGasSpentBeforeRefund = results.execResult.executionGasUsed + intrinsicGas
+  // Calculate tx gas used before refund processing.
+  // Pre-EIP-8037: tx_gas_used = intrinsic + executionGasUsed.
+  // EIP-8037: tx_gas_used_before_refund = tx.gas - gas_left - state_gas_reservoir
+  //                                     = intrinsic_total + executionGasUsed
+  //                                       + (reservoir_initial - reservoir_remaining)
+  // The reservoir delta captures state-gas that was charged to the reservoir
+  // (which is part of `tx.gas` paid upfront but not part of `gasLeft` passed
+  // to the EVM, so executionGasUsed alone misses it).
+  let totalGasSpentBeforeRefund = results.execResult.executionGasUsed + intrinsicGas
+  if (vm.common.isActivatedEIP(8037)) {
+    const reservoirDelta = stateGasReservoirInitial - vm.evm.stateGasReservoir
+    totalGasSpentBeforeRefund =
+      results.execResult.executionGasUsed + intrinsicRegularGas + intrinsicStateGas + reservoirDelta
+  }
   results.totalGasSpent = totalGasSpentBeforeRefund
   if (vm.DEBUG) {
     debugGas(`tx add baseFee ${intrinsicGas} to totalGasSpent (-> ${results.totalGasSpent})`)

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -966,9 +966,21 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // to the EVM, so executionGasUsed alone misses it).
   let totalGasSpentBeforeRefund = results.execResult.executionGasUsed + intrinsicGas
   if (vm.common.isActivatedEIP(8037)) {
+    const executionStateGasUsed = vm.evm.executionStateGasUsed
     const reservoirDelta = stateGasReservoirInitial - vm.evm.stateGasReservoir
     totalGasSpentBeforeRefund =
       results.execResult.executionGasUsed + intrinsicRegularGas + intrinsicStateGas + reservoirDelta
+    // Per-dimension breakdown for the runBlock 2D accumulator. Note that
+    // executionGasUsed reflects everything spent from `gas_left` (regular
+    // ops + state-gas spilled to gas_left). reservoirDelta is the slice of
+    // state-gas paid from the reservoir. Together they cover all state-gas
+    // (= executionStateGasUsed by definition), so:
+    //   execution_regular_gas_used = executionGasUsed - (state-gas spilled to gas_left)
+    //                              = executionGasUsed - (executionStateGasUsed - reservoirDelta)
+    const stateGasFromGasLeft = executionStateGasUsed - reservoirDelta
+    const executionRegularGasUsed = results.execResult.executionGasUsed - stateGasFromGasLeft
+    results.txStateGas = intrinsicStateGas + executionStateGasUsed
+    results.txRegularGas = intrinsicRegularGas + executionRegularGasUsed
   }
   results.totalGasSpent = totalGasSpentBeforeRefund
   if (vm.DEBUG) {

--- a/packages/vm/src/types.ts
+++ b/packages/vm/src/types.ts
@@ -478,6 +478,22 @@ export interface RunTxResult extends EVMResult {
   blockGasSpent: bigint
 
   /**
+   * EIP-8037 per-tx state-gas total (intrinsic_state_gas +
+   * execution_state_gas_used). Undefined when 8037 is inactive.
+   * Used by runBlock to track the block-level state-gas dimension and
+   * compute `gas_used = max(block_regular_gas_used, block_state_gas_used)`.
+   */
+  txStateGas?: bigint
+
+  /**
+   * EIP-8037 per-tx regular-gas total (intrinsic_regular_gas +
+   * execution_regular_gas_used; with the EIP-7623 calldata floor applied
+   * via `max(tx_regular_gas, calldata_floor_gas_cost)` at the block level).
+   * Undefined when 8037 is inactive.
+   */
+  txRegularGas?: bigint
+
+  /**
    * The amount of gas as that was refunded during the transaction (i.e. `gasUsed = totalGasConsumed - gasRefund`)
    */
   gasRefund: bigint


### PR DESCRIPTION
## Summary

Initial scaffolding and partial implementation of [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) (State Creation Gas Cost Increase) on top of the new [snobal-devnet-6@v1.1.0](https://github.com/ethereum/execution-specs/releases/tag/tests-snobal-devnet-6%40v1.1.1) dev fixtures pulled in by #4284.

The EIP introduces a separate "state-gas" dimension with its own per-tx **reservoir** and a 2D block-level gas accounting model. This PR lands the foundational pieces; remaining items (CREATE/CALL state-gas, journal-based revert refund, 7702 auth state-gas, SELFDESTRUCT deferred refund, refund cap formula) are listed below for follow-up.

## Commits

1. **common: scaffold EIP-8037** — register the EIP with required EIPs (2780, 6780, 7702, 7825, 7976, 7981) and add the parameter blocks (regular-gas overrides + new state-gas constants `costPerStateByte`, `stateBytesPerStorageSet`, `stateBytesPerNewAccount`, `stateBytesPerAuthBase`, `systemMaxSstoresPerCall`).
2. **vm/evm: reservoir plumbing + activate in Amsterdam** — add `stateGasReservoir` and `executionStateGasUsed` to `EVM` / `EVMInterface`. `runTx` splits intrinsic gas into regular and state portions and applies the spec's reservoir formula:
   ```
   execution_gas      = tx.gas - intrinsic_gas
   regular_gas_budget = TX_MAX_GAS_LIMIT - intrinsic_regular_gas
   gas_left           = min(regular_gas_budget, execution_gas)
   reservoir          = execution_gas - gas_left
   ```
3. **evm/vm: SSTORE state-gas charge + refund + 7825 cap relaxation** — add `chargeStateGas` / `refillStateGasReservoir` on the interpreter (reservoir-first, gas-left spill, OOG on overflow). SSTORE charges `32 × costPerStateByte` on `original=0, current=0, new!=0`; refills on `original=0, current!=0, new=0`. Also relaxes the EIP-7825 tx-level cap so it applies to the regular-gas dimension only under 8037.
4. **vm: block-level 2D gas accounting** — runBlock keeps independent `block_regular_gas_used` / `block_state_gas_used` accumulators and sets `gas_used = max(...)` for the block header. Per-tx pre-execution check uses the spec's two-dimension form.

## Test results vs the snobal-devnet-6@v1.1.0 fixtures

| Group | Passing | Total | Was on master |
|---|---:|---:|---:|
| `state_gas_reservoir` | 18 | 57 | 0 |
| `state_gas_pricing`   | 4  | 74 | 0 |

22/131 of the targeted dev fixtures pass on this branch (up from 0/131). The other ~109 failures all need pieces not implemented yet (see below) — they are not regressions, they are the known-unimplemented surface of the EIP.

## Not yet implemented (follow-up commits)

| Item | Tests it should unblock |
|---|---|
| CREATE / CREATE2 frame-exit state-gas (`(112+L)·costPerStateByte`) | `create_state_gas_scales_with_cpsb`, creation-tx reservoir tests |
| CALL\* with value to non-existent account state-gas (`112·costPerStateByte`) | `call_new_account_state_gas_scales_with_cpsb` and combos |
| Frame-revert / exceptional-halt journal hook for state-gas | `nested_failure_*`, `subcall_failure_*`, `top_level_failure_*`, `revert_discards_*` (~20 tests) |
| EIP-7702 auth state-gas (intrinsic per-auth + non-empty refund) | `auth_state_gas_scales_with_cpsb` |
| SELFDESTRUCT deferred refund | `selfdestruct_new_beneficiary_scales_with_cpsb` |
| 20% refund cap formula (`tx.gas - gas_left - reservoir`) | `refund_cap_includes_state_gas`, `sstore_refund_scales_with_cpsb` |
| System call gas adjustment (30M + reservoir headroom) | system-contract paths |

## Notes

- The EIP spec is still moving; some fixtures are reportedly incorrect (per the R&D notes from Dragan referenced in our internal discussion). Triage of which failing fixtures are actually wrong vs. genuinely unimplemented should happen alongside the next round of work.
- Depends on #4284 (the fixtures-bump PR) being merged first.
