### PR TITLE
block: use isBlob4844Tx guard instead of instanceof Blob4844Tx

### DIFF
--- a/packages/block/src/block/block.ts
+++ b/packages/block/src/block/block.ts
@@ -1,7 +1,7 @@
 import { ConsensusType } from '@ethereumjs/common'
 import { MerklePatriciaTrie } from '@ethereumjs/mpt'
 import { RLP } from '@ethereumjs/rlp'
-import { Blob4844Tx, Capability } from '@ethereumjs/tx'
+import { Capability, isBlob4844Tx } from '@ethereumjs/tx'
 import {
   BIGINT_0,
   EthereumJSErrorWithoutCode,
@@ -211,7 +211,7 @@ export class Block {
       if (this.common.isActivatedEIP(4844)) {
         const blobGasLimit = this.common.getBlobGasSchedule().maxBlobGasPerBlock
         const blobGasPerBlob = this.common.param('blobGasPerBlob')
-        if (tx instanceof Blob4844Tx) {
+        if (isBlob4844Tx(tx)) {
           blobGasUsed += BigInt(tx.numBlobs()) * blobGasPerBlob
           if (blobGasUsed > blobGasLimit) {
             errs.push(
@@ -334,7 +334,7 @@ export class Block {
       let blobGasPrice
 
       for (const tx of this.transactions) {
-        if (tx instanceof Blob4844Tx) {
+        if (isBlob4844Tx(tx)) {
           blobGasPrice = blobGasPrice ?? this.header.getBlobGasPrice()
           if (tx.maxFeePerBlobGas < blobGasPrice) {
             throw EthereumJSErrorWithoutCode(

--- a/packages/block/src/helpers.ts
+++ b/packages/block/src/helpers.ts
@@ -1,6 +1,6 @@
 import { MerklePatriciaTrie } from '@ethereumjs/mpt'
 import { RLP } from '@ethereumjs/rlp'
-import { Blob4844Tx } from '@ethereumjs/tx'
+import { isBlob4844Tx } from '@ethereumjs/tx'
 import {
   BIGINT_0,
   BIGINT_1,
@@ -123,7 +123,7 @@ export function getDifficulty(headerData: HeaderData): bigint | null {
 export const getNumBlobs = (transactions: TypedTransaction[]) => {
   let numBlobs = 0
   for (const tx of transactions) {
-    if (tx instanceof Blob4844Tx) {
+    if (isBlob4844Tx(tx)) {
       numBlobs += tx.blobVersionedHashes.length
     }
   }


### PR DESCRIPTION
## What

Replaces the three `tx instanceof Blob4844Tx` checks in `@ethereumjs/block` with the `isBlob4844Tx` type guard already exported by `@ethereumjs/tx`, so `block` no longer imports the concrete `Blob4844Tx` class.

- `block/src/helpers.ts` — `getNumBlobs`
- `block/src/block/block.ts` — blob-gas accounting and validation (×2)

## Why

`isBlob4844Tx(tx): tx is Blob4844Tx` narrows to `Blob4844Tx` identically, so all member access inside the branches (`tx.blobVersionedHashes`, `tx.numBlobs()`, `tx.maxFeePerBlobGas`) is unchanged. But the guard keys off the transaction *type* (`tx.type === TransactionType.BlobEIP4844`) rather than prototype identity, which is more robust across dual-package / multi-realm boundaries where `instanceof` can silently fail. It also matches how the rest of the codebase already discriminates blob txs (e.g. `vm/src/runTx.ts`).

Behavior-preserving, internal only — no public API change.