### PR TITLE
fix(util): align BAL validation with numeric storage slot ordering

### DIFF
--- a/packages/util/src/bal/compareStorageSlotKeys.ts
+++ b/packages/util/src/bal/compareStorageSlotKeys.ts
@@ -1,0 +1,26 @@
+import { hexToBytes } from '../bytes.ts'
+import type { PrefixedHexString } from '../types.ts'
+
+/**
+ * Lexicographic compare for BAL storage keys by numeric value (uint256).
+ *
+ * Keys may appear in minimal big-endian form (leading zeros stripped for JSON/RLP
+ * scalars). Compare as 32-byte big-endian integers so ordering matches go-ethereum's
+ * fixed-length `common.Hash` lex order.
+ */
+export function compareStorageSlotKeys(
+  a: PrefixedHexString | Uint8Array,
+  b: PrefixedHexString | Uint8Array,
+): number {
+  const aBytes = a instanceof Uint8Array ? a : hexToBytes(a)
+  const bBytes = b instanceof Uint8Array ? b : hexToBytes(b)
+  const paddedA = new Uint8Array(32)
+  const paddedB = new Uint8Array(32)
+  paddedA.set(aBytes, 32 - aBytes.length)
+  paddedB.set(bBytes, 32 - bBytes.length)
+  for (let i = 0; i < 32; i++) {
+    if (paddedA[i] < paddedB[i]) return -1
+    if (paddedA[i] > paddedB[i]) return 1
+  }
+  return 0
+}

--- a/packages/util/src/bal/index.ts
+++ b/packages/util/src/bal/index.ts
@@ -10,6 +10,7 @@ import {
 } from '../bytes.ts'
 import { padToEven } from '../internal.ts'
 import type { PrefixedHexString } from '../types.ts'
+import { compareStorageSlotKeys } from './compareStorageSlotKeys.ts'
 
 // Base types which can be used for JSON, internal representation and raw format.
 type BALAddressHex = PrefixedHexString // bytes20
