### PR TITLE
tx: re-add access/authority list JSON cache items and test cache behavior

### DIFF
--- a/packages/tx/src/1559/tx.ts
+++ b/packages/tx/src/1559/tx.ts
@@ -29,7 +29,7 @@ import type {
   TransactionInterface,
   TxOptions,
 } from '../types.ts'
-import { accessListBytesToJSON, accessListJSONToBytes } from '../util/access.ts'
+import { accessListJSONToBytes } from '../util/access.ts'
 
 export type TxData = AllTypesTxData[typeof TransactionType.FeeMarketEIP1559]
 export type TxValuesArray = AllTypesTxValuesArray[typeof TransactionType.FeeMarketEIP1559]
@@ -335,7 +335,7 @@ export class FeeMarket1559Tx
    * @returns JSON encoding of the transaction
    */
   toJSON(): JSONTx {
-    const accessListJSON = accessListBytesToJSON(this.accessList)
+    const accessListJSON = EIP2930.getAccessListJSON(this)
     const baseJSON = getBaseJSON(this)
 
     return {

--- a/packages/tx/src/2930/tx.ts
+++ b/packages/tx/src/2930/tx.ts
@@ -27,7 +27,7 @@ import type {
   TransactionInterface,
   TxOptions,
 } from '../types.ts'
-import { accessListBytesToJSON, accessListJSONToBytes } from '../util/access.ts'
+import { accessListJSONToBytes } from '../util/access.ts'
 
 export type TxData = AllTypesTxData[typeof TransactionType.AccessListEIP2930]
 export type TxValuesArray = AllTypesTxValuesArray[typeof TransactionType.AccessListEIP2930]
@@ -310,7 +310,7 @@ export class AccessList2930Tx
    * @returns JSON encoding of the transaction
    */
   toJSON(): JSONTx {
-    const accessListJSON = accessListBytesToJSON(this.accessList)
+    const accessListJSON = EIP2930.getAccessListJSON(this)
     const baseJSON = getBaseJSON(this)
 
     return {

--- a/packages/tx/src/4844/tx.ts
+++ b/packages/tx/src/4844/tx.ts
@@ -18,7 +18,7 @@ import * as EIP2718 from '../capabilities/eip2718.ts'
 import * as EIP2930 from '../capabilities/eip2930.ts'
 import * as Legacy from '../capabilities/legacy.ts'
 import { TransactionType, isAccessList } from '../types.ts'
-import { accessListBytesToJSON, accessListJSONToBytes } from '../util/access.ts'
+import { accessListJSONToBytes } from '../util/access.ts'
 import {
   getBaseJSON,
   getCommon,
@@ -508,7 +508,7 @@ export class Blob4844Tx implements TransactionInterface<typeof TransactionType.B
    * @returns JSON encoding of the transaction
    */
   toJSON(): JSONTx {
-    const accessListJSON = accessListBytesToJSON(this.accessList)
+    const accessListJSON = EIP2930.getAccessListJSON(this)
     const baseJSON = getBaseJSON(this)
 
     return {

--- a/packages/tx/src/7702/tx.ts
+++ b/packages/tx/src/7702/tx.ts
@@ -5,7 +5,6 @@ import {
   bigIntToHex,
   bigIntToUnpaddedBytes,
   bytesToBigInt,
-  eoaCode7702AuthorizationListBytesItemToJSON,
   eoaCode7702AuthorizationListJSONItemToBytes,
   isEOACode7702AuthorizationList,
   toBytes,
@@ -39,7 +38,7 @@ import type {
   TransactionInterface,
   TxOptions,
 } from '../types.ts'
-import { accessListBytesToJSON, accessListJSONToBytes } from '../util/access.ts'
+import { accessListJSONToBytes } from '../util/access.ts'
 
 export type TxData = AllTypesTxData[typeof TransactionType.EOACodeEIP7702]
 export type TxValuesArray = AllTypesTxValuesArray[typeof TransactionType.EOACodeEIP7702]
@@ -368,10 +367,8 @@ export class EOACode7702Tx implements TransactionInterface<typeof TransactionTyp
    * @returns JSON encoding of the transaction
    */
   toJSON(): JSONTx {
-    const accessListJSON = accessListBytesToJSON(this.accessList)
-    const authorizationList = this.authorizationList.map((item) =>
-      eoaCode7702AuthorizationListBytesItemToJSON(item),
-    )
+    const accessListJSON = EIP2930.getAccessListJSON(this)
+    const authorizationList = EIP7702.getAuthorizationListJSON(this)
 
     const baseJSON = getBaseJSON(this)
 

--- a/packages/tx/src/capabilities/eip2930.ts
+++ b/packages/tx/src/capabilities/eip2930.ts
@@ -1,13 +1,42 @@
 import * as Legacy from './legacy.ts'
 
 import { EthereumJSErrorWithoutCode } from '@ethereumjs/util'
-import type { EIP2930CompatibleTx } from '../types.ts'
+import type { AccessList, EIP2930CompatibleTx } from '../types.ts'
+import { accessListBytesToJSON } from '../util/access.ts'
 
 /**
  * The amount of gas paid for the data in this tx
  */
 export function getDataGas(tx: EIP2930CompatibleTx): bigint {
   return Legacy.getDataGas(tx) + getAccessListDataGas(tx)
+}
+
+/**
+ * Returns the access list of the tx in JSON format.
+ *
+ * For frozen txs the result is computed once, frozen (the tx cannot change
+ * anymore, so neither can its JSON representation) and cached, and repeated
+ * calls return the same frozen object. For non-frozen txs a fresh (mutable)
+ * copy is returned on every call, since the underlying access list bytes
+ * could still change.
+ */
+export function getAccessListJSON(tx: EIP2930CompatibleTx): AccessList {
+  if (tx.cache.accessListJSON !== undefined) {
+    return tx.cache.accessListJSON
+  }
+
+  const accessListJSON = accessListBytesToJSON(tx.accessList)
+
+  if (Object.isFrozen(tx)) {
+    for (const item of accessListJSON) {
+      Object.freeze(item.storageKeys)
+      Object.freeze(item)
+    }
+    Object.freeze(accessListJSON)
+    tx.cache.accessListJSON = accessListJSON
+  }
+
+  return accessListJSON
 }
 
 /**

--- a/packages/tx/src/capabilities/eip7702.ts
+++ b/packages/tx/src/capabilities/eip7702.ts
@@ -5,8 +5,10 @@ import {
   MAX_INTEGER,
   MAX_UINT64,
   bytesToBigInt,
+  eoaCode7702AuthorizationListBytesItemToJSON,
   validateNoLeadingZeroes,
 } from '@ethereumjs/util'
+import type { EOACode7702AuthorizationList } from '@ethereumjs/util'
 import type { EIP7702CompatibleTx } from '../types.ts'
 
 /**
@@ -18,6 +20,35 @@ export function getDataGas(tx: EIP7702CompatibleTx): bigint {
     tx.authorizationList.length * Number(tx.common.param('perEmptyAccountCost')),
   )
   return eip2930Cost + eip7702Cost
+}
+
+/**
+ * Returns the authorization list of the tx in JSON format.
+ *
+ * For frozen txs the result is computed once, frozen (the tx cannot change
+ * anymore, so neither can its JSON representation) and cached, and repeated
+ * calls return the same frozen object. For non-frozen txs a fresh (mutable)
+ * copy is returned on every call, since the underlying authorization list
+ * bytes could still change.
+ */
+export function getAuthorizationListJSON(tx: EIP7702CompatibleTx): EOACode7702AuthorizationList {
+  if (tx.cache.authorityListJSON !== undefined) {
+    return tx.cache.authorityListJSON
+  }
+
+  const authorityListJSON = tx.authorizationList.map((item) =>
+    eoaCode7702AuthorizationListBytesItemToJSON(item),
+  )
+
+  if (Object.isFrozen(tx)) {
+    for (const item of authorityListJSON) {
+      Object.freeze(item)
+    }
+    Object.freeze(authorityListJSON)
+    tx.cache.authorityListJSON = authorityListJSON
+  }
+
+  return authorityListJSON
 }
 
 /**

--- a/packages/tx/src/types.ts
+++ b/packages/tx/src/types.ts
@@ -137,10 +137,8 @@ export interface TransactionCache {
     hardfork: string | Hardfork
   }
   senderPubKey?: Uint8Array
-  // TODO: re-add these cache items for the JSON
-  // See: https://github.com/ethereumjs/ethereumjs-monorepo/issues/3932
-  //accessListJSON?: AccessList
-  //authorityListJSON?: EOACode7702AuthorizationList
+  accessListJSON?: AccessList
+  authorityListJSON?: EOACode7702AuthorizationList
 }
 
 export type TransactionType = (typeof TransactionType)[keyof typeof TransactionType]

--- a/packages/tx/test/cache.spec.ts
+++ b/packages/tx/test/cache.spec.ts
@@ -1,0 +1,237 @@
+import { Common, Hardfork, Mainnet } from '@ethereumjs/common'
+import { hexToBytes } from '@ethereumjs/util'
+import { trustedSetup } from '@paulmillr/trusted-setups/fast-peerdas.js'
+import { KZG as microEthKZG } from 'micro-eth-signer/kzg.js'
+import { assert, describe, it } from 'vitest'
+
+import {
+  createAccessList2930Tx,
+  createBlob4844Tx,
+  createEOACode7702Tx,
+  createFeeMarket1559Tx,
+  createLegacyTx,
+  paramsTx,
+} from '../src/index.ts'
+
+import type { EOACode7702AuthorizationListItem, PrefixedHexString } from '@ethereumjs/util'
+import type { AccessList } from '../src/index.ts'
+
+// Tests for the `TransactionCache` behavior (see issue #3932): values should
+// only be cached on frozen txs (a non-frozen tx can still change, so cached
+// values could go stale), and cached JSON objects should themselves be frozen
+// so they cannot be mutated behind the cache's back.
+
+const common = new Common({
+  chain: Mainnet,
+  hardfork: Hardfork.London,
+  params: paramsTx,
+})
+
+const common7702 = new Common({ chain: Mainnet, hardfork: Hardfork.Cancun, eips: [7702] })
+
+const common4844 = new Common({
+  chain: Mainnet,
+  hardfork: Hardfork.Cancun,
+  params: paramsTx,
+  customCrypto: { kzg: new microEthKZG(trustedSetup) },
+})
+
+const pKey = hexToBytes('0x4646464646464646464646464646464646464646464646464646464646464646')
+
+const to: PrefixedHexString = `0x${'11'.repeat(20)}`
+
+const accessList: AccessList = [
+  {
+    address: `0x${'aa'.repeat(20)}`,
+    storageKeys: [`0x${'01'.repeat(32)}`],
+  },
+]
+
+const ones32: PrefixedHexString = `0x${'01'.repeat(32)}`
+const authorizationListItem: EOACode7702AuthorizationListItem = {
+  chainId: '0x',
+  address: `0x${'20'.repeat(20)}`,
+  nonce: '0x1',
+  yParity: '0x1',
+  r: ones32,
+  s: ones32,
+}
+
+describe('TransactionCache', () => {
+  describe('hash / senderPubKey / dataFee', () => {
+    it('should cache on a frozen tx and return the cached value on repeated calls', () => {
+      const tx = createLegacyTx({ data: '0x010200' }, { common }).sign(pKey)
+      assert.isTrue(Object.isFrozen(tx))
+
+      assert.isUndefined(tx.cache.hash)
+      const hash1 = tx.hash()
+      assert.strictEqual(tx.cache.hash, hash1, 'hash should be cached')
+      assert.strictEqual(tx.hash(), hash1, 'repeated call should return the cached object')
+
+      assert.isUndefined(tx.cache.senderPubKey)
+      const pubKey1 = tx.getSenderPublicKey()
+      assert.strictEqual(tx.cache.senderPubKey, pubKey1, 'senderPubKey should be cached')
+      assert.strictEqual(
+        tx.getSenderPublicKey(),
+        pubKey1,
+        'repeated call should return the cached object',
+      )
+
+      assert.isUndefined(tx.cache.dataFee)
+      const dataFee1 = tx.getDataGas()
+      assert.strictEqual(tx.cache.dataFee?.value, dataFee1, 'dataFee should be cached')
+      assert.strictEqual(tx.getDataGas(), dataFee1)
+    })
+
+    it('should not cache on a non-frozen tx', () => {
+      const tx = createLegacyTx({ data: '0x010200' }, { common, freeze: false }).sign(pKey)
+      assert.isFalse(Object.isFrozen(tx))
+
+      const hash1 = tx.hash()
+      const hash2 = tx.hash()
+      assert.isUndefined(tx.cache.hash, 'hash should not be cached')
+      assert.notStrictEqual(hash1, hash2, 'each call should compute a fresh object')
+      assert.deepEqual(hash1, hash2)
+
+      tx.getSenderPublicKey()
+      assert.isUndefined(tx.cache.senderPubKey, 'senderPubKey should not be cached')
+
+      tx.getDataGas()
+      assert.isUndefined(tx.cache.dataFee, 'dataFee should not be cached')
+    })
+
+    it('should recompute values on a non-frozen tx when the tx data changes', () => {
+      // This is the reason non-frozen txs must not cache: their contents can
+      // still change, which would turn a cached value stale.
+      const tx = createLegacyTx({ data: '0x00' }, { common, freeze: false })
+
+      const zeroByteCost = tx.common.param('txDataZeroGas')
+      const nonZeroByteCost = tx.common.param('txDataNonZeroGas')
+      assert.strictEqual(tx.getDataGas(), zeroByteCost)
+
+      tx.data[0] = 0x01
+      assert.strictEqual(
+        tx.getDataGas(),
+        nonZeroByteCost,
+        'dataFee should be recomputed after the data changed',
+      )
+    })
+  })
+
+  describe('accessListJSON', () => {
+    // All four tx types whose toJSON() includes the access list
+    const txTypes = [
+      {
+        name: 'AccessList2930Tx',
+        create: (freeze: boolean) => createAccessList2930Tx({ accessList }, { common, freeze }),
+      },
+      {
+        name: 'FeeMarket1559Tx',
+        create: (freeze: boolean) => createFeeMarket1559Tx({ accessList }, { common, freeze }),
+      },
+      {
+        name: 'Blob4844Tx',
+        create: (freeze: boolean) =>
+          createBlob4844Tx(
+            { accessList, to, blobVersionedHashes: [`0x01${'00'.repeat(31)}`] },
+            { common: common4844, freeze },
+          ),
+      },
+      {
+        name: 'EOACode7702Tx',
+        create: (freeze: boolean) =>
+          createEOACode7702Tx(
+            { accessList, authorizationList: [authorizationListItem], to },
+            { common: common7702, freeze },
+          ),
+      },
+    ]
+
+    for (const txType of txTypes) {
+      it(`${txType.name}: should cache and freeze the JSON on a frozen tx`, () => {
+        const tx = txType.create(true)
+
+        assert.isUndefined(tx.cache.accessListJSON)
+        const json1 = tx.toJSON().accessList!
+        assert.deepEqual(json1, accessList)
+        assert.strictEqual(tx.cache.accessListJSON, json1, 'accessListJSON should be cached')
+
+        const json2 = tx.toJSON().accessList!
+        assert.strictEqual(json2, json1, 'repeated call should return the cached object')
+
+        assert.isTrue(Object.isFrozen(json1), 'the cached list should be frozen')
+        assert.isTrue(Object.isFrozen(json1[0]), 'the cached list items should be frozen')
+        assert.isTrue(
+          Object.isFrozen(json1[0].storageKeys),
+          'the cached storage keys should be frozen',
+        )
+        assert.throws(() => {
+          json1[0].storageKeys.push(ones32)
+        })
+      })
+
+      it(`${txType.name}: should return a fresh mutable copy on a non-frozen tx`, () => {
+        const tx = txType.create(false)
+
+        const json1 = tx.toJSON().accessList!
+        const json2 = tx.toJSON().accessList!
+        assert.isUndefined(tx.cache.accessListJSON, 'accessListJSON should not be cached')
+        assert.notStrictEqual(json1, json2, 'each call should compute a fresh object')
+        assert.deepEqual(json1, json2)
+
+        assert.isFalse(Object.isFrozen(json1))
+        json1[0].storageKeys.push(ones32)
+        assert.deepEqual(
+          tx.toJSON().accessList,
+          accessList,
+          'mutating a returned copy should not affect subsequent calls',
+        )
+      })
+    }
+  })
+
+  describe('authorityListJSON', () => {
+    it('EOACode7702Tx: should cache and freeze the JSON on a frozen tx', () => {
+      const tx = createEOACode7702Tx(
+        { authorizationList: [authorizationListItem], to },
+        { common: common7702 },
+      )
+
+      assert.isUndefined(tx.cache.authorityListJSON)
+      const json1 = tx.toJSON().authorizationList!
+      assert.strictEqual(tx.cache.authorityListJSON, json1, 'authorityListJSON should be cached')
+
+      const json2 = tx.toJSON().authorizationList!
+      assert.strictEqual(json2, json1, 'repeated call should return the cached object')
+
+      assert.isTrue(Object.isFrozen(json1), 'the cached list should be frozen')
+      assert.isTrue(Object.isFrozen(json1[0]), 'the cached list items should be frozen')
+      assert.throws(() => {
+        json1.push(authorizationListItem)
+      })
+    })
+
+    it('EOACode7702Tx: should return a fresh mutable copy on a non-frozen tx', () => {
+      const tx = createEOACode7702Tx(
+        { authorizationList: [authorizationListItem], to },
+        { common: common7702, freeze: false },
+      )
+
+      const json1 = tx.toJSON().authorizationList!
+      const json2 = tx.toJSON().authorizationList!
+      assert.isUndefined(tx.cache.authorityListJSON, 'authorityListJSON should not be cached')
+      assert.notStrictEqual(json1, json2, 'each call should compute a fresh object')
+      assert.deepEqual(json1, json2)
+
+      assert.isFalse(Object.isFrozen(json1))
+      const original = tx.toJSON().authorizationList!
+      json1.push(authorizationListItem)
+      json2[0].nonce = '0x999'
+      assert.deepEqual(
+        tx.toJSON().authorizationList,
+        original,
+        'mutating a returned copy should not affect subsequent calls',
+      )
+    })
+  })
+})


### PR DESCRIPTION
Closes #3932.

### What

Re-adds the `accessListJSON` / `authorityListJSON` items to `TransactionCache` that were removed (with a TODO pointing to #3932) in the #3890 cleanup, and adds dedicated test coverage for the cache behavior as a whole.

Mapping to the three asks in the issue:

1. **Re-add the JSON cache items** — the two commented-out fields in `TransactionCache` are restored (typed `AccessList` / `EOACode7702AuthorizationList`, matching what the current code base uses).
2. **Only cache when the tx is frozen** — the new `EIP2930.getAccessListJSON()` / `EIP7702.getAuthorizationListJSON()` capability helpers follow the exact convention the existing cache items (`hash`, `dataFee`, `senderPubKey`) already implement: an `Object.isFrozen(tx)` guard around cache population, and a fresh mutable copy on every call for non-frozen txs (whose contents could still change, going stale in a cache).
3. **Freeze the cached JSON** — as suggested in the issue, on a frozen tx the computed JSON is (deep-)frozen before caching, so the cached object cannot be mutated behind the cache's back. `toJSON()` on the four access-list tx types (2930, 1559, 4844, 7702) now routes through these helpers.

### Behavior change to be aware of

For a **frozen** tx (the default), repeated `toJSON()` calls now return the *same, frozen* `accessList`/`authorizationList` object instead of a fresh mutable copy each time. I checked all `toJSON()` consumers in the monorepo (`block`, `client` RPC helpers) — they only read these fields, never mutate them. Non-frozen txs are unchanged: fresh mutable copy per call (covered by tests, including that mutating a returned copy does not leak into subsequent calls).

Two deliberate scope decisions, happy to adjust either:

- `blobTxNetworkWrapperToJSON()` still converts the access list directly: it creates a throwaway tx per call, so an instance cache can never pay off there.
- The cache field is named `authorityListJSON` following the TODO comment verbatim, although the tx property it derives from is `authorizationList` — trivial to rename if you prefer the symmetric name.

### Testing

New `test/cache.spec.ts` covering all five cache items:

- frozen tx: repeated calls return the identical cached object, `tx.cache.*` is populated, and the cached JSON (list, items, storage keys) is frozen
- non-frozen tx: `tx.cache.*` stays empty, every call computes a fresh mutable object, and mutating a returned copy does not affect subsequent calls
- non-frozen tx recomputes `dataFee` after its `data` changed (the reason non-frozen txs must not cache)
- the access-list assertions run against **all four** tx types whose `toJSON()` is touched (2930, 1559, 4844 incl. KZG setup, 7702)

`npm run test` (tx package, minus the external-fixture suites): 131/131 passing. Biome and the type-aware ESLint config pass on all changed files; `tsc` build is clean.
