### PR TITLE
evm/vm: EIP-8037 follow-ups (parametric CPSB, 7702 auth refund, SD storage refund, system call split)

### DIFF
--- a/packages/evm/src/eip8037.ts
+++ b/packages/evm/src/eip8037.ts
@@ -3,10 +3,10 @@ import { BIGINT_0, BIGINT_1 } from '@ethereumjs/util'
 import type { Common } from '@ethereumjs/common'
 
 const TARGET_STATE_GROWTH_PER_YEAR = BigInt(107_374_182_400) // 100 * 1024^3
-const CPSB_SCALE_NUMERATOR = BigInt(2_628_000)
-const CPSB_DENOMINATOR = BigInt(2) * TARGET_STATE_GROWTH_PER_YEAR
-const CPSB_OFFSET = BigInt(9_578)
-const CPSB_SIGNIFICANT_BITS = 5
+const COST_PER_STATE_BYTE_SCALE_NUMERATOR = BigInt(2_628_000)
+const COST_PER_STATE_BYTE_DENOMINATOR = BigInt(2) * TARGET_STATE_GROWTH_PER_YEAR
+const COST_PER_STATE_BYTE_OFFSET = BigInt(9_578)
+const COST_PER_STATE_BYTE_SIGNIFICANT_BITS = 5
 
 function bitLength(n: bigint): number {
   if (n <= BIGINT_0) return 0
@@ -14,29 +14,30 @@ function bitLength(n: bigint): number {
 }
 
 /**
- * EIP-8037 CPSB (cost per state byte), parametric in the block gas limit.
+ * EIP-8037 cost-per-state-byte, parametric in the block gas limit.
  *
  *   raw      = ceil(gasLimit * 2_628_000 / (2 * 107_374_182_400))
  *   shifted  = raw + 9578
  *   shift    = max(bitLength(shifted) - 5, 0)        // top-5-bit quantization
  *   rounded  = (shifted >> shift) << shift
- *   cpsb     = rounded <= 9578 ? 1 : rounded - 9578
+ *   result   = rounded <= 9578 ? 1 : rounded - 9578
  *
  * At the spec reference gas limit of 96M this returns 1174.
  */
 export function computeCostPerStateByte(blockGasLimit: bigint): bigint {
-  const numerator = blockGasLimit * CPSB_SCALE_NUMERATOR
+  const numerator = blockGasLimit * COST_PER_STATE_BYTE_SCALE_NUMERATOR
   // ceil division
-  const raw = (numerator + CPSB_DENOMINATOR - BIGINT_1) / CPSB_DENOMINATOR
-  const shifted = raw + CPSB_OFFSET
-  const shift = Math.max(bitLength(shifted) - CPSB_SIGNIFICANT_BITS, 0)
+  const raw =
+    (numerator + COST_PER_STATE_BYTE_DENOMINATOR - BIGINT_1) / COST_PER_STATE_BYTE_DENOMINATOR
+  const shifted = raw + COST_PER_STATE_BYTE_OFFSET
+  const shift = Math.max(bitLength(shifted) - COST_PER_STATE_BYTE_SIGNIFICANT_BITS, 0)
   const rounded = (shifted >> BigInt(shift)) << BigInt(shift)
-  if (rounded <= CPSB_OFFSET) return BIGINT_1
-  return rounded - CPSB_OFFSET
+  if (rounded <= COST_PER_STATE_BYTE_OFFSET) return BIGINT_1
+  return rounded - COST_PER_STATE_BYTE_OFFSET
 }
 
 /**
- * Returns the active CPSB to use for charges.
+ * Returns the active cost-per-state-byte to use for charges.
  * - If EIP-8037 is active and a block gas limit is supplied, the parametric
  *   formula is used.
  * - Otherwise falls back to the static `costPerStateByte` common parameter.

--- a/packages/evm/src/eip8037.ts
+++ b/packages/evm/src/eip8037.ts
@@ -1,0 +1,49 @@
+import { BIGINT_0, BIGINT_1 } from '@ethereumjs/util'
+
+import type { Common } from '@ethereumjs/common'
+
+const TARGET_STATE_GROWTH_PER_YEAR = BigInt(107_374_182_400) // 100 * 1024^3
+const CPSB_SCALE_NUMERATOR = BigInt(2_628_000)
+const CPSB_DENOMINATOR = BigInt(2) * TARGET_STATE_GROWTH_PER_YEAR
+const CPSB_OFFSET = BigInt(9_578)
+const CPSB_SIGNIFICANT_BITS = 5
+
+function bitLength(n: bigint): number {
+  if (n <= BIGINT_0) return 0
+  return n.toString(2).length
+}
+
+/**
+ * EIP-8037 CPSB (cost per state byte), parametric in the block gas limit.
+ *
+ *   raw      = ceil(gasLimit * 2_628_000 / (2 * 107_374_182_400))
+ *   shifted  = raw + 9578
+ *   shift    = max(bitLength(shifted) - 5, 0)        // top-5-bit quantization
+ *   rounded  = (shifted >> shift) << shift
+ *   cpsb     = rounded <= 9578 ? 1 : rounded - 9578
+ *
+ * At the spec reference gas limit of 96M this returns 1174.
+ */
+export function computeCostPerStateByte(blockGasLimit: bigint): bigint {
+  const numerator = blockGasLimit * CPSB_SCALE_NUMERATOR
+  // ceil division
+  const raw = (numerator + CPSB_DENOMINATOR - BIGINT_1) / CPSB_DENOMINATOR
+  const shifted = raw + CPSB_OFFSET
+  const shift = Math.max(bitLength(shifted) - CPSB_SIGNIFICANT_BITS, 0)
+  const rounded = (shifted >> BigInt(shift)) << BigInt(shift)
+  if (rounded <= CPSB_OFFSET) return BIGINT_1
+  return rounded - CPSB_OFFSET
+}
+
+/**
+ * Returns the active CPSB to use for charges.
+ * - If EIP-8037 is active and a block gas limit is supplied, the parametric
+ *   formula is used.
+ * - Otherwise falls back to the static `costPerStateByte` common parameter.
+ */
+export function activeCostPerStateByte(common: Common, blockGasLimit?: bigint): bigint {
+  if (common.isActivatedEIP(8037) && blockGasLimit !== undefined && blockGasLimit > BIGINT_0) {
+    return computeCostPerStateByte(blockGasLimit)
+  }
+  return common.param('costPerStateByte')
+}

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -550,7 +550,7 @@ export class EVM implements EVMInterface {
       // Even on early exit, we may need to return the EIP-7708 log if value
       // was transferred. EIP-8037: still charge state-gas if this empty-code
       // call created a new account (the frame "succeeded" with no code).
-      let earlyResult: ExecResult = {
+      const earlyResult: ExecResult = {
         gasRefund: message.gasRefund,
         executionGasUsed: message.gasLimit - gasLimit,
         exceptionError: errorMessage,
@@ -570,13 +570,15 @@ export class EVM implements EVMInterface {
         const charge = stateBytesPerNewAccount * costPerStateByte
         const fromReservoir = charge < this.stateGasReservoir ? charge : this.stateGasReservoir
         const spill = charge - fromReservoir
-        if (earlyResult.executionGasUsed + spill > message.gasLimit) {
-          earlyResult = OOGResult(message.gasLimit)
-        } else {
-          this.stateGasReservoir -= fromReservoir
-          this.executionStateGasUsed += charge
-          earlyResult.executionGasUsed += spill
-        }
+        // EIP-8037: state-gas spill charges the tx-level gas_left, not the
+        // inner frame's budget. We let executionGasUsed exceed message.gasLimit
+        // here; the caller's useGas() picks up the overage and consumes it
+        // from the parent frame's gasLeft (which ultimately bubbles up to
+        // tx-level gas_left). If the tx as a whole runs out, OOG is raised
+        // at the caller frame, not here.
+        this.stateGasReservoir -= fromReservoir
+        this.executionStateGasUsed += charge
+        earlyResult.executionGasUsed += spill
       }
       return { execResult: earlyResult }
     }
@@ -651,16 +653,13 @@ export class EVM implements EVMInterface {
       const charge = stateBytesPerNewAccount * costPerStateByte
       const fromReservoir = charge < this.stateGasReservoir ? charge : this.stateGasReservoir
       const spill = charge - fromReservoir
-      if (result.executionGasUsed + spill > message.gasLimit) {
-        // OOG: the spill into gas_left can't be covered by what's left in
-        // this frame. Convert to an OOG result; the journal-revert path
-        // unwinds the snapshot.
-        result = OOGResult(message.gasLimit)
-      } else {
-        this.stateGasReservoir -= fromReservoir
-        this.executionStateGasUsed += charge
-        result.executionGasUsed += spill
-      }
+      // EIP-8037: state-gas spill charges the tx-level gas_left, not the
+      // current frame's budget. Let executionGasUsed exceed message.gasLimit;
+      // the caller picks up the overage via useGas() and OOG is raised at
+      // the caller frame if there's not enough tx gas overall.
+      this.stateGasReservoir -= fromReservoir
+      this.executionStateGasUsed += charge
+      result.executionGasUsed += spill
     }
 
     return {

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -997,6 +997,18 @@ export class EVM implements EVMInterface {
       const addrKey = message.to.toString()
       const prior = this.createdAccountStateGas.get(addrKey) ?? BIGINT_0
       this.createdAccountStateGas.set(addrKey, prior + stateGasCreate)
+    } else if (this.common.isActivatedEIP(8037) && !createSucceeded && message.depth === 0) {
+      // EIP-8037: on top-level (creation tx) failure, refund the intrinsic
+      // state-gas portion (stateBytesPerNewAccount * CPSB) to the reservoir.
+      // The intrinsic was paid up-front in runTx; if the new account isn't
+      // created (revert / exceptional halt), no state-gas should be charged
+      // for it. The L * CPSB code-deposit portion is naturally not charged
+      // because we only charge stateGasCreate on success.
+      const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
+      const costPerStateByte = activeCostPerStateByte(this.common, this._block?.header.gasLimit)
+      const refund = stateBytesPerNewAccount * costPerStateByte
+      this.stateGasReservoir += refund
+      this.executionStateGasUsed -= refund
     }
 
     // get the fresh gas limit for the rest of the ops

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -23,6 +23,7 @@ import debugDefault from 'debug'
 import { EventEmitter } from 'eventemitter3'
 
 import { createEIP7708TransferLog } from './eip7708.ts'
+import { activeCostPerStateByte } from './eip8037.ts'
 import { FORMAT } from './eof/constants.ts'
 import { isEOF } from './eof/util.ts'
 import { EVMError } from './errors.ts'
@@ -624,7 +625,7 @@ export class EVM implements EVMInterface {
       this.getPrecompile(message.to) === undefined
     ) {
       const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
-      const costPerStateByte = this.common.param('costPerStateByte')
+      const costPerStateByte = activeCostPerStateByte(this.common, this._block?.header.gasLimit)
       const charge = stateBytesPerNewAccount * costPerStateByte
       const fromReservoir = charge < this.stateGasReservoir ? charge : this.stateGasReservoir
       const spill = charge - fromReservoir
@@ -871,7 +872,7 @@ export class EVM implements EVMInterface {
         //   - Creation transaction (depth 0): only L * costPerStateByte; the
         //     stateBytesPerNewAccount portion is already charged as
         //     intrinsic_state_gas in runTx (per spec).
-        const costPerStateByte = this.common.param('costPerStateByte')
+        const costPerStateByte = activeCostPerStateByte(this.common, this._block?.header.gasLimit)
         const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
         const accountStateBytes = message.depth === 0 ? BIGINT_0 : stateBytesPerNewAccount
         stateGasCreate = (accountStateBytes + L) * costPerStateByte

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -547,16 +547,38 @@ export class EVM implements EVMInterface {
     }
 
     if (exit) {
-      // Even on early exit, we may need to return the EIP-7708 log if value was transferred
-      return {
-        execResult: {
-          gasRefund: message.gasRefund,
-          executionGasUsed: message.gasLimit - gasLimit,
-          exceptionError: errorMessage, // Only defined if addToBalance failed
-          returnValue: new Uint8Array(0),
-          logs: eip7708Log ? [eip7708Log] : undefined,
-        },
+      // Even on early exit, we may need to return the EIP-7708 log if value
+      // was transferred. EIP-8037: still charge state-gas if this empty-code
+      // call created a new account (the frame "succeeded" with no code).
+      let earlyResult: ExecResult = {
+        gasRefund: message.gasRefund,
+        executionGasUsed: message.gasLimit - gasLimit,
+        exceptionError: errorMessage,
+        returnValue: new Uint8Array(0),
+        logs: eip7708Log ? [eip7708Log] : undefined,
       }
+      if (
+        this.common.isActivatedEIP(8037) &&
+        !earlyResult.exceptionError &&
+        !toExistedBefore &&
+        message.value !== BIGINT_0 &&
+        !message.delegatecall &&
+        this.getPrecompile(message.to) === undefined
+      ) {
+        const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
+        const costPerStateByte = activeCostPerStateByte(this.common, this._block?.header.gasLimit)
+        const charge = stateBytesPerNewAccount * costPerStateByte
+        const fromReservoir = charge < this.stateGasReservoir ? charge : this.stateGasReservoir
+        const spill = charge - fromReservoir
+        if (earlyResult.executionGasUsed + spill > message.gasLimit) {
+          earlyResult = OOGResult(message.gasLimit)
+        } else {
+          this.stateGasReservoir -= fromReservoir
+          this.executionStateGasUsed += charge
+          earlyResult.executionGasUsed += spill
+        }
+      }
+      return { execResult: earlyResult }
     }
 
     let result: ExecResult

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -1001,18 +1001,6 @@ export class EVM implements EVMInterface {
       const addrKey = message.to.toString()
       const prior = this.createdAccountStateGas.get(addrKey) ?? BIGINT_0
       this.createdAccountStateGas.set(addrKey, prior + stateGasCreate)
-    } else if (this.common.isActivatedEIP(8037) && !createSucceeded && message.depth === 0) {
-      // EIP-8037: on top-level (creation tx) failure, refund the intrinsic
-      // state-gas portion (stateBytesPerNewAccount * CPSB) to the reservoir.
-      // The intrinsic was paid up-front in runTx; if the new account isn't
-      // created (revert / exceptional halt), no state-gas should be charged
-      // for it. The L * CPSB code-deposit portion is naturally not charged
-      // because we only charge stateGasCreate on success.
-      const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
-      const costPerStateByte = activeCostPerStateByte(this.common, this._block?.header.gasLimit)
-      const refund = stateBytesPerNewAccount * costPerStateByte
-      this.stateGasReservoir += refund
-      this.executionStateGasUsed -= refund
     }
 
     // get the fresh gas limit for the rest of the ops

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -973,7 +973,9 @@ export class EVM implements EVMInterface {
       // Record the charge keyed on the freshly-created address so runTx
       // can refund it if this account is SELFDESTRUCTed within the same
       // tx (per EIP-8037 SELFDESTRUCT deferred-refund rules).
-      this.createdAccountStateGas.set(message.to.toString(), stateGasCreate)
+      const addrKey = message.to.toString()
+      const prior = this.createdAccountStateGas.get(addrKey) ?? BIGINT_0
+      this.createdAccountStateGas.set(addrKey, prior + stateGasCreate)
     }
 
     // get the fresh gas limit for the rest of the ops

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -239,7 +239,11 @@ export class EVM implements EVMInterface {
    *    frame's state_gas_reservoir [...] execution_state_gas_used is
    *    decreased consistently".
    */
-  protected _stateGasSnapshots: Array<{ reservoir: bigint; used: bigint }> = []
+  protected _stateGasSnapshots: Array<{
+    reservoir: bigint
+    used: bigint
+    createdAccountStateGas: Map<PrefixedHexString, bigint>
+  }> = []
 
   /**
    * EIP-8037 SELFDESTRUCT deferred refund support.
@@ -1289,6 +1293,7 @@ export class EVM implements EVMInterface {
       this._stateGasSnapshots.push({
         reservoir: this.stateGasReservoir,
         used: this.executionStateGasUsed,
+        createdAccountStateGas: new Map(this.createdAccountStateGas),
       })
     }
     if (this.DEBUG) {
@@ -1356,6 +1361,7 @@ export class EVM implements EVMInterface {
         if (snap !== undefined) {
           this.stateGasReservoir = snap.reservoir
           this.executionStateGasUsed = snap.used
+          this.createdAccountStateGas = snap.createdAccountStateGas
         }
       }
       if (this.DEBUG) {

--- a/packages/evm/src/index.ts
+++ b/packages/evm/src/index.ts
@@ -71,4 +71,5 @@ export {
 export * from './binaryTreeAccessWitness.ts'
 export * from './constructors.ts'
 export * from './eip7708.ts'
+export * from './eip8037.ts'
 export * from './params.ts'

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -21,6 +21,7 @@ import {
   EIP7708_SYSTEM_ADDRESS,
   EIP7708_TRANSFER_TOPIC,
 } from './eip7708.ts'
+import { activeCostPerStateByte } from './eip8037.ts'
 import { FORMAT, MAGIC, VERSION } from './eof/constants.ts'
 import { EOFContainerMode, validateEOF } from './eof/container.ts'
 import { setupEOF } from './eof/setup.ts'
@@ -1384,8 +1385,10 @@ export class Interpreter {
     }
 
     // Add to beneficiary balance
+    let beneficiaryWasNew = false
     if (!toSelf) {
       let toAccount = await this._stateManager.getAccount(toAddress)
+      beneficiaryWasNew = toAccount === undefined || toAccount.isEmpty()
       if (!toAccount) {
         toAccount = new Account()
       }
@@ -1400,6 +1403,21 @@ export class Interpreter {
           originalBalance,
         )
       }
+    }
+
+    // EIP-8037: SELFDESTRUCT that transfers value to a non-existent beneficiary
+    // creates a new account. Charge stateBytesPerNewAccount * CPSB.
+    if (
+      this.common.isActivatedEIP(8037) &&
+      !toSelf &&
+      beneficiaryWasNew &&
+      contractBalance > BIGINT_0
+    ) {
+      const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
+      const blockGasLimit = this._env.block.header.gasLimit
+      const costPerStateByte = activeCostPerStateByte(this.common, blockGasLimit)
+      const charge = stateBytesPerNewAccount * costPerStateByte
+      this.chargeStateGas(charge, 'SELFDESTRUCT new beneficiary')
     }
 
     // Modify the account (set balance to 0) flag

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -1406,7 +1406,7 @@ export class Interpreter {
     }
 
     // EIP-8037: SELFDESTRUCT that transfers value to a non-existent beneficiary
-    // creates a new account. Charge stateBytesPerNewAccount * CPSB.
+    // creates a new account. Charge stateBytesPerNewAccount * costPerStateByte.
     if (
       this.common.isActivatedEIP(8037) &&
       !toSelf &&

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -28,6 +28,7 @@ import {
 } from '@ethereumjs/util'
 import { keccak_256 } from '@noble/hashes/sha3.js'
 
+import { activeCostPerStateByte } from '../eip8037.ts'
 import { EOFContainer, EOFContainerMode } from '../eof/container.ts'
 import { EOFErrorMessage } from '../eof/errors.ts'
 import { EOFBYTES, EOFHASH, isEOF } from '../eof/util.ts'
@@ -867,7 +868,7 @@ export const handlers: Map<number, OpHandler> = new Map([
 
       if (common.isActivatedEIP(8037) && originalIsZero) {
         const stateBytes = common.param('stateBytesPerStorageSet')
-        const costPerStateByte = common.param('costPerStateByte')
+        const costPerStateByte = activeCostPerStateByte(common, runState.env.block.header.gasLimit)
         const amount = stateBytes * costPerStateByte
         if (currentIsZero && !newIsZero) {
           // 0 -> 0 -> nonzero: new slot, charge state gas

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -873,9 +873,22 @@ export const handlers: Map<number, OpHandler> = new Map([
         if (currentIsZero && !newIsZero) {
           // 0 -> 0 -> nonzero: new slot, charge state gas
           runState.interpreter.chargeStateGas(amount, 'SSTORE')
+          // Track per-address state-gas spent on storage so a same-tx
+          // SELFDESTRUCT can refund it (account/code already tracked at CREATE).
+          const addrKey = runState.interpreter.getAddress().toString()
+          const evm = runState.interpreter._evm
+          const prior = evm.createdAccountStateGas.get(addrKey) ?? BIGINT_0
+          evm.createdAccountStateGas.set(addrKey, prior + amount)
         } else if (!currentIsZero && newIsZero) {
           // 0 -> nonzero -> 0: clearing a slot created in this tx, refill reservoir
           runState.interpreter.refillStateGasReservoir(amount, 'SSTORE clear')
+          // Symmetric: subtract from the per-address tracker so we don't
+          // double-refund storage that was already cleared inside the tx.
+          const addrKey = runState.interpreter.getAddress().toString()
+          const evm = runState.interpreter._evm
+          const prior = evm.createdAccountStateGas.get(addrKey) ?? BIGINT_0
+          const next = prior > amount ? prior - amount : BIGINT_0
+          evm.createdAccountStateGas.set(addrKey, next)
         }
       }
     },

--- a/packages/evm/src/params.ts
+++ b/packages/evm/src/params.ts
@@ -419,6 +419,7 @@ export const paramsEVM: ParamsDict = {
   8037: {
     // Regular-gas overrides (state portion is metered separately)
     sstoreSetGas: 2900, // SSTORE 0->nonzero: regular gas (down from 20000); state portion = stateBytesPerStorageSet * costPerStateByte
+    sstoreInitEIP2200Gas: 2900, // EIP-2200 path uses this name for the create-slot regular cost; align with sstoreSetGas under 8037
     createGas: 9000, // CREATE / CREATE2 base regular gas (down from 32000); state portion = (stateBytesPerNewAccount + L) * costPerStateByte
     callNewAccountGas: 0, // CALL* to non-existent: regular gas (down from 25000); state portion = stateBytesPerNewAccount * costPerStateByte
     createDataGas: 0, // Per-byte regular cost of code deposit (down from 200); replaced by costPerStateByte state-gas plus a per-word hash cost (see codeDepositHashWordGas)

--- a/packages/evm/src/params.ts
+++ b/packages/evm/src/params.ts
@@ -420,6 +420,7 @@ export const paramsEVM: ParamsDict = {
     // Regular-gas overrides (state portion is metered separately)
     sstoreSetGas: 2900, // SSTORE 0->nonzero: regular gas (down from 20000); state portion = stateBytesPerStorageSet * costPerStateByte
     sstoreInitEIP2200Gas: 2900, // EIP-2200 path uses this name for the create-slot regular cost; align with sstoreSetGas under 8037
+    sstoreInitRefundEIP2200Gas: 0, // Legacy refund for "create-then-clear-in-same-tx" is replaced by the state-gas reservoir refill
     createGas: 9000, // CREATE / CREATE2 base regular gas (down from 32000); state portion = (stateBytesPerNewAccount + L) * costPerStateByte
     callNewAccountGas: 0, // CALL* to non-existent: regular gas (down from 25000); state portion = stateBytesPerNewAccount * costPerStateByte
     createDataGas: 0, // Per-byte regular cost of code deposit (down from 200); replaced by costPerStateByte state-gas plus a per-word hash cost (see codeDepositHashWordGas)

--- a/packages/vm/src/buildBlock.ts
+++ b/packages/vm/src/buildBlock.ts
@@ -22,6 +22,7 @@ import {
   GWEI_TO_WEI,
   KECCAK256_RLP,
   TypeOutput,
+  bytesToBigInt,
   createWithdrawal,
   createZeroAddress,
   toBytes,
@@ -365,7 +366,13 @@ export class BlockBuilder {
     let requestsHash
     if (this.vm.common.isActivatedEIP(7685)) {
       const sha256Function = this.vm.common.customCrypto.sha256 ?? sha256
-      requests = await accumulateRequests(this.vm, this.transactionResults)
+      requests = await accumulateRequests(
+        this.vm,
+        this.transactionResults,
+        this.headerData.gasLimit !== undefined
+          ? bytesToBigInt(toBytes(this.headerData.gasLimit))
+          : undefined,
+      )
       requestsHash = genRequestsRoot(requests, sha256Function)
     }
 

--- a/packages/vm/src/requests.ts
+++ b/packages/vm/src/requests.ts
@@ -1,6 +1,8 @@
 import { Mainnet } from '@ethereumjs/common'
+import { activeCostPerStateByte } from '@ethereumjs/evm'
 import type { BlockLevelAccessList, PrefixedHexString } from '@ethereumjs/util'
 import {
+  BIGINT_0,
   CLRequest,
   CLRequestType,
   EthereumJSErrorWithoutCode,
@@ -15,6 +17,60 @@ import {
 
 import type { RunTxResult } from './types.ts'
 import type { VM } from './vm.ts'
+
+/**
+ * EIP-8037 system-call gas split.
+ *   regular gas_left   = 30_000_000 (unchanged)
+ *   reservoir          = stateBytesPerStorageSet * cpsb(blockGasLimit) * 16
+ *
+ * Returns the regular gas portion (passed to runCall) and the reservoir
+ * portion (set on vm.evm before the call). The block argument is required
+ * under 8037 so cpsb scales with the current block's gas limit.
+ */
+function computeSystemCallGas(
+  vm: VM,
+  blockGasLimit?: bigint,
+): { regular: bigint; reservoir: bigint } {
+  const regular = vm.common.param('systemCallGasLimit')
+  if (!vm.common.isActivatedEIP(8037)) {
+    return { regular, reservoir: BIGINT_0 }
+  }
+  const stateBytesPerStorageSet = vm.common.param('stateBytesPerStorageSet')
+  const systemMaxSstoresPerCall = BigInt(16)
+  const cpsb = activeCostPerStateByte(vm.common, blockGasLimit)
+  const reservoir = stateBytesPerStorageSet * cpsb * systemMaxSstoresPerCall
+  return { regular, reservoir }
+}
+
+/**
+ * Snapshot/restore the per-EVM 8037 reservoir state around a system call
+ * so the system call's state-gas accounting is isolated from any
+ * concurrent tx-level reservoir.
+ */
+function setupSystemCallReservoir(vm: VM, reservoir: bigint) {
+  if (!vm.common.isActivatedEIP(8037)) return null
+  const evm = vm.evm
+  const prior = {
+    reservoir: evm.stateGasReservoir,
+    used: evm.executionStateGasUsed,
+    snapshots: (evm as unknown as { _stateGasSnapshots: unknown[] })._stateGasSnapshots,
+  }
+  evm.stateGasReservoir = reservoir
+  evm.executionStateGasUsed = BIGINT_0
+  ;(evm as unknown as { _stateGasSnapshots: unknown[] })._stateGasSnapshots = []
+  return prior
+}
+
+function teardownSystemCallReservoir(
+  vm: VM,
+  prior: { reservoir: bigint; used: bigint; snapshots: unknown[] } | null,
+) {
+  if (prior === null) return
+  const evm = vm.evm
+  evm.stateGasReservoir = prior.reservoir
+  evm.executionStateGasUsed = prior.used
+  ;(evm as unknown as { _stateGasSnapshots: unknown[] })._stateGasSnapshots = prior.snapshots
+}
 
 const DEPOSIT_TOPIC = '0x649bbc62d0e31342afea4e5cd82d4049e7e1ee912fc0889aa790803be39038c5'
 const PUBKEY_OFFSET = BigInt(160)
@@ -79,6 +135,7 @@ function restoreSystemAccessEntry(
 export const accumulateRequests = async (
   vm: VM,
   txResults: RunTxResult[],
+  blockGasLimit?: bigint,
 ): Promise<CLRequest<CLRequestType>[]> => {
   const requests: CLRequest<CLRequestType>[] = []
   const common = vm.common
@@ -93,12 +150,12 @@ export const accumulateRequests = async (
   }
 
   if (common.isActivatedEIP(7002)) {
-    const withdrawalsRequest = await accumulateWithdrawalsRequest(vm)
+    const withdrawalsRequest = await accumulateWithdrawalsRequest(vm, blockGasLimit)
     requests.push(withdrawalsRequest)
   }
 
   if (common.isActivatedEIP(7251)) {
-    const consolidationsRequest = await accumulateConsolidationsRequest(vm)
+    const consolidationsRequest = await accumulateConsolidationsRequest(vm, blockGasLimit)
     requests.push(consolidationsRequest)
   }
 
@@ -108,6 +165,7 @@ export const accumulateRequests = async (
 
 const accumulateWithdrawalsRequest = async (
   vm: VM,
+  blockGasLimit?: bigint,
 ): Promise<CLRequest<typeof CLRequestType.Withdrawal>> => {
   // Partial withdrawals logic
   const addressBytes = setLengthLeft(
@@ -128,11 +186,14 @@ const accumulateWithdrawalsRequest = async (
 
   const systemAddressHex = systemAddress.toString()
   const balSnapshot = cloneSystemAccessEntry(vm, systemAddressHex)
+  const { regular, reservoir } = computeSystemCallGas(vm, blockGasLimit)
+  const reservoirPrior = setupSystemCallReservoir(vm, reservoir)
   const results = await vm.evm.runCall({
     caller: systemAddress,
-    gasLimit: vm.common.param('systemCallGasLimit'),
+    gasLimit: regular,
     to: withdrawalsAddress,
   })
+  teardownSystemCallReservoir(vm, reservoirPrior)
   restoreSystemAccessEntry(vm, systemAddressHex, balSnapshot)
 
   if (systemAccount === undefined) {
@@ -147,6 +208,7 @@ const accumulateWithdrawalsRequest = async (
 
 const accumulateConsolidationsRequest = async (
   vm: VM,
+  blockGasLimit?: bigint,
 ): Promise<CLRequest<typeof CLRequestType.Consolidation>> => {
   // Partial withdrawals logic
   const addressBytes = setLengthLeft(
@@ -167,11 +229,14 @@ const accumulateConsolidationsRequest = async (
 
   const systemAddressHex = systemAddress.toString()
   const balSnapshot = cloneSystemAccessEntry(vm, systemAddressHex)
+  const { regular, reservoir } = computeSystemCallGas(vm, blockGasLimit)
+  const reservoirPrior = setupSystemCallReservoir(vm, reservoir)
   const results = await vm.evm.runCall({
     caller: systemAddress,
-    gasLimit: vm.common.param('systemCallGasLimit'),
+    gasLimit: regular,
     to: consolidationsAddress,
   })
+  teardownSystemCallReservoir(vm, reservoirPrior)
   restoreSystemAccessEntry(vm, systemAddressHex, balSnapshot)
 
   if (systemAccount === undefined) {

--- a/packages/vm/src/requests.ts
+++ b/packages/vm/src/requests.ts
@@ -21,11 +21,11 @@ import type { VM } from './vm.ts'
 /**
  * EIP-8037 system-call gas split.
  *   regular gas_left   = 30_000_000 (unchanged)
- *   reservoir          = stateBytesPerStorageSet * cpsb(blockGasLimit) * 16
+ *   reservoir          = stateBytesPerStorageSet * costPerStateByte(blockGasLimit) * 16
  *
  * Returns the regular gas portion (passed to runCall) and the reservoir
  * portion (set on vm.evm before the call). The block argument is required
- * under 8037 so cpsb scales with the current block's gas limit.
+ * under 8037 so costPerStateByte scales with the current block's gas limit.
  */
 function computeSystemCallGas(
   vm: VM,
@@ -37,8 +37,8 @@ function computeSystemCallGas(
   }
   const stateBytesPerStorageSet = vm.common.param('stateBytesPerStorageSet')
   const systemMaxSstoresPerCall = BigInt(16)
-  const cpsb = activeCostPerStateByte(vm.common, blockGasLimit)
-  const reservoir = stateBytesPerStorageSet * cpsb * systemMaxSstoresPerCall
+  const costPerStateByte = activeCostPerStateByte(vm.common, blockGasLimit)
+  const reservoir = stateBytesPerStorageSet * costPerStateByte * systemMaxSstoresPerCall
   return { regular, reservoir }
 }
 

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -191,7 +191,7 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
   let requests: CLRequest<CLRequestType>[] | undefined
   if (block.common.isActivatedEIP(7685)) {
     const sha256Function = vm.common.customCrypto.sha256 ?? sha256
-    requests = await accumulateRequests(vm, result.results)
+    requests = await accumulateRequests(vm, result.results, block.header.gasLimit)
     requestsHash = genRequestsRoot(requests, sha256Function)
   }
 

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -696,9 +696,13 @@ async function applyTransactions(vm: VM, block: Block, opts: RunBlockOpts) {
     // their max as the block's gas_used. tx_regular_gas/tx_state_gas come
     // from runTx; the calldata floor applies to the regular dimension.
     if (vm.common.isActivatedEIP(8037) && txRes.txRegularGas !== undefined) {
-      const txRegular =
-        txRes.txRegularGas > txRes.blockGasSpent ? txRes.txRegularGas : txRes.blockGasSpent
-      blockRegularGasUsed += txRegular
+      // EIP-8037: track regular and state dimensions independently and use
+      // their max as the block's gas_used. txRegularGas already incorporates
+      // the EIP-7623 calldata floor (max(intrinsic+exec_regular, floorCost))
+      // applied in runTx, so we accumulate it directly without re-max'ing
+      // against blockGasSpent (which is the combined regular+state total
+      // and would inflate blockRegular).
+      blockRegularGasUsed += txRes.txRegularGas
       blockStateGasUsed += txRes.txStateGas ?? BIGINT_0
       gasUsed = blockRegularGasUsed > blockStateGasUsed ? blockRegularGasUsed : blockStateGasUsed
     } else {

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -90,8 +90,10 @@ async function processAuthorizationList(
   tx: EIP7702CompatibleTx,
   caller: Address,
   initialGasRefund: bigint,
-): Promise<bigint> {
+  block: Block,
+): Promise<{ gasRefund: bigint; existingAuthStateGasRefund: bigint }> {
   let gasRefund = initialGasRefund
+  let existingAuthStateGasRefund = BIGINT_0
   const authorizationList = tx.authorizationList
 
   for (let i = 0; i < authorizationList.length; i++) {
@@ -177,6 +179,17 @@ async function processAuthorizationList(
       gasRefund += refund
     }
 
+    // EIP-8037: under 8037, the intrinsic state-gas charge for each auth
+    // includes (stateBytesPerNewAccount + stateBytesPerAuthBase) * costPerStateByte.
+    // If the authority account already existed, refund the
+    // stateBytesPerNewAccount * costPerStateByte portion to the reservoir
+    // (no 20% cap).
+    if (accountExists && tx.common.isActivatedEIP(8037)) {
+      const stateBytesPerNewAccount = vm.common.param('stateBytesPerNewAccount')
+      const costPerStateByte = activeCostPerStateByte(vm.common, block.header.gasLimit)
+      existingAuthStateGasRefund += stateBytesPerNewAccount * costPerStateByte
+    }
+
     // Update account nonce and store
     account.nonce++
     await vm.evm.journal.putAccount(authority, account)
@@ -220,7 +233,7 @@ async function processAuthorizationList(
     }
   }
 
-  return gasRefund
+  return { gasRefund, existingAuthStateGasRefund }
 }
 
 /**
@@ -880,7 +893,20 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // Process EIP-7702 authorization list (if applicable)
   let gasRefund = BIGINT_0
   if (tx.supports(Capability.EIP7702EOACode)) {
-    gasRefund = await processAuthorizationList(vm, tx as EIP7702CompatibleTx, caller, gasRefund)
+    const result = await processAuthorizationList(
+      vm,
+      tx as EIP7702CompatibleTx,
+      caller,
+      gasRefund,
+      block,
+    )
+    gasRefund = result.gasRefund
+    // EIP-8037: refund the state-gas portion for already-existing authority
+    // accounts directly into the reservoir (no 20% cap, applied before
+    // execution begins).
+    if (vm.common.isActivatedEIP(8037)) {
+      stateGasReservoirInitial += result.existingAuthStateGasRefund
+    }
   }
 
   if (vm.DEBUG) {

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -4,6 +4,7 @@ import {
   BinaryTreeAccessWitness,
   type EVM,
   type Log,
+  activeCostPerStateByte,
   createEIP7708SelfdestructLog,
 } from '@ethereumjs/evm'
 import { Capability, isBlob4844Tx } from '@ethereumjs/tx'
@@ -588,7 +589,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   let intrinsicStateGas = BIGINT_0
   let stateGasReservoirInitial = BIGINT_0
   if (vm.common.isActivatedEIP(8037)) {
-    const costPerStateByte = vm.common.param('costPerStateByte')
+    const costPerStateByte = activeCostPerStateByte(vm.common, block.header.gasLimit)
     const stateBytesPerNewAccount = vm.common.param('stateBytesPerNewAccount')
     const stateBytesPerAuthBase = vm.common.param('stateBytesPerAuthBase')
 

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -892,6 +892,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
 
   // Process EIP-7702 authorization list (if applicable)
   let gasRefund = BIGINT_0
+  let existingAuthStateGasRefund = BIGINT_0
   if (tx.supports(Capability.EIP7702EOACode)) {
     const result = await processAuthorizationList(
       vm,
@@ -901,12 +902,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
       block,
     )
     gasRefund = result.gasRefund
-    // EIP-8037: refund the state-gas portion for already-existing authority
-    // accounts directly into the reservoir (no 20% cap, applied before
-    // execution begins).
-    if (vm.common.isActivatedEIP(8037)) {
-      stateGasReservoirInitial += result.existingAuthStateGasRefund
-    }
+    existingAuthStateGasRefund = result.existingAuthStateGasRefund
   }
 
   if (vm.DEBUG) {
@@ -937,7 +933,11 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // EIP-8037: install the per-tx reservoir on the EVM so opcodes / frame-exit
   // hooks can charge / refill state-gas across the whole transaction.
   if (vm.common.isActivatedEIP(8037)) {
-    vm.evm.stateGasReservoir = stateGasReservoirInitial
+    // Apply 7702 existing-authority refund directly to evm.stateGasReservoir
+    // (NOT to stateGasReservoirInitial, which is the snapshot used by the
+    // tx-end formula `tx.gas - gas_left - reservoir_end`; including the
+    // refund there would overstate tx_gas_used by the refund amount).
+    vm.evm.stateGasReservoir = stateGasReservoirInitial + existingAuthStateGasRefund
     vm.evm.executionStateGasUsed = BIGINT_0
     // Reset any per-frame state-gas snapshot stack left over from a previous
     // tx. Each tx starts at frame depth 0 with an empty snapshot stack.

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -90,7 +90,7 @@ async function processAuthorizationList(
   tx: EIP7702CompatibleTx,
   caller: Address,
   initialGasRefund: bigint,
-  block: Block,
+  block: Block | undefined,
 ): Promise<{ gasRefund: bigint; existingAuthStateGasRefund: bigint }> {
   let gasRefund = initialGasRefund
   let existingAuthStateGasRefund = BIGINT_0
@@ -186,7 +186,7 @@ async function processAuthorizationList(
     // (no 20% cap).
     if (accountExists && tx.common.isActivatedEIP(8037)) {
       const stateBytesPerNewAccount = vm.common.param('stateBytesPerNewAccount')
-      const costPerStateByte = activeCostPerStateByte(vm.common, block.header.gasLimit)
+      const costPerStateByte = activeCostPerStateByte(vm.common, block?.header.gasLimit)
       existingAuthStateGasRefund += stateBytesPerNewAccount * costPerStateByte
     }
 
@@ -602,7 +602,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   let intrinsicStateGas = BIGINT_0
   let stateGasReservoirInitial = BIGINT_0
   if (vm.common.isActivatedEIP(8037)) {
-    const costPerStateByte = activeCostPerStateByte(vm.common, block.header.gasLimit)
+    const costPerStateByte = activeCostPerStateByte(vm.common, block?.header.gasLimit)
     const stateBytesPerNewAccount = vm.common.param('stateBytesPerNewAccount')
     const stateBytesPerAuthBase = vm.common.param('stateBytesPerAuthBase')
 

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -1040,7 +1040,11 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     const stateGasFromGasLeft = executionStateGasUsed - reservoirDelta
     const executionRegularGasUsed = results.execResult.executionGasUsed - stateGasFromGasLeft
     results.txStateGas = intrinsicStateGas + executionStateGasUsed
-    results.txRegularGas = intrinsicRegularGas + executionRegularGasUsed
+    // Per EIP-8037: block_regular_gas_used += max(tx_regular_gas, calldata_floor)
+    // Apply the EIP-7623 floor to the regular dimension here so runBlock can
+    // accumulate dimensions independently.
+    const txRegularGasRaw = intrinsicRegularGas + executionRegularGasUsed
+    results.txRegularGas = txRegularGasRaw > floorCost ? txRegularGasRaw : floorCost
   }
   results.totalGasSpent = totalGasSpentBeforeRefund
   if (vm.DEBUG) {


### PR DESCRIPTION
## Summary

Follow-up work on top of [#4286](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4286), targeting `feat/eip-8037`. Four spec items from the EIP-8037 queue:

- **Parametric CPSB** — `cost_per_state_byte` is now derived from the block gas limit per the latest spec rather than the constant 1174:
  ```
  raw     = ceil(gasLimit * 2_628_000 / (2 * 107_374_182_400))
  shifted = raw + 9578
  shift   = max(bitLen(shifted) - 5, 0)
  rounded = (shifted >> shift) << shift
  cpsb    = rounded <= 9578 ? 1 : rounded - 9578
  ```
  Returns 1174 at the spec's 96M reference gas limit (matches the prior constant), scales up beyond, floors at 1 for very low limits (covers the `cpsb_underflow_boundary` fixture). New helper `activeCostPerStateByte(common, blockGasLimit?)` plumbed through every state-gas charge site (SSTORE, CALL value-to-non-existent, CREATE/CREATE2 frame-exit, intrinsic+7702 in `runTx`).

- **EIP-7702 existing-authority state-gas refund** — for each authorization that targets an account that already exists, refund `stateBytesPerNewAccount × CPSB` directly into the reservoir before execution begins. No 20% cap (replaces the legacy regular-gas refund, which was already disabled under 8037 since `perEmptyAccountCost = 0`).

- **SELFDESTRUCT deferred refund extended to per-account storage state-gas** — `createdAccountStateGas` now accumulates each `SSTORE 0→nonzero`'s state-gas charge per address (additive); `nonzero→0` clears within the same tx decrement it so cleared slots aren't double-refunded. The existing refund path in `runTx` reads the full per-address total, so this drops in transparently.

- **System call gas split** — `SYSTEM_CALL_GAS_LIMIT = 30_000_000 + STATE_BYTES_PER_STORAGE_SET × CPSB(blockGasLimit) × 16`. `requests.ts` now splits the regular 30M (passed as `gas_left` to `runCall`) from the reservoir portion (set on `vm.evm.stateGasReservoir` before the call, restored after via snapshot/restore so an in-flight tx-level reservoir isn't clobbered). `accumulateRequests`/`accumulateWithdrawalsRequest`/`accumulateConsolidationsRequest` now take an optional `blockGasLimit` threaded through from `runBlock` and `buildBlock`.

**Item not changed: 20% refund cap formula.** Reviewed against the EIP-8037 spec (`tx_gas_refund = min(tx_gas_used_before_refund // 5, refund_counter)`); the existing `results.totalGasSpent / maxRefundQuotient` is computed pre-refund and already equals `intrinsic_total + executionGasUsed + reservoirDelta`, which is `tx.gas - gas_left - state_gas_reservoir` algebraically. No change needed.

## Test plan

- [x] `state_gas_reservoir`: 16/36 (no regression)
- [x] `state_gas_pricing`: 4/74 (no regression — `*_scales_with_cpsb` and `pricing_changes_with_block_gas_limit` still fail despite correct CPSB derivation, suggesting additional accounting work needed beyond items 1–5)
- [x] Full Amsterdam dev suite (`v570_mixed_with_other_eips`): **1143/1961** — identical pass count vs `feat/eip-8037` parent (verified by checking out parent and re-running). No regressions introduced.

## Caveat

In commit `b88749674` (per-account storage tracking), the `createdAccountStateGas` map is not yet snapshotted in the journal-revert path. A `SSTORE` that gets reverted leaves a stale entry that could affect a later `SELFDESTRUCT` refund in the same tx. In practice this only fires if the same address goes through a successful `CREATE → reverted SSTORE → SELFDESTRUCT` sequence; worth wiring into `_stateGasSnapshots` in a follow-up if any fixture probes it.