### PR TITLE
fix(evm): emit step event before dynamic-gas OOG exceptions

### DIFF
--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -55,6 +55,17 @@ import type {
 
 const debugGas = debugDefault('evm:gas')
 
+function isOutOfGasError(error: unknown): error is EVMError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'errorType' in error &&
+    error.errorType === EVMErrorTypeString &&
+    'error' in error &&
+    error.error === EVMError.errorMessages.OUT_OF_GAS
+  )
+}
+
 export interface InterpreterOpts {
   pc?: number
   /** Logs to prepend to the result (e.g. EIP-7708 ETH transfer log from message-level value transfer) */
@@ -404,7 +415,17 @@ export class Interpreter {
       if (opInfo.dynamicGas) {
         // This function updates the gas in-place.
         // It needs the base fee, for correct gas limit calculation for the CALL opcodes
-        gas = await opEntry.gasHandler(this._runState, gas, this.common)
+        try {
+          gas = await opEntry.gasHandler(this._runState, gas, this.common)
+        } catch (error) {
+          if (
+            isOutOfGasError(error) &&
+            (this._evm.events.listenerCount('step') > 0 || this._evm.DEBUG)
+          ) {
+            await this._runStepHook(gas, this.getGasLeft(), memorySizeCache)
+          }
+          throw error
+        }
       }
 
       if (this._evm.events.listenerCount('step') > 0 || this._evm.DEBUG) {

--- a/packages/evm/test/runCall.spec.ts
+++ b/packages/evm/test/runCall.spec.ts
@@ -277,6 +277,35 @@ describe('RunCall tests', () => {
     )
   })
 
+  it('step event includes CALL when CALL dynamic gas calculation goes OOG', async () => {
+    const caller = new Address(hexToBytes('0x00000000000000000000000000000000000000ee'))
+    const address = new Address(hexToBytes('0x00000000000000000000000000000000000000ff'))
+    const common = new Common({ chain: Mainnet, hardfork: Hardfork.Homestead })
+    const evm = await createEVM({ common })
+    const code = '0x61FFFF60FF60006000600060EE6000F100'
+
+    const stepOpcodes: string[] = []
+
+    evm.events.on('step', (e) => {
+      stepOpcodes.push(e.opcode.name)
+    })
+
+    await evm.stateManager.putCode(address, hexToBytes(code))
+
+    const result = await evm.runCall({
+      caller,
+      to: address,
+      gasLimit: BigInt(200),
+    })
+
+    assert.strictEqual(
+      result.execResult.exceptionError?.error,
+      EVMError.errorMessages.OUT_OF_GAS,
+      'call went out of gas',
+    )
+    assert.strictEqual(stepOpcodes.at(-1), 'CALL', 'step event emitted for CALL before out-of-gas')
+  })
+
   it('ensure selfdestruct pays for creating new accounts', async () => {
     // setup the accounts for this test
     const caller = new Address(hexToBytes('0x00000000000000000000000000000000000000ee')) // caller address


### PR DESCRIPTION
## Summary

Fixes #4313.

The `step` event (used by debuggers/tracers to observe each instruction before it executes) was inconsistently emitted when an instruction ran out of gas:

- Opcodes with a *static* gas fee always got a `step` event before the `OUT_OF_GAS` exception, because `useGas()` (which throws it) runs *after* the step hook in `Interpreter.runStep()`.
- Opcodes with a *dynamic* gas handler (e.g. `CALL`) could throw `OUT_OF_GAS` from inside the handler itself (e.g. during memory-expansion cost calculation), before the step hook ever ran -- so no `step` event was emitted for that instruction at all.

## Fix

In `Interpreter.runStep()`, wrap the dynamic gas handler call in a `try/catch`. If it throws `OUT_OF_GAS`, emit the step event for the current opcode (mirroring what the static-gas path already does), then rethrow the original error unchanged. Gas accounting and the resulting error are untouched -- this only makes `step`-event emission consistent between the two paths.

## Test plan

Locally:

- [x] New test (`packages/evm/test/runCall.spec.ts`): a `CALL` with a small gas limit and a large `outLength` (forcing memory-expansion cost to exceed the limit during dynamic gas calculation) now shows `CALL` as the last opcode observed via the `step` event, and confirms gas consumption / error type (`OUT_OF_GAS`) are unchanged.
- [x] The new test fails (`expected 'PUSH1' to equal 'CALL'`) on code before this fix, and passes with it.
- [x] `packages/evm` full test suite: 1178 passed. The 2 failing suites are unrelated (missing `ethereum-tests` git submodule fixtures) and fail identically on unmodified `master`.
- [x] `biome check` clean on changed files.
