### PR TITLE
fix(vm): delete empty accounts in consumeBal to fix glamsterdam-devnet selfdestruct tests

### DIFF
--- a/packages/vm/src/consumeBal.ts
+++ b/packages/vm/src/consumeBal.ts
@@ -1,6 +1,7 @@
 import {
   type BALJSONBlockAccessList,
   EthereumJSErrorWithoutCode,
+  KECCAK256_NULL,
   bytesToHex,
   createAddressFromString,
   equalsBytes,
@@ -24,6 +25,7 @@ export async function consumeBal(
     ) {
       continue
     }
+    const address = createAddressFromString(acc.address)
     const lastBalanceChange = acc.balanceChanges.at(-1)
     const balance =
       lastBalanceChange?.postBalance !== undefined
@@ -34,21 +36,40 @@ export async function consumeBal(
       lastNonceChange?.postNonce !== undefined ? hexToBigInt(lastNonceChange.postNonce) : undefined
     const code = acc.codeChanges.slice(-1)[0]?.newCode ?? undefined
     if (code !== undefined) {
-      await vm.stateManager.putCode(createAddressFromString(acc.address), hexToBytes(code))
+      await vm.stateManager.putCode(address, hexToBytes(code))
     }
-    await vm.stateManager.modifyAccountFields(createAddressFromString(acc.address), {
-      balance,
-      nonce,
-    })
-    for (const storage of acc.storageChanges) {
-      const value = storage.slotChanges.slice(-1)[0].postValue
-      await vm.stateManager.putStorage(
-        createAddressFromString(acc.address),
-        setLengthLeft(hexToBytes(storage.slot), 32),
-        setLengthLeft(hexToBytes(value), 32),
-      )
+
+    // Read the account after any code update to get the current codeHash
+    const existingAccount = await vm.stateManager.getAccount(address)
+    const finalBalance = balance ?? existingAccount?.balance ?? 0n
+    const finalNonce = nonce ?? existingAccount?.nonce ?? 0n
+    const finalCodeHash = existingAccount?.codeHash ?? KECCAK256_NULL
+
+    if (
+      finalBalance === 0n &&
+      finalNonce === 0n &&
+      equalsBytes(finalCodeHash, KECCAK256_NULL) &&
+      acc.storageChanges.length === 0
+    ) {
+      // The account is empty (EIP-161). Delete it rather than writing a zero-balance
+      // entry into the trie. This correctly handles contracts created and selfdestructed
+      // in the same transaction, where the BAL records postBalance=0 but EVM deletes
+      // the account entirely.
+      await vm.stateManager.deleteAccount(address)
+    } else {
+      await vm.stateManager.modifyAccountFields(address, {
+        balance,
+        nonce,
+      })
+      for (const storage of acc.storageChanges) {
+        const value = storage.slotChanges.slice(-1)[0].postValue
+        await vm.stateManager.putStorage(
+          address,
+          setLengthLeft(hexToBytes(storage.slot), 32),
+          setLengthLeft(hexToBytes(value), 32),
+        )
+      }
     }
-    // await (vm.stateManager as MerkleStateManager).flush()
   }
   const stateRoot = await vm.stateManager.getStateRoot()
   if (expectedStateRoot && !equalsBytes(expectedStateRoot, stateRoot)) {


### PR DESCRIPTION
## Summary

- Fixes 4 failing `test_bal_create_storage_op_then_selfdestruct_same_tx` cases introduced by the glamsterdam-devnet@v6.0.0 submodule bump (#4333)
- All 996 `consumeBal` tests now pass (was 992/996)

## Root cause

When a contract is created and selfdestructed in the same transaction (EIP-6780), the BAL records `postBalance: "0x00"` for the selfdestructed address. `consumeBal` was calling `modifyAccountFields` with `balance=0n`, which left an empty account entry in the Merkle trie. The EVM actually deletes such accounts entirely (EIP-161), so the resulting state roots differed.

## Fix

In `consumeBal`, after computing the final `balance`, `nonce`, and `codeHash` for a BAL entry, if all three are zero/null and there are no storage changes, call `deleteAccount` instead of `modifyAccountFields`. This matches the EIP-161 "empty account deletion" semantics that the EVM applies.

## Test plan

- [x] `packages/vm` — `npx vitest run test/tester/consumeBal.test.ts` → 996/996 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)