### PR TITLE
feat: EIP-8037 frame-revert refund + CREATE/CALL state-gas (continuation)

### DIFF
--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -229,6 +229,29 @@ export class EVM implements EVMInterface {
   public stateGasReservoir: bigint = BIGINT_0
   /** EIP-8037 cumulative state-gas used by the current transaction. */
   public executionStateGasUsed: bigint = BIGINT_0
+  /**
+   * EIP-8037 per-frame state-gas snapshots. Pushed on each message-level
+   * journal.checkpoint() and popped on commit (drop) or revert / exceptional
+   * halt (restore). Restoring on revert refunds all state-gas charges and
+   * undoes all reservoir refills made within the reverted frame, per spec:
+   *   "all state-gas charged on the child frame is refunded to the parent
+   *    frame's state_gas_reservoir [...] execution_state_gas_used is
+   *    decreased consistently".
+   */
+  protected _stateGasSnapshots: Array<{ reservoir: bigint; used: bigint }> = []
+
+  /**
+   * EIP-8037 SELFDESTRUCT deferred refund support.
+   * Per-address record of the state-gas charged for account creation
+   * (stateBytesPerNewAccount × costPerStateByte) plus code deposit
+   * (L × costPerStateByte) at successful CREATE/CREATE2 frame exit.
+   * Reset at the start of each tx and consulted by runTx to refund
+   * state-gas for accounts that were both created and SELFDESTRUCTed
+   * in the same tx (per EIP-6780 + EIP-8037).
+   * Storage-slot state-gas is not tracked here yet; that is a separate
+   * follow-up.
+   */
+  public createdAccountStateGas: Map<PrefixedHexString, bigint> = new Map()
 
   protected readonly _customOpcodes?: CustomOpcode[]
   protected readonly _customPrecompiles?: CustomPrecompile[]
@@ -440,6 +463,11 @@ export class EVM implements EVMInterface {
 
     // Load `to` account
     let toAccount = await this.stateManager.getAccount(message.to)
+    // EIP-8037: capture whether the destination account existed before this
+    // call frame, used below to decide whether to charge new-account state
+    // gas on successful frame exit. Empty accounts are treated as
+    // non-existent (matches the existing callNewAccountGas trigger).
+    const toExistedBefore = toAccount !== undefined && !toAccount.isEmpty()
     if (!toAccount) {
       if (this.common.isActivatedEIP(6800) || this.common.isActivatedEIP(7864)) {
         const absenceProofAccessGas = message.accessWitness!.readAccountHeader(message.to)
@@ -577,6 +605,40 @@ export class EVM implements EVMInterface {
     }
 
     result.executionGasUsed += message.gasLimit - gasLimit
+
+    // EIP-8037: charge state-gas on successful CALL frame exit when this
+    // call created a new account (non-existent or empty `to` + non-zero
+    // value transfer). On revert / exceptional halt the snapshot mechanism
+    // restores the reservoir, so we only charge on success.
+    // Precompile addresses are excluded: they are code-only entities, not
+    // real account state. Funding a precompile via CALL-with-value does not
+    // create a new "stored" account, so no state-gas charge applies (this
+    // matches the behavior the network's other clients exhibit; without the
+    // skip we regress test_bal_precompile_funded and similar fixtures).
+    if (
+      this.common.isActivatedEIP(8037) &&
+      !result.exceptionError &&
+      !toExistedBefore &&
+      message.value !== BIGINT_0 &&
+      !message.delegatecall &&
+      this.getPrecompile(message.to) === undefined
+    ) {
+      const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
+      const costPerStateByte = this.common.param('costPerStateByte')
+      const charge = stateBytesPerNewAccount * costPerStateByte
+      const fromReservoir = charge < this.stateGasReservoir ? charge : this.stateGasReservoir
+      const spill = charge - fromReservoir
+      if (result.executionGasUsed + spill > message.gasLimit) {
+        // OOG: the spill into gas_left can't be covered by what's left in
+        // this frame. Convert to an OOG result; the journal-revert path
+        // unwinds the snapshot.
+        result = OOGResult(message.gasLimit)
+      } else {
+        this.stateGasReservoir -= fromReservoir
+        this.executionStateGasUsed += charge
+        result.executionGasUsed += spill
+      }
+    }
 
     return {
       execResult: result,
@@ -792,9 +854,37 @@ export class EVM implements EVMInterface {
     // fee for size of the return value
     let totalGas = result.executionGasUsed
     let returnFee = BIGINT_0
+    // EIP-8037 state-gas charge for the new account + code deposit. Computed
+    // here (so failure modes can refund), applied below once the success
+    // branch confirms there is enough total gas to cover regular + state.
+    let stateGasCreate = BIGINT_0
+    let stateGasFromReservoir = BIGINT_0
+    let stateGasSpillToGasLeft = BIGINT_0
     if (!result.exceptionError && !this.common.isActivatedEIP(6800)) {
-      returnFee = BigInt(result.returnValue.length) * BigInt(this.common.param('createDataGas'))
-      totalGas = totalGas + returnFee
+      if (this.common.isActivatedEIP(8037)) {
+        // Regular code-deposit cost: 6 * ceil(L / 32) hash words
+        const L = BigInt(result.returnValue.length)
+        const words = (L + BigInt(31)) / BigInt(32)
+        returnFee = words * this.common.param('codeDepositHashWordGas')
+        // State-gas:
+        //   - CREATE/CREATE2 opcode (depth > 0): (stateBytesPerNewAccount + L) * costPerStateByte
+        //   - Creation transaction (depth 0): only L * costPerStateByte; the
+        //     stateBytesPerNewAccount portion is already charged as
+        //     intrinsic_state_gas in runTx (per spec).
+        const costPerStateByte = this.common.param('costPerStateByte')
+        const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
+        const accountStateBytes = message.depth === 0 ? BIGINT_0 : stateBytesPerNewAccount
+        stateGasCreate = (accountStateBytes + L) * costPerStateByte
+        // Tentatively split the state-gas across the reservoir and the
+        // remaining gas in this CREATE frame. Don't mutate evm.* yet — we
+        // commit only if totalGas (including spill) <= message.gasLimit.
+        stateGasFromReservoir =
+          stateGasCreate < this.stateGasReservoir ? stateGasCreate : this.stateGasReservoir
+        stateGasSpillToGasLeft = stateGasCreate - stateGasFromReservoir
+      } else {
+        returnFee = BigInt(result.returnValue.length) * BigInt(this.common.param('createDataGas'))
+      }
+      totalGas = totalGas + returnFee + stateGasSpillToGasLeft
       if (this.DEBUG) {
         debugGas(`Add return value size fee (${returnFee} to gas used (-> ${totalGas}))`)
       }
@@ -812,6 +902,7 @@ export class EVM implements EVMInterface {
 
     // If enough gas and allowed code size
     let CodestoreOOG = false
+    let createSucceeded = false
     if (totalGas <= message.gasLimit && (this.allowUnlimitedContractSize || allowedCodeSize)) {
       if (this.common.isActivatedEIP(3541) && result.returnValue[0] === FORMAT) {
         if (!this.common.isActivatedEIP(3540)) {
@@ -829,9 +920,11 @@ export class EVM implements EVMInterface {
         } else {
           // 3541 is active and current runtime mode is EOF
           result.executionGasUsed = totalGas
+          createSucceeded = true
         }
       } else {
         result.executionGasUsed = totalGas
+        createSucceeded = true
       }
     } else {
       if (this.common.gteHardfork(Hardfork.Homestead)) {
@@ -865,6 +958,21 @@ export class EVM implements EVMInterface {
           result = { ...result, ...OOGResult(message.gasLimit) }
         }
       }
+    }
+
+    // EIP-8037: commit state-gas accounting now that the success / failure
+    // branch has been chosen. On success the reservoir is debited and
+    // execution_state_gas_used is incremented. On failure the tentative
+    // values are dropped (the journal-revert snapshot will also restore the
+    // reservoir to its frame-entry value, so even any in-frame charges from
+    // the body — e.g. SSTORE — are unwound).
+    if (this.common.isActivatedEIP(8037) && createSucceeded && stateGasCreate > BIGINT_0) {
+      this.stateGasReservoir -= stateGasFromReservoir
+      this.executionStateGasUsed += stateGasCreate
+      // Record the charge keyed on the freshly-created address so runTx
+      // can refund it if this account is SELFDESTRUCTed within the same
+      // tx (per EIP-8037 SELFDESTRUCT deferred-refund rules).
+      this.createdAccountStateGas.set(message.to.toString(), stateGasCreate)
     }
 
     // get the fresh gas limit for the rest of the ops
@@ -1139,6 +1247,14 @@ export class EVM implements EVMInterface {
     }
     await this.journal.checkpoint()
     if (this.common.isActivatedEIP(1153)) this.transientStorage.checkpoint()
+    if (this.common.isActivatedEIP(8037)) {
+      // EIP-8037: snapshot reservoir + cumulative state-gas used at frame
+      // entry so revert / exceptional halt can restore them.
+      this._stateGasSnapshots.push({
+        reservoir: this.stateGasReservoir,
+        used: this.executionStateGasUsed,
+      })
+    }
     if (this.DEBUG) {
       debug('-'.repeat(100))
       debug(`message checkpoint`)
@@ -1196,6 +1312,16 @@ export class EVM implements EVMInterface {
       if (this.common.isActivatedEIP(7928)) {
         this.blockLevelAccessList?.revert()
       }
+      if (this.common.isActivatedEIP(8037)) {
+        // EIP-8037: restore reservoir + cumulative state-gas used to their
+        // values at frame entry, refunding any state-gas charged during the
+        // reverted frame and undoing any in-frame reservoir refills.
+        const snap = this._stateGasSnapshots.pop()
+        if (snap !== undefined) {
+          this.stateGasReservoir = snap.reservoir
+          this.executionStateGasUsed = snap.used
+        }
+      }
       if (this.DEBUG) {
         debug(`message checkpoint reverted`)
       }
@@ -1204,6 +1330,11 @@ export class EVM implements EVMInterface {
       if (this.common.isActivatedEIP(1153)) this.transientStorage.commit()
       if (this.common.isActivatedEIP(7928)) {
         this.blockLevelAccessList?.commit()
+      }
+      if (this.common.isActivatedEIP(8037)) {
+        // EIP-8037: drop the frame's snapshot; current reservoir / used
+        // values flow up to the parent frame.
+        this._stateGasSnapshots.pop()
       }
       if (this.DEBUG) {
         debug(`message checkpoint committed`)

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -912,6 +912,13 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   if (vm.common.isActivatedEIP(8037)) {
     vm.evm.stateGasReservoir = stateGasReservoirInitial
     vm.evm.executionStateGasUsed = BIGINT_0
+    // Reset any per-frame state-gas snapshot stack left over from a previous
+    // tx. Each tx starts at frame depth 0 with an empty snapshot stack.
+    ;(vm.evm as unknown as { _stateGasSnapshots: unknown[] })._stateGasSnapshots = []
+    // Reset the per-tx record of state-gas charged for newly-created
+    // accounts, used for the SELFDESTRUCT deferred refund.
+    ;(vm.evm as unknown as { createdAccountStateGas: Map<string, bigint> }).createdAccountStateGas =
+      new Map()
   }
 
   const results = (await vm.evm.runCall({
@@ -956,6 +963,32 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // ===========================
   // RESULTS: Gas and Balances
   // ===========================
+  // EIP-8037 SELFDESTRUCT deferred refund: for any address that was both
+  // created in this tx and SELFDESTRUCTed during it, refund the state-gas
+  // charged at CREATE time (account + code deposit). These refunds go
+  // directly to the reservoir and decrement execution_state_gas_used by
+  // the same amount, and are NOT subject to the 20% refund cap.
+  // (Storage-slot state-gas tracking per-account is a separate follow-up;
+  // this covers the pure account+code-deposit refund cases that otherwise
+  // regress vs the parent branch.)
+  if (vm.common.isActivatedEIP(8037)) {
+    const sd = results.execResult.selfdestruct
+    const created = results.execResult.createdAddresses
+    const map = (vm.evm as unknown as { createdAccountStateGas: Map<string, bigint> })
+      .createdAccountStateGas
+    if (sd !== undefined && created !== undefined && map.size > 0) {
+      for (const addr of sd.keys()) {
+        if (created.has(addr)) {
+          const charge = map.get(addr)
+          if (charge !== undefined && charge > BIGINT_0) {
+            vm.evm.stateGasReservoir += charge
+            vm.evm.executionStateGasUsed -= charge
+          }
+        }
+      }
+    }
+  }
+
   // Calculate tx gas used before refund processing.
   // Pre-EIP-8037: tx_gas_used = intrinsic + executionGasUsed.
   // EIP-8037: tx_gas_used_before_refund = tx.gas - gas_left - state_gas_reservoir


### PR DESCRIPTION
## Summary

Continuation of [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037) on top of #4285. Lands four follow-up pieces:

1. **Frame-revert / exceptional-halt state-gas refund (journal-based snapshot)** — at every message-level `journal.checkpoint()`, snapshot `stateGasReservoir` + `executionStateGasUsed`. On revert / exceptional halt, restore them, refunding any state-gas charged within the reverted frame and undoing in-frame reservoir refills (per spec). On commit, drop the snapshot. The snapshot stack is reset at the start of each tx.
2. **CREATE / CREATE2 frame-exit state-gas charge** — at the end of a successful CREATE/CREATE2 frame:
   ```
   state-gas = (stateBytesPerNewAccount + L) * costPerStateByte   // depth > 0 (CREATE opcode)
   state-gas = L * costPerStateByte                               // depth 0 (creation tx; the
                                                                  // stateBytesPerNewAccount portion
                                                                  // is intrinsic)
   ```
   Regular code-deposit cost is replaced under 8037 by `6 * ceil(L/32) * codeDepositHashWordGas`. State-gas draws from the reservoir first and spills to `gas_left`; if the spill cannot fit in the frame's remaining budget the CREATE is converted to OOG and the snapshot is restored.
3. **CALL\\* with value to non-existent account state-gas charge** — at the end of a successful CALL\\* frame whenever the destination account did not exist (or was empty) before the frame and the call carried non-zero value, charge `stateBytesPerNewAccount * costPerStateByte`. delegatecall is excluded. **Precompile addresses are also excluded** — funding a precompile via CALL-with-value does not create new "stored" account state, so no state-gas charge applies.
4. **SELFDESTRUCT deferred refund (account + code-deposit portion)** — EVM tracks the state-gas charged per newly-created address. After the call returns, runTx refunds those amounts directly to the reservoir for any address that was both created and SELFDESTRUCTed in the same tx (per EIP-6780 + EIP-8037). The refund is not subject to the 20% cap. Storage-slot per-account tracking is a follow-up.

## Test results vs the snobal-devnet-6@v1.1.0 fixtures

| Group | Passing | Total | Parent (#4285) | Δ |
|---|---:|---:|---:|---:|
| **Full Amsterdam dev suite** | **1215** | 1985 | 1187 | **+28** |
| `state_gas_reservoir` | 27 | 57 | 18 | +9 |
| `state_gas_pricing` | 4 | 74 | 4 | 0 |

**0 regressions** vs the parent branch in any group.

## Regression investigation (resolved)

An earlier revision of this branch had 25 regressions vs parent (1181 passing instead of 1187). Triage showed two root causes:

- **A — CALL-with-value to a precompile (20 regressions)**. My new-account state-gas charge fired against precompile addresses (which have no on-chain account state). Fixed by skipping the charge when `getPrecompile(message.to)` returns a function. Closed `test_bal_precompile_funded` ×18 and `test_transfer_to_special_address-precompile_*` ×2.
- **B — CREATE + same-tx SELFDESTRUCT (5 regressions)**. My CREATE state-gas charge fired but no matching deferred refund existed for the EIP-6780 same-tx selfdestruct case. Fixed by tracking `createdAccountStateGas` per-address on the EVM and refunding in runTx when an address is in `createdAddresses ∩ selfdestruct`. Closed `test_create_selfdestruct_*` ×2 and `test_selfdestruct_to_*-CREATE-*` ×3.

## Notes

- `state_gas_pricing` is unchanged. The remaining pricing failures appear to expect `costPerStateByte` to vary with the block gas limit (test names include `_scales_with_cpsb`), while the EIP text I worked from defines it as a fixed `1174`. Likely either a spec change since the reference text or one of the incorrect-fixture cases Dragan flagged in his R&D notes — needs triage in the next branch.

## Still not implemented (queued)

- EIP-7702 authorization state-gas (intrinsic per-auth + non-empty refund)
- Storage-slot per-account tracking for SELFDESTRUCT refund (the spec also refunds new-storage-slot state-gas on same-tx SELFDESTRUCT; this PR refunds only the account + code-deposit portion)
- 20% refund cap formula update (`tx.gas - gas_left - reservoir`)
- System-call gas adjustment (30M + reservoir headroom)
- `costPerStateByte` parametric vs constant triage

## Test plan

- [x] `npm run build` (common, tx, evm, vm)
- [x] `npm run spellcheck:ts` and `npm run spellcheck:md` clean
- [x] Targeted dev fixtures (`state_gas_reservoir`, `state_gas_pricing`)
- [x] Full Amsterdam dev fixtures (no regressions vs parent; +28 net passes)

Stacks on top of #4285 (#4284 → #4285 → this).