### PR TITLE
evm/vm/tx/common: align Amsterdam gas schedule 

### DIFF
--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -630,4 +630,13 @@ export const eipsDict: EIPsDict = {
     minimumHardfork: Hardfork.Amsterdam,
     requiredEIPs: [2929],
   },
+  /**
+   * Description : SELFDESTRUCT no burn (Amsterdam, experimental)
+   * URL         : https://eips.ethereum.org/EIPS/eip-8246
+   * Status      : Draft
+   */
+  8246: {
+    minimumHardfork: Hardfork.Amsterdam,
+    requiredEIPs: [6780],
+  },
 }

--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -109,6 +109,15 @@ export const eipsDict: EIPsDict = {
     minimumHardfork: Hardfork.Chainstart,
   },
   /**
+   * Description : Reduce intrinsic transaction gas (Amsterdam, experimental)
+   * URL         : https://eips.ethereum.org/EIPS/eip-2780
+   * Status      : Draft
+   */
+  2780: {
+    minimumHardfork: Hardfork.Chainstart,
+    requiredEIPs: [7708],
+  },
+  /**
    * Description : Gas cost increases for state access opcodes
    * URL         : https://eips.ethereum.org/EIPS/eip-2929
    * Status      : Final
@@ -611,5 +620,14 @@ export const eipsDict: EIPsDict = {
   8037: {
     minimumHardfork: Hardfork.Amsterdam,
     requiredEIPs: [2780, 6780, 7702, 7825, 7976, 7981],
+  },
+  /**
+   * Description : State Access Gas Cost Increase (Amsterdam, experimental)
+   * URL         : https://eips.ethereum.org/EIPS/eip-8038
+   * Status      : Draft
+   */
+  8038: {
+    minimumHardfork: Hardfork.Amsterdam,
+    requiredEIPs: [2929],
   },
 }

--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -639,4 +639,13 @@ export const eipsDict: EIPsDict = {
     minimumHardfork: Hardfork.Amsterdam,
     requiredEIPs: [6780],
   },
+  /**
+   * Description : Builder execution requests (Amsterdam, experimental)
+   * URL         : https://eips.ethereum.org/EIPS/eip-8282
+   * Status      : Draft
+   */
+  8282: {
+    minimumHardfork: Hardfork.Amsterdam,
+    requiredEIPs: [7685],
+  },
 }

--- a/packages/common/src/hardforks.ts
+++ b/packages/common/src/hardforks.ts
@@ -200,6 +200,6 @@ export const hardforksDict: HardforksDict = {
    * Status     : Draft (implementation incomplete + spec still moving!)
    */
   amsterdam: {
-    eips: [2780, 7708, 7843, 7778, 7928, 7954, 7976, 7981, 8024, 8037, 8038, 8246],
+    eips: [2780, 7708, 7843, 7778, 7928, 7954, 7976, 7981, 8024, 8037, 8038, 8246, 8282],
   },
 }

--- a/packages/common/src/hardforks.ts
+++ b/packages/common/src/hardforks.ts
@@ -200,6 +200,6 @@ export const hardforksDict: HardforksDict = {
    * Status     : Draft (implementation incomplete + spec still moving!)
    */
   amsterdam: {
-    eips: [7708, 7843, 7778, 7928, 7954, 7976, 7981, 8024, 8037],
+    eips: [2780, 7708, 7843, 7778, 7928, 7954, 7976, 7981, 8024, 8037, 8038],
   },
 }

--- a/packages/common/src/hardforks.ts
+++ b/packages/common/src/hardforks.ts
@@ -200,6 +200,6 @@ export const hardforksDict: HardforksDict = {
    * Status     : Draft (implementation incomplete + spec still moving!)
    */
   amsterdam: {
-    eips: [2780, 7708, 7843, 7778, 7928, 7954, 7976, 7981, 8024, 8037, 8038],
+    eips: [2780, 7708, 7843, 7778, 7928, 7954, 7976, 7981, 8024, 8037, 8038, 8246],
   },
 }

