### PR TITLE
vm: EIP-7976 floor-gas test fixes (broaden exception regex)

### DIFF
--- a/packages/vm/test/tester/executionSpecBlockchain.test.ts
+++ b/packages/vm/test/tester/executionSpecBlockchain.test.ts
@@ -309,7 +309,8 @@ const exceptionMessages: Record<string, RegExp> = {
   'TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS':
     /Transaction's maxFeePerBlobGas \d+\) is less than block blobGasPrice \(\d+\)/,
   'TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS': /tx unable to pay base fee/,
-  'TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST': /gasLimit is too low/,
+  'TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST':
+    /gasLimit is too low|INTRINSIC_GAS_TOO_LOW/,
   'TransactionException.INTRINSIC_GAS_TOO_LOW': /gasLimit is too low|INTRINSIC_GAS_TOO_LOW/,
   'TransactionException.NONCE_MISMATCH_TOO_LOW': /the tx doesn't have the correct nonce/,
   'TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS':


### PR DESCRIPTION
## Summary

Broadens the `TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST` regex in the execution-spec blockchain test runner to also match `INTRINSIC_GAS_TOO_LOW`. This is the canonical/documented behavior — see the official spec-tests CLI mapping at [`src/ethereum_clis/clis/ethereumjs.py`](https://github.com/ethereum/execution-spec-tests/blob/main/src/ethereum_clis/clis/ethereumjs.py):

```python
TransactionException.INTRINSIC_GAS_TOO_LOW: "is lower than the minimum gas limit of",
TransactionException.INTRINSIC_GAS_BELOW_FLOOR_GAS_COST: (
    "is lower than the minimum gas limit of"
),
```

EthereumJS uses a single `bigIntMax(intrinsic, floor)` check in `runTx.ts` and throws one unified `INTRINSIC_GAS_TOO_LOW: ...is lower than the minimum gas limit of...` error for both underrun conditions. This matches how EELS itself implements the check (a single `InsufficientTransactionGasError` for `max(intrinsic_gas, data_floor_gas_cost) > tx.gas`, see `forks/amsterdam/transactions.py:564`). The fixture exception names are distinguished by the python test generator but expected to map to the same client message.

## Verification of EIP-7976 itself

The implementation was already in master before this PR. Verified correct:

- **Params**: `totalCostFloorPerToken=16` in `packages/tx/src/params.ts:91`
- **EIP definition**: `packages/common/src/eips.ts:593` with `requiredEIPs: [7623]`
- **Activation**: Amsterdam hardfork (`packages/common/src/hardforks.ts:203`)
- **Floor calc**: `packages/vm/src/runTx.ts:577` and `packages/tx/src/capabilities/legacy.ts:215` — both use `data.length * 4` tokens when 7976 is active, giving `21000 + 64 * data_bytes` floor
- **Hand-verified** against fixtures: every "insufficient_gas" case has gasLimit set to exactly `floor - 1`, and our `minGasLimit` value matches the fixture's expected floor to the byte.

## Submodule

`packages/execution-spec-tests` already at `b06e2d2` on master (bal@v7.1.0), which includes the new `eip7976_increase_calldata_floor_cost` fixtures.

## Test plan

- [x] `TEST_PATH=../execution-spec-tests/dev/blockchain_tests/amsterdam/v700_mixed_with_other_eips/eip7976_increase_calldata_floor_cost npx vitest run test/tester/executionSpecBlockchain.test.ts` → **530/530 passing** across transaction_validity, additional_coverage, eip_mainnet, execution_gas, refunds.