### PR TITLE
fix(evm): emit step event before dynamic-gas OOG exceptions

### DIFF
--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -55,14 +55,12 @@ import type {
 
 const debugGas = debugDefault('evm:gas')
 
-function isOutOfGasError(error: unknown): error is EVMError {
+function isEVMError(error: unknown): error is EVMError {
   return (
     typeof error === 'object' &&
     error !== null &&
     'errorType' in error &&
-    error.errorType === EVMErrorTypeString &&
-    'error' in error &&
-    error.error === EVMError.errorMessages.OUT_OF_GAS
+    error.errorType === EVMErrorTypeString
   )
 }
 
@@ -418,8 +416,14 @@ export class Interpreter {
         try {
           gas = await opEntry.gasHandler(this._runState, gas, this.common)
         } catch (error) {
+          // Static-gas opcodes always emit a `step` event before their gas
+          // charge can fail (the hook below runs before `useGas` and the
+          // opcode handler). Dynamic gas handlers can throw the failure
+          // themselves, before that hook runs, so emit it here for any VM
+          // error to keep tracer output consistent across both paths.
+          // Non-VM errors are genuine bugs and are re-thrown untouched.
           if (
-            isOutOfGasError(error) &&
+            isEVMError(error) &&
             (this._evm.events.listenerCount('step') > 0 || this._evm.DEBUG)
           ) {
             await this._runStepHook(gas, this.getGasLeft(), memorySizeCache)

--- a/packages/evm/src/interpreter.ts
+++ b/packages/evm/src/interpreter.ts
@@ -55,6 +55,17 @@ import type {
 
 const debugGas = debugDefault('evm:gas')
 
+function isOutOfGasError(error: unknown): error is EVMError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'errorType' in error &&
+    error.errorType === EVMErrorTypeString &&
+    'error' in error &&
+    error.error === EVMError.errorMessages.OUT_OF_GAS
+  )
+}
+
 export interface InterpreterOpts {
   pc?: number
   /** Logs to prepend to the result (e.g. EIP-7708 ETH transfer log from message-level value transfer) */
@@ -404,7 +415,17 @@ export class Interpreter {
       if (opInfo.dynamicGas) {
         // This function updates the gas in-place.
         // It needs the base fee, for correct gas limit calculation for the CALL opcodes
-        gas = await opEntry.gasHandler(this._runState, gas, this.common)
+        try {
+          gas = await opEntry.gasHandler(this._runState, gas, this.common)
+        } catch (error) {
+          if (
+            isOutOfGasError(error) &&
+            (this._evm.events.listenerCount('step') > 0 || this._evm.DEBUG)
+          ) {
+            await this._runStepHook(gas, this.getGasLeft(), memorySizeCache)
+          }
+          throw error
+        }
       }
 
       if (this._evm.events.listenerCount('step') > 0 || this._evm.DEBUG) {

--- a/packages/evm/test/runCall.spec.ts
+++ b/packages/evm/test/runCall.spec.ts
@@ -306,6 +306,43 @@ describe('RunCall tests', () => {
     assert.strictEqual(stepOpcodes.at(-1), 'CALL', 'step event emitted for CALL before out-of-gas')
   })
 
+  it('step event includes the opcode when a dynamic gas handler throws a non-OOG VM error', async () => {
+    // SSTORE in a static context throws STATIC_STATE_CHANGE from its dynamic
+    // gas handler (before the gas is even charged). Like the OOG case above,
+    // the step event must still be emitted for the failing opcode.
+    const caller = new Address(hexToBytes('0x00000000000000000000000000000000000000ee'))
+    const address = new Address(hexToBytes('0x00000000000000000000000000000000000000ff'))
+    const common = new Common({ chain: Mainnet, hardfork: Hardfork.London })
+    const evm = await createEVM({ common })
+    // PUSH1 0x01 PUSH1 0x00 SSTORE
+    const code = '0x6001600055'
+
+    const stepOpcodes: string[] = []
+    evm.events.on('step', (e) => {
+      stepOpcodes.push(e.opcode.name)
+    })
+
+    await evm.stateManager.putCode(address, hexToBytes(code))
+
+    const result = await evm.runCall({
+      caller,
+      to: address,
+      gasLimit: BigInt(100000),
+      isStatic: true,
+    })
+
+    assert.strictEqual(
+      result.execResult.exceptionError?.error,
+      EVMError.errorMessages.STATIC_STATE_CHANGE,
+      'call reverted with static state change',
+    )
+    assert.strictEqual(
+      stepOpcodes.at(-1),
+      'SSTORE',
+      'step event emitted for SSTORE before static state change error',
+    )
+  })
+
   it('ensure selfdestruct pays for creating new accounts', async () => {
     // setup the accounts for this test
     const caller = new Address(hexToBytes('0x00000000000000000000000000000000000000ee')) // caller address

--- a/packages/evm/test/runCall.spec.ts
+++ b/packages/evm/test/runCall.spec.ts
@@ -277,6 +277,35 @@ describe('RunCall tests', () => {
     )
   })
 
+  it('step event includes CALL when CALL dynamic gas calculation goes OOG', async () => {
+    const caller = new Address(hexToBytes('0x00000000000000000000000000000000000000ee'))
+    const address = new Address(hexToBytes('0x00000000000000000000000000000000000000ff'))
+    const common = new Common({ chain: Mainnet, hardfork: Hardfork.Homestead })
+    const evm = await createEVM({ common })
+    const code = '0x61FFFF60FF60006000600060EE6000F100'
+
+    const stepOpcodes: string[] = []
+
+    evm.events.on('step', (e) => {
+      stepOpcodes.push(e.opcode.name)
+    })
+
+    await evm.stateManager.putCode(address, hexToBytes(code))
+
+    const result = await evm.runCall({
+      caller,
+      to: address,
+      gasLimit: BigInt(200),
+    })
+
+    assert.strictEqual(
+      result.execResult.exceptionError?.error,
+      EVMError.errorMessages.OUT_OF_GAS,
+      'call went out of gas',
+    )
+    assert.strictEqual(stepOpcodes.at(-1), 'CALL', 'step event emitted for CALL before out-of-gas')
+  })
+
   it('ensure selfdestruct pays for creating new accounts', async () => {
     // setup the accounts for this test
     const caller = new Address(hexToBytes('0x00000000000000000000000000000000000000ee')) // caller address


### PR DESCRIPTION
> **Credits:** Original implementation by @GiHoon1123. Review follow-up
> (broadening the fix beyond OOG + extra test) co-authored.

## Summary

Makes the EVM `step` event (used by tracers/debuggers) emit consistently when
an opcode fails during gas calculation.

## Problem

Static-gas opcodes always emit a `step` event before their gas charge can fail:
the step hook runs before `useGas` and before the opcode handler. Opcodes with a
**dynamic gas handler** (e.g. `CALL`, `SSTORE`), however, compute their cost
inside `gasHandler`, which can `throw` before the step hook is ever reached — so
the failing opcode is silently missing from the trace.

## Fix

Wrap the dynamic gas handler in a try/catch. When it throws a **VM error**, emit
the `step` event for the current opcode before re-throwing, mirroring the
static-gas path. This covers every VM error the handlers raise — `OUT_OF_GAS`,
`STATIC_STATE_CHANGE`, `OUT_OF_RANGE`, `INVALID_OPCODE` — not just OOG. Non-VM
errors (genuine bugs) are re-thrown untouched and do not emit a step, consistent
with the interpreter's existing error handling.

## Tests

- `CALL` going OOG during memory-expansion gas calc → `step` now includes `CALL`.
- `SSTORE` in a static context (`STATIC_STATE_CHANGE`) → `step` now includes
  `SSTORE`, covering the non-OOG path.
- Full EVM suite passes.