### PR TITLE
Util: Fix typo in README

### DIFF
--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -136,7 +136,7 @@ console.log(`Ethereum address ${address.toString()} created`)
 
 ## Module: [signature](src/signature.ts)
 
-Small helpers around signature validation, conversion, recovery as well as selected convenience wrappers for calls to the underlying crypo libraries, using the cryptographic primitive implementations from the [Noble](https://paulmillr.com/noble/) crypto library set. If possible for your use case it is recommended to use the underlying crypto libraries directly for robustness.
+Small helpers around signature validation, conversion, recovery as well as selected convenience wrappers for calls to the underlying crypto libraries, using the cryptographic primitive implementations from the [Noble](https://paulmillr.com/noble/) crypto library set. If possible for your use case it is recommended to use the underlying crypto libraries directly for robustness.
 
 ```ts
 // ./examples/signature.ts


### PR DESCRIPTION
## Summary

Correct a typo in the `signature` module description in the Util README, changing “crypo libraries” to “crypto libraries”.

## Testing

Documentation-only change. The targeted spelling check and `git diff --check` pass.

## Related issues

None.