@@ -246,7 +247,7 @@ export class BlockLevelAccessList {
       const storageChanges = (
         Object.entries(data.storageChanges) as [BALStorageKeyHex, BALRawStorageChange[]][]
       )
-        .sort((a, b) => compareLexicographicHexOrBytes(a[0], b[0]))
+        .sort((a, b) => compareStorageSlotKeys(a[0], b[0]))
         .map(([slot, changes]) => [
           normalizeHexForRLP(slot),
           changes
@@ -260,7 +261,7 @@ export class BlockLevelAccessList {
       // Normalize storage reads for canonical RLP encoding (0 -> empty bytes)
       const storageReads = Array.from(data.storageReads)
         .map(normalizeHexForRLP)
-        .sort((a, b) => compareLexicographicHexOrBytes(a, b))
+        .sort((a, b) => compareStorageSlotKeys(a, b))
 
       const balanceChanges = Array.from(data.balanceChanges.entries())
         .sort(([a], [b]) => a - b)
@@ -587,23 +588,6 @@ export class BlockLevelAccessList {
       // If originalBalance > 0, keep the balance changes (which should show balance = 0)
     }
   }
-}
-
-function compareLexicographicHexOrBytes(
-  a: PrefixedHexString | Uint8Array,
-  b: PrefixedHexString | Uint8Array,
-): number {
-  const aBytes = a instanceof Uint8Array ? a : hexToBytes(a)
-  const bBytes = b instanceof Uint8Array ? b : hexToBytes(b)
-  const paddedA = new Uint8Array(32)
-  const paddedB = new Uint8Array(32)
-  paddedA.set(aBytes, 32 - aBytes.length)
-  paddedB.set(bBytes, 32 - bBytes.length)
-  for (let i = 0; i < 32; i++) {
-    if (paddedA[i] < paddedB[i]) return -1
-    if (paddedA[i] > paddedB[i]) return 1
-  }
-  return 0
 }
 
 /**

--- a/packages/util/src/bal/validation.ts
+++ b/packages/util/src/bal/validation.ts
@@ -5,6 +5,7 @@ import { bytesToHex, equalsBytes, hexToBytes } from '../bytes.ts'
 import { SYSTEM_ADDRESS } from '../constants.ts'
 import { EthereumJSErrorWithoutCode } from '../errors.ts'
 import type { PrefixedHexString } from '../types.ts'
+import { compareStorageSlotKeys } from './compareStorageSlotKeys.ts'
 import {
   type BALJSONAccountChanges,
   type BALJSONBlockAccessList,
@@ -229,7 +230,7 @@ function validateBlockAccessListJSONAccount(account: BALJSONAccountChanges): voi
 
   let prevSlot: PrefixedHexString | undefined
   for (const slotChange of account.storageChanges) {
-    if (prevSlot !== undefined && compareLexicographicHex(prevSlot, slotChange.slot) >= 0) {
+    if (prevSlot !== undefined && compareStorageSlotKeys(prevSlot, slotChange.slot) >= 0) {
       throwInvalidBlockAccessList('storage slots are not sorted')
     }
     prevSlot = slotChange.slot
@@ -245,7 +246,7 @@ function validateBlockAccessListJSONAccount(account: BALJSONAccountChanges): voi
   let prevRead: PrefixedHexString | undefined
   const seenReads = new Set<PrefixedHexString>()
   for (const slot of account.storageReads) {
-    if (prevRead !== undefined && compareLexicographicHex(prevRead, slot) >= 0) {
+    if (prevRead !== undefined && compareStorageSlotKeys(prevRead, slot) >= 0) {
       throwInvalidBlockAccessList('storage reads are not sorted')
     }
     if (seenReads.has(slot)) {
@@ -272,7 +273,7 @@ function validateBlockAccessListJSONAccount(account: BALJSONAccountChanges): voi
 function validateStorageChanges(storageChanges: BALRawAccountChanges[1]): void {
   let prevSlot: PrefixedHexString | undefined
   for (const [slot, changes] of storageChanges) {
-    if (prevSlot !== undefined && compareLexicographicHex(prevSlot, slot) >= 0) {
+    if (prevSlot !== undefined && compareStorageSlotKeys(prevSlot, slot) >= 0) {
       throwInvalidBlockAccessList('storage slots are not sorted')
     }
     prevSlot = slot
@@ -293,7 +294,7 @@ function validateStorageReads(
 
   for (const slot of storageReads) {
     const slotHex = typeof slot === 'string' ? slot : bytesToHex(slot)
-    if (prevRead !== undefined && compareLexicographicHex(prevRead, slotHex) >= 0) {
+    if (prevRead !== undefined && compareStorageSlotKeys(prevRead, slotHex) >= 0) {
       throwInvalidBlockAccessList('storage reads are not sorted')
     }
     if (seenReads.has(slotHex)) {
@@ -350,10 +351,8 @@ function validateAddress(address: PrefixedHexString): void {
   hexToBytes(address)
 }
 
-// Accepts both hex strings and raw bytes because BlockLevelAccessList.raw()
-// runs slot/read keys through normalizeHexForRLP, which returns Uint8Array
-// for the canonical zero-slot case (an empty bytes encoding). The validator
-// sees both shapes when comparing slots that have been normalized for RLP.
+// Address ordering in JSON/raw validation (20-byte keys; variable-length slot
+// ordering uses compareStorageSlotKeys instead).
 function compareLexicographicHex(
   a: PrefixedHexString | Uint8Array,
   b: PrefixedHexString | Uint8Array,

--- a/packages/util/test/bal/compareStorageSlotKeys.spec.ts
+++ b/packages/util/test/bal/compareStorageSlotKeys.spec.ts
@@ -1,0 +1,26 @@
+import { assert, describe, it } from 'vitest'
+
+import { compareStorageSlotKeys } from '../../src/bal/compareStorageSlotKeys.ts'
+import type { PrefixedHexString } from '../../src/types.ts'
+
+describe('compareStorageSlotKeys', () => {
+  it('sorts minimal-representation keys by numeric value, not byte prefix', () => {
+    const slot2: PrefixedHexString = '0x02'
+    const slot256: PrefixedHexString = '0x0100'
+    assert.isBelow(compareStorageSlotKeys(slot2, slot256), 0)
+    assert.isAbove(compareStorageSlotKeys(slot256, slot2), 0)
+
+    const sorted = [slot256, slot2].sort(compareStorageSlotKeys)
+    assert.deepEqual(sorted, [slot2, slot256])
+  })
+
+  it('matches numeric order for same-length keys', () => {
+    assert.isBelow(compareStorageSlotKeys('0x01', '0x02'), 0)
+    assert.equal(compareStorageSlotKeys('0x0a', '0x0a'), 0)
+  })
+
+  it('treats canonical zero slot as less than non-zero keys', () => {
+    assert.isBelow(compareStorageSlotKeys('0x', '0x01'), 0)
+    assert.isBelow(compareStorageSlotKeys(new Uint8Array([]), '0x02'), 0)
+  })
+})

--- a/packages/util/test/bal/index.spec.ts
+++ b/packages/util/test/bal/index.spec.ts
@@ -183,6 +183,34 @@ describe('JSON', () => {
     assert.deepEqual(bytesToHex(bal.serialize()), bytesToHex(expected))
   })
 
+  it('should sort mixed-length storage keys by numeric value in raw()', () => {
+    const address = '0x00000000000000000000000000000000000000aa' as const
+    const bal = createBlockLevelAccessList()
+    bal.blockAccessIndex = 0
+    bal.addAddress(address)
+    // Insert in reverse numeric order; raw() must emit 0x02 before 0x0100.
+    bal.addStorageWrite(address, hexToBytes('0x0100'), hexToBytes('0x99'), 0)
+    bal.addStorageWrite(address, hexToBytes('0x02'), hexToBytes('0x42'), 0)
+
+    const changeSlots = bal
+      .raw()[0][1]
+      .map(([slot]) => (typeof slot === 'string' ? slot : bytesToHex(slot)))
+    assert.deepEqual(changeSlots, ['0x02', '0x0100'])
+  })
+
+  it('should sort mixed-length storage read keys by numeric value in raw()', () => {
+    const address = '0x00000000000000000000000000000000000000bb' as const
+    const bal = createBlockLevelAccessList()
+    bal.addAddress(address)
+    bal.addStorageRead(address, hexToBytes('0x0100'))
+    bal.addStorageRead(address, hexToBytes('0x02'))
+
+    const readSlots = bal
+      .raw()[0][2]
+      .map((slot) => (typeof slot === 'string' ? slot : bytesToHex(slot)))
+    assert.deepEqual(readSlots, ['0x02', '0x0100'])
+  })
+
   it('should include an accessed system address with empty change lists when serializing', () => {
     const bal = createBlockLevelAccessListFromJSON([
       {

--- a/packages/util/test/bal/validation.spec.ts
+++ b/packages/util/test/bal/validation.spec.ts
@@ -84,6 +84,64 @@ describe('validateBlockAccessListJSONStructure', () => {
       /invalid block access list: storage slot appears in both storageChanges and storageReads/,
     )
   })
+
+  it('accepts mixed-length storage slots in numeric order', () => {
+    validateBlockAccessListJSONStructure([
+      {
+        address: '0x0000000000000000000000000000000000000001',
+        nonceChanges: [],
+        balanceChanges: [],
+        codeChanges: [],
+        storageChanges: [
+          {
+            slot: '0x02',
+            slotChanges: [{ blockAccessIndex: '0x00', postValue: '0x42' }],
+          },
+          {
+            slot: '0x0100',
+            slotChanges: [{ blockAccessIndex: '0x00', postValue: '0x99' }],
+          },
+        ],
+        storageReads: [],
+      },
+    ])
+    validateBlockAccessListJSONStructure([
+      {
+        address: '0x0000000000000000000000000000000000000002',
+        nonceChanges: [],
+        balanceChanges: [],
+        codeChanges: [],
+        storageChanges: [],
+        storageReads: ['0x02', '0x0100'],
+      },
+    ])
+  })
+
+  it('rejects mixed-length storage slots out of numeric order', () => {
+    const json: BALJSONBlockAccessList = [
+      {
+        address: '0x0000000000000000000000000000000000000001',
+        nonceChanges: [],
+        balanceChanges: [],
+        codeChanges: [],
+        storageChanges: [
+          {
+            slot: '0x0100',
+            slotChanges: [{ blockAccessIndex: '0x00', postValue: '0x99' }],
+          },
+          {
+            slot: '0x02',
+            slotChanges: [{ blockAccessIndex: '0x00', postValue: '0x42' }],
+          },
+        ],
+        storageReads: [],
+      },
+    ]
+    assert.throws(
+      () => validateBlockAccessListJSONStructure(json),
+      /invalid block access list: storage slots are not sorted/,
+    )
+  })
 })
 
 describe('validateBlockAccessListStructure', () => {
@@ -95,6 +153,30 @@ describe('validateBlockAccessListStructure', () => {
   it('accepts lists built from valid JSON', () => {
     const bal = createBlockLevelAccessListFromJSON(balSimpleJSON as BALJSONBlockAccessList)
     validateBlockAccessListStructure(bal)
+  })
+
+  it('accepts mixed-length storage keys after canonical raw() sorting', () => {
+    validateBlockAccessListStructure(
+      createBlockLevelAccessListFromJSON([
+        {
+          address: '0x00000000000000000000000000000000000000aa',
+          nonceChanges: [],
+          balanceChanges: [],
+          codeChanges: [],
+          storageChanges: [
+            {
+              slot: '0x02',
+              slotChanges: [{ blockAccessIndex: '0x00', postValue: '0x42' }],
+            },
+            {
+              slot: '0x0100',
+              slotChanges: [{ blockAccessIndex: '0x00', postValue: '0x99' }],
+            },
+          ],
+          storageReads: [],
+        },
+      ]),
+    )
   })
 })
 


### PR DESCRIPTION
completes #4341 by fixing the duplicate comparator in validation and adding regression tests. EEST fixture for mixed-length slots still worth opening separately