### PR TITLE
evm: EIP-8037 v7 add create2Gas override + refund pre-charge on CREATE silent-failure paths

### DIFF
--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -1223,16 +1223,34 @@ export class Interpreter {
     // empty the return data buffer
     this._runState.returnBytes = new Uint8Array(0)
 
+    // EIP-8037: helper to refund the pre-charged NEW_ACCOUNT state-gas
+    // when the CREATE short-circuits BEFORE a child frame is spawned
+    // (depth limit, insufficient balance, EIP-2681 nonce overflow,
+    // EIP-3860 oversized initcode). The pre-charge happened in
+    // opcodes/gas.ts; the runCall revert handler won't fire here since
+    // no child frame is created, so refund explicitly.
+    const refundCreatePreCharge = (): void => {
+      if (!this.common.isActivatedEIP(8037)) return
+      const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
+      const blockGasLimit = this._env.block.header.gasLimit
+      const costPerStateByte = activeCostPerStateByte(this.common, blockGasLimit)
+      const newAccountStateGas = stateBytesPerNewAccount * costPerStateByte
+      this._evm.stateGasReservoir += newAccountStateGas
+      this._evm.executionStateGasUsed -= newAccountStateGas
+    }
+
     // Check if account has enough ether and max depth not exceeded
     if (
       this._env.depth >= Number(this.common.param('stackLimit')) ||
       this._env.contract.balance < value
     ) {
+      refundCreatePreCharge()
       return BIGINT_0
     }
 
     // EIP-2681 check
     if (this._env.contract.nonce >= MAX_UINT64) {
+      refundCreatePreCharge()
       return BIGINT_0
     }
 
@@ -1251,6 +1269,7 @@ export class Interpreter {
         codeToRun.length > Number(this.common.param('maxInitCodeSize')) &&
         this._evm.allowUnlimitedInitCodeSize === false
       ) {
+        refundCreatePreCharge()
         return BIGINT_0
       }
     }

--- a/packages/evm/src/params.ts
+++ b/packages/evm/src/params.ts
@@ -421,7 +421,8 @@ export const paramsEVM: ParamsDict = {
     sstoreSetGas: 2900, // SSTORE 0->nonzero: regular gas (down from 20000); state portion = stateBytesPerStorageSet * costPerStateByte
     sstoreInitEIP2200Gas: 2900, // EIP-2200 path uses this name for the create-slot regular cost; align with sstoreSetGas under 8037
     sstoreInitRefundEIP2200Gas: 0, // Legacy refund for "create-then-clear-in-same-tx" is replaced by the state-gas reservoir refill
-    createGas: 9000, // CREATE / CREATE2 base regular gas (down from 32000); state portion = (stateBytesPerNewAccount + L) * costPerStateByte
+    createGas: 9000, // CREATE base regular gas (down from 32000); state portion = (stateBytesPerNewAccount + L) * costPerStateByte
+    create2Gas: 9000, // CREATE2 base regular gas (down from 32000); state portion = (stateBytesPerNewAccount + L) * costPerStateByte
     callNewAccountGas: 0, // CALL* to non-existent: regular gas (down from 25000); state portion = stateBytesPerNewAccount * costPerStateByte
     createDataGas: 0, // Per-byte regular cost of code deposit (down from 200); replaced by costPerStateByte state-gas plus a per-word hash cost (see codeDepositHashWordGas)
     codeDepositHashWordGas: 6, // Per 32-byte word regular hash cost on contract creation (6 * ceil(L/32))


### PR DESCRIPTION
## Summary

Two small follow-ups to the CREATE pre-charge restructure landed in #4294. Together they unlock 43 additional tests on the full Amsterdam dev suite.

### 1. `create2Gas: 9000` override under EIP-8037

The 8037 param overlay set `createGas: 9000` with the comment "CREATE / CREATE2 base regular gas" — but only `createGas` was overridden. `create2Gas` was still the legacy 32,000, so CREATE2 inflated outer gas_left consumption by 23,000 past what the v7 fixtures sized for.

```ts
8037: {
  ...
  createGas: 9000, // CREATE base regular gas (down from 32000)
  create2Gas: 9000, // CREATE2 base regular gas (down from 32000)  ← new
  ...
}
```

Caught while debugging `test_inner_create_succeeds_code_deposit_state_gas[…CREATE2-blockchain_test-outer_succeeds]`: the depth=0 CREATE TX was OOG'ing because its inner CREATE2 was charging `32,000 + new_account` for the opcode, exceeding outer's gas_left budget.

### 2. Refund CREATE pre-charge on silent-failure paths

The CREATE/CREATE2 pre-charge in `opcodes/gas.ts` is refunded by the runCall revert handler when an inner frame is spawned and fails. But `Interpreter.create` has four short-circuit paths that return `BIGINT_0` BEFORE `_evm.runCall` is invoked:

- Depth limit (`depth >= stackLimit`)
- Insufficient balance (`contract.balance < value`)
- EIP-2681 nonce overflow (`contract.nonce >= MAX_UINT64`)
- EIP-3860 oversized initcode (`codeToRun.length > maxInitCodeSize`)

On any of these the inner frame is never created → runCall revert handler never fires → pre-charge was leaking. Refund it explicitly in each branch via a local `refundCreatePreCharge` helper.

Targets `test_create_silent_failure_refunds_state_gas` and `test_oversized_initcode_opcode_no_state_gas` per the fixture descriptions:

> Failures that skip child spawning (nonce overflow, insufficient balance) refund `GAS_NEW_ACCOUNT` to the reservoir.

## Test plan

EIP-8037 group (`amsterdam/v700_mixed_with_other_eips/eip8037_state_creation_gas_cost_increase`):

| Commit | passing / total |
|---|---:|
| #4293 + #4294 base | 386 / 455 |
| + create2Gas override | 414 / 455 (+28) |
| + silent-failure refund | **417 / 455** (+3) |

Full Amsterdam dev suite (`v700_mixed_with_other_eips`):

| | passing / total |
|---|---:|
| #4293 + #4294 base | 1692 / 2042 |
| this PR | **1735 / 2042** (+43) |

## Stacked on

Targets `eip-8037-v7-fixtures` (PR #4293). Will auto-retarget to master when #4293 merges.