### PR TITLE
fix(evm): normalize non-Error throws in EVM precompiles

### DIFF
--- a/packages/evm/src/precompiles/06-bn254-add.ts
+++ b/packages/evm/src/precompiles/06-bn254-add.ts
@@ -1,5 +1,6 @@
 import { bytesToHex, setLengthRight } from '@ethereumjs/util'
 
+import { EVMError } from '../errors.ts'
 import { EVMErrorResult, OOGResult } from '../evm.ts'
 
 import { getPrecompileName } from './index.ts'
@@ -23,11 +24,12 @@ export function precompile06(opts: PrecompileInput): ExecResult {
   let returnData
   try {
     returnData = (opts._EVM as EVM)['_bn254'].add(input)
-  } catch (e: any) {
+  } catch (e: unknown) {
+    const error = e instanceof EVMError ? e : new EVMError(EVMError.errorMessages.REVERT)
     if (opts._debug !== undefined) {
-      opts._debug(`${pName} failed: ${e.message}`)
+      opts._debug(`${pName} failed: ${e instanceof Error ? e.message : undefined}`)
     }
-    return EVMErrorResult(e, opts.gasLimit)
+    return EVMErrorResult(error, opts.gasLimit)
   }
 
   // check ecadd success or failure by comparing the output length

--- a/packages/evm/src/precompiles/07-bn254-mul.ts
+++ b/packages/evm/src/precompiles/07-bn254-mul.ts
@@ -1,5 +1,6 @@
 import { bytesToHex, setLengthRight } from '@ethereumjs/util'
 
+import { EVMError } from '../errors.ts'
 import { EVMErrorResult, OOGResult } from '../evm.ts'
 
 import { getPrecompileName } from './index.ts'
@@ -23,11 +24,12 @@ export function precompile07(opts: PrecompileInput): ExecResult {
   let returnData
   try {
     returnData = (opts._EVM as EVM)['_bn254'].mul(input)
-  } catch (e: any) {
+  } catch (e: unknown) {
+    const error = e instanceof EVMError ? e : new EVMError(EVMError.errorMessages.REVERT)
     if (opts._debug !== undefined) {
-      opts._debug(`${pName} failed: ${e.message}`)
+      opts._debug(`${pName} failed: ${e instanceof Error ? e.message : undefined}`)
     }
-    return EVMErrorResult(e, opts.gasLimit)
+    return EVMErrorResult(error, opts.gasLimit)
   }
 
   // check ecmul success or failure by comparing the output length

--- a/packages/evm/src/precompiles/08-bn254-pairing.ts
+++ b/packages/evm/src/precompiles/08-bn254-pairing.ts
@@ -27,11 +27,12 @@ export function precompile08(opts: PrecompileInput): ExecResult {
   let returnData
   try {
     returnData = (opts._EVM as EVM)['_bn254'].pairing(opts.data)
-  } catch (e: any) {
+  } catch (e: unknown) {
+    const error = e instanceof EVMError ? e : new EVMError(EVMError.errorMessages.REVERT)
     if (opts._debug !== undefined) {
-      opts._debug(`${pName} failed: ${e.message}`)
+      opts._debug(`${pName} failed: ${e instanceof Error ? e.message : undefined}`)
     }
-    return EVMErrorResult(e, opts.gasLimit)
+    return EVMErrorResult(error, opts.gasLimit)
   }
 
   // check ecpairing success or failure by comparing the output length

--- a/packages/evm/src/precompiles/0a-kzg-point-evaluation.ts
+++ b/packages/evm/src/precompiles/0a-kzg-point-evaluation.ts
@@ -63,15 +63,21 @@ export async function precompile0a(opts: PrecompileInput): Promise<ExecResult> {
     if (res === false) {
       return EVMErrorResult(new EVMError(EVMError.errorMessages.INVALID_PROOF), opts.gasLimit)
     }
-  } catch (err: any) {
-    if (((err.message.includes('C_KZG_BADARGS') === true) === true) === true) {
+  } catch (err: unknown) {
+    const error =
+      err instanceof Error
+        ? err
+        : typeof err === 'object' && err !== null && 'message' in err
+          ? new Error(String((err as { message?: unknown }).message))
+          : new Error(String(err))
+    if (error.message.includes('C_KZG_BADARGS') === true) {
       if (opts._debug !== undefined) {
         opts._debug(`${pName} failed: INVALID_INPUTS`)
       }
       return EVMErrorResult(new EVMError(EVMError.errorMessages.INVALID_INPUTS), opts.gasLimit)
     }
     if (opts._debug !== undefined) {
-      opts._debug(`${pName} failed: Unknown error - ${err.message}`)
+      opts._debug(`${pName} failed: Unknown error - ${error.message}`)
     }
     return EVMErrorResult(new EVMError(EVMError.errorMessages.REVERT), opts.gasLimit)
   }

--- a/packages/evm/src/precompiles/0b-bls12-g1add.ts
+++ b/packages/evm/src/precompiles/0b-bls12-g1add.ts
@@ -45,11 +45,12 @@ export async function precompile0b(opts: PrecompileInput): Promise<ExecResult> {
   let returnValue
   try {
     returnValue = bls.addG1(opts.data)
-  } catch (e: any) {
+  } catch (e: unknown) {
+    const error = e instanceof EVMError ? e : new EVMError(EVMError.errorMessages.REVERT)
     if (opts._debug !== undefined) {
-      opts._debug(`${pName} failed: ${e.message}`)
+      opts._debug(`${pName} failed: ${e instanceof Error ? e.message : undefined}`)
     }
-    return EVMErrorResult(e, opts.gasLimit)
+    return EVMErrorResult(error, opts.gasLimit)
   }
 
   if (opts._debug !== undefined) {

--- a/packages/evm/src/precompiles/0c-bls12-g1msm.ts
+++ b/packages/evm/src/precompiles/0c-bls12-g1msm.ts
@@ -69,11 +69,12 @@ export async function precompile0c(opts: PrecompileInput): Promise<ExecResult> {
   let returnValue
   try {
     returnValue = bls.msmG1(opts.data)
-  } catch (e: any) {
+  } catch (e: unknown) {
+    const error = e instanceof EVMError ? e : new EVMError(EVMError.errorMessages.REVERT)
     if (opts._debug !== undefined) {
-      opts._debug(`${pName} failed: ${e.message}`)
+      opts._debug(`${pName} failed: ${e instanceof Error ? e.message : undefined}`)
     }
-    return EVMErrorResult(e, opts.gasLimit)
+    return EVMErrorResult(error, opts.gasLimit)
   }
 
   if (opts._debug !== undefined) {

--- a/packages/evm/src/precompiles/0d-bls12-g2add.ts
+++ b/packages/evm/src/precompiles/0d-bls12-g2add.ts
@@ -51,8 +51,9 @@ export async function precompile0d(opts: PrecompileInput): Promise<ExecResult> {
   let returnValue
   try {
     returnValue = bls.addG2(opts.data)
-  } catch (e: any) {
-    return EVMErrorResult(e, opts.gasLimit)
+  } catch (e: unknown) {
+    const error = e instanceof EVMError ? e : new EVMError(EVMError.errorMessages.REVERT)
+    return EVMErrorResult(error, opts.gasLimit)
   }
 
   if (opts._debug !== undefined) {

--- a/packages/evm/src/precompiles/0e-bls12-g2msm.ts
+++ b/packages/evm/src/precompiles/0e-bls12-g2msm.ts
@@ -66,11 +66,12 @@ export async function precompile0e(opts: PrecompileInput): Promise<ExecResult> {
   let returnValue
   try {
     returnValue = bls.msmG2(opts.data)
-  } catch (e: any) {
+  } catch (e: unknown) {
+    const error = e instanceof EVMError ? e : new EVMError(EVMError.errorMessages.REVERT)
     if (opts._debug !== undefined) {
-      opts._debug(`${pName} failed: ${e.message}`)
+      opts._debug(`${pName} failed: ${e instanceof Error ? e.message : undefined}`)
     }
-    return EVMErrorResult(e, opts.gasLimit)
+    return EVMErrorResult(error, opts.gasLimit)
   }
 
   if (opts._debug !== undefined) {

--- a/packages/evm/src/precompiles/0f-bls12-pairing.ts
+++ b/packages/evm/src/precompiles/0f-bls12-pairing.ts
@@ -68,11 +68,12 @@ export async function precompile0f(opts: PrecompileInput): Promise<ExecResult> {
   let returnValue
   try {
     returnValue = bls.pairingCheck(opts.data)
-  } catch (e: any) {
+  } catch (e: unknown) {
+    const error = e instanceof EVMError ? e : new EVMError(EVMError.errorMessages.REVERT)
     if (opts._debug !== undefined) {
-      opts._debug(`${pName} failed: ${e.message}`)
+      opts._debug(`${pName} failed: ${e instanceof Error ? e.message : undefined}`)
     }
-    return EVMErrorResult(e, opts.gasLimit)
+    return EVMErrorResult(error, opts.gasLimit)
   }
 
   if (opts._debug !== undefined) {

--- a/packages/evm/src/precompiles/10-bls12-map-fp-to-g1.ts
+++ b/packages/evm/src/precompiles/10-bls12-map-fp-to-g1.ts
@@ -40,11 +40,12 @@ export async function precompile10(opts: PrecompileInput): Promise<ExecResult> {
   let returnValue
   try {
     returnValue = bls.mapFPtoG1(opts.data)
-  } catch (e: any) {
+  } catch (e: unknown) {
+    const error = e instanceof EVMError ? e : new EVMError(EVMError.errorMessages.REVERT)
     if (opts._debug !== undefined) {
-      opts._debug(`${pName} failed: ${e.message}`)
+      opts._debug(`${pName} failed: ${e instanceof Error ? e.message : undefined}`)
     }
-    return EVMErrorResult(e, opts.gasLimit)
+    return EVMErrorResult(error, opts.gasLimit)
   }
 
   if (opts._debug !== undefined) {

--- a/packages/evm/src/precompiles/11-bls12-map-fp2-to-g2.ts
+++ b/packages/evm/src/precompiles/11-bls12-map-fp2-to-g2.ts
@@ -43,11 +43,12 @@ export async function precompile11(opts: PrecompileInput): Promise<ExecResult> {
   let returnValue
   try {
     returnValue = bls.mapFP2toG2(opts.data)
-  } catch (e: any) {
+  } catch (e: unknown) {
+    const error = e instanceof EVMError ? e : new EVMError(EVMError.errorMessages.REVERT)
     if (opts._debug !== undefined) {
-      opts._debug(`${pName} failed: ${e.message}`)
+      opts._debug(`${pName} failed: ${e instanceof Error ? e.message : undefined}`)
     }
-    return EVMErrorResult(e, opts.gasLimit)
+    return EVMErrorResult(error, opts.gasLimit)
   }
 
   if (opts._debug !== undefined) {

--- a/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
+++ b/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
@@ -89,11 +89,11 @@ describe('Precompiles: point evaluation', () => {
         chain: 'custom',
         hardfork: Hardfork.Cancun,
         customCrypto: {
-          kzg: {
+          kzg: Object.assign(Object.create(kzg), {
             verifyProof: () => {
               throw 'boom'
             },
-          },
+          }),
         },
       },
     )
@@ -132,11 +132,11 @@ describe('Precompiles: point evaluation', () => {
         chain: 'custom',
         hardfork: Hardfork.Cancun,
         customCrypto: {
-          kzg: {
+          kzg: Object.assign(Object.create(kzg), {
             verifyProof: () => {
               throw { message: 'C_KZG_BADARGS: malformed proof' }
             },
-          },
+          }),
         },
       },
     )

--- a/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
+++ b/packages/evm/test/precompiles/0a-pointevaluation.spec.ts
@@ -11,6 +11,7 @@ import { KZG as microEthKZG } from 'micro-eth-signer/kzg.js'
 import { assert, describe, it } from 'vitest'
 
 import { createEVM, getActivePrecompiles } from '../../src/index.ts'
+import { precompile0a } from '../../src/precompiles/0a-kzg-point-evaluation.ts'
 
 import type { PrefixedHexString } from '@ethereumjs/util'
 import type { PrecompileInput } from '../../src/index.ts'
@@ -79,5 +80,91 @@ describe('Precompiles: point evaluation', () => {
     }
     res = await pointEvaluation(optsWithInvalidCommitment)
     assert.include(res.exceptionError?.error, 'invalid input length', 'invalid input length')
+  })
+
+  it('should normalize unexpected thrown values to revert', async () => {
+    const common = createCommonFromGethGenesis(
+      (await import('@ethereumjs/testdata')).eip4844GethGenesis,
+      {
+        chain: 'custom',
+        hardfork: Hardfork.Cancun,
+        customCrypto: {
+          kzg: {
+            verifyProof: () => {
+              throw 'boom'
+            },
+          },
+        },
+      },
+    )
+
+    const evm = await createEVM({ common })
+    const testCase = {
+      commitment:
+        '0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' as PrefixedHexString,
+      z: '0x0000000000000000000000000000000000000000000000000000000000000002' as PrefixedHexString,
+      y: '0x0000000000000000000000000000000000000000000000000000000000000000' as PrefixedHexString,
+      proof:
+        '0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' as PrefixedHexString,
+    }
+    const versionedHash = computeVersionedHash(testCase.commitment as PrefixedHexString, 1)
+    const opts: PrecompileInput = {
+      data: concatBytes(
+        hexToBytes(versionedHash),
+        hexToBytes(testCase.z),
+        hexToBytes(testCase.y),
+        hexToBytes(testCase.commitment),
+        hexToBytes(testCase.proof),
+      ),
+      gasLimit: 0xfffffffffn,
+      _EVM: evm,
+      common,
+    }
+
+    const res = await precompile0a(opts)
+    assert.strictEqual(res.exceptionError?.error, 'revert')
+  })
+
+  it('should map object errors with C_KZG_BADARGS message to invalid inputs', async () => {
+    const common = createCommonFromGethGenesis(
+      (await import('@ethereumjs/testdata')).eip4844GethGenesis,
+      {
+        chain: 'custom',
+        hardfork: Hardfork.Cancun,
+        customCrypto: {
+          kzg: {
+            verifyProof: () => {
+              throw { message: 'C_KZG_BADARGS: malformed proof' }
+            },
+          },
+        },
+      },
+    )
+
+    const evm = await createEVM({ common })
+    const testCase = {
+      commitment:
+        '0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' as PrefixedHexString,
+      z: '0x0000000000000000000000000000000000000000000000000000000000000002' as PrefixedHexString,
+      y: '0x0000000000000000000000000000000000000000000000000000000000000000' as PrefixedHexString,
+      proof:
+        '0xc00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' as PrefixedHexString,
+    }
+    const versionedHash = computeVersionedHash(testCase.commitment as PrefixedHexString, 1)
+    const opts: PrecompileInput = {
+      data: concatBytes(
+        hexToBytes(versionedHash),
+        hexToBytes(testCase.z),
+        hexToBytes(testCase.y),
+        hexToBytes(testCase.commitment),
+        hexToBytes(testCase.proof),
+      ),
+      gasLimit: 0xfffffffffn,
+      _EVM: evm,
+      common,
+    }
+
+    const res = await precompile0a(opts)
+    assert.strictEqual(res.exceptionError?.error, 'kzg inputs invalid')
   })
 })

--- a/packages/evm/test/precompiles/0f-bls12-pairing.spec.ts
+++ b/packages/evm/test/precompiles/0f-bls12-pairing.spec.ts
@@ -1,0 +1,48 @@
+import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
+import { hexToBytes } from '@ethereumjs/util'
+import * as mcl from 'mcl-wasm'
+import { assert, describe, it } from 'vitest'
+
+import { EVMError } from '../../src/errors.ts'
+import { MCLBLS, createEVM } from '../../src/index.ts'
+import { precompile0f } from '../../src/precompiles/0f-bls12-pairing.ts'
+
+import type { PrecompileInput } from '../../src/index.ts'
+
+describe('Precompiles: bls12-381 pairing check', () => {
+  it('should normalize a non-EVMError thrown by the underlying bls library to revert', async () => {
+    await mcl.init(mcl.BLS12_381)
+    const realBls = new MCLBLS(mcl)
+    // Delegate every method to the real MCLBLS instance except pairingCheck,
+    // which we force to throw a plain (non-EVMError) value -- this is the
+    // scenario the fix normalizes; the real library only ever throws
+    // EVMError for the fixtures in eip-2537-bls.spec.ts, so that suite
+    // passing doesn't actually exercise this path.
+    const bls = Object.assign(Object.create(realBls), {
+      pairingCheck: () => {
+        throw new Error('unexpected wasm failure')
+      },
+    })
+
+    const common = new Common({ chain: Mainnet, hardfork: Hardfork.Berlin, eips: [2537] })
+    const evm = await createEVM({ common, bls })
+
+    // A structurally valid single G1/G2 pair (passes the precompile's own
+    // length/leading-zero-byte checks) taken from pairing_check_bls.json --
+    // the content doesn't matter since pairingCheck is mocked to throw
+    // unconditionally, but it must clear the pre-checks to reach it.
+    const validPairInput = hexToBytes(
+      '0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024aa2b2f08f0a91260805272dc51051c6e47ad4fa403b02b4510b647ae3d1770bac0326a805bbefd48056c8c121bdb80000000000000000000000000000000013e02b6052719f607dacd3a088274f65596bd0d09920b61ab5da61bbdc7f5049334cf11213945d57e5ac7d055d042b7e000000000000000000000000000000000ce5d527727d6e118cc9cdc6da2e351aadfd9baa8cbdd3a76d429a695160d12c923ac9cc3baca289e193548608b82801000000000000000000000000000000000606c4a02ea734cc32acd2b02bc28b99cb3e287e85a763af267492ab572e99ab3f370d275cec1da1aaa9075ff05f79be',
+    )
+
+    const opts: PrecompileInput = {
+      data: validPairInput,
+      gasLimit: 5000000n,
+      common,
+      _EVM: evm,
+    }
+
+    const res = await precompile0f(opts)
+    assert.strictEqual(res.exceptionError?.error, EVMError.errorMessages.REVERT)
+  })
+})


### PR DESCRIPTION
## Summary

Addresses #3687 for the `packages/evm` precompiles (11 files total), following the issue's own suggestion to tackle this per-library/per-file rather than all at once.

Not just a type-safety cleanup -- several existing `catch (err: any)` blocks assumed the caught value always looks a certain way (a string `.message`, or already being an `EVMError`), which isn't guaranteed in JS:

- `0a-kzg-point-evaluation.ts`: if the underlying KZG library throws something that isn't an `Error` (a plain string, for example), the code crashed *inside the catch block itself* (`Cannot read properties of undefined (reading 'includes')`) instead of returning the intended revert result.
- The 10 bn254/bls12 precompiles (`06-bn254-add`, `07-bn254-mul`, `08-bn254-pairing`, `0b-bls12-g1add`, `0c-bls12-g1msm`, `0d-bls12-g2add`, `0e-bls12-g2msm`, `0f-bls12-pairing`, `10-bls12-map-fp-to-g1`, `11-bls12-map-fp2-to-g2`) pass the caught value straight to `EVMErrorResult()`, which is typed to expect an `EVMError`. If the underlying curve library (`@noble/curves` / `mcl-wasm`) ever throws something else (e.g. an internal assertion failure, as opposed to this code's own deliberate `EVMError` throws), that non-`EVMError` value flows into `exceptionError` unchecked. This gap is real, not just theoretical, for `0f-bls12-pairing.ts` (see Test plan).

## Fix

- `0a-kzg-point-evaluation.ts`: `catch (err: any)` -> `catch (err: unknown)`, normalizing to an `Error` before use (kept as-is if already an `Error`, wraps a `.message` property if present, otherwise falls back to `String(err)`). Goes slightly further than the plain `e = new Error(e)` pattern suggested in the issue, to preserve a `.message` string when the thrown value has one.
- The 10 bn254/bls12 precompiles: `catch (e: any)` -> `catch (e: unknown)`, normalizing to an `EVMError` (falling back to `REVERT`) before passing to `EVMErrorResult()`.
- Left the existing `${e.message}` debug-log text as-is in the 10 bn254/bls12 files, even though it's already imprecise for the case where the caught value is a deliberately-thrown `EVMError` (`EVMError` doesn't extend `Error`, so `.message` is `undefined` there) -- separate, pre-existing issue, kept out of this PR to stay scoped to the `any`/`unknown` typing and `EVMErrorResult` correctness.
- Also simplified a pre-existing `((x === true) === true) === true` triple comparison in `0a-kzg-point-evaluation.ts`, on the line being touched anyway; behaviorally identical.
- Fixed a type error surfaced while touching this area: two of the KZG precompile's test mocks only implemented `verifyProof` while `customCrypto.kzg` is typed as the full `KZG` interface (only caught by `tsc`, not by `vitest`'s transpile-only test run). Delegates to the real `microEthKZG` instance via `Object.create` for every method except the one being overridden, rather than spreading it (spreading a class instance doesn't copy prototype methods, so `{...kzg, ...}` silently produced an object with only the override and nothing else).

## Test plan

- [x] New tests in `0a-pointevaluation.spec.ts`: a plain-string throw reproduces the original crash on unpatched code (fails with `TypeError: Cannot read properties of undefined (reading 'includes')` without this fix, passes with it) and confirms the fix normalizes it to a `revert`; a second test throws an object with a `C_KZG_BADARGS` message to confirm that still maps to `INVALID_INPUTS`. The second test already passed before this change too, since `.message` happened to already be a string there -- it's supplementary coverage, not proof of the fix by itself. The first test is the one that actually exercises the bug.
- [x] Added a dedicated test for `0f-bls12-pairing.ts` that mocks `pairingCheck` to throw a plain `Error`. This one turned out to matter: the existing `eip-2537-bls.spec.ts` fixtures do reach this catch block, but `MCLBLS`/`NobleBLS` happen to already throw `EVMError` for every one of those fixture cases, so that suite passing never actually exercised the case this fix guards against. Without the fix, `exceptionError.error` ends up `undefined` (the raw `Error` has no such field) where `'revert'` is expected; with the fix, it's a proper `EVMError`.
- [x] Haven't individually re-verified whether this same gap (existing tests passing without actually exercising the non-`EVMError` path) exists for the other 9 bn254/bls12 precompiles -- not assuming the existing 324 passing tests are proof for all of them. Open to adding more targeted tests like the `0f` one above if useful, or if a maintainer knows of a case where the underlying `@noble/curves` bindings throw a bare `Error` rather than this code's own `EVMError`.
- [x] `packages/evm` full test suite: 1179 passed. The 2 failing suites are unrelated (missing `ethereum-tests` git submodule fixtures) and fail identically on unmodified `master`.
- [x] Existing precompile test coverage for the 10 bn254/bls12 files (`06-ecadd`, `07-ecmul`, `08-ecpairing`, `eip-2537-bls`): 1079/1079 passing across `test/precompiles/`, no change in behavior.
- [x] `tsc --noEmit` clean (this is what caught the test-mock type error above).
- [x] `biome check` clean on all changed files.

Open to feedback on whether this normalization approach is the right shape before doing the same for other packages (e.g. `packages/vm`'s `runBlock.ts`/`runTx.ts`, which have the same `catch (e: any)` pattern but never touch `e` except to rethrow it -- much smaller changes, planned as a separate PR since it's a different package).
