### PR TITLE
mpt: fix and optimize `_walkTrie` async generator

### DIFF
--- a/packages/mpt/README.md
+++ b/packages/mpt/README.md
@@ -181,6 +181,42 @@ async function main() {
 void main()
 ```
 
+### `walkTrieIterable` vs. `walkTrie` (`WalkController`)
+
+The package ships two different traversal implementations, and it's worth knowing which one you're reaching for:
+
+- **`walkTrieIterable`** (backed by the async generator in `src/util/asyncWalk.ts`, also used internally by `walkAllNodes`/`walkAllValueNodes`/`getValueMap`) yields `{ node, currentKey }` pairs one at a time for consumption with `for await`.
+- **`walkTrie`** (backed by `WalkController` in `src/util/walkController.ts`, also used internally by `findPath` and by pruning/integrity checks) is callback-driven: it calls your `onFound(nodeRef, node, currentKey, walkController)` for each node, and hands you the `walkController` to decide what happens next.
+
+```ts
+import { createMPT } from '@ethereumjs/mpt'
+import { utf8ToBytes } from '@ethereumjs/util'
+
+async function main() {
+  const trie = await createMPT()
+  await trie.put(utf8ToBytes('key'), utf8ToBytes('val'))
+
+  await trie.walkTrie(trie.root(), async (nodeRef, node, currentKey, walkController) => {
+    if (node === null) return
+    // ... do something with `node`
+    walkController.allChildren(node, currentKey) // opt in to keep descending
+  })
+}
+void main()
+```
+
+Use **`walkTrieIterable`** when:
+
+- You want plain `for await` control flow — `break`/early `return` stop the walk for free since it's a lazy generator.
+- You want every reachable node visited without extra bookkeeping — it always recurses into all children of branch/extension nodes automatically (a `filter` can control what gets *yielded*, but not what gets *traversed*).
+- The trie may be sparse or partially pruned: a `'Missing node in DB'` error only drops the affected subtree, and the walk quietly continues over sibling branches rather than failing outright.
+
+Use **`walkTrie`/`WalkController`** when:
+
+- You want DB reads to happen concurrently instead of one at a time — `WalkController` pipelines `lookupNode` calls through a `PrioritizedTaskExecutor` (pool size 500 by default), which matters for latency-bound backends (e.g. remote/networked DBs) on large tries.
+- You need per-node control over traversal — e.g. follow only one branch index instead of the whole subtree (this is how `findPath` walks down a single key's path via `walkController.onlyBranchIndex`), or decide dynamically whether to keep descending based on the node you just saw.
+- A missing node should be treated as a hard failure by default: `WalkController` rejects the entire walk on any `lookupNode` error. Callers that want pruning-tolerant behavior (like `findPath`) opt into that explicitly by catching and checking for the `'Missing node in DB'` message themselves.
+
 ## Merkle Patricia Tries
 
 ### Database Options

--- a/packages/mpt/README.md
+++ b/packages/mpt/README.md
@@ -196,7 +196,7 @@ async function main() {
   const trie = await createMPT()
   await trie.put(utf8ToBytes('key'), utf8ToBytes('val'))
 
-  await trie.walkTrie(trie.root(), async (nodeRef, node, currentKey, walkController) => {
+  await trie.walkTrie(trie.root(), (nodeRef, node, currentKey, walkController) => {
     if (node === null) return
     // ... do something with `node`
     walkController.allChildren(node, currentKey) // opt in to keep descending

--- a/packages/mpt/src/util/asyncWalk.ts
+++ b/packages/mpt/src/util/asyncWalk.ts
@@ -34,9 +34,6 @@ export async function* _walkTrie(
   }
   try {
     const node = await this.lookupNode(nodeHash)
-    if (node === undefined) {
-      return
-    }
     const nodeHashHex = bytesToHex(this.hash(node.serialize()))
     if (visited.has(nodeHashHex)) {
       return
@@ -61,7 +58,9 @@ export async function* _walkTrie(
       const nextKey = [...currentKey, ...node._nibbles]
       yield* _walkTrie.call(this, childNode, nextKey, onFound, filter, visited)
     }
-  } catch {
-    return
+  } catch (error: any) {
+    if (error.message !== 'Missing node in DB') {
+      throw error
+    }
   }
 }

--- a/packages/mpt/src/util/asyncWalk.ts
+++ b/packages/mpt/src/util/asyncWalk.ts
@@ -33,11 +33,11 @@ export async function* _walkTrie(
     return
   }
   try {
-    const node = await this.lookupNode(nodeHash)
-    const nodeHashHex = bytesToHex(this.hash(node.serialize()))
+    const nodeHashHex = bytesToHex(nodeHash)
     if (visited.has(nodeHashHex)) {
       return
     }
+    const node = await this.lookupNode(nodeHash)
     visited.add(nodeHashHex)
     await onFound(node, currentKey)
     if (await filter(node, currentKey)) {

--- a/packages/mpt/src/util/asyncWalk.ts
+++ b/packages/mpt/src/util/asyncWalk.ts
@@ -44,10 +44,7 @@ export async function* _walkTrie(
       yield { node, currentKey }
     }
     if (node instanceof BranchMPTNode) {
-      for (const [nibble, childNode] of node._branches.entries()) {
-        if (childNode === null) {
-          continue
-        }
+      for (const [nibble, childNode] of node.getChildren()) {
         const nextKey = [...currentKey, nibble]
         const _childNode: Uint8Array =
           childNode instanceof Uint8Array ? childNode : this.hash(RLP.encode(childNode))

--- a/packages/mpt/src/util/asyncWalk.ts
+++ b/packages/mpt/src/util/asyncWalk.ts
@@ -8,7 +8,7 @@ import type { MerklePatriciaTrie } from '../mpt.ts'
 import type { MPTNode } from '../types.ts'
 
 export type NodeFilter = (node: MPTNode, key: number[]) => Promise<boolean>
-export type OnFound = (node: MPTNode, key: number[]) => Promise<any>
+export type OnFound = (node: MPTNode, key: number[]) => Promise<void>
 
 /**
  * Walk MerklePatriciaTrie via async generator
@@ -34,13 +34,17 @@ export async function* _walkTrie(
   }
   try {
     const node = await this.lookupNode(nodeHash)
-    if (node === undefined || visited.has(bytesToHex(this.hash(node!.serialize())))) {
+    if (node === undefined) {
       return
     }
-    visited.add(bytesToHex(this.hash(node!.serialize())))
-    await onFound(node!, currentKey)
-    if (await filter(node!, currentKey)) {
-      yield { node: node!, currentKey }
+    const nodeHashHex = bytesToHex(this.hash(node.serialize()))
+    if (visited.has(nodeHashHex)) {
+      return
+    }
+    visited.add(nodeHashHex)
+    await onFound(node, currentKey)
+    if (await filter(node, currentKey)) {
+      yield { node, currentKey }
     }
     if (node instanceof BranchMPTNode) {
       for (const [nibble, childNode] of node._branches.entries()) {

--- a/packages/mpt/src/util/asyncWalk.ts
+++ b/packages/mpt/src/util/asyncWalk.ts
@@ -8,7 +8,7 @@ import type { MerklePatriciaTrie } from '../mpt.ts'
 import type { MPTNode } from '../types.ts'
 
 export type NodeFilter = (node: MPTNode, key: number[]) => Promise<boolean>
-export type OnFound = (node: MPTNode, key: number[]) => Promise<void>
+export type OnFound = (node: MPTNode, key: number[]) => Promise<unknown>
 
 /**
  * Walk MerklePatriciaTrie via async generator

--- a/packages/mpt/src/util/asyncWalk.ts
+++ b/packages/mpt/src/util/asyncWalk.ts
@@ -44,15 +44,18 @@ export async function* _walkTrie(
     }
     if (node instanceof BranchMPTNode) {
       for (const [nibble, childNode] of node._branches.entries()) {
+        if (childNode === null) {
+          continue
+        }
         const nextKey = [...currentKey, nibble]
         const _childNode: Uint8Array =
           childNode instanceof Uint8Array ? childNode : this.hash(RLP.encode(childNode))
-        yield* _walkTrie.bind(this)(_childNode, nextKey, onFound, filter, visited)
+        yield* _walkTrie.call(this, _childNode, nextKey, onFound, filter, visited)
       }
     } else if (node instanceof ExtensionMPTNode) {
       const childNode = node.value()
       const nextKey = [...currentKey, ...node._nibbles]
-      yield* _walkTrie.bind(this)(childNode, nextKey, onFound, filter, visited)
+      yield* _walkTrie.call(this, childNode, nextKey, onFound, filter, visited)
     }
   } catch {
     return

--- a/packages/mpt/test/util/asyncWalk.spec.ts
+++ b/packages/mpt/test/util/asyncWalk.spec.ts
@@ -2,6 +2,7 @@ import { bytesToHex, equalsBytes, hexToBytes, isHexString, utf8ToBytes } from '@
 import { assert, describe, it } from 'vitest'
 
 import {
+  BranchMPTNode,
   LeafMPTNode,
   MerklePatriciaTrie,
   createMPTFromProof,
@@ -130,4 +131,145 @@ describe('walk a sparse trie', async () => {
   } catch (err) {
     assert.strictEqual((err as any).message, 'Missing node in DB')
   }
+})
+
+/**
+ * Builds a trie with two 32-byte keys whose first nibble differs (0x0 vs 0xf),
+ * so the root is a single BranchMPTNode with exactly two populated slots (0
+ * and 15) and fourteen empty ones, each pointing directly to a LeafMPTNode
+ * (32-byte keys/values are large enough to avoid raw/embedded child nodes).
+ */
+async function twoLeafBranchTrie(trie: MerklePatriciaTrie) {
+  const key1 = new Uint8Array(32).fill(0)
+  key1[31] = 1
+  const key2 = new Uint8Array(32).fill(0)
+  key2[0] = 0xff
+  key2[31] = 2
+  const value1 = new Uint8Array(32).fill(0xaa)
+  const value2 = new Uint8Array(32).fill(0xbb)
+  await trie.put(key1, value1)
+  await trie.put(key2, value2)
+  return { key1, key2, value1, value2 }
+}
+
+describe('branch node child iteration', () => {
+  class CountingTrie extends MerklePatriciaTrie {
+    lookupCalls = 0
+    async lookupNode(node: Uint8Array | Uint8Array[]) {
+      this.lookupCalls++
+      return super.lookupNode(node)
+    }
+  }
+
+  it('walks only the populated slots of a branch node, without a DB lookup per empty slot', async () => {
+    const trie = new CountingTrie()
+    await twoLeafBranchTrie(trie)
+
+    const rootNode = await trie.lookupNode(trie.root())
+    assert.instanceOf(rootNode, BranchMPTNode, 'test setup should produce a branch root')
+
+    trie.lookupCalls = 0
+    const visited: { node: any; currentKey: number[] }[] = []
+    for await (const entry of trie.walkTrieIterable(trie.root())) {
+      visited.push(entry)
+    }
+
+    assert.strictEqual(visited.length, 3, 'should visit exactly the branch and its two leaves')
+    assert.strictEqual(
+      trie.lookupCalls,
+      3,
+      'should call lookupNode once per real node, not once per branch slot (14 of the 16 are empty)',
+    )
+    const leafNibbles = visited
+      .filter((v) => v.node instanceof LeafMPTNode)
+      .map((v) => v.currentKey[0])
+      .sort((a, b) => a - b)
+    assert.deepEqual(leafNibbles, [0, 15], 'should only descend into the two populated slots')
+  })
+})
+
+describe('trie walk error handling', () => {
+  it('silently skips a subtree with a missing node while still walking sibling branches', async () => {
+    const trie = new MerklePatriciaTrie()
+    const { key1 } = await twoLeafBranchTrie(trie)
+
+    const { node: leaf1 } = await trie.findPath(key1)
+    assert.isNotNull(leaf1, 'test setup should find the leaf for key1')
+    const leaf1Hash = (trie as any).hash(leaf1!.serialize())
+    await (trie as any)._db.del(leaf1Hash) // simulate a pruned/missing node
+
+    const visited: { node: any; currentKey: number[] }[] = []
+    for await (const entry of trie.walkTrieIterable(trie.root())) {
+      visited.push(entry)
+    }
+
+    assert.strictEqual(
+      visited.length,
+      2,
+      'the root branch and the surviving leaf should still be visited',
+    )
+    assert.isFalse(
+      visited.some((v) => v.node instanceof LeafMPTNode && v.currentKey[0] === 0),
+      'the pruned leaf should be absent from the results',
+    )
+    assert.isTrue(
+      visited.some((v) => v.node instanceof LeafMPTNode && v.currentKey[0] === 15),
+      'the sibling leaf should still be found',
+    )
+  })
+
+  it('propagates an unexpected (non "Missing node in DB") error instead of swallowing it', async () => {
+    const trie = new MerklePatriciaTrie()
+    await twoLeafBranchTrie(trie)
+
+    // Patch lookupNode only after the trie is built: `put` uses lookupNode
+    // internally, so throwing from construction would fail the test setup
+    // rather than the walk itself.
+    const originalLookupNode = trie.lookupNode.bind(trie)
+    trie.lookupNode = (async (node: Uint8Array | Uint8Array[]) => {
+      const result = await originalLookupNode(node)
+      if (result instanceof LeafMPTNode) {
+        throw new Error('boom')
+      }
+      return result
+    }) as typeof trie.lookupNode
+
+    const visited: { node: any; currentKey: number[] }[] = []
+    try {
+      for await (const entry of trie.walkTrieIterable(trie.root())) {
+        visited.push(entry)
+      }
+      assert.fail('walk should have thrown the unexpected error')
+    } catch (err) {
+      assert.strictEqual((err as any).message, 'boom')
+    }
+    assert.isFalse(
+      visited.some((v) => v.node instanceof LeafMPTNode),
+      'no leaf should be yielded once an unexpected error aborts the walk',
+    )
+  })
+})
+
+describe('visited set deduplication', () => {
+  it('does not yield a node whose hash is already present in the visited set', async () => {
+    const trie = new MerklePatriciaTrie()
+    await trie.put(utf8ToBytes('key1'), utf8ToBytes('value1'))
+    const rootHash = trie.root()
+    const rootNode = await trie.lookupNode(rootHash)
+    const rootHashHex = bytesToHex((trie as any).hash(rootNode.serialize()))
+
+    const results: { node: any; currentKey: number[] }[] = []
+    for await (const entry of _walkTrie.call(
+      trie,
+      rootHash,
+      [],
+      undefined,
+      undefined,
+      new Set<string>([rootHashHex]),
+    )) {
+      results.push(entry)
+    }
+
+    assert.strictEqual(results.length, 0, 'a node already in the visited set should be skipped')
+  })
 })

--- a/packages/mpt/test/util/asyncWalk.spec.ts
+++ b/packages/mpt/test/util/asyncWalk.spec.ts
@@ -152,15 +152,16 @@ async function twoLeafBranchTrie(trie: MerklePatriciaTrie) {
   return { key1, key2, value1, value2 }
 }
 
-describe('branch node child iteration', () => {
-  class CountingTrie extends MerklePatriciaTrie {
-    lookupCalls = 0
-    async lookupNode(node: Uint8Array | Uint8Array[]) {
-      this.lookupCalls++
-      return super.lookupNode(node)
-    }
+/** Counts calls to lookupNode, i.e. how many times the walk actually hit the DB. */
+class CountingTrie extends MerklePatriciaTrie {
+  lookupCalls = 0
+  async lookupNode(node: Uint8Array | Uint8Array[]) {
+    this.lookupCalls++
+    return super.lookupNode(node)
   }
+}
 
+describe('branch node child iteration', () => {
   it('walks only the populated slots of a branch node, without a DB lookup per empty slot', async () => {
     const trie = new CountingTrie()
     await twoLeafBranchTrie(trie)
@@ -251,13 +252,12 @@ describe('trie walk error handling', () => {
 })
 
 describe('visited set deduplication', () => {
-  it('does not yield a node whose hash is already present in the visited set', async () => {
-    const trie = new MerklePatriciaTrie()
+  it('skips both yielding and looking up a node whose hash is already in the visited set', async () => {
+    const trie = new CountingTrie()
     await trie.put(utf8ToBytes('key1'), utf8ToBytes('value1'))
     const rootHash = trie.root()
-    const rootNode = await trie.lookupNode(rootHash)
-    const rootHashHex = bytesToHex((trie as any).hash(rootNode.serialize()))
 
+    trie.lookupCalls = 0
     const results: { node: any; currentKey: number[] }[] = []
     for await (const entry of _walkTrie.call(
       trie,
@@ -265,11 +265,16 @@ describe('visited set deduplication', () => {
       [],
       undefined,
       undefined,
-      new Set<string>([rootHashHex]),
+      new Set<string>([bytesToHex(rootHash)]),
     )) {
       results.push(entry)
     }
 
     assert.strictEqual(results.length, 0, 'a node already in the visited set should be skipped')
+    assert.strictEqual(
+      trie.lookupCalls,
+      0,
+      'a node already in the visited set should not trigger a lookupNode/DB read',
+    )
   })
 })


### PR DESCRIPTION
# mpt: fix and optimize `_walkTrie` async generator

## Summary

`packages/mpt/src/util/asyncWalk.ts` backs several public trie-walking APIs
(`walkAllNodes`, `walkAllValueNodes`, `getValueMap`). A review turned up one
correctness/robustness issue and a handful of avoidable overhead in the
per-node hot path.

## Changes

- [x] **Wasted work on empty branch slots**: `BranchMPTNode._branches` uses
  `null` for empty children only when freshly constructed in memory — nodes
  decoded from RLP (i.e. any node fetched from the DB while walking, the
  normal case) represent empty slots as a zero-length `Uint8Array` instead.
  An initial fix that checked `childNode === null` was therefore a no-op in
  practice: every empty slot still went through `RLP.encode`/`hash` and a
  recursive call that resolved to a bogus zero-length "hash", triggering a
  `lookupNode` call that threw and was silently swallowed as `'Missing node
  in DB'`. Measured 17 `lookupNode` calls for a trie with only 3 real nodes.
  Fixed by switching to `BranchMPTNode.getChildren()`, the class's own
  accessor that already treats both `null` and zero-length entries as empty
  (same check `getBranch()` uses internally) — down to 3 `lookupNode` calls
  for the same trie.

- [x] **Per-call `.bind(this)` allocation**: each recursive step created a
  new bound function via `_walkTrie.bind(this)(...)`, allocating an extra
  function object per node visited. Switched to `_walkTrie.call(this, ...)`,
  which attaches `this` without allocating.

- [x] **Duplicate hash computation**: the visited-set check and insert each
  independently computed `this.hash(node.serialize())` for the same node.
  Hoisted into a single local variable, then went further: `_walkTrie`
  already receives the node's hash as its `nodeHash` argument, so
  re-serializing and re-hashing the *decoded* node to get the visited-set
  key was redundant work on top of redundant work. Content-addressed
  storage guarantees `nodeHash === hash(node.serialize())` for whatever
  `lookupNode` returns, so the visited-set key is now just `nodeHash`
  itself, checked *before* calling `lookupNode` — an already-visited node
  now skips the DB round trip entirely instead of only skipping the yield.

- [x] **Redundant non-null assertions**: `node!` was used repeatedly after a
  guard that already lets TypeScript narrow `node` to non-undefined.
  Removed the assertions

- [x] **Silent error swallowing**: the whole recursive walk (including child
  `yield*` calls) was wrapped in a `try { ... } catch { return }`, so any
  DB/lookup error anywhere in a subtree silently truncated that branch with
  no signal. This directly affects `getValueMap`, `walkAllNodes`, and
  `walkAllValueNodes`, which could return incomplete results with no
  indication of failure.

  `lookupNode` never actually returns `undefined` for a missing node — it
  throws `'Missing node in DB'` — so the `node === undefined` guard was dead
  code. Brought `_walkTrie` in line with the existing codebase convention
  (`checkRoot`, `findPath`, `proof.ts`, `range.ts`): swallow only the
  expected `'Missing node in DB'` error (e.g. from pruning) and rethrow
  anything else.

## Test coverage added

`packages/mpt/test/util/asyncWalk.spec.ts` had no direct coverage of the
branch/error-handling paths this change touches. Added:

- **branch node child iteration**: a 2-leaf branch trie (14 of 16 slots
  empty) is walked while counting `lookupNode` calls, asserting exactly one
  call per real node and that only the two populated slots are descended
  into. This is the test that caught the `getChildren()` bug above — it
  failed with 17 calls against the naive `null`-check fix.
- **missing-node handling**: deletes one leaf's DB entry directly (same
  pattern used elsewhere in the test suite for simulating pruning) and
  asserts the walk completes without throwing, drops only that leaf, and
  still finds its sibling.
