### PR TITLE
ci: always checkout in child workflows to provide the lockfile

### DIFF
--- a/.github/workflows/binarytree-build.yml
+++ b/.github/workflows/binarytree-build.yml
@@ -31,8 +31,10 @@ jobs:
 
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # EIP-CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'

--- a/.github/workflows/block-build.yml
+++ b/.github/workflows/block-build.yml
@@ -33,10 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
         with:
-          submodules: recursive
+          submodules: ${{ inputs.submodule-cache-key == 'none' && 'recursive' || '' }}
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'

--- a/.github/workflows/blockchain-build.yml
+++ b/.github/workflows/blockchain-build.yml
@@ -30,8 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # EIP-CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - uses: actions/cache/restore@v4

--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -36,10 +36,12 @@ jobs:
       # Deps/cache on the host runner (same pattern as util-build et al.).
       # actions/cache cannot reliably restore host-created caches inside a
       # container job, even with zstd installed — restore here, test in Docker.
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
         with:
-          submodules: recursive
+          submodules: ${{ inputs.submodule-cache-key == 'none' && 'recursive' || '' }}
 
       - if: inputs.dep-cache-key != 'none'
         uses: actions/cache/restore@v4

--- a/.github/workflows/client-build.yml
+++ b/.github/workflows/client-build.yml
@@ -33,8 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # EIP-CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
 
       - if: inputs.dep-cache-key != 'none'
         uses: actions/cache/restore@v4
@@ -72,8 +74,10 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # EIP-CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'

--- a/.github/workflows/common-build.yml
+++ b/.github/workflows/common-build.yml
@@ -31,8 +31,10 @@ jobs:
 
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # EIP-CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'

--- a/.github/workflows/devp2p-build.yml
+++ b/.github/workflows/devp2p-build.yml
@@ -28,8 +28,10 @@ jobs:
 
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # EIP-CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'

--- a/.github/workflows/evm-build.yml
+++ b/.github/workflows/evm-build.yml
@@ -33,10 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
         with:
-          submodules: recursive
+          submodules: ${{ inputs.submodule-cache-key == 'none' && 'recursive' || '' }}
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -23,10 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
         with:
-          submodules: recursive
+          submodules: ${{ inputs.submodule-cache-key == 'none' && 'recursive' || '' }}
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,8 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # EIP-CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'

--- a/.github/workflows/mpt-build.yml
+++ b/.github/workflows/mpt-build.yml
@@ -31,8 +31,10 @@ jobs:
 
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # EIP-CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'

--- a/.github/workflows/rlp-ethash-genesis-wallet-build.yml
+++ b/.github/workflows/rlp-ethash-genesis-wallet-build.yml
@@ -26,8 +26,10 @@ jobs:
 
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # EIP-CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'

--- a/.github/workflows/statemanager-build.yml
+++ b/.github/workflows/statemanager-build.yml
@@ -31,8 +31,10 @@ jobs:
 
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # EIP-CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'

--- a/.github/workflows/tx-build.yml
+++ b/.github/workflows/tx-build.yml
@@ -34,10 +34,12 @@ jobs:
 
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
         with:
-          submodules: recursive
+          submodules: ${{ inputs.submodule-cache-key == 'none' && 'recursive' || '' }}
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -26,8 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # EIP-CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'

--- a/.github/workflows/util-build.yml
+++ b/.github/workflows/util-build.yml
@@ -30,8 +30,10 @@ jobs:
 
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # EIP-CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'

--- a/.github/workflows/vm-pr.yml
+++ b/.github/workflows/vm-pr.yml
@@ -33,10 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
         with:
-          submodules: recursive
+          submodules: ${{ inputs.submodule-cache-key == 'none' && 'recursive' || '' }}
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'
@@ -82,10 +84,12 @@ jobs:
       fail-fast: false
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
         with:
-          submodules: recursive
+          submodules: ${{ inputs.submodule-cache-key == 'none' && 'recursive' || '' }}
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'
@@ -258,10 +262,12 @@ jobs:
       fail-fast: false
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
         with:
-          submodules: recursive
+          submodules: ${{ inputs.submodule-cache-key == 'none' && 'recursive' || '' }}
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'
@@ -310,10 +316,12 @@ jobs:
       fail-fast: false
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
         with:
-          submodules: recursive
+          submodules: ${{ inputs.submodule-cache-key == 'none' && 'recursive' || '' }}
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'
@@ -381,10 +389,12 @@ jobs:
       fail-fast: false
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
         with:
-          submodules: recursive
+          submodules: ${{ inputs.submodule-cache-key == 'none' && 'recursive' || '' }}
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'
@@ -420,8 +430,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # We clone the repo and submodules if triggered from work-flow dispatch
-      - if: inputs.submodule-cache-key == 'none'
-        uses: actions/checkout@v5
+      # CI fix: always checkout so the lockfile is present for setup-node's
+      # `cache: 'npm'`. The workspace dep-cache restore further down can miss
+      # for fresh PRs and would otherwise leave the workspace empty.
+      - uses: actions/checkout@v5
 
       # We restore the code/deps from cache if triggered from workflow_call (i.e. have valid cache key)
       - if: inputs.dep-cache-key != 'none'


### PR DESCRIPTION
## Summary
- Child build/test workflows previously skipped `actions/checkout` when relying on a restored submodule cache, leaving the workspace empty when the cache restore missed.
- When the workspace is empty, `actions/setup-node` with `cache: 'npm'` fails with **"Dependencies lock file is not found"** because there is no `package-lock.json` to hash/restore against.
- This race surfaced intermittently in CI: a parent build job saves a run-scoped npm cache, and a sibling child job racing for the same key reports "Cache not found", skips checkout, and then fails at setup-node.

## Fix
- Always run `actions/checkout` in the 17 affected child workflows so the lockfile is present for `setup-node`.
- For the 6 workflows that need submodules, the recursive fetch is made conditional on whether a submodule cache key is provided:
  `submodules: ${{ inputs.submodule-cache-key == 'none' && 'recursive' || '' }}`
- The remaining 11 workflows use a plain `actions/checkout@v5`.

## Test plan
- [x] CI runs green across the affected workflows
- [x] No "Dependencies lock file is not found" failures on child jobs
- [x] Submodule-dependent jobs still fetch submodules correctly