### PR TITLE
Implement log events for live-tracing in EVM and VM (EIP-7708 + generic)

### DIFF
--- a/packages/evm/README.md
+++ b/packages/evm/README.md
@@ -165,6 +165,28 @@ See [`examples/emitLogs.ts`](./examples/emitLogs.ts) for a minimal `LOG1` byteco
 - A **reverted** top-level execution clears logs (same as on-chain).
 - For transaction receipts and block blooms, use `@ethereumjs/vm` — see [Receipts and event logs](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/vm#receipts-and-event-logs).
 
+### Live tracing with the `log` event
+
+For live observation (including [EIP-7708](https://eips.ethereum.org/EIPS/eip-7708) synthetic logs that are not tied to a `LOGN` step), subscribe to `evm.events.on('log')`:
+
+```ts
+import type { LogEvent } from '@ethereumjs/evm'
+
+evm.events.on('log', (event: LogEvent) => {
+  const { log, origin, depth, address } = event
+  // origin: 'opcode' | 'callTransfer' | 'createTransfer' | 'selfdestructTransfer'
+  //         | 'selfdestructBurn' | 'finalizationBurn'
+  // address: executing frame; log[0] is the on-chain emitter (system address for EIP-7708)
+})
+```
+
+**Notes:**
+
+- Events are emitted **optimistically** when a log is created. If the enclosing frame later reverts, the log is removed from `ExecResult.logs` / the receipt, but the event is not retracted — correlate with `afterMessage` and `exceptionError` if needed.
+- Async listeners are **awaited** for synthetic logs (EIP-7708) and for VM finalization burns. For `LOGN` opcode logs, emission is fire-and-forget from the synchronous opcode handler (listeners run, but execution does not pause on them).
+- Post-transaction finalization burns (`finalizationBurn`) are emitted through the same EVM emitter from `@ethereumjs/vm` (`depth: -1`).
+- When no listeners are registered, emission is skipped (zero overhead).
+
 ## Examples
 
 See the [examples](./examples/) folder for different meaningful examples on how to use the EVM package and invoke certain aspects of it, e.g. running a bytecode snippet, listening to events, or to activate an EVM with a certain EIP for experimental purposes. Opcode-focused samples live under [`examples/opcodes/`](./examples/opcodes/) (e.g. [EIP-8024 DUPN/SWAPN/EXCHANGE](./examples/opcodes/0xe6-e8-eip8024-stack-opcodes.ts) on `Hardfork.Amsterdam`).
@@ -710,6 +732,7 @@ You can subscribe to the following events:
 - `beforeMessage`: Emits a `Message` right after running it.
 - `afterMessage`: Emits an `EVMResult` right after running a message.
 - `step`: Emits an `InterpreterStep` right before running an EVM step.
+- `log`: Emits a `LogEvent` when a log is created (`LOG0`–`LOG4` or EIP-7708 synthetic logs). See [Live tracing with the `log` event](#live-tracing-with-the-log-event).
 - `newContract`: Emits a `NewContractEvent` right before creating a contract. This event contains the deployment code, not the deployed code, as the creation message may not return such a code.
 
 #### Event listeners

--- a/packages/evm/examples/emitLogs.ts
+++ b/packages/evm/examples/emitLogs.ts
@@ -47,6 +47,8 @@ const main = async () => {
     console.log(`           topics=${formatted.topics.join(', ')}`)
     console.log(`           data=${formatted.data} (value=${bytesToBigInt(log[2])})`)
   }
+
+  // The same logs are also emitted live via evm.events.on('log', ...) during execution.
 }
 
 void main()

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -50,6 +50,7 @@ import {
   type EVMRunCodeOpts,
   type ExecResult,
   type Log,
+  type LogEvent,
 } from './types.ts'
 
 import type { Common, StateManagerInterface } from '@ethereumjs/common'
@@ -428,6 +429,18 @@ export class EVM implements EVMInterface {
   }
 
   /**
+   * Emits a `log` tracing event when listeners are registered.
+   *
+   * @remarks Experimental (Amsterdam): may change on patch releases.
+   */
+  async emitLog(event: LogEvent): Promise<void> {
+    if (this.events.listenerCount('log') === 0) {
+      return
+    }
+    await this._emit('log', event)
+  }
+
+  /**
    * Returns a list with the currently activated opcodes
    * available for EVM execution
    */
@@ -573,6 +586,12 @@ export class EVM implements EVMInterface {
           `EIP-7708: Created ETH transfer log from ${message.caller} to ${message.to} value=${message.value}`,
         )
       }
+      await this.emitLog({
+        log: eip7708Log,
+        origin: 'callTransfer',
+        depth: message.depth ?? 0,
+        address: message.to,
+      })
     }
 
     if (exit) {
@@ -815,6 +834,12 @@ export class EVM implements EVMInterface {
           `EIP-7708: Created ETH transfer log for CREATE from ${message.caller} to ${message.to} value=${message.value}`,
         )
       }
+      await this.emitLog({
+        log: eip7708CreateLog,
+        origin: 'createTransfer',
+        depth: message.depth ?? 0,
+        address: message.to,
+      })
     }
 
     if (exit) {

--- a/packages/evm/src/index.ts
+++ b/packages/evm/src/index.ts
@@ -29,6 +29,8 @@ import type {
   EVMRunCodeOpts,
   ExecResult,
   Log,
+  LogEvent,
+  LogOrigin,
   SelfdestructMap,
 } from './types.ts'
 export * from './logger.ts'
@@ -48,6 +50,8 @@ export type {
   ExecResult,
   InterpreterStep,
   Log,
+  LogEvent,
+  LogOrigin,
   SelfdestructMap,
   PrecompileFunc,
   PrecompileInput,

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -1407,6 +1407,12 @@ export class Interpreter {
         data,
       ]
       this._result.logs.push(transferLog)
+      await this._evm.emitLog({
+        log: transferLog,
+        origin: 'selfdestructTransfer',
+        depth: this._env.depth,
+        address: this._env.address,
+      })
     }
 
     // Add to beneficiary balance
@@ -1468,6 +1474,12 @@ export class Interpreter {
       const data = setLengthLeft(bigIntToBytes(contractBalance), 32)
       const burnLog: Log = [EIP7708_SYSTEM_ADDRESS, [EIP7708_BURN_TOPIC, contractTopic], data]
       this._result.logs.push(burnLog)
+      await this._evm.emitLog({
+        log: burnLog,
+        origin: 'selfdestructBurn',
+        depth: this._env.depth,
+        address: this._env.address,
+      })
     }
 
     // Set contract balance to 0
@@ -1503,6 +1515,12 @@ export class Interpreter {
 
     const log: Log = [this._env.address.bytes, topics, data]
     this._result.logs.push(log)
+    void this._evm.emitLog({
+      log,
+      origin: 'opcode',
+      depth: this._env.depth,
+      address: this._env.address,
+    })
   }
 
   private _getReturnCode(results: EVMResult, isEOFCreate = false) {

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -150,11 +150,42 @@ interface NewContractEvent {
   code: Uint8Array
 }
 
+/**
+ * Origin of a log emission for the `log` tracing event.
+ *
+ * @remarks Experimental (Amsterdam): may change on patch releases.
+ */
+export type LogOrigin =
+  | 'opcode'
+  | 'callTransfer'
+  | 'createTransfer'
+  | 'selfdestructTransfer'
+  | 'selfdestructBurn'
+  | 'finalizationBurn'
+
+/**
+ * Payload for the EVM `log` tracing event.
+ *
+ * The `log` tuple uses the on-chain emitter address (for EIP-7708 synthetic logs this is the
+ * system address). `address` is the executing call-frame address for attribution.
+ *
+ * @remarks Experimental (Amsterdam): may change on patch releases.
+ */
+export interface LogEvent {
+  log: Log
+  origin: LogOrigin
+  /** Call-frame depth (`-1` for post-tx finalization burns). */
+  depth: number
+  /** Executing frame address (contract context), not necessarily `log[0]`. */
+  address: Address
+}
+
 export type EVMEvent = {
   newContract: (data: NewContractEvent, resolve?: (result?: any) => void) => void
   beforeMessage: (data: Message, resolve?: (result?: any) => void) => void
   afterMessage: (data: EVMResult, resolve?: (result?: any) => void) => void
   step: (data: InterpreterStep, resolve?: (result?: any) => void) => void
+  log: (data: LogEvent, resolve?: (result?: any) => void) => void
 }
 
 export interface EVMInterface {
@@ -179,6 +210,7 @@ export interface EVMInterface {
   getPrecompile?(address: Address | PrefixedHexString): PrecompileFunc | undefined
   runCall(opts: EVMRunCallOpts): Promise<EVMResult>
   runCode(opts: EVMRunCodeOpts): Promise<ExecResult>
+  emitLog(event: LogEvent): Promise<void>
   events?: EventEmitter<EVMEvent>
   binaryTreeAccessWitness?: BinaryTreeAccessWitness
   systemBinaryTreeAccessWitness?: BinaryTreeAccessWitness

--- a/packages/evm/test/logEvents.spec.ts
+++ b/packages/evm/test/logEvents.spec.ts
@@ -1,0 +1,159 @@
+import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
+import { EIP7708_TRANSFER_TOPIC } from '@ethereumjs/evm'
+import {
+  bytesToHex,
+  createAccount,
+  createAddressFromPrivateKey,
+  createAddressFromString,
+  equalsBytes,
+  hexToBytes,
+} from '@ethereumjs/util'
+import { assert, describe, it } from 'vitest'
+
+import { createEVM } from '../src/index.ts'
+
+import type { LogEvent, LogOrigin } from '@ethereumjs/evm'
+
+describe('log tracing events', () => {
+  it('emits opcode logs from LOG1 bytecode', async () => {
+    const common = new Common({ chain: Mainnet, hardfork: Hardfork.Shanghai })
+    const evm = await createEVM({ common })
+
+    const contract = createAddressFromString('0x00000000000000000000000000000000000000c0')
+    const topic = hexToBytes(`0x${'11'.repeat(32)}`)
+    const dataWord = hexToBytes(`0x${'00'.repeat(31)}42`)
+    const code = hexToBytes(
+      `0x7f${bytesToHex(dataWord).slice(2)}6000527f${bytesToHex(topic).slice(2)}60206000a100`,
+    )
+    await evm.stateManager.putCode(contract, code)
+
+    const events: LogEvent[] = []
+    evm.events.on('log', (event) => {
+      events.push(event)
+    })
+
+    await evm.runCode({ code, to: contract, gasLimit: 100_000n })
+
+    assert.strictEqual(events.length, 1)
+    assert.strictEqual(events[0].origin, 'opcode')
+    assert.strictEqual(events[0].depth, 0)
+    assert.isTrue(equalsBytes(events[0].log[0], contract.bytes))
+    assert.strictEqual(events[0].log[1].length, 1)
+    assert.isTrue(equalsBytes(events[0].log[1][0], topic))
+  })
+
+  it('emits callTransfer for EIP-7708 value transfers', async () => {
+    const common = new Common({ chain: Mainnet, hardfork: Hardfork.Amsterdam })
+    const evm = await createEVM({ common })
+
+    const senderKey = hexToBytes(`0x${'20'.repeat(32)}`)
+    const sender = createAddressFromPrivateKey(senderKey)
+    const recipient = createAddressFromString('0x00000000000000000000000000000000000000aa')
+    await evm.stateManager.putAccount(sender, createAccount({ nonce: 0n, balance: BigInt(1e18) }))
+
+    const events: LogEvent[] = []
+    evm.events.on('log', (event) => {
+      events.push(event)
+    })
+
+    await evm.runCall({
+      caller: sender,
+      to: recipient,
+      value: 1_000n,
+      gasLimit: 100_000n,
+    })
+
+    assert.strictEqual(events.length, 1)
+    assert.strictEqual(events[0].origin, 'callTransfer')
+    assert.strictEqual(events[0].depth, 0)
+    assert.isTrue(equalsBytes(events[0].address.bytes, recipient.bytes))
+    assert.isTrue(equalsBytes(events[0].log[1][0], EIP7708_TRANSFER_TOPIC))
+  })
+
+  it('emits createTransfer and selfdestructBurn for CREATE + SELFDESTRUCT to self', async () => {
+    const common = new Common({ chain: Mainnet, hardfork: Hardfork.Amsterdam })
+    const evm = await createEVM({ common })
+
+    const senderKey = hexToBytes(`0x${'21'.repeat(32)}`)
+    const sender = createAddressFromPrivateKey(senderKey)
+    await evm.stateManager.putAccount(sender, createAccount({ nonce: 0n, balance: BigInt(1e18) }))
+
+    // Init code runs in the new account context: ADDRESS; SELFDESTRUCT (to self).
+    const initCode = hexToBytes('0x30ff')
+
+    const origins: LogOrigin[] = []
+    evm.events.on('log', (event) => {
+      origins.push(event.origin)
+    })
+
+    await evm.runCall({
+      caller: sender,
+      data: initCode,
+      value: 1_000n,
+      gasLimit: 1_000_000n,
+    })
+
+    assert.include(origins, 'createTransfer')
+    assert.include(origins, 'selfdestructBurn')
+  })
+
+  it('supports async log listeners on synthetic transfer logs', async () => {
+    const common = new Common({ chain: Mainnet, hardfork: Hardfork.Amsterdam })
+    const evm = await createEVM({ common })
+
+    const senderKey = hexToBytes(`0x${'23'.repeat(32)}`)
+    const sender = createAddressFromPrivateKey(senderKey)
+    const recipient = createAddressFromString('0x00000000000000000000000000000000000000ee')
+    await evm.stateManager.putAccount(sender, createAccount({ nonce: 0n, balance: BigInt(1e18) }))
+
+    let didPause = false
+    evm.events.on('log', async (_event, next) => {
+      await new Promise<void>((resolve) => setTimeout(resolve, 50))
+      didPause = true
+      next?.()
+    })
+
+    await evm.runCall({
+      caller: sender,
+      to: recipient,
+      value: 1_000n,
+      gasLimit: 100_000n,
+    })
+    assert.isTrue(didPause)
+  })
+
+  it('documents optimistic emission when a reverting frame clears logs', async () => {
+    const common = new Common({ chain: Mainnet, hardfork: Hardfork.Amsterdam })
+    const evm = await createEVM({ common })
+
+    const senderKey = hexToBytes(`0x${'22'.repeat(32)}`)
+    const sender = createAddressFromPrivateKey(senderKey)
+    await evm.stateManager.putAccount(sender, createAccount({ nonce: 0n, balance: BigInt(1e18) }))
+
+    const inner = createAddressFromString('0x00000000000000000000000000000000000000bb')
+    const outer = createAddressFromString('0x00000000000000000000000000000000000000cc')
+    await evm.stateManager.putCode(inner, hexToBytes('0x00'))
+    // CALL inner with 1 wei, then REVERT the outer frame.
+    await evm.stateManager.putCode(
+      outer,
+      hexToBytes(
+        '0x6000600060006000600173bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb620f4240f15060006000fd',
+      ),
+    )
+
+    const events: LogEvent[] = []
+    evm.events.on('log', (event) => {
+      events.push(event)
+    })
+
+    const result = await evm.runCall({
+      caller: sender,
+      to: outer,
+      value: 1n,
+      gasLimit: 1_000_000n,
+    })
+
+    assert.isTrue(events.some((event) => event.origin === 'callTransfer'))
+    assert.strictEqual(result.execResult.logs?.length ?? 0, 0)
+  })
+})

--- a/packages/vm/README.md
+++ b/packages/vm/README.md
@@ -129,6 +129,7 @@ See [`examples/runTxTransferLogs.ts`](./examples/runTxTransferLogs.ts) for an Am
 **Notes:**
 
 - Reverted transactions produce receipts with **empty** `logs` (Byzantium+ `status: 0`).
+- For **live tracing** during execution, subscribe to `vm.evm.events.on('log')` — including EIP-7708 synthetic logs and post-tx finalization burns. See [`@ethereumjs/evm` — Live tracing with the `log` event](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/evm#live-tracing-with-the-log-event).
 - The debug logger sections below (`DEBUG=ethjs,...`) refer to **development tracing**, not EVM event logs.
 
 ### Running an RPC Mainnet Block
@@ -707,6 +708,8 @@ You can subscribe to the following events:
 - `afterBlock`: Emits `AfterBlockEvent` right after running a block.
 - `beforeTx`: Emits a `Transaction` right before running it.
 - `afterTx`: Emits a `AfterTxEvent` right after running a transaction.
+
+For **log tracing** during execution (opcode `LOG*` and EIP-7708 synthetic logs), use `vm.evm.events.on('log')` — see [`@ethereumjs/evm` — Live tracing with the `log` event](https://github.com/ethereumjs/ethereumjs-monorepo/tree/master/packages/evm#live-tracing-with-the-log-event).
 
 Note, if subscribing to events with an async listener, specify the second parameter of your listener as a `resolve` function that must be called once your listener code has finished.
 

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -284,7 +284,14 @@ async function processSelfdestructs(vm: VM, results: RunTxResult): Promise<void>
       const account = await vm.stateManager.getAccount(address)
       const finalizationBalance = account?.balance ?? BIGINT_0
       if (finalizationBalance > BIGINT_0) {
-        finalizationLogs.push(createEIP7708BurnLog(address, finalizationBalance))
+        const burnLog = createEIP7708BurnLog(address, finalizationBalance)
+        finalizationLogs.push(burnLog)
+        await vm.evm.emitLog({
+          log: burnLog,
+          origin: 'finalizationBurn',
+          depth: -1,
+          address,
+        })
       }
     }
 

--- a/packages/vm/test/api/EIPs/eip-7708-log-events.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-7708-log-events.spec.ts
@@ -1,0 +1,88 @@
+import { createBlock } from '@ethereumjs/block'
+import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
+import { createLegacyTx } from '@ethereumjs/tx'
+import {
+  createAccount,
+  createAddressFromPrivateKey,
+  createZeroAddress,
+  hexToBytes,
+} from '@ethereumjs/util'
+import { assert, describe, it } from 'vitest'
+
+import { createVM, runTx } from '../../../src/index.ts'
+
+import type { LogEvent } from '@ethereumjs/evm'
+
+describe('EIP-7708 log tracing events (VM)', () => {
+  it('emits callTransfer on a simple value transfer tx', async () => {
+    const common = new Common({ chain: Mainnet, hardfork: Hardfork.Amsterdam })
+    const vm = await createVM({ common })
+
+    const senderKey = hexToBytes(`0x${'20'.repeat(32)}`)
+    const sender = createAddressFromPrivateKey(senderKey)
+    await vm.stateManager.putAccount(sender, createAccount({ nonce: 0n, balance: BigInt(1e18) }))
+
+    const block = createBlock(
+      { header: { number: 1n, gasLimit: 30_000_000n, baseFeePerGas: 1n } },
+      { common, skipConsensusFormatValidation: true },
+    )
+
+    const tx = createLegacyTx(
+      {
+        gasLimit: 100_000n,
+        gasPrice: 10n,
+        value: 1_000_000_000_000_000n,
+        to: createZeroAddress(),
+      },
+      { common },
+    ).sign(senderKey)
+
+    const events: LogEvent[] = []
+    vm.evm.events.on('log', (event) => {
+      events.push(event)
+    })
+
+    await runTx(vm, { tx, block })
+
+    assert.strictEqual(events.length, 1)
+    assert.strictEqual(events[0].origin, 'callTransfer')
+    assert.strictEqual(events[0].depth, 0)
+  })
+
+  it('emits finalizationBurn through the shared EVM event emitter', async () => {
+    const common = new Common({ chain: Mainnet, hardfork: Hardfork.Amsterdam })
+    const vm = await createVM({ common })
+
+    const senderKey = hexToBytes(`0x${'31'.repeat(32)}`)
+    const sender = createAddressFromPrivateKey(senderKey)
+    await vm.stateManager.putAccount(sender, createAccount({ nonce: 0n, balance: BigInt(1e18) }))
+
+    const block = createBlock(
+      { header: { number: 1n, gasLimit: 30_000_000n, baseFeePerGas: 1n } },
+      { common, skipConsensusFormatValidation: true },
+    )
+
+    // Init code runs in the new account context: ADDRESS; SELFDESTRUCT (to self).
+    const initCode = hexToBytes('0x30ff')
+    const tx = createLegacyTx(
+      {
+        gasLimit: 1_000_000n,
+        gasPrice: 10n,
+        value: 1_000n,
+        data: initCode,
+      },
+      { common },
+    ).sign(senderKey)
+
+    const origins: string[] = []
+    vm.evm.events.on('log', (event) => {
+      origins.push(event.origin)
+    })
+
+    const result = await runTx(vm, { tx, block })
+
+    assert.include(origins, 'createTransfer')
+    assert.include(origins, 'selfdestructBurn')
+    assert.isAtLeast(result.receipt.logs.length, 2)
+  })
+})


### PR DESCRIPTION
Currently it's cumbersome to live-trace/follow log events on the EVM, since one need to manually fuddle out of the step events. This problem only expands with EIP-7708 where logs are not necessarily bound to an opcode execution anymore.

PR adds a unified **log event** for both EVM and VM (taking the logic from EVM, so only subscription is necessary) to have a one-stop-shop to follow on what happens around logs (note that these are not necessarily the logs ending up in the receipts, e.g. in the REVERT case, this is documented though. So this is only for tracers/debuggers/whatever other "live use cases").

- Introduced `LogOrigin` type and `LogEvent` interface to define log emission sources and payload structure.
- Added `emitLog` method in the EVM class to handle log tracing events.
- Updated the Interpreter and VM to emit logs for various operations, including self-destructs and transfers.
- Enhanced documentation to include live tracing examples and usage notes for the `log` event.

AI-validated against both potential EIP-7708 spec changes (SELFDESTRUCT burn might get out again) + backwards compatibility concerns.