### PR TITLE
chore: add .npmrc with min-release-age=3 days

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3


### PR DESCRIPTION
## Summary
- Adds a root `.npmrc` setting `min-release-age=3`, so npm will only install package versions that were published at least 3 days ago.
- Supply-chain hardening: gives a buffer against malicious versions getting pulled in immediately after publication.

Resolves #4289 