--- a/packages/evm/src/eip8037.ts
+++ b/packages/evm/src/eip8037.ts
@@ -22,6 +22,8 @@ export function activeCostPerStateByte(common: Common, _blockGasLimit?: bigint):
 interface IntrinsicDimensionsTx {
   type: number
   common: Common
+  value: bigint
+  to?: { bytes: Uint8Array }
   getIntrinsicGas(): bigint
   toCreationAddress(): boolean
   // EIP-7702 (type 4) txs expose an authorization list.
@@ -50,6 +52,7 @@ export function computeIntrinsicGasDimensions8037(
   common: Common,
   tx: IntrinsicDimensionsTx,
   blockGasLimit?: bigint,
+  sender?: { bytes: Uint8Array },
 ): { intrinsicRegular: bigint; intrinsicState: bigint } {
   const intrinsicRegular0 = tx.getIntrinsicGas()
   if (!common.isActivatedEIP(8037)) {
@@ -63,23 +66,49 @@ export function computeIntrinsicGasDimensions8037(
   // 7702 regular correction. getIntrinsicGas() (via getDataGas in
   // tx/capabilities/eip7702.ts) adds `authCount * perEmptyAccountCost` to
   // the regular intrinsic. Under EIP-8037 perEmptyAccountCost = 0 and the
-  // regular per-auth charge is perAuthBaseGas; add the missing amount here.
+  // regular per-auth charge is accountWriteGas + perAuthBaseGas; add the
+  // missing amount here.
   let authCount = 0
   let intrinsicRegular = intrinsicRegular0
   if (tx.type === 4 && Array.isArray(tx.authorizationList)) {
     authCount = tx.authorizationList.length
-    intrinsicRegular += BigInt(authCount) * common.param('perAuthBaseGas')
+    intrinsicRegular +=
+      BigInt(authCount) * (common.param('accountWriteGas') + common.param('perAuthBaseGas'))
   }
 
-  // State-dimension intrinsic: state portion of creation-tx new-account
-  // charge plus per-auth state base (new-account + auth-base bytes).
-  let intrinsicState = BIGINT_0
   let isCreate = false
   try {
     isCreate = tx.toCreationAddress()
   } catch {
     isCreate = false
   }
+
+  // EIP-2780 recipient/value components. Self-transfers (sender == to) skip
+  // the recipient and value charges entirely.
+  if (common.isActivatedEIP(2780)) {
+    const hasValue = tx.value > BIGINT_0
+    if (isCreate) {
+      // Creation recipient cost (CREATE_ACCESS, via txCreationGas) is already
+      // part of getIntrinsicGas(); a value-bearing create adds the EIP-7708
+      // transfer-log cost.
+      if (hasValue) {
+        intrinsicRegular += common.param('transferLogCost')
+      }
+    } else {
+      const isSelfTransfer =
+        sender !== undefined && tx.to !== undefined && equalsBytes8037(sender.bytes, tx.to.bytes)
+      if (!isSelfTransfer) {
+        intrinsicRegular += common.param('txRecipientAccessGas')
+        if (hasValue) {
+          intrinsicRegular += common.param('transferLogCost') + common.param('txValueCost')
+        }
+      }
+    }
+  }
+
+  // State-dimension intrinsic: state portion of creation-tx new-account
+  // charge plus per-auth state base (new-account + auth-base bytes).
+  let intrinsicState = BIGINT_0
   if (isCreate) {
     intrinsicState += stateBytesPerNewAccount * costPerStateByte
   }
@@ -89,4 +118,12 @@ export function computeIntrinsicGasDimensions8037(
   }
 
   return { intrinsicRegular, intrinsicState }
+}
+
+function equalsBytes8037(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
 }

--- a/packages/evm/src/evm.ts
+++ b/packages/evm/src/evm.ts
@@ -248,6 +248,14 @@ export class EVM implements EVMInterface {
    */
   public eip7928CallPostTargetOog = false
   /**
+   * EIP-8037: whether the target account of a top-level creation transaction
+   * was already alive (EIP-161 non-empty) before creation. runTx refunds the
+   * intrinsic new-account state gas when this is true or the creation failed.
+   *
+   * @remarks Experimental (Amsterdam): may change on patch releases.
+   */
+  public createTxTargetAlive = false
+  /**
    * EIP-8037 per-frame state-gas snapshots. Pushed on each message-level
    * journal.checkpoint() and popped on commit (drop) or revert / exceptional
    * halt (restore). Restoring on revert refunds all state-gas charges and
@@ -482,6 +490,44 @@ export class EVM implements EVMInterface {
       }
     }
 
+    // EIP-2780 top-frame charges (Amsterdam, experimental): applied at the
+    // top of a transaction's call frame, after authorizations and before any
+    // opcode runs. Reads pre-value-transfer state so the EIP-161-empty check
+    // sees the recipient as it was at the start of the frame.
+    if (message.depth === 0 && this.common.isActivatedEIP(2780)) {
+      // Dead recipient receiving value: charge the new-account state gas
+      // (reservoir first, spilling into the frame's regular gas).
+      if (message.value > BIGINT_0 && !message.delegatecall) {
+        const recipient = await this.stateManager.getAccount(message.to)
+        if (recipient === undefined || recipient.isEmpty()) {
+          const amount =
+            this.common.param('stateBytesPerNewAccount') * activeCostPerStateByte(this.common)
+          if (this.stateGasReservoir >= amount) {
+            this.stateGasReservoir -= amount
+          } else if (this.stateGasReservoir + gasLimit >= amount) {
+            const remainder = amount - this.stateGasReservoir
+            this.stateGasReservoir = BIGINT_0
+            gasLimit -= remainder
+          } else {
+            return { execResult: OOGResult(message.gasLimit) }
+          }
+          this.executionStateGasUsed += amount
+        }
+      }
+      // Delegated recipient: charge a cold account access for the delegation
+      // resolution (the delegated address is warmed in _loadCode at depth 0).
+      if (this.common.isActivatedEIP(7702)) {
+        const recipientCode = await this.stateManager.getCode(message.to)
+        if (equalsBytes(recipientCode.slice(0, 3), DELEGATION_7702_FLAG)) {
+          const cost = this.common.param('coldaccountaccessGas')
+          if (gasLimit < cost) {
+            return { execResult: OOGResult(message.gasLimit) }
+          }
+          gasLimit -= cost
+        }
+      }
+    }
+
     let account = await this.stateManager.getAccount(fromAddress)
     if (!account) {
       account = new Account()
@@ -704,6 +750,20 @@ export class EVM implements EVMInterface {
     let toAccount = await this.stateManager.getAccount(message.to)
     if (!toAccount) {
       toAccount = new Account()
+    }
+
+    // EIP-8037: record whether the create target account was already alive
+    // (EIP-161 non-empty) before creation — the new-account state gas is
+    // refunded in that case since no new account leaf persists. For inner
+    // CREATE/CREATE2 the caller (interpreter `create()`) reads the message
+    // field; for top-level creation transactions runTx reads the EVM field.
+    if (this.common.isActivatedEIP(8037)) {
+      const targetAlive =
+        (await this.stateManager.getAccount(message.to)) !== undefined && !toAccount.isEmpty()
+      message.createdTargetAlive = targetAlive
+      if (message.depth === 0) {
+        this.createTxTargetAlive = targetAlive
+      }
     }
 
     if (this.common.isActivatedEIP(6800) || this.common.isActivatedEIP(7864)) {
@@ -981,6 +1041,12 @@ export class EVM implements EVMInterface {
       if (stateGasCreate > BIGINT_0) {
         this.stateGasReservoir -= stateGasFromReservoir
         this.executionStateGasUsed += stateGasCreate
+        // The gas_left-spilled slice of the code-deposit state gas belongs to
+        // this frame's spill tracker so an ancestor revert (or a later LIFO
+        // refund) credits it back to regular gas.
+        if (stateGasSpillToGasLeft > BIGINT_0) {
+          result.stateGasSpilled = (result.stateGasSpilled ?? BIGINT_0) + stateGasSpillToGasLeft
+        }
       }
       // Record the charge keyed on the freshly-created address so runTx
       // can refund it if this account is SELFDESTRUCTed within the same
@@ -1197,6 +1263,7 @@ export class EVM implements EVMInterface {
       gas: interpreterRes.runState?.gasLeft,
       executionGasUsed: gasUsed,
       gasRefund: interpreterRes.runState!.gasRefund,
+      stateGasSpilled: interpreterRes.runState!.stateGasSpilled,
       returnValue: result.returnValue ?? new Uint8Array(0),
     }
   }
@@ -1287,7 +1354,6 @@ export class EVM implements EVMInterface {
 
     await this._emit('beforeMessage', message)
 
-    const isCreate = !message.to
     if (!message.to && this.common.isActivatedEIP(2929)) {
       message.code = message.data
       this.journal.addWarmedAddress((await this._generateAddress(message)).bytes)
@@ -1366,56 +1432,35 @@ export class EVM implements EVMInterface {
         this.blockLevelAccessList?.revert()
       }
       if (this.common.isActivatedEIP(8037)) {
-        // EIP-8037 §"Gas accounting for halts and reverts": restore the
-        // reservoir + cumulative state-gas used to their frame-entry values,
-        // undoing all state-gas charged during the failed frame.
-        //
-        // The snapshot pop restores the reservoir to its entry value, refunding
-        // the reservoir-paid portion. In addition, when a child call frame is
-        // entered and then reverts or halts, the spec refunds the gas_left-
-        // spilled portion of its state-gas charges to the parent reservoir too,
-        // so the parent (or tx) is credited for all state-gas charged on the
-        // failed frame ("all state-gas charged on the child frame is refunded
-        // to the parent frame's state_gas_reservoir").
-        //
-        // The exception is a STATIC_STATE_CHANGE: a CREATE/CREATE2 (or other
-        // state-modifying op) attempted in a static context aborts the EXECUTING
-        // frame *before any child call frame is entered*. The state-gas
-        // pre-charged for the would-be account creation is not associated with a
-        // child frame that the parent can reclaim; the executing frame instead
-        // exceptionally halts and consumes its gas_left, so the spilled portion
-        // stays consumed and is counted as regular gas (it must NOT be credited
-        // back to the reservoir).
-        const consumeSpilled = err.error === EVMError.errorMessages.STATIC_STATE_CHANGE
+        // EIP-8037 frame-failure state-gas rollback (per the pinned
+        // execution-specs Amsterdam revision, `refill_frame_state_gas`):
+        // the failed frame's state changes are undone, so its state-gas
+        // pools reset to their frame-entry values. The gas_left-spilled
+        // portion is credited back to the frame's gas_left: on an
+        // exceptional halt it is then consumed with the rest of the frame's
+        // gas (counted as regular gas); on a REVERT it is returned to the
+        // parent as unused gas (executionGasUsed is reduced below).
         const snap = this._stateGasSnapshots.pop()
         if (snap !== undefined) {
-          const usedThisFrame = this.executionStateGasUsed - snap.used
-          const reservoirPaidThisFrame = snap.reservoir - this.stateGasReservoir
-          const spilledThisFrame =
-            usedThisFrame > reservoirPaidThisFrame
-              ? usedThisFrame - reservoirPaidThisFrame
-              : BIGINT_0
-          this.stateGasReservoir = snap.reservoir + (consumeSpilled ? BIGINT_0 : spilledThisFrame)
+          this.stateGasReservoir = snap.reservoir
           this.executionStateGasUsed = snap.used
           this.createdAccountStateGas = snap.createdAccountStateGas
           this.createdAccountIntrinsicStateGas = snap.createdAccountIntrinsicStateGas
         }
-        // EIP-8037: on ANY creation-frame failure (revert / halt / OOG /
-        // collision / oversized code etc.), refund the
-        // stateBytesPerNewAccount * costPerStateByte portion that was paid
-        // for this frame's new-account allocation. The pre-charge happened
-        // either as intrinsic_state_gas (depth=0 creation tx, paid up-front
-        // in runTx) or as the CREATE/CREATE2 opcode pre-charge (depth>0,
-        // applied in opcodes/gas.ts). In neither case is it part of the
-        // per-frame snapshot, so the snapshot pop doesn't credit it; do it
-        // explicitly here.
-        if (isCreate) {
-          const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
-          const costPerStateByte = activeCostPerStateByte(this.common, this._block?.header.gasLimit)
-          const newAccountStateGas = stateBytesPerNewAccount * costPerStateByte
-          this.stateGasReservoir += newAccountStateGas
-          this.executionStateGasUsed -= newAccountStateGas
+        if (err.error === EVMError.errorMessages.REVERT) {
+          const spilled = result.execResult.stateGasSpilled ?? BIGINT_0
+          if (spilled > BIGINT_0) {
+            result.execResult.executionGasUsed -= spilled
+          }
         }
+        // The frame failed: its spilled state gas must not propagate to the
+        // parent frame's spill tracker.
+        result.execResult.stateGasSpilled = BIGINT_0
+        // EIP-8037: the new-account state gas pre-charged for a failed
+        // creation frame is refunded by the caller: the interpreter's
+        // `create()` wrapper for inner CREATE/CREATE2, or runTx for a
+        // top-level creation transaction. (Neither charge is part of the
+        // per-frame snapshot, so the snapshot pop doesn't credit it.)
       }
       if (this.DEBUG) {
         debug(`message checkpoint reverted`)

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -1549,10 +1549,24 @@ export class Interpreter {
       }
     }
 
+    // EIP-8246: SELFDESTRUCT no longer burns ETH. A self-beneficiary keeps
+    // its balance (the account clearing at transaction end preserves the
+    // balance); zeroing only completes a transfer to a different account.
+    if (this.common.isActivatedEIP(8246) && toSelf) {
+      doModify = false
+    }
+
     // EIP-7708: Emit a Burn log (LOG2) for SELFDESTRUCT to self only when the balance
     // is actually zeroed (doModify=true, i.e. same-tx contract creation). Pre-existing
     // contracts where EIP-6780 prevents the burn should not emit a log.
-    if (this.common.isActivatedEIP(7708) && contractBalance > BIGINT_0 && toSelf && doModify) {
+    // Under EIP-8246 nothing is burned, so no burn log is ever emitted.
+    if (
+      this.common.isActivatedEIP(7708) &&
+      !this.common.isActivatedEIP(8246) &&
+      contractBalance > BIGINT_0 &&
+      toSelf &&
+      doModify
+    ) {
       const contractTopic = setLengthLeft(this._env.address.bytes, 32)
       const data = setLengthLeft(bigIntToBytes(contractBalance), 32)
       const burnLog: Log = [EIP7708_SYSTEM_ADDRESS, [EIP7708_BURN_TOPIC, contractTopic], data]

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -11,6 +11,8 @@ import {
   bytesToBigInt,
   bytesToHex,
   equalsBytes,
+  generateAddress,
+  generateAddress2,
   setLengthLeft,
   setLengthRight,
 } from '@ethereumjs/util'
@@ -124,6 +126,18 @@ export interface RunState {
   interpreter: Interpreter
   gasRefund: bigint // Tracks the current refund
   gasLeft: bigint // Current gas left
+  /**
+   * EIP-8037: state gas paid from `gasLeft` (spilled) in this frame,
+   * including spill merged from successful child frames. State-gas refunds
+   * credit `gasLeft` first up to this amount (LIFO), then the reservoir.
+   */
+  stateGasSpilled: bigint
+  /**
+   * EIP-8037: the new-account state gas charged by the most recent CALL
+   * opcode's gas handler; refunded if the call fails fast (depth limit /
+   * insufficient balance) before a child frame is entered.
+   */
+  lastCallNewAccountStateGas?: bigint
   returnBytes: Uint8Array /* Current bytes in the return Uint8Array. Cleared each time a CALL/CREATE is made in the current frame. */
 }
 
@@ -220,6 +234,7 @@ export class Interpreter {
       interpreter: this,
       gasRefund: env.gasRefund,
       gasLeft,
+      stateGasSpilled: BIGINT_0,
       returnBytes: new Uint8Array(0),
     }
     this.journal = journal
@@ -686,11 +701,37 @@ export class Interpreter {
         remaining,
         context !== undefined ? `state-gas spill: ${context}` : 'state-gas spill',
       )
+      this._runState.stateGasSpilled += remaining
     }
     evm.executionStateGasUsed += amount
     if (evm.DEBUG) {
       debugGas(
-        `${context !== undefined ? context + ': ' : ''}charged ${amount} state gas (reservoir=${evm.stateGasReservoir}, executionStateGasUsed=${evm.executionStateGasUsed}, gasLeft=${this._runState.gasLeft})`,
+        `${context !== undefined ? context + ': ' : ''}charged ${amount} state gas (reservoir=${evm.stateGasReservoir}, executionStateGasUsed=${evm.executionStateGasUsed}, gasLeft=${this._runState.gasLeft}, spilled=${this._runState.stateGasSpilled})`,
+      )
+    }
+  }
+
+  /**
+   * EIP-8037: credit a state-gas refund to the local frame, in LIFO order.
+   * State-gas charges draw from the reservoir first and from `gasLeft` last,
+   * so refunds credit the pool charged last first: `gasLeft` up to the
+   * frame's spilled amount, then the reservoir. Decrements
+   * `execution_state_gas_used` by the full amount.
+   * @param amount - The refund amount to credit
+   * @param context - Usage context for debugging
+   */
+  creditStateGasRefund(amount: bigint, context?: string): void {
+    if (amount === BIGINT_0) return
+    const evm = this._evm
+    const runState = this._runState
+    const fromGasLeft = amount < runState.stateGasSpilled ? amount : runState.stateGasSpilled
+    runState.gasLeft += fromGasLeft
+    runState.stateGasSpilled -= fromGasLeft
+    evm.stateGasReservoir += amount - fromGasLeft
+    evm.executionStateGasUsed -= amount
+    if (evm.DEBUG) {
+      debugGas(
+        `${context !== undefined ? context + ': ' : ''}credited ${amount} state gas refund (gasLeft +${fromGasLeft}, reservoir=${evm.stateGasReservoir}, executionStateGasUsed=${evm.executionStateGasUsed})`,
       )
     }
   }
@@ -1169,6 +1210,13 @@ export class Interpreter {
       this._env.depth >= Number(this.common.param('stackLimit')) ||
       (msg.delegatecall !== true && this._env.contract.balance < msg.value)
     ) {
+      // EIP-8037: the call fails fast before a child frame is entered, so
+      // the new-account state gas pre-charged at the CALL opcode is refunded.
+      const preCharged = this._runState.lastCallNewAccountStateGas ?? BIGINT_0
+      if (preCharged > BIGINT_0) {
+        this.creditStateGasRefund(preCharged, 'CALL fail-fast new_account')
+        this._runState.lastCallNewAccountStateGas = BIGINT_0
+      }
       return BIGINT_0
     }
 
@@ -1180,6 +1228,20 @@ export class Interpreter {
 
     // this should always be safe
     this.useGas(results.execResult.executionGasUsed, 'CALL, STATICCALL, DELEGATECALL, CALLCODE')
+
+    // EIP-8037: merge the successful child frame's spilled state gas into
+    // this frame's spill tracker (LIFO refunds may credit it back to
+    // gasLeft). Failed frames return stateGasSpilled = 0. On any child
+    // failure the new-account state gas pre-charged at the CALL opcode is
+    // refunded (no account leaf persists).
+    if (this.common.isActivatedEIP(8037)) {
+      this._runState.stateGasSpilled += results.execResult.stateGasSpilled ?? BIGINT_0
+      const preCharged = this._runState.lastCallNewAccountStateGas ?? BIGINT_0
+      if (results.execResult.exceptionError !== undefined && preCharged > BIGINT_0) {
+        this.creditStateGasRefund(preCharged, 'CALL child-failure new_account')
+      }
+      this._runState.lastCallNewAccountStateGas = BIGINT_0
+    }
 
     // Set return value
     if (
@@ -1229,20 +1291,20 @@ export class Interpreter {
     // empty the return data buffer
     this._runState.returnBytes = new Uint8Array(0)
 
-    // EIP-8037: helper to refund the pre-charged NEW_ACCOUNT state-gas
-    // when the CREATE short-circuits BEFORE a child frame is spawned
-    // (depth limit, insufficient balance, EIP-2681 nonce overflow,
-    // EIP-3860 oversized initcode). The pre-charge happened in
-    // opcodes/gas.ts; the runCall revert handler won't fire here since
-    // no child frame is created, so refund explicitly.
-    const refundCreatePreCharge = (): void => {
+    // EIP-8037: helper to refund the pre-charged NEW_ACCOUNT state-gas when
+    // no new account leaf persists: the CREATE short-circuits before a child
+    // frame is spawned (depth limit, insufficient balance, EIP-2681 nonce
+    // overflow, EIP-3860 oversized initcode), the creation frame fails
+    // (revert / halt / collision), or the target account was already alive.
+    // The pre-charge happened in opcodes/gas.ts; refunds credit this
+    // (parent) frame's pools in LIFO order.
+    const refundCreatePreCharge = (context: string): void => {
       if (!this.common.isActivatedEIP(8037)) return
       const stateBytesPerNewAccount = this.common.param('stateBytesPerNewAccount')
       const blockGasLimit = this._env.block.header.gasLimit
       const costPerStateByte = activeCostPerStateByte(this.common, blockGasLimit)
       const newAccountStateGas = stateBytesPerNewAccount * costPerStateByte
-      this._evm.stateGasReservoir += newAccountStateGas
-      this._evm.executionStateGasUsed -= newAccountStateGas
+      this.creditStateGasRefund(newAccountStateGas, context)
     }
 
     // Check if account has enough ether and max depth not exceeded
@@ -1250,14 +1312,24 @@ export class Interpreter {
       this._env.depth >= Number(this.common.param('stackLimit')) ||
       this._env.contract.balance < value
     ) {
-      refundCreatePreCharge()
+      refundCreatePreCharge('CREATE fail-fast new_account')
       return BIGINT_0
     }
 
     // EIP-2681 check
     if (this._env.contract.nonce >= MAX_UINT64) {
-      refundCreatePreCharge()
+      refundCreatePreCharge('CREATE fail-fast new_account')
       return BIGINT_0
+    }
+
+    // EIP-8038: warm the create target only now, after the fail-fast checks
+    // (an aborted create must not warm the address). Uses the pre-increment
+    // nonce, matching the address generated in `_executeCreate`.
+    if (this.common.isActivatedEIP(8038) && this.common.isActivatedEIP(2929)) {
+      const targetAddressBytes = salt
+        ? generateAddress2(this._env.address.bytes, salt, codeToRun)
+        : generateAddress(this._env.address.bytes, bigIntToBytes(this._env.contract.nonce))
+      this.journal.addWarmedAddress(targetAddressBytes)
     }
 
     this._env.contract.nonce += BIGINT_1
@@ -1275,7 +1347,7 @@ export class Interpreter {
         codeToRun.length > Number(this.common.param('maxInitCodeSize')) &&
         this._evm.allowUnlimitedInitCodeSize === false
       ) {
-        refundCreatePreCharge()
+        refundCreatePreCharge('CREATE fail-fast new_account')
         return BIGINT_0
       }
     }
@@ -1308,6 +1380,23 @@ export class Interpreter {
 
     // this should always be safe
     this.useGas(results.execResult.executionGasUsed, 'CREATE')
+
+    if (this.common.isActivatedEIP(8037)) {
+      if (results.execResult.exceptionError !== undefined) {
+        // Creation frame failed (revert / halt / collision): no account
+        // leaf persists, refund the pre-charged new-account state gas.
+        refundCreatePreCharge('CREATE failure new_account')
+      } else {
+        // Merge the successful child frame's spilled state gas into this
+        // frame's spill tracker (LIFO refunds may credit it to gasLeft).
+        this._runState.stateGasSpilled += results.execResult.stateGasSpilled ?? BIGINT_0
+        if (message.createdTargetAlive === true) {
+          // The create target was already alive (EIP-161 non-empty): no new
+          // account leaf was added, refund the new-account state gas.
+          refundCreatePreCharge('CREATE onto alive account new_account')
+        }
+      }
+    }
 
     // Set return buffer in case revert happened
     if (

--- a/packages/evm/src/message.ts
+++ b/packages/evm/src/message.ts
@@ -74,6 +74,14 @@ export class Message {
    */
   blobVersionedHashes?: PrefixedHexString[]
   accessWitness?: BinaryTreeAccessWitnessInterface
+  /**
+   * EIP-8037: set by the EVM during creation-message execution when the
+   * create target account was already alive (EIP-161 non-empty). The caller
+   * refunds the new-account state gas in that case.
+   *
+   * @remarks Experimental (Amsterdam): may change on patch releases.
+   */
+  createdTargetAlive?: boolean
 
   constructor(opts: MessageOpts) {
     this.to = opts.to

--- a/packages/evm/src/opcodes/EIP2200.ts
+++ b/packages/evm/src/opcodes/EIP2200.ts
@@ -9,6 +9,81 @@ import type { Common } from '@ethereumjs/common'
 import type { RunState } from '../interpreter.ts'
 
 /**
+ * SSTORE gas per the Amsterdam gas schedule (EIP-8038, experimental):
+ * - access cost (cold or warm) is always charged
+ * - a flat `storageWriteGas` is charged on the first change to the slot in
+ *   the transaction, refunded if the slot is restored to its original value
+ * - clearing an originally non-zero slot refunds `refundStorageClearGas`
+ *   (reversed if the slot is later recreated)
+ * The EIP-8037 state-gas portion for newly set slots is metered separately
+ * in the SSTORE opcode handler.
+ *
+ * Returns the regular gas cost (including the access cost) and warms the
+ * storage slot.
+ */
+export function updateSstoreGasEIP8038(
+  runState: RunState,
+  currentStorage: Uint8Array,
+  originalStorage: Uint8Array,
+  value: Uint8Array,
+  key: Uint8Array,
+  common: Common,
+): bigint {
+  // EIP-2200 sentry: fail if not enough gas is left to guarantee the stipend
+  if (runState.interpreter.getGasLeft() <= common.param('sstoreSentryEIP2200Gas')) {
+    trap(EVMError.errorMessages.OUT_OF_GAS)
+  }
+
+  const address = runState.interpreter.getAddress().bytes
+  const slotIsCold = !runState.interpreter.journal.isWarmedStorage(address, key)
+
+  // Access cost: cold or warm, always charged.
+  let gas: bigint
+  if (slotIsCold) {
+    runState.interpreter.journal.addWarmedStorage(address, key)
+    gas = common.param('coldsloadGas')
+  } else {
+    gas = common.param('warmstoragereadGas')
+  }
+
+  const currentEqualsNew = equalsBytes(currentStorage, value)
+  const originalEqualsCurrent = equalsBytes(originalStorage, currentStorage)
+  const originalEqualsNew = equalsBytes(originalStorage, value)
+
+  // Write cost: charged on the first change to the slot this transaction.
+  if (originalEqualsCurrent && !currentEqualsNew) {
+    gas += common.param('storageWriteGas')
+  }
+
+  if (!currentEqualsNew) {
+    if (originalStorage.length > 0 && currentStorage.length > 0 && value.length === 0) {
+      // Storage is cleared for the first time in the transaction
+      runState.interpreter.refundGas(
+        common.param('refundStorageClearGas'),
+        'EIP-8038 -> refundStorageClear',
+      )
+    }
+    if (originalStorage.length > 0 && currentStorage.length === 0) {
+      // Gas refund issued earlier to be reversed
+      runState.interpreter.subRefund(
+        common.param('refundStorageClearGas'),
+        'EIP-8038 -> refundStorageClear (reversed)',
+      )
+    }
+    if (originalEqualsNew) {
+      // Slot restored to its original value: refund the storageWriteGas
+      // charged on the first-time change earlier this transaction.
+      runState.interpreter.refundGas(
+        common.param('storageWriteGas'),
+        'EIP-8038 -> storageWrite restore refund',
+      )
+    }
+  }
+
+  return gas
+}
+
+/**
  * Adjusts gas usage and refunds of SStore ops per EIP-2200 (Istanbul)
  *
  * @param {RunState} runState

--- a/packages/evm/src/opcodes/EIP7928.ts
+++ b/packages/evm/src/opcodes/EIP7928.ts
@@ -156,17 +156,17 @@ function finalizeCallMessageGas(
   }
 
   // EIP-8037: pre-charge the new-account state-gas BEFORE the inner call
-  // runs. This matches the EELS amsterdam (tests-bal) reference, where
+  // runs. This matches the pinned execution-specs Amsterdam reference, where
   // `charge_state_gas(STATE_BYTES_PER_NEW_ACCOUNT * COST_PER_STATE_BYTE)`
   // happens in the CALL opcode body before the sub-frame is processed and
-  // before the insufficient-balance check. The charge is unconditional
-  // (per spec it sticks even when the sub-call later fails for insufficient
-  // balance or reverts), so we charge here rather than after frame exit.
-  // The post-frame charge in evm.ts is skipped under EIP-8037 to avoid
-  // double-counting (see `_executeCall` post-execution block).
+  // before the insufficient-balance check. The charge sticks when the
+  // sub-call reverts or halts; it is refunded only when the call fails fast
+  // (depth limit / insufficient balance) before a child frame is entered
+  // (see `_baseCall`).
   if (common.isActivatedEIP(8037) && newAccountStateGas > BIGINT_0) {
     runState.interpreter.chargeStateGas(newAccountStateGas, 'CALL pre-charge new_account')
   }
+  runState.lastCallNewAccountStateGas = common.isActivatedEIP(8037) ? newAccountStateGas : BIGINT_0
 
   runState.messageGasLimit = gasLimit
   return gas
@@ -356,7 +356,11 @@ export async function create7928Gas(
     }
   }
 
-  if (common.isActivatedEIP(2929)) {
+  if (common.isActivatedEIP(2929) && !common.isActivatedEIP(8038)) {
+    // Pre-Amsterdam: the create target is warmed during the gas step.
+    // Under EIP-8038 warming happens only after the fail-fast checks
+    // (depth / balance / nonce overflow) in the interpreter `create()`
+    // wrapper, so an aborted create does not warm the address.
     warmAddress(runState, targetAddress)
   }
 

--- a/packages/evm/src/opcodes/functions.ts
+++ b/packages/evm/src/opcodes/functions.ts
@@ -879,8 +879,10 @@ export const handlers: Map<number, OpHandler> = new Map([
           const prior = evm.createdAccountStateGas.get(addrKey) ?? BIGINT_0
           evm.createdAccountStateGas.set(addrKey, prior + amount)
         } else if (!currentIsZero && newIsZero) {
-          // 0 -> nonzero -> 0: clearing a slot created in this tx, refill reservoir
-          runState.interpreter.refillStateGasReservoir(amount, 'SSTORE clear')
+          // 0 -> nonzero -> 0: clearing a slot created in this tx, credit the
+          // state-gas refund in LIFO order (gasLeft first up to the frame's
+          // spilled amount, then the reservoir)
+          runState.interpreter.creditStateGasRefund(amount, 'SSTORE clear')
           // Symmetric: subtract from the per-address tracker so we don't
           // double-refund storage that was already cleared inside the tx.
           const addrKey = runState.interpreter.getAddress().toString()

--- a/packages/evm/src/opcodes/gas.ts
+++ b/packages/evm/src/opcodes/gas.ts
@@ -19,7 +19,7 @@ import { EVMError } from '../errors.ts'
 import { DELEGATION_7702_FLAG } from '../types.ts'
 
 import { updateSstoreGasEIP1283 } from './EIP1283.ts'
-import { updateSstoreGasEIP2200 } from './EIP2200.ts'
+import { updateSstoreGasEIP2200, updateSstoreGasEIP8038 } from './EIP2200.ts'
 import {
   accessAddressEIP2929,
   accessStorageEIP2929,
@@ -223,6 +223,11 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           gas += accessAddressEIP2929(runState, address.bytes, common, charge2929Gas)
         }
 
+        // EIP-8038: additional code-reading cost on top of the account access
+        if (common.isActivatedEIP(8038)) {
+          gas += common.param('warmstoragereadGas')
+        }
+
         return gas
       },
     ],
@@ -251,6 +256,11 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
 
         if (common.isActivatedEIP(2929)) {
           gas += accessAddressEIP2929(runState, address.bytes, common, charge2929Gas)
+        }
+
+        // EIP-8038: additional code-reading cost on top of the account access
+        if (common.isActivatedEIP(8038)) {
+          gas += common.param('warmstoragereadGas')
         }
 
         if (dataLength !== BIGINT_0) {
@@ -398,7 +408,21 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
         const originalStorage = setLengthLeftStorage(
           await runState.interpreter.storageLoad(keyBytes, true, false),
         )
-        if (common.hardfork() === Hardfork.Constantinople) {
+        let sstoreCharge2929Gas = true
+        if (common.isActivatedEIP(8038)) {
+          // Amsterdam schedule: access cost (cold/warm) + flat write cost on
+          // the first change to the slot, with matching restore refunds.
+          // Access cost is charged inside; skip the 2929 access charge below.
+          gas += updateSstoreGasEIP8038(
+            runState,
+            currentStorage,
+            originalStorage,
+            setLengthLeftStorage(value),
+            keyBytes,
+            common,
+          )
+          sstoreCharge2929Gas = false
+        } else if (common.hardfork() === Hardfork.Constantinople) {
           gas += updateSstoreGasEIP1283(
             runState,
             currentStorage,
@@ -432,7 +456,7 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
           )
         }
 
-        let charge2929Gas = true
+        let charge2929Gas = sstoreCharge2929Gas
         if (common.isActivatedEIP(6800) || common.isActivatedEIP(7864)) {
           const contract = runState.interpreter.getAddress()
           const coldAccessGas = runState.env.accessWitness!.writeAccountStorage(contract, key)
@@ -993,7 +1017,14 @@ export const dynamicGasHandlers: Map<number, AsyncDynamicGasHandler | SyncDynami
             // This technically checks if account is empty or non-existent
             const account = await runState.stateManager.getAccount(selfdestructToAddress)
             if (account === undefined || account.isEmpty()) {
-              newAccountGas = common.param('callNewAccountGas')
+              if (common.isActivatedEIP(8038)) {
+                // Amsterdam: positive balance sent to an empty account costs
+                // accountWriteGas (regular). The new-account state-gas portion
+                // is charged in the SELFDESTRUCT opcode handler (interpreter).
+                newAccountGas = common.param('accountWriteGas')
+              } else {
+                newAccountGas = common.param('callNewAccountGas')
+              }
             }
           }
         } else if (common.gteHardfork(Hardfork.TangerineWhistle)) {

--- a/packages/evm/src/params.ts
+++ b/packages/evm/src/params.ts
@@ -415,8 +415,8 @@ export const paramsEVM: ParamsDict = {
    */
   7954: {
     // evm
-    maxCodeSize: 32768, // EIP-7954: Maximum length of contract code (raised from 24 KiB)
-    maxInitCodeSize: 65536, // EIP-7954: Maximum length of initialization code (raised from 48 KiB)
+    maxCodeSize: 65536, // EIP-7954: Maximum length of contract code (raised from 24 KiB)
+    maxInitCodeSize: 131072, // EIP-7954: Maximum length of initialization code (2 * maxCodeSize, raised from 48 KiB)
   },
   /**
    * State Creation Gas Cost Increase
@@ -426,19 +426,33 @@ export const paramsEVM: ParamsDict = {
    */
   8037: {
     // Regular-gas overrides (state portion is metered separately)
-    sstoreSetGas: 2900, // SSTORE 0->nonzero: regular gas (down from 20000); state portion = stateBytesPerStorageSet * costPerStateByte
-    sstoreInitEIP2200Gas: 2900, // EIP-2200 path uses this name for the create-slot regular cost; align with sstoreSetGas under 8037
-    sstoreInitRefundEIP2200Gas: 0, // Legacy refund for "create-then-clear-in-same-tx" is replaced by the state-gas reservoir refill
-    createGas: 9000, // CREATE base regular gas (down from 32000); state portion = (stateBytesPerNewAccount + L) * costPerStateByte
-    create2Gas: 9000, // CREATE2 base regular gas (down from 32000); state portion = (stateBytesPerNewAccount + L) * costPerStateByte
-    callNewAccountGas: 0, // CALL* to non-existent: regular gas (down from 25000); state portion = stateBytesPerNewAccount * costPerStateByte
+    createGas: 11000, // CREATE base regular gas (CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS); state portion = (stateBytesPerNewAccount + L) * costPerStateByte
+    create2Gas: 11000, // CREATE2 base regular gas (CREATE_ACCESS = ACCOUNT_WRITE + COLD_STORAGE_ACCESS); state portion = (stateBytesPerNewAccount + L) * costPerStateByte
+    callNewAccountGas: 0, // CALL* to non-existent: regular gas (down from 25000); state portion = stateBytesPerNewAccount * costPerStateByte (charged only for value-bearing calls)
     createDataGas: 0, // Per-byte regular cost of code deposit (down from 200); replaced by costPerStateByte state-gas plus a per-word hash cost (see codeDepositHashWordGas)
     codeDepositHashWordGas: 6, // Per 32-byte word regular hash cost on contract creation (6 * ceil(L/32))
     // New state-gas constants (used to compute state-gas charges)
-    costPerStateByte: 1530, // Cost per state byte (v7 fixtures)
-    stateBytesPerStorageSet: 64, // Bytes accounted per new storage slot (v7 fixtures)
-    stateBytesPerNewAccount: 120, // Bytes accounted per newly created account (v7 fixtures)
+    costPerStateByte: 1530, // Cost per state byte
+    stateBytesPerStorageSet: 64, // Bytes accounted per new storage slot
+    stateBytesPerNewAccount: 120, // Bytes accounted per newly created account
     stateBytesPerAuthBase: 23, // Bytes accounted per EIP-7702 authorization base
     systemMaxSstoresPerCall: 16, // Reservoir headroom for system contract calls
+  },
+  /**
+   * State Access Gas Cost Increase (Amsterdam, experimental).
+   * Repriced access/write constants per the pinned execution-specs Amsterdam
+   * gas schedule. The SSTORE model becomes: access cost (cold/warm) always,
+   * plus a flat storageWriteGas on the first change to a slot in the
+   * transaction (with a matching refund when the slot is restored), plus the
+   * EIP-8037 state-gas portion for newly set slots.
+   */
+  8038: {
+    // gasPrices
+    coldsloadGas: 3000, // COLD_STORAGE_ACCESS (up from 2100)
+    coldaccountaccessGas: 3000, // COLD_ACCOUNT_ACCESS (up from 2600)
+    storageWriteGas: 10000, // STORAGE_WRITE: charged on the first change to a storage slot per transaction
+    refundStorageClearGas: 12480, // REFUND_STORAGE_CLEAR = (STORAGE_WRITE + COLD_STORAGE_ACCESS) * 4800 / 5000
+    callValueTransferGas: 10300, // CALL_VALUE = ACCOUNT_WRITE (8000) + CALL_STIPEND (2300), up from 9000
+    accountWriteGas: 8000, // ACCOUNT_WRITE: positive-balance transfer to an empty account (e.g. SELFDESTRUCT beneficiary)
   },
 }

--- a/packages/evm/src/types.ts
+++ b/packages/evm/src/types.ts
@@ -207,6 +207,15 @@ export interface EVMInterface {
    * @remarks Experimental (Amsterdam): may change on patch releases.
    */
   eip7928CallPostTargetOog?: boolean
+  /**
+   * EIP-8037: whether the target account of a top-level creation transaction
+   * was already alive (EIP-161 non-empty) before creation; `runTx` refunds
+   * the intrinsic new-account state gas when true or the creation failed.
+   * Optional for custom {@link EVMInterface} implementations.
+   *
+   * @remarks Experimental (Amsterdam): may change on patch releases.
+   */
+  createTxTargetAlive?: boolean
 }
 
 export type EVMProfilerOpts = {
@@ -493,6 +502,14 @@ export interface ExecResult {
    * Amount of blob gas consumed by the transaction
    */
   blobGasUsed?: bigint
+  /**
+   * EIP-8037: state gas paid from the frame's regular gas (spilled),
+   * including spill merged from successful child frames. Propagated to the
+   * parent frame's spill tracker on success; zeroed on frame failure.
+   *
+   * @remarks Experimental (Amsterdam): may change on patch releases.
+   */
+  stateGasSpilled?: bigint
 }
 
 /**

--- a/packages/tx/src/params.ts
+++ b/packages/tx/src/params.ts
@@ -58,6 +58,29 @@ export const paramsTx: ParamsDict = {
     totalCostFloorPerToken: 10,
   },
   /**
+   * Reduce intrinsic transaction gas (Amsterdam, experimental).
+   * The recipient/value components (COLD_ACCOUNT_ACCESS for plain calls,
+   * txValueCost + transferLogCost for value transfers) are added in the
+   * intrinsic-gas dimension splitter, which knows the sender (self-transfers
+   * skip the recipient and value charges).
+   */
+  2780: {
+    txGas: 12000, // TX_BASE: base sender cost per transaction (down from 21000)
+    txValueCost: 4244, // TX_VALUE_COST: extra regular gas for value-bearing non-self-transfer calls
+    transferLogCost: 1756, // TRANSFER_LOG_COST: regular gas for the EIP-7708 transfer log of the tx-level value transfer
+    txRecipientAccessGas: 3000, // Recipient cost for a non-self-transfer call (= COLD_ACCOUNT_ACCESS under EIP-8038)
+  },
+  /**
+   * Access list data pricing (Amsterdam, experimental).
+   * Repriced to match COLD_ACCOUNT_ACCESS / COLD_STORAGE_ACCESS under EIP-8038.
+   * The floor-token component (80 tokens/address + 128 tokens/storage key at
+   * totalCostFloorPerToken) is added in the access-list data gas calculation.
+   */
+  7981: {
+    accessListStorageKeyGas: 3000, // Gas cost per storage key in an Access List transaction (up from 1900)
+    accessListAddressGas: 3000, // Gas cost per address in an Access List transaction (up from 2400)
+  },
+  /**
 .  * Set EOA account code for one transaction
 .  */
   7702: {
@@ -83,7 +106,7 @@ export const paramsTx: ParamsDict = {
    */
   7954: {
     // format
-    maxInitCodeSize: 65536, // EIP-7954: Maximum length of initialization code (raised from 48 KiB)
+    maxInitCodeSize: 131072, // EIP-7954: Maximum length of initialization code (2 * maxCodeSize, raised from 48 KiB)
   },
   /**
    * Increase calldata floor cost (uniform 64 gas/byte floor)
@@ -98,8 +121,9 @@ export const paramsTx: ParamsDict = {
    * constants (see evm params block).
    */
   8037: {
-    perAuthBaseGas: 7500, // Regular gas per authorization (down from 12500); state portion = stateBytesPerAuthBase * costPerStateByte
-    perEmptyAccountCost: 0, // Regular gas for empty authority (down from 25000); state portion = stateBytesPerNewAccount * costPerStateByte (refunded if authority is non-empty)
-    txCreationGas: 9000, // Regular gas for a creation tx (down from 32000); state portion = stateBytesPerNewAccount * costPerStateByte
+    perAuthBaseGas: 7816, // REGULAR_PER_AUTH_BASE_COST: AUTH_TUPLE_BYTES (101) * totalCostFloorPerToken (16) + ecrecover (3000) + cold account access (3000) + 2 * warm access (200)
+    perEmptyAccountCost: 0, // Regular gas for empty authority (down from 25000); replaced by accountWriteGas + perAuthBaseGas plus the state-gas portion ((stateBytesPerNewAccount + stateBytesPerAuthBase) * costPerStateByte)
+    accountWriteGas: 8000, // ACCOUNT_WRITE: regular gas per authorization for the account write (refunded when the authority account already exists)
+    txCreationGas: 11000, // CREATE_ACCESS = ACCOUNT_WRITE (8000) + COLD_STORAGE_ACCESS (3000); state portion = stateBytesPerNewAccount * costPerStateByte
   },
 }

--- a/packages/util/src/bal/index.ts
+++ b/packages/util/src/bal/index.ts
@@ -548,7 +548,10 @@ export class BlockLevelAccessList {
    *
    * @remarks Experimental (Amsterdam): may change on patch releases.
    */
-  public cleanupSelfdestructed(addresses: Array<BALAddressHex>): void {
+  public cleanupSelfdestructed(
+    addresses: Array<BALAddressHex>,
+    finalBalances?: Map<BALAddressHex, bigint>,
+  ): void {
     for (const address of addresses) {
       const access = this.accesses[address]
       if (access === undefined) {
@@ -564,14 +567,21 @@ export class BlockLevelAccessList {
       access.nonceChanges.clear()
       access.codeChanges = []
 
-      // EIP-7928: If the account had a positive pre-transaction balance,
-      // the balance change to zero MUST be recorded.
-      // The balance change to 0 is already added during SELFDESTRUCT execution.
-      // We only clear balance changes if pre-transaction balance was 0 (no actual change).
       const originalBalance = this.originalBalances.get(address)
-      if (originalBalance === undefined || originalBalance === BigInt(0)) {
-        // Pre-transaction balance was 0 or unknown - clear balance changes
-        // (0 -> 0 is no change, so nothing to record)
+      if (finalBalances !== undefined) {
+        // EIP-8246: SELFDESTRUCT preserves the account balance. Keep the
+        // recorded balance changes only when the balance changed net over
+        // the transaction (final != pre-transaction).
+        const finalBalance = finalBalances.get(address) ?? BigInt(0)
+        if (finalBalance === (originalBalance ?? BigInt(0))) {
+          access.balanceChanges.clear()
+        }
+      } else if (originalBalance === undefined || originalBalance === BigInt(0)) {
+        // EIP-7928 (pre-8246 destruction semantics): if the account had a
+        // positive pre-transaction balance, the balance change to zero MUST
+        // be recorded (already added during SELFDESTRUCT execution). Clear
+        // balance changes only when the pre-transaction balance was 0
+        // (0 -> 0 is no change, so nothing to record).
         access.balanceChanges.clear()
       }
       // If originalBalance > 0, keep the balance changes (which should show balance = 0)

--- a/packages/util/src/request.ts
+++ b/packages/util/src/request.ts
@@ -10,6 +10,14 @@ export const CLRequestType = {
   Deposit: 0,
   Withdrawal: 1,
   Consolidation: 2,
+  /**
+   * EIP-8282 builder deposit request (Amsterdam, experimental)
+   */
+  BuilderDeposit: 3,
+  /**
+   * EIP-8282 builder exit request (Amsterdam, experimental)
+   */
+  BuilderExit: 4,
 } as const
 
 export interface RequestJSON {
@@ -42,6 +50,10 @@ export function createCLRequest(bytes: Uint8Array): CLRequest<CLRequestType> {
       return new CLRequest(CLRequestType.Withdrawal, bytes.subarray(1))
     case CLRequestType.Consolidation:
       return new CLRequest(CLRequestType.Consolidation, bytes.subarray(1))
+    case CLRequestType.BuilderDeposit:
+      return new CLRequest(CLRequestType.BuilderDeposit, bytes.subarray(1))
+    case CLRequestType.BuilderExit:
+      return new CLRequest(CLRequestType.BuilderExit, bytes.subarray(1))
     default:
       throw Error(`Invalid request type=${bytes[0]}`)
   }

--- a/packages/vm/examples/runBlockBalValidate.ts
+++ b/packages/vm/examples/runBlockBalValidate.ts
@@ -3,10 +3,13 @@ import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { createLegacyTx } from '@ethereumjs/tx'
 import {
   Account,
+  bigIntToBytes,
   bytesToHex,
   createAddressFromPrivateKey,
+  createAddressFromString,
   createZeroAddress,
   hexToBytes,
+  setLengthLeft,
 } from '@ethereumjs/util'
 import { createVM, runBlock } from '@ethereumjs/vm'
 
@@ -19,6 +22,17 @@ const sender = createAddressFromPrivateKey(senderKey)
 
 async function fundSender(vm: Awaited<ReturnType<typeof createVM>>) {
   await vm.stateManager.putAccount(sender, new Account(0n, BigInt(1e18)))
+  // EIP-8282: deploy stub builder request contracts — validating an
+  // Amsterdam block fails when the checked system-call contracts are
+  // missing. STOP with no return data yields empty builder requests.
+  const stop = hexToBytes('0x00')
+  for (const param of ['builderDepositContractAddress', 'builderExitContractAddress'] as const) {
+    const address = createAddressFromString(
+      bytesToHex(setLengthLeft(bigIntToBytes(common.param(param)), 20)),
+    )
+    await vm.stateManager.putAccount(address, new Account(1n, 0n))
+    await vm.stateManager.putCode(address, stop)
+  }
 }
 
 function createTransferBlock() {

--- a/packages/vm/src/params.ts
+++ b/packages/vm/src/params.ts
@@ -101,4 +101,14 @@ export const paramsVM: ParamsDict = {
     maxBlobGasPerBlock: 1179648, // The max blob gas allowable per block
     blobGasPriceUpdateFraction: 5007716, // The denominator used in the exponential when calculating a blob gas price
   },
+  /**
+   * Builder execution requests (Amsterdam, experimental)
+   */
+  8282: {
+    // config
+    systemAddress: SYSTEM_ADDRESS, // The system address to perform operations on the builder request contracts
+    builderDepositContractAddress: '0x0000884d2AA32eAa155F59A2f24eFa73D9008282', // Address of the builder deposit contract
+    builderExitContractAddress: '0x000014574A74c805590AFF9499fc7A690f008282', // Address of the builder exit contract
+    systemCallGasLimit: 30_000_000, // EIP-8282 system call gas limit
+  },
 }

--- a/packages/vm/src/requests.ts
+++ b/packages/vm/src/requests.ts
@@ -136,6 +136,7 @@ export const accumulateRequests = async (
   vm: VM,
   txResults: RunTxResult[],
   blockGasLimit?: bigint,
+  generate = false,
 ): Promise<CLRequest<CLRequestType>[]> => {
   const requests: CLRequest<CLRequestType>[] = []
   const common = vm.common
@@ -159,8 +160,94 @@ export const accumulateRequests = async (
     requests.push(consolidationsRequest)
   }
 
+  if (common.isActivatedEIP(8282)) {
+    const builderDepositsRequest = await accumulateBuilderRequest(
+      vm,
+      CLRequestType.BuilderDeposit,
+      'builderDepositContractAddress',
+      blockGasLimit,
+      generate,
+    )
+    requests.push(builderDepositsRequest)
+    const builderExitsRequest = await accumulateBuilderRequest(
+      vm,
+      CLRequestType.BuilderExit,
+      'builderExitContractAddress',
+      blockGasLimit,
+      generate,
+    )
+    requests.push(builderExitsRequest)
+  }
+
   // requests are already type byte ordered by construction
   return requests
+}
+
+/**
+ * EIP-8282: run a checked system call against a builder request contract
+ * (deposit or exit) and wrap the returned data as a CL request.
+ *
+ * Per the pinned execution-specs Amsterdam revision this is a *checked*
+ * system transaction when validating: a missing/codeless contract or a
+ * failing call makes the block invalid. When building a block (`generate`),
+ * a missing or failing contract yields an empty request instead (matching
+ * the withdrawal/consolidation accumulators).
+ *
+ * @remarks Experimental (Amsterdam): may change on patch releases.
+ */
+const accumulateBuilderRequest = async (
+  vm: VM,
+  requestType: typeof CLRequestType.BuilderDeposit | typeof CLRequestType.BuilderExit,
+  contractAddressParam: 'builderDepositContractAddress' | 'builderExitContractAddress',
+  blockGasLimit?: bigint,
+  generate = false,
+): Promise<CLRequest<CLRequestType>> => {
+  const addressBytes = setLengthLeft(bigIntToBytes(vm.common.param(contractAddressParam)), 20)
+  const builderAddress = createAddressFromString(bytesToHex(addressBytes))
+
+  const systemAddressBytes = bigIntToAddressBytes(vm.common.param('systemAddress'))
+  const systemAddress = createAddressFromString(bytesToHex(systemAddressBytes))
+  const systemAccount = await vm.stateManager.getAccount(systemAddress)
+
+  const contractCode = await vm.stateManager.getCode(builderAddress)
+  if (contractCode.length === 0) {
+    if (generate) {
+      return new CLRequest(requestType, new Uint8Array(0))
+    }
+    throw EthereumJSErrorWithoutCode(
+      `system contract empty: no code at builder request contract ${builderAddress}`,
+    )
+  }
+
+  const systemAddressHex = systemAddress.toString()
+  const balSnapshot = cloneSystemAccessEntry(vm, systemAddressHex)
+  const { regular, reservoir } = computeSystemCallGas(vm, blockGasLimit)
+  const reservoirPrior = setupSystemCallReservoir(vm, reservoir)
+  const results = await vm.evm.runCall({
+    caller: systemAddress,
+    gasLimit: regular,
+    to: builderAddress,
+  })
+  teardownSystemCallReservoir(vm, reservoirPrior)
+  restoreSystemAccessEntry(vm, systemAddressHex, balSnapshot)
+
+  if (systemAccount === undefined) {
+    await vm.stateManager.deleteAccount(systemAddress)
+  } else {
+    await vm.stateManager.putAccount(systemAddress, systemAccount)
+  }
+
+  if (results.execResult.exceptionError !== undefined) {
+    if (generate) {
+      return new CLRequest(requestType, new Uint8Array(0))
+    }
+    throw EthereumJSErrorWithoutCode(
+      `system contract call failed: builder request contract ${builderAddress} (${results.execResult.exceptionError.error})`,
+    )
+  }
+
+  const resultsBytes = results.execResult.returnValue
+  return new CLRequest(requestType, resultsBytes)
 }
 
 const accumulateWithdrawalsRequest = async (

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -1,6 +1,6 @@
 import { createBlock, genRequestsRoot } from '@ethereumjs/block'
 import { ConsensusType, Hardfork } from '@ethereumjs/common'
-import { type EVM, type EVMInterface, computeIntrinsicGasDimensions8037 } from '@ethereumjs/evm'
+import { type EVM, type EVMInterface } from '@ethereumjs/evm'
 import { MerklePatriciaTrie } from '@ethereumjs/mpt'
 import { RLP } from '@ethereumjs/rlp'
 import { TransactionType } from '@ethereumjs/tx'
@@ -717,14 +717,10 @@ async function applyTransactions(vm: VM, block: Block, opts: RunBlockOpts) {
     //   regular: min(TX_MAX_GAS_LIMIT, tx.gas - intrinsic_state) > regular_available  → reject
     //   state:   tx.gas - intrinsic_regular                       > state_available    → reject
     // where *_available = block.gas_limit - block_*_gas_used.
-    // The intrinsic.state subtraction in the regular check and the
-    // intrinsic_regular subtraction in the state check are essential: a tx's
-    // regular execution can only use `tx.gas - intrinsic_state`, and its
-    // worst-case state-gas consumption is `tx.gas - intrinsic_regular` (the
-    // residual after paying regular intrinsic). See
-    // execution-specs/tests/amsterdam/eip8037.../test_state_gas_reservoir.py
-    // (`test_block_state_gas_limit_boundary` and
-    // `test_creation_tx_regular_check_subtracts_intrinsic_state`).
+    // EIP-8037 per-dimension inclusion check (per the pinned execution-specs
+    // Amsterdam revision):
+    //   min(TX_MAX_GAS_LIMIT, tx.gas) > regular_gas_available → reject
+    //   tx.gas > state_gas_available                          → reject
     // Pre-EIP-8037 keeps the original check (`tx.gasLimit + gasUsed <= block.gasLimit`).
     if (vm.common.isActivatedEIP(8037)) {
       const txMax = tx.common.param('maxTransactionGasLimit')
@@ -736,17 +732,8 @@ async function applyTransactions(vm: VM, block: Block, opts: RunBlockOpts) {
         block.header.gasLimit > blockStateGasUsed
           ? block.header.gasLimit - blockStateGasUsed
           : BIGINT_0
-      const { intrinsicRegular, intrinsicState } = computeIntrinsicGasDimensions8037(
-        tx.common,
-        tx,
-        block.header.gasLimit,
-      )
-      const txRegularContrib =
-        tx.gasLimit > intrinsicState ? tx.gasLimit - intrinsicState : BIGINT_0
-      const txStateContrib =
-        tx.gasLimit > intrinsicRegular ? tx.gasLimit - intrinsicRegular : BIGINT_0
-      const txRegularBound = txRegularContrib < txMax ? txRegularContrib : txMax
-      if (txRegularBound > regularAvailable || txStateContrib > stateAvailable) {
+      const txRegularBound = tx.gasLimit < txMax ? tx.gasLimit : txMax
+      if (txRegularBound > regularAvailable || tx.gasLimit > stateAvailable) {
         const msg = _errorMsg('tx has a higher gas limit than the block', vm, block)
         throw EthereumJSErrorWithoutCode(msg)
       }
@@ -1052,7 +1039,7 @@ function parseProvidedBlockAccessList(
   }
   const json: BALJSONBlockAccessList = blockAccessList
   validateBlockAccessListJSONStructure(json)
-  if (isAccountOrderOnlyViolation(json)) {
+  if (isAccountOrderOnlyViolation(json) === true) {
     throw EthereumJSErrorWithoutCode('invalid header: block access list accounts are not sorted')
   }
   if (blockAccessListHash !== undefined && generateFields === false) {

--- a/packages/vm/src/runBlock.ts
+++ b/packages/vm/src/runBlock.ts
@@ -215,7 +215,17 @@ export async function runBlock(vm: VM, opts: RunBlockOpts): Promise<RunBlockResu
   let requests: CLRequest<CLRequestType>[] | undefined
   if (block.common.isActivatedEIP(7685)) {
     const sha256Function = vm.common.customCrypto.sha256 ?? sha256
-    requests = await accumulateRequests(vm, result.results, block.header.gasLimit)
+    try {
+      requests = await accumulateRequests(vm, result.results, block.header.gasLimit, generateFields)
+    } catch (err) {
+      // A checked system call failed (e.g. EIP-8282 builder request
+      // contract missing or reverting): the block is invalid, revert it.
+      await vm.evm.journal.revert()
+      if (vm.DEBUG) {
+        debug(`block checkpoint reverted`)
+      }
+      throw err
+    }
     requestsHash = genRequestsRoot(requests, sha256Function)
   }
 
@@ -579,7 +589,12 @@ export async function accumulateParentBlockHash(
   const code = await vm.stateManager.getCode(historyAddress)
 
   if (code.length === 0) {
-    // Exit early, system contract has no code so no storage is written
+    // Exit early, system contract has no code so no storage is written.
+    // EIP-7928: the attempted system-call access is still recorded in the
+    // block access list as an address-only entry.
+    if (vm.common.isActivatedEIP(7928)) {
+      vm.evm.blockLevelAccessList!.addAddress(historyAddress.toString())
+    }
     return
   }
 
@@ -632,6 +647,11 @@ export async function accumulateParentBeaconBlockRoot(vm: VM, root: Uint8Array, 
   if (code.length === 0) {
     // Exit early, system contract has no code so no storage is written
     // TODO: verify with Gabriel that this is fine regarding binary trees (should we put an empty account?)
+    // EIP-7928: the attempted system-call access is still recorded in the
+    // block access list as an address-only entry.
+    if (vm.common.isActivatedEIP(7928)) {
+      vm.evm.blockLevelAccessList!.addAddress(parentBeaconBlockRootAddress.toString())
+    }
     return
   }
   if (vm.common.isActivatedEIP(7928)) {

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -338,15 +338,31 @@ async function processSelfdestructs(vm: VM, results: RunTxResult): Promise<void>
       }
     }
 
-    if (vm.common.isActivatedEIP(7708)) {
-      const account = await vm.stateManager.getAccount(address)
-      const finalizationBalance = account?.balance ?? BIGINT_0
-      if (finalizationBalance > BIGINT_0) {
-        finalizationLogs.push(createEIP7708BurnLog(address, finalizationBalance))
+    if (vm.common.isActivatedEIP(8246)) {
+      // EIP-8246: SELFDESTRUCT no longer burns ETH. Clear the account's
+      // nonce, code, and storage while preserving its balance (no burn log
+      // is emitted since nothing is burned). An account left with zero
+      // balance is EIP-161-empty and is cleaned up by the journal.
+      if ((await vm.stateManager.getAccount(address)) !== undefined) {
+        await vm.stateManager.putCode(address, new Uint8Array())
+        await vm.stateManager.clearStorage(address)
+        const account = await vm.stateManager.getAccount(address)
+        if (account !== undefined) {
+          account.nonce = BIGINT_0
+          await vm.evm.journal.putAccount(address, account)
+        }
       }
-    }
+    } else {
+      if (vm.common.isActivatedEIP(7708)) {
+        const account = await vm.stateManager.getAccount(address)
+        const finalizationBalance = account?.balance ?? BIGINT_0
+        if (finalizationBalance > BIGINT_0) {
+          finalizationLogs.push(createEIP7708BurnLog(address, finalizationBalance))
+        }
+      }
 
-    await vm.evm.journal.deleteAccount(address)
+      await vm.evm.journal.deleteAccount(address)
+    }
     destroyedForBAL.add(address.toString())
     if (vm.DEBUG) {
       debug(`tx selfdestruct on address=${address}`)

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -104,6 +104,23 @@ async function processAuthorizationList(
   // their delegation-indicator refills against the original slot.
   const preDelegatedByAuthority = new Map<string, boolean>()
 
+  // EIP-8037: an invalid authorization refunds the full worst-case per-auth
+  // charge from the intrinsic cost: the state portion
+  // ((stateBytesPerNewAccount + stateBytesPerAuthBase) * costPerStateByte)
+  // to the state-gas reservoir and the regular accountWriteGas to the
+  // regular refund counter.
+  const is8037 = tx.common.isActivatedEIP(8037)
+  const invalidAuthStateRefund = is8037
+    ? (vm.common.param('stateBytesPerNewAccount') + vm.common.param('stateBytesPerAuthBase')) *
+      activeCostPerStateByte(vm.common, block?.header.gasLimit)
+    : BIGINT_0
+  const applyInvalidAuthRefund = () => {
+    if (is8037) {
+      existingAuthStateGasRefund += invalidAuthStateRefund
+      gasRefund += tx.common.param('accountWriteGas')
+    }
+  }
+
   for (let i = 0; i < authorizationList.length; i++) {
     const data = authorizationList[i]
 
@@ -111,6 +128,7 @@ async function processAuthorizationList(
     const chainId = data[0]
     const chainIdBN = bytesToBigInt(chainId)
     if (chainIdBN !== BIGINT_0 && chainIdBN !== vm.common.chainId()) {
+      applyInvalidAuthRefund()
       continue
     }
 
@@ -119,6 +137,7 @@ async function processAuthorizationList(
     if (bytesToBigInt(authorityNonce) >= MAX_UINT64) {
       // Authority nonce >= 2^64 - 1. Bumping this nonce by one will not make this fit in an uint64.
       // EIPs PR: https://github.com/ethereum/EIPs/pull/8938
+      applyInvalidAuthRefund()
       continue
     }
 
@@ -126,12 +145,14 @@ async function processAuthorizationList(
     const s = data[5]
     if (bytesToBigInt(s) > SECP256K1_ORDER_DIV_2) {
       // Malleability protection to avoid "flipping" a valid signature
+      applyInvalidAuthRefund()
       continue
     }
 
     // Validate yParity
     const yParity = bytesToBigInt(data[3])
     if (yParity > BIGINT_1) {
+      applyInvalidAuthRefund()
       continue
     }
 
@@ -141,6 +162,7 @@ async function processAuthorizationList(
       authority = eoaCode7702RecoverAuthority(data)
     } catch {
       // Invalid signature
+      applyInvalidAuthRefund()
       continue
     }
 
@@ -161,6 +183,7 @@ async function processAuthorizationList(
     if (account.isContract()) {
       const code = await vm.stateManager.getCode(authority)
       if (!equalsBytes(code.slice(0, 3), DELEGATION_7702_FLAG)) {
+        applyInvalidAuthRefund()
         continue
       }
     }
@@ -170,21 +193,25 @@ async function processAuthorizationList(
       // Edge case: caller is the authority (self-signing delegation)
       // Virtually bump the account nonce by one for comparison
       if (account.nonce + BIGINT_1 !== bytesToBigInt(authorityNonce)) {
+        applyInvalidAuthRefund()
         continue
       }
     } else if (account.nonce !== bytesToBigInt(authorityNonce)) {
+      applyInvalidAuthRefund()
       continue
     }
 
     // Calculate gas refund for existing accounts
-    // EIP-8037: under 8037, the existing-authority refund is moved to the
-    // state-gas reservoir (refund of stateBytesPerNewAccount × costPerStateByte), and is
-    // applied during authorization processing in a follow-up step. Skip the
-    // legacy regular-gas refund here to avoid producing a negative refund
-    // (under 8037 perEmptyAccountCost = 0, perAuthBaseGas = 7500).
+    // EIP-8037: under 8037, the existing-authority refund is split into the
+    // state-gas portion (stateBytesPerNewAccount × costPerStateByte, refilled
+    // below) and the regular accountWriteGas (refunded here, since the
+    // worst-case account write charged at intrinsic time is not needed).
     if (accountExists && !tx.common.isActivatedEIP(8037)) {
       const refund = tx.common.param('perEmptyAccountCost') - tx.common.param('perAuthBaseGas')
       gasRefund += refund
+    }
+    if (accountExists && is8037) {
+      gasRefund += tx.common.param('accountWriteGas')
     }
 
     // EIP-8037: intrinsic gas charges the worst-case state-gas cost
@@ -215,8 +242,8 @@ async function processAuthorizationList(
 
       let refillStateBytes = BIGINT_0
       // Account-leaf refill: refill the new-account portion when the authority
-      // leaf already exists (non-zero nonce, balance, or non-empty code).
-      if (!account.isEmpty()) {
+      // account already exists in the state trie.
+      if (accountExists) {
         refillStateBytes += stateBytesPerNewAccount
       }
       // Delegation-indicator refill.
@@ -224,6 +251,11 @@ async function processAuthorizationList(
         // Clearing (delegate to zero address) writes no indicator, so the
         // auth-base portion is always refilled.
         refillStateBytes += stateBytesPerAuthBase
+        if (curDelegated && !preDelegated) {
+          // Clearing a delegation that was set earlier in this transaction
+          // also reclaims the earlier in-tx indicator write.
+          refillStateBytes += stateBytesPerAuthBase
+        }
       } else if (curDelegated || preDelegated) {
         // Setting a delegation over an already-occupied indicator slot writes no
         // new bytes, so the auth-base portion is refilled.
@@ -643,7 +675,7 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   let stateGasReservoirInitial = BIGINT_0
   vm.evm.eip7928CallPostTargetOog = false
   const { intrinsicRegular: intrinsicRegularGas, intrinsicState: intrinsicStateGas } =
-    computeIntrinsicGasDimensions8037(tx.common, tx, block?.header.gasLimit)
+    computeIntrinsicGasDimensions8037(tx.common, tx, block?.header.gasLimit, caller)
   const totalIntrinsic = intrinsicRegularGas + intrinsicStateGas
 
   let gasLimit = tx.gasLimit
@@ -1038,11 +1070,31 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   if (
     vm.common.isActivatedEIP(8037) &&
     results.execResult.exceptionError?.error === EVMError.errorMessages.OUT_OF_GAS &&
-    vm.evm.eip7928CallPostTargetOog
+    vm.evm.eip7928CallPostTargetOog === true
   ) {
     vm.evm.stateGasReservoir = BIGINT_0
   }
   vm.evm.eip7928CallPostTargetOog = false
+
+  // EIP-8037: refund the intrinsic new-account state gas for a creation
+  // transaction whose target account was already alive or whose execution
+  // failed — in either case no new account leaf persists. The refund is
+  // credited to the reservoir (reducing tx_gas_used_before_refund via the
+  // reservoir delta) and subtracted from execution_state_gas_used (reducing
+  // tx_state_gas), per the pinned execution-specs Amsterdam revision.
+  if (
+    vm.common.isActivatedEIP(8037) &&
+    tx.to === undefined &&
+    (results.execResult.exceptionError !== undefined || vm.evm.createTxTargetAlive === true)
+  ) {
+    const newAccountStateGas =
+      vm.common.param('stateBytesPerNewAccount') *
+      activeCostPerStateByte(vm.common, block?.header.gasLimit)
+    vm.evm.stateGasReservoir += newAccountStateGas
+    vm.evm.executionStateGasUsed -= newAccountStateGas
+  }
+  vm.evm.createTxTargetAlive = false
+
   let totalGasSpentBeforeRefund = results.execResult.executionGasUsed + intrinsicGas
   if (vm.common.isActivatedEIP(8037)) {
     const executionStateGasUsed = vm.evm.executionStateGasUsed
@@ -1056,19 +1108,19 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
     // (= executionStateGasUsed by definition), so:
     //   execution_regular_gas_used = executionGasUsed - (state-gas spilled to gas_left)
     //                              = executionGasUsed - (executionStateGasUsed - reservoirDelta)
-    const stateGasFromGasLeft = executionStateGasUsed - reservoirDelta
-    const executionRegularGasUsed = results.execResult.executionGasUsed - stateGasFromGasLeft
-    // Apply the intrinsic-create-selfdestruct refund to tx_state_gas only.
-    // It does not affect totalGasSpent (the sender still pays the gross)
-    // and it does not affect tx_regular_gas (it's a state-dim accounting
-    // adjustment that brings block_state_gas_used to 0 for an account that
-    // never persists).
-    results.txStateGas = intrinsicStateGas + executionStateGasUsed - txCreateIntrinsicStateGasRefund
-    // Per EIP-8037: block_regular_gas_used += max(tx_regular_gas, calldata_floor)
-    // Apply the EIP-7623 floor to the regular dimension here so runBlock can
-    // accumulate dimensions independently.
-    const txRegularGasRaw = intrinsicRegularGas + executionRegularGasUsed
-    results.txRegularGas = txRegularGasRaw > floorCost ? txRegularGasRaw : floorCost
+    // Per the pinned execution-specs Amsterdam revision:
+    //   tx_state_gas   = intrinsic_state + state_gas_used - state_refund
+    //                    (state refunds are already folded into
+    //                    executionStateGasUsed, which may be negative)
+    //   tx_regular_gas = tx_gas_used_before_refund - max(0, tx_state_gas)
+    // No refund subtraction and no calldata floor are applied to the
+    // block-level dimensions; the floor and refunds only affect the
+    // user-paid gas (totalGasSpent) and receipt cumulative gas.
+    const txStateGasRaw =
+      intrinsicStateGas + executionStateGasUsed - txCreateIntrinsicStateGasRefund
+    const txStateGasClamped = txStateGasRaw > BIGINT_0 ? txStateGasRaw : BIGINT_0
+    results.txStateGas = txStateGasClamped
+    results.txRegularGas = totalGasSpentBeforeRefund - txStateGasClamped
   }
   results.totalGasSpent = totalGasSpentBeforeRefund
   if (vm.DEBUG) {
@@ -1111,8 +1163,10 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
 
   // EIP-7778: block-level gas accounting does not subtract tx refunds.
   // For pre-7778 forks this equals the amount paid by the sender.
+  // (When EIP-8037 is also active, runBlock uses the txRegularGas/txStateGas
+  // dimensions instead of this field.)
   results.blockGasSpent = vm.common.isActivatedEIP(7778)
-    ? bigIntMax(results.totalGasSpent, floorCost)
+    ? bigIntMax(totalGasSpentBeforeRefund, floorCost)
     : results.totalGasSpent
 
   results.amountSpent = results.totalGasSpent * gasPrice

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -1070,7 +1070,9 @@ async function _runTx(vm: VM, opts: RunTxOpts): Promise<RunTxResult> {
   if (
     vm.common.isActivatedEIP(8037) &&
     results.execResult.exceptionError?.error === EVMError.errorMessages.OUT_OF_GAS &&
-    vm.evm.eip7928CallPostTargetOog === true
+    // Boolean() defeats control-flow narrowing: the flag is reset to `false`
+    // before execution but set by the EVM during runCall.
+    Boolean(vm.evm.eip7928CallPostTargetOog)
   ) {
     vm.evm.stateGasReservoir = BIGINT_0
   }

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -323,6 +323,9 @@ async function processSelfdestructs(vm: VM, results: RunTxResult): Promise<void>
   }
 
   const destroyedForBAL: Set<PrefixedHexString> = new Set()
+  // EIP-8246: post-clear balances of selfdestructed accounts, used by the
+  // BAL cleanup to decide whether the net balance change must be kept.
+  const finalBalancesForBAL: Map<PrefixedHexString, bigint> = new Map()
   const finalizationLogs: Log[] = []
   const sortedSelfdestructs = [...results.execResult.selfdestruct.entries()].sort(([a], [b]) =>
     a.localeCompare(b),
@@ -351,6 +354,9 @@ async function processSelfdestructs(vm: VM, results: RunTxResult): Promise<void>
           account.nonce = BIGINT_0
           await vm.evm.journal.putAccount(address, account)
         }
+        finalBalancesForBAL.set(address.toString(), account?.balance ?? BIGINT_0)
+      } else {
+        finalBalancesForBAL.set(address.toString(), BIGINT_0)
       }
     } else {
       if (vm.common.isActivatedEIP(7708)) {
@@ -374,7 +380,10 @@ async function processSelfdestructs(vm: VM, results: RunTxResult): Promise<void>
   }
 
   if (destroyedForBAL.size > 0 && vm.common.isActivatedEIP(7928)) {
-    vm.evm.blockLevelAccessList!.cleanupSelfdestructed([...destroyedForBAL])
+    vm.evm.blockLevelAccessList!.cleanupSelfdestructed(
+      [...destroyedForBAL],
+      vm.common.isActivatedEIP(8246) ? finalBalancesForBAL : undefined,
+    )
   }
 }
 

--- a/packages/vm/test/api/EIPs/eip-7928.spec.ts
+++ b/packages/vm/test/api/EIPs/eip-7928.spec.ts
@@ -3,11 +3,14 @@ import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
 import { createLegacyTx } from '@ethereumjs/tx'
 import {
   Account,
+  bigIntToBytes,
   bytesToHex,
   createAddressFromPrivateKey,
+  createAddressFromString,
   createZeroAddress,
   equalsBytes,
   hexToBytes,
+  setLengthLeft,
 } from '@ethereumjs/util'
 import { assert, describe, it } from 'vitest'
 
@@ -24,6 +27,17 @@ const recipient = createZeroAddress()
 
 async function fundSender(vm: Awaited<ReturnType<typeof createVM>>) {
   await vm.stateManager.putAccount(sender, new Account(0n, BigInt(1e18)))
+  // EIP-8282: deploy stub builder request contracts (checked system calls
+  // fail the block when the contracts are missing). STOP with no return
+  // data yields empty builder requests.
+  const stop = hexToBytes('0x00')
+  for (const param of ['builderDepositContractAddress', 'builderExitContractAddress'] as const) {
+    const address = createAddressFromString(
+      bytesToHex(setLengthLeft(bigIntToBytes(common.param(param)), 20)),
+    )
+    await vm.stateManager.putAccount(address, new Account(1n, 0n))
+    await vm.stateManager.putCode(address, stop)
+  }
 }
 
 function createTransferBlock() {


### PR DESCRIPTION
Reworks the Amsterdam gas-schedule EIP implementations to match the execution-specs revision pinned by the glamsterdam-devnet fixtures (ethereum/execution-specs@d0338f56):

- EIP-2780 (new): reduce intrinsic tx gas — TX_BASE 12000, recipient access / value-transfer components (txValueCost 4244, transferLogCost 1756), self-transfer exemption, and top-frame charges (dead-recipient state gas, delegated-recipient access)
- EIP-8038 (new): state access gas cost increase — cold account/storage access 3000, SSTORE model (access cost + flat STORAGE_WRITE 10000 with restore refunds, REFUND_STORAGE_CLEAR 12480), CALL_VALUE 10300, ACCOUNT_WRITE 8000, EXTCODESIZE/EXTCODECOPY code-reading cost, SELFDESTRUCT empty-beneficiary accountWriteGas, aborted-create warming
- EIP-8037 fixes: CREATE_ACCESS 11000, auth costs (ACCOUNT_WRITE + REGULAR_PER_AUTH_BASE_COST 7816 with full invalid-auth refunds), per-frame state-gas spill tracking with LIFO refunds (credit_state_gas_refund), frame-failure rollback semantics (refill_frame_state_gas), CALL/CREATE new-account refund paths, creation-tx target-alive refund, simplified per-dimension block inclusion checks
- EIP-7981 fixes: access-list address/storage-key gas 3000/3000
- EIP-7954 fixes: maxCodeSize 65536, maxInitCodeSize 131072
- EIP-7778/8037 block accounting: tx_regular_gas/tx_state_gas per the pinned revision (pre-refund, no floor on block dimensions)

Dev fixture results (glamsterdam-devnet@v6.1.1): eip2780, eip7708, eip7776/7976, eip7843, eip7981, eip8024, eip7778 dirs fully passing; eip8037 592/606 and eip8038 191/192 (remaining failures are EIP-8246 selfdestruct-no-burn interactions, addressed separately). Overall dev suite: 536 → 2570 passing. Stable execution-spec suites (blockchain 2246, state 10993) and VM API tests remain fully green.