### PR TITLE
test(vm): improve typing and readability of execution-spec test runner

### DIFF
--- a/packages/vm/test/tester/executionSpecBlockchain.test.ts
+++ b/packages/vm/test/tester/executionSpecBlockchain.test.ts
@@ -3,9 +3,12 @@ import { assert, describe, it } from 'vitest'
 import fs from 'fs'
 import path from 'path'
 
-import type { Block } from '@ethereumjs/block'
+import type { Block, HeaderData } from '@ethereumjs/block'
 import { createBlock, createBlockFromRLP } from '@ethereumjs/block'
+import type { Blockchain } from '@ethereumjs/blockchain'
 import { createBlockchain } from '@ethereumjs/blockchain'
+import type { Common } from '@ethereumjs/common'
+import type { BALJSONBlockAccessList, BlockLevelAccessList } from '@ethereumjs/util'
 import {
   bytesToHex,
   createAddressFromString,
@@ -17,9 +20,11 @@ import {
 import { keccak_256 } from '@noble/hashes/sha3.js'
 import { trustedSetup } from '@paulmillr/trusted-setups/fast-peerdas.js'
 import { KZG as microEthKZG } from 'micro-eth-signer/kzg.js'
+import type { VM } from '../../src/index.ts'
 import { createVM, runBlock } from '../../src/index.ts'
 import { setupPreConditions } from '../util.ts'
 import { createCommonForFork, loadExecutionSpecFixtures } from './executionSpecTestLoader.ts'
+import type { BlockchainTestFixtureData } from './executionSpecTypes.ts'
 import { compareBAL } from './util/balComparatorAI.ts'
 import { annotateFixture } from './util/perDirectoryReporter.ts'
 
@@ -89,66 +94,72 @@ if (fs.existsSync(fixturesPath) === false) {
 
 export async function runBlockchainTestCase(
   fork: string,
-  testData: any,
+  testData: BlockchainTestFixtureData,
   t: typeof assert,
   kzg: microEthKZG,
   fixtureFilePath = '',
 ) {
   const isEip7928BalFixture = fixtureFilePath.includes('eip7928_block_level_access_lists')
   const common = createCommonForFork(fork, testData, kzg)
-  const genesisBlockData = { header: testData.genesisBlockHeader }
-  const genesisBlock = createBlock(genesisBlockData, { common, setHardfork: true })
-  const blockchain = await createBlockchain({
-    common,
-    genesisBlock,
-  })
-  const vm = await createVM({
-    common,
-    blockchain,
-  })
-  await setupPreConditions(vm.stateManager, testData)
 
-  //const rlp = hexToBytes(testData.genesisRLP)
-  //t.deepEqual(genesisBlock.serialize(), rlp, 'correct genesis RLP')
+  const genesisBlock = createBlock(
+    { header: testData.genesisBlockHeader as HeaderData },
+    { common, setHardfork: true },
+  )
+  const blockchain = await createBlockchain({ common, genesisBlock })
+  const vm = await createVM({ common, blockchain })
+  await setupPreConditions(vm.stateManager, testData)
 
   t.deepEqual(
     await vm.stateManager.getStateRoot(),
     genesisBlock.header.stateRoot,
     'correct pre stateRoot',
   )
-
   t.equal(
     bytesToHex(genesisBlock.hash()),
     testData.genesisBlockHeader.hash,
     'correct genesis block hash',
   )
 
+  // Capture an unexpected block-processing error so the post-state checks below
+  // still run; this surfaces state-divergence details even when a block throws.
+  const runError = await runBlocks(vm, common, genesisBlock, testData, isEip7928BalFixture, t)
+
+  // Always check final head and post state, even if block processing threw.
+  // Individual diffs go into `postFailures` so they show up alongside any
+  // block-processing error rather than being masked by an early throw.
+  const postFailures = await collectPostStateFailures(vm, blockchain, testData, t)
+
+  if (runError === undefined && postFailures.length === 0) return
+
+  throwCombinedFailure(runError, postFailures)
+}
+
+/**
+ * Runs every block in the fixture against the VM. Returns an unexpected error
+ * if one occurred (so the caller can still run post-state checks), or
+ * `undefined` if all blocks processed as expected.
+ */
+async function runBlocks(
+  vm: VM,
+  common: Common,
+  genesisBlock: Block,
+  testData: BlockchainTestFixtureData,
+  isEip7928BalFixture: boolean,
+  t: typeof assert,
+): Promise<Error | undefined> {
   let parentBlock = genesisBlock
 
-  // Capture errors from block processing so post-state checks still run; this
-  // surfaces state-divergence details even when a block throws unexpectedly.
-  let runError: Error | undefined
-
   try {
-    for (const {
-      rlp,
-      expectException,
-      blockHeader,
-      rlp_decoded,
-      blockAccessList,
-    } of testData.blocks) {
-      const expectedHash = blockHeader?.hash ?? rlp_decoded?.blockHeader?.hash ?? undefined
-      let block: Block | undefined
+    for (const { rlp, expectException, blockAccessList, rlp_decoded } of testData.blocks) {
+      const providedBalJson = blockAccessList ?? rlp_decoded?.blockAccessList
       try {
-        block = createBlockFromRLP(hexToBytes(rlp), { common: vm.common, setHardfork: true })
-        //t.equal(bytesToHex(block.serialize()), rlp, 'correct block RLP')
-        if (expectedHash !== undefined) {
-          //t.equal(bytesToHex(block.hash()), expectedHash, 'correct block hash')
-        }
-        const providedBalJson = blockAccessList ?? rlp_decoded?.blockAccessList
-        // Enforce provided BAL in runBlock only for invalid-block tests. Other Amsterdam v7
-        // fixtures may include a reference BAL without requiring strict client equality.
-        const validateProvidedBalInRunBlock =
+        const block = createBlockFromRLP(hexToBytes(rlp), { common: vm.common, setHardfork: true })
+
+        // Enforce the provided BAL inside runBlock only for invalid-block tests.
+        // Other Amsterdam v7 fixtures may ship a reference BAL without requiring
+        // strict client equality.
+        const enforceProvidedBal =
           common.isActivatedEIP(7928) &&
           providedBalJson !== undefined &&
           expectException !== undefined
@@ -156,131 +167,156 @@ export async function runBlockchainTestCase(
           block,
           root: parentBlock.header.stateRoot,
           setHardfork: true,
-          ...(validateProvidedBalInRunBlock ? { blockAccessList: providedBalJson } : {}),
+          ...(enforceProvidedBal ? { blockAccessList: providedBalJson } : {}),
         })
         await vm.blockchain.putBlock(block)
         parentBlock = block
+
         t.notExists(expectException, `Should have thrown with: ${expectException}`)
 
         if (common.isActivatedEIP(7928) && isEip7928BalFixture) {
-          let balDiffMessage = ''
-          if (providedBalJson !== undefined) {
-            const expectedBAL = createBlockLevelAccessListFromJSON(providedBalJson)
-            const { diffString } = compareBAL(
-              expectedBAL.raw(),
-              result.blockLevelAccessList!.raw(),
-              false,
-            )
-            balDiffMessage = diffString
-            t.deepEqual(
-              bytesToHex(expectedBAL.hash()),
-              bytesToHex(block.header.blockAccessListHash!),
-              `expected block level access list correct${balDiffMessage}`,
-            )
-          }
-          t.deepEqual(
-            bytesToHex(result.blockLevelAccessList!.hash()),
-            bytesToHex(block.header.blockAccessListHash!),
-            `generated block level access list correct${balDiffMessage}`,
-          )
+          assertBlockAccessList(block, result.blockLevelAccessList!, providedBalJson, t)
         }
       } catch (e: any) {
+        // Re-throw genuinely unexpected errors; otherwise verify the failure
+        // matches the exception the fixture expects.
         if (expectException === undefined) {
           throw e
         }
-        // Check if the block failed due to an expected exception
-        t.exists(
-          expectException,
-          `expectException should be defined.  Error: ${e.message}\n${e.stack}`,
-        )
-
-        if (expectException.includes('|') === true) {
-          const exceptions = expectException.split('|')
-          let i = 0
-          while (i < exceptions.length) {
-            try {
-              t.isTrue(
-                exceptions[i] in exceptionMessages,
-                `expectException: (${exceptions[i]}) should be in exceptionMessages.  Error: ${e.message}\n${e.stack}`,
-              )
-              t.match(
-                e.message,
-                exceptionMessages[exceptions[i]],
-                `Should have correct error for ${exceptions[i]}`,
-              )
-              break
-            } catch {
-              if (i === exceptions.length - 1) {
-                t.fail(
-                  `Should have thrown one of the following exceptions: ${expectException}.  Threw: ${e.message}`,
-                )
-                break
-              }
-              i++
-            }
-          }
-        } else {
-          t.isTrue(
-            expectException in exceptionMessages,
-            `expectException: (${expectException}) should be in exceptionMessages.  Error: ${e.message}\n${e.stack}`,
-          )
-          // Check if the error message matches the expected exception
-          t.match(
-            e.message,
-            exceptionMessages[expectException],
-            `Should have correct error for ${expectException} -- got: ${e.message}`,
-          )
-        }
+        assertExpectedException(expectException, e, t)
       }
     }
   } catch (e: any) {
-    runError = e
+    return e
+  }
+  return undefined
+}
+
+/**
+ * Asserts that the generated block-level access list (EIP-7928) matches the
+ * block header, and — when the fixture provides a reference BAL — that the
+ * reference matches too.
+ */
+function assertBlockAccessList(
+  block: Block,
+  generatedBAL: BlockLevelAccessList,
+  providedBalJson: BALJSONBlockAccessList | undefined,
+  t: typeof assert,
+) {
+  let balDiffMessage = ''
+  if (providedBalJson !== undefined) {
+    const expectedBAL = createBlockLevelAccessListFromJSON(providedBalJson)
+    balDiffMessage = compareBAL(expectedBAL.raw(), generatedBAL.raw(), false).diffString
+    t.deepEqual(
+      bytesToHex(expectedBAL.hash()),
+      bytesToHex(block.header.blockAccessListHash!),
+      `expected block level access list correct${balDiffMessage}`,
+    )
+  }
+  t.deepEqual(
+    bytesToHex(generatedBAL.hash()),
+    bytesToHex(block.header.blockAccessListHash!),
+    `generated block level access list correct${balDiffMessage}`,
+  )
+}
+
+/**
+ * Asserts that `error` matches the fixture's `expectException`. The field may
+ * list several acceptable exceptions separated by `|`; matching any one passes.
+ */
+function assertExpectedException(expectException: string, error: any, t: typeof assert) {
+  const context = `Error: ${error.message}\n${error.stack}`
+  const assertMatches = (candidate: string) => {
+    t.isTrue(
+      candidate in exceptionMessages,
+      `expectException: (${candidate}) should be in exceptionMessages. ${context}`,
+    )
+    t.match(
+      error.message,
+      exceptionMessages[candidate],
+      `Should have correct error for ${candidate}`,
+    )
   }
 
-  // Always check final state and post state, even if block processing threw.
-  // Individual diffs go into `postFailures` so we can show them alongside any
-  // block-processing error rather than masking them with an early throw.
-  const postFailures: string[] = []
+  // Single expected exception: let the assertion throw directly for a precise message.
+  if (expectException.includes('|') === false) {
+    assertMatches(expectException)
+    return
+  }
+
+  // Multiple acceptable exceptions: pass if any one matches.
+  const candidates = expectException.split('|')
+  for (let i = 0; i < candidates.length; i++) {
+    try {
+      assertMatches(candidates[i])
+      return
+    } catch {
+      if (i === candidates.length - 1) {
+        t.fail(
+          `Should have thrown one of the following exceptions: ${expectException}. Threw: ${error.message}`,
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Verifies the canonical head hash and every account in `postState`. Returns a
+ * list of human-readable failure messages instead of throwing, so all diffs can
+ * be reported together.
+ */
+async function collectPostStateFailures(
+  vm: VM,
+  blockchain: Blockchain,
+  testData: BlockchainTestFixtureData,
+  t: typeof assert,
+): Promise<string[]> {
+  const failures: string[] = []
 
   try {
     const head = await blockchain.getCanonicalHeadBlock()
     t.equal(
       bytesToHex(head.hash()),
       testData.lastblockhash,
-      `head block hash matches lastblockhash`,
+      'head block hash matches lastblockhash',
     )
   } catch (e: any) {
-    postFailures.push(`head block hash: ${e?.message ?? String(e)}`)
+    failures.push(`head block hash: ${e?.message ?? String(e)}`)
   }
 
   const postState = testData.postState ?? {}
   for (const address of Object.keys(postState)) {
     try {
       const account = await vm.stateManager.getAccount(createAddressFromString(address))
-      t.exists(account, `account should be defined.  Got: ${address}`)
-      const accountInfo = postState[address]
-      t.equal(account.balance, hexToBigInt(accountInfo.balance), `correct balance (${address})`)
-      t.equal(account.nonce, hexToBigInt(accountInfo.nonce), `correct nonce (${address})`)
+      t.exists(account, `account should be defined. Got: ${address}`)
+      const expected = postState[address]
+      t.equal(account!.balance, hexToBigInt(expected.balance), `correct balance (${address})`)
+      t.equal(account!.nonce, hexToBigInt(expected.nonce), `correct nonce (${address})`)
       t.deepEqual(
-        account.codeHash,
-        keccak_256(hexToBytes(accountInfo.code)),
+        account!.codeHash,
+        keccak_256(hexToBytes(expected.code)),
         `correct code (${address})`,
       )
 
-      for (const [key, value] of Object.entries(accountInfo.storage)) {
+      for (const [key, value] of Object.entries(expected.storage)) {
         const keyBytes = setLengthLeft(hexToBytes(key as `0x${string}`), 32)
         const storage = await vm.stateManager.getStorage(createAddressFromString(address), keyBytes)
         t.equal(bytesToHex(storage), value, `correct storage[${key}] (${address})`)
       }
     } catch (e: any) {
-      postFailures.push(e?.message ?? String(e))
+      failures.push(e?.message ?? String(e))
     }
   }
 
-  if (runError === undefined && postFailures.length === 0) return
+  return failures
+}
 
-  // Build a combined failure. If a block-run error was the root cause, keep
-  // its original stack so vitest's source-mapped frames still point there.
+/**
+ * Combines an optional block-run error with post-state failure messages into a
+ * single thrown Error. When a block-run error is the root cause, its stack is
+ * preserved so vitest's source-mapped frames still point at the original throw.
+ */
+function throwCombinedFailure(runError: Error | undefined, postFailures: string[]): never {
   const sections: string[] = []
   if (runError !== undefined) sections.push(runError.message)
   if (postFailures.length > 0) {

--- a/packages/vm/test/tester/executionSpecState.test.ts
+++ b/packages/vm/test/tester/executionSpecState.test.ts
@@ -10,7 +10,12 @@ import { toBytes } from 'viem'
 import { createVM } from '../../src/constructors.ts'
 import { runTx } from '../../src/runTx.ts'
 import { makeBlockFromEnv, makeTx, setupPreConditions } from '../util.ts'
-import { loadExecutionSpecFixtures, parseTest } from './executionSpecTestLoader.ts'
+import {
+  loadExecutionSpecFixtures,
+  normalizeForkName,
+  parseStateTest,
+} from './executionSpecTestLoader.ts'
+import type { ParsedStateTest } from './executionSpecTypes.ts'
 import { annotateFixture } from './util/perDirectoryReporter.ts'
 
 const customFixturesPath = process.env.TEST_PATH ?? '../execution-spec-tests'
@@ -56,9 +61,9 @@ if (fs.existsSync(fixturesPath) === false) {
     for (const { id, fork, filePath, data } of fixtures) {
       it(`${fork}: ${id}`, async ({ task }) => {
         annotateFixture(task, filePath, fixturesPath, 'state tests')
-        const testCase = parseTest(fork, data)
+        const parsed = parseStateTest(fork, data)
         try {
-          await runStateTestCase(fork, testCase, assert, kzg)
+          await runStateTestCase(fork, parsed, kzg)
         } catch (e: any) {
           assert.fail(e?.toString() + e.stack)
         }
@@ -67,40 +72,39 @@ if (fs.existsSync(fixturesPath) === false) {
   })
 }
 
+/**
+ * Runs a single resolved state-test case: applies the pre-state, executes the
+ * transaction and asserts that the resulting state root matches the fixture.
+ */
 export async function runStateTestCase(
   fork: string,
-  testData: any,
-  t: typeof assert,
+  test: ParsedStateTest,
   kzg: microEthKZG,
+  t: typeof assert = assert,
 ) {
   const common = new Common({
     chain: Mainnet,
-    hardfork:
-      fork.toLowerCase() === 'frontier'
-        ? 'chainstart'
-        : fork.toLowerCase() === 'constantinoplefix'
-          ? 'petersburg'
-          : fork.toLowerCase(),
+    hardfork: normalizeForkName(fork),
     customCrypto: { kzg },
   })
-  const vm = await createVM({
-    common,
-  })
+  const vm = await createVM({ common })
 
-  await setupPreConditions(vm.stateManager, testData)
+  await setupPreConditions(vm.stateManager, { pre: test.pre })
 
+  // Try to build and run the transaction, recording what happened for the
+  // assertion message. The state-root check below is what actually decides
+  // pass/fail — a rejected or invalid tx simply leaves the state unchanged.
   let execInfo = ''
   let tx
-
   try {
-    tx = makeTx(testData.transaction, { common })
+    tx = makeTx(test.transaction, { common })
   } catch {
     execInfo = 'tx instantiation exception'
   }
 
-  if (tx) {
+  if (tx !== undefined) {
     if (tx.isValid()) {
-      const block = makeBlockFromEnv(testData.env, { common })
+      const block = makeBlockFromEnv(test.env, { common })
       try {
         await runTx(vm, { tx, block })
         execInfo = 'successful tx run'
@@ -112,10 +116,12 @@ export async function runStateTestCase(
     }
   }
 
-  const stateManagerStateRoot = await vm.stateManager.getStateRoot()
-  const testDataPostStateRoot = toBytes(testData.postStateRoot)
+  const stateRoot = await vm.stateManager.getStateRoot()
+  const expectedStateRoot = toBytes(test.postStateRoot)
 
-  const msg = `State Root should match test fixture.  Tx result: (${execInfo})`
-
-  t.deepEqual(stateManagerStateRoot, testDataPostStateRoot, msg)
+  t.deepEqual(
+    stateRoot,
+    expectedStateRoot,
+    `State root should match test fixture. Tx result: (${execInfo})`,
+  )
 }

--- a/packages/vm/test/tester/executionSpecTestLoader.ts
+++ b/packages/vm/test/tester/executionSpecTestLoader.ts
@@ -12,16 +12,30 @@ import { TypeOutput, toType } from '@ethereumjs/util'
 import { trustedSetup } from '@paulmillr/trusted-setups/fast-peerdas.js'
 import { KZG as microEthKZG } from 'micro-eth-signer/kzg.js'
 
-export type ExecutionSpecFixtureType = 'state_tests' | 'blockchain_tests'
+import type {
+  BlockchainTestFixtureData,
+  ExecutionSpecFixture,
+  ExecutionSpecFixtureType,
+  FixtureConfig,
+  ParsedStateTest,
+  StateTestFixtureData,
+} from './executionSpecTypes.ts'
 
-export interface ExecutionSpecFixture {
-  id: string
-  fork: string
-  filePath: string
-  data: any
-}
+export type {
+  ExecutionSpecFixture,
+  ExecutionSpecFixtureType,
+} from './executionSpecTypes.ts'
 
-function findJSONFiles(root: string, fixtureType: ExecutionSpecFixtureType) {
+// ---------------------------------------------------------------------------
+// Fixture discovery / loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively collects `.json` fixture files under `root` that belong to the
+ * given fixture type. A file qualifies if its path contains a
+ * `/<fixtureType>/` segment or its immediate parent directory is `fixtureType`.
+ */
+function findJSONFiles(root: string, fixtureType: ExecutionSpecFixtureType): string[] {
   const files: string[] = []
   const stack = [root]
 
@@ -57,13 +71,29 @@ function findJSONFiles(root: string, fixtureType: ExecutionSpecFixtureType) {
 
 export function loadExecutionSpecFixtures(
   root: string,
+  fixtureType: 'state_tests',
+): ExecutionSpecFixture<StateTestFixtureData>[]
+export function loadExecutionSpecFixtures(
+  root: string,
+  fixtureType: 'blockchain_tests',
+): ExecutionSpecFixture<BlockchainTestFixtureData>[]
+/**
+ * Loads and flattens every fixture of `fixtureType` found under `root`.
+ *
+ * A single JSON file holds multiple named tests. Each test expands into one
+ * fixture entry per fork it targets:
+ * - state tests: one entry per key of the test's `post` object;
+ * - blockchain tests: a single entry, using the test's `network` field.
+ */
+export function loadExecutionSpecFixtures(
+  root: string,
   fixtureType: ExecutionSpecFixtureType,
 ): ExecutionSpecFixture[] {
   const files = findJSONFiles(root, fixtureType)
   const fixtures: ExecutionSpecFixture[] = []
 
   for (const filePath of files) {
-    let parsed: Record<string, any>
+    let parsed: Record<string, unknown>
     try {
       parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'))
     } catch {
@@ -72,14 +102,15 @@ export function loadExecutionSpecFixtures(
 
     for (const [id, data] of Object.entries(parsed)) {
       if (fixtureType === 'state_tests') {
-        const forks = Object.keys((data as any).post ?? {})
-        for (const fork of forks) {
-          fixtures.push({ id, fork, filePath, data })
+        const test = data as StateTestFixtureData
+        for (const fork of Object.keys(test.post ?? {})) {
+          fixtures.push({ id, fork, filePath, data: test })
         }
       } else {
-        const fork = (data as any).network ?? (data as any).config?.network
+        const test = data as BlockchainTestFixtureData
+        const fork = test.network ?? test.config?.network
         if (fork !== undefined) {
-          fixtures.push({ id, fork, filePath, data })
+          fixtures.push({ id, fork, filePath, data: test })
         }
       }
     }
@@ -88,18 +119,24 @@ export function loadExecutionSpecFixtures(
   return fixtures
 }
 
-export function parseTest(fork: string, testData: any) {
-  const postState = testData['post']?.[fork]
-  const testCase = postState[0]
-  const testIndexes = testCase['indexes']
-  const tx = { ...testData.transaction }
+/**
+ * Resolves a state-test fixture for a single fork into an executable case.
+ *
+ * State-test transactions store `data`, `gasLimit` and `value` as parallel
+ * arrays; the post entry's `indexes` pick one element from each to form the
+ * concrete transaction this case should run.
+ */
+export function parseStateTest(fork: string, testData: StateTestFixtureData): ParsedStateTest {
+  const testCase = testData.post[fork][0]
+  const indexes = testCase.indexes
+  const tx: Record<string, unknown> = { ...testData.transaction }
 
-  tx.data = testData.transaction.data[testIndexes['data']]
-  tx.gasLimit = testData.transaction.gasLimit[testIndexes['gas']]
-  tx.value = testData.transaction.value[testIndexes['value']]
+  tx.data = testData.transaction.data[indexes.data]
+  tx.gasLimit = testData.transaction.gasLimit[indexes.gas]
+  tx.value = testData.transaction.value[indexes.value]
 
-  if (tx.accessLists !== undefined) {
-    tx.accessList = testData.transaction.accessLists[testIndexes['data']]
+  if (testData.transaction.accessLists !== undefined) {
+    tx.accessList = testData.transaction.accessLists[indexes.data]
     if (tx.chainId === undefined) {
       tx.chainId = 1
     }
@@ -107,101 +144,17 @@ export function parseTest(fork: string, testData: any) {
 
   return {
     transaction: tx,
-    postStateRoot: testCase['hash'],
-    logs: testCase['logs'],
-    env: testData['env'],
-    pre: testData['pre'],
-    expectException: testCase['expectException'],
+    postStateRoot: testCase.hash,
+    logs: testCase.logs,
+    env: testData.env,
+    pre: testData.pre,
+    expectException: testCase.expectException,
   }
 }
 
-function customHardforkHistory(fork: string): HardforkTransitionConfig[] {
-  // Include all hardforks from Mainnet up to and including the "from" hardfork
-  // This is necessary for gteHardfork() to work correctly
-  const mainnetHardforks = Mainnet.hardforks
-  const hardforks: HardforkTransitionConfig[] = []
-  let foundFrom = false
-  for (const hf of mainnetHardforks) {
-    if (hf.name === fork) {
-      foundFrom = true
-      // Add the "from" hardfork at block 0
-      hardforks.push({
-        name: fork,
-        block: 0,
-        timestamp: 0,
-      })
-      break
-    } else {
-      // Include all previous hardforks at block 0
-      hardforks.push({
-        name: hf.name,
-        block: null,
-        timestamp: 0,
-      })
-    }
-  }
-  if (!foundFrom) {
-    // If "from" hardfork not found in Mainnet hardforks, just add it
-    hardforks.push({
-      name: fork,
-      block: 0,
-      timestamp: 0,
-    })
-  }
-  return hardforks
-}
-
-function buildTransitionChainConfig(
-  blobSchedule: any,
-  from: string,
-  to: string,
-  timestamp: number,
-): ChainConfig {
-  const hardforks: HardforkTransitionConfig[] = customHardforkHistory(from)
-  // Add the "to" hardfork at the specified timestamp
-  hardforks.push({
-    name: to,
-    block: null,
-    timestamp,
-  })
-
-  const customHardforks: HardforksDict = {}
-  // Extract BPO parameters from blobSchedule
-  if (blobSchedule !== undefined) {
-    for (const [hfName, params] of Object.entries(blobSchedule)) {
-      const hfNameLower = hfName.toLowerCase()
-      if (hfNameLower.startsWith('bpo')) {
-        const bpoParams = params as any
-        customHardforks[hfNameLower] = {
-          params: {
-            target: toType(bpoParams.target, TypeOutput.Number),
-            max: toType(bpoParams.max, TypeOutput.Number),
-            blobGasPriceUpdateFraction: toType(bpoParams.baseFeeUpdateFraction, TypeOutput.Number),
-          },
-        }
-      }
-    }
-  }
-
-  // Build chain config with custom hardforks and additional hardforks in the hardforks list
-  const chainConfig: ChainConfig = {
-    ...Mainnet,
-    customHardforks,
-    defaultHardfork: from,
-    hardforks,
-    consensus: preMergeForks.includes(from)
-      ? {
-          type: ConsensusType.ProofOfStake,
-          algorithm: 'casper',
-        }
-      : {
-          type: ConsensusType.ProofOfWork,
-          algorithm: 'ethash',
-        },
-  }
-
-  return chainConfig
-}
+// ---------------------------------------------------------------------------
+// Common construction
+// ---------------------------------------------------------------------------
 
 const preMergeForks = [
   'chainstart',
@@ -220,64 +173,119 @@ const preMergeForks = [
   'grayGlacier',
 ]
 
-export function createCommonForFork(fork: string, testData?: any, kzg?: microEthKZG) {
-  const kzgInstance = kzg ?? new microEthKZG(trustedSetup)
+/** Matches transition-fork names, e.g. `OsakaToBPO1AtTime15k`. */
+const TRANSITION_FORK_REGEX = /^([A-Za-z0-9]+)To([A-Za-z0-9]+)AtTime(\d+)([Kk])?$/
 
-  try {
-    let forkLower = fork.toLowerCase()
-    if (forkLower === 'frontier') {
-      forkLower = 'chainstart'
-    } else if (forkLower === 'constantinoplefix') {
-      forkLower = 'petersburg'
+/**
+ * Maps a fixture fork name to the hardfork name used by `@ethereumjs/common`.
+ * Fixtures use a few historical aliases that differ from our internal names.
+ */
+export function normalizeForkName(fork: string): string {
+  const lower = fork.toLowerCase()
+  if (lower === 'frontier') return 'chainstart'
+  if (lower === 'constantinoplefix') return 'petersburg'
+  return lower
+}
+
+function consensusForFork(fork: string): ChainConfig['consensus'] {
+  return preMergeForks.includes(fork)
+    ? { type: ConsensusType.ProofOfWork, algorithm: 'ethash' }
+    : { type: ConsensusType.ProofOfStake, algorithm: 'casper' }
+}
+
+/**
+ * Builds the mainnet hardfork history with every fork up to and including
+ * `fork` present (so `gteHardfork()` resolves correctly), `fork` activated at
+ * block 0 and all earlier forks disabled.
+ */
+function hardforkHistoryUpTo(fork: string): HardforkTransitionConfig[] {
+  const hardforks: HardforkTransitionConfig[] = []
+  for (const hf of Mainnet.hardforks) {
+    if (hf.name === fork) {
+      hardforks.push({ name: fork, block: 0, timestamp: 0 })
+      return hardforks
     }
-    const hardforks: HardforkTransitionConfig[] = customHardforkHistory(forkLower)
-
-    const chainConfig: ChainConfig = {
-      ...Mainnet,
-      hardforks,
-      consensus: preMergeForks.includes(forkLower)
-        ? {
-            type: ConsensusType.ProofOfWork,
-            algorithm: 'ethash',
-          }
-        : {
-            type: ConsensusType.ProofOfStake,
-            algorithm: 'casper',
-          },
-      defaultHardfork: forkLower,
-    }
-    // Only set chainId if it's provided in testData, otherwise use Mainnet's chainId
-    if (testData?.config?.chainId !== undefined) {
-      chainConfig.chainId = testData.config.chainId
-    }
-    return new Common({
-      chain: chainConfig,
-      hardfork: forkLower,
-      customCrypto: { kzg: kzgInstance },
-    })
-  } catch {
-    // Transition Fork (e.g. OsakaToBPO1AtTime15K)
-
-    // Check if this is a transition fork
-    const transitionMatch = fork.match(/^([A-Za-z0-9]+)To([A-Za-z0-9]+)AtTime(\d+)([Kk])?$/)
-    if (transitionMatch === null) {
-      throw new Error(`Unable to parse transition fork: ${fork}`)
-    }
-
-    // extract fork names and timestamp
-    const [, fromFork, toFork, timestampStr, suffix] = transitionMatch
-    const from = fromFork.toLowerCase()
-    const to = toFork.toLowerCase()
-    let timestamp = Number(timestampStr)
-    if (suffix && suffix.toLowerCase() === 'k') {
-      timestamp *= 1000
-    }
-
-    const blobSchedule = testData.config.blobSchedule
-
-    // Build chain config with custom hardforks and blob schedule
-    const chainConfig = buildTransitionChainConfig(blobSchedule, from, to, timestamp)
-
-    return new Common({ chain: chainConfig, hardfork: from, customCrypto: { kzg: kzgInstance } })
+    hardforks.push({ name: hf.name, block: null, timestamp: 0 })
   }
+  // `fork` is not a known mainnet hardfork (e.g. a devnet fork): add it anyway.
+  hardforks.push({ name: fork, block: 0, timestamp: 0 })
+  return hardforks
+}
+
+/** Common for a single (non-transition) fork. */
+function createSingleForkCommon(
+  fork: string,
+  testData: { config?: FixtureConfig } | undefined,
+  kzg: microEthKZG,
+): Common {
+  const forkName = normalizeForkName(fork)
+  const chainConfig: ChainConfig = {
+    ...Mainnet,
+    hardforks: hardforkHistoryUpTo(forkName),
+    consensus: consensusForFork(forkName),
+    defaultHardfork: forkName,
+  }
+  // Only override chainId when the fixture specifies one; otherwise keep Mainnet's.
+  if (testData?.config?.chainId !== undefined) {
+    chainConfig.chainId = testData.config.chainId
+  }
+  return new Common({ chain: chainConfig, hardfork: forkName, customCrypto: { kzg } })
+}
+
+/** Common for a `<from>To<to>AtTime<n>` transition fork. */
+function createTransitionCommon(
+  match: RegExpMatchArray,
+  testData: { config?: FixtureConfig } | undefined,
+  kzg: microEthKZG,
+): Common {
+  const [, fromFork, toFork, timestampStr, suffix] = match
+  const from = fromFork.toLowerCase()
+  const to = toFork.toLowerCase()
+  const timestamp = Number(timestampStr) * (suffix?.toLowerCase() === 'k' ? 1000 : 1)
+
+  const hardforks = hardforkHistoryUpTo(from)
+  // The "to" fork activates at the transition timestamp.
+  hardforks.push({ name: to, block: null, timestamp })
+
+  // Extract BPO (blob parameter only) fork params from the fixture's blob schedule.
+  const customHardforks: HardforksDict = {}
+  const blobSchedule = testData?.config?.blobSchedule
+  if (blobSchedule !== undefined) {
+    for (const [hfName, params] of Object.entries(blobSchedule)) {
+      if (hfName.toLowerCase().startsWith('bpo')) {
+        customHardforks[hfName.toLowerCase()] = {
+          params: {
+            target: toType(params.target, TypeOutput.Number),
+            max: toType(params.max, TypeOutput.Number),
+            blobGasPriceUpdateFraction: toType(params.baseFeeUpdateFraction, TypeOutput.Number),
+          },
+        }
+      }
+    }
+  }
+
+  const chainConfig: ChainConfig = {
+    ...Mainnet,
+    customHardforks,
+    defaultHardfork: from,
+    hardforks,
+    consensus: consensusForFork(from),
+  }
+  return new Common({ chain: chainConfig, hardfork: from, customCrypto: { kzg } })
+}
+
+/**
+ * Returns the `Common` to run a fixture against. Handles both single forks
+ * (e.g. `Prague`) and transition forks (e.g. `OsakaToBPO1AtTime15k`).
+ */
+export function createCommonForFork(
+  fork: string,
+  testData?: { config?: FixtureConfig },
+  kzg?: microEthKZG,
+): Common {
+  const kzgInstance = kzg ?? new microEthKZG(trustedSetup)
+  const transitionMatch = fork.match(TRANSITION_FORK_REGEX)
+  return transitionMatch !== null
+    ? createTransitionCommon(transitionMatch, testData, kzgInstance)
+    : createSingleForkCommon(fork, testData, kzgInstance)
 }

--- a/packages/vm/test/tester/executionSpecTypes.ts
+++ b/packages/vm/test/tester/executionSpecTypes.ts
@@ -1,0 +1,170 @@
+/**
+ * Type definitions for execution-spec-tests fixtures.
+ *
+ * These describe the JSON shape produced by
+ * https://github.com/ethereum/execution-spec-tests and consumed by the
+ * `executionSpecState.test.ts` / `executionSpecBlockchain.test.ts` runners.
+ *
+ * The fixtures are external data, so these types are intentionally permissive:
+ * every interface carries an index signature (or `unknown` fields) for keys we
+ * do not explicitly model, while still typing the fields the runners read.
+ */
+import type { BALJSONBlockAccessList, PrefixedHexString } from '@ethereumjs/util'
+
+/** Which kind of fixtures to load from a fixtures directory. */
+export type ExecutionSpecFixtureType = 'state_tests' | 'blockchain_tests'
+
+/** A single account's pre-/post-state as encoded in a fixture. */
+export interface FixtureAccountState {
+  nonce: PrefixedHexString
+  balance: PrefixedHexString
+  code: PrefixedHexString
+  storage: Record<string, PrefixedHexString>
+}
+
+/** The `env` object describing the execution environment (block context). */
+export interface FixtureEnv {
+  currentCoinbase: PrefixedHexString
+  currentGasLimit: PrefixedHexString
+  currentNumber: PrefixedHexString
+  currentTimestamp: PrefixedHexString
+  currentRandom?: PrefixedHexString
+  currentDifficulty?: PrefixedHexString
+  currentBaseFee?: PrefixedHexString
+  currentExcessBlobGas?: PrefixedHexString
+  [key: string]: unknown
+}
+
+/** Per-hardfork blob parameters, present in transition-fork fixtures. */
+export interface FixtureBlobScheduleEntry {
+  target: PrefixedHexString | number
+  max: PrefixedHexString | number
+  baseFeeUpdateFraction: PrefixedHexString | number
+}
+
+/** Optional `config` block: chain id and (for transition forks) blob schedule. */
+export interface FixtureConfig {
+  network?: string
+  chainId?: number
+  /** Lowercase spelling used by some blockchain fixtures. */
+  chainid?: number
+  blobSchedule?: Record<string, FixtureBlobScheduleEntry>
+  [key: string]: unknown
+}
+
+// ---------------------------------------------------------------------------
+// State tests
+// ---------------------------------------------------------------------------
+
+/**
+ * A state-test transaction. `data`, `gasLimit` and `value` are parallel arrays;
+ * a post entry's {@link StateTestIndexes} selects one element from each.
+ */
+export interface StateTestTransaction {
+  data: PrefixedHexString[]
+  gasLimit: PrefixedHexString[]
+  value: PrefixedHexString[]
+  accessLists?: unknown[]
+  nonce?: PrefixedHexString
+  gasPrice?: PrefixedHexString
+  to?: PrefixedHexString
+  sender?: PrefixedHexString
+  secretKey?: PrefixedHexString
+  chainId?: number
+  [key: string]: unknown
+}
+
+/** Indexes into the transaction's parallel arrays for a single post entry. */
+export interface StateTestIndexes {
+  data: number
+  gas: number
+  value: number
+}
+
+/** One expected result of a state test (one data/gas/value combination). */
+export interface StateTestPostEntry {
+  hash: PrefixedHexString
+  logs: PrefixedHexString
+  txbytes?: PrefixedHexString
+  indexes: StateTestIndexes
+  state?: Record<string, FixtureAccountState>
+  expectException?: string
+}
+
+/** A full state-test fixture body (`post` is keyed by fork name). */
+export interface StateTestFixtureData {
+  env: FixtureEnv
+  pre: Record<string, FixtureAccountState>
+  transaction: StateTestTransaction
+  post: Record<string, StateTestPostEntry[]>
+  config?: FixtureConfig
+}
+
+/**
+ * A single state-test case resolved for one fork and one index combination,
+ * ready to be executed. Produced by `parseStateTest`.
+ */
+export interface ParsedStateTest {
+  /** Transaction with `data`/`gasLimit`/`value` collapsed to single values. */
+  transaction: Record<string, unknown>
+  postStateRoot: PrefixedHexString
+  logs: PrefixedHexString
+  env: FixtureEnv
+  pre: Record<string, FixtureAccountState>
+  expectException?: string
+}
+
+// ---------------------------------------------------------------------------
+// Blockchain tests
+// ---------------------------------------------------------------------------
+
+/** A block header as embedded in a blockchain fixture. */
+export interface FixtureBlockHeader {
+  hash?: PrefixedHexString
+  stateRoot?: PrefixedHexString
+  [key: string]: unknown
+}
+
+/** One block within a blockchain test. */
+export interface BlockchainTestBlock {
+  rlp: PrefixedHexString
+  blockHeader?: FixtureBlockHeader
+  /** Present on fixtures that also ship a decoded form of the block. */
+  rlp_decoded?: {
+    blockHeader?: FixtureBlockHeader
+    blockAccessList?: BALJSONBlockAccessList
+  }
+  /** EIP-7928 block-level access list (Amsterdam+), when provided. */
+  blockAccessList?: BALJSONBlockAccessList
+  /** Set when the block is expected to be rejected; names the exception(s). */
+  expectException?: string
+  transactions?: unknown[]
+}
+
+/** A full blockchain-test fixture body. */
+export interface BlockchainTestFixtureData {
+  network: string
+  genesisBlockHeader: FixtureBlockHeader & { hash: PrefixedHexString }
+  genesisRLP?: PrefixedHexString
+  pre: Record<string, FixtureAccountState>
+  postState?: Record<string, FixtureAccountState>
+  lastblockhash: PrefixedHexString
+  blocks: BlockchainTestBlock[]
+  config?: FixtureConfig
+  sealEngine?: string
+}
+
+/**
+ * A loaded fixture entry. One JSON file can expand into several of these: one
+ * per (test id, fork) pair for state tests, one per test id for blockchain
+ * tests. `TData` is the fixture body, keyed by {@link ExecutionSpecFixtureType}.
+ * The type-narrowing overloads of `loadExecutionSpecFixtures` supply a concrete
+ * `TData` ({@link StateTestFixtureData} / {@link BlockchainTestFixtureData}); the
+ * `any` default only applies to callers that use the bare, untyped form.
+ */
+export interface ExecutionSpecFixture<TData = any> {
+  id: string
+  fork: string
+  filePath: string
+  data: TData
+}


### PR DESCRIPTION
Refactor the execution-spec-tests runner (the current, non-deprecated VM test runner) to be easier to understand and better typed:

- Add `executionSpecTypes.ts` with documented fixture types, replacing the pervasive `any` used for fixture data.
- Give `loadExecutionSpecFixtures` typed overloads so callers get concrete state/blockchain fixture types.
- Rewrite `createCommonForFork` to detect transition forks explicitly instead of relying on the `Common` constructor throwing (try/catch as control flow), splitting it into small named helpers.
- Extract the shared `normalizeForkName` fork-alias helper (was duplicated).
- Break the ~200-line blockchain `runBlockchainTestCase` into named helpers (`runBlocks`, `assertBlockAccessList`, `assertExpectedException`, `collectPostStateFailures`, `throwCombinedFailure`) and drop dead commented-out assertions.

Behavior is unchanged: state (shanghai) 376/376 and blockchain (osaka) 2246/2246 pass identically before and after; tsc clean.