### PR TITLE
fix(client): ignore Node.js process warnings in CLI test stderr capture

### DIFF
--- a/packages/client/test/cli/cli.spec.ts
+++ b/packages/client/test/cli/cli.spec.ts
@@ -8,6 +8,27 @@ import { wait } from '../integration/util.ts'
 
 import type { ChildProcessWithoutNullStreams } from 'child_process'
 
+/**
+ * Strips Node.js process warnings (e.g. `MaxListenersExceededWarning`,
+ * `ExperimentalWarning`, `DeprecationWarning`) from a stderr chunk and returns
+ * the remaining, meaningful output. These warnings are emitted to stderr by the
+ * spawned process but are not client errors, so they must not be treated as
+ * test failures. They are formatted as:
+ *
+ *   (node:12345) MaxListenersExceededWarning: Possible EventEmitter memory leak ...
+ *   (Use `node --trace-warnings ...` to show where the warning was created)
+ */
+function stripNodeWarnings(message: string): string {
+  return message
+    .split('\n')
+    .filter((line) => {
+      const trimmed = line.trim()
+      return !/^\(node:\d+\)\s.*Warning:/.test(trimmed) && !trimmed.startsWith('(Use `node')
+    })
+    .join('\n')
+    .trim()
+}
+
 export function clientRunHelper(
   cliArgs: string[],
   onData: (message: string, child: ChildProcessWithoutNullStreams, resolve: Function) => void,
@@ -15,7 +36,9 @@ export function clientRunHelper(
 ) {
   const file = require.resolve('../../bin/cli.ts')
   const child = spawn('tsx', [file, ...cliArgs])
-  // Increase max listeners to avoid Node.js warnings about memory leaks
+  // Increase max listeners to avoid Node.js warnings about memory leaks on the
+  // parent's handle to the child. Note this does not cover warnings emitted from
+  // within the spawned process itself, which are filtered out via stripNodeWarnings.
   child.setMaxListeners(20)
   return new Promise((resolve) => {
     child.stdout.on('data', async (data) => {
@@ -24,6 +47,9 @@ export function clientRunHelper(
     })
     child.stderr.on('data', (data) => {
       const message: string = data.toString()
+      // Node.js process warnings land on stderr but are not client errors; ignore
+      // a chunk that contains nothing but warnings.
+      if (stripNodeWarnings(message) === '') return
       if (shouldError) onData(message, child, resolve)
       else assert.fail(`stderr: ${message}`)
     })


### PR DESCRIPTION
## Problem

The CLI test suite (`packages/client/test/cli/cli.spec.ts`) fails intermittently with:

```
AssertionError: stderr: (node:NNNN) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 exit listeners added to [ChildProcess]. MaxListeners is 10. ...
 ❯ Socket.<anonymous> test/cli/cli.spec.ts:28:19
```

### Root cause

`clientRunHelper` spawns the client with `spawn('tsx', …)` and, for normal-startup tests, calls `assert.fail()` on **any** data received on the child's stderr:

```ts
child.stderr.on('data', (data) => {
  const message = data.toString()
  if (shouldError) onData(message, child, resolve)
  else assert.fail(`stderr: ${message}`)   // <-- fails on warnings too
})
```

Node.js diagnostic warnings (`MaxListenersExceededWarning`, `ExperimentalWarning`, `DeprecationWarning`, …) are written to stderr but are **not** client errors. The specific `MaxListenersExceededWarning` is emitted from **inside** the spawned process (note the `(node:NNNN)` PID differs from the test runner), where `tsx` accumulates `exit` listeners on its inner child process.

The existing `child.setMaxListeners(20)` (added in #4184) only raises the limit on the **parent's** handle to the child — it cannot affect emitters living inside the spawned process, which is why the warning still surfaces and the failure is non-deterministic (it depends on how many listeners `tsx` happens to register under load).

## Fix

Add a `stripNodeWarnings()` helper that removes Node warning lines (`(node:PID) …Warning:` and the trailing `` (Use `node --trace-warnings …` ``) from each stderr chunk. The handler ignores a chunk that contains nothing but warnings, so only genuine error output trips the assertion. The `shouldError` path is preserved (real expected-error chunks still flow to `onData`); a chunk mixing a warning with a real error still fails (warnings stripped, remainder asserted).

`setMaxListeners(20)` is kept (harmless, addresses the parent-side handle) with a clarifying comment.

## Verification

- `stripNodeWarnings` unit-checked against the exact `MaxListenersExceededWarning` string (→ empty), an `ExperimentalWarning` (→ empty), a real `Error` (→ preserved), and a mixed warning+error chunk (→ only the error line preserved).
- `npx vitest run … cli.spec.ts -t "dev"` (expected-error path): passes 3/3.
- `-t "unknown parameters"`, `-t "conflicting parameters"` (expected-error paths): pass.
- `-t "trie cache"` (normal client startup, the path that previously asserted on the warning): passes.
- biome + eslint clean on the changed file.

Scope: deprecated `client` package, test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)