### PR TITLE
Final BAL Fixes

### DIFF
--- a/packages/evm/src/opcodes/EIP7928.ts
+++ b/packages/evm/src/opcodes/EIP7928.ts
@@ -330,7 +330,6 @@ export async function create7928Gas(
   if (common.isActivatedEIP(2929)) {
     warmAddress(runState, targetAddress)
   }
-  addAddressToBAL(runState, targetAddress, common)
 
   if (common.isActivatedEIP(2929)) {
     gas += accessAddressEIP2929(runState, runState.interpreter.getAddress().bytes, common, false)
@@ -338,9 +337,11 @@ export async function create7928Gas(
 
   if (common.isActivatedEIP(8037)) {
     if (!canAfford(runState, gas, newAccountStateGas)) {
+      addAddressToBAL(runState, targetAddress, common)
       return eip7928PostTargetCreateOog(runState, common, gas)
     }
     if (gas > runState.interpreter.getGasLeft()) {
+      addAddressToBAL(runState, targetAddress, common)
       return eip7928PostTargetCreateOog(runState, common, gas)
     }
     if (gas > BIGINT_0) {
@@ -349,6 +350,7 @@ export async function create7928Gas(
     }
     runState.interpreter.chargeStateGas(newAccountStateGas, `${preChargeLabel} new_account`)
   } else if (gas > runState.interpreter.getGasLeft()) {
+    addAddressToBAL(runState, targetAddress, common)
     return eip7928PostTargetCreateOog(runState, common, gas)
   }
 
@@ -356,6 +358,7 @@ export async function create7928Gas(
   gasLimit = maxCallGas(gasLimit, gasLimit, runState, common)
 
   if (gas > runState.interpreter.getGasLeft()) {
+    addAddressToBAL(runState, targetAddress, common)
     return eip7928PostTargetCreateOog(runState, common, gas)
   }
 

--- a/packages/util/src/bal/index.ts
+++ b/packages/util/src/bal/index.ts
@@ -321,15 +321,24 @@ export class BlockLevelAccessList {
     // Only no-op writes (writing same value as original) are treated as reads
     // EIP-7928: Zeroing a slot (pre-value exists, post-value is zero) IS a write
     if (isNoOp) {
-      // EIP-7928: If a slot is written back to its original value (net-zero change),
-      // it should appear in storageReads, not storageChanges.
-      // This handles nested calls where intermediate frames write different values
-      // but the final value equals the original.
+      // EIP-7928: A no-op write within a transaction only affects that tx's
+      // blockAccessIndex entry. Prior tx changes for the same slot must remain.
       if (this.accesses[address] !== undefined) {
-        // Remove any existing storageChanges for this slot since final == original
-        delete this.accesses[address].storageChanges[strippedKey]
+        const slotChanges = this.accesses[address].storageChanges[strippedKey]
+        if (slotChanges !== undefined) {
+          const remaining = slotChanges.filter(([idx]) => idx !== blockAccessIndex)
+          if (remaining.length === 0) {
+            delete this.accesses[address].storageChanges[strippedKey]
+            this.addStorageRead(address, storageKey)
+          } else {
+            this.accesses[address].storageChanges[strippedKey] = remaining
+          }
+        } else {
+          this.addStorageRead(address, storageKey)
+        }
+      } else {
+        this.addStorageRead(address, storageKey)
       }
-      this.addStorageRead(address, storageKey)
       return
     }
     if (this.accesses[address] === undefined) {

--- a/packages/util/src/bal/validation.ts
+++ b/packages/util/src/bal/validation.ts
@@ -12,6 +12,35 @@ import {
   createBlockLevelAccessListFromJSON,
 } from './index.ts'
 
+/** EIP-7928: gas cost attributed to each BAL item (address or storage key). */
+export const BLOCK_ACCESS_LIST_ITEM_COST = 2000
+
+/**
+ * Counts BAL items per EIP-7928: `addresses + storage_keys`.
+ * Uses the canonical {@link BlockLevelAccessList.raw()} view.
+ */
+export function countBlockAccessListItems(bal: BlockLevelAccessList): number {
+  let items = 0
+  for (const [, storageChanges, storageReads] of bal.raw()) {
+    items += 1 + storageChanges.length + storageReads.length
+  }
+  return items
+}
+
+/**
+ * Ensures `bal_items <= block_gas_limit // ITEM_COST` (EIP-7928).
+ */
+export function validateBlockAccessListGasLimit(
+  bal: BlockLevelAccessList,
+  blockGasLimit: bigint,
+): void {
+  const maxItems = blockGasLimit / BigInt(BLOCK_ACCESS_LIST_ITEM_COST)
+  const items = BigInt(countBlockAccessListItems(bal))
+  if (items > maxItems) {
+    throwBlockAccessListGasLimitExceeded()
+  }
+}
+
 /**
  * Validates canonical BAL structure and, when provided, the header hash commitment.
  */
@@ -319,4 +348,8 @@ function throwInvalidBlockAccessList(detail: string): never {
 
 function throwInvalidBalHash(detail: string): never {
   throw EthereumJSErrorWithoutCode(`invalid block access list hash: ${detail}`)
+}
+
+function throwBlockAccessListGasLimitExceeded(): never {
+  throw EthereumJSErrorWithoutCode('block access list gas limit exceeded')
 }

--- a/packages/util/test/bal/validation.spec.ts
+++ b/packages/util/test/bal/validation.spec.ts
@@ -9,8 +9,11 @@ import {
 import { assert, describe, it } from 'vitest'
 
 import {
+  BLOCK_ACCESS_LIST_ITEM_COST,
+  countBlockAccessListItems,
   equalsBlockAccessList,
   isAccountOrderOnlyViolation,
+  validateBlockAccessListGasLimit,
   validateBlockAccessListHash,
   validateBlockAccessListHashFromJSON,
   validateBlockAccessListJSONStructure,
@@ -139,6 +142,69 @@ describe('execution-spec invalid BAL fixtures', () => {
     assert.throws(
       () => validateBlockAccessListHashFromJSON(balJSON, headerHash),
       /invalid block access list hash:/,
+    )
+  })
+})
+
+describe('validateBlockAccessListGasLimit', () => {
+  // Minimal fixture mirroring bal_gas_limit_boundary (4 addresses + 11 storage keys = 15 items)
+  const boundaryBalJson: BALJSONBlockAccessList = [
+    {
+      address: '0x00000961ef480eb55e80d19ad83579a64c007002',
+      nonceChanges: [],
+      balanceChanges: [],
+      codeChanges: [],
+      storageChanges: [],
+      storageReads: ['0x00', '0x01', '0x02', '0x03'],
+    },
+    {
+      address: '0x0000bbddc7ce488642fb579f8b00f3a590007251',
+      nonceChanges: [],
+      balanceChanges: [],
+      codeChanges: [],
+      storageChanges: [],
+      storageReads: ['0x00', '0x01', '0x02', '0x03'],
+    },
+    {
+      address: '0x0000f90827f1c53a10cb7a02335b175320002935',
+      nonceChanges: [],
+      balanceChanges: [],
+      codeChanges: [],
+      storageChanges: [
+        {
+          slot: '0x00',
+          slotChanges: [{ blockAccessIndex: '0x00', postValue: '0x01' }],
+        },
+      ],
+      storageReads: [],
+    },
+    {
+      address: '0x000f3df6d732807ef1319fb7b8bb8522d0beac02',
+      nonceChanges: [],
+      balanceChanges: [],
+      codeChanges: [],
+      storageChanges: [
+        {
+          slot: '0x0c',
+          slotChanges: [{ blockAccessIndex: '0x00', postValue: '0x0c' }],
+        },
+      ],
+      storageReads: ['0x200b'],
+    },
+  ]
+
+  it('counts BAL items as addresses plus storage keys', () => {
+    const bal = createBlockLevelAccessListFromJSON(boundaryBalJson)
+    assert.equal(countBlockAccessListItems(bal), 15)
+    assert.equal(BLOCK_ACCESS_LIST_ITEM_COST, 2000)
+  })
+
+  it('accepts at-boundary gas limit and rejects one below', () => {
+    const bal = createBlockLevelAccessListFromJSON(boundaryBalJson)
+    validateBlockAccessListGasLimit(bal, 30000n)
+    assert.throws(
+      () => validateBlockAccessListGasLimit(bal, 29999n),
+      /block access list gas limit exceeded/,
     )
   })
 })

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -34,6 +34,7 @@ import {
   setLengthLeft,
   short,
   unprefixedHexToBytes,
+  validateBlockAccessListGasLimit,
   validateBlockAccessListHash,
   validateBlockAccessListHashFromJSON,
   validateBlockAccessListJSONStructure,
@@ -209,12 +210,30 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
     }
     throw err
   }
+
   let requestsHash: Uint8Array | undefined
   let requests: CLRequest<CLRequestType>[] | undefined
   if (block.common.isActivatedEIP(7685)) {
     const sha256Function = vm.common.customCrypto.sha256 ?? sha256
     requests = await accumulateRequests(vm, result.results, block.header.gasLimit)
     requestsHash = genRequestsRoot(requests, sha256Function)
+  }
+
+  if (vm.common.isActivatedEIP(7928) && vm.evm.blockLevelAccessList !== undefined) {
+    try {
+      validateBlockAccessListGasLimit(vm.evm.blockLevelAccessList, block.header.gasLimit)
+    } catch {
+      await vm.evm.journal.revert()
+      if (vm.DEBUG) {
+        debug(`block checkpoint reverted`)
+      }
+      if (enableProfiler) {
+        // eslint-disable-next-line no-console
+        console.timeEnd(withdrawalsRewardsCommitLabel)
+      }
+      const msg = _errorMsg('block access list gas limit exceeded', vm, block)
+      throw EthereumJSErrorWithoutCode(msg)
+    }
   }
 
   const stateRoot = await stateManager.getStateRoot()

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -184,11 +184,26 @@ async function processAuthorizationList(
     // includes (stateBytesPerNewAccount + stateBytesPerAuthBase) * costPerStateByte.
     // If the authority account already existed, refund the
     // stateBytesPerNewAccount * costPerStateByte portion to the reservoir
-    // (no 20% cap).
+    // (no 20% cap). When the pre-state code slot already holds a delegation
+    // indicator, also refund stateBytesPerAuthBase — the refill keys off the
+    // pre-state code slot, not the bytes being written.
+    const codeBeforeAuth =
+      vm.common.isActivatedEIP(7928) || vm.common.isActivatedEIP(8037)
+        ? await vm.stateManager.getCode(authority)
+        : undefined
     if (accountExists && tx.common.isActivatedEIP(8037)) {
       const stateBytesPerNewAccount = vm.common.param('stateBytesPerNewAccount')
+      const stateBytesPerAuthBase = vm.common.param('stateBytesPerAuthBase')
       const costPerStateByte = activeCostPerStateByte(vm.common, block?.header.gasLimit)
-      existingAuthStateGasRefund += stateBytesPerNewAccount * costPerStateByte
+      let refundStateBytes = stateBytesPerNewAccount
+      if (
+        codeBeforeAuth !== undefined &&
+        codeBeforeAuth.length >= 3 &&
+        equalsBytes(codeBeforeAuth.slice(0, 3), DELEGATION_7702_FLAG)
+      ) {
+        refundStateBytes += stateBytesPerAuthBase
+      }
+      existingAuthStateGasRefund += refundStateBytes * costPerStateByte
     }
 
     // Update account nonce and store
@@ -205,9 +220,8 @@ async function processAuthorizationList(
     // Set delegation code
     const address = data[1]
     // Get current code before modifying (needed for BAL tracking)
-    const currentCode = vm.common.isActivatedEIP(7928)
-      ? await vm.stateManager.getCode(authority)
-      : undefined
+    const currentCode =
+      vm.common.isActivatedEIP(7928) || vm.common.isActivatedEIP(8037) ? codeBeforeAuth : undefined
     if (equalsBytes(address, new Uint8Array(20))) {
       // Special case: clear delegation when delegating to zero address
       // See EIP PR: https://github.com/ethereum/EIPs/pull/8929

--- a/packages/vm/test/tester/executionSpecBlockchain.test.ts
+++ b/packages/vm/test/tester/executionSpecBlockchain.test.ts
@@ -349,6 +349,7 @@ const exceptionMessages: Record<string, RegExp> = {
   'BlockException.INVALID_BAL_HASH': /invalid block access list hash/,
   'BlockException.INVALID_BLOCK_HASH': /invalid block access list hash/,
   'BlockException.INVALID_BLOCK_ACCESS_LIST': /invalid block access list/,
+  'BlockException.BLOCK_ACCESS_LIST_GAS_LIMIT_EXCEEDED': /block access list gas limit exceeded/,
   'BlockException.INVALID_WITHDRAWALS_ROOT': /invalid withdrawals trie/,
   'BlockException.SYSTEM_CONTRACT_CALL_FAILED': /system contract call failed/,
   'BlockException.SYSTEM_CONTRACT_EMPTY': /system contract empty/,


### PR DESCRIPTION
Fixes "per commit" (all with Composer 2.5):

Group D is done — **22/22** tests in `block_access_lists_eip7702/` pass.

# First Commit

## Root cause

The failures were not primarily BAL hash mismatches. They came from **EIP-8037 auth state-gas refund logic** in `processAuthorizationList()`.

For a **clear/update** auth when the authority already has delegation code (`0xef0100…`), the spec refunds the **full** pre-state slot cost (`stateBytesPerNewAccount + stateBytesPerAuthBase`), not just the new-account portion. The refill is keyed off the **pre-state code slot**, not what is being written.

Our code only refunded `stateBytesPerNewAccount × costPerStateByte`, so tx2 in `delegation_clear` (clear after set) still paid full auth state gas (`0x8976`), which broke:

- receipt trie / block `gasUsed`
- sender balance in BAL (one balance mismatch)

## Fix

In `packages/vm/src/runTx.ts`, when computing `existingAuthStateGasRefund` under EIP-8037, also add `stateBytesPerAuthBase` if pre-state code is a delegation indicator:

```183:206:packages/vm/src/runTx.ts
    const codeBeforeAuth =
      vm.common.isActivatedEIP(7928) || vm.common.isActivatedEIP(8037)
        ? await vm.stateManager.getCode(authority)
        : undefined
    if (accountExists && tx.common.isActivatedEIP(8037)) {
      const stateBytesPerNewAccount = vm.common.param('stateBytesPerNewAccount')
      const stateBytesPerAuthBase = vm.common.param('stateBytesPerAuthBase')
      const costPerStateByte = activeCostPerStateByte(vm.common, block?.header.gasLimit)
      let refundStateBytes = stateBytesPerNewAccount
      if (
        codeBeforeAuth !== undefined &&
        codeBeforeAuth.length >= 3 &&
        equalsBytes(codeBeforeAuth.slice(0, 3), DELEGATION_7702_FLAG)
      ) {
        refundStateBytes += stateBytesPerAuthBase
      }
      existingAuthStateGasRefund += refundStateBytes * costPerStateByte
    }
```

That aligns with the existing `auth_refund_block_gas_accounting` EIP-8037 fixtures.

## Test results

| Suite | Result |
|-------|--------|
| `block_access_lists_eip7702/` | **22/22** |
| `auth_refund_block_gas_accounting.json` (8037) | **4/4** |
| `bal_call_7702_delegation_and_oog.json` (Group C regression) | **64/64** |
| `block_access_lists_invalid/` | **55/55** |

Suggested commit message:

```
fix(vm): EIP-8037 full auth state-gas refund for existing delegation
```

# Second Commit

Group E is done — **2/2** on `bal_gas_limit_boundary.json`.

## Root cause

The gas-limit check ran right after `applyBlock()`, but the full BAL is not built until **after** `accumulateRequests()` (EIP-7685). Withdrawal/consolidation system calls (EIP-7002/7251) add storage reads on the predeploy contracts (`0x961…`, `0xbbdd…`), which account for most of the 15 items.

At the old checkpoint only ~2 items were counted; after requests accumulation the BAL reached 15 items, so `below_boundary` (gas limit 29 999 → max 14 items) incorrectly passed.

## Fix

Moved `validateBlockAccessListGasLimit()` to **after** `accumulateRequests()` and before header/state validation in `runBlock.ts`. Removed the temporary `DEBUG_BAL_GAS` logging.

## Verification

| Suite | Result |
|-------|--------|
| `bal_gas_limit_boundary.json` | **2/2** |
| `block_access_lists_invalid/` | **55/55** |
| `packages/util/test/bal/validation.spec.ts` | **14/14** |

Suggested commit message when you're ready:

```
feat(vm,util): enforce EIP-7928 BAL item gas limit (ITEM_COST)
```

# Third Commit

All three failures are fixed. The full EIP-7928 BAL slice is green: **679/679**.

## What was wrong

### 1–2. `bal_create2_selfdestruct_then_recreate_same_block` (no_balance + with_balance)

The factory runs CREATE2 in **both** txs and always `SSTORE`s slot 0 with the same CREATE2 address. In tx2 that write is a per-tx no-op (value unchanged since tx start), but our no-op handler **deleted the entire slot** from `storageChanges` — including tx1’s legitimate change at `blockAccessIndex 0x01` — and replaced it with a `storageReads` entry.

**Fix** (`packages/util/src/bal/index.ts`): On no-op writes, only remove the change at the **current** `blockAccessIndex`. If earlier txs still have changes for that slot, keep them.

### 3. `bal_create_early_failure`

`create7928Gas()` added the computed CREATE target to the BAL **during gas calculation**, before execution. A CREATE that fails on insufficient endowment never reaches `track_address` (nonce bump), but the address was already recorded.

**Fix** (`packages/evm/src/opcodes/EIP7928.ts`): Stop adding the target address unconditionally in the gas handler. Add it only on **post-target OOG** paths (after the target is warmed), matching the CREATE OOG boundary tests. Successful CREATE, collision, and `_addToBalance` paths still add the address as before.

## Verification

| Suite | Result |
|-------|--------|
| Full `eip7928_block_level_access_lists/` | **679/679** |
| `block_access_lists_invalid/` | **55/55** |
| `bal_gas_limit_boundary.json` | **2/2** |
| `packages/util/test/bal/` | **28/28** |

The BAL front is closed. 🎉