### PR TITLE
EIP-8024 dupn/swapn/exchange Test Fixes

### DIFF
--- a/config/cspell-ts.json
+++ b/config/cspell-ts.json
@@ -34,6 +34,7 @@
     "bytelist",
     "bytestring",
     "binarytree",
+    "divmod",
     "merkelize",
     "kaust",
     "EEST",

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -26,8 +26,8 @@ import { EVMError, EVMErrorTypeString } from './errors.ts'
 import { type EVMPerformanceLogger, type Timer } from './logger.ts'
 import { Memory } from './memory.ts'
 import { Message } from './message.ts'
+import { isEIP8024PairImmediateValid, isEIP8024SingleImmediateValid } from './opcodes/EIP8024.ts'
 import { trap } from './opcodes/index.ts'
-import { isEIP8024PairImmediateValid, isEIP8024SingleImmediateValid } from './opcodes/util.ts'
 import { Stack } from './stack.ts'
 
 import type {

--- a/packages/evm/src/opcodes/EIP8024.ts
+++ b/packages/evm/src/opcodes/EIP8024.ts
@@ -1,0 +1,72 @@
+import { EVMError } from '../errors.ts'
+
+import { trap } from './util.ts'
+
+/**
+ * EIP-8024: Backward compatible SWAPN, DUPN, EXCHANGE.
+ *
+ * This module hosts the immediate-byte validity checks and decoders for the
+ * three opcodes introduced by the EIP:
+ *   - DUPN     (0xe6, single-byte immediate)
+ *   - SWAPN    (0xe7, single-byte immediate)
+ *   - EXCHANGE (0xe8, single-byte immediate encoding a pair (n, m))
+ *
+ * The encoding intentionally forbids immediate bytes that look like
+ * `JUMPDEST` (0x5b) or `PUSH1..PUSH32` (0x60..0x7f) so that JUMPDEST analysis
+ * can remain unchanged from pre-EIP behavior.
+ */
+
+/**
+ * Single-byte immediate validity for DUPN / SWAPN.
+ * Spec: invalid when 90 (0x5a) < x < 128 (0x80).
+ */
+export function isEIP8024SingleImmediateValid(immediate: number): boolean {
+  return immediate <= 0x5a || immediate >= 0x80
+}
+
+/**
+ * Decodes the DUPN / SWAPN immediate byte into the stack depth `n`.
+ *
+ * Spec: `n = (x + 145) mod 256`, mapping valid bytes bidirectionally onto
+ * n ∈ [17, 235].
+ *
+ * Traps with INVALID_OPCODE when the immediate is in the disallowed range.
+ */
+export function decodeEIP8024SingleImmediate(immediate: number): number {
+  if (!isEIP8024SingleImmediateValid(immediate)) {
+    trap(EVMError.errorMessages.INVALID_OPCODE)
+  }
+  return (immediate + 145) & 0xff
+}
+
+/**
+ * Pair-byte immediate validity for EXCHANGE.
+ * Spec: invalid when 81 (0x51) < x < 128 (0x80).
+ */
+export function isEIP8024PairImmediateValid(immediate: number): boolean {
+  return immediate <= 0x51 || immediate >= 0x80
+}
+
+/**
+ * Decodes the EXCHANGE immediate byte into stack distances `(n, m)`
+ * expected by `Stack.exchange()`. Returned values are 1-based depths
+ * below the top (top itself is never an EXCHANGE target).
+ *
+ * Spec: `k = x XOR 143`, `(q, r) = divmod(k, 16)`, then
+ *   - `(q + 1, r + 1)` if `q < r`
+ *   - `(r + 1, 29 - q)` otherwise
+ *
+ * Traps with INVALID_OPCODE when the immediate is in the disallowed range.
+ */
+export function decodeEIP8024PairImmediate(immediate: number): [number, number] {
+  if (!isEIP8024PairImmediateValid(immediate)) {
+    trap(EVMError.errorMessages.INVALID_OPCODE)
+  }
+  const k = immediate ^ 0x8f
+  const q = (k >> 4) & 0xf
+  const r = k & 0xf
+  if (q < r) {
+    return [q + 1, r + 1]
+  }
+  return [r + 1, 29 - q]
+}

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -34,10 +34,9 @@ import { EOFErrorMessage } from '../eof/errors.ts'
 import { EOFBYTES, EOFHASH, isEOF } from '../eof/util.ts'
 import { EVMError } from '../errors.ts'
 
+import { decodeEIP8024PairImmediate, decodeEIP8024SingleImmediate } from './EIP8024.ts'
 import {
   createAddressFromStackBigInt,
-  decodeEIP8024PairImmediate,
-  decodeEIP8024SingleImmediate,
   describeLocation,
   exponentiation,
   fromTwos,

--- a/packages/evm/src/opcodes/util.ts
+++ b/packages/evm/src/opcodes/util.ts
@@ -98,40 +98,6 @@ export function readImmediateByteOrZero(runState: RunState): number {
   return immediate
 }
 
-export function isEIP8024SingleImmediateValid(immediate: number): boolean {
-  return immediate <= 0x5a || immediate >= 0x80
-}
-
-export function decodeEIP8024SingleImmediate(immediate: number): number {
-  if (!isEIP8024SingleImmediateValid(immediate)) {
-    trap(EVMError.errorMessages.INVALID_OPCODE)
-  }
-  return immediate <= 0x5a ? immediate + 17 : immediate - 20
-}
-
-export function isEIP8024PairImmediateValid(immediate: number): boolean {
-  return immediate <= 0x4f || immediate >= 0x80
-}
-
-/**
- * Decodes EIP-8024 EXCHANGE immediate into stack depths expected by `Stack.exchange()`.
- *
- * Returned values are stack distances from the top where `0` is top.
- * EIP-8024 EXCHANGE never targets depth `0`, so decoded values are always >= 1.
- */
-export function decodeEIP8024PairImmediate(immediate: number): [number, number] {
-  if (!isEIP8024PairImmediateValid(immediate)) {
-    trap(EVMError.errorMessages.INVALID_OPCODE)
-  }
-  const k = immediate <= 0x4f ? immediate : immediate - 48
-  const q = Math.floor(k / 16)
-  const r = k % 16
-  if (q < r) {
-    return [q + 1, r + 1]
-  }
-  return [r + 1, 29 - q]
-}
-
 /**
  * Error message helper - generates location string
  */


### PR DESCRIPTION
 + Small refactoring (dedicated util file)
 
### New Test Status:
 
<img width="773" height="293" alt="grafik" src="https://github.com/user-attachments/assets/0f949dd1-597f-4038-9faa-1c382206a653" />

### Bug Analysis (Opus 4.7):
 
 ---
 
 ## EIP-8024 — First-round failure mode analysis

### Current state — per sub-folder

| Sub-folder | Pass / Total | % | Notes |
|---|---|---|---|
| `dupn/` | 43/61 | 70.5% | mixed |
| `swapn/` | 4/20 | **20.0%** | most acute |
| `exchange/` | 63/86 | 73.3% | mixed |
| `eip_vectors/` | 9/21 | 42.9% | canonical spec test vectors |
| `pc_advancement/` | **0/5** | **0.0%** | all failing |
| **TOTAL** | **119/193** | **61.7%** | |

### Implementation surface (mapped)

- Opcode registration: `evm/src/opcodes/codes.ts` — `0xe6=DUPN`, `0xe7=SWAPN`, `0xe8=EXCHANGE` properly gated on `isActivatedEIP(8024)`.
- Gas: `evm/src/params.ts` — `dupnGas=3`, `swapnGas=3`, `exchangeGas=3` (matches spec).
- Opcode handlers: `evm/src/opcodes/functions.ts` lines 1282–1317 — each reads the immediate via `readImmediateByteOrZero`, decodes, then calls `runState.stack.{dup,swap,exchange}`.
- `Stack.dup/swap/exchange` in `evm/src/stack.ts` — already use 1-based-depth semantics consistent with how the spec wants the decoded `n` (and `n+1`/`m+1` for EXCHANGE) plumbed through. **Correct as-is.**
- JUMPDEST analysis in `interpreter.ts::_getValidJumpDestinations` — has an 8024-specific branch that skips the immediate iff `isEIP8024*ImmediateValid` returns true. Behaviorally equivalent to the spec's "JUMPDEST analysis unchanged" requirement on the test cases I walked through (`e6805b`, `e75b`, `e6605b`, etc. all decode the same way under both formulations).
- EOF stack-delta wiring (`eof/stackDelta.ts`) — input/output/intermediates set correctly. Not exercised in v700 fixtures (no EOF tests here), but worth keeping in mind.

So the **opcode-dispatch, gas, stack-method, and JUMPDEST plumbing all look right.** The bugs are concentrated in two small utility functions in `evm/src/opcodes/util.ts`.

### Root causes

**Bug A — wrong `decode_single` formula (affects every DUPN and SWAPN execution)**

`evm/src/opcodes/util.ts:105-110`:

```108:110:packages/evm/src/opcodes/util.ts
  return immediate <= 0x5a ? immediate + 17 : immediate - 20
```

Spec: `decode_single(x) = (x + 145) mod 256`. The two formulas produce the same *output range* `[17, 235]` but completely different *mappings*:

| Byte `x` | Spec `n` | Our `n` |
|---|---|---|
| `0x00` | 145 | 17 |
| `0x5a` (90) | 235 | 107 |
| `0x80` (128) | **17** | 108 |
| `0xdb` (219) | **108** | 199 |
| `0xff` (255) | 144 | 235 |

The EIP's own test cases confirm the spec direction:
- `e6 80` is `DUPN 17` (spec) — our impl turns it into `DUPN 108`.
- `e7 db` is `SWAPN 108` (spec) — our impl turns it into `SWAPN 199`.

This is why `swapn/` is at 20% — its fixtures push exactly enough items to exercise the spec-decoded depth, then SWAPN with a high-byte immediate. Our wrong `n` either overshoots (STACK_UNDERFLOW), or swaps the wrong slot, or both.

**Bug B — wrong `decode_pair` formula (affects every EXCHANGE execution)**

`evm/src/opcodes/util.ts:122-133`:

```126:132:packages/evm/src/opcodes/util.ts
  const k = immediate <= 0x4f ? immediate : immediate - 48
  const q = Math.floor(k / 16)
  const r = k % 16
  if (q < r) {
    return [q + 1, r + 1]
  }
  return [r + 1, 29 - q]
```

Spec: `k = x XOR 143`, same `(q, r) = divmod(k, 16)` then same branch. The XOR isn't equivalent to the subtractive trick — they produce different `k` for every `x`.

EIP test cases:
- `e8 9d` should be `EXCHANGE 2 3`. Spec: `k = 0x9d ^ 0x8f = 18` → `(q,r)=(1,2)` → `(2, 3)`. Ours: `k = 157 − 48 = 109` → `(q,r)=(6,13)` → `(7, 14)`. **Wrong.**
- `e8 2f` should be `EXCHANGE 1 19`. Spec: `k = 0x2f ^ 0x8f = 160` → `(10, 0)` → `(1, 19)`. Ours: `k = 47` → `(2, 15)` → `(3, 16)`. **Wrong.**

**Bug C — wrong `isEIP8024PairImmediateValid` range (off by 2)**

`evm/src/opcodes/util.ts:112-114`:

```112:114:packages/evm/src/opcodes/util.ts
export function isEIP8024PairImmediateValid(immediate: number): boolean {
  return immediate <= 0x4f || immediate >= 0x80
}
```

Spec: invalid only when `81 < x < 128`, i.e. valid range is `x <= 0x51`. Our impl rejects `0x50` and `0x51` as invalid, but the EIP test cases say `e8 50` is `EXCHANGE 14 16` and `e8 51` is `EXCHANGE 14 15` — both valid.

There are even dedicated canonical test vectors for these exact bytes (`vector_exchange_valid_0x50.json`, `vector_exchange_valid_0x51.json`) — predicted to be among the 12 `eip_vectors/` failures right now.

**Note:** the validity check for SingleImmediate (`<= 0x5a || >= 0x80`) is correct vs. the spec's "invalid when `90 < x < 128`", so no fix needed there.

### Failure mapping

| Category | Failures | Root cause |
|---|---|---|
| All DUPN/SWAPN with byte ≥ 0x80 (and many with 0x00–0x5a too) | majority of `dupn/`, `swapn/`, `eip_vectors/dupn|swapn` vectors | Bug A |
| All EXCHANGE executions producing wrong `(n, m)` | `exchange/`, `eip_vectors/exchange*` | Bug B |
| `vector_exchange_valid_0x50`, `vector_exchange_valid_0x51` | 2 of `eip_vectors/` | Bug C |
| `pc_advancement/*` (5 fixtures) | 5 / 5 | Bugs A/B trip stack mid-sequence → tx fails → wrong post-state. PC advancement itself is fine. |

In other words: **all 74 failures should be attributable to Bugs A, B, and C in `evm/src/opcodes/util.ts`.** Nothing else looks structurally broken.

### Proposed fix (single file, three constants/formulas)

`evm/src/opcodes/util.ts`:

1. **Bug A** — replace the single-immediate decoder body with the spec's modular form:

```typescript
return (immediate + 145) & 0xff
```

(Using `& 0xff` instead of `% 256` is slightly faster and unambiguous for non-negative ints. Could equivalently do `(immediate + 145) % 256`.)

2. **Bug B** — replace the pair decoder's `k` computation with the spec's XOR:

```typescript
const k = immediate ^ 0x8f
const q = (k >> 4) & 0xf
const r = k & 0xf
```

3. **Bug C** — widen the pair-immediate valid range from `0x4f` to `0x51`:

```typescript
return immediate <= 0x51 || immediate >= 0x80
```

That's the entire diff — three small in-place edits, no API surface change, no new files. The function/parameter names remain stable, so no call-site updates needed in `functions.ts` or `interpreter.ts`.

### Risk assessment

- **Blast radius:** purely the three opcodes from EIP-8024. No other EIPs touch these helpers (verified via the file's import graph).
- **Cross-EIP regression risk:** essentially zero — the helpers are only called from the three opcode handlers and from JUMPDEST analysis. The JUMPDEST branch only uses `isEIP8024PairImmediateValid` / `isEIP8024SingleImmediateValid` (the latter unchanged; the former widens by 2 bytes which can only *avoid* incorrectly stopping at 0x50/0x51, never create new false jumps).
- **Could the spec's `decode_single` formula be encoded as a piecewise add/subtract?** Yes, but with different constants per range than what's there now: `x in [0, 90]` → `x + 145`, `x in [128, 255]` → `x − 111`. Cleaner to just use `(x + 145) & 0xff` and be done.

### Expected payoff

Best estimate, conservative: clears ~70 of the 74 failures in this folder. The remaining few (if any) would likely be edge cases in `eip_vectors/` around JUMPDEST analysis ordering or end-of-code semantics that I haven't fully exercised. We can mop up after the main bugs are out.

### Stop point

I'll stop here for your sign-off. Ready to apply the three edits in `util.ts` and then run the per-folder + full-v700 regression sweeps as we did for 7708. Want me to proceed?