### PR TITLE
evm/vm: EIP-8037 v7 CREATE collision restructure (pre-charge new_account state-gas at opcode entry)

### DIFF
--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -264,7 +264,7 @@ export class EVM implements EVMInterface {
    * is paid up-front in runTx and isn't part of stateGasCreate. On a same-tx
    * SELFDESTRUCT of the freshly-created contract, runTx refunds the STATE
    * dimension only (decrement execution_state_gas_used) — the reservoir is
-   * NOT credited, so the user still pays the gross intrinsic. This realises
+   * NOT credited, so the user still pays the gross intrinsic. This realizes
    * the v7 spec note "tx doesn't over charge for an account that never
    * persists" at the block_state_gas_used level.
    */
@@ -904,15 +904,16 @@ export class EVM implements EVMInterface {
         const L = BigInt(result.returnValue.length)
         const words = (L + BigInt(31)) / BigInt(32)
         returnFee = words * this.common.param('codeDepositHashWordGas')
-        // State-gas:
-        //   - CREATE/CREATE2 opcode (depth > 0): (stateBytesPerNewAccount + L) * costPerStateByte
-        //   - Creation transaction (depth 0): only L * costPerStateByte; the
-        //     stateBytesPerNewAccount portion is already charged as
-        //     intrinsic_state_gas in runTx (per spec).
+        // State-gas at frame-exit success: only the L * costPerStateByte
+        // code-deposit portion. The stateBytesPerNewAccount portion is
+        // already accounted for elsewhere:
+        //   - depth=0 creation transactions: paid in intrinsic_state_gas in
+        //     runTx (refunded on top-level failure by the runCall handler).
+        //   - depth>0 inner CREATE/CREATE2: pre-charged at the opcode entry
+        //     in opcodes/gas.ts (refunded on any inner-frame failure by the
+        //     runCall handler).
         const costPerStateByte = activeCostPerStateByte(this.common, this._block?.header.gasLimit)
-        const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
-        const accountStateBytes = message.depth === 0 ? BIGINT_0 : stateBytesPerNewAccount
-        stateGasCreate = (accountStateBytes + L) * costPerStateByte
+        stateGasCreate = L * costPerStateByte
         // Tentatively split the state-gas across the reservoir and the
         // remaining gas in this CREATE frame. Don't mutate evm.* yet — we
         // commit only if totalGas (including spill) <= message.gasLimit.
@@ -1012,9 +1013,25 @@ export class EVM implements EVMInterface {
       // Record the charge keyed on the freshly-created address so runTx
       // can refund it if this account is SELFDESTRUCTed within the same
       // tx (per EIP-8037 SELFDESTRUCT deferred-refund rules).
+      //
+      // For depth>0 inner CREATE: the new-account portion was pre-charged
+      // at the CREATE opcode (in opcodes/gas.ts). It isn't part of
+      // stateGasCreate (which is only L*costPerStateByte for code deposit
+      // here), so bake it back into the deferred-refund map alongside
+      // stateGasCreate so a same-tx SELFDESTRUCT refunds the full amount.
+      // For depth=0 (creation tx), the new-account portion was paid via
+      // intrinsic_state_gas — tracked separately in
+      // createdAccountIntrinsicStateGas (which has different refund
+      // semantics: state-dim only, no reservoir credit).
       const addrKey = message.to.toString()
       const prior = this.createdAccountStateGas.get(addrKey) ?? BIGINT_0
-      this.createdAccountStateGas.set(addrKey, prior + stateGasCreate)
+      let bakedIn = stateGasCreate
+      if (message.depth > 0) {
+        const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
+        const costPerStateByte = activeCostPerStateByte(this.common, this._block?.header.gasLimit)
+        bakedIn += stateBytesPerNewAccount * costPerStateByte
+      }
+      this.createdAccountStateGas.set(addrKey, prior + bakedIn)
       // For depth=0 creation transactions, the intrinsic
       // stateBytesPerNewAccount * costPerStateByte was paid up-front in
       // runTx and isn't covered by stateGasCreate. Track it separately so
@@ -1401,18 +1418,21 @@ export class EVM implements EVMInterface {
           this.createdAccountStateGas = snap.createdAccountStateGas
           this.createdAccountIntrinsicStateGas = snap.createdAccountIntrinsicStateGas
         }
-        // EIP-8037: on a TOP-LEVEL creation-tx failure (revert / halt /
-        // OOG / collision / oversized code etc.), additionally refund the
-        // intrinsic stateBytesPerNewAccount * costPerStateByte portion that
-        // runTx paid up-front. The intrinsic was not part of any frame's
-        // state-gas charges (it was deducted from tx.gas before EVM start),
-        // so the snapshot pop doesn't credit it; do it explicitly here.
-        if (isCreate && message.depth === 0) {
+        // EIP-8037: on ANY creation-frame failure (revert / halt / OOG /
+        // collision / oversized code etc.), refund the
+        // stateBytesPerNewAccount * costPerStateByte portion that was paid
+        // for this frame's new-account allocation. The pre-charge happened
+        // either as intrinsic_state_gas (depth=0 creation tx, paid up-front
+        // in runTx) or as the CREATE/CREATE2 opcode pre-charge (depth>0,
+        // applied in opcodes/gas.ts). In neither case is it part of the
+        // per-frame snapshot, so the snapshot pop doesn't credit it; do it
+        // explicitly here.
+        if (isCreate) {
           const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
           const costPerStateByte = activeCostPerStateByte(this.common, this._block?.header.gasLimit)
-          const intrinsicAccountStateGas = stateBytesPerNewAccount * costPerStateByte
-          this.stateGasReservoir += intrinsicAccountStateGas
-          this.executionStateGasUsed -= intrinsicAccountStateGas
+          const newAccountStateGas = stateBytesPerNewAccount * costPerStateByte
+          this.stateGasReservoir += newAccountStateGas
+          this.executionStateGasUsed -= newAccountStateGas
         }
       }
       if (this.DEBUG) {

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -11,6 +11,7 @@ import {
   setLengthLeft,
 } from '@ethereumjs/util'
 
+import { activeCostPerStateByte } from '../eip8037.ts'
 import { EOFErrorMessage } from '../eof/errors.ts'
 import { EVMError } from '../errors.ts'
 import { DELEGATION_7702_FLAG } from '../types.ts'
@@ -568,6 +569,25 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         gas += subMemUsage(runState, offset, length, common)
 
+        // EIP-8037 (v7): pre-charge the NEW_ACCOUNT state-gas portion at the
+        // CREATE opcode entry (BEFORE the EIP-150 1/64 retention is computed)
+        // so the forwarded amount reflects the reduced gas_left. The
+        // _executeCreate path refunds this amount on any inner-frame failure
+        // (collision / revert / halt / OOG / oversized code), and on success
+        // the frame-exit logic skips the account portion to avoid
+        // double-charging.
+        if (common.isActivatedEIP(8037)) {
+          const stateBytesPerNewAccount = common.param('stateBytesPerNewAccount')
+          const blockGasLimit = runState.env.block.header.gasLimit
+          const costPerStateByte = activeCostPerStateByte(common, blockGasLimit)
+          const newAccountStateGas = stateBytesPerNewAccount * costPerStateByte
+          if (gas > BIGINT_0) {
+            runState.interpreter.useGas(gas, 'CREATE pre-charges')
+            gas = BIGINT_0
+          }
+          runState.interpreter.chargeStateGas(newAccountStateGas, 'CREATE pre-charge new_account')
+        }
+
         let gasLimit = BigInt(runState.interpreter.getGasLeft()) - gas
         gasLimit = maxCallGas(gasLimit, gasLimit, runState, common)
 
@@ -937,6 +957,21 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         }
 
         gas += common.param('keccak256WordGas') * divCeil(length, BIGINT_32)
+
+        // EIP-8037 (v7): pre-charge NEW_ACCOUNT state-gas at CREATE2 opcode
+        // entry (mirrors CREATE).
+        if (common.isActivatedEIP(8037)) {
+          const stateBytesPerNewAccount = common.param('stateBytesPerNewAccount')
+          const blockGasLimit = runState.env.block.header.gasLimit
+          const costPerStateByte = activeCostPerStateByte(common, blockGasLimit)
+          const newAccountStateGas = stateBytesPerNewAccount * costPerStateByte
+          if (gas > BIGINT_0) {
+            runState.interpreter.useGas(gas, 'CREATE2 pre-charges')
+            gas = BIGINT_0
+          }
+          runState.interpreter.chargeStateGas(newAccountStateGas, 'CREATE2 pre-charge new_account')
+        }
+
         let gasLimit = runState.interpreter.getGasLeft() - gas
         gasLimit = maxCallGas(gasLimit, gasLimit, runState, common) // CREATE2 is only available after TangerineWhistle (Constantinople introduced this opcode)
         runState.messageGasLimit = gasLimit


### PR DESCRIPTION
## Summary

Restructures CREATE/CREATE2 state-gas accounting under EIP-8037 v7 to match the spec formula:

```
gas_at_create_after_state = gas_limit - intrinsic - factory_pre_create
                          - memory_expansion - create_base - new_account
retained = gas_at_create_after_state // 64
baseline_gas_used = gas_limit - retained - new_account + post_create_static
```

i.e. the `new_account = stateBytesPerNewAccount * costPerStateByte` portion is pre-charged at the CREATE/CREATE2 opcode entry (so the EIP-150 1/64 retention is computed on the post-state-charge balance), and refunded on any inner-frame failure (collision / revert / halt / OOG / oversized code).

## Changes

**`packages/evm/src/opcodes/gas.ts`** — CREATE / CREATE2 dynamic gas handlers now pre-charge the new-account state-gas:

```ts
if (common.isActivatedEIP(8037)) {
  const newAccountStateGas = stateBytesPerNewAccount * cpsb
  if (gas > BIGINT_0) {
    runState.interpreter.useGas(gas, 'CREATE pre-charges')
    gas = BIGINT_0
  }
  runState.interpreter.chargeStateGas(newAccountStateGas, 'CREATE pre-charge new_account')
}
```

The `useGas(gas)` deducts the existing dynamic charges first so `chargeStateGas` sees the post-charge `gas_left` for its reservoir/spill split. Returning `gas = 0` keeps the framework's downstream `useGas(gas, opInfo)` a no-op.

**`packages/evm/src/evm.ts`** —
- `_executeCreate` frame-exit success: `stateGasCreate` is now only `L * costPerStateByte` (code deposit). The `stateBytesPerNewAccount` portion is already accounted for elsewhere (intrinsic at depth=0, opcode pre-charge at depth>0).
- For depth>0 success, the `createdAccountStateGas` map now bakes in `stateBytesPerNewAccount * cpsb` alongside the code-deposit portion, so a same-tx SELFDESTRUCT refund restores the full account+deposit amount.
- `runCall` revert handler: the existing top-level CREATE refund (depth=0 intrinsic) is extended to fire on ANY `isCreate` failure regardless of depth — the pre-charge lives outside the per-frame snapshot in both cases (intrinsic in runTx for depth=0; opcode pre-charge for depth>0).

## Test plan

EIP-8037 group (`amsterdam/v700_mixed_with_other_eips/eip8037_state_creation_gas_cost_increase`):

| | passing / total |
|---|---:|
| baseline (#4293) | 372 / 455 |
| this PR | **386 / 455** (+14) |

Full Amsterdam dev suite (`v700_mixed_with_other_eips`):

| Branch | passing / total |
|---|---:|
| master | 1181 / 2042 |
| #4293 | 1672 / 2042 |
| this PR | **1692 / 2042** (+20) |

The `test_create_collision_burned_gas_counted_in_block_regular` fixture now passes for the CREATE case. Some remaining failures in this cluster need extra work — e.g. CREATE2 sub-cases of `test_inner_create_succeeds_code_deposit_state_gas` where the test sizes gas tightly around the legacy frame-exit model and our pre-charge timing shifts where OOG triggers. Those are tracked as follow-ups; this PR is the structural change.

## Builds on

Depends on the param/spill/auth/intrinsic-refund changes in [#4293](https://github.com/ethereumjs/ethereumjs-monorepo/pull/4293).