### PR TITLE
vm: fix EIP-7778 / EIP-8037 fixture regressions

### DIFF
--- a/packages/evm/src/eip8037.ts
+++ b/packages/evm/src/eip8037.ts
@@ -1,3 +1,5 @@
+import { BIGINT_0 } from '@ethereumjs/util'
+
 import type { Common } from '@ethereumjs/common'
 
 /**
@@ -9,4 +11,78 @@ import type { Common } from '@ethereumjs/common'
  */
 export function activeCostPerStateByte(common: Common, _blockGasLimit?: bigint): bigint {
   return common.param('costPerStateByte')
+}
+
+/**
+ * Minimal shape of a tx needed to split intrinsic gas into the EIP-8037
+ * regular/state dimensions. Avoids a `@ethereumjs/tx` import cycle here.
+ */
+interface IntrinsicDimensionsTx {
+  type: number
+  common: Common
+  getIntrinsicGas(): bigint
+  toCreationAddress(): boolean
+  // EIP-7702 (type 4) txs expose an authorization list.
+  authorizationList?: unknown[]
+}
+
+/**
+ * EIP-8037 intrinsic-gas decomposition.
+ *
+ * Returns `{ intrinsicRegular, intrinsicState }` such that
+ * `intrinsicRegular + intrinsicState` equals the tx's total intrinsic
+ * charge under EIP-8037. Callers may then use the split for the per-tx
+ * block-gas pre-execution checks:
+ *
+ *   regular check: min(TX_MAX, tx.gas - intrinsicState) > regular_available  → reject
+ *   state check:   (tx.gas - intrinsicRegular)         > state_available     → reject
+ *
+ * and for sizing the EIP-8037 state-gas reservoir.
+ *
+ * When EIP-8037 is not active, returns `{ intrinsicRegular: tx.getIntrinsicGas(),
+ * intrinsicState: 0n }` so callers can use a single code path.
+ */
+export function computeIntrinsicGasDimensions8037(
+  common: Common,
+  tx: IntrinsicDimensionsTx,
+  blockGasLimit?: bigint,
+): { intrinsicRegular: bigint; intrinsicState: bigint } {
+  const intrinsicRegular0 = tx.getIntrinsicGas()
+  if (!common.isActivatedEIP(8037)) {
+    return { intrinsicRegular: intrinsicRegular0, intrinsicState: BIGINT_0 }
+  }
+
+  const costPerStateByte = activeCostPerStateByte(common, blockGasLimit)
+  const stateBytesPerNewAccount = common.param('stateBytesPerNewAccount')
+  const stateBytesPerAuthBase = common.param('stateBytesPerAuthBase')
+
+  // 7702 regular correction. getIntrinsicGas() (via getDataGas in
+  // tx/capabilities/eip7702.ts) adds `authCount * perEmptyAccountCost` to
+  // the regular intrinsic. Under EIP-8037 perEmptyAccountCost = 0 and the
+  // regular per-auth charge is perAuthBaseGas; add the missing amount here.
+  let authCount = 0
+  let intrinsicRegular = intrinsicRegular0
+  if (tx.type === 4 && Array.isArray(tx.authorizationList)) {
+    authCount = tx.authorizationList.length
+    intrinsicRegular += BigInt(authCount) * common.param('perAuthBaseGas')
+  }
+
+  // State-dimension intrinsic: state portion of creation-tx new-account
+  // charge plus per-auth state base (new-account + auth-base bytes).
+  let intrinsicState = BIGINT_0
+  let isCreate = false
+  try {
+    isCreate = tx.toCreationAddress()
+  } catch {
+    isCreate = false
+  }
+  if (isCreate) {
+    intrinsicState += stateBytesPerNewAccount * costPerStateByte
+  }
+  if (authCount > 0) {
+    intrinsicState +=
+      BigInt(authCount) * (stateBytesPerNewAccount + stateBytesPerAuthBase) * costPerStateByte
+  }
+
+  return { intrinsicRegular, intrinsicState }
 }

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -485,11 +485,6 @@ export class EVM implements EVMInterface {
 
     // Load `to` account
     let toAccount = await this.stateManager.getAccount(message.to)
-    // EIP-8037: capture whether the destination account existed before this
-    // call frame, used below to decide whether to charge new-account state
-    // gas on successful frame exit. Empty accounts are treated as
-    // non-existent (matches the existing callNewAccountGas trigger).
-    const toExistedBefore = toAccount !== undefined && !toAccount.isEmpty()
     if (!toAccount) {
       if (this.common.isActivatedEIP(6800) || this.common.isActivatedEIP(7864)) {
         const absenceProofAccessGas = message.accessWitness!.readAccountHeader(message.to)

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -578,36 +578,12 @@ export class EVM implements EVMInterface {
         returnValue: new Uint8Array(0),
         logs: eip7708Log ? [eip7708Log] : undefined,
       }
-      if (
-        this.common.isActivatedEIP(8037) &&
-        // At depth=0 (top-level value-transferring tx), the new-account
-        // state-gas (callNewAccountGas equivalent) is the EIP-2780 intrinsic
-        // add-on, not a per-frame charge. For the amsterdam v700 fixture set
-        // EIP-2780 is not activated, so a top-level tx.value > 0 to a fresh
-        // EOA pays only the 21,000 intrinsic. Inner CALL frames continue to
-        // charge new-account state-gas here.
-        message.depth !== 0 &&
-        !earlyResult.exceptionError &&
-        !toExistedBefore &&
-        message.value !== BIGINT_0 &&
-        !message.delegatecall &&
-        this.getPrecompile(message.to) === undefined
-      ) {
-        const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
-        const costPerStateByte = activeCostPerStateByte(this.common, this._block?.header.gasLimit)
-        const charge = stateBytesPerNewAccount * costPerStateByte
-        const fromReservoir = charge < this.stateGasReservoir ? charge : this.stateGasReservoir
-        const spill = charge - fromReservoir
-        // EIP-8037: state-gas spill charges the tx-level gas_left, not the
-        // inner frame's budget. We let executionGasUsed exceed message.gasLimit
-        // here; the caller's useGas() picks up the overage and consumes it
-        // from the parent frame's gasLeft (which ultimately bubbles up to
-        // tx-level gas_left). If the tx as a whole runs out, OOG is raised
-        // at the caller frame, not here.
-        this.stateGasReservoir -= fromReservoir
-        this.executionStateGasUsed += charge
-        earlyResult.executionGasUsed += spill
-      }
+      // EIP-8037: new-account state-gas for inner CALLs is now pre-charged at
+      // the CALL opcode (callFamilyGas → finalizeCallMessageGas), matching
+      // the EELS amsterdam (tests-bal) `charge_state_gas` placement. The
+      // charge is unconditional w.r.t. inner-frame outcome (it stays charged
+      // even when the call fails on insufficient balance or reverts), so no
+      // additional charge is applied on the early-exit path here.
       return { execResult: earlyResult }
     }
 
@@ -659,36 +635,12 @@ export class EVM implements EVMInterface {
 
     result.executionGasUsed += message.gasLimit - gasLimit
 
-    // EIP-8037: charge state-gas on successful CALL frame exit when this
-    // call created a new account (non-existent or empty `to` + non-zero
-    // value transfer). On revert / exceptional halt the snapshot mechanism
-    // restores the reservoir, so we only charge on success.
-    // Precompile addresses are excluded: they are code-only entities, not
-    // real account state. Funding a precompile via CALL-with-value does not
-    // create a new "stored" account, so no state-gas charge applies (this
-    // matches the behavior the network's other clients exhibit; without the
-    // skip we regress test_bal_precompile_funded and similar fixtures).
-    if (
-      this.common.isActivatedEIP(8037) &&
-      !result.exceptionError &&
-      !toExistedBefore &&
-      message.value !== BIGINT_0 &&
-      !message.delegatecall &&
-      this.getPrecompile(message.to) === undefined
-    ) {
-      const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
-      const costPerStateByte = activeCostPerStateByte(this.common, this._block?.header.gasLimit)
-      const charge = stateBytesPerNewAccount * costPerStateByte
-      const fromReservoir = charge < this.stateGasReservoir ? charge : this.stateGasReservoir
-      const spill = charge - fromReservoir
-      // EIP-8037: state-gas spill charges the tx-level gas_left, not the
-      // current frame's budget. Let executionGasUsed exceed message.gasLimit;
-      // the caller picks up the overage via useGas() and OOG is raised at
-      // the caller frame if there's not enough tx gas overall.
-      this.stateGasReservoir -= fromReservoir
-      this.executionStateGasUsed += charge
-      result.executionGasUsed += spill
-    }
+    // EIP-8037: the new-account state-gas charge is now pre-charged at the
+    // CALL opcode (see callFamilyGas → finalizeCallMessageGas), matching the
+    // EELS amsterdam (tests-bal) `charge_state_gas` placement before the
+    // sub-frame runs. The charge is therefore independent of inner-frame
+    // success/failure (per spec it sticks even when the sub-call fails for
+    // insufficient balance or reverts). No post-frame charge is needed here.
 
     return {
       execResult: result,

--- a/packages/evm/src/opcodes/EIP7928.ts
+++ b/packages/evm/src/opcodes/EIP7928.ts
@@ -155,6 +155,19 @@ function finalizeCallMessageGas(
     return postTargetCallOogOrTrap(runState, common, outOffset, outLength)
   }
 
+  // EIP-8037: pre-charge the new-account state-gas BEFORE the inner call
+  // runs. This matches the EELS amsterdam (tests-bal) reference, where
+  // `charge_state_gas(STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE)`
+  // happens in the CALL opcode body before the sub-frame is processed and
+  // before the insufficient-balance check. The charge is unconditional
+  // (per spec it sticks even when the sub-call later fails for insufficient
+  // balance or reverts), so we charge here rather than after frame exit.
+  // The post-frame charge in evm.ts is skipped under EIP-8037 to avoid
+  // double-counting (see `_executeCall` post-execution block).
+  if (common.isActivatedEIP(8037) && newAccountStateGas > BIGINT_0) {
+    runState.interpreter.chargeStateGas(newAccountStateGas, 'CALL pre-charge new_account')
+  }
+
   runState.messageGasLimit = gasLimit
   return gas
 }

--- a/packages/evm/src/opcodes/EIP7928.ts
+++ b/packages/evm/src/opcodes/EIP7928.ts
@@ -307,6 +307,22 @@ export async function create7928Gas(
 ): Promise<bigint> {
   const { offset, length, salt, extraPreTargetGas = BIGINT_0, preChargeLabel } = opts
 
+  // EIP-3860: reject oversized initcode BEFORE any state-gas pre-charge so
+  // that EIP-8037's reservoir is preserved when the size check fails. This
+  // matches the EELS amsterdam (tests-bal) reference, which raises
+  // OutOfGasError from `generic_create` ahead of `charge_state_gas`. Without
+  // this, the new-account state-gas pre-charge runs first and is hard to
+  // unwind cleanly at the tx-root frame (depth=0): the frame-revert handler
+  // refunds the spilled slice to a parent reservoir that doesn't exist, and
+  // the user is overcharged by `STATE_BYTES_PER_NEW_ACCOUNT * costPerStateByte`.
+  if (
+    common.isActivatedEIP(3860) &&
+    length > Number(common.param('maxInitCodeSize')) &&
+    !runState.interpreter._evm.allowUnlimitedInitCodeSize
+  ) {
+    trap(EVMError.errorMessages.INITCODE_SIZE_VIOLATION)
+  }
+
   gas += subMemUsage(runState, offset, length, common)
   if (common.isActivatedEIP(3860)) {
     gas += ((length + BIGINT_31) / BIGINT_32) * common.param('initCodeWordGas')

--- a/packages/util/src/bal/validation.ts
+++ b/packages/util/src/bal/validation.ts
@@ -325,9 +325,16 @@ function validateAddress(address: PrefixedHexString): void {
   hexToBytes(address)
 }
 
-function compareLexicographicHex(a: PrefixedHexString, b: PrefixedHexString): number {
-  const aBytes = hexToBytes(a)
-  const bBytes = hexToBytes(b)
+// Accepts both hex strings and raw bytes because BlockLevelAccessList.raw()
+// runs slot/read keys through normalizeHexForRLP, which returns Uint8Array
+// for the canonical zero-slot case (an empty bytes encoding). The validator
+// sees both shapes when comparing slots that have been normalized for RLP.
+function compareLexicographicHex(
+  a: PrefixedHexString | Uint8Array,
+  b: PrefixedHexString | Uint8Array,
+): number {
+  const aBytes = a instanceof Uint8Array ? a : hexToBytes(a)
+  const bBytes = b instanceof Uint8Array ? b : hexToBytes(b)
   const minLength = Math.min(aBytes.length, bBytes.length)
   for (let i = 0; i < minLength; i++) {
     if (aBytes[i] < bBytes[i]) return -1

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -1,6 +1,6 @@
 import { createBlock, genRequestsRoot } from '@ethereumjs/block'
 import { ConsensusType, Hardfork } from '@ethereumjs/common'
-import { type EVM, type EVMInterface } from '@ethereumjs/evm'
+import { type EVM, type EVMInterface, computeIntrinsicGasDimensions8037 } from '@ethereumjs/evm'
 import { MerklePatriciaTrie } from '@ethereumjs/mpt'
 import { RLP } from '@ethereumjs/rlp'
 import { TransactionType } from '@ethereumjs/tx'
@@ -703,9 +703,17 @@ async function applyTransactions(vm: VM, block: Block, opts: RunBlockOpts) {
     }
 
     // EIP-8037 pre-execution check (spec):
-    //   min(TX_MAX_GAS_LIMIT, tx.gas) <= regular_gas_available
-    //   tx.gas <= state_gas_available
+    //   regular: min(TX_MAX_GAS_LIMIT, tx.gas - intrinsic_state) > regular_available  → reject
+    //   state:   tx.gas - intrinsic_regular                       > state_available    → reject
     // where *_available = block.gas_limit - block_*_gas_used.
+    // The intrinsic.state subtraction in the regular check and the
+    // intrinsic_regular subtraction in the state check are essential: a tx's
+    // regular execution can only use `tx.gas - intrinsic_state`, and its
+    // worst-case state-gas consumption is `tx.gas - intrinsic_regular` (the
+    // residual after paying regular intrinsic). See
+    // execution-specs/tests/amsterdam/eip8037.../test_state_gas_reservoir.py
+    // (`test_block_state_gas_limit_boundary` and
+    // `test_creation_tx_regular_check_subtracts_intrinsic_state`).
     // Pre-EIP-8037 keeps the original check (`tx.gasLimit + gasUsed <= block.gasLimit`).
     if (vm.common.isActivatedEIP(8037)) {
       const txMax = tx.common.param('maxTransactionGasLimit')
@@ -717,8 +725,17 @@ async function applyTransactions(vm: VM, block: Block, opts: RunBlockOpts) {
         block.header.gasLimit > blockStateGasUsed
           ? block.header.gasLimit - blockStateGasUsed
           : BIGINT_0
-      const txRegularBound = tx.gasLimit < txMax ? tx.gasLimit : txMax
-      if (txRegularBound > regularAvailable || tx.gasLimit > stateAvailable) {
+      const { intrinsicRegular, intrinsicState } = computeIntrinsicGasDimensions8037(
+        tx.common,
+        tx,
+        block.header.gasLimit,
+      )
+      const txRegularContrib =
+        tx.gasLimit > intrinsicState ? tx.gasLimit - intrinsicState : BIGINT_0
+      const txStateContrib =
+        tx.gasLimit > intrinsicRegular ? tx.gasLimit - intrinsicRegular : BIGINT_0
+      const txRegularBound = txRegularContrib < txMax ? txRegularContrib : txMax
+      if (txRegularBound > regularAvailable || txStateContrib > stateAvailable) {
         const msg = _errorMsg('tx has a higher gas limit than the block', vm, block)
         throw EthereumJSErrorWithoutCode(msg)
       }

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -6,6 +6,7 @@ import {
   EVMError,
   type Log,
   activeCostPerStateByte,
+  computeIntrinsicGasDimensions8037,
   createEIP7708BurnLog,
 } from '@ethereumjs/evm'
 import { Capability, isBlob4844Tx } from '@ethereumjs/tx'
@@ -613,40 +614,10 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // for state-creation charges and is plumbed onto the EVM instance so
   // child frames can draw from / refill it across the whole transaction.
   // ===========================
-  let intrinsicRegularGas = intrinsicGas
-  let intrinsicStateGas = BIGINT_0
   let stateGasReservoirInitial = BIGINT_0
   vm.evm.eip7928CallPostTargetOog = false
-  if (vm.common.isActivatedEIP(8037)) {
-    const costPerStateByte = activeCostPerStateByte(vm.common, block?.header.gasLimit)
-    const stateBytesPerNewAccount = vm.common.param('stateBytesPerNewAccount')
-    const stateBytesPerAuthBase = vm.common.param('stateBytesPerAuthBase')
-
-    // 7702 intrinsic correction: getDataGas adds (authCount * perEmptyAccountCost)
-    // to the regular intrinsic, but under EIP-8037 perEmptyAccountCost = 0 and
-    // the regular per-auth cost is perAuthBaseGas instead. Add the missing
-    // regular per-auth amount here.
-    let authCount = 0
-    if (tx.type === 4 /* EOACode7702Tx */) {
-      authCount = (tx as EIP7702CompatibleTx).authorizationList.length
-      intrinsicRegularGas += BigInt(authCount) * tx.common.param('perAuthBaseGas')
-    }
-
-    // intrinsic_state_gas = creation tx state portion + per-auth state portion
-    let isCreate = false
-    try {
-      isCreate = tx.toCreationAddress()
-    } catch {
-      isCreate = false
-    }
-    if (isCreate) {
-      intrinsicStateGas += stateBytesPerNewAccount * costPerStateByte
-    }
-    if (authCount > 0) {
-      intrinsicStateGas +=
-        BigInt(authCount) * (stateBytesPerNewAccount + stateBytesPerAuthBase) * costPerStateByte
-    }
-  }
+  const { intrinsicRegular: intrinsicRegularGas, intrinsicState: intrinsicStateGas } =
+    computeIntrinsicGasDimensions8037(tx.common, tx, block?.header.gasLimit)
   const totalIntrinsic = intrinsicRegularGas + intrinsicStateGas
 
   let gasLimit = tx.gasLimit
@@ -1033,27 +1004,17 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   // The reservoir delta captures state-gas that was charged to the reservoir
   // (which is part of `tx.gas` paid upfront but not part of `gasLeft` passed
   // to the EVM, so executionGasUsed alone misses it).
-  // EIP-8037 + EIP-3860: when a CREATE/CREATE2 opcode traps with
-  // INITCODE_SIZE_VIOLATION, the gas function (opcodes/gas.ts) has already
-  // pre-charged the NEW_ACCOUNT state-gas portion (spilled to gas_left
-  // because no reservoir was available). The opcode function then traps
-  // BEFORE the sub-frame is entered, so the frame-revert handler in evm.ts
-  // refunds the spilled slice back to the reservoir. That refund is correct
-  // for nested-frame reverts (the parent gets credited), but for a tx that
-  // exceptionally halts due to the trap the entire `tx.gasLimit` must be
-  // burned. Force-drain the reservoir here so the user pays for the full
-  // tx gas (matches EVM spec: exceptional halt consumes all gas).
-  if (vm.common.isActivatedEIP(8037)) {
-    const err = results.execResult.exceptionError?.error
-    // INITCODE_SIZE_VIOLATION: frame revert refunds reservoir spill; tx must still pay full gas.
-    // INITCODE_SIZE_VIOLATION: pre-charged state gas must not be refunded on exceptional halt.
-    // EIP-7928 CALL post-target OOG: burn the full tx gas limit (reservoir slice included).
-    if (
-      err === EVMError.errorMessages.INITCODE_SIZE_VIOLATION ||
-      (err === EVMError.errorMessages.OUT_OF_GAS && vm.evm.eip7928CallPostTargetOog)
-    ) {
-      vm.evm.stateGasReservoir = BIGINT_0
-    }
+  // EIP-7928 CALL post-target OOG: burn the full tx gas limit (reservoir
+  // slice included). EIP-3860 INITCODE_SIZE_VIOLATION is now caught in
+  // create7928Gas BEFORE the new-account state-gas pre-charge, matching the
+  // EELS amsterdam (tests-bal) ordering, so the reservoir is naturally
+  // preserved across the trap and no force-drain is needed there.
+  if (
+    vm.common.isActivatedEIP(8037) &&
+    results.execResult.exceptionError?.error === EVMError.errorMessages.OUT_OF_GAS &&
+    vm.evm.eip7928CallPostTargetOog
+  ) {
+    vm.evm.stateGasReservoir = BIGINT_0
   }
   vm.evm.eip7928CallPostTargetOog = false
   let totalGasSpentBeforeRefund = results.execResult.executionGasUsed + intrinsicGas


### PR DESCRIPTION
## Summary

Four independent fixes that bring the v700 amsterdam fixtures from 12 failing → **0 failing**:
- **EIP-7778** `block_gas_accounting_without_refunds`: 27/31 → **31/31 (100%)** ✓
- **EIP-8037** `state_creation_gas_cost_increase`: 455/463 → **463/463 (100%)** ✓
- (EIP-7976 stays at 530/530, no regression.)

Branch: off `master`. PRs #4305 / #4306 already in.

## Changes

### 1. `util/bal/validation`: widen `compareLexicographicHex` types

`BlockLevelAccessList.raw()` runs slot/read keys through `normalizeHexForRLP`, which returns `Uint8Array.from([])` for the canonical zero-slot case. The validator's comparator was typed `PrefixedHexString` only and crashed on `hex.startsWith is not a function` whenever any tx wrote to slot 0 in a fixture that also supplied a BAL for validation. The crash short-circuited the actual block-rejection check (e.g. `GAS_USED_OVERFLOW`, `GAS_ALLOWANCE_EXCEEDED`) which is what the fixture is asserting.

Mirrors the same widening already present on the producer side (`bal/index.ts:compareLexicographicHexOrBytes`). Resolves all 4 failing 7778 cases and 5 of the failing 8037 cases.

### 2. `vm/runBlock` + new `evm/computeIntrinsicGasDimensions8037`: spec-correct 2D block check

The per-tx pre-execution block-gas check now uses the formulas from `execution-specs/tests-bal@v7.1.0` (see `test_state_gas_reservoir.py::test_block_state_gas_limit_boundary` and `test_creation_tx_regular_check_subtracts_intrinsic_state`):

```
regular: min(TX_MAX, tx.gas - intrinsic_state) > regular_available  → reject
state:   tx.gas - intrinsic_regular           > state_available     → reject
```

Both intrinsic subtractions were missing previously. The regular/state intrinsic split logic is pulled out of `runTx.ts` into a shared `computeIntrinsicGasDimensions8037(common, tx, blockGasLimit?)` helper used by both `runBlock` (block check) and `runTx` (reservoir sizing) so the two stay in lockstep.

### 3. `evm/opcodes/EIP7928`: EIP-3860 size check before state-gas pre-charge

EIP-3860's oversized-initcode check now runs at the top of `create7928Gas`, matching the EELS `generic_create` order (size check raises `OutOfGasError` ahead of `charge_state_gas`). Previously the state-gas pre-charge ran first; on trap from the opcode body the runTx end-of-tx accounting force-drained the reservoir to compensate, which over-charged the user by `STATE_BYTES_PER_NEW_ACCOUNT * costPerStateByte` whenever the trap fired at the tx-root frame.

With the size check moved up, the natural reservoir-preservation on exceptional halt (`evm.gas_left = 0` while `state_gas_left` is kept) refunds the unused state slice via the standard tx-end formula. The dedicated `INITCODE_SIZE_VIOLATION` force-drain in `runTx.ts` is therefore removed; the unrelated EIP-7928 post-target CALL OOG drain branch is preserved.

### 4. `evm/opcodes/EIP7928` + `evm`: pre-charge new-account state-gas at the CALL opcode

Per EELS `forks/amsterdam/vm/instructions/system.py::call()`, the CALL opcode pre-charges `STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE` BEFORE the sub-frame runs and the charge is unconditional — it stays charged even when the sub-call later fails on insufficient balance or reverts. Our previous flow charged the same amount AFTER the inner frame in `evm.ts:_executeCall` (post-success only), so a CALL with value to a non-existent target undercharged by exactly NEW_ACCOUNT state gas whenever the inner call failed, producing the receipt-root mismatch in `test_call_insufficient_balance_returns_reservoir[new_account]`.

`finalizeCallMessageGas` now calls `chargeStateGas(newAccountStateGas)` once `canAfford` and gas-limit checks pass. The pre-charge sits in the parent frame's gas context, BEFORE the child snapshot push, so the child's revert handler does not refund it — matching the EELS rule. Both post-frame state-gas charges in `evm.ts` (`_executeCall` early-exit + post-execution paths) are removed to avoid double-counting on successful inner calls. The existing_account variant is unaffected: `getCallNewAccountPostCosts` returns `state=0` when the target is alive.

## Test plan

```
TEST_PATH=…/eip7778_block_gas_accounting_without_refunds  →  31/31 ✓
TEST_PATH=…/eip8037_state_creation_gas_cost_increase      → 463/463 ✓
TEST_PATH=…/eip7976_increase_calldata_floor_cost          → 530/530 ✓ (no regression)
```