### PR TITLE
ci: lint-diff falls back to origin/HEAD when no upstream is set

### DIFF
--- a/config/cli/lint-diff.sh
+++ b/config/cli/lint-diff.sh
@@ -1,10 +1,35 @@
 #!/bin/sh
-REMOTE=$(git rev-parse --symbolic-full-name --abbrev-ref @{u})
+# Lint only the .js / .ts files that have changed on this branch.
+#
+# Resolution order for the comparison base:
+#   1. The branch's configured upstream (`@{u}`), if any.
+#   2. The merge-base with the remote's default branch (origin/HEAD), if any.
+#   3. The merge-base with origin/master, as a final fallback.
+#
+# Linting the entire repo (the previous fallback when no upstream was
+# configured) is intentionally avoided: pre-existing lint findings on the
+# default branch would otherwise block first-time pushes of unrelated branches.
+# If no base can be determined, we lint nothing and exit cleanly rather than
+# fail the push on errors that are not part of the current diff.
 
-if [ -z "$REMOTE" ]; then
-    FILESCHANGED=". --ext .js,.ts"
+# Suppress stderr — `@{u}` errors when no upstream is configured, which is the
+# normal first-push case we want to handle gracefully below.
+REMOTE=$(git rev-parse --symbolic-full-name --abbrev-ref '@{u}' 2>/dev/null)
+
+if [ -n "$REMOTE" ]; then
+    BASE="$REMOTE"
 else
-    FILESCHANGED=$(git diff --diff-filter=d --name-only --relative $REMOTE | grep -E '\.(js|ts)')
+    DEFAULT_REF=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)
+    if [ -z "$DEFAULT_REF" ]; then
+        DEFAULT_REF="origin/master"
+    fi
+    BASE=$(git merge-base HEAD "$DEFAULT_REF" 2>/dev/null)
+fi
+
+if [ -n "$BASE" ]; then
+    FILESCHANGED=$(git diff --diff-filter=d --name-only --relative "$BASE" | grep -E '\.(js|ts)')
+else
+    FILESCHANGED=""
 fi
 
 echo $FILESCHANGED


### PR DESCRIPTION
## Summary

The pre-push `lint:diff` hook runs [`config/cli/lint-diff.sh`](config/cli/lint-diff.sh), which is meant to lint only files changed on the current branch. When a fresh branch has no configured upstream (`@{u}`) — i.e. the first push of any new branch — the previous fallback was to lint the entire repo with `eslint .`. That fallback turns any pre-existing lint finding on master into a hard block on every first push of every new branch, even when the branch's actual diff is lint-clean.

In practice this surfaces today as two errors on master (`packages/vm/src/runBlock.ts:1055`, `packages/vm/src/runTx.ts:1015`) blocking unrelated first-time pushes (e.g. my own #4317 had to manually pre-set upstream to `origin/master` to bypass this).

## Fix

Resolution order is now:

1. The branch's upstream, if configured (unchanged behavior).
2. The merge-base with the remote's default branch (`origin/HEAD`).
3. The merge-base with `origin/master` as a final fallback.

If no base can be determined, lint nothing and exit cleanly — this matches the intent of a diff-only lint pre-push hook (only gate on files this branch actually changed; never block on pre-existing master findings).

## Test plan

- [x] Manual: on this very branch with `--unset-upstream` and a fresh first push:
  ```
  $ git rev-parse --symbolic-full-name --abbrev-ref @{u} 2>/dev/null  # empty
  $ git symbolic-ref --short refs/remotes/origin/HEAD                  # origin/master
  $ git merge-base HEAD origin/master                                  # 84e5106fd
  $ sh config/cli/lint-diff.sh                                         # exits 0, lints nothing
  ```
- [x] Dogfood: this PR was pushed with plain `git push -u origin chore/lint-diff-handle-no-upstream` (no upstream-prep workaround) and the pre-push hook passed cleanly.
- [x] When an upstream IS configured: behavior is unchanged (identical `git diff $upstream` path).

## Out of scope

The two pre-existing lint errors on master (`runBlock.ts:1055`, `runTx.ts:1015`) are not addressed here — they're under the active EIP-8037 work and should be fixed in that thread.