- **unexpected error propagation**: patches `lookupNode` (after trie
  construction, since `put` also calls `lookupNode` internally) to throw a
  generic error and asserts it propagates out of the `for await` instead of
  being swallowed.
- **visited-set dedup**: calls `_walkTrie` directly with a pre-seeded
  `visited` set containing the root's hash and asserts nothing is yielded
  *and* that `lookupNode` is never called, using a small `CountingTrie`
  test helper (now shared with the branch-iteration test above) that
  counts DB lookups.

## Documentation added

The README only documented the async-generator walk API
(`walkTrieIterable`), with no mention of the alternative `WalkController`-
based `trie.walkTrie`, or guidance on when to reach for which. Added a
"`walkTrieIterable` vs. `walkTrie` (`WalkController`)" section covering the
concrete tradeoffs:

- `walkTrieIterable`: lazy, `for await`-friendly, always visits every
  reachable node, and tolerates sparse/pruned tries by dropping only the
  affected subtree on a `'Missing node in DB'` error (per the fix above).
- `walkTrie`/`WalkController`: callback-driven, pipelines `lookupNode`
  calls concurrently through a `PrioritizedTaskExecutor` (pool size 500),
  gives per-node control over traversal (e.g. `findPath`'s single-branch
  following via `onlyBranchIndex`), and rejects the whole walk on any
  lookup error unless the caller opts into pruning-tolerant handling
  itself.

## Testing

- `npx tsc --noEmit` in `packages/mpt` — passes
- `npm run test:node` in `packages/mpt` — 1505 tests passing
- (`npm run test:browser` fails locally due to missing Playwright browser
  setup in this sandbox — unrelated to these changes)
- New README code example verified to run correctly against the real API
  via `tsx`
