### PR TITLE
evm/vm/common: implement EIP-8246 SELFDESTRUCT no burn (Amsterdam)

### DIFF
--- a/packages/common/src/eips.ts
+++ b/packages/common/src/eips.ts
@@ -630,4 +630,13 @@ export const eipsDict: EIPsDict = {
     minimumHardfork: Hardfork.Amsterdam,
     requiredEIPs: [2929],
   },
+  /**
+   * Description : SELFDESTRUCT no burn (Amsterdam, experimental)
+   * URL         : https://eips.ethereum.org/EIPS/eip-8246
+   * Status      : Draft
+   */
+  8246: {
+    minimumHardfork: Hardfork.Amsterdam,
+    requiredEIPs: [6780],
+  },
 }

--- a/packages/common/src/hardforks.ts
+++ b/packages/common/src/hardforks.ts
@@ -200,6 +200,6 @@ export const hardforksDict: HardforksDict = {
    * Status     : Draft (implementation incomplete + spec still moving!)
    */
   amsterdam: {
-    eips: [2780, 7708, 7843, 7778, 7928, 7954, 7976, 7981, 8024, 8037, 8038],
+    eips: [2780, 7708, 7843, 7778, 7928, 7954, 7976, 7981, 8024, 8037, 8038, 8246],
   },
 }

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -1549,10 +1549,24 @@ export class Interpreter {
       }
     }
 
+    // EIP-8246: SELFDESTRUCT no longer burns ETH. A self-beneficiary keeps
+    // its balance (the account clearing at transaction end preserves the
+    // balance); zeroing only completes a transfer to a different account.
+    if (this.common.isActivatedEIP(8246) && toSelf) {
+      doModify = false
+    }
+
     // EIP-7708: Emit a Burn log (LOG2) for SELFDESTRUCT to self only when the balance
     // is actually zeroed (doModify=true, i.e. same-tx contract creation). Pre-existing
     // contracts where EIP-6780 prevents the burn should not emit a log.
-    if (this.common.isActivatedEIP(7708) && contractBalance > BIGINT_0 && toSelf && doModify) {
+    // Under EIP-8246 nothing is burned, so no burn log is ever emitted.
+    if (
+      this.common.isActivatedEIP(7708) &&
+      !this.common.isActivatedEIP(8246) &&
+      contractBalance > BIGINT_0 &&
+      toSelf &&
+      doModify
+    ) {
       const contractTopic = setLengthLeft(this._env.address.bytes, 32)
       const data = setLengthLeft(bigIntToBytes(contractBalance), 32)
       const burnLog: Log = [EIP7708_SYSTEM_ADDRESS, [EIP7708_BURN_TOPIC, contractTopic], data]

--- a/packages/vm/src/runTx.ts
+++ b/packages/vm/src/runTx.ts
@@ -338,15 +338,31 @@ async function processSelfdestructs(vm: VM, results: RunTxResult): Promise<void>
       }
     }
 
-    if (vm.common.isActivatedEIP(7708)) {
-      const account = await vm.stateManager.getAccount(address)
-      const finalizationBalance = account?.balance ?? BIGINT_0
-      if (finalizationBalance > BIGINT_0) {
-        finalizationLogs.push(createEIP7708BurnLog(address, finalizationBalance))
+    if (vm.common.isActivatedEIP(8246)) {
+      // EIP-8246: SELFDESTRUCT no longer burns ETH. Clear the account's
+      // nonce, code, and storage while preserving its balance (no burn log
+      // is emitted since nothing is burned). An account left with zero
+      // balance is EIP-161-empty and is cleaned up by the journal.
+      if ((await vm.stateManager.getAccount(address)) !== undefined) {
+        await vm.stateManager.putCode(address, new Uint8Array())
+        await vm.stateManager.clearStorage(address)
+        const account = await vm.stateManager.getAccount(address)
+        if (account !== undefined) {
+          account.nonce = BIGINT_0
+          await vm.evm.journal.putAccount(address, account)
+        }
       }
-    }
+    } else {
+      if (vm.common.isActivatedEIP(7708)) {
+        const account = await vm.stateManager.getAccount(address)
+        const finalizationBalance = account?.balance ?? BIGINT_0
+        if (finalizationBalance > BIGINT_0) {
+          finalizationLogs.push(createEIP7708BurnLog(address, finalizationBalance))
+        }
+      }
 
-    await vm.evm.journal.deleteAccount(address)
+      await vm.evm.journal.deleteAccount(address)
+    }
     destroyedForBAL.add(address.toString())
     if (vm.DEBUG) {
       debug(`tx selfdestruct on address=${address}`)


### PR DESCRIPTION
Adds EIP-8246 (define in common, activate in Amsterdam): SELFDESTRUCT no longer burns ETH, per the pinned execution-specs Amsterdam revision:

- self-beneficiary SELFDESTRUCT keeps its balance (no zeroing, no burn log); zeroing only completes a transfer to a different beneficiary
- same-tx-created accounts are cleared at transaction end preserving their balance (nonce/code/storage reset instead of account deletion); a zero-balance cleared account is EIP-161-empty and pruned as usual
- the EIP-7708 burn-log finalization is skipped when 8246 is active (nothing is burned, so no burn logs exist under the pinned revision)

Dev fixture results (glamsterdam-devnet@v6.1.1): eip8246 654/654, eip8037 606/606, eip8038 192/192, eip7708 72/72 (all previously failing selfdestruct-interaction cases now pass). Stable execution-spec blockchain suite (2246) and VM API tests (174) remain green.